### PR TITLE
acme_certificate/letsencrypt: fixing deprecation message

### DIFF
--- a/lib/ansible/modules/web_infrastructure/acme_certificate.py
+++ b/lib/ansible/modules/web_infrastructure/acme_certificate.py
@@ -876,7 +876,7 @@ def main():
         supports_check_mode=True,
     )
     if module._name == 'letsencrypt':
-        module.deprecate("The 'letsencrypt' module is being renamed 'acme_certificate'", version=2.10)
+        module.deprecate("The 'letsencrypt' module is being renamed 'acme_certificate'", version='2.10')
 
     # AnsibleModule() changes the locale, so change it back to C because we rely on time.strptime() when parsing certificate dates.
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')


### PR DESCRIPTION
##### SUMMARY
As can be seen in #42495, the warning message claims that the feature will be removed in 2.1 instead of 2.10.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
acme_certificate
letsencrypt

##### ANSIBLE VERSION
```
2.6.1
```
