### PR TITLE
Updating the nios_test_container version to 1.1.0 from 1.0.0

### DIFF
--- a/test/runner/lib/cloud/nios.py
+++ b/test/runner/lib/cloud/nios.py
@@ -31,7 +31,7 @@ class NiosProvider(CloudProvider):
 
     DOCKER_SIMULATOR_NAME = 'nios-simulator'
 
-    DOCKER_IMAGE = 'quay.io/ansible/nios-test-container:1.0.0'
+    DOCKER_IMAGE = 'quay.io/ansible/nios-test-container:1.2.0'
     """Default image to run the nios simulator.
 
     The simulator must be pinned to a specific version

--- a/test/runner/lib/cloud/nios.py
+++ b/test/runner/lib/cloud/nios.py
@@ -31,7 +31,7 @@ class NiosProvider(CloudProvider):
 
     DOCKER_SIMULATOR_NAME = 'nios-simulator'
 
-    DOCKER_IMAGE = 'quay.io/ansible/nios-test-container:1.2.0'
+    DOCKER_IMAGE = 'quay.io/ansible/nios-test-container:1.1.0'
     """Default image to run the nios simulator.
 
     The simulator must be pinned to a specific version


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
New module `record:ptr` is added, and corresponding changes are made in `nios_test_container`
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 -  New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nios
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
The PTR module would allow the recording of an individual reverse DNS record
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
