### PR TITLE
ovirt_affinity_lables_facts: Raise error when host/vm not found

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_affinity_label_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_affinity_label_facts.py
@@ -98,6 +98,7 @@ from ansible.module_utils.ovirt import (
     create_connection,
     get_dict_of_struct,
     ovirt_facts_full_argument_spec,
+    search_by_name,
 )
 
 
@@ -127,6 +128,8 @@ def main():
             ])
         if module.params['host']:
             hosts_service = connection.system_service().hosts_service()
+            if search_by_name(hosts_service, module.params['host']) is None:
+                raise Exception("Host '%s' was not found." % module.params['host'])
             labels.extend([
                 label
                 for label in all_labels
@@ -135,6 +138,8 @@ def main():
             ])
         if module.params['vm']:
             vms_service = connection.system_service().vms_service()
+            if search_by_name(vms_service, module.params['vm']) is None:
+                raise Exception("Vm '%s' was not found." % module.params['vm'])
             labels.extend([
                 label
                 for label in all_labels


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When virtual machine or host is not found for affinity lable, we should raise error so user knows it don't exists and he has typo most probably.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt_affinity_label_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.2
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
