### PR TITLE
[WIP] meraki_switchport - Change payload creation to not overwrite previous config

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_switchport.py
+++ b/lib/ansible/modules/network/meraki/meraki_switchport.py
@@ -33,6 +33,8 @@ options:
     allowed_vlans:
         description:
         - List of VLAN numbers to be allowed on switchport.
+        - Relevant only for trunk ports.
+        - Defaults to C(all) if not specified.
     enabled:
         description:
         - Whether a switchport should be enabled or disabled.

--- a/lib/ansible/modules/network/meraki/meraki_switchport.py
+++ b/lib/ansible/modules/network/meraki/meraki_switchport.py
@@ -33,21 +33,17 @@ options:
     allowed_vlans:
         description:
         - List of VLAN numbers to be allowed on switchport.
-        default: all
     enabled:
         description:
         - Whether a switchport should be enabled or disabled.
         type: bool
-        default: yes
     isolation_enabled:
         description:
         - Isolation status of switchport.
-        default: no
         type: bool
     link_negotiation:
         description:
         - Link speed for the switchport.
-        default: Auto negotiate
         choices: [Auto negotiate, 100Megabit (auto), 100 Megabit full duplex (forced)]
     name:
         description:
@@ -60,12 +56,10 @@ options:
         description:
         - Enable or disable Power Over Ethernet on a port.
         type: bool
-        default: true
     rstp_enabled:
         description:
         - Enable or disable Rapid Spanning Tree Protocol on a port.
         type: bool
-        default: true
     serial:
         description:
         - Serial nubmer of the switch.
@@ -73,7 +67,6 @@ options:
         description:
         - Set state of STP guard.
         choices: [disabled, root guard, bpdu guard, loop guard]
-        default: disabled
     tags:
         description:
         - Space delimited list of tags to assign to a port.
@@ -81,7 +74,6 @@ options:
         description:
         - Set port type.
         choices: [access, trunk]
-        default: access
     vlan:
         description:
         - VLAN number assigned to port.
@@ -228,26 +220,18 @@ def main():
                          number=dict(type='str'),
                          name=dict(type='str', aliases=['description']),
                          tags=dict(type='str'),
-                         # enabled=dict(type='bool', default=True),
                          enabled=dict(type='bool'),
                          type=dict(type='str', choices=['access', 'trunk']),
-                         # type=dict(type='str', choices=['access', 'trunk'], default='access'),
                          vlan=dict(type='int'),
                          voice_vlan=dict(type='int'),
                          allowed_vlans=dict(type='list'),
-                         # allowed_vlans=dict(type='list', default='all'),
                          poe_enabled=dict(type='bool'),
-                         # poe_enabled=dict(type='bool', default=True),
-                         # isolation_enabled=dict(type='bool', default=False),
                          isolation_enabled=dict(type='bool'),
                          rstp_enabled=dict(type='bool'),
-                         # rstp_enabled=dict(type='bool', default=True),
                          stp_guard=dict(type='str', choices=['disabled', 'root guard', 'bpdu guard', 'loop guard']),
-                         # stp_guard=dict(type='str', choices=['disabled', 'root guard', 'bpdu guard', 'loop guard'], default='disabled'),
                          access_policy_number=dict(type='str'),
                          link_negotiation=dict(type='str',
                                                choices=['Auto negotiate', '100Megabit (auto)', '100 Megabit full duplex (forced)']),
-                                               # default='Auto negotiate'),
                          )
 
     # the AnsibleModule object will be our abstraction working with Ansible
@@ -307,7 +291,7 @@ def main():
     elif meraki.params['state'] == 'present':
         payload = dict()
         proposed = dict()
-        for k,v in param_map.items():
+        for k, v in param_map.items():
             for i in param_map:
                 if meraki.params[v] or meraki.params[v] is False:
                     if v not in ('number'):

--- a/test/integration/targets/meraki_switchport/tasks/main.yml
+++ b/test/integration/targets/meraki_switchport/tasks/main.yml
@@ -3,277 +3,290 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Test an API key is provided
-  fail:
-    msg: Please define an API key
-  when: auth_key is not defined
-  
-- name: Use an invalid domain
-  meraki_switchport:
-    auth_key: '{{ auth_key }}'
-    host: marrrraki.com
-    state: query
-    serial: Q2HP-2C6E-GTLD
-    org_name: IntTestOrg
-  delegate_to: localhost
-  register: invaliddomain
-  ignore_errors: yes
-  
-- name: Disable HTTP
-  meraki_switchport:
-    auth_key: '{{ auth_key }}'
-    use_https: false
-    state: query
-    serial: Q2HP-2C6E-
-    output_level: debug
-  delegate_to: localhost
-  register: http
-  ignore_errors: yes
+- block:
+  - name: Test an API key is provided
+    fail:
+      msg: Please define an API key
+    when: auth_key is not defined
+    
+  - name: Use an invalid domain
+    meraki_switchport:
+      auth_key: '{{ auth_key }}'
+      host: marrrraki.com
+      state: query
+      serial: Q2HP-2C6E-GTLD
+      org_name: IntTestOrg
+    delegate_to: localhost
+    register: invaliddomain
+    ignore_errors: yes
 
