### PR TITLE
disable_excludes

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -146,6 +146,14 @@ options:
         The disabled plugins will not persist beyond the transaction.
     required: false
     version_added: "2.5"
+  disable_excludes:
+    description:
+      - Disable the excludes defined in YUM config files.
+      - If set to C(all), disables all excludes.
+      - If set to C(main), disable excludes defined in [main] in yum.conf.
+      - If set to C(repoid), disable excludes defined for given repo id.
+    required: false
+    version_added: "2.7"
 notes:
   - When used with a `loop:` each package will be processed individually,
     it is much more efficient to pass the list directly to the `name` option.
@@ -298,7 +306,8 @@ def_qf = "%{epoch}:%{name}-%{version}-%{release}.%{arch}"
 rpmbin = None
 
 
-def yum_base(conf_file=None, installroot='/', enabled_plugins=None, disabled_plugins=None):
+def yum_base(conf_file=None, installroot='/', enabled_plugins=None,
+             disabled_plugins=None, disable_excludes=None):
     my = yum.YumBase()
     my.preconf.debuglevel = 0
     my.preconf.errorlevel = 0
@@ -321,6 +330,8 @@ def yum_base(conf_file=None, installroot='/', enabled_plugins=None, disabled_plu
             cachedir = yum.misc.getCacheDir()
             my.repos.setCacheDir(cachedir)
             my.conf.cache = 0
+    if disable_excludes:
+        my.conf.disable_excludes = disable_excludes
 
     return my
 
@@ -367,10 +378,11 @@ def po_to_envra(po):
     return '%s:%s-%s-%s.%s' % (po.epoch, po.name, po.version, po.release, po.arch)
 
 
-def is_group_env_installed(name, conf_file, en_plugins=None, dis_plugins=None, installroot='/'):
+def is_group_env_installed(name, conf_file, en_plugins=None, dis_plugins=None,
+                           installroot='/', disable_excludes=None):
     name_lower = name.lower()
 
-    my = yum_base(conf_file, installroot, en_plugins, dis_plugins)
+    my = yum_base(conf_file, installroot, en_plugins, dis_plugins, disable_excludes)
     if yum.__version_info__ >= (3, 4):
         groups_list = my.doGroupLists(return_evgrps=True)
     else:
@@ -392,7 +404,8 @@ def is_group_env_installed(name, conf_file, en_plugins=None, dis_plugins=None, i
     return False
 
 
-def is_installed(module, repoq, pkgspec, conf_file, qf=None, en_repos=None, dis_repos=None, en_plugins=None, dis_plugins=None, is_pkg=False, installroot='/'):
+def is_installed(module, repoq, pkgspec, conf_file, qf=None, en_repos=None, dis_repos=None, en_plugins=None, dis_plugins=None, is_pkg=False,
+                 installroot='/', disable_excludes=None):
     if en_repos is None:
         en_repos = []
     if dis_repos is None:
@@ -403,7 +416,7 @@ def is_installed(module, repoq, pkgspec, conf_file, qf=None, en_repos=None, dis_
     if not repoq:
         pkgs = []
         try:
-            my = yum_base(conf_file, installroot, en_plugins, dis_plugins)
+            my = yum_base(conf_file, installroot, en_plugins, dis_plugins, disable_excludes)
             for rid in dis_repos:
                 my.repos.disableRepo(rid)
             for rid in en_repos:
@@ -454,7 +467,8 @@ def is_installed(module, repoq, pkgspec, conf_file, qf=None, en_repos=None, dis_
     return []
 
 
-def is_available(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=None, dis_repos=None, en_plugins=None, dis_plugins=None, installroot='/'):
+def is_available(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=None, dis_repos=None, en_plugins=None, dis_plugins=None,
+                 installroot='/', disable_excludes=None):
     if en_repos is None:
         en_repos = []
     if dis_repos is None:
@@ -464,7 +478,7 @@ def is_available(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=None, di
 
         pkgs = []
         try:
-            my = yum_base(conf_file, installroot, en_plugins, dis_plugins)
+            my = yum_base(conf_file, installroot, en_plugins, dis_plugins, disable_excludes)
             for rid in dis_repos:
                 my.repos.disableRepo(rid)
             for rid in en_repos:
@@ -498,7 +512,8 @@ def is_available(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=None, di
     return []
 
 
-def is_update(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=None, dis_repos=None, en_plugins=None, dis_plugins=None, installroot='/'):
+def is_update(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=None, dis_repos=None, en_plugins=None, dis_plugins=None,
+              installroot='/', disable_excludes=None):
     if en_repos is None:
         en_repos = []
     if dis_repos is None:
@@ -511,7 +526,7 @@ def is_update(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=None, dis_r
         updates = []
 
         try:
-            my = yum_base(conf_file, installroot, en_plugins, dis_plugins)
+            my = yum_base(conf_file, installroot, en_plugins, dis_plugins, disable_excludes)
             for rid in dis_repos:
                 my.repos.disableRepo(rid)
             for rid in en_repos:
@@ -552,7 +567,7 @@ def is_update(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=None, dis_r
 
 def what_provides(module, repoq, yum_basecmd, req_spec, conf_file, qf=def_qf,
                   en_repos=None, dis_repos=None, en_plugins=None,
-                  dis_plugins=None, installroot='/'):
+                  dis_plugins=None, installroot='/', disable_excludes=None):
     if en_repos is None:
         en_repos = []
     if dis_repos is None:
@@ -562,7 +577,7 @@ def what_provides(module, repoq, yum_basecmd, req_spec, conf_file, qf=def_qf,
 
         pkgs = []
         try:
-            my = yum_base(conf_file, installroot, en_plugins, dis_plugins)
+            my = yum_base(conf_file, installroot, en_plugins, dis_plugins, disable_excludes)
             for rid in dis_repos:
                 my.repos.disableRepo(rid)
             for rid in en_repos:
@@ -609,7 +624,7 @@ def what_provides(module, repoq, yum_basecmd, req_spec, conf_file, qf=def_qf,
             out += out2
             pkgs = set([p for p in out.split('\n') if p.strip()])
             if not pkgs:
-                pkgs = is_installed(module, repoq, req_spec, conf_file, qf=qf, installroot=installroot)
+                pkgs = is_installed(module, repoq, req_spec, conf_file, qf=qf, installroot=installroot, disable_excludes=disable_excludes)
             return pkgs
         else:
             module.fail_json(msg='Error from repoquery: %s: %s' % (cmd, err + err2))
@@ -741,7 +756,7 @@ def repolist(module, repoq, qf="%{repoid}"):
     return ret
 
 
-def list_stuff(module, repoquerybin, conf_file, stuff, installroot='/', disablerepo='', enablerepo=''):
+def list_stuff(module, repoquerybin, conf_file, stuff, installroot='/', disablerepo='', enablerepo='', disable_excludes=None):
 
     qf = "%{name}|%{epoch}|%{version}|%{release}|%{arch}|%{repoid}"
     # is_installed goes through rpm instead of repoquery so it needs a slightly different format
@@ -757,19 +772,24 @@ def list_stuff(module, repoquerybin, conf_file, stuff, installroot='/', disabler
         repoq += ['-c', conf_file]
 
     if stuff == 'installed':
-        return [pkg_to_dict(p) for p in sorted(is_installed(module, repoq, '-a', conf_file, qf=is_installed_qf, installroot=installroot)) if p.strip()]
+        return [pkg_to_dict(p) for p in sorted(is_installed(module, repoq, '-a', conf_file, qf=is_installed_qf,
+                                                            installroot=installroot, disable_excludes=disable_excludes)) if p.strip()]
 
     if stuff == 'updates':
-        return [pkg_to_dict(p) for p in sorted(is_update(module, repoq, '-a', conf_file, qf=qf, installroot=installroot)) if p.strip()]
+        return [pkg_to_dict(p) for p in sorted(is_update(module, repoq, '-a', conf_file, qf=qf,
+                                                         installroot=installroot, disable_excludes=disable_excludes)) if p.strip()]
 
     if stuff == 'available':
-        return [pkg_to_dict(p) for p in sorted(is_available(module, repoq, '-a', conf_file, qf=qf, installroot=installroot)) if p.strip()]
+        return [pkg_to_dict(p) for p in sorted(is_available(module, repoq, '-a', conf_file, qf=qf,
+                                                            installroot=installroot, disable_excludes=disable_excludes)) if p.strip()]
 
     if stuff == 'repos':
         return [dict(repoid=name, state='enabled') for name in sorted(repolist(module, repoq)) if name.strip()]
 
-    return [pkg_to_dict(p) for p in sorted(is_installed(module, repoq, stuff, conf_file, qf=is_installed_qf, installroot=installroot) +
-                                           is_available(module, repoq, stuff, conf_file, qf=qf, installroot=installroot)) if p.strip()]
+    return [pkg_to_dict(p) for p in sorted(is_installed(module, repoq, stuff, conf_file, qf=is_installed_qf,
+                                                        installroot=installroot, disable_excludes=disable_excludes) +
+                                           is_available(module, repoq, stuff, conf_file, qf=qf, installroot=installroot,
+                                                         disable_excludes=disable_excludes)) if p.strip()]
 
 
 def exec_install(module, items, action, pkgs, res, yum_basecmd):
@@ -807,7 +827,8 @@ def exec_install(module, items, action, pkgs, res, yum_basecmd):
     return res
 
 
-def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, en_plugins, dis_plugins, installroot='/', allow_downgrade=False):
+def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, en_plugins, dis_plugins, installroot='/',
+            allow_downgrade=False, disable_excludes=None):
 
     pkgs = []
     downgrade_pkgs = []
@@ -841,15 +862,15 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, e
                 module.fail_json(msg="Failed to get nevra information from RPM package: %s" % spec)
             installed_pkgs = is_installed(module, repoq, envra, conf_file, en_repos=en_repos,
                                           dis_repos=dis_repos, en_plugins=en_plugins,
-                                          dis_plugins=dis_plugins, installroot=installroot)
+                                          dis_plugins=dis_plugins, installroot=installroot, disable_excludes=disable_excludes)
             if installed_pkgs:
                 res['results'].append('%s providing %s is already installed' % (installed_pkgs[0], package))
                 continue
 
             (name, ver, rel, epoch, arch) = splitFilename(envra)
             installed_pkgs = is_installed(module, repoq, name, conf_file, en_repos=en_repos,
-                                          dis_repos=dis_repos, en_plugins=en_plugins,
-                                          dis_plugins=dis_plugins, installroot=installroot)
+                                          dis_repos=dis_repos, en_plugins=en_plugins, dis_plugins=dis_plugins,
+                                          installroot=installroot, disable_excludes=disable_excludes)
 
             # case for two same envr but differrent archs like x86_64 and i686
             if len(installed_pkgs) == 2:
@@ -884,7 +905,8 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, e
 
         # groups
         elif spec.startswith('@'):
-            if is_group_env_installed(spec, conf_file, en_plugins=en_plugins, dis_plugins=dis_plugins, installroot=installroot):
+            if is_group_env_installed(spec, conf_file, en_plugins=en_plugins, dis_plugins=dis_plugins, installroot=installroot,
+                                      disable_excludes=disable_excludes):
                 continue
 
             pkg = spec
@@ -898,7 +920,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, e
                 installed_pkgs = is_installed(module, repoq, spec, conf_file, en_repos=en_repos,
                                               dis_repos=dis_repos, en_plugins=en_plugins,
                                               dis_plugins=dis_plugins, is_pkg=True,
-                                              installroot=installroot)
+                                              installroot=installroot, disable_excludes=disable_excludes)
                 if installed_pkgs:
                     res['results'].append('%s providing %s is already installed' % (installed_pkgs[0], spec))
                     continue
@@ -906,7 +928,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, e
             # look up what pkgs provide this
             pkglist = what_provides(module, repoq, yum_basecmd, spec, conf_file, en_repos=en_repos,
                                     dis_repos=dis_repos, en_plugins=en_plugins, dis_plugins=dis_plugins,
-                                    installroot=installroot)
+                                    installroot=installroot, disable_excludes=disable_excludes)
             if not pkglist:
                 res['msg'] += "No package matching '%s' found available, installed or updated" % spec
                 res['results'].append("No package matching '%s' found available, installed or updated" % spec)
@@ -928,7 +950,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, e
             for this in pkglist:
                 if is_installed(module, repoq, this, conf_file, en_repos=en_repos, dis_repos=dis_repos,
                                 en_plugins=en_plugins, dis_plugins=dis_plugins, is_pkg=True,
-                                installroot=installroot):
+                                installroot=installroot, disable_excludes=disable_excludes):
                     found = True
                     res['results'].append('%s providing %s is already installed' % (this, spec))
                     break
@@ -940,7 +962,8 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, e
             # highly irritating
             if not found:
                 if is_installed(module, repoq, spec, conf_file, en_repos=en_repos, dis_repos=dis_repos,
-                                en_plugins=en_plugins, dis_plugins=dis_plugins, installroot=installroot):
+                                en_plugins=en_plugins, dis_plugins=dis_plugins, installroot=installroot,
+                                disable_excludes=disable_excludes):
                     found = True
                     res['results'].append('package providing %s is already installed' % (spec))
 
@@ -960,7 +983,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, e
                     # Check if any version of the requested package is installed
                     inst_pkgs = is_installed(module, repoq, name, conf_file, en_repos=en_repos,
                                              dis_repos=dis_repos, en_plugins=en_plugins,
-                                             dis_plugins=dis_plugins, is_pkg=True)
+                                             dis_plugins=dis_plugins, is_pkg=True, disable_excludes=disable_excludes)
                     if inst_pkgs:
                         (cur_name, cur_ver, cur_rel, cur_epoch, cur_arch) = splitFilename(inst_pkgs[0])
                         compare = compareEVR((cur_epoch, cur_ver, cur_rel), (epoch, ver, rel))
@@ -989,7 +1012,8 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, e
     return res
 
 
-def remove(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, en_plugins, dis_plugins, installroot='/'):
+def remove(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, en_plugins, dis_plugins,
+           installroot='/', disable_excludes=None):
 
     pkgs = []
     res = {}
@@ -1000,11 +1024,11 @@ def remove(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, en
 
     for pkg in items:
         if pkg.startswith('@'):
-            installed = is_group_env_installed(pkg, conf_file, en_plugins=en_plugins, dis_plugins=dis_plugins, installroot=installroot)
+            installed = is_group_env_installed(pkg, conf_file, en_plugins=en_plugins, dis_plugins=dis_plugins, installroot=installroot,
+                                               disable_excludes=disable_excludes)
         else:
-            installed = is_installed(module, repoq, pkg, conf_file, en_repos=en_repos,
-                                     dis_repos=dis_repos, en_plugins=en_plugins,
-                                     dis_plugins=dis_plugins, installroot=installroot)
+            installed = is_installed(module, repoq, pkg, conf_file, en_repos=en_repos, dis_repos=dis_repos, en_plugins=en_plugins,
+                                     dis_plugins=dis_plugins, installroot=installroot,disable_excludes=disable_excludes)
 
         if installed:
             pkgs.append(pkg)
@@ -1035,11 +1059,11 @@ def remove(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, en
         # at this point we check to see if the pkg is no longer present
         for pkg in pkgs:
             if pkg.startswith('@'):
-                installed = is_group_env_installed(pkg, conf_file, en_plugins=en_plugins, dis_plugins=dis_plugins, installroot=installroot)
+                installed = is_group_env_installed(pkg, conf_file, en_plugins=en_plugins, dis_plugins=dis_plugins,
+                                                   installroot=installroot, disable_excludes=disable_excludes)
             else:
-                installed = is_installed(module, repoq, pkg, conf_file, en_repos=en_repos,
-                                         dis_repos=dis_repos, en_plugins=en_plugins,
-                                         dis_plugins=dis_plugins, installroot=installroot)
+                installed = is_installed(module, repoq, pkg, conf_file, en_repos=en_repos, dis_repos=dis_repos, en_plugins=en_plugins,
+                                         dis_plugins=dis_plugins, installroot=installroot, disable_excludes=disable_excludes)
 
             if installed:
                 module.fail_json(**res)
@@ -1095,7 +1119,8 @@ def parse_check_update(check_update_output):
     return updates
 
 
-def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, en_plugins, dis_plugins, update_only, installroot='/'):
+def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, en_plugins, dis_plugins, update_only,
+           installroot='/', disable_excludes=None):
 
     res = {}
     res['results'] = []
@@ -1155,9 +1180,8 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, en
                     module.fail_json(msg="Failed to get nevra information from RPM package: %s" % spec)
 
                 # local rpm files can't be updated
-                if not is_installed(module, repoq, envra, conf_file, en_repos=en_repos,
-                                    dis_repos=dis_repos, en_plugins=en_plugins,
-                                    dis_plugins=dis_plugins, installroot=installroot):
+                if not is_installed(module, repoq, envra, conf_file, en_repos=en_repos, dis_repos=dis_repos, en_plugins=en_plugins,
+                                    dis_plugins=dis_plugins, installroot=installroot, disable_excludes=disable_excludes):
                     pkgs['install'].append(spec)
                 continue
 
@@ -1172,22 +1196,22 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, en
                     module.fail_json(msg="Failed to get nevra information from RPM package: %s" % spec)
 
                 # local rpm files can't be updated
-                if not is_installed(module, repoq, envra, conf_file, en_repos=en_repos,
-                                    dis_repos=dis_repos, en_plugins=en_plugins,
-                                    dis_plugins=dis_plugins, installroot=installroot):
+                if not is_installed(module, repoq, envra, conf_file, en_repos=en_repos, dis_repos=dis_repos, en_plugins=en_plugins,
+                                    dis_plugins=dis_plugins, installroot=installroot, disable_excludes=disable_excludes):
                     pkgs['install'].append(package)
                 continue
 
             # dep/pkgname  - find it
             else:
                 if is_installed(module, repoq, spec, conf_file, en_repos=en_repos, dis_repos=dis_repos,
-                                en_plugins=en_plugins, dis_plugins=dis_plugins, installroot=installroot) or update_only:
+                                en_plugins=en_plugins, dis_plugins=dis_plugins, installroot=installroot,
+                                disable_excludes=disable_excludes) or update_only:
                     pkgs['update'].append(spec)
                 else:
                     pkgs['install'].append(spec)
             pkglist = what_provides(module, repoq, yum_basecmd, spec, conf_file, en_repos=en_repos,
                                     dis_repos=dis_repos, en_plugins=en_plugins, dis_plugins=dis_plugins,
-                                    installroot=installroot)
+                                    installroot=installroot, disable_excludes=disable_excludes)
             # FIXME..? may not be desirable to throw an exception here if a single package is missing
             if not pkglist:
                 res['msg'] += "No package matching '%s' found available, installed or updated" % spec
