### PR TITLE
cloudstack: tests: use expected vpc offering

### DIFF
--- a/test/integration/targets/cs_network/tasks/vpc_network_tier.yml
+++ b/test/integration/targets/cs_network/tasks/vpc_network_tier.yml
@@ -23,6 +23,7 @@
     name: vpc_network_test
     cidr: 10.43.0.0/16
     zone: "{{ cs_common_zone_adv }}"
+    vpc_offering: Redundant VPC offering
     network_domain: cs2sandbox.simulator.example.com
   register: vpc
 - name: verify setup vpc

--- a/test/integration/targets/cs_network_acl/tasks/main.yml
+++ b/test/integration/targets/cs_network_acl/tasks/main.yml
@@ -4,6 +4,7 @@
     name: "{{ cs_resource_prefix }}_vpc"
     display_text: "{{ cs_resource_prefix }}_display_text"
     cidr: 10.10.0.0/16
+    vpc_offering: Redundant VPC offering
     zone: "{{ cs_common_zone_adv }}"
   register: vpc
 - name: verify setup vpc


### PR DESCRIPTION
##### SUMMARY
set expected vpc offering. the default (order) might have changed. compatibility fix for 4.11 simulator.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
cloudstack

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
