### PR TITLE
adds check mode to ec2_elb and elb_instance

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_elb.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb.py
@@ -332,6 +332,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
+        supports_check_mode=True
     )
 
     if not HAS_BOTO:
@@ -359,10 +360,11 @@ def main():
                 msg = "ELB %s does not exist" % elb
                 module.fail_json(msg=msg)
 
-    if module.params['state'] == 'present':
-        elb_man.register(wait, enable_availability_zone, timeout)
-    elif module.params['state'] == 'absent':
-        elb_man.deregister(wait, timeout)
+    if not module.check_mode:
+        if module.params['state'] == 'present':
+            elb_man.register(wait, enable_availability_zone, timeout)
+        elif module.params['state'] == 'absent':
+            elb_man.deregister(wait, timeout)
 
     ansible_facts = {'ec2_elbs': [lb.name for lb in elb_man.lbs]}
     ec2_facts_result = dict(changed=elb_man.changed, ansible_facts=ansible_facts)

--- a/lib/ansible/modules/cloud/amazon/elb_instance.py
+++ b/lib/ansible/modules/cloud/amazon/elb_instance.py
@@ -328,6 +328,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
+        supports_check_mode=True
     )
 
     if not HAS_BOTO:
@@ -355,10 +356,11 @@ def main():
                 msg = "ELB %s does not exist" % elb
                 module.fail_json(msg=msg)
 
-    if module.params['state'] == 'present':
-        elb_man.register(wait, enable_availability_zone, timeout)
-    elif module.params['state'] == 'absent':
-        elb_man.deregister(wait, timeout)
+    if not module.check_mode:
+        if module.params['state'] == 'present':
+            elb_man.register(wait, enable_availability_zone, timeout)
+        elif module.params['state'] == 'absent':
+            elb_man.deregister(wait, timeout)
 
     ansible_facts = {'ec2_elbs': [lb.name for lb in elb_man.lbs]}
     ec2_facts_result = dict(changed=elb_man.changed, ansible_facts=ansible_facts)


### PR DESCRIPTION


##### SUMMARY
This will let you determine what ELBs an instance will be deregistered from prior to actually executing. It also works for registration, though that's not as important of a use case since you can typically figure that out based on the inputs you're using. The approach is pretty simple, it just wont' register or deregister if check mode is on, but it will still set the ec2_elbs fact so you can introspect that to get the information.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_elb elb_instance

##### ANSIBLE VERSION
```
ansible 2.5.3
  config file = None
  configured module search path = ['/Users/ykuperman/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/ykuperman/venvs/ansible2/lib/python3.6/site-packages/ansible
  executable location = /Users/ykuperman/venvs/ansible2/bin/ansible
  python version = 3.6.3 (default, Nov 16 2017, 10:24:04) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```


##### ADDITIONAL INFORMATION