@@ -1200,7 +1224,7 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, en
                 if spec in pkgs['install'] and is_available(module, repoq, pkg, conf_file,
                                                             en_repos=en_repos, dis_repos=dis_repos,
                                                             en_plugins=en_plugins, dis_plugins=dis_plugins,
-                                                            installroot=installroot):
+                                                            installroot=installroot, disable_excludes=disable_excludes):
                     nothing_to_do = False
                     break
 
@@ -1220,7 +1244,7 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, en
 
             if not is_installed(module, repoq, spec, conf_file, en_repos=en_repos,
                                 dis_repos=dis_repos, en_plugins=en_plugins,
-                                dis_plugins=dis_plugins, installroot=installroot) and update_only:
+                                dis_plugins=dis_plugins, installroot=installroot, disable_excludes=disable_excludes) and update_only:
                 res['results'].append("Packages providing %s not installed due to update_only specified" % spec)
                 continue
             if nothing_to_do:
@@ -1285,7 +1309,8 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, en
 
 def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
            disable_gpg_check, exclude, repoq, skip_broken, update_only, security,
-           bugfix, installroot='/', allow_downgrade=False, disable_plugin=None, enable_plugin=None):
+           bugfix, installroot='/', allow_downgrade=False, disable_plugin=None,
+           enable_plugin=None, disable_excludes=None):
 
     # fedora will redirect yum to dnf, which has incompatibilities
     # with how this module expects yum to operate. If yum-deprecated