-- name: Connection assertions
-  assert:
-    that:
-      - '"Failed to connect to" in invaliddomain.msg'
-      - '"http" in http.url'
+  - name: Disable HTTP
+    meraki_switchport:
+      auth_key: '{{ auth_key }}'
+      use_https: false
+      state: query
+      serial: '{{serial}}'
+      output_level: debug
+    delegate_to: localhost
+    register: http
+    ignore_errors: yes
 
-- name: Query all switchports
-  meraki_switchport:
-    auth_key: '{{auth_key}}'
-    state: query
-    serial: Q2HP-2C6E-GTLD
-  delegate_to: localhost
-  register: query_all
+  - debug:
+      msg: '{{http}}'
 
-- debug:
-    msg: '{{query_all}}'
+  - name: Connection assertions
+    assert:
+      that:
+        - '"Failed to connect to" in invaliddomain.msg'
+        - '"http" in http.url'
 
-- name: Query one switchport
-  meraki_switchport:
-    auth_key: '{{auth_key}}'
-    state: query
-    serial: Q2HP-2C6E-GTLD
-    number: 1
-  delegate_to: localhost
-  register: query_one
+  - name: Query all switchports
+    meraki_switchport:
+      auth_key: '{{auth_key}}'
+      state: query
+      serial: Q2HP-2C6E-GTLD
+    delegate_to: localhost
+    register: query_all
 
-- debug:
-    msg: '{{query_one}}'
+  - debug:
+      msg: '{{query_all}}'
 
-- name: Enable switchport
-  meraki_switchport:
-    auth_key: '{{auth_key}}'
-    state: present
-    serial: Q2HP-2C6E-GTLD
-    number: 7
-    enabled: true
-  delegate_to: localhost
-  register: update_port_true
+  - name: Query one switchport
+    meraki_switchport:
+      auth_key: '{{auth_key}}'
+      state: query
+      serial: Q2HP-2C6E-GTLD
+      number: 1
+    delegate_to: localhost
+    register: query_one
 
-- debug:
-    msg: '{{update_port_true}}'
+  - debug:
+      msg: '{{query_one}}'
 
-- assert:
-    that:
-      - update_port_true.data.enabled == True
+  - name: Enable switchport
+    meraki_switchport:
+      auth_key: '{{auth_key}}'
+      state: present
+      serial: Q2HP-2C6E-GTLD
+      number: 7
+      enabled: true
+    delegate_to: localhost
+    register: update_port_true
 
-- name: Disable switchport
-  meraki_switchport:
-    auth_key: '{{auth_key}}'
-    state: present
-    serial: Q2HP-2C6E-GTLD
-    number: 7
-    enabled: false
-  delegate_to: localhost
-  register: update_port_false
+  - debug:
+      msg: '{{update_port_true}}'
 
-- debug:
-    msg: '{{update_port_false}}'
+  - assert:
+      that:
+        - update_port_true.data.enabled == True
 
-- assert:
-    that:
-      - update_port_false.data.enabled == False
+  - name: Disable switchport
+    meraki_switchport:
+      auth_key: '{{auth_key}}'
+      state: present
+      serial: Q2HP-2C6E-GTLD
+      number: 7
+      enabled: false
+    delegate_to: localhost
+    register: update_port_false
 
+  - debug:
+      msg: '{{update_port_false}}'
 
-- name: Name switchport
-  meraki_switchport:
-    auth_key: '{{auth_key}}'
-    state: present
-    serial: Q2HP-2C6E-GTLD
-    number: 7
-    name: Test Port
-  delegate_to: localhost
-  register: update_port_name
+  - assert:
+      that:
+        - update_port_false.data.enabled == False
 
-- debug:
-    msg: '{{update_port_name}}'
+  - name: Name switchport
+    meraki_switchport:
+      auth_key: '{{auth_key}}'
+      state: present
+      serial: Q2HP-2C6E-GTLD
+      number: 7
+      name: Test Port
+    delegate_to: localhost
+    register: update_port_name
 
