### PR TITLE
Revert "Make ansible doesn't parse template-like password in user's i…

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -38,7 +38,6 @@ from ansible.errors import AnsibleOptionsError, AnsibleError
 from ansible.inventory.manager import InventoryManager
 from ansible.module_utils.six import with_metaclass, string_types
 from ansible.module_utils._text import to_bytes, to_text
-from ansible.utils.unsafe_proxy import AnsibleUnsafeText
 from ansible.parsing.dataloader import DataLoader
 from ansible.release import __version__
 from ansible.utils.path import unfrackpath
@@ -330,7 +329,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                 sshpass = getpass.getpass(prompt="SSH password: ")
                 become_prompt = "%s password[defaults to SSH password]: " % become_prompt_method
                 if sshpass:
-                    sshpass = AnsibleUnsafeText(to_bytes(sshpass, errors='strict', nonstring='simplerepr'))
+                    sshpass = to_bytes(sshpass, errors='strict', nonstring='simplerepr')
             else:
                 become_prompt = "%s password: " % become_prompt_method
 
@@ -339,7 +338,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                 if op.ask_pass and becomepass == '':
                     becomepass = sshpass
                 if becomepass:
-                    becomepass = AnsibleUnsafeText(to_bytes(becomepass))
+                    becomepass = to_bytes(becomepass)
         except EOFError:
             pass
 


### PR DESCRIPTION
…nput (#42275)"

This reverts commit de40ac02a5cd4ac3bb758d4e284955763c013938.

Passwords from the cli need to remain bytes on input otherwise we have
encoding problems when users input non-utf8

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE

 - Bugfix Pull Request


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```
