### PR TITLE
Don't use deepcopy when creating attributes unless really needed

### DIFF
--- a/lib/ansible/playbook/attribute.py
+++ b/lib/ansible/playbook/attribute.py
@@ -19,7 +19,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from copy import deepcopy
+from copy import copy, deepcopy
+
+
+_CONTAINERS = frozenset(('list', 'dict', 'set'))
 
 
 class Attribute:
@@ -84,8 +87,17 @@ class Attribute:
         self.extend = extend
         self.prepend = prepend
 
-        if default is not None and self.isa in ('list', 'dict', 'set'):
-            self.default = deepcopy(default)
+        if default is not None and self.isa in _CONTAINERS:
+            if default:
+                self.default = deepcopy(default)
+            else:
+                # Don't need to deepcopy default if the container is empty
+                # Note: switch to try: except once Python3 is more widespread
+                if hasattr(default, 'copy'):
+                    self.default = default.copy()
+                else:
+                    # list on python2 does not have .copy()
+                    self.default = copy(default)
         else:
             self.default = default
 


### PR DESCRIPTION
##### SUMMARY
deepcopy is 85-90% slower than copy() on an empty dictionary so avoid deepcopy when we can.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Attributes

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
We only have 163 Attributes so far so I don't anticipate this will make a big difference but unnecessary deepcopy is wasteful.