### PR TITLE
[elb_target_group] fix docs and add default for wait_timeout - fixes #42324

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -130,6 +130,15 @@ options:
     description:
       - The identifier of the virtual private cloud (VPC). Required when I(state) is C(present).
     required: false
+  wait:
+    description:
+      - Whether or not to wait for the target group.
+    type: bool
+    default: false
+  wait_timeout:
+    description:
+      - The time to wait for the target group.
+    default: 200
 extends_documentation_fragment:
     - aws
     - ec2
@@ -515,7 +524,7 @@ def create_or_update_target_group(connection, module):
                     if module.params.get("wait"):
                         status_achieved, registered_instances = wait_for_status(connection, module, tg['TargetGroupArn'], instances_to_add, 'healthy')
                         if not status_achieved:
-                            module.fail_json(msg='Error waiting for target registration - please check the AWS console')
+                            module.fail_json(msg='Error waiting for target registration to be healthy - please check the AWS console')
 
                 remove_instances = set(current_instance_ids) - set(new_instance_ids)
 
@@ -578,7 +587,7 @@ def create_or_update_target_group(connection, module):
             if module.params.get("wait"):
                 status_achieved, registered_instances = wait_for_status(connection, module, tg['TargetGroupArn'], params['Targets'], 'healthy')
                 if not status_achieved:
-                    module.fail_json(msg='Error waiting for target registration - please check the AWS console')
+                    module.fail_json(msg='Error waiting for target registration to be healthy - please check the AWS console')
 
     # Now set target group attributes
     update_attributes = []
@@ -685,8 +694,8 @@ def main():
             targets=dict(type='list'),
             unhealthy_threshold_count=dict(type='int'),
             vpc_id=dict(),
-            wait_timeout=dict(type='int'),
-            wait=dict(type='bool')
+            wait_timeout=dict(type='int', default=200),
+            wait=dict(type='bool', default=False)
         )
     )
 

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -135,10 +135,12 @@ options:
       - Whether or not to wait for the target group.
     type: bool
     default: false
+    version_added: "2.4"
   wait_timeout:
     description:
       - The time to wait for the target group.
     default: 200
+    version_added: "2.4"
 extends_documentation_fragment:
     - aws
     - ec2

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -96,7 +96,6 @@ lib/ansible/modules/cloud/amazon/elb_application_lb.py E324
 lib/ansible/modules/cloud/amazon/elb_classic_lb_facts.py E323
 lib/ansible/modules/cloud/amazon/elb_instance.py E326
 lib/ansible/modules/cloud/amazon/elb_target.py E327
-lib/ansible/modules/cloud/amazon/elb_target_group.py E322
 lib/ansible/modules/cloud/amazon/elb_target_group.py E324
 lib/ansible/modules/cloud/amazon/elb_target_group.py E325
 lib/ansible/modules/cloud/amazon/elb_target_group.py E326


### PR DESCRIPTION
##### SUMMARY
Document wait and wait_timeout and add a default for wait_timeout. Fixes #42324

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/elb_target_group.py

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0
```
