### PR TITLE
Vultr: Introducing vr_plan_facts module

### DIFF
--- a/lib/ansible/modules/cloud/vultr/vr_plan_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vr_plan_facts.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# (c) 2018, Yanis Guenane <yanis+ansible@guenane.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: vr_plan_facts
+short_description: Gather facts about the Vultr plans available.
+description:
+  - Gather facts about plans available to boot servers.
+version_added: "2.7"
+author: "Yanis Guenane (@Spredzy)"
+extends_documentation_fragment: vultr
+'''
+
+EXAMPLES = r'''
+- name: Gather Vultr plans facts
+  local_action:
+    module: vr_plan_facts
+
+- name: Print the gathered facts
+  debug:
+    var: ansible_facts.vultr_plan_facts
+'''
+
+RETURN = r'''
+---
+vultr_api:
+  description: Response from Vultr API with a few additions/modification
+  returned: success
+  type: complex
+  contains:
+    api_account:
+      description: Account used in the ini file to select the key
+      returned: success
+      type: string
+      sample: default
+    api_timeout:
+      description: Timeout used for the API requests
+      returned: success
+      type: int
+      sample: 60
+    api_retries:
+      description: Amount of max retries for the API requests
+      returned: success
+      type: int
+      sample: 5
+    api_endpoint:
+      description: Endpoint used for the API requests
+      returned: success
+      type: string
+      sample: "https://api.vultr.com"
+vultr_plan_facts:
+  description: Response from Vultr API
+  returned: success
+  type: complex
+  contains:
+    plan:
+      description: List of the plans available.
+      returned: success
+      type: list
+      sample: [{
+        "available_locations": [
+          1
+        ],
+        "bandwidth": 40.0,
+        "bandwidth_gb": 40960,
+        "disk": 110,
+        "id": 118,
+        "name": "32768 MB RAM,110 GB SSD,40.00 TB BW",
+        "plan_type": "DEDICATED",
+        "price_per_month": 240.0,
+        "ram": 32768,
+        "vcpu_count": 8,
+        "windows": false
+      }]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vultr import (
+    Vultr,
+    vultr_argument_spec,
+)
+
+
+class AnsibleVultrPlanFacts(Vultr):
+
+    def __init__(self, module):
+        super(AnsibleVultrPlanFacts, self).__init__(module, "vultr_plan_facts")
+
+        self.returns = {
+            "VPSPLANID": dict(key='id', convert_to='int'),
+            "available_locations": dict(),
+            "bandwidth": dict(convert_to='float'),
+            "bandwidth_gb": dict(convert_to='int'),
+            "disk": dict(convert_to='int'),
+            "name": dict(),
+            "plan_type": dict(),
+            "price_per_month": dict(convert_to='float'),
+            "ram": dict(convert_to='int'),
+            "vcpu_count": dict(convert_to='int'),
+            "windows": dict(convert_to='bool')
+        }
+
+    def get_plans(self):
+        return self.api_query(path="/v1/plans/list")
+
+
+def parse_plans_list(plans_list):
+    return [plan for id, plan in plans_list.items()]
+
+
+def main():
+    argument_spec = vultr_argument_spec()
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    plan_facts = AnsibleVultrPlanFacts(module)
+    result = plan_facts.get_result(parse_plans_list(plan_facts.get_plans()))
+    ansible_facts = {
+        'vultr_plan_facts': result['vultr_plan_facts']
+    }
+    module.exit_json(ansible_facts=ansible_facts, **result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/legacy/roles/vr_plan_facts/tasks/main.yml
+++ b/test/legacy/roles/vr_plan_facts/tasks/main.yml
@@ -1,0 +1,19 @@
+# Copyright (c) 2018, Yanis Guenane <yanis+ansible@guenane.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: test gather vultr plan facts in check mode
+  vr_plan_facts:
+  check_mode: yes
+
+- name: verify test gather vultr plan facts in check mode
+  assert:
+    that:
+    - ansible_facts.vultr_plan_facts|selectattr('name','equalto','16384 MB RAM,110 GB SSD,20.00 TB BW') | list | count == 1
+
+- name: test gather vultr plan fact
+  vr_plan_facts:
+
+- name: verify test gather vultr plan facts
+  assert:
+    that:
+    - ansible_facts.vultr_plan_facts|selectattr('name','equalto','16384 MB RAM,110 GB SSD,20.00 TB BW') | list | count == 1

--- a/test/legacy/vultr.yml
+++ b/test/legacy/vultr.yml
@@ -11,6 +11,7 @@
     - { role: vr_firewall_group, tags: test_vr_firewall_group }
     - { role: vr_firewall_rule, tags: test_vr_firewall_rule }
     - { role: vr_os_facts, tags: test_vr_os_facts }
+    - { role: vr_plan_facts, tags: test_vr_plan_facts }
     - { role: vr_region_facts, tags: test_vr_region_facts }
     - { role: vr_server, tags: test_vr_server }
     - { role: vr_ssh_key, tags: test_vr_ssh_key }


### PR DESCRIPTION
##### SUMMARY

This commit introduces a new module called vr_plan_facts.

This module aims to return the list of plan avaiable avaiable to use on
booted servers.

Sample available here:

```
"vultr_plan_facts": [
  {
    "VPSPLANID": "118",
    "available_locations": [
      {
        "DCID": "1",
        "name": "New Jersey"
      }
    ],
    "bandwidth": "40.00",
    "bandwidth_gb": "40960",
    "disk": "110",
    "name": "32768 MB RAM,110 GB SSD,40.00 TB BW",
    "plan_type": "DEDICATED",
    "price_per_month": "240.00",
    "ram": "32768",
    "vcpu_count": "8",
    "windows": false
  }
]
```

##### ISSUE TYPE

 - New Module Pull Request

##### COMPONENT NAME

  - vr_plan_facts

##### ANSIBLE VERSION
  
- devel

##### ADDITIONAL INFORMATION

  - N/A