### PR TITLE
Add boilerplate from __future__ and type declarations

### DIFF
--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2018, Ansible Project
 # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import errno
 import os
 import stat
@@ -29,7 +32,7 @@ class LockTimeout(Exception):
     pass
 
 
-class FileLock():
+class FileLock:
     '''
     Currently FileLock is implemented via fcntl.flock on a lock file, however this
     behaviour may change in the future. Avoid mixing lock types fcntl.flock,


### PR DESCRIPTION
##### SUMMARY
By adding this, the FileLock class will be a new-style class.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/common/file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7.0
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
