### PR TITLE
[backport-2.6] meraki_network - Added proper response documentation (#42393)

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -91,18 +91,43 @@ RETURN = r'''
 data:
     description: Information about the created or manipulated object.
     returned: info
-    type: list
-    sample:
-        [
-            {
-                "id": "N_12345",
-                "name": "YourNetwork",
-                "organizationId": "0987654321",
-                "tags": " production ",
-                "timeZone": "America/Chicago",
-                "type": "switch"
-            }
-        ]
+    type: complex
+    contains:
+      id:
+        description: Identification string of network.
+        returned: success
+        type: string
+        sample: N_12345
+      name:
+        description: Written name of network.
+        returned: success
+        type: string
+        sample: YourNet
+      organizationId:
+        description: Organization ID which owns the network.
+        returned: success
+        type: string
+        sample: 0987654321
+      tags:
+        description: Space delimited tags assigned to network.
+        returned: success
+        type: string
+        sample: " production wireless "
+      timeZone:
+        description: Timezone where network resides.
+        returned: success
+        type: string
+        sample: America/Chicago
+      type:
+        description: Functional type of network.
+        returned: success
+        type: string
+        sample: switch
+      disableMyMerakiCom:
+        description: States whether U(my.meraki.com) and other device portals should be disabled.
+        returned: success
+        type: bool
+        sample: true
 '''
 
 import os


### PR DESCRIPTION
##### SUMMARY
* Added proper response documentation to meraki_network

* Missing colon

(cherry picked from commit c644e3da79061189fd951e81158b11c043401b17)

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
meraki_network

##### ANSIBLE VERSION
```
ansible 2.6.1 (backport/2.6/42393 61666bd37a) last updated 2018/07/09 08:07:56 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION
The following playbook will generate this information.
```
- name: Create network with type switch
  meraki_network:
    auth_key: abc123
    state: present
    org_name: YourOrg
    net_name: IntTestNetworkSwitch
    type: switch
    timezone: America/Chicago
```
