### PR TITLE
Fix list k8s objects

### DIFF
--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -87,6 +87,8 @@ class KubernetesRawModule(KubernetesAnsibleModule):
             api_version = definition.get('apiVersion')
             resource = self.find_resource(search_kind, api_version, fail=True)
             definition['kind'] = resource.kind
+            if kind.lower().endswith('list'):
+                definition['kind'] += 'list'
             definition['apiVersion'] = resource.group_version
             result = self.perform_action(resource, definition)
             changed = changed or result['changed']


### PR DESCRIPTION
##### SUMMARY
When the k8s module is used to retrieve object information, it seems to ignore the list suffix to kind attributes.
This pull fixes the issue

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
k8s_raw

##### ANSIBLE VERSION
```
 ansible 2.6.1
  config file = /home/dev/cluster-dev/ansible/ansible.cfg
  configured module search path = ['/home/dev/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules', '/home/dev/cluster-dev/ansible/library/tools']
  ansible python module location = /home/dev/cluster-dev/dev-env/lib/python3.6/site-packages/ansible
  executable location = /home/dev/cluster-dev/dev-env/bin/ansible
  python version = 3.6.3 (default, Nov 21 2017, 14:55:19) [GCC 6.4.0]
```


##### ADDITIONAL INFORMATION
