### PR TITLE
Update pagerduty modules to rest v2

### DIFF
--- a/lib/ansible/modules/monitoring/pagerduty.py
+++ b/lib/ansible/modules/monitoring/pagerduty.py
@@ -179,9 +179,9 @@ class PagerDutyRequest(object):
 
     def _create_services_payload(self, service):
         if (isinstance(service, list)):
-            return [{'id': s, 'type':'service_reference'} for s in service]
+            return [{'id': s, 'type': 'service_reference'} for s in service]
         else:
-            return [{'id': service, 'type':'service_reference'}]
+            return [{'id': service, 'type': 'service_reference'}]
 
     def _compute_start_end_time(self, hours, minutes):
         now = datetime.datetime.utcnow()

--- a/lib/ansible/modules/monitoring/pagerduty.py
+++ b/lib/ansible/modules/monitoring/pagerduty.py
@@ -38,7 +38,7 @@ options:
             - PagerDuty unique subdomain. Obsolete. It is not used with PagerDuty REST v2 API.
     user:
         description:
-            - PagerDuty user ID. Obsolete. Please, use token for authorization.
+            - PagerDuty user ID. Obsolete. Please, use I(token) for authorization.
     token:
         description:
             - A pagerduty token, generated on the pagerduty site. It is used for authorization.
@@ -55,7 +55,7 @@ options:
     window_id:
         description:
             - ID of maintenance window. Only needed when absent a maintenance_window.
-        version_added: '2.7.0'
+        version_added: "2.7"
     hours:
         description:
             - Length of maintenance window in hours.

--- a/lib/ansible/modules/monitoring/pagerduty.py
+++ b/lib/ansible/modules/monitoring/pagerduty.py
@@ -152,8 +152,11 @@ class PagerDutyRequest(object):
         self.token = token
 
     def ongoing(self, http_call=fetch_url):
-        url = "https://" + self.name + ".pagerduty.com/api/v1/maintenance_windows/ongoing"
-        headers = {"Authorization": self._auth_header()}
+        url = "https://api.pagerduty.com/maintenance_windows?filter=ongoing"
+        headers = {
+            "Authorization": self._auth_header(),
+            'Accept': 'application/vnd.pagerduty+json;version=2'
+        }
 
         response, info = http_call(self.module, url, headers=headers)
         if info['status'] != 200:

--- a/lib/ansible/modules/monitoring/pagerduty_alert.py
+++ b/lib/ansible/modules/monitoring/pagerduty_alert.py
@@ -28,10 +28,10 @@ options:
         description:
             - PagerDuty unique subdomain.
         required: true
-    service_key:
+    integration_key:
         description:
             - The GUID of one of your "Generic API" services.
-            - This is the "service key" listed on a Generic API's service detail page.
+            - This is the "integration key" listed on a "Integrations" tab of PagerDuty service.
         required: true
     state:
         description:
@@ -76,14 +76,14 @@ EXAMPLES = '''
 # Trigger an incident with just the basic options
 - pagerduty_alert:
     name: companyabc
-    service_key: xxx
+    integration_key: xxx
     api_key: yourapikey
     state: triggered
     desc: problem that led to this trigger
 
 # Trigger an incident with more options
 - pagerduty_alert:
-    service_key: xxx
+    integration_key: xxx
     api_key: yourapikey
     state: triggered
     desc: problem that led to this trigger
@@ -93,7 +93,7 @@ EXAMPLES = '''
 
 # Acknowledge an incident based on incident_key
 - pagerduty_alert:
-    service_key: xxx
+    integration_key: xxx
     api_key: yourapikey
     state: acknowledged
     incident_key: somekey
