### PR TITLE
etcd3: Enable deleting of whole prefixes

### DIFF
--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -488,7 +488,6 @@ lib/ansible/modules/clustering/consul_kv.py E322
 lib/ansible/modules/clustering/consul_kv.py E324
 lib/ansible/modules/clustering/consul_kv.py E325
 lib/ansible/modules/clustering/consul_session.py E322
-lib/ansible/modules/clustering/etcd3.py E326
 lib/ansible/modules/clustering/k8s/_kubernetes.py E322
 lib/ansible/modules/clustering/k8s/_kubernetes.py E323
 lib/ansible/modules/clustering/k8s/_kubernetes.py E324


### PR DESCRIPTION
##### SUMMARY
- Add the possibility to delete whole ranges of keys using a prefix.
- Made the 'value' parameter optional when 'state!=present'.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
etcd3

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.1
```
