### PR TITLE
Accelerated networking ip forwarding

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -193,6 +193,7 @@ options:
             - ip_forwarding
         type: bool
         default: 'no'
+        version_added: 2.7
 extends_documentation_fragment:
     - azure
     - azure_tags

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -185,6 +185,14 @@ options:
             - When a default security group is created for a Linux host a rule will be added allowing inbound TCP
               connections to the default SSH port 22, and for a Windows host rules will be added allowing inbound
               access to RDP ports 3389 and 5986. Override the default ports by providing a list of open ports.
+    enable_ip_forwarding:
+        description:
+            - This disable's Azure's check on the source and destination IPs for a network interface,
+              allowing VMs attached to this network interface to route traffic to interfaces other than its own
+        aliases:
+            - ip_forwarding
+        type: bool
+        default: 'no'
 extends_documentation_fragment:
     - azure
     - azure_tags
@@ -290,6 +298,7 @@ state:
             "internal_dns_name_label": null,
             "internal_fqdn": null
         },
+        "enable_accelerated_networking": false,
         "enable_ip_forwarding": false,
         "etag": 'W/"be115a43-2148-4545-a324-f33ad444c926"',
         "id": "/subscriptions/XXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXX/resourceGroups/Testing/providers/Microsoft.Network/networkInterfaces/nic003",

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -415,6 +415,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             ip_configurations=dict(type='list', default=None, elements='dict', options=ip_configuration_spec),
             os_type=dict(type='str', choices=['Windows', 'Linux'], default='Linux'),
             open_ports=dict(type='list'),
