### PR TITLE
Make sure we are comparing bytes extensions in inventory plugins 

### DIFF
--- a/changelogs/fragments/inventory_dir_ext_compare_fix.yaml
+++ b/changelogs/fragments/inventory_dir_ext_compare_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- inventory - When using an inventory directory, ensure extension comparison uses text types (https://github.com/ansible/ansible/pull/42475)

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -259,7 +259,7 @@ class InventoryManager(object):
 
                 # initialize and figure out if plugin wants to attempt parsing this file
                 try:
-                    plugin_wants = bool(plugin.verify_file(source))
+                    plugin_wants = bool(plugin.verify_file(to_text(source)))
                 except Exception:
                     plugin_wants = False
 


### PR DESCRIPTION

* Ensure we are comparing text paths with extensions. 

(cherry picked from commit abb05c98f3cd0770cce69f4d90f00d4f2800060f)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and del
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
inventory
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```