### PR TITLE
Fix openstack inventory plugin to prevent generating empty groups

### DIFF
--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -253,7 +253,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         groups.append(cloud)
 
         # Create a group on region
-        groups.append(region)
+        if region:
+            groups.append(region)
 
         # And one by cloud_region
         groups.append("%s_%s" % (cloud, region))


### PR DESCRIPTION
##### SUMMARY
There is no need to add an empty hosts group, when region is not set

https://github.com/ansible/ansible/issues/42042

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/opentack

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.5
  config file = /Users/igor.tiunov/Sources/ansible-openstack-bug/ansible.cfg
  configured module search path = [u'/Users/igor.tiunov/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
Region is an optional authentication parameter. When it is not present an empty group should not be created
