### PR TITLE
Clarify uncertain nature of tracebacks on Python 2

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2384,9 +2384,10 @@ class AnsibleModule(object):
             raise AssertionError("implementation error -- msg to explain the error is required")
         kwargs['failed'] = True
 
-        # add traceback if debug or high verbosity and it is missing
-        # Note: badly named as exception, it is really always been 'traceback'
-        if 'exception' not in kwargs and sys.exc_info()[2] and (self._debug or self._verbosity >= 3):
+        # Add traceback if debug or high verbosity and it is missing
+        # NOTE: Only do this for Python 3, as prior versions would add last (stack frame) exception
+        # NOTE: Badly named as exception, it has really always been 'traceback'
+        if 'exception' not in kwargs and PY3 and sys.exc_info()[2] and (self._debug or self._verbosity >= 3):
             kwargs['exception'] = ''.join(traceback.format_tb(sys.exc_info()[2]))
 
         self.do_cleanup_files()

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2385,10 +2385,14 @@ class AnsibleModule(object):
         kwargs['failed'] = True
 
         # Add traceback if debug or high verbosity and it is missing
-        # NOTE: Only do this for Python 3, as prior versions would add last (stack frame) exception
-        # NOTE: Badly named as exception, it has really always been 'traceback'
-        if 'exception' not in kwargs and PY3 and sys.exc_info()[2] and (self._debug or self._verbosity >= 3):
-            kwargs['exception'] = ''.join(traceback.format_tb(sys.exc_info()[2]))
+        # NOTE: Badly named as exception, it really always has been a traceback
+        if 'exception' not in kwargs and sys.exc_info()[2] and (self._debug or self._verbosity >= 3):
+            if PY2:
+                # On Python 2 this is the last (stack frame) exception and as such may be unrelated to the failure
+                kwargs['exception'] = 'WARNING: The below traceback may *not* be related to the actual failure.\n' +\
+                                      ''.join(traceback.format_tb(sys.exc_info()[2]))
+            else:
+                kwargs['exception'] = ''.join(traceback.format_tb(sys.exc_info()[2]))
 
         self.do_cleanup_files()
         self._return_formatted(kwargs)


### PR DESCRIPTION
##### SUMMARY
On Python 2 the traceback could be any exception from the stack frame
and *likely unrelated* to the fail_json call when fail_json() was called outside
the except: block.

On Python 3 the traceback is cleared outside an exception frame, so the
call always returns the most inner traceback (if any), and therefor is
*most likely related* to the fail_json call.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/basic 

##### ANSIBLE VERSION
v2.7 and earlier

##### ADDITIONAL INFORMATION
Eligible to be backported to v2.6 and v2.5 (as an unrelated backtrace is confusing and misguiding).

##### EXAMPLE SHOWING ISSUE
In the below output there's an unrelated traceback while the module failed because the status code was not 200. Users may assume the reason for the error is that there's a JSON-related issue, which is just another caught exception testing if the returned data contained JSON.

Relates to #39526
```
[dag@moria ~]$ ansible -m uri -vvv -a url=http://httpbin.org/status/202 localhost
ansible 2.7.0.dev0 (aci-docs-type 57e116cba8) last updated 2018/07/17 16:14:15 (GMT +200)
  config file = None
  configured module search path = [u'/home/dag/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/anvers/default/lib/ansible
  executable location = /opt/anvers/default/bin/ansible
  python version = 2.7.5 (default, Feb 20 2018, 09:19:12) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
No config file found; using defaults
--snip--
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/dag/.ansible/tmp/ansible-tmp-1531846777.37-100327007151919/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
  File "/tmp/ansible_9tOvt1/ansible_module_uri.py", line 581, in main
    js = json.loads(u_content)
  File "/usr/lib64/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")

localhost | FAILED! => {
    "access_control_allow_credentials": "true", 
    "access_control_allow_origin": "*", 
    "changed": false, 
    "connection": "close", 
    "content": "", 
    "content_length": "0", 
    "content_type": "text/html; charset=utf-8", 
    "cookies": {}, 
    "cookies_string": "", 
    "date": "Tue, 17 Jul 2018 16:59:37 GMT", 
  --snip--
    "msg": "Status code was 202 and not [200]: OK (0 bytes)", 
    "redirected": false, 
    "server": "gunicorn/19.8.1", 
    "status": 202, 
    "url": "http://httpbin.org/status/202", 
    "via": "1.1 vegur, 1.1 aer01-mda2-dmz-wsa-6.cisco.com:80 (Cisco-WSA/X)"
}
```