@@ -101,7 +101,7 @@ EXAMPLES = '''
 
 # Resolve an incident based on incident_key
 - pagerduty_alert:
-    service_key: xxx
+    integration_key: xxx
     api_key: yourapikey
     state: resolved
     incident_key: somekey
@@ -111,23 +111,31 @@ import json
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.six.moves.urllib.parse import urlparse, urlencode, urlunparse
 
 
-def check(module, name, state, service_key, api_key, incident_key=None):
-    url = "https://%s.pagerduty.com/api/v1/incidents" % name
+def check(module, name, state, service_id, integration_key, api_key, incident_key=None, http_call=fetch_url):
+    url = 'https://api.pagerduty.com/incidents'
     headers = {
         "Content-type": "application/json",
-        "Authorization": "Token token=%s" % api_key
+        "Authorization": "Token token=%s" % api_key,
+        'Accept': 'application/vnd.pagerduty+json;version=2'
     }
 
-    data = {
-        "service_key": service_key,
-        "incident_key": incident_key,
-        "sort_by": "incident_number:desc"
+    params = {
+        'service_ids[]': service_id,
+        'sort_by': 'incident_number:desc',
+        'time_zone': 'UTC'
     }
+    if incident_key:
+        params['incident_key'] = incident_key
 
-    response, info = fetch_url(module, url, method='get',
-                               headers=headers, data=json.dumps(data))
+    url_parts = list(urlparse(url))
+    url_parts[4] = urlencode(params, True)
+
+    url = urlunparse(url_parts)
+
+    response, info = http_call(module, url, method='get', headers=headers)
 
     if info['status'] != 200:
         module.fail_json(msg="failed to check current incident status."
@@ -168,7 +176,8 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(required=True),
-            service_key=dict(required=True),
+            service_id=dict(required=True),
+            integration_key=dict(require=True),
             api_key=dict(required=True),
             state=dict(required=True,
                        choices=['triggered', 'acknowledged', 'resolved']),
@@ -181,7 +190,8 @@ def main():
     )
 
     name = module.params['name']
-    service_key = module.params['service_key']
+    service_id = module.params['service_id']
+    integration_key = module.params['integration_key']
     api_key = module.params['api_key']
     state = module.params['state']
     client = module.params['client']
@@ -201,11 +211,11 @@ def main():
         module.fail_json(msg="incident_key is required for "
                              "acknowledge or resolve events")
 
-    out, changed = check(module, name, state,
-                         service_key, api_key, incident_key)
+    out, changed = check(module, name, state, service_id,
+                         integration_key, api_key, incident_key)
 
     if not module.check_mode and changed is True:
-        out = send_event(module, service_key, event_type, desc,
+        out = send_event(module, integration_key, event_type, desc,
                          incident_key, client, client_url)
 
     module.exit_json(result=out, changed=changed)

--- a/lib/ansible/modules/monitoring/pagerduty_alert.py
+++ b/lib/ansible/modules/monitoring/pagerduty_alert.py
@@ -31,13 +31,13 @@ options:
         description:
             - ID of PagerDuty service when incidents will be triggered, acknowledged or resolved.
         required: true
-        version_added: '2.7.0'
+        version_added: "2.7"
     integration_key:
         description:
             - The GUID of one of your "Generic API" services.
             - This is the "integration key" listed on a "Integrations" tab of PagerDuty service.
         required: true
-        version_added: '2.7.0'
+        version_added: "2.7"
     state:
         description:
             - Type of event to be sent.
@@ -67,7 +67,7 @@ options:
             - For C(acknowledged) or C(resolved) I(state) - This should be the incident_key you received back when the incident was first opened by a
               trigger event. Acknowledge events referencing resolved or nonexistent incidents will be discarded.
         required: false
-        version_added: '2.7.0'
+        version_added: "2.7"
     client:
         description:
         - The name of the monitoring client that is triggering this event.

--- a/lib/ansible/modules/monitoring/pagerduty_alert.py
+++ b/lib/ansible/modules/monitoring/pagerduty_alert.py
@@ -26,7 +26,10 @@ requirements:
 options:
     name:
         description:
-            - PagerDuty unique subdomain.
+            - PagerDuty unique subdomain. Obsolete. It is not used with PagerDuty REST v2 API.
+    service_id:
+        description:
+            - ID of PagerDuty service when incidents will be triggered, acknowledged or resolved.
         required: true
     integration_key:
         description:
@@ -78,6 +81,7 @@ EXAMPLES = '''
     name: companyabc
     integration_key: xxx
     api_key: yourapikey
