### PR TITLE
meraki_snmp - Added full response documentation for normal responses

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_snmp.py
+++ b/lib/ansible/modules/network/meraki/meraki_snmp.py
@@ -98,19 +98,55 @@ EXAMPLES = r'''
 
 RETURN = r'''
 data:
-    description: Information about queried or updated object.
-    type: list
-    returned: info
-    sample:
-      "data": {
-          "hostname": "n110.meraki.com",
-          "peer_ips": null,
-          "port": 16100,
-          "v2c_enabled": false,
-          "v3_auth_mode": null,
-          "v3_enabled": false,
-          "v3_priv_mode": null
-      }
+    description: Information about SNMP settings.
+    type: complex
+    returned: always
+    contains:
+        hostname:
+            description: Hostname of SNMP server.
+            returned: always
+            type: string
+            sample: n1.meraki.com
+        peerIps:
+            description: Semi-colon delimited list of IPs which can poll SNMP information.
+            returned: always
+            type: string
+            sample: 192.0.1.1
+        port:
+            description: Port number of SNMP.
+            returned: always
+            type: string
+            sample: 16100
+        v2cEnabled:
+            description: Shows enabled state of SNMPv2c
+            returned: always
+            type: bool
+            sample: true
+        v3Enabled:
+            description: Shows enabled state of SNMPv3
+            returned: always
+            type: bool
+            sample: true
+        v3AuthMode:
+            description: The SNMP version 3 authentication mode either MD5 or SHA.
+            returned: always
+            type: string
+            sample: SHA
+        v3PrivMode:
+            description: The SNMP version 3 privacy mode DES or AES128.
+            returned: always
+            type: string
+            sample: AES128
+        v2CommunityString:
+            description: Automatically generated community string for SNMPv2c.
+            returned: When SNMPv2c is enabled.
+            type: string
+            sample: o/8zd-JaSb
+        v3User:
+            description: Automatically generated username for SNMPv3.
+            returned: When SNMPv3c is enabled.
+            type: string
+            sample: o/8zd-JaSb
 '''
 
 import os

--- a/lib/ansible/modules/network/meraki/meraki_snmp.py
+++ b/lib/ansible/modules/network/meraki/meraki_snmp.py
@@ -104,37 +104,37 @@ data:
     contains:
         hostname:
             description: Hostname of SNMP server.
-            returned: always
+            returned: success
             type: string
             sample: n1.meraki.com
         peerIps:
             description: Semi-colon delimited list of IPs which can poll SNMP information.
-            returned: always
+            returned: success
             type: string
             sample: 192.0.1.1
         port:
             description: Port number of SNMP.
-            returned: always
+            returned: success
             type: string
             sample: 16100
         v2cEnabled:
             description: Shows enabled state of SNMPv2c
-            returned: always
+            returned: success
             type: bool
             sample: true
         v3Enabled:
             description: Shows enabled state of SNMPv3
-            returned: always
+            returned: success
             type: bool
             sample: true
         v3AuthMode:
             description: The SNMP version 3 authentication mode either MD5 or SHA.
-            returned: always
+            returned: success
             type: string
             sample: SHA
         v3PrivMode:
             description: The SNMP version 3 privacy mode DES or AES128.
-            returned: always
+            returned: success
             type: string
             sample: AES128
         v2CommunityString:


### PR DESCRIPTION
##### SUMMARY
Added full response documentation.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
meraki_snmp

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (meraki/doc-resp-snmp 90dfb88eba) last updated 2018/07/08 21:26:08 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]

```


##### ADDITIONAL INFORMATION
Following is a task which would generate full information.
```
- name: Enable SNMPv3
  meraki_snmp:
    auth_key: '{{auth_key}}'
    org_name: '{{test_org_name}}'
    state: present
    v2c_enabled: true
    v3_enabled: true
    v3_auth_mode: SHA
    v3_auth_pass: ansiblepass
    v3_priv_mode: AES128
    v3_priv_pass: ansiblepass
```
