### PR TITLE
katello.rb - fail with clear error when issues opening manifest to be uploaded

### DIFF
--- a/lib/ansible/modules/remote_management/foreman/katello.py
+++ b/lib/ansible/modules/remote_management/foreman/katello.py
@@ -226,8 +226,12 @@ class NailGun(object):
         try:
             file = open(os.getcwd() + params['content'], 'r')
             content = file.read()
+        except Exception as e:
+            self._module.fail_json(msg="Manifest import failed with %s" % to_native(e),
+                                   exception=traceback.format_exc())
         finally:
-            file.close()
+            if file:
+                file.close()
 
         manifest = self._entities.Subscription(self._server)
 


### PR DESCRIPTION
##### SUMMARY
Currently if there is an issue opening a specified manifest file to upload then you get a cryptic error such as:

```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_nbJlxo/ansible_module_katello.py", line 520, in <module>
    main()
  File "/tmp/ansible_nbJlxo/ansible_module_katello.py", line 497, in main
    result = ng.manifest(params)
  File "/tmp/ansible_nbJlxo/ansible_module_katello.py", line 230, in manifest
    file.close()
UnboundLocalError: local variable 'file' referenced before assignment

fatal: [localhost -> localhost]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_nbJlxo/ansible_module_katello.py\", line 520, in <module>\n    main()\n  File \"/tmp/ansible_nbJlxo/ansible_module_katello.py\", line 497, in main\n    result = ng.manifest(params)\n  File \"/tmp/ansible_nbJlxo/ansible_module_katello.py\", line 230, in manifest\n    file.close()\nUnboundLocalError: local variable 'file' referenced before assignment\n",
    "module_stdout": "",
    "rc": 1
}

MSG:

MODULE FAILURE
```

This is due to the fact that the file is failing to open and thus the variable is never initialized and so the file close fails.

<!--- Describe the change, including rationale and design decisions -->

The fix is to both verify the `file` variable exists before trying to close it and also handle the exception better when a file does not exist.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module: `katello`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```


##### ADDITIONAL INFORMATION

Before:
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_nbJlxo/ansible_module_katello.py", line 520, in <module>
    main()
  File "/tmp/ansible_nbJlxo/ansible_module_katello.py", line 497, in main
    result = ng.manifest(params)
  File "/tmp/ansible_nbJlxo/ansible_module_katello.py", line 230, in manifest
    file.close()
UnboundLocalError: local variable 'file' referenced before assignment

fatal: [localhost -> localhost]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_nbJlxo/ansible_module_katello.py\", line 520, in <module>\n    main()\n  File \"/tmp/ansible_nbJlxo/ansible_module_katello.py\", line 497, in main\n    result = ng.manifest(params)\n  File \"/tmp/ansible_nbJlxo/ansible_module_katello.py\", line 230, in manifest\n    file.close()\nUnboundLocalError: local variable 'file' referenced before assignment\n",
    "module_stdout": "",
    "rc": 1
}

MSG:

MODULE FAILURE
```

After:
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_ActNll/ansible_module_katello.py", line 227, in manifest
    file = open(os.getcwd() + params['content'], 'r')
IOError: [Errno 2] No such file or directory: '/root/ansible-redhat_satellite6/playbooks/root/manifest_IAN_TEST_20180708T164433Z.zip'

fatal: [localhost -> localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "action": null,
            "entity": "manifest",
            "params": {
                "content": "/root/manifest_IAN_TEST_20180708T164433Z.zip",
                "name": "IanTest",
                "organization": 13,
                "src": "/root/manifest_IAN_TEST_20180708T164433Z.zip"
            },
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "server_url": "https://satellite.rhc-lab.iad.redhat.com",
            "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "verify_ssl": false
        }
    }
}

MSG:

Manifest import failed with [Errno 2] No such file or directory: '/root/ansible-redhat_satellite6/playbooks/root/manifest_IAN_TEST_20180708T164433Z.zip'
```
