### PR TITLE
add scratch option to vyos_config module

### DIFF
--- a/test/units/modules/network/vyos/test_vyos_config.py
+++ b/test/units/modules/network/vyos/test_vyos_config.py
@@ -18,6 +18,7 @@
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 from ansible.compat.tests.mock import patch, MagicMock
@@ -28,7 +29,6 @@ from .vyos_module import TestVyosModule, load_fixture
 
 
 class TestVyosConfigModule(TestVyosModule):
-
     module = vyos_config
 
     def setUp(self):
@@ -115,3 +115,13 @@ class TestVyosConfigModule(TestVyosModule):
         candidate = '\n'.join(lines)
         self.conn.get_diff = MagicMock(return_value=self.cliconf_obj.get_diff(candidate, None, match='none'))
         self.execute_module(changed=True, commands=lines, sort=False)
+
+    def test_vyos_scratch(self):
+        # pick from fixture file: vyos_config_config.cfg
+        lines = ['set system name-server 8.8.8.8',
+                 'set system name-server 8.8.4.4',
+                 'set system host-name test_vyos_scratch']
+        delete_lines = ['delete system', 'delete interfaces']
+        expected_lines = delete_lines + lines
+        set_module_args(dict(lines=lines, scratch=True))
+        self.execute_module(commands=expected_lines)


### PR DESCRIPTION
##### SUMMARY
* Add `scratch` option to vyos_config module
* if `scratch` option is yes, run delete all configuration prior to `src` or `lines` commands
* WHY
    * I don't care about current configurations
        * Using this option, just delete from src file or lines.
    * For migrating running vyos config to ansible, we want to check ansible config is correct with command differences. In this situation, we want to check whether all configurations included ansible files or not.
        * Currently, vyos_config just _append_ `src` or `lines` commands to `config`, so doesn't notify if some configuration missing.
* if another option name is suitable, please comment.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
vyos_config

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.7.0.dev0
  config file = None
  configured module search path = ['/home/hitsu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/hitsu/.pyenv/versions/3.6.2/envs/3.6_global/lib/python3.6/site-packages/ansible
  executable location = /home/hitsu/.pyenv/versions/global/bin/ansible
  python version = 3.6.2 (default, Nov 23 2017, 16:58:38) [GCC 7.2.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