+    service_id: PDservice
     state: triggered
     desc: problem that led to this trigger
 
@@ -85,6 +89,7 @@ EXAMPLES = '''
 - pagerduty_alert:
     integration_key: xxx
     api_key: yourapikey
+    service_id: PDservice
     state: triggered
     desc: problem that led to this trigger
     incident_key: somekey
@@ -95,6 +100,7 @@ EXAMPLES = '''
 - pagerduty_alert:
     integration_key: xxx
     api_key: yourapikey
+    service_id: PDservice
     state: acknowledged
     incident_key: somekey
     desc: "some text for incident's log"
@@ -103,6 +109,7 @@ EXAMPLES = '''
 - pagerduty_alert:
     integration_key: xxx
     api_key: yourapikey
+    service_id: PDservice
     state: resolved
     incident_key: somekey
     desc: "some text for incident's log"
@@ -175,7 +182,7 @@ def send_event(module, service_key, event_type, desc,
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(required=True),
+            name=dict(required=False),
             service_id=dict(required=True),
             integration_key=dict(require=True),
             api_key=dict(required=True),

--- a/lib/ansible/modules/monitoring/pagerduty_alert.py
+++ b/lib/ansible/modules/monitoring/pagerduty_alert.py
@@ -31,11 +31,13 @@ options:
         description:
             - ID of PagerDuty service when incidents will be triggered, acknowledged or resolved.
         required: true
+        version_added: '2.7.0'
     integration_key:
         description:
             - The GUID of one of your "Generic API" services.
             - This is the "integration key" listed on a "Integrations" tab of PagerDuty service.
         required: true
+        version_added: '2.7.0'
     state:
         description:
             - Type of event to be sent.
@@ -65,6 +67,7 @@ options:
             - For C(acknowledged) or C(resolved) I(state) - This should be the incident_key you received back when the incident was first opened by a
               trigger event. Acknowledge events referencing resolved or nonexistent incidents will be discarded.
         required: false
+        version_added: '2.7.0'
     client:
         description:
         - The name of the monitoring client that is triggering this event.

--- a/lib/ansible/modules/monitoring/pagerduty_alert.py
+++ b/lib/ansible/modules/monitoring/pagerduty_alert.py
@@ -32,6 +32,9 @@ options:
             - ID of PagerDuty service when incidents will be triggered, acknowledged or resolved.
         required: true
         version_added: "2.7"
+    service_key:
+        description:
+            - The GUID of one of your "Generic API" services. Obsolete. Please use I(integration_key).
     integration_key:
         description:
             - The GUID of one of your "Generic API" services.
@@ -187,7 +190,8 @@ def main():
         argument_spec=dict(
             name=dict(required=False),
             service_id=dict(required=True),
-            integration_key=dict(require=True),
+            service_key=dict(require=False),
+            integration_key=dict(require=False),
             api_key=dict(required=True),
             state=dict(required=True,
                        choices=['triggered', 'acknowledged', 'resolved']),
@@ -202,12 +206,21 @@ def main():
     name = module.params['name']
     service_id = module.params['service_id']
     integration_key = module.params['integration_key']
+    service_key = module.params['service_key']
     api_key = module.params['api_key']
     state = module.params['state']
     client = module.params['client']
     client_url = module.params['client_url']
     desc = module.params['desc']
     incident_key = module.params['incident_key']
+
+    if integration_key is None:
+        if service_key is not None:
+            integration_key = service_key
+            module.warn('"service_key" is obsolete parameter and will be removed.'
+                        ' Please, use "integration_key" instead')
+        else:
+            module.fail_json(msg="'integration_key' is required parameter")
 
     state_event_dict = {
         'triggered': 'trigger',

--- a/test/units/modules/monitoring/test_pagerduty.py
+++ b/test/units/modules/monitoring/test_pagerduty.py
@@ -5,24 +5,100 @@ import json
 
 class PagerDutyTest(unittest.TestCase):
     def setUp(self):
-        self.module = pagerduty
+        self.pd = pagerduty.PagerDutyRequest(module=pagerduty, name='name', user='user', passwd='password', token='token')
 
-    def _retrieve_ongoing_maintenance_windows(self, module, url, headers):
-        self.assertEquals(url, 'https://api.pagerduty.com/maintenance_windows?filter=ongoing')
+    def _assert_ongoing_maintenance_windows(self, module, url, headers):
+        self.assertEquals('https://api.pagerduty.com/maintenance_windows?filter=ongoing', url)
         return object(), {'status': 200}
 
-    def _with_v1_v2_backward_compatible_header(self, module, url, headers):
+    def _assert_ongoing_window_with_v1_compatible_header(self, module, url, headers, data=None, method=None):
         self.assertDictContainsSubset(
           {'Accept': 'application/vnd.pagerduty+json;version=2'},
           headers,
-          'No Accept:application/vnd.pagerduty+json;version=2 HTTP header'
+          'Accept:application/vnd.pagerduty+json;version=2 HTTP header not found'
         )
         return object(), {'status': 200}
 
-    def test_ongoing_maintenance_windos_urls(self):
-        pd = pagerduty.PagerDutyRequest(module=self.module, name='name', user='user', passwd='password', token='token')
-        pd.ongoing(http_call=self._retrieve_ongoing_maintenance_windows)
+    def _assert_create_a_maintenance_window_url(self, module, url, headers, data=None, method=None):
+        self.assertEquals('https://api.pagerduty.com/maintenance_windows', url)
+        return object(), {'status': 201}
 
-    def test_compatibility_header(self):
-        pd = pagerduty.PagerDutyRequest(module=self.module, name='name', user='user', passwd='password', token='token')
-        pd.ongoing(http_call=self._with_v1_v2_backward_compatible_header)
+    def _assert_create_a_maintenance_window_http_method(self, module, url, headers, data=None, method=None):
+        self.assertEquals('POST', method)
+        return object(), {'status': 201}
+
+    def _assert_create_a_maintenance_window_from_header(self, module, url, headers, data=None, method=None):
+        self.assertDictContainsSubset(
+            {'From': 'requester_id'},
+            headers,
+            'From:requester_id HTTP header not found'
+        )
+        return object(), {'status': 201}
+
+    def _assert_create_window_with_v1_compatible_header(self, module, url, headers, data=None, method=None):
+        self.assertDictContainsSubset(
+          {'Accept': 'application/vnd.pagerduty+json;version=2'},
+          headers,
+          'Accept:application/vnd.pagerduty+json;version=2 HTTP header not found'
+        )
+        return object(), {'status': 201}
+
+    def _assert_create_window_payload(self, module, url, headers, data=None, method=None):
+        payload = json.loads(data)
+        window_data = payload['maintenance_window']
+        self.assertTrue('start_time' in window_data, '"start_time" is requiered attribute')
+        self.assertTrue('end_time' in window_data, '"end_time" is requiered attribute')
+        self.assertTrue('services' in window_data, '"services" is requiered attribute')
+        return object(), {'status': 201}
+
+    def _assert_create_window_single_service(self, module, url, headers, data=None, method=None):
+        payload = json.loads(data)
+        window_data = payload['maintenance_window']
+        services = window_data['services']
+        self.assertEquals(
+            [{'id': 'service_id', 'type': 'service_reference'}],
+            services
+        )
+        return object(), {'status': 201}
+
+    def _assert_create_window_multiple_service(self, module, url, headers, data=None, method=None):
+        payload = json.loads(data)
+        window_data = payload['maintenance_window']
+        services = window_data['services']
+        print(services)
+        self.assertEquals(
+            [
+                {'id': 'service_id_1', 'type': 'service_reference'},
+                {'id': 'service_id_2', 'type': 'service_reference'},
+                {'id': 'service_id_3', 'type': 'service_reference'},
+            ],
+            services
+        )
+        return object(), {'status': 201}
+
+    def test_ongoing_maintenance_windos_url(self):
+        self.pd.ongoing(http_call=self._assert_ongoing_maintenance_windows)
+
+    def test_ongoing_maintenance_windos_compatibility_header(self):
+        self.pd.ongoing(http_call=self._assert_ongoing_window_with_v1_compatible_header)
+
+    def test_create_maintenance_window_url(self):
+        self.pd.create('requester_id', 'service', 1, 0, 'desc', http_call=self._assert_create_a_maintenance_window_url)
+
+    def test_create_maintenance_window_http_method(self):
+        self.pd.create('requester_id', 'service', 1, 0, 'desc', http_call=self._assert_create_a_maintenance_window_http_method)
+
+    def test_create_maintenance_from_header(self):
+        self.pd.create('requester_id', 'service', 1, 0, 'desc', http_call=self._assert_create_a_maintenance_window_from_header)
+
+    def test_create_maintenance_compatibility_header(self):
+        self.pd.create('requester_id', 'service', 1, 0, 'desc', http_call=self._assert_create_window_with_v1_compatible_header)
+
+    def test_create_maintenance_request_payload(self):
+        self.pd.create('requester_id', 'service', 1, 0, 'desc', http_call=self._assert_create_window_payload)
+
+    def test_create_maintenance_for_single_service(self):
+        self.pd.create('requester_id', 'service_id', 1, 0, 'desc', http_call=self._assert_create_window_single_service)
+
+    def test_create_maintenance_for_multiple_services(self):
+        self.pd.create('requester_id', ['service_id_1', 'service_id_2', 'service_id_3'], 1, 0, 'desc', http_call=self._assert_create_window_multiple_service)

--- a/test/units/modules/monitoring/test_pagerduty.py
+++ b/test/units/modules/monitoring/test_pagerduty.py
@@ -5,7 +5,7 @@ import json
 
 class PagerDutyTest(unittest.TestCase):
     def setUp(self):
-        self.pd = pagerduty.PagerDutyRequest(module=pagerduty, name='name', user='user', passwd='password', token='token')
+        self.pd = pagerduty.PagerDutyRequest(module=pagerduty, name='name', user='user', token='token')
 
     def _assert_ongoing_maintenance_windows(self, module, url, headers):
         self.assertEquals('https://api.pagerduty.com/maintenance_windows?filter=ongoing', url)

--- a/test/units/modules/monitoring/test_pagerduty.py
+++ b/test/units/modules/monitoring/test_pagerduty.py
@@ -3,6 +3,7 @@ from ansible.modules.monitoring import pagerduty
 
 import json
 
+
 class PagerDutyTest(unittest.TestCase):
     def setUp(self):
         self.pd = pagerduty.PagerDutyRequest(module=pagerduty, name='name', user='user', token='token')
@@ -13,9 +14,9 @@ class PagerDutyTest(unittest.TestCase):
 
     def _assert_ongoing_window_with_v1_compatible_header(self, module, url, headers, data=None, method=None):
         self.assertDictContainsSubset(
-          {'Accept': 'application/vnd.pagerduty+json;version=2'},
-          headers,
-          'Accept:application/vnd.pagerduty+json;version=2 HTTP header not found'
+            {'Accept': 'application/vnd.pagerduty+json;version=2'},
+            headers,
+            'Accept:application/vnd.pagerduty+json;version=2 HTTP header not found'
         )
         return object(), {'status': 200}
 
@@ -37,9 +38,9 @@ class PagerDutyTest(unittest.TestCase):
 
     def _assert_create_window_with_v1_compatible_header(self, module, url, headers, data=None, method=None):
         self.assertDictContainsSubset(
-          {'Accept': 'application/vnd.pagerduty+json;version=2'},
-          headers,
-          'Accept:application/vnd.pagerduty+json;version=2 HTTP header not found'
+            {'Accept': 'application/vnd.pagerduty+json;version=2'},
+            headers,
+            'Accept:application/vnd.pagerduty+json;version=2 HTTP header not found'
         )
         return object(), {'status': 201}
 
@@ -82,9 +83,9 @@ class PagerDutyTest(unittest.TestCase):
 
     def _assert_absent_window_with_v1_compatible_header(self, module, url, headers, method=None):
         self.assertDictContainsSubset(
-          {'Accept': 'application/vnd.pagerduty+json;version=2'},
-          headers,
-          'Accept:application/vnd.pagerduty+json;version=2 HTTP header not found'
+            {'Accept': 'application/vnd.pagerduty+json;version=2'},
+            headers,
+            'Accept:application/vnd.pagerduty+json;version=2 HTTP header not found'
         )
         return object(), {'status': 204}
 

--- a/test/units/modules/monitoring/test_pagerduty.py
+++ b/test/units/modules/monitoring/test_pagerduty.py
@@ -1,0 +1,28 @@
+from ansible.compat.tests import unittest
+from ansible.modules.monitoring import pagerduty
+
+import json
+
+class PagerDutyTest(unittest.TestCase):
+    def setUp(self):
+        self.module = pagerduty
+
+    def _retrieve_ongoing_maintenance_windows(self, module, url, headers):
+        self.assertEquals(url, 'https://api.pagerduty.com/maintenance_windows?filter=ongoing')
+        return object(), {'status': 200}
+
+    def _with_v1_v2_backward_compatible_header(self, module, url, headers):
+        self.assertDictContainsSubset(
+          {'Accept': 'application/vnd.pagerduty+json;version=2'},
+          headers,
+          'No Accept:application/vnd.pagerduty+json;version=2 HTTP header'
+        )
+        return object(), {'status': 200}
+
+    def test_ongoing_maintenance_windos_urls(self):
+        pd = pagerduty.PagerDutyRequest(module=self.module, name='name', user='user', passwd='password', token='token')
+        pd.ongoing(http_call=self._retrieve_ongoing_maintenance_windows)
+
+    def test_compatibility_header(self):
+        pd = pagerduty.PagerDutyRequest(module=self.module, name='name', user='user', passwd='password', token='token')
+        pd.ongoing(http_call=self._with_v1_v2_backward_compatible_header)

--- a/test/units/modules/monitoring/test_pagerduty.py
+++ b/test/units/modules/monitoring/test_pagerduty.py
@@ -76,6 +76,18 @@ class PagerDutyTest(unittest.TestCase):
         )
         return object(), {'status': 201}
 
+    def _assert_absent_maintenance_window_url(self, module, url, headers, method=None):
+        self.assertEquals('https://api.pagerduty.com/maintenance_windows/window_id', url)
+        return object(), {'status': 204}
+
+    def _assert_absent_window_with_v1_compatible_header(self, module, url, headers, method=None):
+        self.assertDictContainsSubset(
+          {'Accept': 'application/vnd.pagerduty+json;version=2'},
+          headers,
+          'Accept:application/vnd.pagerduty+json;version=2 HTTP header not found'
+        )
+        return object(), {'status': 204}
+
     def test_ongoing_maintenance_windos_url(self):
         self.pd.ongoing(http_call=self._assert_ongoing_maintenance_windows)
 
@@ -102,3 +114,9 @@ class PagerDutyTest(unittest.TestCase):
 
     def test_create_maintenance_for_multiple_services(self):
         self.pd.create('requester_id', ['service_id_1', 'service_id_2', 'service_id_3'], 1, 0, 'desc', http_call=self._assert_create_window_multiple_service)
+
+    def test_absent_maintenance_window_url(self):
+        self.pd.absent('window_id', http_call=self._assert_absent_maintenance_window_url)
+
+    def test_absent_maintenance_compatibility_header(self):
+        self.pd.absent('window_id', http_call=self._assert_absent_window_with_v1_compatible_header)

--- a/test/units/modules/monitoring/test_pagerduty_alert.py
+++ b/test/units/modules/monitoring/test_pagerduty_alert.py
@@ -1,0 +1,39 @@
+from ansible.compat.tests import unittest
+from ansible.modules.monitoring import pagerduty_alert
+
+from ansible.module_utils.six.moves.urllib.parse import urlparse, urlencode, urlunparse
+
+
+class PagerDutyAlertsTest(unittest.TestCase):
+    def _assert_incident_api(self, module, url, method, headers):
+        self.assertTrue('https://api.pagerduty.com/incidents' in url, 'url must contain REST API v2 network path')
+        self.assertTrue('service_ids%5B%5D=service_id' in url, 'url must contain service id to filter incidents')
+        self.assertTrue('sort_by=incident_number%3Adesc' in url, 'url should contain sorting parameter')
+        self.assertTrue('time_zone=UTC' in url, 'url should contain time zone parameter')
+        return Response(), {'status': 200}
+
+    def _assert_compatibility_header(self, module, url, method, headers):
+        self.assertDictContainsSubset(
+          {'Accept': 'application/vnd.pagerduty+json;version=2'},
+          headers,
+          'Accept:application/vnd.pagerduty+json;version=2 HTTP header not found'
+        )
+        return Response(), {'status': 200}
+
+    def _assert_incident_key(self, module, url, method, headers):
+        self.assertTrue('incident_key=incident_key_value' in url, 'url must contain incident key')
+        return Response(), {'status': 200}
+
+    def test_incident_url(self):
+        pagerduty_alert.check(None, 'name', 'state', 'service_id', 'integration_key', 'api_key', http_call=self._assert_incident_api)
+
+    def test_compatibility_header(self):
+        pagerduty_alert.check(None, 'name', 'state', 'service_id', 'integration_key', 'api_key', http_call=self._assert_compatibility_header)
+
+    def test_incident_key_in_url_when_it_is_given(self):
+        pagerduty_alert.check(None, 'name', 'state', 'service_id', 'integration_key', 'api_key', incident_key='incident_key_value', http_call=self._assert_incident_key)
+
+
+class Response(object):
+    def read(self):
+        return '{"incidents":[{"id": "incident_id", "status": "triggered"}]}'

--- a/test/units/modules/monitoring/test_pagerduty_alert.py
+++ b/test/units/modules/monitoring/test_pagerduty_alert.py
@@ -14,9 +14,9 @@ class PagerDutyAlertsTest(unittest.TestCase):
 
     def _assert_compatibility_header(self, module, url, method, headers):
         self.assertDictContainsSubset(
-          {'Accept': 'application/vnd.pagerduty+json;version=2'},
-          headers,
-          'Accept:application/vnd.pagerduty+json;version=2 HTTP header not found'
+            {'Accept': 'application/vnd.pagerduty+json;version=2'},
+            headers,
+            'Accept:application/vnd.pagerduty+json;version=2 HTTP header not found'
         )
         return Response(), {'status': 200}
 
@@ -31,7 +31,9 @@ class PagerDutyAlertsTest(unittest.TestCase):
         pagerduty_alert.check(None, 'name', 'state', 'service_id', 'integration_key', 'api_key', http_call=self._assert_compatibility_header)
 
     def test_incident_key_in_url_when_it_is_given(self):
-        pagerduty_alert.check(None, 'name', 'state', 'service_id', 'integration_key', 'api_key', incident_key='incident_key_value', http_call=self._assert_incident_key)
+        pagerduty_alert.check(
+            None, 'name', 'state', 'service_id', 'integration_key', 'api_key', incident_key='incident_key_value', http_call=self._assert_incident_key
+        )
 
 
 class Response(object):


### PR DESCRIPTION
##### SUMMARY
This PR updates modules that work with PagerDuty REST API from version 1 to version 2.
The v1 is in the [process of decommission](https://v2.developer.pagerduty.com/v2/docs/v1-rest-api-decommissioning-faq) and ansible modules have to be updated to v2 to continue work with PagerDuty.
Users that have api v1 token can still use it till the end of decommissioning process, which will end on ```October 19, 2018, at 22:00 PDT (UTC+7)```

The PR:
 * contains structural changes of `pagerduty` module, it's made more OOP stylish
 * introduces changes to work with PagerDuty REST API v2 and support for v1 tokens
 * adds unit tests for `pagerduty` and `pagerduty_alerts` modules
 * updates documentation to both modules

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
```pagerduty``` and ```pagerduty_alerts``` modules

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (update-pagerduty-modules-to-REST-v2 cea693b000) last updated 2018/07/11 14:07:07 (GMT +300)
  config file = /Users/adukhno/.ansible.cfg
  configured module search path = [u'/Users/adukhno/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/adukhno/Workspace/ansible/lib/ansible
  executable location = /Users/adukhno/Workspace/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```
