### PR TITLE
VMware: add support for boot option firmware

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/boot_firmware_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/boot_firmware_d1_c1_f0.yml
@@ -1,0 +1,149 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of VMS from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=VM
+  register: vmlist
+
+- debug: var=vcsim_instance
+- debug: var=vmlist
+
+- name: create new VMs with boot_firmware as 'bios'
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_' + item|basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    hardware:
+        num_cpus: 4
+        boot_firmware: "bios"
+        memory_mb: 512
+    disk:
+        - size: 1gb
+          type: thin
+          autoselect_datastore: True
+    state: poweredoff
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'] }}"
+  register: clone_d1_c1_f0
+
+- debug: var=clone_d1_c1_f0
+
+- name: assert that changes were made
+  assert:
+    that:
+        - "clone_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+
+# VCSIM does not recognizes existing VMs boot firmware
+#- name: create new VMs again with boot_firmware as 'bios'
+#  vmware_guest:
+#    validate_certs: False
+#    hostname: "{{ vcsim }}"
+#    username: "{{ vcsim_instance['json']['username'] }}"
+#    password: "{{ vcsim_instance['json']['password'] }}"
+#    name: "{{ 'newvm_' + item|basename }}"
+#    guest_id: centos64Guest
+#    datacenter: "{{ (item|basename).split('_')[0] }}"
+#    hardware:
+#        num_cpus: 4
+#        boot_firmware: "bios"
+#        memory_mb: 512
+#    disk:
+#        - size: 1gb
+#          type: thin
+#          autoselect_datastore: True
+#    state: poweredoff
+#    folder: "{{ item|dirname }}"
+#  with_items: "{{ vmlist['json'] }}"
+#  register: clone_d1_c1_f0
+
+#- debug: var=clone_d1_c1_f0
+
+#- name: assert that changes were not made
+#  assert:
+#    that:
+#        - "clone_d1_c1_f0.results|map(attribute='changed')|unique|list == [false]"
+
+- name: create new VMs with boot_firmware as 'efi'
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_efi_' + item|basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    hardware:
+        num_cpus: 4
+        boot_firmware: "efi"
+        memory_mb: 512
+    disk:
+        - size: 1gb
+          type: thin
+          autoselect_datastore: True
+    state: poweredoff
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'] }}"
+  register: clone_d1_c1_f0
+
+- debug: var=clone_d1_c1_f0
+
+- name: assert that changes were made
+  assert:
+    that:
+        - "clone_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+
+# VCSIM does not recognizes existing VMs boot firmware
+#- name: create new VMs again with boot_firmware as 'efi'
+#  vmware_guest:
+#    validate_certs: False
+#    hostname: "{{ vcsim }}"
+#    username: "{{ vcsim_instance['json']['username'] }}"
+#    password: "{{ vcsim_instance['json']['password'] }}"
+#    name: "{{ 'newvm_efi_' + item|basename }}"
+#    guest_id: centos64Guest
+#    datacenter: "{{ (item|basename).split('_')[0] }}"
+#    hardware:
+#        num_cpus: 4
+#        boot_firmware: "efi"
+#        memory_mb: 512
+#    disk:
+#        - size: 1gb
+#          type: thin
+#          autoselect_datastore: True
+#    state: poweredoff
+#    folder: "{{ item|dirname }}"
+#  with_items: "{{ vmlist['json'] }}"
+#  register: clone_d1_c1_f0
+
+#- debug: var=clone_d1_c1_f0
+
+#- name: assert that changes were not made
+#  assert:
+#    that:
+#        - "clone_d1_c1_f0.results|map(attribute='changed')|unique|list == [false]"

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -31,3 +31,4 @@
 - include: network_with_device.yml
 - include: disk_mode_d1_c1_f0.yml
 - include: linked_clone_d1_c1_f0.yml
+- include: boot_firmware_d1_c1_f0.yml


### PR DESCRIPTION
##### SUMMARY
This fix adds support for the boot option 'firmware'

Fixes: #42541

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest.py
test/integration/targets/vmware_guest/tasks/boot_firmware_d1_c1_f0.yml
test/integration/targets/vmware_guest/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```