### PR TITLE
issue with activation_key and proxy on subscription-manager

### DIFF
--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -331,14 +331,14 @@ class Rhsm(RegistrationBase):
             args.extend(['--serverurl', server_hostname])
 
         if org_id:
-            args.extend(['--org', org_id])  
-         
+            args.extend(['--org', org_id])
+
         if server_proxy_hostname and server_proxy_port:
             args.extend(['--proxy', server_proxy_hostname + ':' + server_proxy_port])
-            
+
         if server_proxy_user:
             args.extend(['--proxyuser', server_proxy_user])
-            
+
         if server_proxy_password:
             args.extend(['--proxypassword', server_proxy_password])
 

--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -331,7 +331,16 @@ class Rhsm(RegistrationBase):
             args.extend(['--serverurl', server_hostname])
 
         if org_id:
-            args.extend(['--org', org_id])
+            args.extend(['--org', org_id])  
+         
+        if server_proxy_hostname and server_proxy_port:
+            args.extend(['--proxy', server_proxy_hostname + ':' + server_proxy_port])
+            
+        if server_proxy_user:
+            args.extend(['--proxyuser', server_proxy_user])
+            
+        if server_proxy_password:
+            args.extend(['--proxypassword', server_proxy_password])
 
         if activationkey:
             args.extend(['--activationkey', activationkey])
@@ -350,12 +359,6 @@ class Rhsm(RegistrationBase):
                 args.extend(['--consumerid', consumer_id])
             if environment:
                 args.extend(['--environment', environment])
-            if server_proxy_hostname and server_proxy_port:
-                args.extend(['--proxy', server_proxy_hostname + ':' + server_proxy_port])
-            if server_proxy_user:
-                args.extend(['--proxyuser', server_proxy_user])
-            if server_proxy_password:
-                args.extend(['--proxypassword', server_proxy_password])
 
         rc, stderr, stdout = self.module.run_command(args, check_rc=True)
 


### PR DESCRIPTION
I need to use a proxy server/user/password also if I user an activation_key

##### SUMMARY
I have changed the function to compose the command with arguments. Is not possible to use the activation_key and proxy because the proxy set is mutual excluded by the if statement.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
redhat_subscription

##### ANSIBLE VERSION

ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]


##### ADDITIONAL INFORMATION
