### PR TITLE
Remove unwanted containers at CI job start.

### DIFF
--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -12,6 +12,12 @@ test="$1"
 docker images ansible/ansible
 docker ps
 
+for container in $(docker ps --format '{{.Image}} {{.ID}}' | grep -v '^drydock/' | sed 's/^.* //'); do
+    docker rm -f "${container}"
+done
+
+docker ps
+
 if [ -d /home/shippable/cache/ ]; then
     ls -la /home/shippable/cache/
 fi


### PR DESCRIPTION
##### SUMMARY

Remove unwanted containers at CI job start.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Shippable

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (container-cleanup c305f5c6e6) last updated 2018/07/09 21:07:55 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
