### PR TITLE
Solve race condition in password lookup

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -275,7 +275,7 @@ def _get_lock(b_path):
     b_pathdir = os.path.dirname(b_path)
     lockfile_name = to_bytes("%s.ansible_lockfile" % hashlib.md5(b_path).hexdigest())
     lockfile = os.path.join(b_pathdir, lockfile_name)
-    if not os.path.exists(lockfile):
+    if not os.path.exists(lockfile) and b_path != to_bytes('/dev/null'):
         try:
             makedirs_safe(b_pathdir, mode=0o700)
             fd = os.open(lockfile, os.O_CREAT | os.O_EXCL)

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -282,7 +282,7 @@ class LookupModule(LookupBase):
             writer_process = False
             b_pathdir = os.path.dirname(b_path)
             # get a unique lock file name for each password file
-            lockfile_name = "%s.ansible_lockfile" % hashlib.md5(b_path).hexdigest()
+            lockfile_name = to_bytes("%s.ansible_lockfile" % hashlib.md5(b_path).hexdigest())
             lockfile = os.path.join(b_pathdir, lockfile_name)
             if not os.path.exists(lockfile) and not os.path.exists(b_path):
                 try:

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -282,11 +282,12 @@ class LookupModule(LookupBase):
             b_path = to_bytes(path, errors='surrogate_or_strict')
             chars = _gen_candidate_chars(params['chars'])
 
-            b_pathdir = os.path.dirname(b_path)
-            makedirs_safe(b_pathdir, mode=0o700)
-
+            content = None
             changed = False
-            content = _read_password_file(b_path)
+            if b_path != to_bytes('/dev/null'):
+                b_pathdir = os.path.dirname(b_path)
+                makedirs_safe(b_pathdir, mode=0o700)
+                content = _read_password_file(b_path)
 
             if content is None or b_path == to_bytes('/dev/null'):
                 plaintext_password = random_password(params['length'], chars)

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -285,15 +285,15 @@ def _get_lock(b_path):
             if e.strerror != 'File exists':
                 raise
 
-    timeout = 0
+    counter = 0
     # if the lock is got by other process, wait until it's released
     while os.path.exists(lockfile) and not first_process:
-        timeout += 1
-        time.sleep(0.1)
-        if timeout > 20:
-            raise AnsibleError("Password lookup cannot get the lock in 2 seconds, abort..."
+        time.sleep(2 ** counter)
+        if counter >= 2:
+            raise AnsibleError("Password lookup cannot get the lock in 7 seconds, abort..."
                                "This may caused by un-removed lockfile"
                                "you can manually remove it from controller machine at %s and try again" % lockfile)
+        counter += 1
     return first_process, lockfile
 
 

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -104,7 +104,7 @@ from ansible.utils.path import makedirs_safe
 
 DEFAULT_LENGTH = 20
 VALID_PARAMS = frozenset(('length', 'encrypt', 'chars'))
-LOCKFILE_NAME = "ansible_lookup_password.lockfile"
+LOCKFILE_NAME = to_bytes("ansible_lookup_password.lockfile")
 
 
 def _parse_parameters(term):

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -298,7 +298,7 @@ class LookupModule(LookupBase):
                             timeout += 1
                             if timeout > 20:
                                 raise AnsibleError("Password lookup cannot get the lock in 2 seconds, abort..."
-                                                   "This may caused by un-removed lockfile, you can manually remove it at %s and try again" % lockfile)
+                                                   "This may caused by un-removed lockfile, you can manually remove it from controller machine at %s and try again" % lockfile)
                     else:
                         raise
             if not writer_process:

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -473,7 +473,7 @@ class TestLookupModule(unittest.TestCase):
             with patch.object(builtins, 'open', mock_open(read_data=b'hunter42 salt=87654321\n')) as m:
                 # should timeout here
                 results = self.password_lookup.run([u'/path/to/somewhere chars=anything'], None)
-                self.fail('Lookup didnt timeout when lock already been held, testcase failed')
+                self.fail("Lookup didn't timeout when lock already been held")
         except AnsibleError:
             pass
 
@@ -485,7 +485,7 @@ class TestLookupModule(unittest.TestCase):
                 # should not timeout here
                 results = self.password_lookup.run([u'/path/to/somewhere chars=anything'], None)
         except AnsibleError:
-            self.fail('Lookup timeouts when lock is free, testcase failed')
+            self.fail('Lookup timeouts when lock is free')
 
         for result in results:
             self.assertEqual(result, u'hunter42')

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -29,6 +29,7 @@ from ansible.compat.tests.mock import mock_open, patch
 from ansible.errors import AnsibleError
 from ansible.module_utils.six import text_type
 from ansible.module_utils.six.moves import builtins
+from ansible.module_utils._text import to_bytes
 from ansible.plugins.loader import PluginLoader
 from ansible.plugins.lookup import password
 from ansible.utils import encrypt
