### PR TITLE
aci_ap: Ensure AP is removed before tests start

### DIFF
--- a/test/integration/targets/aci_ap/tasks/main.yml
+++ b/test/integration/targets/aci_ap/tasks/main.yml
@@ -21,6 +21,12 @@
     tenant: anstest
   register: tenant_present
 
+- name: ensure ap does not exist initially
+  aci_ap:
+    <<: *aci_tenant_present
+    ap: anstest
+    state: absent
+
 - name: create ap - check mode works
   aci_ap: &aci_ap_present
     <<: *aci_tenant_present


### PR DESCRIPTION
##### SUMMARY
This fixes the test if it was incorrectly aborted (on a local system).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aci_ap

##### ANSIBLE VERSION
v2.7 and earlier