### PR TITLE
Display task banner before showing file diff

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -207,6 +207,9 @@ class CallbackModule(CallbackBase):
         self._display.banner(msg)
 
     def v2_on_file_diff(self, result):
+        if self._last_task_banner != result._task._uuid:
+            self._print_task_banner(result._task)
+
         if result._task.loop and 'results' in result._result:
             for res in result._result['results']:
                 if 'diff' in res and res['diff'] and res.get('changed', False):


### PR DESCRIPTION
##### SUMMARY
When using `--diff` and `DISPLAY_SKIPPED_HOSTS=no`, the file diff would show up before the task banner. This is another follow-up to #41058

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`default` callback plugin

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (merge_stdout_callbacks_3 b12d6082fa) last updated 2018/07/10 07:59:44 (GMT -500)
```

##### ADDITIONAL INFORMATION
N/A