### PR TITLE
Ecs service force new deployment

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -513,7 +513,9 @@ def main():
         update = False
 
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
-            if service_mgr.is_matching_service(module.params, existing):
+            if module.params['force_new_deployment']:
+                update = True
+            elif service_mgr.is_matching_service(module.params, existing):
                 matching = True
                 results['service'] = existing
             else:

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -86,7 +86,8 @@ options:
         description:
           - Force deployment of service even if there are no changes
         required: false
-        version_added: 2.6
+        version_added: 2.7
+        type: bool
     deployment_configuration:
         description:
           - Optional parameters that control the deployment_configuration; format is '{"maximum_percent":<integer>, "minimum_healthy_percent":<integer>}

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -82,6 +82,11 @@ options:
           - The number of times to check that the service is available
         required: false
         default: 10
+    force_new_deployment:
+        description:
+          - Force deployment of service even if there are no changes
+        required: false
+        version_added: 2.6
     deployment_configuration:
         description:
           - Optional parameters that control the deployment_configuration; format is '{"maximum_percent":<integer>, "minimum_healthy_percent":<integer>}
@@ -405,13 +410,15 @@ class EcsServiceManager:
         return self.jsonize(response['service'])
 
     def update_service(self, service_name, cluster_name, task_definition,
-                       desired_count, deployment_configuration, network_configuration):
+                       desired_count, deployment_configuration, network_configuration,
+                       force_new_deployment):
         params = dict(
             cluster=cluster_name,
             service=service_name,
             taskDefinition=task_definition,
             desiredCount=desired_count,
-            deploymentConfiguration=deployment_configuration)
+            deploymentConfiguration=deployment_configuration,
+            forceNewDeployment=force_new_deployment)
         if network_configuration:
             params['networkConfiguration'] = network_configuration
         response = self.ecs.update_service(**params)
@@ -458,6 +465,7 @@ def main():
         role=dict(required=False, default='', type='str'),
         delay=dict(required=False, type='int', default=10),
         repeat=dict(required=False, type='int', default=10),
+        force_new_deployment=dict(required=False, default=False, type='bool'),
         deployment_configuration=dict(required=False, default={}, type='dict'),
         placement_constraints=dict(required=False, default=[], type='list'),
         placement_strategy=dict(required=False, default=[], type='list'),
@@ -527,7 +535,8 @@ def main():
                                                           module.params['task_definition'],
                                                           module.params['desired_count'],
                                                           deploymentConfiguration,
-                                                          network_configuration)
+                                                          network_configuration,
+                                                          module.params['force_new_deployment'])
                 else:
                     for loadBalancer in loadBalancers:
                         if 'containerPort' in loadBalancer:


### PR DESCRIPTION
##### SUMMARY
Allow forcing a deployment of an ECS service.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
ecs_service

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
  config file = /home/via/automation/ansible.cfg
  configured module search path = [u'/home/via/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/via/venv/lib/python2.7/site-packages/ansible
  executable location = /home/via/venv/bin/ansible
  python version = 2.7.9 (default, Apr 27 2015, 17:49:25) [GCC 4.6.3]
```


##### ADDITIONAL INFORMATION
This has the same goal as https://github.com/ansible/ansible/pull/39600 but it seems incomplete and hasn't been updated in some time.

