### PR TITLE
play, block, task: New attribute forks

### DIFF
--- a/docs/docsite/keyword_desc.yml
+++ b/docs/docsite/keyword_desc.yml
@@ -31,6 +31,7 @@ environment: A dictionary that gets converted into environment vars to be provid
 fact_path: Set the fact path option for the fact gathering plugin controlled by :term:`gather_facts`.
 failed_when: "Conditional expression that overrides the task's normal 'failed' status."
 force_handlers: Will force notified handler execution for hosts even if they failed during the play. Will not trigger if the play itself fails.
+forks: Limit number of concurrent task runs on task, block and playbook level.
 gather_facts: "A boolean that controls if the play will automatically run the 'setup' task to gather facts for the hosts."
 gather_subset: Allows you to pass subset options to the  fact gathering plugin controlled by :term:`gather_facts`.
 gather_timeout: Allows you to set the timeout for the fact gathering plugin controlled by :term:`gather_facts`.

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -611,6 +611,7 @@ class Base(FieldAttributeBase):
     _check_mode = FieldAttribute(isa='bool', default=context.cliargs_deferred_get('check'))
     _diff = FieldAttribute(isa='bool', default=context.cliargs_deferred_get('diff'))
     _any_errors_fatal = FieldAttribute(isa='bool', default=C.ANY_ERRORS_FATAL)
+    _forks = FieldAttribute(isa='list', extend=True, prepend=True, static=True)
 
     # explicitly invoke a debugger on tasks
     _debugger = FieldAttribute(isa='string')

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -300,6 +300,14 @@ class StrategyBase:
             queued = False
             starting_worker = self._cur_worker
             while True:
