### PR TITLE
genmac filter plugin and lookup

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
@@ -611,7 +611,7 @@ Generate MAC address based on OUI prefix filter
 .. versionadded:: 2.7
 
 You can use ``genmac()`` filter to generate random mac address based on `OUI`_
-prefix. Examples:: 
+prefix. Examples::
 
     # Example prefix
     prefix = '52:54:00'

--- a/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
@@ -612,11 +612,13 @@ Generate MAC address based on OUI prefix filter
 
 You can use ``genmac()`` filter to generate random mac address based on `OUI`_ prefix.
 
-    # Example MAC address
+    # Example prefix
     prefix = '52:54:00'
+
     # Generate a random MAC address with OUI prefix
     # {{ prefix | genmac }}
     52:54:00:0C:F5:10
+
     # Generate a random MAC address without OUI prefix
     # {{ '' | genmac }}
     AC:DE:48:54:4B:54

--- a/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
@@ -610,7 +610,8 @@ Generate MAC address based on OUI prefix filter
 
 .. versionadded:: 2.7
 
-You can use ``genmac()`` filter to generate random mac address based on `OUI`_ prefix.
+You can use ``genmac()`` filter to generate random mac address based on `OUI`_
+prefix. Examples:: 
 
     # Example prefix
     prefix = '52:54:00'

--- a/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
@@ -605,6 +605,31 @@ convert it between various formats. Examples::
     # {{ macaddress | hwaddr('cisco') }}
     1a2b.3c4d.5e6f
 
+Generate MAC address based on OUI prefix filter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.7
+
+You can use ``genmac()`` filter to generate random mac address based on `OUI`_ prefix.
+
+      # Example MAC address
+      prefix = '52:54:00'
+      # Generate a random MAC address with OUI prefix
+      # {{ prefix | genmac }}
+      52:54:00:0C:F5:10
+      # Generate a random MAC address without OUI prefix
+      # {{ '' | genmac }}
+      AC:DE:48:54:4B:54
+
+Common prefixes:
+   - ``00:16:3E`` -- Xen
+   - ``00:18:51`` -- OpenVZ
+   - ``00:50:56`` -- VMware (manually generated)
+   - ``52:54:00`` -- QEMU/KVM
+   - ``AC:DE:48`` -- PRIVATE
+
+.. _OUI: http://standards-oui.ieee.org/oui/oui.txt
+
 .. seealso::
 
    :doc:`playbooks`

--- a/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
@@ -612,14 +612,14 @@ Generate MAC address based on OUI prefix filter
 
 You can use ``genmac()`` filter to generate random mac address based on `OUI`_ prefix.
 
-      # Example MAC address
-      prefix = '52:54:00'
-      # Generate a random MAC address with OUI prefix
-      # {{ prefix | genmac }}
-      52:54:00:0C:F5:10
-      # Generate a random MAC address without OUI prefix
-      # {{ '' | genmac }}
-      AC:DE:48:54:4B:54
+    # Example MAC address
+    prefix = '52:54:00'
+    # Generate a random MAC address with OUI prefix
+    # {{ prefix | genmac }}
+    52:54:00:0C:F5:10
+    # Generate a random MAC address without OUI prefix
+    # {{ '' | genmac }}
+    AC:DE:48:54:4B:54
 
 Common prefixes:
    - ``00:16:3E`` -- Xen

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -22,6 +22,7 @@ __metaclass__ = type
 from functools import partial
 import types
 from ansible.module_utils import six
+import random
 
 try:
     import netaddr
@@ -1077,6 +1078,12 @@ def hwaddr(value, query='', alias='hwaddr'):
 def macaddr(value, query=''):
     return hwaddr(value, query, alias='macaddr')
 
