### PR TITLE
openvswitch_db: Make 'key' parameter optional (#42110)

### DIFF
--- a/changelogs/fragments/openvswitch_db_make_key_optional.yaml
+++ b/changelogs/fragments/openvswitch_db_make_key_optional.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openvswitch_db - make 'key' argument optional https://github.com/ansible/ansible/issues/42108

--- a/test/integration/targets/openvswitch_db/tests/basic.yaml
+++ b/test/integration/targets/openvswitch_db/tests/basic.yaml
@@ -33,7 +33,7 @@
     that:
       - "result.changed == false"
 
-- name: Change column value
+- name: Change column value in a map
   openvswitch_db:
     table: Bridge
     record: br-test
@@ -46,7 +46,7 @@
     that:
       - "result.changed == true"
 
-- name: Change column value again (idempotent)
+- name: Change column value in a map again (idempotent)
   openvswitch_db:
     table: Bridge
     record: br-test
@@ -58,6 +58,43 @@
 - assert:
     that:
       - "result.changed == false"
+
+- name: Change column value
+  openvswitch_db:
+    table: Bridge
+    record: br-test
+    col: stp_enable
+    value: true
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: Change column value again (idempotent)
+  openvswitch_db:
+    table: Bridge
+    record: br-test
+    col: stp_enable
+    value: true
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: Try to set value on a map type without a key (negative)
+  ignore_errors: true
+  openvswitch_db:
+    table: Bridge
+    record: br-test
+    col: other_config
+    value: true
+  register: result
+
+- assert:
+    that:
+      - "result.failed == true"
 
 - name: Remove bridge
   openvswitch_db:

--- a/test/units/modules/network/ovs/test_openvswitch_db.py
+++ b/test/units/modules/network/ovs/test_openvswitch_db.py
@@ -41,6 +41,12 @@ test_name_side_effect_matrix = {
     'test_openvswitch_db_present_updates_key': [
         (0, 'openvswitch_db_disable_in_band_true.cfg', None),
         (0, None, None)],
+    'test_openvswitch_db_present_missing_key_on_map': [
+        (0, 'openvswitch_db_disable_in_band_true.cfg', None),
+        (0, None, None)],
+    'test_openvswitch_db_present_stp_enable': [
+        (0, 'openvswitch_db_disable_in_band_true.cfg', None),
+        (0, None, None)],
 }
 
 
@@ -122,3 +128,20 @@ class TestOpenVSwitchDBModule(TestOpenVSwitchModule):
             commands=['/usr/bin/ovs-vsctl -t 5 set Bridge test-br other_config'
                       ':disable-in-band=False'],
             test_name='test_openvswitch_db_present_updates_key')
+
+    def test_openvswitch_db_present_missing_key_on_map(self):
+        set_module_args(dict(state='present',
+                             table='Bridge', record='test-br',
+                             col='other_config',
+                             value='False'))
+        self.execute_module(
+            failed=True,
+            test_name='test_openvswitch_db_present_idempotent')
+
+    def test_openvswitch_db_present_stp_enable(self):
+        set_module_args(dict(state='present',
+                             table='Bridge', record='test-br',
+                             col='stp_enable',
+                             value='False'))
+        self.execute_module(changed=True,
+                            test_name='test_openvswitch_db_present_stp_enable')


### PR DESCRIPTION
The OVSDB schema consists of typed columns. The 'key' parameter is
required only for columns with type of a 'map'. This patch makes 'key'
an optional parameter to allow setting values for other column types
like int.

Fixes #42108

(cherry picked from commit 26b0908270ec54db241cada516b56abd79e2e2cc)

This is a backport of fix https://github.com/ansible/ansible/pull/42110 to stable-2.6 branch.