+                if len(task.forks) > 0 and task._parent._play.strategy != "free":
+                    if task.run_once:
+                        display.debug("Ignoring 'forks' as 'run_once' is also set for '%s'" % task.get_name())
+                    else:
+                        forks = min(task.forks)
+                        display.debug("task: %s, forks: %d" % (task.get_name(), forks))
+                        if forks > 0 and self._cur_worker >= forks:
+                            self._cur_worker = 0
                 worker_prc = self._workers[self._cur_worker]
                 if worker_prc is None or not worker_prc.is_alive():
                     self._queued_task_cache[(host.name, task._uuid)] = {

--- a/test/integration/targets/forks/aliases
+++ b/test/integration/targets/forks/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group2

--- a/test/integration/targets/forks/inventory
+++ b/test/integration/targets/forks/inventory
@@ -1,0 +1,6 @@
+[localhosts]
+testhost[00:11]
+
+[localhosts:vars]
+ansible_connection=local
+ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/forks/runme.sh
+++ b/test/integration/targets/forks/runme.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# https://github.com/ansible/ansible/pull/42528
+ANSIBLE_STRATEGY='linear' ansible-playbook test_forks.yml -vv -i inventory --forks 12 "$@"
+ANSIBLE_STRATEGY='free' ansible-playbook test_forks.yml -vv -i inventory --forks 12 "$@"

--- a/test/integration/targets/forks/test_forks.yml
+++ b/test/integration/targets/forks/test_forks.yml
@@ -1,0 +1,229 @@
+---
+- hosts: localhosts
+  gather_facts: false
+  vars:
+    forksdir: ~/ansible_testing/forks.dir/
+  tasks:
+    - name: Clean forksdir '{{ forksdir }}'
+      file:
+        state: absent
+        path: '{{ forksdir }}'
+      ignore_errors: yes
+      run_once: yes
+    - name: Create forksdir '{{ forksdir }}'
+      file:
+        state: directory
+        path: '{{ forksdir }}'
+      run_once: yes
+    - block:
+      - name: "Test 1 (max forks: 3)"
+        command: "{{ ansible_python_interpreter }}"
+        args:
+          stdin: |
+            import os, time
+            forksdir ='{{ forksdir | expanduser }}1/'
+            forksfile = forksdir + '{{ inventory_hostname }}'
+            max_forks = 3
+            try:
+              os.mkdir(forksdir)
+            except OSError:
+              pass
+            try:
+              with(open(forksfile, 'a')):
+                os.utime(forksfile, None)
+              time.sleep(0.5)
+              forkslist = os.listdir(forksdir)
+              print("tasks: %d/%d" % (len(forkslist), max_forks))
+              if len(forkslist) > max_forks:
+                raise ValueError("Too many concurrent tasks: %d/%d" % (len(forkslist), max_forks))
+              time.sleep(0.5)
+            finally:
+              os.unlink(forksfile)
+        #run_once: true
+      forks: 3
+    - block:
+      - name: "Test 2 (max forks: 5)"
+        command: "{{ ansible_python_interpreter }}"
+        args:
+          stdin: |
+            import os, time
+            forksdir ='{{ forksdir | expanduser }}2/'
+            forksfile = forksdir + '{{ inventory_hostname }}'
+            max_forks = 5
+            try:
+              os.mkdir(forksdir)
+            except OSError:
+              pass
+            try:
+              with(open(forksfile, 'a')):
+                os.utime(forksfile, None)
+              time.sleep(0.5)
+              forkslist = os.listdir(forksdir)
+              print("tasks: %d/%d" % (len(forkslist), max_forks))
+              if len(forkslist) > max_forks:
+                raise ValueError("Too many concurrent tasks: %d/%d" % (len(forkslist), max_forks))
+              time.sleep(0.5)
+            finally:
+              os.unlink(forksfile)
+        forks: 5
+      - block:
+        - name: "Test 3 (max forks: 6)"
+          command: "{{ ansible_python_interpreter }}"
+          args:
+            stdin: |
+              import os, time
+              forksdir ='{{ forksdir | expanduser }}3/'
+              forksfile = forksdir + '{{ inventory_hostname }}'
+              max_forks = 6
+              try:
+                os.mkdir(forksdir)
+              except OSError:
+                pass
+              try:
+                with(open(forksfile, 'a')):
+                  os.utime(forksfile, None)
+                time.sleep(0.5)
+                forkslist = os.listdir(forksdir)
+                print("tasks: %d/%d" % (len(forkslist), max_forks))
+                if len(forkslist) > max_forks:
+                  raise ValueError("Too many concurrent tasks: %d/%d" % (len(forkslist), max_forks))
+                time.sleep(0.5)
+              finally:
+                os.unlink(forksfile)
+          forks: 8
+        forks: 6
+      - block:
+        - block:
+          - name: "Test 4 (max forks: 8)"
+            command: "{{ ansible_python_interpreter }}"
+            args:
+              stdin: |
+                import os, time
+                forksdir ='{{ forksdir | expanduser }}4/'
+                forksfile = forksdir + '{{ inventory_hostname }}'
+                max_forks = 8
+                try:
+                  os.mkdir(forksdir)
+                except OSError:
+                  pass
+                try:
+                  with(open(forksfile, 'a')):
+                    os.utime(forksfile, None)
+                  time.sleep(0.5)
+                  forkslist = os.listdir(forksdir)
+                  print("tasks: %d/%d" % (len(forkslist), max_forks))
+                  if len(forkslist) > max_forks:
+                    raise ValueError("Too many concurrent tasks: %d/%d" % (len(forkslist), max_forks))
+                  time.sleep(0.5)
+                finally:
+                  os.unlink(forksfile)
+            forks: 10
+          forks: 8
+        forks: 12
+      forks: 15
+    - block:
+      - name: "Test 1 (max forks: 3)"
+        command: "{{ ansible_python_interpreter }}"
+        args:
+          stdin: |
+            import os, time
+            forksdir ='{{ forksdir | expanduser }}5/'
+            forksfile = forksdir + '{{ inventory_hostname }}'
+            max_forks = 3
+            try:
+              os.mkdir(forksdir)
+            except OSError:
+              pass
+            try:
+              with(open(forksfile, 'a')):
+                os.utime(forksfile, None)
+              time.sleep(0.5)
+              forkslist = os.listdir(forksdir)
+              print("tasks: %d/%d" % (len(forkslist), max_forks))
+              if len(forkslist) > max_forks:
+                raise ValueError("Too many concurrent tasks: %d/%d" % (len(forkslist), max_forks))
+              time.sleep(0.5)
+            finally:
+              os.unlink(forksfile)
+        #run_once: true
+      forks: 3
+    - block:
+      - name: "Test 2 (max forks: 5)"
+        command: "{{ ansible_python_interpreter }}"
+        args:
+          stdin: |
+            import os, time
+            forksdir ='{{ forksdir | expanduser }}6/'
+            forksfile = forksdir + '{{ inventory_hostname }}'
+            max_forks = 5
+            try:
+              os.mkdir(forksdir)
+            except OSError:
+              pass
+            try:
+              with(open(forksfile, 'a')):
+                os.utime(forksfile, None)
+              time.sleep(0.5)
+              forkslist = os.listdir(forksdir)
+              print("tasks: %d/%d" % (len(forkslist), max_forks))
+              if len(forkslist) > max_forks:
+                raise ValueError("Too many concurrent tasks: %d/%d" % (len(forkslist), max_forks))
+              time.sleep(0.5)
+            finally:
+              os.unlink(forksfile)
+        forks: 5
+      - block:
+        - name: "Test 3 (max forks: 6)"
+          command: "{{ ansible_python_interpreter }}"
+          args:
+            stdin: |
+              import os, time
+              forksdir ='{{ forksdir | expanduser }}7/'
+              forksfile = forksdir + '{{ inventory_hostname }}'
+              max_forks = 6
+              try:
+                os.mkdir(forksdir)
+              except OSError:
+                pass
+              try:
+                with(open(forksfile, 'a')):
+                  os.utime(forksfile, None)
+                time.sleep(0.5)
+                forkslist = os.listdir(forksdir)
+                print("tasks: %d/%d" % (len(forkslist), max_forks))
+                if len(forkslist) > max_forks:
+                  raise ValueError("Too many concurrent tasks: %d/%d" % (len(forkslist), max_forks))
+                time.sleep(0.5)
+              finally:
+                os.unlink(forksfile)
+          forks: 8
+        forks: 6
+      - block:
+        - block:
+          - name: "Test 4 (max forks: 8)"
+            command: "{{ ansible_python_interpreter }}"
+            args:
+              stdin: |
+                import os, time
+                forksdir ='{{ forksdir | expanduser }}8/'
+                forksfile = forksdir + '{{ inventory_hostname }}'
+                max_forks = 8
+                try:
+                  os.mkdir(forksdir)
+                except OSError:
+                  pass
+                try:
+                  with(open(forksfile, 'a')):
+                    os.utime(forksfile, None)
+                  time.sleep(0.5)
+                  forkslist = os.listdir(forksdir)
+                  print("tasks: %d/%d" % (len(forkslist), max_forks))
+                  if len(forkslist) > max_forks:
+                    raise ValueError("Too many concurrent tasks: %d/%d" % (len(forkslist), max_forks))
+                  time.sleep(0.5)
+                finally:
+                  os.unlink(forksfile)
+            forks: 10
+          forks: 8
+        forks: 12
+      forks: 15


### PR DESCRIPTION
With this patch it is possible to limit the number of concurrent task runs for the task where it has been added. This is similar to forks, but affects only one task. It can be used to serialize one or more tasks.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The ability to limit concurrent task executions for a specific task would help [ansible-freeipa](https://github.com/freeipa/ansible-freeipa) to deploy a bigger number of replicas and dependant clients in a cluster environment in a nearly parallel way.

Right now it is not possible to install several replicas with [FreeIPA](https://freeipa.org/page/Main_Page) at the same time due to conflicts in the CA configuration step. For ansible-freeipa the installers have been split up into smaller pieces already to be able to replace some of the parts with new roles later on. With this patch in ansible it is possible to have a nearly parallel installation as only the affected step need to be executed in a serial way. The remaining tasks in the role can be done in parallel.

The creation of all replicas with ```forks:1``` is resulting in a by far longer deployment time. Also the proposals from [issue #12170](https://github.com/ansible/ansible/issues/12170) are not working as the registered output of previous tasks is needed.

This fixes #12170
This fixes #24037

##### ISSUE TYPE
 - Feature Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Excerpt from the tasks/install.yml file used to install the replica with the new ```forks``` directive:

```yaml
...
  - name: Install - Setup CA
    ipareplica_setup_ca:
      ### server ###
      setup_ca: "{{ ipareplica_setup_ca }}"
      setup_kra: "{{ result_ipareplica_test.setup_kra }}"
      no_pkinit: "{{ ipareplica_no_pkinit }}"
      no_ui_redirect: "{{ ipareplica_no_ui_redirect }}"
      ### certificate system ###
      subject_base: "{{ result_ipareplica_prepare.subject_base }}"
      ### additional ###
      ccache: "{{ result_ipareplica_prepare.ccache }}"
      _ca_enabled: "{{ result_ipareplica_prepare._ca_enabled }}"
      _ca_file: "{{ result_ipareplica_prepare._ca_file }}"
      _ca_subject: "{{ result_ipareplica_prepare._ca_subject }}"
      _subject_base: "{{ result_ipareplica_prepare._subject_base }}"
      _pkinit_pkcs12_info: "{{ result_ipareplica_prepare._pkinit_pkcs12_info }}"
      _top_dir: "{{ result_ipareplica_prepare._top_dir }}"
      dirman_password: "{{ ipareplica_dirman_password }}"
      config_setup_ca: "{{ result_ipareplica_prepare.config_setup_ca }}"
      config_master_host_name: "{{ result_ipareplica_install_ca_certs.config_master_host_name }}"
      config_ca_host_name: "{{ result_ipareplica_install_ca_certs.config_ca_host_name }}"
      config_ips: "{{ result_ipareplica_prepare.config_ips }}"
    when: result_ipareplica_prepare._ca_enabled
    forks: 1
...
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
Parallel execution without `forks: 1`:
```
...
TASK [ipareplica : Install - Setup CA] *****************************************
task path: /root/ansible/ansible-freeipa/roles/ipareplica/tasks/install.yml:419
fatal: [ipareplica3.test3.local]: FAILED! => {"changed": false, "module_stderr": "Shared connection to ipareplica3.test3.local closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_MJSMjy/ansible_module_ipareplica_setup_ca.py\", line 229, in <module>\r\n    main()\r\n  File \"/tmp/ansible_MJSMjy/ansible_module_ipareplica_setup_ca.py\", line 222, in main\r\n    ca.install(False, config, options, custodia=custodia)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/ca.py\", line 223, in install\r\n    install_step_0(standalone, replica_config, options, custodia=custodia)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/ca.py\", line 303, in install_step_0\r\n    use_ldaps=standalone)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/cainstance.py\", line 467, in configure_instance\r\n    self.start_creation(runtime=runtime)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/service.py\", line 520, in start_creation\r\n    run_step(full_msg, method)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/service.py\", line 510, in run_step\r\n    method()\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/dogtaginstance.py\", line 473, in setup_admin\r\n    master_conn.simple_bind(self.admin_dn, self.admin_password)\r\n  File \"/usr/lib/python2.7/site-packages/ipapython/ipaldap.py\", line 1142, in simple_bind\r\n    bind_dn, bind_password, server_controls, client_controls)\r\n  File \"/usr/lib64/python2.7/contextlib.py\", line 35, in __exit__\r\n    self.gen.throw(type, value, traceback)\r\n  File \"/usr/lib/python2.7/site-packages/ipapython/ipaldap.py\", line 1030, in error_handler\r\n    raise errors.ACIError(info=\"%s %s\" % (info, desc))\r\nipalib.errors.ACIError: Insufficient access:  Invalid credentials\r\n", "msg": "MODULE FAILURE", "rc": 1}
fatal: [ipareplica4.test3.local]: FAILED! => {"changed": false, "module_stderr": "Shared connection to ipareplica4.test3.local closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_muUnai/ansible_module_ipareplica_setup_ca.py\", line 229, in <module>\r\n    main()\r\n  File \"/tmp/ansible_muUnai/ansible_module_ipareplica_setup_ca.py\", line 222, in main\r\n    ca.install(False, config, options, custodia=custodia)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/ca.py\", line 223, in install\r\n    install_step_0(standalone, replica_config, options, custodia=custodia)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/ca.py\", line 303, in install_step_0\r\n    use_ldaps=standalone)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/cainstance.py\", line 467, in configure_instance\r\n    self.start_creation(runtime=runtime)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/service.py\", line 520, in start_creation\r\n    run_step(full_msg, method)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/service.py\", line 510, in run_step\r\n    method()\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/dogtaginstance.py\", line 473, in setup_admin\r\n    master_conn.simple_bind(self.admin_dn, self.admin_password)\r\n  File \"/usr/lib/python2.7/site-packages/ipapython/ipaldap.py\", line 1142, in simple_bind\r\n    bind_dn, bind_password, server_controls, client_controls)\r\n  File \"/usr/lib64/python2.7/contextlib.py\", line 35, in __exit__\r\n    self.gen.throw(type, value, traceback)\r\n  File \"/usr/lib/python2.7/site-packages/ipapython/ipaldap.py\", line 1030, in error_handler\r\n    raise errors.ACIError(info=\"%s %s\" % (info, desc))\r\nipalib.errors.ACIError: Insufficient access:  Invalid credentials\r\n", "msg": "MODULE FAILURE", "rc": 1}
fatal: [ipareplica1.test3.local]: FAILED! => {"changed": false, "module_stderr": "Shared connection to ipareplica1.test3.local closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_QegF3A/ansible_module_ipareplica_setup_ca.py\", line 229, in <module>\r\n    main()\r\n  File \"/tmp/ansible_QegF3A/ansible_module_ipareplica_setup_ca.py\", line 222, in main\r\n    ca.install(False, config, options, custodia=custodia)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/ca.py\", line 223, in install\r\n    install_step_0(standalone, replica_config, options, custodia=custodia)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/ca.py\", line 303, in install_step_0\r\n    use_ldaps=standalone)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/cainstance.py\", line 467, in configure_instance\r\n    self.start_creation(runtime=runtime)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/service.py\", line 520, in start_creation\r\n    run_step(full_msg, method)\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/service.py\", line 510, in run_step\r\n    method()\r\n  File \"/usr/lib/python2.7/site-packages/ipaserver/install/dogtaginstance.py\", line 473, in setup_admin\r\n    master_conn.simple_bind(self.admin_dn, self.admin_password)\r\n  File \"/usr/lib/python2.7/site-packages/ipapython/ipaldap.py\", line 1142, in simple_bind\r\n    bind_dn, bind_password, server_controls, client_controls)\r\n  File \"/usr/lib64/python2.7/contextlib.py\", line 35, in __exit__\r\n    self.gen.throw(type, value, traceback)\r\n  File \"/usr/lib/python2.7/site-packages/ipapython/ipaldap.py\", line 1030, in error_handler\r\n    raise errors.ACIError(info=\"%s %s\" % (info, desc))\r\nipalib.errors.ACIError: Insufficient access:  Invalid credentials\r\n", "msg": "MODULE FAILURE", "rc": 1}
changed: [ipareplica2.test3.local] => {"changed": true}
...
```
Serial execution with ```forks: 1```:
```
...
TASK [ipareplica : Install - Setup CA] *****************************************
task path: /root/ansible/ansible-freeipa/roles/ipareplica/tasks/install.yml:419
changed: [ipareplica1.test3.local] => {"changed": true}
changed: [ipareplica2.test3.local] => {"changed": true}
changed: [ipareplica3.test3.local] => {"changed": true}
changed: [ipareplica4.test3.local] => {"changed": true}
...
```