### PR TITLE
empty host/group name is an error

### DIFF
--- a/changelogs/fragments/empty_gh_error.yaml
+++ b/changelogs/fragments/empty_gh_error.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - emtpy host/group name is an error https://github.com/ansible/ansible/issues/42044

--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -161,13 +161,16 @@ class InventoryData(object):
     def add_group(self, group):
         ''' adds a group to inventory if not there already '''
 
-        if group not in self.groups:
-            g = Group(group)
-            self.groups[group] = g
-            self._groups_dict_cache = {}
-            display.debug("Added group %s to inventory" % group)
+        if group:
+            if group not in self.groups:
+                g = Group(group)
+                self.groups[group] = g
+                self._groups_dict_cache = {}
+                display.debug("Added group %s to inventory" % group)
+            else:
+                display.debug("group %s already in inventory" % group)
         else:
-            display.debug("group %s already in inventory" % group)
+            raise AnsibleError("Invalid empty/false group name provided: %s" % group)
 
     def remove_group(self, group):
 
@@ -183,38 +186,41 @@ class InventoryData(object):
     def add_host(self, host, group=None, port=None):
         ''' adds a host to inventory and possibly a group if not there already '''
 
-        g = None
-        if group:
-            if group in self.groups:
-                g = self.groups[group]
-            else:
-                raise AnsibleError("Could not find group %s in inventory" % group)
-
-        if host not in self.hosts:
-            h = Host(host, port)
-            self.hosts[host] = h
-            if self.current_source:  # set to 'first source' in which host was encountered
-                self.set_variable(host, 'inventory_file', self.current_source)
-                self.set_variable(host, 'inventory_dir', basedir(self.current_source))
-            else:
-                self.set_variable(host, 'inventory_file', None)
-                self.set_variable(host, 'inventory_dir', None)
-            display.debug("Added host %s to inventory" % (host))
-
-            # set default localhost from inventory to avoid creating an implicit one. Last localhost defined 'wins'.
-            if host in C.LOCALHOST:
-                if self.localhost is None:
-                    self.localhost = self.hosts[host]
-                    display.vvvv("Set default localhost to %s" % h)
+        if host:
+            g = None
+            if group:
+                if group in self.groups:
+                    g = self.groups[group]
                 else:
-                    display.warning("A duplicate localhost-like entry was found (%s). First found localhost was %s" % (h, self.localhost.name))
-        else:
-            h = self.hosts[host]
+                    raise AnsibleError("Could not find group %s in inventory" % group)
 
-        if g:
-            g.add_host(h)
-            self._groups_dict_cache = {}
-            display.debug("Added host %s to group %s" % (host, group))
+            if host not in self.hosts:
+                h = Host(host, port)
+                self.hosts[host] = h
+                if self.current_source:  # set to 'first source' in which host was encountered
+                    self.set_variable(host, 'inventory_file', self.current_source)
+                    self.set_variable(host, 'inventory_dir', basedir(self.current_source))
+                else:
+                    self.set_variable(host, 'inventory_file', None)
+                    self.set_variable(host, 'inventory_dir', None)
+                display.debug("Added host %s to inventory" % (host))
+
+                # set default localhost from inventory to avoid creating an implicit one. Last localhost defined 'wins'.
+                if host in C.LOCALHOST:
+                    if self.localhost is None:
+                        self.localhost = self.hosts[host]
+                        display.vvvv("Set default localhost to %s" % h)
+                    else:
+                        display.warning("A duplicate localhost-like entry was found (%s). First found localhost was %s" % (h, self.localhost.name))
+            else:
+                h = self.hosts[host]
+
+            if g:
+                g.add_host(h)
+                self._groups_dict_cache = {}
+                display.debug("Added host %s to group %s" % (host, group))
+        else:
+            raise AnsibleError("Invalid empty host name provided: %s" % host)
 
     def remove_host(self, host):
 


### PR DESCRIPTION
##### SUMMARY
* error on false host/group name

(cherry picked from commit 12a8363fae9db871a478e12cd82af9b5fa2ccd5a)

NOTE: we might want to wait until openstack inventory plugin is fixed before backporting, as this will cause it to error out in some cases
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
inventory
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```