### PR TITLE
Add ssl support to consul_kv lookup

### DIFF
--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -37,6 +37,7 @@ DOCUMENTATION = """
         ini:
           - section: lookup_consul
             key: host
+        version_added: '2.7'
       port:
         description: The port of the target host to connect to.
         default: 8500

--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -32,7 +32,7 @@ DOCUMENTATION = """
         default: localhost
         description:
            - The target to connect to, must be a resolvable address.
-           - Will be determined from C(ANSIBLE_CONSUL_URL) if that is set
+             Will be determined from C(ANSIBLE_CONSUL_URL) if that is set
            - C(ANSIBLE_CONSUL_URL) should look like this: C(https://my.consul.server:8500)
         env:
           - name: ANSIBLE_CONSUL_URL
@@ -47,9 +47,9 @@ DOCUMENTATION = """
         default: 8500
       scheme:
         default: http
-        description: 
+        description:
           - Whether to use http or https.
-          - If you use C(ANSIBLE_CONSUL_URL) this value will be used from there. 
+          - If you use C(ANSIBLE_CONSUL_URL) this value will be used from there.
         version_added: '2.7'
       validate_certs:
         default: True

--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 DOCUMENTATION = """
     lookup: consul_kv
     version_added: "1.9"
-    short_description: Fetch  metadata from a Consul key value store.
+    short_description: Fetch metadata from a Consul key value store.
     description:
       - Lookup metadata for a playbook from the key value store in a Consul cluster.
         Values can be easily set in the kv store with simple rest commands
@@ -25,21 +25,22 @@ DOCUMENTATION = """
         description: If true, will retrieve all the values that have the given key as prefix.
         default: False
       index:
-        description: If the key has a value with the specified index then this is returned allowing access to historical values.
+        description: 
+          - If the key has a value with the specified index then this is returned allowing access to historical values.
       token:
         description: The acl token to allow access to restricted values.
       host:
         default: localhost
         description:
           - The target to connect to, must be a resolvable address.
-            Will be determined from C(ANSIBLE_CONSUL_URL) if that is set
+            Will be determined from C(ANSIBLE_CONSUL_URL) if that is set.
           - C(ANSIBLE_CONSUL_URL) should look like this: C(https://my.consul.server:8500)
         env:
           - name: ANSIBLE_CONSUL_URL
         ini:
           - section: lookup_consul
             key: host
-        version_added: '2.7'
+        version_added: "2.8"
       port:
         description:
           - The port of the target host to connect to.
@@ -50,25 +51,25 @@ DOCUMENTATION = """
         description:
           - Whether to use http or https.
           - If you use C(ANSIBLE_CONSUL_URL) this value will be used from there.
-        version_added: '2.7'
+        version_added: "2.8"
       validate_certs:
         default: True
-        description: Whether to verify the ssl connection or not
+        description: Whether to verify the ssl connection or not.
         env:
           - name: ANSIBLE_CONSUL_VALIDATE_CERTS
         ini:
           - section: lookup_consul
             key: validate_certs
-        version_added: '2.7'
+        version_added: "2.8"
       client_cert:
         default: None
-        description: The client cert to verify the ssl connection
+        description: The client cert to verify the ssl connection.
         env:
           - name: ANSIBLE_CONSUL_CLIENT_CERT
         ini:
           - section: lookup_consul
             key: client_cert
-        version_added: '2.7'
+        version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -31,9 +31,9 @@ DOCUMENTATION = """
       host:
         default: localhost
         description:
-           - The target to connect to, must be a resolvable address.
-             Will be determined from C(ANSIBLE_CONSUL_URL) if that is set
-           - C(ANSIBLE_CONSUL_URL) should look like this: C(https://my.consul.server:8500)
+          - The target to connect to, must be a resolvable address.
+            Will be determined from C(ANSIBLE_CONSUL_URL) if that is set
+          - C(ANSIBLE_CONSUL_URL) should look like this: C(https://my.consul.server:8500)
         env:
           - name: ANSIBLE_CONSUL_URL
         ini:
@@ -43,7 +43,7 @@ DOCUMENTATION = """
       port:
         description:
           - The port of the target host to connect to.
-          - If you use C(ANSIBLE_CONSUL_URL) this value will be used from there
+          - If you use C(ANSIBLE_CONSUL_URL) this value will be used from there.
         default: 8500
       scheme:
         default: http

--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -34,7 +34,7 @@ DOCUMENTATION = """
         description:
           - The target to connect to, must be a resolvable address.
             Will be determined from C(ANSIBLE_CONSUL_URL) if that is set.
-          - C(ANSIBLE_CONSUL_URL) should look like this: C(https://my.consul.server:8500)
+          - "C(ANSIBLE_CONSUL_URL) should look like this: C(https://my.consul.server:8500)"
         env:
           - name: ANSIBLE_CONSUL_URL
         ini:

--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -25,7 +25,7 @@ DOCUMENTATION = """
         description: If true, will retrieve all the values that have the given key as prefix.
         default: False
       index:
-        description: 
+        description:
           - If the key has a value with the specified index then this is returned allowing access to historical values.
       token:
         description: The acl token to allow access to restricted values.

--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -32,6 +32,8 @@ DOCUMENTATION = """
         default: localhost
         description:
            - The target to connect to, must be a resolvable address.
+           - Will be determined from C(ANSIBLE_CONSUL_URL) if that is set
+           - C(ANSIBLE_CONSUL_URL) should look like this: C(https://my.consul.server:8500)
         env:
           - name: ANSIBLE_CONSUL_URL
         ini:
@@ -39,11 +41,15 @@ DOCUMENTATION = """
             key: host
         version_added: '2.7'
       port:
-        description: The port of the target host to connect to.
+        description:
+          - The port of the target host to connect to.
+          - If you use C(ANSIBLE_CONSUL_URL) this value will be used from there
         default: 8500
       scheme:
         default: http
-        description: Whether to use http or https
+        description: 
+          - Whether to use http or https.
+          - If you use C(ANSIBLE_CONSUL_URL) this value will be used from there. 
         version_added: '2.7'
       validate_certs:
         default: True
@@ -121,7 +127,7 @@ class LookupModule(LookupBase):
                 try:
                     url = os.environ['ANSIBLE_CONSUL_URL']
                     validate_certs = os.environ['ANSIBLE_CONSUL_VALIDATE_CERTS'] or True
-                    client_cert = os.environ['ANSIBLE_CONSUL_CLIENT_CERT']
+                    client_cert = os.environ['ANSIBLE_CONSUL_CLIENT_CERT'] or None
                     u = urlparse(url)
                     consul_api = consul.Consul(host=u.hostname, port=u.port, scheme=u.scheme, verify=validate_certs,
                                                cert=client_cert)

--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -2,6 +2,7 @@
 # (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -33,9 +34,34 @@ DOCUMENTATION = """
            - The target to connect to, must be a resolvable address.
         env:
           - name: ANSIBLE_CONSUL_URL
+        ini:
+          - section: lookup_consul
+            key: host
       port:
         description: The port of the target host to connect to.
         default: 8500
+      scheme:
+        default: http
+        description: Whether to use http or https
+        version_added: '2.7'
+      validate_certs:
+        default: True
+        description: Whether to verify the ssl connection or not
+        env:
+          - name: ANSIBLE_CONSUL_VALIDATE_CERTS
+        ini:
+          - section: lookup_consul
+            key: validate_certs
+        version_added: '2.7'
+      client_cert:
+        default: None
+        description: The client cert to verify the ssl connection
+        env:
+          - name: ANSIBLE_CONSUL_CLIENT_CERT
+        ini:
+          - section: lookup_consul
+            key: client_cert
+        version_added: '2.7'
 """
 
 EXAMPLES = """
@@ -62,7 +88,6 @@ RETURN = """
 """
 
 import os
-import sys
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.plugins.lookup import LookupBase
@@ -74,6 +99,7 @@ except ImportError:
 
 try:
     import consul
+
     HAS_CONSUL = True
 except ImportError as e:
     HAS_CONSUL = False
@@ -84,7 +110,8 @@ class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
 
         if not HAS_CONSUL:
-            raise AnsibleError('python-consul is required for consul_kv lookup. see https://python-consul.readthedocs.io/en/latest/#installation')
+            raise AnsibleError(
+                'python-consul is required for consul_kv lookup. see http://python-consul.readthedocs.org/en/latest/#installation')
 
         values = []
         try:
@@ -92,12 +119,19 @@ class LookupModule(LookupBase):
                 params = self.parse_params(term)
                 try:
                     url = os.environ['ANSIBLE_CONSUL_URL']
+                    validate_certs = os.environ['ANSIBLE_CONSUL_VALIDATE_CERTS'] or True
+                    client_cert = os.environ['ANSIBLE_CONSUL_CLIENT_CERT']
                     u = urlparse(url)
-                    consul_api = consul.Consul(host=u.hostname, port=u.port, scheme=u.scheme)
+                    consul_api = consul.Consul(host=u.hostname, port=u.port, scheme=u.scheme, verify=validate_certs,
+                                               cert=client_cert)
                 except KeyError:
                     port = kwargs.get('port', '8500')
                     host = kwargs.get('host', 'localhost')
-                    consul_api = consul.Consul(host=host, port=port)
+                    scheme = kwargs.get('scheme', 'http')
+                    validate_certs = kwargs.get('validate_certs', True)
+                    client_cert = kwargs.get('client_cert', None)
+                    consul_api = consul.Consul(host=host, port=port, scheme=scheme, verify=validate_certs,
+                                               cert=client_cert)
 
                 results = consul_api.kv.get(params['key'],
                                             token=params['token'],


### PR DESCRIPTION
##### SUMMARY
Added the params scheme, cert and verify to the consul_kv lookup module
Fixes #40877
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lookup/consul_kv

##### ANSIBLE VERSION
```
ansible 2.5.3 (stable-2.5 9d8d1de182) last updated 2018/05/22 09:25:46 (GMT +200)
  config file = /mnt/c/Projekte/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/lib/ansible
  executable location = /opt/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```
