### PR TITLE
vyos_config: allow empty line in src template file

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -146,10 +146,15 @@ CONFIG_FILTERS = [
 def get_candidate(module):
     contents = module.params['src'] or module.params['lines']
 
-    if module.params['lines']:
-        contents = '\n'.join(contents)
+    if module.params['src']:
+        contents = format_commands(contents.splitlines())
 
+    contents = '\n'.join(contents)
     return contents
+
+
+def format_commands(commands):
+    return [line for line in commands if len(line.strip()) > 0]
 
 
 def diff_config(commands, config):

--- a/test/units/modules/network/vyos/fixtures/vyos_config_src.cfg
+++ b/test/units/modules/network/vyos/fixtures/vyos_config_src.cfg
@@ -1,4 +1,5 @@
 set system host-name foo
+
 delete interfaces ethernet eth0 address
 set interfaces ethernet eth1 address '6.7.8.9/24'
 set interfaces ethernet eth1 description 'test string'

--- a/test/units/modules/network/vyos/test_vyos_config.py
+++ b/test/units/modules/network/vyos/test_vyos_config.py
@@ -75,15 +75,17 @@ class TestVyosConfigModule(TestVyosModule):
     def test_vyos_config_src(self):
         src = load_fixture('vyos_config_src.cfg')
         set_module_args(dict(src=src))
+        candidate = '\n'.join(self.module.format_commands(src.splitlines()))
         commands = ['set system host-name foo', 'delete interfaces ethernet eth0 address']
-        self.conn.get_diff = MagicMock(return_value=self.cliconf_obj.get_diff(src, self.running_config))
+        self.conn.get_diff = MagicMock(return_value=self.cliconf_obj.get_diff(candidate, self.running_config))
         self.execute_module(changed=True, commands=commands)
 
     def test_vyos_config_src_brackets(self):
         src = load_fixture('vyos_config_src_brackets.cfg')
         set_module_args(dict(src=src))
+        candidate = '\n'.join(self.module.format_commands(src.splitlines()))
         commands = ['set interfaces ethernet eth0 address 10.10.10.10/24', 'set system host-name foo']
-        self.conn.get_diff = MagicMock(return_value=self.cliconf_obj.get_diff(src, self.running_config))
+        self.conn.get_diff = MagicMock(return_value=self.cliconf_obj.get_diff(candidate, self.running_config))
         self.execute_module(changed=True, commands=commands)
 
     def test_vyos_config_backup(self):


### PR DESCRIPTION
##### SUMMARY

* allow empty lines in vyos_config src file
* WHY
    * vyos_config src file can include jinja2 template
    * For readability, I want to add empty line between config blocks, but vyos_config module raise error
        * line must start with either `set` or `delete`

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
vyos_config

##### ANSIBLE VERSION
I checked current devel branch. : https://github.com/ansible/ansible/tree/d7c3d5501bdc7482a330fb7b29ad8dd7ed3683b6

```
$ ansible --version
ansible 2.7.0.dev0
  config file = /home/hitsu/work/src/github.sakura.codes/iot-pf/router-conf-ansible/ansible.cfg
  configured module search path = ['/home/hitsu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']                                                                                                  
  ansible python module location = /home/hitsu/.pyenv/versions/3.6.2/envs/3.6_global/lib/python3.6/site-packages/ansible                                                                                          
  executable location = /home/hitsu/.pyenv/versions/global/bin/ansible
  python version = 3.6.2 (default, Nov 23 2017, 16:58:38) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION

* src file examples
    * OK (no error)
    ```
    {# config A #}
    set firewall all-ping 'enable'
    {# config B #}
    set firewall broadcast-ping 'disable'
   ```

    * error occurred: file includes empty line between configs
    ```
    {# config A #}
    set firewall all-ping 'enable'
    
    {# config B #}
    set firewall broadcast-ping 'disable'
    ```
