### PR TITLE
Fix referenced before assignment in sysvinit module

### DIFF
--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -181,7 +181,6 @@ def main():
     if pattern:
         worked = is_started = get_ps(module, pattern)
     else:
-        worked = False
         if location.get('service'):
             # standard tool that has been 'destandarized' by reimplementation in other OS/distros
             cmd = '%s %s status' % (location['service'], name)

--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -175,10 +175,11 @@ def main():
 
     # figure out started status, everyone does it different!
     is_started = False
+    worked = False
 
     # user knows other methods fail and supplied pattern
     if pattern:
-        is_started = get_ps(module, pattern)
+        worked = is_started = get_ps(module, pattern)
     else:
         worked = False
         if location.get('service'):


### PR DESCRIPTION
##### SUMMARY
Using ```pattern``` keyword in service module leads to ```UnboundLocalError```, e.g.
```
- name: Start redundant-router
  service: enabled=yes state=started name=redundant-router pattern=redundant-router
```
Here is ansible-playbook output for this error

```
fatal: [10-0-16-3.ams.flops.ru]: FAILED! => {
    "changed": false,
    "module_stderr": "Shared connection to 10-0-16-3.ams.flops.ru closed.\r\n",
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_CSMBg8/ansible_module_sysvinit.py\", line 351, in <module>\r\n    main()\r\n  File \"/tmp/ansible_CSMBg8/ansible_module_sysvinit.py\", line 232, in main\r\n    if not worked:\r\nUnboundLocalError: local variable 'worked' referenced before assignment\r\n",
    "msg": "MODULE FAILURE",
    "rc": 1
}
```

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/sysvinit.py

##### ANSIBLE VERSION
```
2.6.1
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
```