@@ -1328,6 +1353,9 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
         e_cmd = ['--exclude=%s' % exclude]
         yum_basecmd.extend(e_cmd)
 
+    if disable_excludes:
+        yum_basecmd.extend(['--disableexcludes=%s' % disable_excludes])
+
     if installroot != '/':
         # do not setup installroot by default, because of error
         # CRITICAL:yum.cli:Config Error: Error accessing file for config file:////etc/yum.conf
@@ -1364,7 +1392,7 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
         if module.params.get('update_cache'):
             module.run_command(yum_basecmd + ['clean', 'expire-cache'])
 
-        my = yum_base(conf_file, installroot, enable_plugin, disable_plugin)
+        my = yum_base(conf_file, installroot, enable_plugin, disable_plugin, disable_excludes)
         try:
             if disablerepo:
                 my.repos.disableRepo(disablerepo)
@@ -1387,9 +1415,10 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
             yum_basecmd.append('--nogpgcheck')
         res = install(module, pkgs, repoq, yum_basecmd, conf_file, en_repos, dis_repos,
                       enable_plugin, disable_plugin, installroot=installroot,
-                      allow_downgrade=allow_downgrade)
+                      allow_downgrade=allow_downgrade, disable_excludes=disable_excludes)
     elif state in ['removed', 'absent']:
-        res = remove(module, pkgs, repoq, yum_basecmd, conf_file, en_repos, dis_repos, enable_plugin, disable_plugin, installroot=installroot)
+        res = remove(module, pkgs, repoq, yum_basecmd, conf_file, en_repos, dis_repos, enable_plugin, disable_plugin,
+                     installroot=installroot, disable_excludes=disable_excludes)
     elif state == 'latest':
         if disable_gpg_check:
             yum_basecmd.append('--nogpgcheck')
@@ -1397,7 +1426,8 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
             yum_basecmd.append('--security')
         if bugfix:
             yum_basecmd.append('--bugfix')
-        res = latest(module, pkgs, repoq, yum_basecmd, conf_file, en_repos, dis_repos, enable_plugin, disable_plugin, update_only, installroot=installroot)
+        res = latest(module, pkgs, repoq, yum_basecmd, conf_file, en_repos, dis_repos, enable_plugin, disable_plugin, update_only,
+                     installroot=installroot, disable_excludes=disable_excludes)
     else:
         # should be caught by AnsibleModule argument_spec
         module.fail_json(msg="we should never get here unless this all failed",
@@ -1440,6 +1470,7 @@ def main():
             bugfix=dict(required=False, type='bool', default=False),
             enable_plugin=dict(type='list', default=[]),
             disable_plugin=dict(type='list', default=[]),
+            disable_excludes=dict(type='str', default=None),
         ),
         required_one_of=[['name', 'list']],
         mutually_exclusive=[['name', 'list']],
