### PR TITLE
Add option to control CDATA tags stripping

### DIFF
--- a/lib/ansible/modules/files/xml.py
+++ b/lib/ansible/modules/files/xml.py
@@ -109,7 +109,7 @@ options:
   strip_cdata_tags:
     description:
       - Remove CDATA tags surrounding text values.
-      - Note that this might break your XML file if text values contain characters that could be interpreted as XML
+      - Note that this might break your XML file if text values contain characters that could be interpreted as XML.
     type: bool
     default: 'no'
     version_added: '2.7'

--- a/lib/ansible/modules/files/xml.py
+++ b/lib/ansible/modules/files/xml.py
@@ -106,6 +106,12 @@ options:
         the original file back if you somehow clobbered it incorrectly.
     type: bool
     default: 'no'
+  strip_cdata_tags:
+    description:
+      - Remove CDATA tags surrounding text values. This might break your XML
+        file if text values contain characters that could be interpreted as XML
+    type: bool
+    default: 'no'
 requirements:
 - lxml >= 2.3.0
 notes:
@@ -732,6 +738,7 @@ def main():
             content=dict(type='str', choices=['attribute', 'text']),
             input_type=dict(type='str', default='yaml', choices=['xml', 'yaml']),
             backup=dict(type='bool', default=False),
+            strip_cdata_tags=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
         # TODO: Implement this as soon as #28662 (required_by functionality) is merged
@@ -772,6 +779,7 @@ def main():
     print_match = module.params['print_match']
     count = module.params['count']
     backup = module.params['backup']
+    strip_cdata_tags = module.params['strip_cdata_tags']
 
     # Check if we have lxml 2.3.0 or newer installed
     if not HAS_LXML:
@@ -800,7 +808,7 @@ def main():
 
     # Try to parse in the target XML file
     try:
-        parser = etree.XMLParser(remove_blank_text=pretty_print)
+        parser = etree.XMLParser(remove_blank_text=pretty_print,strip_cdata=strip_cdata_tags)
         doc = etree.parse(infile, parser)
     except etree.XMLSyntaxError as e:
         module.fail_json(msg="Error while parsing document: %s (%s)" % (xml_file or 'xml_string', e))

--- a/lib/ansible/modules/files/xml.py
+++ b/lib/ansible/modules/files/xml.py
@@ -108,10 +108,11 @@ options:
     default: 'no'
   strip_cdata_tags:
     description:
-      - Remove CDATA tags surrounding text values. This might break your XML
-        file if text values contain characters that could be interpreted as XML
+      - Remove CDATA tags surrounding text values.
+      - Note that this might break your XML file if text values contain characters that could be interpreted as XML
     type: bool
     default: 'no'
+    version_added: '2.7'
 requirements:
 - lxml >= 2.3.0
 notes:
@@ -808,7 +809,7 @@ def main():
 
     # Try to parse in the target XML file
     try:
-        parser = etree.XMLParser(remove_blank_text=pretty_print,strip_cdata=strip_cdata_tags)
+        parser = etree.XMLParser(remove_blank_text=pretty_print, strip_cdata=strip_cdata_tags)
         doc = etree.parse(infile, parser)
     except etree.XMLSyntaxError as e:
         module.fail_json(msg="Error while parsing document: %s (%s)" % (xml_file or 'xml_string', e))


### PR DESCRIPTION
##### SUMMARY
Currently, when parsing XML files with text values enclosed in CDATA
tags, this module strips them and text values are converted to plain values.

At least, CDATA tags shouldn't be touched if user didn't explicitly requested so.
With this patch we revert that behaviour and also introduce strip_cdata_tags option.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
xml

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 15 2018, 15:37:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```