### PR TITLE
Vultr: Introducing vr_os_facts module

### DIFF
--- a/lib/ansible/modules/cloud/vultr/vr_os_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vr_os_facts.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# (c) 2018, Yanis Guenane <yanis+ansible@guenane.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: vr_os_facts
+short_description: Gather facts about the Vultr OSes available.
+description:
+  - Gather facts about OSes available to boot servers.
+version_added: "2.7"
+author: "Yanis Guenane (@Spredzy)"
+extends_documentation_fragment: vultr
+'''
+
+EXAMPLES = r'''
+- name: Gather Vultr OSes facts
+  local_action:
+    module: vr_os_facts
+
+- name: Print the gathered facts
+  debug:
+    var: ansible_facts.vultr_os_facts
+'''
+
+RETURN = r'''
+---
+vultr_api:
+  description: Response from Vultr API with a few additions/modification
+  returned: success
+  type: complex
+  contains:
+    api_account:
+      description: Account used in the ini file to select the key
+      returned: success
+      type: string
+      sample: default
+    api_timeout:
+      description: Timeout used for the API requests
+      returned: success
+      type: int
+      sample: 60
+    api_retries:
+      description: Amount of max retries for the API requests
+      returned: success
+      type: int
+      sample: 5
+    api_endpoint:
+      description: Endpoint used for the API requests
+      returned: success
+      type: string
+      sample: "https://api.vultr.com"
+ansible_facts:
+  description: Response from Vultr API
+  returned: success
+  type: complex
+  contains:
+    "vultr_os_facts": [
+      {
+        "arch": "x64",
+        "family": "openbsd",
+        "id": 234,
+        "name": "OpenBSD 6 x64",
+        "windows": false
+      }
+    ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vultr import (
+    Vultr,
+    vultr_argument_spec,
+)
+
+
+class AnsibleVultrOSFacts(Vultr):
+
+    def __init__(self, module):
+        super(AnsibleVultrOSFacts, self).__init__(module, "vultr_os_facts")
+
+        self.returns = {
+            "OSID": dict(key='id', convert_to='int'),
+            "arch": dict(),
+            "family": dict(),
+            "name": dict(),
+            "windows": dict(convert_to='bool')
+        }
+
+    def get_oses(self):
+        return self.api_query(path="/v1/os/list")
+
+
+def parse_oses_list(oses_list):
+        return [os for id, os in oses_list.items()]
+
+
+def main():
+    argument_spec = vultr_argument_spec()
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    os_facts = AnsibleVultrOSFacts(module)
+    result = os_facts.get_result(parse_oses_list(os_facts.get_oses()))
+    ansible_facts = {
+        'vultr_os_facts': result['vultr_os_facts']
+    }
+    module.exit_json(ansible_facts=ansible_facts, **result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/legacy/roles/vr_os_facts/tasks/main.yml
+++ b/test/legacy/roles/vr_os_facts/tasks/main.yml
@@ -1,0 +1,19 @@
+# Copyright (c) 2018, Yanis Guenane <yanis+ansible@guenane.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: test gather vultr os facts in check mode
+  vr_os_facts:
+  check_mode: yes
+
+- name: verify test gather vultr os facts in check mode
+  assert:
+    that:
+    - ansible_facts.vultr_os_facts|selectattr('name','equalto', 'CentOS 7 x64') | list | count == 1
+
+- name: test gather vultr os fact
+  vr_os_facts:
+
+- name: verify test gather vultr os facts
+  assert:
+    that:
+    - ansible_facts.vultr_os_facts|selectattr('name','equalto', 'CentOS 7 x64') | list | count == 1

--- a/test/legacy/vultr.yml
+++ b/test/legacy/vultr.yml
@@ -10,6 +10,7 @@
     - { role: vr_dns_record, tags: test_vr_dns_record }
     - { role: vr_firewall_group, tags: test_vr_firewall_group }
     - { role: vr_firewall_rule, tags: test_vr_firewall_rule }
+    - { role: vr_os_facts, tags: test_vr_os_facts }
     - { role: vr_region_facts, tags: test_vr_region_facts }
     - { role: vr_server, tags: test_vr_server }
     - { role: vr_ssh_key, tags: test_vr_ssh_key }


### PR DESCRIPTION
##### SUMMARY

This commit introduces a new module called vr_os_facts.

This module aims to return the list of OSes avaiable avaiable to use to
boot servers.

Sample available here:

```
"vultr_os_facts": [
  {
    "arch": "i386",
    "family": "ubuntu",
    "id": 216,    
    "name": "Ubuntu 16.04 i386",
    "windows": false
  }
]
```


##### ISSUE TYPE

 - New Module Pull Request

##### COMPONENT NAME

  - vr_os_facts

##### ANSIBLE VERSION

  - devel


##### ADDITIONAL INFORMATION

  - N/A