### PR TITLE
changed winrm _reset to reset and make ssh reset show warning

### DIFF
--- a/changelogs/fragments/connection_reset.yaml
+++ b/changelogs/fragments/connection_reset.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-- ssh - reset connection will show a warning instead of failing when resetting the ControlPath for older OpenSSH versions
+- ssh - reset connection will show a warning instead of failing for older OpenSSH versions
 - winrm - change the _reset() method to use reset() that is part of ConnectionBase

--- a/changelogs/fragments/connection_reset.yaml
+++ b/changelogs/fragments/connection_reset.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- ssh - reset connection will show a warning instead of failing when resetting the ControlPath for older OpenSSH versions
+- winrm - change the _reset() method to use reset() that is part of ConnectionBase

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -767,7 +767,7 @@ class TaskExecutor:
                 display.vvvv("Exception during async poll, retrying... (%s)" % to_text(e))
                 display.debug("Async poll exception was:\n%s" % to_text(traceback.format_exc()))
                 try:
-                    normal_handler._connection._reset()
+                    normal_handler._connection.reset()
                 except AttributeError:
                     pass
 

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -82,7 +82,7 @@ class ActionModule(ActionBase):
             display.vvv("wait_for_connection: attempting ping module test")
             # call connection reset between runs if it's there
             try:
-                self._connection._reset()
+                self._connection.reset()
             except AttributeError:
                 pass
 

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -158,7 +158,7 @@ class ActionModule(ActionBase):
                 try:
                     self._connection.set_option("connection_timeout",
                                                 connect_timeout)
-                    self._connection._reset()
+                    self._connection.reset()
                 except AttributeError:
                     display.warning("Connection plugin does not allow the "
                                     "connection timeout to be overridden")
@@ -178,7 +178,7 @@ class ActionModule(ActionBase):
             try:
                 self._connection.set_option("connection_timeout",
                                             connection_timeout_orig)
-                self._connection._reset()
+                self._connection.reset()
             except (AnsibleError, AttributeError) as e:
                 display.debug("Failed to reset connection_timeout back to default: %s" % to_native(e))
 
@@ -192,7 +192,7 @@ class ActionModule(ActionBase):
                     # (another reboot occurred) we need to reset the connection
                     # to make sure we are not re-using the same shell id
                     try:
-                        self._connection._reset()
+                        self._connection.reset()
                     except AttributeError:
                         pass
                     raise

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1108,7 +1108,7 @@ class Connection(ConnectionBase):
             stdout, stderr = p.communicate()
             status_code = p.wait()
             if status_code != 0:
-                raise AnsibleError("Cannot reset connection:\n%s" % stderr)
+                display.warning("Failed to reset connection:%s" % stderr)
 
         self.close()
 

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -483,7 +483,7 @@ class Connection(ConnectionBase):
             self._connected = True
         return self
 
-    def _reset(self):  # used by win_reboot (and any other action that might need to bounce the state)
+    def reset(self):
         self.protocol = None
         self.shell_id = None
         self._connect()


### PR DESCRIPTION
##### SUMMARY
EL6's OpenSSH package does not support the `-O stop` command causing a failure when calling `-meta: reset_connection`. This change makes a failure here non fatal and will log the warning.

This also changes the winrm `_reset()` to `reset()` to align with ConnectionBase.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
winrm
ssh

##### ANSIBLE VERSION
```
devel
```