-- assert:
-    that:
-      - update_port_name.data.name == 'Test Port'
+  - debug:
+      msg: '{{update_port_name}}'
 
-- name: Configure access port
-  meraki_switchport:
-    auth_key: '{{auth_key}}'
-    state: present
-    serial: Q2HP-2C6E-GTLD
-    number: 7
-    enabled: true
-    name: Test Port
-    tags: desktop
-    type: access
-    vlan: 10
-  delegate_to: localhost
-  register: update_access_port
+  - assert:
+      that:
+        - update_port_name.data.name == 'Test Port'
 
-- debug:
-    msg: '{{update_access_port}}'
+  - name: Configure access port
+    meraki_switchport:
+      auth_key: '{{auth_key}}'
+      state: present
+      serial: Q2HP-2C6E-GTLD
+      number: 7
+      enabled: true
+      name: Test Port
+      tags: desktop
+      type: access
+      vlan: 10
+    delegate_to: localhost
+    register: update_access_port
 
-- assert:
-    that:
-      - update_access_port.data.vlan == 10
+  - debug:
+      msg: '{{update_access_port}}'
 
-- name: Configure access port with voice VLAN
-  meraki_switchport:
-    auth_key: '{{auth_key}}'
-    state: present
-    serial: Q2HP-2C6E-GTLD
-    number: 7
-    enabled: true
-    name: Test Port
-    tags: desktop
-    type: access
-    vlan: 10
-    voice_vlan: 11
-  delegate_to: localhost
-  register: update_port_vvlan
+  - assert:
+      that:
+        - update_access_port.data.vlan == 10
 
-- debug:
-    msg: '{{update_port_vvlan}}'
+  - name: Configure access port with voice VLAN
+    meraki_switchport:
+      auth_key: '{{auth_key}}'
+      state: present
+      serial: Q2HP-2C6E-GTLD
+      number: 7
+      enabled: true
+      name: Test Port
+      tags: desktop
+      type: access
+      vlan: 10
+      voice_vlan: 11
+    delegate_to: localhost
+    register: update_port_vvlan
 
-- assert:
-    that:
-      - update_port_vvlan.data.voiceVlan == 11
-      - update_port_vvlan.changed == True
+  - debug:
+      msg: '{{update_port_vvlan}}'
 
-- name: Check access port for idempotenty
-  meraki_switchport:
-    auth_key: '{{auth_key}}'
-    state: present
-    serial: Q2HP-2C6E-GTLD
-    number: 7
-    enabled: true
-    name: Test Port
-    tags: desktop
-    type: access
-    vlan: 10
-    voice_vlan: 11
-  delegate_to: localhost
-  register: update_port_access_idempotent
+  - assert:
+      that:
+        - update_port_vvlan.data.voiceVlan == 11
+        - update_port_vvlan.changed == True
 
-- debug:
-    msg: '{{update_port_access_idempotent}}'
+  - name: Check access port for idempotency
+    meraki_switchport:
+      auth_key: '{{auth_key}}'
+      state: present
+      serial: Q2HP-2C6E-GTLD
+      number: 7
+      enabled: true
+      name: Test Port
+      tags: desktop
+      type: access
+      vlan: 10
+      voice_vlan: 11
+    delegate_to: localhost
+    register: update_port_access_idempotent
 
-- assert:
-    that:
-      - update_port_access_idempotent.changed == False
+  - debug:
+      msg: '{{update_port_access_idempotent}}'
 
-- name: Configure trunk port
-  meraki_switchport:
-    auth_key: '{{auth_key}}'
-    state: present
-    serial: Q2HP-2C6E-GTLD
-    number: 7
-    enabled: true
-    name: Server port
-    tags: server
-    type: trunk
-    allowed_vlans: all
-  delegate_to: localhost
-  register: update_trunk
+  - assert:
+      that:
+        - update_port_access_idempotent.changed == False
 
-- debug:
-    msg: '{{update_trunk}}'
+  - name: Configure trunk port with all VLANs
+    meraki_switchport:
+      auth_key: '{{auth_key}}'
+      state: present
+      serial: Q2HP-2C6E-GTLD
+      number: 7
+      enabled: true
+      name: Server port
+      tags: server
+      type: trunk
+      allowed_vlans: all
+    delegate_to: localhost
+    register: update_trunk
 
-- assert:
-    that:
-      - update_trunk.data.tags == 'server'
-      - update_trunk.data.type == 'trunk'
-      - update_trunk.data.allowedVlans == 'all'
+  - debug:
+      msg: '{{update_trunk}}'
 
