### PR TITLE
run ovs tests on centos/rhel

### DIFF
--- a/test/integration/targets/openvswitch_db/tests/basic.yaml
+++ b/test/integration/targets/openvswitch_db/tests/basic.yaml
@@ -2,10 +2,12 @@
 
 - name: Make sure test bridge does not exist before tests
   command: ovs-vsctl del-br br-test
+  become: yes
   ignore_errors: yes
 
 - name: Create test bridge
   command: ovs-vsctl add-br br-test
+  become: yes
 
 - name: Create bridge
   openvswitch_db:
@@ -14,6 +16,7 @@
     col: other_config
     key: disable-in-band
     value: true
+  become: yes
   register: result
 
 - assert:
@@ -27,6 +30,7 @@
     col: other_config
     key: disable-in-band
     value: true
+  become: yes
   register: result
 
 - assert:
@@ -40,6 +44,7 @@
     col: other_config
     key: disable-in-band
     value: false
+  become: yes
   register: result
 
 - assert:
@@ -53,6 +58,7 @@
     col: other_config
     key: disable-in-band
     value: false
+  become: yes
   register: result
 
 - assert:
@@ -67,6 +73,7 @@
     key: disable-in-band
     value: false
     state: absent
+  become: yes
   register: result
 
 - assert:
@@ -81,6 +88,7 @@
     key: disable-in-band
     value: false
     state: absent
+  become: yes
   register: result
 
 - assert:
@@ -89,3 +97,4 @@
 
 - name: Tear down test bridge
   command: ovs-vsctl del-br br-test
+  become: yes

--- a/test/integration/targets/prepare_ovs_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_ovs_tests/tasks/main.yml
@@ -1,9 +1,17 @@
 ---
+# No easy way to know OS type without python or without ansible facts.
+# Run below raw commands and one would succeed with apt/yum on debian/centos
+- name: Install python
+  raw:
+    test -e /usr/bin/python || (apt-get -y update && apt-get install -y python-minimal)
+  become: yes
+  ignore_errors: yes
 
 - name: Install python
   raw:
-    test -e /usr/bin/python || apt-get -y update && apt-get install -y python-minimal
+    test -e /usr/bin/python || (yum -y update && yum install -y python)
   become: yes
+  ignore_errors: yes
 
 # network-integration test are ran with gather_facts: no
 # We need to explicitly call setup so ansible_distribution is set


### PR DESCRIPTION
##### SUMMARY
- Fix issue in task "Install python" which was installing python even if it was already installed. It will install python if not already installed on centos also.

- ovs rpm in installed with root access so we need root privilege to run ovs operations

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

openvswitch
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```