### PR TITLE
acme_certificate/letsencrypt: fixing deprecation message [2.6]

### DIFF
--- a/lib/ansible/modules/web_infrastructure/acme_certificate.py
+++ b/lib/ansible/modules/web_infrastructure/acme_certificate.py
@@ -826,7 +826,7 @@ def main():
         supports_check_mode=True,
     )
     if module._name == 'letsencrypt':
-        module.deprecate("The 'letsencrypt' module is being renamed 'acme_certificate'", version=2.10)
+        module.deprecate("The 'letsencrypt' module is being renamed 'acme_certificate'", version='2.10')
 
     # AnsibleModule() changes the locale, so change it back to C because we rely on time.strptime() when parsing certificate dates.
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')


### PR DESCRIPTION
##### SUMMARY
Backport of #42496 to `stable-2.6`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
letsencrypt
acme_certificate

##### ANSIBLE VERSION
```
2.6.1
```
