### PR TITLE
Fix ios_linkagg issue CP in 2.5

### DIFF
--- a/changelogs/fragments/ios_linkagg_fix.yml
+++ b/changelogs/fragments/ios_linkagg_fix.yml
@@ -1,0 +1,2 @@
+- bugfixes:
+    - ios_linkagg - fix picking correct interface names issue (https://github.com/ansible/ansible/pull/42557)

--- a/lib/ansible/modules/network/ios/ios_linkagg.py
+++ b/lib/ansible/modules/network/ios/ios_linkagg.py
@@ -227,7 +227,7 @@ def parse_members(module, config, group):
 
 
 def get_channel(module, config, group):
-    match = re.findall(r'interface (\S+)', config, re.M)
+    match = re.findall(r'^interface (\S+)', config, re.M)
 
     if not match:
         return {}


### PR DESCRIPTION
(cherry picked from commit https://github.com/ansible/ansible/commit/fa624eba29573fe5dcaab33aff25143454b6f96c )

##### SUMMARY
- Fixes #42511 in stable-2.5
- With this fix, ios_linkagg will pick correct interface names.
- Added changelog

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
ios_linkagg.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
stable-2.5
```

