### PR TITLE
Mark vars from facts cache as unsafe (fixes #42656)

### DIFF
--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -308,7 +308,7 @@ class VariableManager:
 
             # finally, the facts caches for this host, if it exists
             try:
-                facts = self._fact_cache.get(host.name, {})
+                facts = wrap_var(self._fact_cache.get(host.name, {}))
                 all_vars.update(namespace_facts(facts))
 
                 # push facts to main namespace


### PR DESCRIPTION
##### SUMMARY
Mark vars from facts cache as unsafe (fixes #42656)

Facts are marked as unsafe when originally gathered, but they lose that
marking when they are serialized to JSON and parsed back out.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
facts cache

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (fact_cache_unsafe f6ad92ae44) last updated 2018/07/12 07:43:30 (GMT -500)
```

##### ADDITIONAL INFORMATION
N/A