### PR TITLE
Add missing methods to AnsibleAWSModule

### DIFF
--- a/lib/ansible/module_utils/aws/core.py
+++ b/lib/ansible/module_utils/aws/core.py
@@ -135,6 +135,12 @@ class AnsibleAWSModule(object):
     def warn(self, *args, **kwargs):
         return self._module.warn(*args, **kwargs)
 
+    def deprecate(self, *args, **kwargs):
+        return self._module.deprecate(*args, **kwargs)
+
+    def boolean(self, *args, **kwargs):
+        return self._module.boolean(*args, **kwargs)
+
     def md5(self, *args, **kwargs):
         return self._module.md5(*args, **kwargs)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
```
File \"/tmp/ansible_ZEFAmR/ansible_module_s3.py\", line 692, in main
module.deprecate(\"The 's3' module is being renamed 'aws_s3'\", version=2.7)
AttributeError: 'AnsibleAWSModule' object has no attribute 'deprecate'
```
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/aws/core.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
devel
```


##### ADDITIONAL INFORMATION