### PR TITLE
[backport-2.6] meraki_admin - Added full return documentation for normal responses (…

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -106,47 +106,60 @@ EXAMPLES = r'''
 
 RETURN = r'''
 data:
-    description: Information about the created or manipulated object.
-    returned: info
-    type: list
-    sample:
-        [
-            {
-                "email": "john@doe.com",
-                "id": "12345677890",
-                "name": "John Doe",
-                "networks": [],
-                "orgAccess": "full",
-                "tags": []
-            }
-        ]
-changed:
-    description: Whether object changed as a result of the request.
-    returned: info
-    type: string
-    sample:
-        "changed": false
-
-status:
-    description: HTTP response code
-    returned: info
-    type: int
-    sample:
-        "status": 200
-
-response:
-    description: HTTP response description and bytes
-    returned: info
-    type: string
-    sample:
-        "response": "OK (unknown bytes)"
-
-failed:
-    description: Boolean value whether the task failed
-    returned: info
-    type: bool
-    sample:
-        "failed": false
+    description: List of administrators.
+    returned: success
+    type: complex
+    contains:
+        email:
+            description: Email address of administrator.
+            returned: success
+            type: string
+            sample: your@email.com
+        id:
+            description: Unique identification number of administrator.
+            returned: success
+            type: string
+            sample: 1234567890
+        name:
+            description: Given name of administrator.
+            returned: success
+            type: string
+            sample: John Doe
+        networks:
+            description: List of networks administrator has access on.
+            returned: success
+            type: complex
+            contains:
+                id:
+                     description: The network ID.
+                     returned: when network permissions are set
+                     type: string
+                     sample: N_0123456789
+                access:
+                     description: Access level of administrator. Options are 'full', 'read-only', or 'none'.
+                     returned: when network permissions are set
+                     type: string
+                     sample: read-only
+        tags:
+            description: Tags the adminsitrator has access on.
+            returned: success
+            type: complex
+            contains:
+                tag:
+                    description: Tag name.
+                    returned: when tag permissions are set
+                    type: string
+                    sample: production
+                access:
+                    description: Access level of administrator. Options are 'full', 'read-only', or 'none'.
+                    returned: when tag permissions are set
+                    type: string
+                    sample: full
+        orgAccess:
+            description: The privilege of the dashboard administrator on the organization. Options are 'full', 'read-only', or 'none'.
+            returned: success
+            type: string
+            sample: full
 '''
 
 import os


### PR DESCRIPTION
##### SUMMARY
* Added full return documentation for normal responses

* Changed returned for responses

- Old responses were saying always returned, should have been success
or something more refined

(cherry picked from commit 5960b215bb5ecff37c170ed49e73ab36a90d4299)

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
meraki_admin

##### ANSIBLE VERSION
```
ansible 2.6.1 (backport/2.6/42487 e346156a36) last updated 2018/07/09 08:04:10 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```