### PR TITLE
VMware: Fixed vmware fact gathering when no physical interfaces have IP Addresses

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -355,7 +355,7 @@ def gather_vm_facts(content, vm):
             net_dict[device.macAddress] = list(device.ipAddress)
 
     if vm.guest.ipAddress:
-        if '::' in vm.guest.ipAddress:
+        if ':' in vm.guest.ipAddress:
             facts['ipv6'] = vm.guest.ipAddress
         else:
             facts['ipv4'] = vm.guest.ipAddress

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -354,13 +354,11 @@ def gather_vm_facts(content, vm):
         for device in vmnet:
             net_dict[device.macAddress] = list(device.ipAddress)
 
-    for dummy, v in iteritems(net_dict):
-        for ipaddress in v:
-            if ipaddress:
-                if '::' in ipaddress:
-                    facts['ipv6'] = ipaddress
-                else:
-                    facts['ipv4'] = ipaddress
+    if vm.guest.ipAddress:
+        if '::' in vm.guest.ipAddress:
+            facts['ipv6'] = vm.guest.ipAddress
+        else:
+            facts['ipv4'] = vm.guest.ipAddress
 
     ethernet_idx = 0
     for entry in vm.config.hardware.device:


### PR DESCRIPTION
…enter

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #42597 

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This changes the way the guest IP address is reported, using guest.ipAddress ensures that if vmware-tools is reporting it then it will get returned (In this specific case no IP for a specific physical interface but a virtual interface exists that vmware-tools detected and reports).

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
vmware_guest_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.x
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
