### PR TITLE
cs_vpc: fix ignore disabled default vpc offerings

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_vpc.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vpc.py
@@ -231,7 +231,15 @@ class AnsibleCloudStackVpc(AnsibleCloudStack):
 
         vpc_offerings = self.query_api('listVPCOfferings', **args)
         if vpc_offerings:
-            return self._get_by_key(key, vpc_offerings['vpcoffering'][0])
+            # The API name argument filter also matches substrings, we have to
+            # iterate over the results to get an exact match
+            for vo in vpc_offerings['vpcoffering']:
+                if 'name' in args:
+                    if args['name'] == vo['name']:
+                        return self._get_by_key(key, vo)
+                #  Return the first offering found, if not queried for the name
+                else:
+                    return self._get_by_key(key, vo)
         self.module.fail_json(msg=fail_msg)
 
     def get_vpc(self):

--- a/lib/ansible/modules/cloud/cloudstack/cs_vpc.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vpc.py
@@ -219,16 +219,20 @@ class AnsibleCloudStackVpc(AnsibleCloudStack):
 
     def get_vpc_offering(self, key=None):
         vpc_offering = self.module.params.get('vpc_offering')
-        args = {}
+        args = {
+            'state': 'Enabled',
+        }
         if vpc_offering:
             args['name'] = vpc_offering
+            fail_msg = "VPC offering not found or not enabled: %s" % vpc_offering
         else:
             args['isdefault'] = True
+            fail_msg = "No enabled default VPC offering found"
 
         vpc_offerings = self.query_api('listVPCOfferings', **args)
         if vpc_offerings:
             return self._get_by_key(key, vpc_offerings['vpcoffering'][0])
-        self.module.fail_json(msg="VPC offering not found: %s" % vpc_offering)
+        self.module.fail_json(msg=fail_msg)
 
     def get_vpc(self):
         if self.vpc:

--- a/test/integration/targets/cs_vpc/tasks/main.yml
+++ b/test/integration/targets/cs_vpc/tasks/main.yml
@@ -47,6 +47,21 @@
     - vpc is failed
     - 'vpc.msg == "VPC offering not found or not enabled: does_not_exist"'
 
+- name: test fail name substring match
+  cs_vpc:
+    name: "{{ cs_resource_prefix }}_vpc"
+    # Full name is "Redundant VPC offering"
+    vpc_offering: "Redundant"
+    zone: "{{ cs_common_zone_adv }}"
+    cidr: 10.10.1.0/16
+  ignore_errors: true
+  register: vpc
+- name: verify test fail name substring match
+  assert:
+    that:
+    - vpc is failed
+    - 'vpc.msg == "VPC offering not found or not enabled: Redundant"'
+
 - name: test create vpc with custom offering in check mode
   cs_vpc:
     name: "{{ cs_resource_prefix }}_vpc_custom"

--- a/test/integration/targets/cs_vpc/tasks/main.yml
+++ b/test/integration/targets/cs_vpc/tasks/main.yml
@@ -45,7 +45,7 @@
   assert:
     that:
     - vpc is failed
-    - 'vpc.msg == "VPC offering not found: does_not_exist"'
+    - 'vpc.msg == "VPC offering not found or not enabled: does_not_exist"'
 
 - name: test create vpc with custom offering in check mode
   cs_vpc:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

Disabled vpc offerings can not be used, we should skip them and yes, a default offering can be disabled as it seems

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cs_vpc

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
