### PR TITLE
Fix for starttls connections for notification mail module

### DIFF
--- a/changelogs/fragments/fix_tls_mail.yaml
+++ b/changelogs/fragments/fix_tls_mail.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - fix mail module when using starttls https://github.com/ansible/ansible/issues/42338

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -263,6 +263,11 @@ def main():
     except smtplib.SMTPException as e:
         module.fail_json(rc=1, msg='Unable to Connect %s:%s: %s' % (host, port, to_native(e)), exception=traceback.format_exc())
 
+    try:
+        smtp.ehlo()
+    except smtplib.SMTPException as e:
+            module.fail_json(rc=1, msg='Helo failed for host %s:%s: %s' % (host, port, to_native(e)), exception=traceback.format_exc())
+
     if int(code) > 0:
         if not secure_state and secure in ('starttls', 'try'):
             if smtp.has_extn('STARTTLS'):
@@ -272,13 +277,13 @@ def main():
                 except smtplib.SMTPException as e:
                     module.fail_json(rc=1, msg='Unable to start an encrypted session to %s:%s: %s' %
                                      (host, port, to_native(e)), exception=traceback.format_exc())
+                try:
+                    smtp.ehlo()
+                except smtplib.SMTPException as e:
+                    module.fail_json(rc=1, msg='Helo failed for host %s:%s: %s' % (host, port, to_native(e)), exception=traceback.format_exc())
             else:
                 if secure == 'starttls':
                     module.fail_json(rc=1, msg='StartTLS is not offered on server %s:%s' % (host, port))
-        try:
-            smtp.ehlo()
-        except smtplib.SMTPException as e:
-            module.fail_json(rc=1, msg='Helo failed for host %s:%s: %s' % (host, port, to_native(e)), exception=traceback.format_exc())
 
     if username and password:
         if smtp.has_extn('AUTH'):


### PR DESCRIPTION
##### SUMMARY
* starttls connection usage is now adding smtp.ehlo before smtp.has_extn function.
* Fixes #42338

(cherry picked from commit 5df01abd58a98b39f7f21432a6e56fea5e0e7c51)


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
mail
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```