@@ -1458,6 +1489,10 @@ def main():
     params = module.params
     enable_plugin = params.get('enable_plugin')
     disable_plugin = params.get('disable_plugin')
+    +        if yum.__version_info__ >= (3, 4):
+    +            yum_basecmd.extend(['--disableincludes', disable_includes])
+    +        else:
+    +            module.fail_json(msg="'disable_includes' is available in yum version 3.4 and onwards.")
 
     if params['list']:
         repoquerybin = ensure_yum_utils(module)
@@ -1465,13 +1500,13 @@ def main():
             module.fail_json(msg="repoquery is required to use list= with this module. Please install the yum-utils package.")
         results = {'results': list_stuff(module, repoquerybin, params['conf_file'],
                                          params['list'], params['installroot'],
-                                         params['disablerepo'], params['enablerepo'])}
+                                         params['disablerepo'], params['enablerepo'],params['disable_excludes'])}
     else:
         # If rhn-plugin is installed and no rhn-certificate is available on
         # the system then users will see an error message using the yum API.
         # Use repoquery in those cases.
 
-        my = yum_base(params['conf_file'], params['installroot'], enable_plugin, disable_plugin)
+        my = yum_base(params['conf_file'], params['installroot'], enable_plugin, disable_plugin, params['disable_excludes'])
         # A sideeffect of accessing conf is that the configuration is
         # loaded and plugins are discovered
         my.conf
@@ -1499,10 +1534,11 @@ def main():
         security = params['security']
         bugfix = params['bugfix']
         allow_downgrade = params['allow_downgrade']
+        disable_excludes=params['disable_excludes']
         results = ensure(module, state, pkg, params['conf_file'], enablerepo,
                          disablerepo, disable_gpg_check, exclude, repoquery,
                          skip_broken, update_only, security, bugfix, params['installroot'], allow_downgrade,
-                         disable_plugin=disable_plugin, enable_plugin=enable_plugin)
+                         disable_plugin=disable_plugin, enable_plugin=enable_plugin, disable_excludes=disable_excludes)
         if repoquery:
             results['msg'] = '%s %s' % (
                 results.get('msg', ''),

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1489,10 +1489,8 @@ def main():
     params = module.params
     enable_plugin = params.get('enable_plugin')
     disable_plugin = params.get('disable_plugin')
-    +        if yum.__version_info__ >= (3, 4):
-    +            yum_basecmd.extend(['--disableincludes', disable_includes])
-    +        else:
-    +            module.fail_json(msg="'disable_includes' is available in yum version 3.4 and onwards.")
+    if params['disable_excludes'] and yum.__version_info__ < (3, 4):
+        module.fail_json(msg="'disable_includes' is available in yum version 3.4 and onwards.")
 
     if params['list']:
         repoquerybin = ensure_yum_utils(module)
@@ -1534,11 +1532,10 @@ def main():
         security = params['security']
         bugfix = params['bugfix']
         allow_downgrade = params['allow_downgrade']
-        disable_excludes=params['disable_excludes']
         results = ensure(module, state, pkg, params['conf_file'], enablerepo,
                          disablerepo, disable_gpg_check, exclude, repoquery,
                          skip_broken, update_only, security, bugfix, params['installroot'], allow_downgrade,
-                         disable_plugin=disable_plugin, enable_plugin=enable_plugin, disable_excludes=disable_excludes)
+                         disable_plugin=disable_plugin, enable_plugin=enable_plugin, disable_excludes=params['disable_excludes'])
         if repoquery:
             results['msg'] = '%s %s' % (
                 results.get('msg', ''),

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -789,7 +789,7 @@ def list_stuff(module, repoquerybin, conf_file, stuff, installroot='/', disabler
     return [pkg_to_dict(p) for p in sorted(is_installed(module, repoq, stuff, conf_file, qf=is_installed_qf,
                                                         installroot=installroot, disable_excludes=disable_excludes) +
                                            is_available(module, repoq, stuff, conf_file, qf=qf, installroot=installroot,
-                                                         disable_excludes=disable_excludes)) if p.strip()]
+                                                        disable_excludes=disable_excludes)) if p.strip()]
 
 
 def exec_install(module, items, action, pkgs, res, yum_basecmd):
@@ -1028,7 +1028,7 @@ def remove(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, en
                                                disable_excludes=disable_excludes)
         else:
             installed = is_installed(module, repoq, pkg, conf_file, en_repos=en_repos, dis_repos=dis_repos, en_plugins=en_plugins,
-                                     dis_plugins=dis_plugins, installroot=installroot,disable_excludes=disable_excludes)
+                                     dis_plugins=dis_plugins, installroot=installroot, disable_excludes=disable_excludes)
 
         if installed:
             pkgs.append(pkg)
