### PR TITLE
Fix ios_vlan issue CP into 2.6

### DIFF
--- a/changelogs/fragments/fix_ios_vlan.yaml
+++ b/changelogs/fragments/fix_ios_vlan.yaml
@@ -1,2 +1,3 @@
-- bugfixes:
-    - ios_vlan - fix unable to identify correct vlans issue (https://github.com/ansible/ansible/pull/42247)
+---
+bugfixes:
+  - ios_vlan - fix unable to identify correct vlans issue (https://github.com/ansible/ansible/pull/42247)

--- a/changelogs/fragments/fix_ios_vlan.yaml
+++ b/changelogs/fragments/fix_ios_vlan.yaml
@@ -1,0 +1,2 @@
+- bugfixes:
+    - ios_vlan - fix unable to identify vlans starting with '9' issue (https://github.com/ansible/ansible/pull/42247)

--- a/changelogs/fragments/fix_ios_vlan.yaml
+++ b/changelogs/fragments/fix_ios_vlan.yaml
@@ -1,2 +1,2 @@
 - bugfixes:
-    - ios_vlan - fix unable to identify vlans starting with '9' issue (https://github.com/ansible/ansible/pull/42247)
+    - ios_vlan - fix unable to identify correct vlans issue (https://github.com/ansible/ansible/pull/42247)

--- a/lib/ansible/modules/network/ios/ios_vlan.py
+++ b/lib/ansible/modules/network/ios/ios_vlan.py
@@ -218,7 +218,7 @@ def parse_to_logical_rows(out):
         if not l:
             """Skip empty lines."""
             continue
-        if '0' < l[0] < '9':
+        if '0' < l[0] <= '9':
             """Line starting with a number."""
             if started_yielding:
                 yield cur_row

--- a/test/units/modules/network/ios/fixtures/ios_vlan_config.cfg
+++ b/test/units/modules/network/ios/fixtures/ios_vlan_config.cfg
@@ -4,5 +4,6 @@ VLAN Name                             Status    Ports
                                                 Gi1/0/52
                                                 Gi1/0/54
 2    vlan2                            active    Gi1/0/6, Gi1/0/7
+9    vlan9                            active    Gi1/0/6
 1002 fddi-default                     act/unsup 
 1003 fddo-default                     act/unsup

--- a/test/units/modules/network/ios/test_ios_vlan.py
+++ b/test/units/modules/network/ios/test_ios_vlan.py
@@ -59,6 +59,12 @@ class TestIosVlanModule(TestIosModule):
         ]
         self.assertEqual(result['commands'], expected_commands)
 
+    def test_ios_vlan_id_startwith_9(self):
+        set_module_args({'vlan_id': '9', 'name': 'vlan9', 'state': 'present'})
+        result = self.execute_module(changed=False)
+        expected_commands = []
+        self.assertEqual(result['commands'], expected_commands)
+
     def test_ios_vlan_rename(self):
         set_module_args({'vlan_id': '2', 'name': 'test', 'state': 'present'})
         result = self.execute_module(changed=True)
@@ -120,6 +126,14 @@ class TestIosVlanModule(TestIosModule):
                 ],
                 'state': 'active',
                 'vlan_id': '2',
+            },
+            {
+                'name': 'vlan9',
+                'interfaces': [
+                    'GigabitEthernet1/0/6',
+                ],
+                'state': 'active',
+                'vlan_id': '9',
             },
             {
                 'name': 'fddi-default',


### PR DESCRIPTION
(cherry picked from commit https://github.com/ansible/ansible/commit/70e33ef92c7a453032ad068198ea82fc1f9838a8)

##### SUMMARY
- Fixes https://github.com/ansible/ansible/issues/42242
- With this fix, _ios_vlan_ will be able to correctly identify vlans with vlan_id starting from '9'
- Added unit test
- Added changelog

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
ios_vlan.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
stable-2.6
```