### PR TITLE
fix a (forgotten?) change in moving createhome -> create_home

### DIFF
--- a/changelogs/fragments/user-freebsd-createhome-name-fix.yaml
+++ b/changelogs/fragments/user-freebsd-createhome-name-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - use correct attribute name in FreeBSD for creat_home (https://github.com/ansible/ansible/pull/42711)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1008,7 +1008,7 @@ class FreeBsdUser(User):
             cmd.append(self.comment)
 
         if self.home is not None:
-            if (info[5] != self.home and self.move_home) or (not os.path.exists(self.home) and self.createhome):
+            if (info[5] != self.home and self.move_home) or (not os.path.exists(self.home) and self.create_home):
                 cmd.append('-m')
             cmd.append('-d')
             cmd.append(self.home)


### PR DESCRIPTION
##### SUMMARY

One-char fix for following bug on FreeBSD host whith user module:
```
fatal: [webssp]: FAILED! => {"changed": false, "module_stderr": "X11 forwarding request failed
Traceback (most recent call last):
  File \"/tmp/ansible_2rmlBl/ansible_module_user.py\", line 2487, in <module>
    main()\n  File \"/tmp/ansible_2rmlBl/ansible_module_user.py\", line 2426, in main
    (rc, out, err) = user.modify_user()
  File \"/tmp/ansible_2rmlBl/ansible_module_user.py\", line 1011, in modify_user
    if (info[5] != self.home and self.move_home) or (not os.path.exists(self.home) and self.createhome):
AttributeError: 'FreeBsdUser' object has no attribute 'createhome'
", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
```

It happenned with 'createhome' AND with 'create_home' form, with python 2.7 AND python 3.6

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`user.py`

##### ANSIBLE VERSION
```
ansible-3.6 2.6.1
  config file = /users/info/dgeo/.ansible.cfg
  configured module search path = ['/usr/local/share/py36-ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible-3.6
  python version = 3.6.6 (default, Jul  6 2018, 18:35:08) [GCC 4.2.1 Compatible FreeBSD Clang 4.0.0 (tags/RELEASE_400/final 297347)]

```


##### ADDITIONAL INFORMATION
On a freebsd host, using 'user' module with createhome or create_home
