### PR TITLE
Fix openshift integration test requirements.

### DIFF
--- a/test/integration/targets/k8s/tasks/main.yml
+++ b/test/integration/targets/k8s/tasks/main.yml
@@ -1,12 +1,3 @@
-- name: Install requirements
-  pip:
-    name: openshift
-
-- name: Install requirements on localhost
-  pip:
-    name: openshift
-  delegate_to: localhost
-
 # TODO: This is the only way I could get the kubeconfig, I don't know why. Running the lookup outside of debug seems to return an empty string
 - debug: msg={{ lookup('env', 'K8S_AUTH_KUBECONFIG') }}
   register: kubeconfig

--- a/test/runner/requirements/integration.cloud.openshift.txt
+++ b/test/runner/requirements/integration.cloud.openshift.txt
@@ -1,0 +1,1 @@
+openshift


### PR DESCRIPTION
##### SUMMARY

Fix openshift integration test requirements.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

openshift integration tests

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (k8s-fix 9d2c56eff4) last updated 2018/07/10 09:56:12 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