+def genmac(value='AC:DE:48'):
+    ret = '{0}:{1:02X}:{2:02X}:{3:02X}'.format(value,
+                                               random.randint(0, 0xff),
+                                               random.randint(0, 0xff),
+                                               random.randint(0, 0xff))
+    return ret
 
 def _need_netaddr(f_name, *args, **kwargs):
     raise errors.AnsibleFilterError("The %s filter requires python's netaddr be "
@@ -1112,7 +1119,8 @@ class FilterModule(object):
 
         # MAC / HW addresses
         'hwaddr': hwaddr,
-        'macaddr': macaddr
+        'macaddr': macaddr,
+        'genmac': genmac
     }
 
     def filters(self):

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -1078,6 +1078,7 @@ def hwaddr(value, query='', alias='hwaddr'):
 def macaddr(value, query=''):
     return hwaddr(value, query, alias='macaddr')
 
+
 def genmac(value):
     if not value:
         value = 'AC:DE:48'
@@ -1086,6 +1087,7 @@ def genmac(value):
                                                random.randint(0, 0xff),
                                                random.randint(0, 0xff))
     return ret
+
 
 def _need_netaddr(f_name, *args, **kwargs):
     raise errors.AnsibleFilterError("The %s filter requires python's netaddr be "

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -23,6 +23,7 @@ from functools import partial
 import types
 from ansible.module_utils import six
 import random
+import re
 
 try:
     import netaddr
@@ -1082,7 +1083,12 @@ def macaddr(value, query=''):
 def genmac(value):
     if not value:
         value = 'AC:DE:48'
-    ret = '{0}:{1:02X}:{2:02X}:{3:02X}'.format(value,
+
+    if not re.match("[0-9a-f]{2}([-:]?)[0-9a-f]{2}(\\1[0-9a-f]{2}){1}$", value.lower()):
+        raise errors.AnsibleFilterError('Invalid OUI prefix (%s) for genmac: 3 colon(:) or hyphen(-) with two hexadecimal digit is required or leave it empty.' % value)
+
+    prefix = value.replace('-', ':')
+    ret = '{0}:{1:02X}:{2:02X}:{3:02X}'.format(prefix,
                                                random.randint(0, 0xff),
                                                random.randint(0, 0xff),
                                                random.randint(0, 0xff))

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -1085,7 +1085,9 @@ def genmac(value):
         value = 'AC:DE:48'
 
     if not re.match("[0-9a-f]{2}([-:]?)[0-9a-f]{2}(\\1[0-9a-f]{2}){1}$", value.lower()):
-        raise errors.AnsibleFilterError('Invalid OUI prefix (%s) for genmac: 3 colon(:) or hyphen(-) with two hexadecimal digit is required or leave it empty.' % value)
+        raise errors.AnsibleFilterError('Invalid OUI prefix (%s) for genmac: 3 colon(:) '
+                                        'or hyphen(-) with two hexadecimal digit is '
+                                        'required or leave it empty.' % value)
 
     prefix = value.replace('-', ':')
     ret = '{0}:{1:02X}:{2:02X}:{3:02X}'.format(prefix,

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -1078,7 +1078,9 @@ def hwaddr(value, query='', alias='hwaddr'):
 def macaddr(value, query=''):
     return hwaddr(value, query, alias='macaddr')
 
-def genmac(value='AC:DE:48'):
+def genmac(value):
+    if not value:
+        value = 'AC:DE:48'
     ret = '{0}:{1:02X}:{2:02X}:{3:02X}'.format(value,
                                                random.randint(0, 0xff),
                                                random.randint(0, 0xff),

--- a/lib/ansible/plugins/lookup/genmac.py
+++ b/lib/ansible/plugins/lookup/genmac.py
@@ -1,0 +1,48 @@
+# (c) 2018, Abdoul Bah (@helldorado) <bahabdoul at gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    lookup: genmac
+    author:
+      - Abdoul Bah (@helldorado) <bahabdoul(at)gmail.com>
+    version_added: "2.7"
+    short_description: Generates a MAC address with the defined OUI prefix
+    description:
+      - This lookup return a random mac address.
+    options:
+      _terms:
+        description: OUI prefix. See http://standards-oui.ieee.org/oui/oui.txt
+        default: 'AC:DE:48'
+      format:
+        description: Convert MAC address to given format
+"""
+
+EXAMPLES = """
+- name: Generate mac address
+  debug: msg="{{ lookup('genmac', '52:54:00', format='cisco'}}"
+"""
+
+RETURN = """
+_raw:
+  description: random mac address.
+"""
+
+import os
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+from ansible.plugins.filter import ipaddr
+class LookupModule(LookupBase):
+    def run(self, terms, variables=None, **kwargs):
+        format = kwargs.get('format', None)
+        if not terms:
+            terms = ['AC:DE:48']
+        ret = []
+        for term in terms:
+            ret = ipaddr.genmac(term)
+
+        if format and format not in ['bool','int']:
+           return ipaddr.hwaddr(ret, format).split(',')
+        else:
+            return ret.split(',')

--- a/lib/ansible/plugins/lookup/genmac.py
+++ b/lib/ansible/plugins/lookup/genmac.py
@@ -43,6 +43,6 @@ class LookupModule(LookupBase):
             ret = ipaddr.genmac(term)
 
         if format and format not in ['bool','int']:
-           return ipaddr.hwaddr(ret, format).split(',')
+            return ipaddr.hwaddr(ret, format).split(',')
         else:
             return ret.split(',')

--- a/lib/ansible/plugins/lookup/genmac.py
+++ b/lib/ansible/plugins/lookup/genmac.py
@@ -33,7 +33,10 @@ import os
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.plugins.filter import ipaddr
+
+
 class LookupModule(LookupBase):
+
     def run(self, terms, variables=None, **kwargs):
         format = kwargs.get('format', None)
         if not terms:
@@ -42,7 +45,7 @@ class LookupModule(LookupBase):
         for term in terms:
             ret = ipaddr.genmac(term)
 
-        if format and format not in ['bool','int']:
+        if format and format not in ['bool', 'int']:
             return ipaddr.hwaddr(ret, format).split(',')
         else:
             return ret.split(',')

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -323,7 +323,7 @@
 
 - name: Generate mac address with bad prefix
   debug:
-    var : "'52:54'|genmac"
+    var: "'52:54'|genmac"
   register: genmac_badprefix
   ignore_errors: yes
 

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -311,3 +311,25 @@
     - assert:
         that:
           - "combined.key2 == 'is_defined'"
+
+# GENMAC filter
+- name: Gen mac address with OUI prefix
+  set_fact:
+    genmac_oui: "{{ '52:54:00'|genmac }}"
+
+- name: Generate mac address without OUI prefix
+  set_fact:
+    genmac_nooui: "{{ ''|genmac }}"
+
+- name: Generate mac address with bad prefix
+  debug:
+    var : "'52:54'|genmac"
+  register: genmac_badprefix
+  ignore_errors: yes
+
+- name:  Verify genmac filter
+  assert:
+    that:
+      - genmac_oui|hwaddr
+      - genmac_nooui|hwaddr
+      - "'Invalid OUI prefix' in genmac_badprefix.msg"

--- a/test/integration/targets/lookups/runme.sh
+++ b/test/integration/targets/lookups/runme.sh
@@ -7,6 +7,7 @@ source virtualenv.sh
 # Requirements have to be installed prior to running ansible-playbook
 # because plugins and requirements are loaded before the task runs
 pip install passlib
+pip install netaddr
 
 ANSIBLE_ROLES_PATH=../ ansible-playbook lookups.yml -i ../../inventory -e @../../integration_config.yml "$@"
 

--- a/test/integration/targets/lookups/tasks/main.yml
+++ b/test/integration/targets/lookups/tasks/main.yml
@@ -302,3 +302,31 @@
     that:
       - 'var_host_info[0] == ansible_host'
       - 'var_host_info[1] == ansible_user'
+
+# GENMAC lookup
+
+- name: Generate mac address with OUI prefix
+  set_fact:
+    genmac_oui: "{{ lookup('genmac', '52:54:00') }}"
+
+- name: Generate mac address without OUI prefix
+  set_fact:
+    genmac_nooui: "{{ lookup('genmac') }}"
+
+- name: Generate mac address with custom format
+  set_fact:
+    genmac_oui_format: "{{ lookup('genmac', '52:54:00', format='cisco') }}"
+
+- name: Generate mac address with badprefix
+  debug:
+    var: "{{ lookup('genmac', '52:54') }}"
+  register: genmac_badprefix
+  ignore_errors: yes
+
+- name:  Verify genmac lookup
+  assert:
+    that:
+      - genmac_oui|hwaddr
+      - genmac_nooui|hwaddr
+      - genmac_oui_format|hwaddr
+      - "'Invalid OUI prefix' in genmac_badprefix.msg"

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -22,17 +22,9 @@ import pytest
 
 from units.compat import unittest
 from ansible.errors import AnsibleFilterError
-<<<<<<< HEAD
 from ansible.plugins.filter.ipaddr import (ipaddr, _netmask_query, nthhost, next_nth_usable, ipsubnet,
-=======
-from ansible.plugins.filter.ipaddr import (ipaddr, _netmask_query, nthhost, next_nth_usable,
-<<<<<<< HEAD
->>>>>>> Fix merge conflict
                                            previous_nth_usable, network_in_usable, network_in_network,
-                                           cidr_merge, ipmath)
-=======
-                                           previous_nth_usable, network_in_usable, network_in_network, cidr_merge, ipmath, genmac)
->>>>>>> Fix merge conflict
+                                           cidr_merge, ipmath, genmac)
 netaddr = pytest.importorskip('netaddr')
 
 
@@ -488,8 +480,6 @@ class TestIpFilter(unittest.TestCase):
         self.assertEqual(ipmath('192.168.1.5', 5), '192.168.1.10')
         self.assertEqual(ipmath('192.168.1.5', -5), '192.168.1.0')
         self.assertEqual(ipmath('192.168.0.5', -10), '192.167.255.251')
-<<<<<<< HEAD
-=======
 
         self.assertEqual(ipmath('2001::1', 8), '2001::9')
         self.assertEqual(ipmath('2001::1', 9), '2001::a')
@@ -511,6 +501,7 @@ class TestIpFilter(unittest.TestCase):
         )
         with self.assertRaises(AnsibleFilterError) as exc:
             ipmath('1.2.3.4', 'some_number')
+        self.assertEqual(exc.exception.message, expected)
 
     def test_genmac(self):
         expected = r"[0-9a-f]{2}([-:]?)[0-9a-f]{2}(\1[0-9a-f]{2}){4}$"
@@ -518,28 +509,11 @@ class TestIpFilter(unittest.TestCase):
         self.assertRegex(genmac(prefix).lower(), expected)
         prefix = 'AC-DE-48'
         self.assertRegex(genmac(prefix).lower(), expected)
->>>>>>> Fix merge conflict
 
-        self.assertEqual(ipmath('2001::1', 8), '2001::9')
-        self.assertEqual(ipmath('2001::1', 9), '2001::a')
-        self.assertEqual(ipmath('2001::1', 10), '2001::b')
-        self.assertEqual(ipmath('2001::5', -3), '2001::2')
-        self.assertEqual(
-            ipmath('2001::5', -10),
-            '2000:ffff:ffff:ffff:ffff:ffff:ffff:fffb'
-        )
-
-        expected = 'You must pass a valid IP address; invalid_ip is invalid'
+        bad_prefix = "52:AC"
+        expected = 'Invalid OUI prefix (52:AC) for genmac: 3 colon(:) or hyphen(-) with two hexadecimal digit is required or leave it empty.'
         with self.assertRaises(AnsibleFilterError) as exc:
-            ipmath('invalid_ip', 8)
-        self.assertEqual(exc.exception.message, expected)
-
-        expected = (
-            'You must pass an integer for arithmetic; '
-            'some_number is not a valid integer'
-        )
-        with self.assertRaises(AnsibleFilterError) as exc:
-            ipmath('1.2.3.4', 'some_number')
+            genmac(bad_prefix)
         self.assertEqual(exc.exception.message, expected)
 
     def test_ipsubnet(self):

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -506,9 +506,9 @@ class TestIpFilter(unittest.TestCase):
     def test_genmac(self):
         expected = r"[0-9a-f]{2}([-:]?)[0-9a-f]{2}(\1[0-9a-f]{2}){4}$"
         prefix = '52:54:00'
-        self.assertRegex(genmac(prefix).lower(), expected)
+        self.assertRegexpMatches(genmac(prefix).lower(), expected)
         prefix = 'AC-DE-48'
-        self.assertRegex(genmac(prefix).lower(), expected)
+        self.assertRegexpMatches(genmac(prefix).lower(), expected)
 
         bad_prefix = "52:AC"
         expected = (

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -22,9 +22,17 @@ import pytest
 
 from units.compat import unittest
 from ansible.errors import AnsibleFilterError
+<<<<<<< HEAD
 from ansible.plugins.filter.ipaddr import (ipaddr, _netmask_query, nthhost, next_nth_usable, ipsubnet,
+=======
+from ansible.plugins.filter.ipaddr import (ipaddr, _netmask_query, nthhost, next_nth_usable,
+<<<<<<< HEAD
+>>>>>>> Fix merge conflict
                                            previous_nth_usable, network_in_usable, network_in_network,
                                            cidr_merge, ipmath)
+=======
+                                           previous_nth_usable, network_in_usable, network_in_network, cidr_merge, ipmath, genmac)
+>>>>>>> Fix merge conflict
 netaddr = pytest.importorskip('netaddr')
 
 
@@ -480,6 +488,37 @@ class TestIpFilter(unittest.TestCase):
         self.assertEqual(ipmath('192.168.1.5', 5), '192.168.1.10')
         self.assertEqual(ipmath('192.168.1.5', -5), '192.168.1.0')
         self.assertEqual(ipmath('192.168.0.5', -10), '192.167.255.251')
+<<<<<<< HEAD
+=======
+
+        self.assertEqual(ipmath('2001::1', 8), '2001::9')
+        self.assertEqual(ipmath('2001::1', 9), '2001::a')
+        self.assertEqual(ipmath('2001::1', 10), '2001::b')
+        self.assertEqual(ipmath('2001::5', -3), '2001::2')
+        self.assertEqual(
+            ipmath('2001::5', -10),
+            '2000:ffff:ffff:ffff:ffff:ffff:ffff:fffb'
+        )
+
+        expected = 'You must pass a valid IP address; invalid_ip is invalid'
+        with self.assertRaises(AnsibleFilterError) as exc:
+            ipmath('invalid_ip', 8)
+        self.assertEqual(exc.exception.message, expected)
+
+        expected = (
+            'You must pass an integer for arithmetic; '
+            'some_number is not a valid integer'
+        )
+        with self.assertRaises(AnsibleFilterError) as exc:
+            ipmath('1.2.3.4', 'some_number')
+
+    def test_genmac(self):
+        expected = r"[0-9a-f]{2}([-:]?)[0-9a-f]{2}(\1[0-9a-f]{2}){4}$"
+        prefix = '52:54:00'
+        self.assertRegex(genmac(prefix).lower(), expected)
+        prefix = 'AC-DE-48'
+        self.assertRegex(genmac(prefix).lower(), expected)
+>>>>>>> Fix merge conflict
 
         self.assertEqual(ipmath('2001::1', 8), '2001::9')
         self.assertEqual(ipmath('2001::1', 9), '2001::a')

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -512,8 +512,8 @@ class TestIpFilter(unittest.TestCase):
 
         bad_prefix = "52:AC"
         expected = (
-           'Invalid OUI prefix (52:AC) for genmac: 3 colon(:) or hyphen(-) '
-           'with two hexadecimal digit is required or leave it empty.'
+            'Invalid OUI prefix (52:AC) for genmac: 3 colon(:) or hyphen(-) '
+            'with two hexadecimal digit is required or leave it empty.'
         )
         with self.assertRaises(AnsibleFilterError) as exc:
             genmac(bad_prefix)

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -511,7 +511,10 @@ class TestIpFilter(unittest.TestCase):
         self.assertRegex(genmac(prefix).lower(), expected)
 
         bad_prefix = "52:AC"
-        expected = 'Invalid OUI prefix (52:AC) for genmac: 3 colon(:) or hyphen(-) with two hexadecimal digit is required or leave it empty.'
+        expected = (
+           'Invalid OUI prefix (52:AC) for genmac: 3 colon(:) or hyphen(-) '
+           'with two hexadecimal digit is required or leave it empty.'
+        )
         with self.assertRaises(AnsibleFilterError) as exc:
             genmac(bad_prefix)
         self.assertEqual(exc.exception.message, expected)


### PR DESCRIPTION
##### SUMMARY
The `genmac` filter plugin and lookup allow to generate random mac address with the defined OUI prefix. For more info see => http://standards-oui.ieee.org/oui/oui.txt



##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/lookup/genmac.py
lib/ansible/plugins/filter/ipadrr.py

##### ANSIBLE VERSION
```bash
ansible --version
ansible 2.6.0
  config file = None
  configured module search path = [u'/Users/helldorado/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Aug 23 2017, 00:43:19) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
###### Generate mac from `genmac` **filter**

```yaml
- name: Gen mac from filter with OUI prefix
  debug: msg="{{ '52:54:00'|genmac }}"
```

```bash
TASK [Gen mac from filter with OUI prefix] **********************************************
ok: [localhost] => {
    "msg": "52:54:00:A7:7C:0C"
}
```

* it's possible to generate mac address from empty [OUI](http://standards-oui.ieee.org/oui/oui.txt
) prefix. Defaulted to PRIVATE `AC:DE:48`.

```yaml
- name: Gen mac from filter without OUI prefix
  debug: msg="{{ ''|genmac }}"
```

```bash
TASK [Gen mac from filter without OUI prefix] ********************************************
ok: [localhost] => {
    "msg": "AC:DE:48:79:2F:4F"
}
```


###### Generate mac from `genmac` **lookup**

```yaml
- name: Generate mac address from lookup with OUI prefix
  debug: msg="{{ lookup('genmac', '52:54:00') }}"
```

```bash
TASK [Generate mac address from lookup with OUI prefix] *********************************
ok: [localhost] => {
    "msg": "52:54:00:0B:96:82"
}
```

* it's possible to generate mac address from empty [OUI](http://standards-oui.ieee.org/oui/oui.txt
) prefix. Defaulted to PRIVATE `AC:DE:48`.

```yaml
- name: Generate mac address from lookup without OUI prefix
   debug: msg="{{ lookup('genmac') }}"
```

```bash
TASK [Generate mac address from lookup without OUI prefix] ******************************
ok: [localhost] => {
    "msg": "AC:DE:48:54:4B:54"
}
```

* it's also possible to generate mac whit custom format. Please see  [mac-address-filter](https://docs.ansible.com/ansible/devel/user_guide/playbooks_filters_ipaddr.html#mac-address-filter) for more info.

```yaml
- name: Generate mac address whith custom format
  debug: msg="{{ item + ' => ' + lookup('genmac', '52:54:00', format=item) }}"
  with_items:
      - psql
      - cisco
      - linux
      - unix
      - win
      - bare
      - ''
```

```bash
TASK [Generate mac address whith custom format] ****************************************
ok: [localhost] => (item=psql) => {
    "msg": "psql => 525400:697815"
}
ok: [localhost] => (item=cisco) => {
    "msg": "cisco => 5254.00ff.a05c"
}
ok: [localhost] => (item=linux) => {
    "msg": "linux => 52:54:00:97:93:cf"
}
ok: [localhost] => (item=unix) => {
    "msg": "unix => 52:54:0:83:dd:ef"
}
ok: [localhost] => (item=win) => {
    "msg": "win => 52-54-00-4A-55-4A"
}
ok: [localhost] => (item=bare) => {
    "msg": "bare => 525400B6C533"
}
ok: [localhost] => (item=) => {
    "msg": " => 52:54:00:0C:F5:10"
}
```