### PR TITLE
preserve delegation info on no_log (#42577)

### DIFF
--- a/changelogs/fragments/preserve_delegate_nolog.yml
+++ b/changelogs/fragments/preserve_delegate_nolog.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - preseve delegation info on nolog https://github.com/ansible/ansible/issues/42344

--- a/lib/ansible/executor/task_result.py
+++ b/lib/ansible/executor/task_result.py
@@ -12,6 +12,7 @@ from ansible.vars.clean import strip_internal_keys
 
 _IGNORE = ('failed', 'skipped')
 _PRESERVE = ('attempts', 'changed', 'retries')
+_SUB_PRESERVE = {'_ansible_delegated_vars': ('ansible_host', 'ansible_port', 'ansible_user', 'ansible_connection')}
 
 
 class TaskResult:
@@ -112,9 +113,19 @@ class TaskResult:
 
         if self._task.no_log or self._result.get('_ansible_no_log', False):
             x = {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result"}
+
+            # preserve full
             for preserve in _PRESERVE:
                 if preserve in self._result:
                     x[preserve] = self._result[preserve]
+
+            # preserve subset
+            for sub in _SUB_PRESERVE:
+                if sub in self._result:
+                    x[sub] = {}
+                    for key in _SUB_PRESERVE[sub]:
+                        x[sub][key] = self._result[sub][key]
+
             result._result = x
         elif self._result:
             result._result = deepcopy(self._result)


### PR DESCRIPTION
##### SUMMARY
* preserve delegation info on no_log

fixes #42344


(cherry picked from commit e115e6496fa8339be93a6e8c56de7fd55965f673)


<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
task results
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```