### PR TITLE
Fix ec2_asg metric* option's version introduction - refs #25168

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -157,12 +157,12 @@ options:
       - Enable ASG metrics collection
     type: bool
     default: 'no'
-    version_added: "2.5"
+    version_added: "2.6"
   metrics_granularity:
     description:
       - When metrics_collection is enabled this will determine granularity of metrics collected by CloudWatch
     default: "1minute"
-    version_added: "2.5"
+    version_added: "2.6"
   metrics_list:
     description:
       - List of autoscaling metrics to collect when enabling metrics_collection
@@ -175,7 +175,7 @@ options:
         - 'GroupStandbyInstances'
         - 'GroupTerminatingInstances'
         - 'GroupTotalInstances'
-    version_added: "2.5"
+    version_added: "2.6"
 extends_documentation_fragment:
     - aws
     - ec2


### PR DESCRIPTION
##### SUMMARY
Options are introduced in current dev/ future 2.6 version, however docs say it's already introduced. I realised only after trying to run changes on ansible 2.5.2

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
module

##### ANSIBLE VERSION
2.5.2

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
 "Unsupported parameters for (ec2_asg) module: metrics_collection, metrics_list Supported parameters include: availability_zones, aws_access_key, aws_secret_key, default_cooldown, desired_capacity, ec2_url, health_check_period, health_check_type, launch_config_name, lc_check, load_balancers, max_size, min_size, name, notification_topic, notification_types, placement_group, profile, region, replace_all_instances, replace_batch_size, replace_instances, security_token, state, suspend_processes, tags, target_group_arns, termination_policies, validate_certs, vpc_zone_identifier, wait_for_instances, wait_timeout
```