@@ -372,6 +373,14 @@ class TestLookupModule(unittest.TestCase):
         self.fake_loader = DictDataLoader({'/path/to/somewhere': 'sdfsdf'})
         self.password_lookup = password.LookupModule(loader=self.fake_loader)
         self.os_path_exists = password.os.path.exists
+        self.os_open = password.os.open
+        password.os.open = lambda path, flag: None
+        self.os_close = password.os.close
+        password.os.close = lambda fd: None
+        self.os_remove = password.os.remove
+        password.os.remove = lambda path: None
+        self.makedirs_safe = password.makedirs_safe
+        password.makedirs_safe = lambda path, mode: None
 
         # Different releases of passlib default to a different number of rounds
         self.sha256 = passlib.registry.get_crypt_handler('pbkdf2_sha256')
@@ -380,6 +389,10 @@ class TestLookupModule(unittest.TestCase):
 
     def tearDown(self):
         password.os.path.exists = self.os_path_exists
+        password.os.open = self.os_open
+        password.os.close = self.os_close
+        password.os.remove = self.os_remove
+        password.makedirs_safe = self.makedirs_safe
         passlib.registry.register_crypt_handler(self.sha256, force=True)
 
     @patch.object(PluginLoader, '_get_paths')
@@ -425,7 +438,7 @@ class TestLookupModule(unittest.TestCase):
     @patch('ansible.plugins.lookup.password._write_password_file')
     def test_password_already_created_encrypt(self, mock_get_paths, mock_write_file):
         mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
-        password.os.path.exists = lambda x: True
+        password.os.path.exists = lambda x: True if x == to_bytes('/path/to/somewhere') else False
 
         with patch.object(builtins, 'open', mock_open(read_data=b'hunter42 salt=87654321\n')) as m:
             results = self.password_lookup.run([u'/path/to/somewhere chars=anything encrypt=pbkdf2_sha256'], None)
@@ -436,7 +449,7 @@ class TestLookupModule(unittest.TestCase):
     @patch('ansible.plugins.lookup.password._write_password_file')
     def test_password_already_created_no_encrypt(self, mock_get_paths, mock_write_file):
         mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
-        password.os.path.exists = lambda x: True
+        password.os.path.exists = lambda x: True if x == to_bytes('/path/to/somewhere') else False
 
         with patch.object(builtins, 'open', mock_open(read_data=b'hunter42 salt=87654321\n')) as m:
             results = self.password_lookup.run([u'/path/to/somewhere chars=anything'], None)

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -438,7 +438,7 @@ class TestLookupModule(unittest.TestCase):
     @patch('ansible.plugins.lookup.password._write_password_file')
     def test_password_already_created_encrypt(self, mock_get_paths, mock_write_file):
         mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
-        password.os.path.exists = lambda x: True if x == to_bytes('/path/to/somewhere') else False
+        password.os.path.exists = lambda x: x == to_bytes('/path/to/somewhere')
 
         with patch.object(builtins, 'open', mock_open(read_data=b'hunter42 salt=87654321\n')) as m:
             results = self.password_lookup.run([u'/path/to/somewhere chars=anything encrypt=pbkdf2_sha256'], None)
@@ -449,7 +449,7 @@ class TestLookupModule(unittest.TestCase):
     @patch('ansible.plugins.lookup.password._write_password_file')
     def test_password_already_created_no_encrypt(self, mock_get_paths, mock_write_file):
         mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
-        password.os.path.exists = lambda x: True if x == to_bytes('/path/to/somewhere') else False
+        password.os.path.exists = lambda x: x == to_bytes('/path/to/somewhere')
 
         with patch.object(builtins, 'open', mock_open(read_data=b'hunter42 salt=87654321\n')) as m:
             results = self.password_lookup.run([u'/path/to/somewhere chars=anything'], None)
@@ -477,7 +477,7 @@ class TestLookupModule(unittest.TestCase):
         except AnsibleError:
             pass
         # pretend now there is password file but no lock
-        password.os.path.exists = lambda x: True if x == to_bytes('/path/to/somewhere') else False
+        password.os.path.exists = lambda x: x == to_bytes('/path/to/somewhere')
         try:
             with patch.object(builtins, 'open', mock_open(read_data=b'hunter42 salt=87654321\n')) as m:
                 # should not timeout here


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Password lookup will face race conditions when running parallelly, this PR use atomic file creation to solve the race condition.
Fix #37116 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ansible/lib/ansible/plugins/lookup/password.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (issue_37116 23c68b7ad2) last updated 2018/07/09 15:57:37 (GMT -400)
  config file = None
  configured module search path = [u'/home/zhikangzhang/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/zhikangzhang/Desktop/ansible/lib/ansible
  executable location = /home/zhikangzhang/Desktop/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

NOTE:
1. use os.open() with os.O_CREAT|os.O_EXCL to check existence
and create a lock file if not exists, it's an atomic operation
2. the fastest process will create the lock file and others will
wait until the lock file is removed
3. after the writer finished writing to the password file, all the reading
operations use built-in open so processes can read the file parallel