### PR TITLE
Update terraform.py documentation. plan_file is required is state is 'planned'

### DIFF
--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -42,6 +42,7 @@ options:
     description:
       - The path to an existing Terraform plan file to apply. If this is not
         specified, Ansible will build a new TF plan and execute it.
+        Note that this option is required if 'state' has the 'planned' value.
     required: false
   state_file:
     description:


### PR DESCRIPTION
plan_file is required if state: planned is used. This should be mentionned in the documentation.

+label: docsite_pr

##### SUMMARY

Doc says plan_file isn't required. If 'state' value is 'planned'. It is required.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
terraform

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = None
  configured module search path = [u'/home/bpetit/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION

Found the mismatch, running this task:

```
- name: ensure terraform init has been runned
  terraform:
    state: planned
    force_init: yes
    project_path: "{{ iaas_tf_dir }}/libvirt"
```

result:

```
TASK [../.. : ensure terraform init has been runned] *****************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "state is planned but all of the following are missing: plan_file"}
```
which seems to be related to 

```
required_if=[('state', 'planned', ['plan_file'])],
```
on line 206 in terraform.py