### PR TITLE
dnsimple: refactor dnsimple module

### DIFF
--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -659,8 +659,6 @@ lib/ansible/modules/net_tools/basics/uri.py E326
 lib/ansible/modules/net_tools/cloudflare_dns.py E317
 lib/ansible/modules/net_tools/cloudflare_dns.py E325
 lib/ansible/modules/net_tools/cloudflare_dns.py E327
-lib/ansible/modules/net_tools/dnsimple.py E325
-lib/ansible/modules/net_tools/dnsimple.py E327
 lib/ansible/modules/net_tools/haproxy.py E317
 lib/ansible/modules/net_tools/haproxy.py E324
 lib/ansible/modules/net_tools/haproxy.py E325


### PR DESCRIPTION

##### SUMMARY
* Update dnsimple-python minimum version to 1.0.0 as it supports API v2 and API v1 is deprecated.
* Update examples.
* Update documentation.

Fixes: #42495

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/net_tools/dnsimple.py

##### ANSIBLE VERSION
```
2.7-devel
```