@@ -1498,7 +1498,7 @@ def main():
             module.fail_json(msg="repoquery is required to use list= with this module. Please install the yum-utils package.")
         results = {'results': list_stuff(module, repoquerybin, params['conf_file'],
                                          params['list'], params['installroot'],
-                                         params['disablerepo'], params['enablerepo'],params['disable_excludes'])}
+                                         params['disablerepo'], params['enablerepo'], params['disable_excludes'])}
     else:
         # If rhn-plugin is installed and no rhn-certificate is available on
         # the system then users will see an error message using the yum API.

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -153,6 +153,7 @@ options:
       - If set to C(main), disable excludes defined in [main] in yum.conf.
       - If set to C(repoid), disable excludes defined for given repo id.
     required: false
+    choices: [ all, main, repoid ]
     version_added: "2.7"
 notes:
   - When used with a `loop:` each package will be processed individually,
@@ -1470,7 +1471,7 @@ def main():
             bugfix=dict(required=False, type='bool', default=False),
             enable_plugin=dict(type='list', default=[]),
             disable_plugin=dict(type='list', default=[]),
-            disable_excludes=dict(type='str', default=None, choices=['all', 'main', 'repoid', None]),
+            disable_excludes=dict(type='str', default=None, choices=['all', 'main', 'repoid']),
         ),
         required_one_of=[['name', 'list']],
         mutually_exclusive=[['name', 'list']],

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1470,7 +1470,7 @@ def main():
             bugfix=dict(required=False, type='bool', default=False),
             enable_plugin=dict(type='list', default=[]),
             disable_plugin=dict(type='list', default=[]),
-            disable_excludes=dict(type='str', default=None),
+            disable_excludes=dict(type='str', default=None, choices=['all', 'main', 'repoid', None]),
         ),
         required_one_of=[['name', 'list']],
         mutually_exclusive=[['name', 'list']],

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -571,7 +571,7 @@
   yum: name=sos state=present
   register: yum_result
 
-  name: verify packages did not install
+- name: verify packages did not install
     assert:
       that:
           - "yum_result is failed"

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -572,9 +572,9 @@
   register: yum_result
 
 - name: verify packages did not install
-    assert:
-      that:
-          - "yum_result is failed"
+  assert:
+    that:
+      - "yum_result is failed"
 
 - name: install sos
   yum: name=sos state=present disable_excludes=all
@@ -583,8 +583,8 @@
 - name: verify packages installed
   assert:
     that:
-        - "yum_result is success"
-        - "yum_result is changed"
+      - "yum_result is success"
+      - "yum_result is changed"
 
 - name: exclude sos
   lineinfile:

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -554,11 +554,11 @@
 
 - name: set yum_version
   set_fact:
-    yum_version: "{{ yum_version.results | selectattr('yumstate','match','installed') | map(attribute='version') | list | first }}"
+    yum_version: "{{ yum_version.results | selectattr('yumstate','match','installed') | list | first }}"
 
 - name: check wheter yum supports disableexcludes (>= 3.4)
   set_fact:
-    supports_disable_excludes: yum_version is version_compare('3.4.0', '>=')
+    supports_disable_excludes: yum_version.version is version_compare('3.4.0', '>=')
 
 - name: uninstall zip
   yum: name=zip state=removed

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -627,7 +627,7 @@
   assert:
     that:
       - "yum_fail_zip_result_old_yum is failed"
-  when: supports_disable_excludes
+  when: not supports_disable_excludes
 
 - name: remove exclude zip (cleanup yum.conf)
   lineinfile:
@@ -648,5 +648,5 @@
       - "yum_zip_result_old_yum is success"
       - "yum_zip_result_old_yum is changed"
       - "yum_zip_result_old_yum is not failed"
-  when: supports_disable_excludes
+  when: not supports_disable_excludes
 # end test case where disable_excludes is not supported

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -547,6 +547,19 @@
     name: "/tmp/non_existent_pkg.rpm"
     state: absent
 
+- name: get yum version
+  yum:
+    list: yum
+  register: yum_version
+
+- name: set yum_version
+  set_fact:
+    yum_version: "{{ yum_version.results | selectattr('yumstate','match','installed') | map(attribute='version') | list | first }}"
+
+- name: check wheter yum supports disableexcludes (>= 3.4)
+  set_fact:
+    supports_disable_excludes: yum_version is version_compare('3.4.0', '>=')
+
 - name: uninstall zip
   yum: name=zip state=removed
 
@@ -567,20 +580,24 @@
     line: "exclude=zip*"
     state: present
 
+# begin test case where disable_excludes is supported
 - name: install zip
   yum: name=zip state=latest
   register: yum_zip_result
   ignore_errors: True
+  when: supports_disable_excludes
 
 - name: verify packages did not install
   assert:
     that:
       - "yum_zip_result is failed"
+  when: supports_disable_excludes
 
 - name: install zip
   yum: name=zip state=latest disable_excludes=all
   register: yum_zip_result
       - "yum_result is changed"
+  when: supports_disable_excludes
 
 - name: remoe exclude zip
   lineinfile:
@@ -588,3 +605,29 @@
     regexp: (^exclude=zip*)
     line: "exclude="
     state: present
+  when: supports_disable_excludes
+# end test case where disable_excludes is supported
+
+# begin test case where disable_excludes is not supported
+- name: install zip
+  yum: name=zip state=latest disable_excludes=all
+  register: yum_zip_result
+      - "yum_result is failed"
+  ignore_errors: True
+  when: not supports_disable_excludes
+
+- name: remoe exclude zip
+  lineinfile:
+    dest: /etc/yum.conf
+    regexp: (^exclude=zip*)
+    line: "exclude="
+    state: present
+  when: not supports_disable_excludes
+
+- name: install zip
+  yum: name=zip state=latest
+  register: yum_zip_result
+      - "yum_result is changed"
+  when: not supports_disable_excludes
+# end test case where disable_excludes is not supported
+

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -632,7 +632,7 @@
 - name: verify yum module outputs
   assert:
     that:
