### PR TITLE
Fixes #23078 - eliminate trailing whitespace in to_nice_json

### DIFF
--- a/changelogs/fragments/to-nice-json-separators.yaml
+++ b/changelogs/fragments/to-nice-json-separators.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- to_nice_json - specify separators to json.dumps to normalize the output between python2 and python3 (https://github.com/ansible/ansible/pull/42633)

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -87,7 +87,7 @@ def to_json(a, *args, **kw):
 def to_nice_json(a, indent=4, *args, **kw):
     '''Make verbose, human readable JSON'''
     try:
-        return json.dumps(a, indent=indent, sort_keys=True, cls=AnsibleJSONEncoder, *args, **kw)
+        return json.dumps(a, indent=indent, sort_keys=True, separators=(',', ': '), cls=AnsibleJSONEncoder, *args, **kw)
     except Exception as e:
         # Fallback to the to_json filter
         display.warning(u'Unable to convert data using to_nice_json, falling back to to_json: %s' % to_text(e))


### PR DESCRIPTION
##### SUMMARY
Fixes #23078

While the defaults of python json module are unfortunately choosen, there is an easy fix for this issue by using appropriate arguments to json.dump, e.g. `json.dump(obj, f, indent=2, sort_keys=True, separators=(',', ': '))` produces formatted json *without* trailing whitespace. This way is also documented in the python json documentation https://docs.python.org/2/library/json.html#basic-usage

> Note Since the default item separator is ', ', the output might include trailing whitespace when indent is specified. You can use separators=(',', ': ') to avoid this.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
filter - core - to_nice_json

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /home/d0eXXXXX/.ansible.cfg
  configured module search path = [u'/home/d0eXXXXX/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/d0eXXXXX/.local/lib/python2.7/site-packages/ansible
  executable location = /home/d0eXXXXX/.local/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->


