### PR TITLE
Add config to fail on invalid task attributes

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1375,6 +1375,17 @@ HOST_KEY_CHECKING:
   ini:
   - {key: host_key_checking, section: defaults}
   type: boolean
+INVALID_TASK_ATTRIBUTE_FAILED:
+  name: Controls whether invalid attributes for a task result in errors instead of warnings
+  default: false
+  description: If 'true', invalid attributes for a task will result in errors instead of warnings
+  type: boolean
+  env:
+    - name: ANSIBLE_INVALID_TASK_ATTRIBUTE_FAILED
+  ini:
+    - key: invalid_task_attribute_failed
+      section: defaults
+  version_added: "2.7"
 INVENTORY_ANY_UNPARSED_IS_FAILED:
   name: Controls whether any unparseable inventory source is a fatal error
   default: False

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -231,7 +231,7 @@ class Task(Base, Conditional, Taggable, Become):
                                        " Please see:\nhttps://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-encouraging-reuse\n\n"
                                        " for currently supported syntax regarding included files and variables", version="2.7")
                     new_ds['vars'][k] = v
-                elif k in self._valid_attrs:
+                elif C.INVALID_TASK_ATTRIBUTE_FAILED or k in self._valid_attrs:
                     new_ds[k] = v
                 else:
                     display.warning("Ignoring invalid attribute: %s" % k)


### PR DESCRIPTION
##### SUMMARY
Add config to fail on invalid task attributes. Fixes #42479 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/playbook/task.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
With this feature disabled (default):

```
 [WARNING]: Ignoring invalid attribute: username

 [WARNING]: Ignoring invalid attribute: password

 [WARNING]: Ignoring invalid attribute: email
```

With this feature enabled:

```
ERROR! 'username' is not a valid attribute for a Task

The error appears to have been in '/Users/matt/projects/ansibledev/playbooks/42479/42479.yml': line 7, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  tasks:
    - name: 'Log into the Docker account'
      ^ here
```