+            enable_ip_forwarding=dict(type='bool', default=False),
         )
 
         required_if = [
@@ -439,6 +440,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
         self.os_type = None
         self.open_ports = None
         self.ip_configurations = None
+        self.enable_ip_forwarding = None
 
         self.results = dict(
             changed=False,
@@ -540,6 +542,10 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                     self.log("CHANGED: network interface {0} ip configurations".format(self.name))
                     changed = True
 
+                if self.enable_ip_forwarding != results['enable_ip_forwarding']:
+                    self.log("CHANGED: network interface {0} ip forwarding".format(self.name))
+                    changed = True
+
             elif self.state == 'absent':
                 self.log("CHANGED: network interface {0} exists but requested state is 'absent'".format(self.name))
                 changed = True
@@ -591,7 +597,8 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                     tags=self.tags,
                     ip_configurations=nic_ip_configurations,
                     enable_accelerated_networking=self.enable_accelerated_networking,
-                    network_security_group=nsg
+                    network_security_group=nsg,
+                    enable_ip_forwarding=self.enable_ip_forwarding
                 )
                 self.results['state'] = self.create_or_update_nic(nic)
             elif self.state == 'absent':

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -185,12 +185,16 @@ options:
             - When a default security group is created for a Linux host a rule will be added allowing inbound TCP
               connections to the default SSH port 22, and for a Windows host rules will be added allowing inbound
               access to RDP ports 3389 and 5986. Override the default ports by providing a list of open ports.
+    enable_accelerated_networking:
+        description:
+            - This enables accelerated networking on the network interface
+        type: bool
+        default: 'no'
+        version_added: 2.7
     enable_ip_forwarding:
         description:
             - This disable's Azure's check on the source and destination IPs for a network interface,
               allowing VMs attached to this network interface to route traffic to interfaces other than its own
-        aliases:
-            - ip_forwarding
         type: bool
         default: 'no'
         version_added: 2.7
@@ -550,6 +554,10 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                 ip_configuration_request = self.construct_ip_configuration_set(self.ip_configurations)
                 if ip_configuration_result != ip_configuration_request:
                     self.log("CHANGED: network interface {0} ip configurations".format(self.name))
+                    changed = True
+
+                if self.enable_accelerated_networking != results['enable_accelerated_networking']:
+                    self.log("CHANGED: network interface {0} accelerated networking".format(self.name))
                     changed = True
 
                 if self.enable_ip_forwarding != results['enable_ip_forwarding']:

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -516,19 +516,19 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
 
                 if not changed:
                     nsg = self.get_security_group(self.security_group['resource_group'], self.security_group['name'])
-                    if nsg and results.get('network_security_group') and results['network_security_group'].get('id') != nsg.id:
+                    if nsg and results.get('network_security_group') and results['network_security_group'].get('id').lower() != nsg.id.lower():
                         self.log("CHANGED: network interface {0} network security group".format(self.name))
                         changed = True
 
-                if results['ip_configurations'][0]['subnet']['virtual_network_name'] != self.virtual_network['name']:
+                if results['ip_configurations'][0]['subnet']['virtual_network_name'].lower() != self.virtual_network['name'].lower():
                     self.log("CHANGED: network interface {0} virtual network name".format(self.name))
                     changed = True
 
-                if results['ip_configurations'][0]['subnet']['resource_group'] != self.virtual_network['resource_group']:
+                if results['ip_configurations'][0]['subnet']['resource_group'].lower() != self.virtual_network['resource_group'].lower():
                     self.log("CHANGED: network interface {0} virtual network resource group".format(self.name))
                     changed = True
 
-                if results['ip_configurations'][0]['subnet']['name'] != self.subnet_name:
+                if results['ip_configurations'][0]['subnet']['name'].lower() != self.subnet_name.lower():
                     self.log("CHANGED: network interface {0} subnet name".format(self.name))
                     changed = True
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -530,19 +530,19 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
 
                 if not changed:
                     nsg = self.get_security_group(self.security_group['resource_group'], self.security_group['name'])
-                    if nsg and results.get('network_security_group') and results['network_security_group'].get('id').lower() != nsg.id.lower():
+                    if nsg and results.get('network_security_group') and results['network_security_group'].get('id') != nsg.id:
                         self.log("CHANGED: network interface {0} network security group".format(self.name))
                         changed = True
 
-                if results['ip_configurations'][0]['subnet']['virtual_network_name'].lower() != self.virtual_network['name'].lower():
+                if results['ip_configurations'][0]['subnet']['virtual_network_name'] != self.virtual_network['name']:
                     self.log("CHANGED: network interface {0} virtual network name".format(self.name))
                     changed = True
 
-                if results['ip_configurations'][0]['subnet']['resource_group'].lower() != self.virtual_network['resource_group'].lower():
+                if results['ip_configurations'][0]['subnet']['resource_group'] != self.virtual_network['resource_group']:
                     self.log("CHANGED: network interface {0} virtual network resource group".format(self.name))
                     changed = True
 
-                if results['ip_configurations'][0]['subnet']['name'].lower() != self.subnet_name.lower():
+                if results['ip_configurations'][0]['subnet']['name'] != self.subnet_name:
                     self.log("CHANGED: network interface {0} subnet name".format(self.name))
                     changed = True
 

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -126,6 +126,234 @@
       - output.changed
       - output.state.ip_configuration.subnet.name == 'tn{{ rpfx }}'
 
+- name: Enable accelerated networking on NIC (check mode)
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
+      public_ip_allocation_method: Static
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      enable_accelerated_networking: yes
+  register: output
+  check_mode: yes
+
+- assert:
+    that:
+      - output.changed
+
+- name: Enable accelerated networking on NIC
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
+      public_ip_allocation_method: Static
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      enable_accelerated_networking: yes
+  register: output
+
+- assert:
+    that:
+      - output.changed
+      - output.state.enable_accelerated_networking
+
+- name: Enable accelerated networking on NIC (idempotent)
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
+      public_ip_allocation_method: Static
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      enable_accelerated_networking: yes
+  register: output
+
+- assert:
+    that:
+      - not output.changed
+      - output.state.enable_accelerated_networking
+
+- name: Disable accelerated networking on NIC (check mode)
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
+      public_ip_allocation_method: Static
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      enable_accelerated_networking: no
+  register: output
+  check_mode: yes
+
+- assert:
+    that:
+      - output.changed
+
+- name: Disable accelerated networking on NIC
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
+      public_ip_allocation_method: Static
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      enable_accelerated_networking: no
+  register: output
+
+- assert:
+    that:
+      - output.changed
+      - not output.state.enable_accelerated_networking
+
+- name: Disable accelerated networking on NIC (idempotent)
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
+      public_ip_allocation_method: Static
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      enable_accelerated_networking: no
+  register: output
+
+- assert:
+    that:
+      - not output.changed
+      - not output.state.enable_accelerated_networking
+
+- name: Enable IP forwarding on NIC (check mode)
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
+      public_ip_allocation_method: Static
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      enable_ip_forwarding: yes
+  register: output
+  check_mode: yes
+
+- assert:
+    that:
+      - output.changed
+
+- name: Enable IP forwarding on NIC
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
+      public_ip_allocation_method: Static
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      enable_ip_forwarding: yes
+  register: output
+
+- assert:
+    that:
+      - output.changed
+      - output.state.enable_ip_forwarding
+
+- name: Enable IP forwarding on NIC (idempotent)
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
+      public_ip_allocation_method: Static
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      enable_ip_forwarding: yes
+  register: output
+
+- assert:
+    that:
+      - not output.changed
+      - output.state.enable_ip_forwarding
+
+- name: Disable IP forwarding on NIC (check mode)
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
+      public_ip_allocation_method: Static
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      enable_ip_forwarding: no
+  register: output
+  check_mode: yes
+
+- assert:
+    that:
+      - output.changed
+
+- name: Disable IP forwarding on NIC
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
+      public_ip_allocation_method: Static
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      enable_ip_forwarding: no
+  register: output
+
+- assert:
+    that:
+      - output.changed
+      - not output.state.enable_ip_forwarding
+
+- name: Disable IP forwarding on NIC (idempotent)
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
+      public_ip_allocation_method: Static
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      enable_ip_forwarding: no
+  register: output
+
+- assert:
+    that:
+      - not output.changed
+      - not output.state.enable_ip_forwarding
+
 - name: Update the NIC with mutilple ip configurations (check mode)
   azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Reopening to trigger another CI run as the last one timed out. 

Adds options for configuring accelerated networking and ip forwarding on AzureRm network interfaces

Additionally makes the string comparisons for:
 - Virtual network names
 - Resource group names
 - Network security group IDs
 - Subnet names

Case insensitive, because Azure is case insensitive about those values. Without this the module was not idempotent, and was changing every time when given a vNet name that had a different case than Azure was returning.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
`azure_rm_networkinterface`
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (accelerated-networking-ip-forwarding 488c4ed9b9) last updated 2018/07/03 14:36:55 (GMT -500)
  config file = None
  configured module search path = [u'/Users/tgregory/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/tgregory/Code/ansible/lib/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```