-        - "'is available in yum version 3.4 and onwards.' in yum_fail_zip_result_old_yum"
+        - "'is available in yum version 3.4 and onwards.' in yum_fail_zip_result_old_yum.msg"
   when: not supports_disable_excludes
 
 - name: remove exclude zip (cleanup yum.conf)

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -568,8 +568,9 @@
     state: present
 
 - name: install sos
-  yum: name=sos state=present
+  yum: name=sos state=latest
   register: yum_result
+  ignore_errors: True
 
 - name: verify packages did not install
   assert:
@@ -577,8 +578,9 @@
       - "yum_result is failed"
 
 - name: install sos
-  yum: name=sos state=present disable_excludes=all
+  yum: name=sos state=latest disable_excludes=all
   register: yum_result
+      - "yum_result is changed"
 
 - name: verify packages installed
   assert:

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -559,7 +559,7 @@
 
 - name: check wheter yum supports disableexcludes (>= 3.4)
   set_fact:
-    supports_disable_excludes: yum_version is version_compare('3.4.0', '>=')
+    supports_disable_excludes: "{{ yum_version is version_compare('3.4.0', '>=') }}"
 
 - name: uninstall zip
   yum: name=zip state=removed
@@ -569,7 +569,7 @@
   ignore_errors: True
   register: rpm_zip_result
 
-- name: verify packages installed
+- name: verify zip is uninstalled
   assert:
     that:
       - "rpm_zip_result is failed"

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -557,7 +557,7 @@
     yum_version: "{%- if item.yumstate == 'installed' -%}{{ item.version }}{%- else -%}{{ yum_version }}{%- endif -%}"
   with_items: "{{ yum_version.results }}"
 
-- name: check wheter yum supports disableexcludes (>= 3.4)
+- name: check whether yum supports disableexcludes (>= 3.4)
   set_fact:
     supports_disable_excludes: "{{ yum_version is version_compare('3.4.0', '>=') }}"
 
@@ -588,7 +588,7 @@
   ignore_errors: True
   when: supports_disable_excludes
 
-- name: verify packages did not install because it is in exclude list
+- name: verify zip did not install because it is in exclude list
   assert:
     that:
       - "yum_zip_result is failed"
@@ -596,15 +596,15 @@
 
 - name: install zip with disable_excludes
   yum: name=zip state=latest disable_excludes=all
-  register: yum_zip_result_uing_excludes
+  register: yum_zip_result_using_excludes
   when: supports_disable_excludes
 
-- name: verify packages did install using disable_excludes=all
+- name: verify zip did install using disable_excludes=all
   assert:
     that:
-      - "yum_zip_result_uing_excludes is success"
-      - "yum_zip_result_uing_excludes is changed"
-      - "yum_zip_result_uing_excludes is not failed"
+      - "yum_zip_result_using_excludes is success"
+      - "yum_zip_result_using_excludes is changed"
+      - "yum_zip_result_using_excludes is not failed"
   when: supports_disable_excludes
 
 - name: remove exclude zip (cleanup yum.conf)
@@ -627,6 +627,12 @@
   assert:
     that:
       - "yum_fail_zip_result_old_yum is failed"
+  when: not supports_disable_excludes
+
+- name: verify yum module outputs
+  assert:
+    that:
+        - "'is available in yum version 3.4 and onwards.' in yum_fail_zip_result_old_yum"
   when: not supports_disable_excludes
 
 - name: remove exclude zip (cleanup yum.conf)

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -552,13 +552,14 @@
     list: yum
   register: yum_version
 
-- name: set yum_version
+- name: set yum_version of installed version
   set_fact:
-    yum_version: "{{ yum_version.results | selectattr('yumstate','match','installed') | list | first }}"
+    yum_version: "{%- if item.yumstate == 'installed' -%}{{ item.version }}{%- else -%}{{ yum_version }}{%- endif -%}"
+  with_items: "{{ yum_version.results }}"
 
 - name: check wheter yum supports disableexcludes (>= 3.4)
   set_fact:
-    supports_disable_excludes: yum_version.version is version_compare('3.4.0', '>=')
+    supports_disable_excludes: yum_version is version_compare('3.4.0', '>=')
 
 - name: uninstall zip
   yum: name=zip state=removed

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -546,3 +546,49 @@
   file:
     name: "/tmp/non_existent_pkg.rpm"
     state: absent
+
+- name: uninstall sos
+  yum: name=sos state=removed
+
+- name: check sos with rpm
+  shell: rpm -q sos
+  ignore_errors: True
+  register: rpm_sos_result
+
+- name: verify packages installed
+  assert:
+    that:
+        - "rpm_sos_result is failed"
+
+- name: exclude sos
+  lineinfile:
+    dest: /etc/yum.conf
+    regexp: (^exclude=)(.)*
+    line: "exclude=sos"
+    state: present
+
+- name: install sos
+  yum: name=sos state=present
+  register: yum_result
+
+  name: verify packages did not install
+    assert:
+      that:
+          - "yum_result is failed"
+
+- name: install sos
+  yum: name=sos state=present disable_excludes=all
+  register: yum_result
+
+- name: verify packages installed
+  assert:
+    that:
+        - "yum_result is success"
+        - "yum_result is changed"
+
+- name: exclude sos
+  lineinfile:
+    dest: /etc/yum.conf
+    regexp: (^exclude=sos)
+    line: "exclude="
+    state: present

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -214,7 +214,7 @@
 - name: check sos with rpm
   shell: rpm -q sos
 