-- name: Configure trunk port with specific VLANs
-  meraki_switchport:
-    auth_key: '{{auth_key}}'
-    state: present
-    serial: Q2HP-2C6E-GTLD
-    number: 7
-    enabled: true
-    name: Server port
-    tags: server
-    type: trunk
-    allowed_vlans:
-      - 10
-      - 15
-      - 20
-  delegate_to: localhost
-  register: update_trunk
+  - assert:
+      that:
+        - update_trunk.data.tags == 'server'
+        - update_trunk.data.type == 'trunk'
+        - update_trunk.data.allowedVlans == 'all'
 
-- debug:
-    msg: '{{update_trunk}}'
+  - name: Configure trunk port with specific VLANs
+    meraki_switchport:
+      auth_key: '{{auth_key}}'
+      state: present
+      serial: Q2HP-2C6E-GTLD
+      number: 7
+      enabled: true
+      name: Server port
+      tags: server
+      type: trunk
+      allowed_vlans:
+        - 10
+        - 15
+        - 20
+    delegate_to: localhost
+    register: update_trunk
 
-- assert:
-    that:
-      - update_trunk.data.tags == 'server'
-      - update_trunk.data.type == 'trunk'
-      - update_trunk.data.allowedVlans == '10,15,20'
+  - debug:
+      msg: '{{update_trunk}}'
 
-- name: Configure trunk port with specific VLANs and native VLAN
-  meraki_switchport:
-    auth_key: '{{auth_key}}'
-    state: present
-    serial: Q2HP-2C6E-GTLD
-    number: 7
-    enabled: true
-    name: Server port
-    tags: server
-    type: trunk
-    vlan: 2
-    allowed_vlans:
-      - 10
-      - 15
-      - 20
-  delegate_to: localhost
-  register: update_trunk
+  - assert:
+      that:
+        - update_trunk.data.tags == 'server'
+        - update_trunk.data.type == 'trunk'
+        - update_trunk.data.allowedVlans == '1,10,15,20'
 
-- debug:
-    msg: '{{update_trunk}}'
+  - name: Configure trunk port with specific VLANs and native VLAN
+    meraki_switchport:
+      auth_key: '{{auth_key}}'
+      state: present
+      serial: Q2HP-2C6E-GTLD
+      number: 7
+      enabled: true
+      name: Server port
+      tags: server
+      type: trunk
+      vlan: 2
+      allowed_vlans:
+        - 10
+        - 15
+        - 20
+    delegate_to: localhost
+    register: update_trunk
 
-- assert:
-    that:
-      - update_trunk.data.tags == 'server'
-      - update_trunk.data.type == 'trunk'
-      - update_trunk.data.allowedVlans == '2,10,15,20'
+  - debug:
+      msg: '{{update_trunk}}'
 
-- name: Check for idempotency on trunk port
-  meraki_switchport:
-    auth_key: '{{auth_key}}'
-    state: present
-    serial: Q2HP-2C6E-GTLD
-    number: 7
-    enabled: true
-    name: Server port
-    tags: server
-    type: trunk
-    vlan: 2
-    allowed_vlans:
-      - 10
-      - 15
-      - 20
-  delegate_to: localhost
-  register: update_trunk_idempotent
+  - assert:
+      that:
+        - update_trunk.data.tags == 'server'
+        - update_trunk.data.type == 'trunk'
+        - update_trunk.data.allowedVlans == '2,10,15,20'
 
-- debug:
-    msg: '{{update_trunk_idempotent}}'
+  - name: Check for idempotency on trunk port
+    meraki_switchport:
+      auth_key: '{{auth_key}}'
+      state: present
+      serial: Q2HP-2C6E-GTLD
+      number: 7
+      enabled: true
+      name: Server port
+      tags: server
+      type: trunk
+      vlan: 2
+      allowed_vlans:
+        - 10
+        - 15
+        - 20
+    delegate_to: localhost
+    register: update_trunk_idempotent
 
-- assert:
-    that:
-      - update_trunk_idempotent.changed == False
+  - debug:
+      msg: '{{update_trunk_idempotent}}'
+
+  - assert:
+      that:
+        - update_trunk_idempotent.changed == False
+
+  always:
+  - name: Reset VLAN for future tests
+    meraki_switchport:
+      auth_key: '{{auth_key}}'
+      state: present
+      serial: Q2HP-2C6E-GTLD
+      number: 7
+      vlan: 1
+    delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY
- Uses new idempotency check
- Only assembles payload for specified items
- Move integration tests to block for cleanup
- Fixes #42390

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
meraki_switchport

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (meraki/bug-42390 918588397d) last updated 2018/07/07 19:59:19 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]

```
