### PR TITLE
remove unused templar._clean_data()

### DIFF
--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -177,71 +177,12 @@ class TestTemplarTemplate(BaseTemplar, unittest.TestCase):
         res = self.templar.template(unsafe_obj)
         self.assertTrue(self.is_unsafe(res), 'returned value from template.template (%s) is not marked unsafe' % res)
 
-    # TODO: not sure what template is supposed to do it, but it currently throws attributeError
-    @patch('ansible.template.Templar._clean_data')
-    def test_template_unsafe_non_string_clean_data_exception(self, mock_clean_data):
-        msg = 'Error raised from _clean_data by test_template_unsafe_non_string_clean_data_exception'
-        mock_clean_data.side_effect = AnsibleError(msg)
-        unsafe_obj = AnsibleUnsafe()
-        res = self.templar.template(unsafe_obj)
-        self.assertTrue(self.is_unsafe(res), 'returned value from template.template (%s) is not marked unsafe' % res)
-
-    # TODO: not sure what template is supposed to do it, but it currently throws attributeError
-    @patch('ansible.template.Templar._clean_data', side_effect=AnsibleError)
-    def test_template_unsafe_non_string_subclass_clean_data_exception(self, mock_clean_data):
-        unsafe_obj = SomeUnsafeClass()
-        self.assertTrue(self.is_unsafe(unsafe_obj))
-        res = self.templar.template(unsafe_obj)
-        self.assertTrue(self.is_unsafe(res), 'returned value from template.template (%s) is not marked unsafe' % res)
-
     def test_weird(self):
         data = u'''1 2 #}huh{# %}ddfg{% }}dfdfg{{  {%what%} {{#foo#}} {%{bar}%} {#%blip%#} {{asdfsd%} 3 4 {{foo}} 5 6 7'''
         self.assertRaisesRegexp(AnsibleError,
                                 'template error while templating string',
                                 self.templar.template,
                                 data)
-
-
-class TestTemplarCleanData(BaseTemplar, unittest.TestCase):
-    def test_clean_data(self):
-        res = self.templar._clean_data(u'some string')
-        self.assertEqual(res, u'some string')
-
-    def test_clean_data_not_stringtype(self):
-        res = self.templar._clean_data(None)
-        # None vs NoneType
-        self.assertEqual(res, None)
-
-    def test_clean_data_jinja(self):
-        res = self.templar._clean_data(u'1 2 {what} 3 4 {{foo}} 5 6 7')
-        self.assertEqual(res, u'1 2 {what} 3 4 {#foo#} 5 6 7')
-
-    def test_clean_data_block(self):
-        res = self.templar._clean_data(u'1 2 {%what%} 3 4 {{foo}} 5 6 7')
-        self.assertEqual(res, u'1 2 {#what#} 3 4 {#foo#} 5 6 7')
-
-#    def test_clean_data_weird(self):
-#        res = self.templar._clean_data(u'1 2 #}huh{# %}ddfg{% }}dfdfg{{  {%what%} {{#foo#}} {%{bar}%} {#%blip%#} {{asdfsd%} 3 4 {{foo}} 5 6 7')
-#        print(res)
-
-        self.assertEqual(res, u'1 2 {#what#} 3 4 {#foo#} 5 6 7')
-
-    def test_clean_data_object(self):
-        obj = {u'foo': [1, 2, 3, u'bdasdf', u'{what}', u'{{foo}}', 5]}
-        clean_obj = {u'foo': [1, 2, 3, u'bdasdf', u'{what}', u'{#foo#}', 5]}
-        res = self.templar._clean_data(obj)
-        self.assertNotEqual(res, obj)
-        self.assertEqual(res, clean_obj)
-
-    def test_clean_data_bad_dict(self):
-        res = self.templar._clean_data(u'{{bad_dict}}')
-        self.assertEqual(res, u'{#bad_dict#}')
-
-    def test_clean_data_unsafe_obj(self):
-        some_obj = SomeClass()
-        unsafe_obj = wrap_var(some_obj)
-        res = self.templar._clean_data(unsafe_obj)
-        self.assertIsInstance(res, SomeClass)
 
 
 class TestTemplarMisc(BaseTemplar, unittest.TestCase):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
remove unused '_clean_data()' function.  This is only used it its tests.  It seems like it is no longer needed, as this is modernly handled with the UnsafeProxy class.

Its last use was removed in https://github.com/ansible/ansible/pull/23742 commit 4594bee65ae2123061e2f262503310a9a57a5a59

It was added to its current location in commit cdc6c5208ec018ad48bc9281bb2621deec596113 as a response to https://github.com/ansible/ansible/issues/12513

Looks like the concept was originally introduced in 8ed6350e65c82292a631f08845dfaacffe7f07f5

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
template engine

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (remove-clean-data b112d3c11c) last updated 2018/07/13 08:50:44 (GMT -400)
  config file = /home/user/ansible-ops/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/ansible-ansible/lib/ansible
  executable location = /home/user/ansible-ansible/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
