### PR TITLE
Add espeak ng support to 'say' module. Closes #42438

### DIFF
--- a/lib/ansible/modules/notification/say.py
+++ b/lib/ansible/modules/notification/say.py
@@ -68,20 +68,17 @@ def main():
 
     msg = module.params['msg']
     voice = module.params['voice']
+    possibles = ('say', 'espeak', 'espeak-ng')
 
-    executable = module.get_bin_path('say')
-    if not executable:
-        executable = module.get_bin_path('espeak')
-        if not executable:
-            executable = module.get_bin_path('espeak-ng')
-    elif get_platform() != 'Darwin':
-        # 'say' binary available, it might be GNUstep tool which doesn't support 'voice' parameter
-        voice = None
-        module.warn("'say' executable found but system is '%s': ignoring voice parameter" % get_platform())
-
-    if not executable:
-        module.fail_json(msg="Unable to find either 'say', 'espeak' or 'espeak-ng' executable")
-
+    for possible in possibles:
+        executable = module.get_bin_path(possible)
+        if executable and get_platform() != 'Darwin':
+            # 'say' binary available, it might be GNUstep tool which doesn't support 'voice' parameter
+            voice = None
+        elif executable:
+            break
+        else:
+            module.fail_json(msg='Unable to find either %s' % ', '.join(possibles))
     if module.check_mode:
         module.exit_json(msg=msg, changed=False)
 

--- a/lib/ansible/modules/notification/say.py
+++ b/lib/ansible/modules/notification/say.py
@@ -32,7 +32,7 @@ options:
     description:
       What voice to use
     required: false
-requirements: [ say or espeak ]
+requirements: [ say or espeak or espeak-ng ]
 author:
     - "Ansible Core Team"
     - "Michael DeHaan (@mpdehaan)"
@@ -72,13 +72,15 @@ def main():
     executable = module.get_bin_path('say')
     if not executable:
         executable = module.get_bin_path('espeak')
+        if not executable:
+            executable = module.get_bin_path('espeak-ng')
     elif get_platform() != 'Darwin':
         # 'say' binary available, it might be GNUstep tool which doesn't support 'voice' parameter
         voice = None
         module.warn("'say' executable found but system is '%s': ignoring voice parameter" % get_platform())
 
     if not executable:
-        module.fail_json(msg="Unable to find either 'say' or 'espeak' executable")
+        module.fail_json(msg="Unable to find either 'say', 'espeak' or 'espeak-ng' executable")
 
     if module.check_mode:
         module.exit_json(msg=msg, changed=False)

--- a/lib/ansible/modules/notification/say.py
+++ b/lib/ansible/modules/notification/say.py
@@ -70,15 +70,17 @@ def main():
     voice = module.params['voice']
     possibles = ('say', 'espeak', 'espeak-ng')
 
+    if get_platform() != 'Darwin':
+        # 'say' binary available, it might be GNUstep tool which doesn't support 'voice' parameter
+        voice = None
+
     for possible in possibles:
         executable = module.get_bin_path(possible)
-        if executable and get_platform() != 'Darwin':
-            # 'say' binary available, it might be GNUstep tool which doesn't support 'voice' parameter
-            voice = None
-        elif executable:
+        if executable:
             break
-        else:
-            module.fail_json(msg='Unable to find either %s' % ', '.join(possibles))
+    else:
+        module.fail_json(msg='Unable to find either %s' % ', '.join(possibles))
+
     if module.check_mode:
         module.exit_json(msg=msg, changed=False)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Add support for espeak-ng on module "say". Closes #42438 


<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
say

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/marcos/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
