### PR TITLE
Add json to nxos get_capabilities output key when it is supported

### DIFF
--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -403,6 +403,8 @@ class Nxapi:
                 if 'Chassis' in info['name']:
                     device_info['network_os_platform'] = info['productid']
 
+        device_info['network_os_json_support'] = True
+
         return device_info
 
     def get_capabilities(self):

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -403,12 +403,12 @@ class Nxapi:
                 if 'Chassis' in info['name']:
                     device_info['network_os_platform'] = info['productid']
 
-        device_info['network_os_json_support'] = True
-
         return device_info
 
     def get_capabilities(self):
         result = {}
+        result['output'] = []
+        result['output'].append('json')
         result['device_info'] = self.get_device_info()
         result['network_api'] = 'nxapi'
         return result

--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -39,7 +39,7 @@ author:
   - Gabriele Gerbino (@GGabriele)
 notes:
   - This module is only supported on the NX-OS device that supports JSON
-    structured output. NX-OS OS version should be 6.0(2)A8 or 7.x or later.
+    structured output.
 options:
   gather_subset:
     description:
@@ -544,9 +544,7 @@ def main():
 
     capabilities = get_capabilities(module)
     if capabilities:
-        os_version = capabilities['device_info']['network_os_version']
-        os_version_major = int(os_version[0])
-        if os_version_major < 7 and "6.0(2)A8" not in os_version:
+        if not capabilities['device_info']['network_os_json_support']:
             module.fail_json(msg="this module requires JSON structured output support on the NX-OS device")
 
     warnings = list()

--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -544,7 +544,7 @@ def main():
 
     capabilities = get_capabilities(module)
     if capabilities:
-        if not capabilities['device_info']['network_os_json_support']:
+        if 'json' not in capabilities['output']:
             module.fail_json(msg="this module requires JSON structured output support on the NX-OS device")
 
     warnings = list()

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -55,14 +55,14 @@ class Cliconf(CliconfBase):
 
     def check_json_support(self):
         """
-        The method returns boolean value that determines whether JSON
-        structured output is supported on the device or not
+        The method returns 'json' if JSON structured output is
+        supported on the device
         """
         try:
             self.get('show version | json')
-            return True
-        except AnsibleConnectionFailure as exc:
-            return False
+            return 'json'
+        except AnsibleConnectionFailure:
+            pass
 
     def get_device_info(self):
         device_info = {}
@@ -110,8 +110,6 @@ class Cliconf(CliconfBase):
         if match_os_platform:
             device_info['network_os_platform'] = match_os_platform.group(1)
 
-        device_info['network_os_json_support'] = self.check_json_support()
-
         return device_info
 
     def get_config(self, source='running', format='text', flags=None):
@@ -136,12 +134,15 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = {}
+        result['output'] = []
+        result['output'].append(self.check_json_support())
         result['rpc'] = self.get_base_rpc()
         result['device_info'] = self.get_device_info()
         if isinstance(self._connection, NetworkCli):
             result['network_api'] = 'cliconf'
         else:
             result['network_api'] = 'nxapi'
+
         return json.dumps(result)
 
     # Migrated from module_utils

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -53,6 +53,17 @@ class Cliconf(CliconfBase):
             resp = self._connection.send_request(command, **kwargs)
         return resp
 
+    def check_json_support(self):
+        """
+        The method returns boolean value that determines whether JSON
+        structured output is supported on the device or not
+        """
+        try:
+            self.get('show version | json')
+            return True
+        except AnsibleConnectionFailure as exc:
+            return False
+
     def get_device_info(self):
         device_info = {}
 
@@ -98,6 +109,8 @@ class Cliconf(CliconfBase):
                                       r'PID:\s+(\S+)', platform_reply, re.M)
         if match_os_platform:
             device_info['network_os_platform'] = match_os_platform.group(1)
+
+        device_info['network_os_json_support'] = self.check_json_support()
 
         return device_info
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/42707
Instead of hard coding nxos version in nxos_facts module, Add json to nxos get_capabilities output key when it is supported
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
plugins/cliconf/nxos.py
module_utils/network/nxos/nxos.py
modules/network/nxos/nxos_facts.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```