### PR TITLE
Implement signed_request for sigV4 requests

### DIFF
--- a/lib/ansible/module_utils/aws/urls.py
+++ b/lib/ansible/module_utils/aws/urls.py
@@ -1,6 +1,9 @@
 # (C) Unknown?
 
-import datetime, hashlib, hmac, operator
+import datetime
+import hashlib
+import hmac
+import operator
 
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.ec2 import get_aws_connection_info
@@ -136,7 +139,7 @@ def signed_request(method="GET", service=None, host=None, uri=None, query=None, 
 
     # Make auth header with that info
 
-    authorization_header = "{} Credential={}/{}, SignedHeaders={}, Signature={}".format(
+    authorization_header = "{0} Credential={1}/{2}, SignedHeaders={3}, Signature={4}".format(
         algorithm, access_key, credential_scope, signed_headers, signature
     )
 
@@ -155,4 +158,3 @@ def signed_request(method="GET", service=None, host=None, uri=None, query=None, 
     final_headers.update(headers)
 
     return open_url(url, method=method, data=body, headers=final_headers)
-

--- a/lib/ansible/module_utils/aws/urls.py
+++ b/lib/ansible/module_utils/aws/urls.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # Copyright: (c) 2018, Aaron Haaf <aabonh@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/lib/ansible/module_utils/aws/urls.py
+++ b/lib/ansible/module_utils/aws/urls.py
@@ -1,0 +1,158 @@
+# (C) Unknown?
+
+import datetime, hashlib, hmac, operator
+
+from ansible.module_utils.urls import open_url
+from ansible.module_utils.ec2 import get_aws_connection_info
+import ansible.module_utils.six.moves.urllib.urlencode as urlencode
+
+def hexdigest(s):
+    """
+    Returns the sha256 hexdigest of a string after encoding.
+    """
+    return hashlib.sha256(s.encode('utf-8')).hexdigest()
+
+# Request parameters are in the query string. Query string values must
+# be URL-encoded (space=%20). The parameters must be sorted by name.
+def format_querystring(params=None):
+    """
+    Returns properly url-encoded query string from the provided params dict.
+
+    It's specially sorted for cannonical requests
+    """
+
+    if not params:
+        return ""
+    return urlencode(sorted(params.items(), operator.itemgetter(0)))
+
+# Key derivation functions. See:
+# http://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html#signature-v4-examples-python
+def sign(key, msg):
+    '''
+    Return digest for key applied to msg
+    '''
+    return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()
+
+def get_signature_key(key, dateStamp, regionName, serviceName):
+    '''
+    Returns signature key for AWS resource
+    '''
+    kDate = sign(('AWS4' + key).encode('utf-8'), dateStamp)
+    kRegion = sign(kDate, regionName)
+    kService = sign(kRegion, serviceName)
+    kSigning = sign(kService, 'aws4_request')
+    return kSigning
+
+# Reference: https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
+def signed_request(method="GET", service=None, host=None, uri=None, query=None, body="", module=None, boto3=True, headers=None):
+    """Generate a SigV4 request to an AWS resource for a module
+
+    This is used if you wish to authenticate with AWS credentials to a secure endpoint like an elastisearch domain.
+
+    Returns :class:`HTTPResponse` object.
+
+    Example:
+        result = signed_request(
+            module=this,
+            service="es",
+            host="search-recipes1-xxxxxxxxx.us-west-2.es.amazonaws.com",
+        )
+
+    :kwarg host: endpoint to talk to
+    :kwarg service: AWS id of service (like `ec2` or `es`)
+    :kwarg module: An AnsibleAWSModule to gather connection info from
+
+    :kwarg body: (optional) Payload to send
+    :kwarg method: (optional) HTTP verb to use
+    :kwarg query: (optional) dict of query params to handle
+    :kwarg uri: (optional) Resource path without query parameters
+    :returns: HTTPResponse
+    """
+
+    # Values
+
+    ## "Constants"
+    t = datetime.datetime.utcnow()
+    amz_date = t.strftime('%Y%m%dT%H%M%SZ')
+    datestamp = t.strftime('%Y%m%d') # Date w/o time, used in credential scope
+    algorithm = 'AWS4-HMAC-SHA256'
+
+    ## AWS stuff
+    region, _, boto_params = get_aws_connection_info(module, boto3)
+
+    access_key = boto_params["aws_access_key_id"]
+    secret_key = boto_params["aws_secret_access_key"]
+
+    if not access_key:
+        module.fail_json(msg="aws_access_key_id is missing")
+    if not secret_key:
+        module.fail_json(msg="aws_secret_access_key is missing")
+
+    credential_scope = '/'.join([datestamp, region, service, 'aws4_request'])
+
+    ## Argument Defaults
+    uri = uri or "/"
+    query_string = format_querystring(query) if query else ""
+
+    headers = headers or dict()
+    query = query or dict()
+
+    headers.update({
+        "host": host,
+        'x-amz-date': amz_date,
+    })
+
+    if method is "GET":
+        body = ""
+
+    body = body
+
+    # Derived data
+
+    body_hash = hexdigest(body)
+    signed_headers = ";".join(sorted(headers.keys()))
+
+    # Setup Cannonical request to generate auth token
+
+    cannonical_headers = "\n".join([
+        key.lower().strip() + ":" + value for key,value in headers.items()
+    ]) + '\n' # Note additional trailing newline
+
+    cannonical_request = "\n".join([
+        method,
+        uri,
+        query_string,
+        cannonical_headers,
+        signed_headers,
+        body_hash,
+    ])
+
+    string_to_sign = '\n'.join([algorithm, amz_date, credential_scope, hexdigest(cannonical_request)])
+
+    # Sign the Cannonical request
+
+    signing_key = get_signature_key(secret_key, datestamp, region, service)
+    signature = hmac.new(signing_key, string_to_sign.encode('utf-8'), hashlib.sha256).hexdigest()
+
+    # Make auth header with that info
+
+    authorization_header = "{} Credential={}/{}, SignedHeaders={}, Signature={}".format(
+        algorithm, access_key, credential_scope, signed_headers, signature
+    )
+
+    # PERFORM THE REQUEST!
+
+    url = "https://" + host + uri
+
+    if query_string is not "":
+        url = url + "?" + query_string
+
+    final_headers = {
+        'x-amz-date': amz_date,
+        'Authorization': authorization_header,
+    }
+
+    final_headers.update(headers)
+
+    return open_url(url, method=method, data=body, headers=final_headers)
+

--- a/lib/ansible/module_utils/aws/urls.py
+++ b/lib/ansible/module_utils/aws/urls.py
@@ -81,7 +81,7 @@ def signed_request(method="GET", service=None, host=None, uri=None, query=None, 
 
     t = datetime.datetime.utcnow()
     amz_date = t.strftime('%Y%m%dT%H%M%SZ')
-    datestamp = t.strftime('%Y%m%d') # Date w/o time, used in credential scope
+    datestamp = t.strftime('%Y%m%d')  # Date w/o time, used in credential scope
     algorithm = 'AWS4-HMAC-SHA256'
 
     # AWS stuff
@@ -125,7 +125,7 @@ def signed_request(method="GET", service=None, host=None, uri=None, query=None, 
 
     cannonical_headers = "\n".join([
         key.lower().strip() + ":" + value for key, value in headers.items()
-    ]) + '\n' # Note additional trailing newline
+    ]) + '\n'  # Note additional trailing newline
 
     cannonical_request = "\n".join([
         method,

--- a/lib/ansible/module_utils/aws/urls.py
+++ b/lib/ansible/module_utils/aws/urls.py
@@ -7,7 +7,7 @@ import operator
 
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.ec2 import get_aws_connection_info
-import ansible.module_utils.six.moves.urllib.parse.urlencode as urlencode
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 
 def hexdigest(s):

--- a/lib/ansible/module_utils/aws/urls.py
+++ b/lib/ansible/module_utils/aws/urls.py
@@ -65,7 +65,7 @@ def get_aws_key_pair(module):
     if not HAS_BOTO3:
         module.fail_json("get_aws_key_pair requires boto3")
 
-    region, dummy, boto_params = get_aws_connection_info(module, boto3=True)
+    dummy, dummy, boto_params = get_aws_connection_info(module, boto3=True)
 
     profile = boto_params.get('profile_name')
 

--- a/lib/ansible/module_utils/aws/urls.py
+++ b/lib/ansible/module_utils/aws/urls.py
@@ -9,7 +9,12 @@ import operator
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, HAS_BOTO3
 from ansible.module_utils.six.moves.urllib.parse import urlencode
-from boto3 import session
+
+try:
+    from boto3 import session
+except ImportError:
+    pass
+
 
 def hexdigest(s):
     """

--- a/lib/ansible/module_utils/aws/urls.py
+++ b/lib/ansible/module_utils/aws/urls.py
@@ -80,7 +80,7 @@ def signed_request(
         method="GET", service=None, host=None, uri=None,
         query=None, body="", headers=None,
         session_in_header=True, session_in_query=False
-    ):
+):
     """Generate a SigV4 request to an AWS resource for a module
 
     This is used if you wish to authenticate with AWS credentials to a secure endpoint like an elastisearch domain.

--- a/lib/ansible/module_utils/aws/urls.py
+++ b/lib/ansible/module_utils/aws/urls.py
@@ -75,7 +75,12 @@ def get_aws_credentials_object(module):
 
 
 # Reference: https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
-def signed_request(method="GET", service=None, host=None, uri=None, query=None, body="", module=None, headers=None, session_in_header=True, session_in_query=False):
+def signed_request(
+        module=None,
+        method="GET", service=None, host=None, uri=None,
+        query=None, body="", headers=None,
+        session_in_header=True, session_in_query=False
+    ):
     """Generate a SigV4 request to an AWS resource for a module
 
     This is used if you wish to authenticate with AWS credentials to a secure endpoint like an elastisearch domain.

--- a/lib/ansible/module_utils/aws/urls.py
+++ b/lib/ansible/module_utils/aws/urls.py
@@ -21,7 +21,7 @@ def hexdigest(s):
     Returns the sha256 hexdigest of a string after encoding.
     """
 
-    return hashlib.sha256(s.encode('utf-8')).hexdigest()
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
 
 
 def format_querystring(params=None):
@@ -45,7 +45,7 @@ def sign(key, msg):
     Return digest for key applied to msg
     '''
 
-    return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()
+    return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
 
 
 def get_signature_key(key, dateStamp, regionName, serviceName):
@@ -53,10 +53,10 @@ def get_signature_key(key, dateStamp, regionName, serviceName):
     Returns signature key for AWS resource
     '''
 
-    kDate = sign(('AWS4' + key).encode('utf-8'), dateStamp)
+    kDate = sign(("AWS4" + key).encode("utf-8"), dateStamp)
     kRegion = sign(kDate, regionName)
     kService = sign(kRegion, serviceName)
-    kSigning = sign(kService, 'aws4_request')
+    kSigning = sign(kService, "aws4_request")
     return kSigning
 
 
@@ -110,9 +110,9 @@ def signed_request(method="GET", service=None, host=None, uri=None, query=None, 
     # "Constants"
 
     t = datetime.datetime.utcnow()
-    amz_date = t.strftime('%Y%m%dT%H%M%SZ')
-    datestamp = t.strftime('%Y%m%d')  # Date w/o time, used in credential scope
-    algorithm = 'AWS4-HMAC-SHA256'
+    amz_date = t.strftime("%Y%m%dT%H%M%SZ")
+    datestamp = t.strftime("%Y%m%d")  # Date w/o time, used in credential scope
+    algorithm = "AWS4-HMAC-SHA256"
 
     # AWS stuff
 
@@ -127,7 +127,7 @@ def signed_request(method="GET", service=None, host=None, uri=None, query=None, 
     if not secret_key:
         module.fail_json(msg="aws_secret_access_key is missing")
 
-    credential_scope = '/'.join([datestamp, region, service, 'aws4_request'])
+    credential_scope = "/".join([datestamp, region, service, "aws4_request"])
 
     # Argument Defaults
 
@@ -139,7 +139,7 @@ def signed_request(method="GET", service=None, host=None, uri=None, query=None, 
 
     headers.update({
         "host": host,
-        'x-amz-date': amz_date,
+        "x-amz-date": amz_date,
     })
 
     # Handle adding of session_token if present
@@ -163,7 +163,7 @@ def signed_request(method="GET", service=None, host=None, uri=None, query=None, 
 
     cannonical_headers = "\n".join([
         key.lower().strip() + ":" + value for key, value in headers.items()
-    ]) + '\n'  # Note additional trailing newline
+    ]) + "\n"  # Note additional trailing newline
 
     cannonical_request = "\n".join([
         method,
@@ -174,12 +174,12 @@ def signed_request(method="GET", service=None, host=None, uri=None, query=None, 
         body_hash,
     ])
 
-    string_to_sign = '\n'.join([algorithm, amz_date, credential_scope, hexdigest(cannonical_request)])
+    string_to_sign = "\n".join([algorithm, amz_date, credential_scope, hexdigest(cannonical_request)])
 
     # Sign the Cannonical request
 
     signing_key = get_signature_key(secret_key, datestamp, region, service)
-    signature = hmac.new(signing_key, string_to_sign.encode('utf-8'), hashlib.sha256).hexdigest()
+    signature = hmac.new(signing_key, string_to_sign.encode("utf-8"), hashlib.sha256).hexdigest()
 
     # Make auth header with that info
 
@@ -195,8 +195,8 @@ def signed_request(method="GET", service=None, host=None, uri=None, query=None, 
         url = url + "?" + query_string
 
     final_headers = {
-        'x-amz-date': amz_date,
-        'Authorization': authorization_header,
+        "x-amz-date": amz_date,
+        "Authorization": authorization_header,
     }
 
     final_headers.update(headers)

--- a/lib/ansible/module_utils/aws/urls.py
+++ b/lib/ansible/module_utils/aws/urls.py
@@ -1,4 +1,7 @@
-# (C) Unknown?
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Aaron Haaf <aabonh@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 import datetime
 import hashlib


### PR DESCRIPTION
##### SUMMARY
In order to write modules to request to endpoints with security provided by IAM, sigV4 requests must be written. This implements the `signed_request` function in a new package `module_utils.aws.urls` to facilitate this.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /ansible/ansible.cfg
  configured module search path = ['/ansible/library', '/usr/share/ansible']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, May  5 2018, 03:09:35) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION

This enables a module that's something like:

```
  tasks:
  - es_request:
      host: "{{my_domain}}"
      aws_access_key: "{{my_key}}"
      aws_secret_key: "{{my_secret}}"
```

to return 

```
{
  "changed": false,
  "msg": "success",
  "result": {
    "cluster_name": "shh",
    "cluster_uuid": "shhh",
    "name": "shhhh",
    "tagline": "You Know, for Search",
    "version": {
      "build_date": "2018-05-07T13:32:30.335985Z",
      "build_hash": "c59ff00",
      "build_snapshot": false,
      "lucene_version": "7.2.1",
      "minimum_index_compatibility_version": "5.0.0",
      "minimum_wire_compatibility_version": "5.6.0",
      "number": "6.2.3"
    }
  }
}
```
