### PR TITLE
FreeIPA: Add SRV and MX record types to ipa_dnsrecord

### DIFF
--- a/changelogs/fragments/42482-ipa_dnsrecord-srv_mx_record.yml
+++ b/changelogs/fragments/42482-ipa_dnsrecord-srv_mx_record.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Added support for MX and SRV record in ipa_dnsrecord module (https://github.com/ansible/ansible/pull/42482).


### PR DESCRIPTION
##### SUMMARY
Found myself having to template shell scripts to add SRV records, figured would try to add to the ipa_dnsrecord module to make first class. Seems it was pretty straight forward, tested it out and worked as expected. Unclear if there are any other changes required that I am missing?

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ipa_dnsrecord

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
```

##### ADDITIONAL INFORMATION