### PR TITLE
Ensure openshift dependency is also installed on test runner

### DIFF
--- a/test/integration/targets/k8s/tasks/main.yml
+++ b/test/integration/targets/k8s/tasks/main.yml
@@ -2,6 +2,11 @@
   pip:
     name: openshift
 
+- name: Install requirements on localhost
+  pip:
+    name: openshift
+  delegate_to: localhost
+
 # TODO: This is the only way I could get the kubeconfig, I don't know why. Running the lookup outside of debug seems to return an empty string
 - debug: msg={{ lookup('env', 'K8S_AUTH_KUBECONFIG') }}
   register: kubeconfig


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes failing k8s test by ensuring openshift dependency is installed on test runner

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
k8s
