### PR TITLE
vyos_config: print compare command result in diff mode

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -223,7 +223,7 @@ def run(module, result):
         result['changed'] = True
 
     if module._diff:
-        result['diff'] = diff
+        result['diff'] = {'prepared': diff}
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
* print diff with vyos_config
    * as diff, use output of compare command
* example
    ```
    TASK [vyos : config example]  
  *******************************************************************************************************************************************************************
    [edit firewall name to_gslb_filter]
    +rule 7 {
    +    action drop
    +    destination {
    +        address 192.168.10.1
    +        port 23
    +    }
    +    protocol tcp
    +}
    ```

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`vyos_config` module

##### ANSIBLE VERSION
I checked current devel branch. : https://github.com/ansible/ansible/tree/d7c3d5501bdc7482a330fb7b29ad8dd7ed3683b6

```
$ ansible --version
ansible 2.7.0.dev0
  config file = /home/hitsu/work/src/github.sakura.codes/iot-pf/router-conf-ansible/ansible.cfg
  configured module search path = ['/home/hitsu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']                                                                                                  
  ansible python module location = /home/hitsu/.pyenv/versions/3.6.2/envs/3.6_global/lib/python3.6/site-packages/ansible                                                                                          
  executable location = /home/hitsu/.pyenv/versions/global/bin/ansible
  python version = 3.6.2 (default, Nov 23 2017, 16:58:38) [GCC 7.2.0]
```

