### PR TITLE
meraki_device - Change URL for organization device lookup

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_device.py
+++ b/lib/ansible/modules/network/meraki/meraki_device.py
@@ -272,7 +272,7 @@ def main():
     meraki.params['follow_redirects'] = 'all'
 
     query_urls = {'device': '/networks/{net_id}/devices'}
-    query_org_urls = {'device': '/organizations/{org_id}/deviceStatuses'}
+    query_org_urls = {'device': '/organizations/{org_id}/inventory'}
     query_device_urls = {'device': '/networks/{net_id}/devices/'}
     claim_device_urls = {'device': '/networks/{net_id}/devices/claim'}
     bind_org_urls = {'device': '/organizations/{org_id}/claim'}

--- a/test/integration/targets/meraki_device/tasks/main.yml
+++ b/test/integration/targets/meraki_device/tasks/main.yml
@@ -195,7 +195,7 @@
         - update_device_idempotent.changed == False
 
   always:
-  - name: Remove a device
+  - name: Remove a device from a network
     meraki_device:
       auth_key: '{{auth_key}}'
       org_name: '{{test_org_name}}'


### PR DESCRIPTION
##### SUMMARY
Old URL showed device information/status only when it was part of a network. This URL will show a device whether or not it's in a network

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
meraki_device

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (meraki/device_all_in_org ebd770db7a) last updated 2018/07/11 19:33:15 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]

```
