### PR TITLE
Change method of checking for apt_module deb download success (#42756)

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -854,9 +854,9 @@ def download(module, deb):
 
     try:
         rsp, info = fetch_url(module, deb, method='GET')
-        if info['status'] != 200:
-            module.fail_json(msg="Failed to download %s, %s" % (deb,
-                                                                info['msg']))
+        if info['status'] != 200 and not deb.startswith('file:/') and not (deb.startswith('ftp:/') and info.get('msg', '').startswith('OK')):
+            module.fail_json(msg="Download failed: {0}".format(deb), status_code=info['status'], response=info['msg'])
+
         # Ensure file is open in binary mode for Python 3
         f = open(package, 'wb')
         # Read 1kb at a time to save on ram


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fixes #42756 by imitating the download check used in get_url module

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
apt_module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
      config file = /etc/ansible/ansible.cfg
      configured module search path = [u'/Users/calvinmclean/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
      ansible python module location = /Users/calvinmclean/ansible/lib/python2.7/site-packages/ansible
      executable location = /Users/calvinmclean/ansible/bin/ansible
      python version = 2.7.14 (default, Mar 22 2018, 14:43:05) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

When downloading deb files from ftp url, it would say the download failed but show the message `OK`. This led me to believe that the download was actually successful but didn't have the expected download result code. I looked at the `get_url` module and it had a [similar check for `200` code](https://github.com/ansible/ansible/blob/stable-2.6/lib/ansible/modules/net_tools/basics/get_url.py#L331-L332) but also made sure it wasn't an ftp url so I imitated that here.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Test playbook:
```
---
- name: TEST
  hosts: vbox1
  tasks:
    - apt:
        deb: 'ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-dev-4.1.9-ubuntu14-x86_64.deb'
        state: 'present'
```

Result before change:
```
fatal: [vbox1]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "allow_unauthenticated": false,
            "autoclean": false,
            "autoremove": false,
            "cache_valid_time": 0,
            "deb": "ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-dev-4.1.9-ubuntu14-x86_64.deb",
            "default_release": null,
            "dpkg_options": "force-confdef,force-confold",
            "force": false,
            "force_apt_get": false,
            "install_recommends": null,
            "only_upgrade": false,
            "package": null,
            "purge": false,
            "state": "present",
            "update_cache": null,
            "upgrade": null
        }
    },
    "msg": "Failed to download ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-dev-4.1.9-ubuntu14-x86_64.deb, OK (31422924 bytes)"
}
```

Result after change:
```
changed: [vbox1] => {
    "changed": true,
    "diff": {},
    "invocation": {
        "module_args": {
            "allow_unauthenticated": false,
            "autoclean": false,
            "autoremove": false,
            "cache_valid_time": 0,
            "deb": "/tmp/ansible_iLLpRD/irods-dev-4.1.9-ubuntu14-x86_64.deb",
            "default_release": null,
            "dpkg_options": "force-confdef,force-confold",
            "force": false,
            "force_apt_get": false,
            "install_recommends": null,
            "only_upgrade": false,
            "package": null,
            "purge": false,
            "state": "present",
            "update_cache": null,
            "upgrade": null
        }
    },
    "stderr": "",
    "stderr_lines": [],
    "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following extra packages will be installed:\n  libssl-doc libssl1.0.0 zlib1g-dev\nThe following NEW packages will be installed:\n  libssl-dev libssl-doc zlib1g-dev\nThe following packages will be upgraded:\n  libssl1.0.0\n1 upgraded, 3 newly installed, 0 to remove and 105 not upgraded.\nNeed to get 2872 kB/3056 kB of archives.\nAfter this operation, 8290 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libssl1.0.0 amd64 1.0.1f-1ubuntu2.26 [829 kB]\nGet:2 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libssl-dev amd64 1.0.1f-1ubuntu2.26 [1072 kB]\nGet:3 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libssl-doc all 1.0.1f-1ubuntu2.26 [971 kB]\nPreconfiguring packages ...\nFetched 2872 kB in 1s (1512 kB/s)\n(Reading database ... 63113 files and directories currently installed.)\nPreparing to unpack .../libssl1.0.0_1.0.1f-1ubuntu2.26_amd64.deb ...\nUnpacking libssl1.0.0:amd64 (1.0.1f-1ubuntu2.26) over (1.0.1f-1ubuntu2.23) ...\nSelecting previously unselected package zlib1g-dev:amd64.\nPreparing to unpack .../zlib1g-dev_1%3a1.2.8.dfsg-1ubuntu1_amd64.deb ...\nUnpacking zlib1g-dev:amd64 (1:1.2.8.dfsg-1ubuntu1) ...\nSelecting previously unselected package libssl-dev:amd64.\nPreparing to unpack .../libssl-dev_1.0.1f-1ubuntu2.26_amd64.deb ...\nUnpacking libssl-dev:amd64 (1.0.1f-1ubuntu2.26) ...\nSelecting previously unselected package libssl-doc.\nPreparing to unpack .../libssl-doc_1.0.1f-1ubuntu2.26_all.deb ...\nUnpacking libssl-doc (1.0.1f-1ubuntu2.26) ...\nProcessing triggers for man-db (2.6.7.1-1ubuntu1) ...\nSetting up libssl1.0.0:amd64 (1.0.1f-1ubuntu2.26) ...\nSetting up zlib1g-dev:amd64 (1:1.2.8.dfsg-1ubuntu1) ...\nSetting up libssl-dev:amd64 (1.0.1f-1ubuntu2.26) ...\nSetting up libssl-doc (1.0.1f-1ubuntu2.26) ...\nProcessing triggers for libc-bin (2.19-0ubuntu6.14) ...\nSelecting previously unselected package irods-dev.\n(Reading database ... 64562 files and directories currently installed.)\nPreparing to unpack .../irods-dev-4.1.9-ubuntu14-x86_64.deb ...\nUnpacking irods-dev (4.1.9) ...\nSetting up irods-dev (4.1.9) ...\n",
    "stdout_lines": [
        "Reading package lists...",
        "Building dependency tree...",
        "Reading state information...",
        "The following extra packages will be installed:",
        "  libssl-doc libssl1.0.0 zlib1g-dev",
        "The following NEW packages will be installed:",
        "  libssl-dev libssl-doc zlib1g-dev",
        "The following packages will be upgraded:",
        "  libssl1.0.0",
        "1 upgraded, 3 newly installed, 0 to remove and 105 not upgraded.",
        "Need to get 2872 kB/3056 kB of archives.",
        "After this operation, 8290 kB of additional disk space will be used.",
        "Get:1 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libssl1.0.0 amd64 1.0.1f-1ubuntu2.26 [829 kB]",
        "Get:2 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libssl-dev amd64 1.0.1f-1ubuntu2.26 [1072 kB]",
        "Get:3 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libssl-doc all 1.0.1f-1ubuntu2.26 [971 kB]",
        "Preconfiguring packages ...",
        "Fetched 2872 kB in 1s (1512 kB/s)",
        "(Reading database ... 63113 files and directories currently installed.)",
        "Preparing to unpack .../libssl1.0.0_1.0.1f-1ubuntu2.26_amd64.deb ...",
        "Unpacking libssl1.0.0:amd64 (1.0.1f-1ubuntu2.26) over (1.0.1f-1ubuntu2.23) ...",
        "Selecting previously unselected package zlib1g-dev:amd64.",
        "Preparing to unpack .../zlib1g-dev_1%3a1.2.8.dfsg-1ubuntu1_amd64.deb ...",
        "Unpacking zlib1g-dev:amd64 (1:1.2.8.dfsg-1ubuntu1) ...",
        "Selecting previously unselected package libssl-dev:amd64.",
        "Preparing to unpack .../libssl-dev_1.0.1f-1ubuntu2.26_amd64.deb ...",
        "Unpacking libssl-dev:amd64 (1.0.1f-1ubuntu2.26) ...",
        "Selecting previously unselected package libssl-doc.",
        "Preparing to unpack .../libssl-doc_1.0.1f-1ubuntu2.26_all.deb ...",
        "Unpacking libssl-doc (1.0.1f-1ubuntu2.26) ...",
        "Processing triggers for man-db (2.6.7.1-1ubuntu1) ...",
        "Setting up libssl1.0.0:amd64 (1.0.1f-1ubuntu2.26) ...",
        "Setting up zlib1g-dev:amd64 (1:1.2.8.dfsg-1ubuntu1) ...",
        "Setting up libssl-dev:amd64 (1.0.1f-1ubuntu2.26) ...",
        "Setting up libssl-doc (1.0.1f-1ubuntu2.26) ...",
        "Processing triggers for libc-bin (2.19-0ubuntu6.14) ...",
        "Selecting previously unselected package irods-dev.",
        "(Reading database ... 64562 files and directories currently installed.)",
        "Preparing to unpack .../irods-dev-4.1.9-ubuntu14-x86_64.deb ...",
        "Unpacking irods-dev (4.1.9) ...",
        "Setting up irods-dev (4.1.9) ..."
    ]
}
```

Result of **intentional** failure (with bad url) after fix:
```
fatal: [vbox1]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "allow_unauthenticated": false,
            "autoclean": false,
            "autoremove": false,
            "cache_valid_time": 0,
            "deb": "ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-dev-4.1.9-ubuntu14-x86_64wow.deb",
            "default_release": null,
            "dpkg_options": "force-confdef,force-confold",
            "force": false,
            "force_apt_get": false,
            "install_recommends": null,
            "only_upgrade": false,
            "package": null,
            "purge": false,
            "state": "present",
            "update_cache": null,
            "upgrade": null
        }
    },
    "msg": "Download failed: ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-dev-4.1.9-ubuntu14-x86_64wow.deb",
    "response": "Request failed: <urlopen error ftp error: [Errno ftp error] 550 irods-dev-4.1.9-ubuntu14-x86_64wow.deb: No such file or directory>",
    "status_code": -1
}
```