-- name: check sos with rpm
+- name: check bc with rpm
   shell: rpm -q bc
 
 - name: uninstall sos and bc
@@ -547,50 +547,44 @@
     name: "/tmp/non_existent_pkg.rpm"
     state: absent
 
-- name: uninstall sos
-  yum: name=sos state=removed
+- name: uninstall zip
+  yum: name=zip state=removed
 
-- name: check sos with rpm
-  shell: rpm -q sos
+- name: check zip with rpm
+  shell: rpm -q zip
   ignore_errors: True
-  register: rpm_sos_result
+  register: rpm_zip_result
 
 - name: verify packages installed
   assert:
     that:
-        - "rpm_sos_result is failed"
+        - "rpm_zip_result is failed"
 
-- name: exclude sos
+- name: exclude zip
   lineinfile:
     dest: /etc/yum.conf
     regexp: (^exclude=)(.)*
-    line: "exclude=sos"
+    line: "exclude=zip*"
     state: present
 
-- name: install sos
-  yum: name=sos state=latest
-  register: yum_result
+- name: install zip
+  yum: name=zip state=latest
+  register: yum_zip_result
   ignore_errors: True
 
 - name: verify packages did not install
   assert:
     that:
-      - "yum_result is failed"
+      - "yum_zip_result is failed"
 
-- name: install sos
-  yum: name=sos state=latest disable_excludes=all
-  register: yum_result
+- name: install zip
+  yum: name=zip state=latest disable_excludes=all
+  register: yum_zip_result
       - "yum_result is changed"
 
-- name: verify packages installed
-  assert:
-    that:
-      - "yum_result is success"
-      - "yum_result is changed"
-
-- name: exclude sos
+- name: remoe exclude zip
   lineinfile:
     dest: /etc/yum.conf
-    regexp: (^exclude=sos)
+    regexp: (^exclude=zip*)
     line: "exclude="
     state: present

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -630,4 +630,3 @@
       - "yum_result is changed"
   when: not supports_disable_excludes
 # end test case where disable_excludes is not supported
-

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -572,7 +572,7 @@
 - name: verify packages installed
   assert:
     that:
-        - "rpm_zip_result is failed"
+      - "rpm_zip_result is failed"
 
 - name: exclude zip
   lineinfile:
@@ -582,25 +582,32 @@
     state: present
 
 # begin test case where disable_excludes is supported
-- name: install zip
+- name: Try install zip without disable_excludes
   yum: name=zip state=latest
   register: yum_zip_result
   ignore_errors: True
   when: supports_disable_excludes
 
-- name: verify packages did not install
+- name: verify packages did not install because it is in exclude list
   assert:
     that:
       - "yum_zip_result is failed"
   when: supports_disable_excludes
 
-- name: install zip
+- name: install zip with disable_excludes
   yum: name=zip state=latest disable_excludes=all
-  register: yum_zip_result
-      - "yum_result is changed"
+  register: yum_zip_result_uing_excludes
   when: supports_disable_excludes
 
-- name: remoe exclude zip
+- name: verify packages did install using disable_excludes=all
+  assert:
+    that:
+      - "yum_zip_result_uing_excludes is success"
+      - "yum_zip_result_uing_excludes is changed"
+      - "yum_zip_result_uing_excludes is not failed"
+  when: supports_disable_excludes
+
+- name: remove exclude zip (cleanup yum.conf)
   lineinfile:
     dest: /etc/yum.conf
     regexp: (^exclude=zip*)
@@ -610,14 +617,19 @@
 # end test case where disable_excludes is supported
 
 # begin test case where disable_excludes is not supported
-- name: install zip
+- name: Try install zip with disable_excludes
   yum: name=zip state=latest disable_excludes=all
-  register: yum_zip_result
-      - "yum_result is failed"
+  register: yum_fail_zip_result_old_yum
   ignore_errors: True
   when: not supports_disable_excludes
 
-- name: remoe exclude zip
+- name: verify packages did not install because yum version is unsupported
+  assert:
+    that:
+      - "yum_fail_zip_result_old_yum is failed"
+  when: supports_disable_excludes
+
+- name: remove exclude zip (cleanup yum.conf)
   lineinfile:
     dest: /etc/yum.conf
     regexp: (^exclude=zip*)
@@ -625,9 +637,16 @@
     state: present
   when: not supports_disable_excludes
 
-- name: install zip
+- name: install zip (bring test env in same state as when testing started)
   yum: name=zip state=latest
-  register: yum_zip_result
-      - "yum_result is changed"
+  register: yum_zip_result_old_yum
   when: not supports_disable_excludes
+
+- name: verify zip installed
+  assert:
+    that:
+      - "yum_zip_result_old_yum is success"
+      - "yum_zip_result_old_yum is changed"
+      - "yum_zip_result_old_yum is not failed"
+  when: supports_disable_excludes
 # end test case where disable_excludes is not supported


### PR DESCRIPTION
##### SUMMARY
we have exclude=kernel* in our yum.conf file, and want a way to install it such that ansbel only returns changed when it actually did install something therefore I have been looking at various attempts at implementing this. This implementation is inspired by 
@jfchevrette
https://github.com/ansible/ansible-modules-core/issues/3629
and 
@rm-you who did
https://github.com/ansible/ansible/pull/41506/files

<!--the change does.-->
add ansible option to disable_excludes on yum 3.4+

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
Feature Pull Request
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
yum
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
