### PR TITLE
Fix ios_linkagg issue #42511

### DIFF
--- a/lib/ansible/modules/network/ios/ios_linkagg.py
+++ b/lib/ansible/modules/network/ios/ios_linkagg.py
@@ -227,7 +227,7 @@ def parse_members(module, config, group):
 
 
 def get_channel(module, config, group):
-    match = re.findall(r'interface (\S+)', config, re.M)
+    match = re.findall(r'^interface (\S+)', config, re.M)
 
     if not match:
         return {}


### PR DESCRIPTION
##### SUMMARY
- Fixes #42511 
- With this fix ios_linkagg picks up correct interfaces

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ios_linkagg.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```

