### PR TITLE
Fix ios_linkagg issue CP in 2.6

### DIFF
--- a/lib/ansible/modules/network/ios/ios_linkagg.py
+++ b/lib/ansible/modules/network/ios/ios_linkagg.py
@@ -227,7 +227,7 @@ def parse_members(module, config, group):
 
 
 def get_channel(module, config, group):
-    match = re.findall(r'interface (\S+)', config, re.M)
+    match = re.findall(r'^interface (\S+)', config, re.M)
 
     if not match:
         return {}


### PR DESCRIPTION
(cherry picked from commit fa624eba29573fe5dcaab33aff25143454b6f96c)

##### SUMMARY
- Fixes #42511 in stable-2.6
- With this fix, _ios_linkagg_ will pick correct interface names. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
ios_linkagg.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
stable-2.6
```
