### PR TITLE
aci_bd_subnet: Support parameter scope not set in 2.6

### DIFF
--- a/lib/ansible/modules/network/aci/aci_bd_subnet.py
+++ b/lib/ansible/modules/network/aci/aci_bd_subnet.py
@@ -355,10 +355,11 @@ def main():
     route_profile = module.params['route_profile']
     route_profile_l3_out = module.params['route_profile_l3_out']
     scope = module.params['scope']
-    if 'private' in scope and 'public' in scope:
-        module.fail_json(msg="Parameter 'scope' cannot be both 'private' and 'public', got: %s" % scope)
-    else:
-        scope = ','.join(sorted(scope))
+    if scope is not None:
+        if 'private' in scope and 'public' in scope:
+            module.fail_json(msg="Parameter 'scope' cannot be both 'private' and 'public', got: %s" % scope)
+        else:
+            scope = ','.join(sorted(scope))
     state = module.params['state']
     subnet_control = module.params['subnet_control']
     if subnet_control:


### PR DESCRIPTION
##### SUMMARY
If parameter scope is not set (is None) the usual handling of lists does
not apply, and should be avoided or we get an exception.

This is a backport of #42675 to  Ansible v2.6

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aci_bd_subnet

##### ANSIBLE VERSION
v2.7 and earlier