### PR TITLE
Make sure we are comparing bytes extensions in inventory plugins

### DIFF
--- a/changelogs/fragments/inventory_dir_ext_compare_fix.yaml
+++ b/changelogs/fragments/inventory_dir_ext_compare_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- inventory - When using an inventory directory, ensure extension comparison uses text types (https://github.com/ansible/ansible/pull/42475)

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -258,7 +258,7 @@ class InventoryManager(object):
 
                 # initialize and figure out if plugin wants to attempt parsing this file
                 try:
-                    plugin_wants = bool(plugin.verify_file(source))
+                    plugin_wants = bool(plugin.verify_file(to_text(source)))
                 except Exception:
                     plugin_wants = False
 


### PR DESCRIPTION
##### SUMMARY

Make sure we are comparing bytes extensions in inventory plugins. 
Fixes #42118 #42512

This issue was introduced in https://github.com/ansible/ansible/commit/e707e71ec52 and affects plugins performing extension comparison in py3 when using an inventory dir

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 lib/ansible/plugins/inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6.0
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```