### PR TITLE
Backport #42038 for 2.5 - Fix NameError in pause module 

### DIFF
--- a/changelogs/fragments/pause-try-except-curses.yaml
+++ b/changelogs/fragments/pause-try-except-curses.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pause - nest try except when importing curses to gracefully fail if curses is not present (https://github.com/ansible/ansible/issues/42004)

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -39,9 +39,14 @@ except ImportError:
 
 try:
     import curses
-    curses.setupterm()
-    HAS_CURSES = True
-except (ImportError, curses.error):
+
+    # Nest the try except since curses.error is not available if curses did not import
+    try:
+        curses.setupterm()
+        HAS_CURSES = True
+    except curses.error:
+        HAS_CURSES = False
+except ImportError:
     HAS_CURSES = False
 
 if HAS_CURSES:


### PR DESCRIPTION
##### SUMMARY
Backport of #42038 for Ansible 2.5

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
`pause.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```