### PR TITLE
win_chocolatey: add TLSv1.2 support for install phase (#41992)

### DIFF
--- a/changelogs/fragments/win_chocoalatey_install_tls12.yml
+++ b/changelogs/fragments/win_chocoalatey_install_tls12.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_chocolatey - enable TLSv1.2 support when downloading the Chocolatey installer https://github.com/ansible/ansible/issues/41906

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -47,8 +47,17 @@ Function Chocolatey-Install-Upgrade
     $ChocoAlreadyInstalled = Get-Command -Name "choco.exe" -ErrorAction SilentlyContinue
     if ($ChocoAlreadyInstalled -eq $null)
     {
+        # We need to install chocolatey
+        # Enable TLS1.1/TLS1.2 if they're available but disabled (eg. .NET 4.5)
+        $security_protcols = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::SystemDefault
+        if ([Net.SecurityProtocolType].GetMember("Tls11").Count -gt 0) {
+            $security_protcols = $security_protcols -bor [Net.SecurityProtocolType]::Tls11
+        }
+        if ([Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
+            $security_protcols = $security_protcols -bor [Net.SecurityProtocolType]::Tls12
+        }
+        [Net.ServicePointManager]::SecurityProtocol = $security_protcols
 
-        #We need to install chocolatey
         $wc = New-Object System.Net.WebClient;
         if ($proxy_url)
         {


### PR DESCRIPTION
(cherry picked from commit e3521776f5c737207bd0930dc174b3e490479b26)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/41992

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_chocolatey

##### ANSIBLE VERSION
```
2.6
```