### PR TITLE
Disable get_url tests on RHEL, FreeBSD and OSX.

### DIFF
--- a/test/integration/targets/get_url/aliases
+++ b/test/integration/targets/get_url/aliases
@@ -1,2 +1,5 @@
 destructive
 posix/ci/group1
+skip/rhel
+skip/freebsd
+skip/osx


### PR DESCRIPTION
##### SUMMARY

Disable get_url tests on RHEL, FreeBSD and OSX.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

get_url integration test

##### ANSIBLE VERSION

```
ansible 2.4.6.0 (disable-test-2.4 c61b277a75) last updated 2018/07/10 15:30:14 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
