### PR TITLE
Fix patching of wrong boto3_conn in API Gateway tests

### DIFF
--- a/test/units/modules/cloud/amazon/test_api_gateway.py
+++ b/test/units/modules/cloud/amazon/test_api_gateway.py
@@ -31,6 +31,7 @@ if not HAS_BOTO3:
     pytestmark = pytest.mark.skip("test_api_gateway.py requires the `boto3` and `botocore` modules")
 
 import ansible.modules.cloud.amazon.aws_api_gateway as agw
+import ansible.module_utils.aws.core as core
 
 
 exit_return_dict = {}
@@ -53,8 +54,8 @@ def test_upload_api(monkeypatch):
     def return_fake_connection(*args, **kwargs):
         return FakeConnection()
 
-    monkeypatch.setattr(agw, "boto3_conn", return_fake_connection)
-    monkeypatch.setattr(agw.AnsibleModule, "exit_json", fake_exit_json)
+    monkeypatch.setattr(core, "boto3_conn", return_fake_connection)
+    monkeypatch.setattr(core.AnsibleAWSModule, "exit_json", fake_exit_json)
 
     set_module_args({
         "api_id": "fred",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
The patching in API Gateway unit tests don't play nicely with the way AnsibleAWSModule connects to AWS. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
aws_api_gateway

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
