### PR TITLE
Support lookup etcd3

### DIFF
--- a/lib/ansible/plugins/lookup/etcd3.py
+++ b/lib/ansible/plugins/lookup/etcd3.py
@@ -78,8 +78,7 @@ class Etcd3:
         try:
             client = etcd3.client(host, port)
             resp = []
-            print("ok")
-            for value, _ in client.get_prefix(key):
+            for value, i in client.get_prefix(key):
                 if value is not None:
                     resp.append(json.loads(value))
             if len(resp) < 1:

--- a/lib/ansible/plugins/lookup/etcd3.py
+++ b/lib/ansible/plugins/lookup/etcd3.py
@@ -78,7 +78,7 @@ class Etcd3:
         try:
             client = etcd3.client(host, port)
             resp = []
-            for value, i in client.get_prefix(key):
+            for value, x in client.get_prefix(key):
                 if value is not None:
                     resp.append(json.loads(value))
             if len(resp) < 1:

--- a/lib/ansible/plugins/lookup/etcd3.py
+++ b/lib/ansible/plugins/lookup/etcd3.py
@@ -2,14 +2,14 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = '''
-    author: 
+    author:
         - Caio Tedim <caiotedim(at)gmail(dot)com>
     lookup: etcd3
     short_description: get on etcd3 server
     description:
         - Retrieves data from etcd3 server
     options:
-        url: 
+        url:
             description:
                 - URL for etcd3 server
             default: 127.0.0.1:2379
@@ -20,7 +20,6 @@ DOCUMENTATION = '''
                 - Key to lookup on etcd3 server
             type: string
             required: True
-            
     response:
         - Return value in a json format
         - If key not found the return comes on stdout attribute
@@ -29,19 +28,13 @@ DOCUMENTATION = '''
 EXAMPLES = '''
     - name: "Get key from etcd3 server"
       debug: msg="{{ lookup('etcd3', key='test',url='127.0.0.1:2379').foo }}"
-      
     - name: "Get key from etcd3 server, this key is not-found"
       debug: msg="{{ lookup('etcd3', key='testt',url='127.0.0.1:2379').stdout }}"
 '''
 
 RETURN = '''
-    ok: [localhost] => {
-        "msg": "bar"
-    }
-    
-    ok: [localhost] => {
-        "msg": "key not-found"
-    }
+    _raw:
+        description: field data requested
 '''
 import json
 
@@ -54,7 +47,9 @@ try:
 except ImportError as e:
     HAS_ETCD3 = False
 
+
 class Etcd3:
+
     def __init__(self):
         if not HAS_ETCD3:
             raise AnsibleError('python-etcd3 is required for etcd3 lookup, '
@@ -103,6 +98,7 @@ class Etcd3:
             return False, None, None
         else:
             return True, address[0], address[1]
+
 
 class LookupModule(LookupBase):
 

--- a/lib/ansible/plugins/lookup/etcd3.py
+++ b/lib/ansible/plugins/lookup/etcd3.py
@@ -1,0 +1,110 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    author: 
+        - Caio Tedim <caiotedim(at)gmail(dot)com>
+    lookup: etcd3
+    short_description: get on etcd3 server
+    description:
+        - Retrieves data from etcd3 server
+    options:
+        url: 
+            description:
+                - URL for etcd3 server
+            default: 127.0.0.1:2379
+            type: string
+            required: True
+        key:
+            description:
+                - Key to lookup on etcd3 server
+            type: string
+            required: True
+            
+    response:
+        - Return value in a json format
+        - If key not found the return comes on stdout attribute
+'''
+
+EXAMPLES = '''
+    - name: "Get key from etcd3 server"
+      debug: msg="{{ lookup('etcd3', key='test',url='127.0.0.1:2379').foo }}"
+      
+    - name: "Get key from etcd3 server, this key is not-found"
+      debug: msg="{{ lookup('etcd3', key='testt',url='127.0.0.1:2379').stdout }}"
+'''
+
+RETURN = '''
+    ok: [localhost] => {
+        "msg": "bar"
+    }
+    
+    ok: [localhost] => {
+        "msg": "key not-found"
+    }
+'''
+import json
+
+from ansible.plugins.lookup import LookupBase
+from ansible.errors import AnsibleError
+
+try:
+    import etcd3
+    HAS_ETCD3 = True
+except ImportError as e:
+    HAS_ETCD3 = False
+
+class Etcd3:
+    def __init__(self):
+        if not HAS_ETCD3:
+            raise AnsibleError('python-etcd3 is required for etcd3 lookup, '
+                               'take a look on https://pypi.org/project/etcd3/')
+
+    def run(self, terms, variables=None, **kwargs):
+        self.params = kwargs
+
+        url = kwargs.get('url')
+        key = kwargs.get('key')
+
+        if url is None:
+            url = "127.0.0.1:2379"
+
+        address = url.split(':')
+        isValid, host, port = self.validAddress(address)
+
+        if not isValid:
+            raise AnsibleError("Please check if your url param is defined follow documentation "
+                               "url=<host:port>")
+
+        resp = self.get(key, host, port)
+        return resp
+
+    def get(self, key, host, port):
+        try:
+            client = etcd3.client(host, port)
+            resp = []
+            print("ok")
+            for value, _ in client.get_prefix(key):
+                if value is not None:
+                    resp.append(json.loads(value))
+            if len(resp) < 1:
+                resp = [{"stdout": "key not-found"}]
+            return resp
+        except Exception:
+            raise
+
+    def validAddress(self, address):
+        if address[0] == '' or address[1] == '':
+            return False, None, None
+
+        if len(address) < 2 or len(address) > 2:
+            if address[0] == 'http' or address[0] == 'https':
+                return True, address[1].split('/')[2], address[2]
+            return False, None, None
+        else:
+            return True, address[0], address[1]
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables=None, **kwargs):
+        return Etcd3().run(terms, variables=variables, **kwargs)


### PR DESCRIPTION
**SUMMARY**

Add support to only read data on etcd3 kv using lookup.

**ISSUE TYPE**

- Feature Pull Request

**COMPONENT NAME**

lookup etcd3

**ANSIBLE VERSION**
```
ansible 2.6.0
  config file = /home/caiotedim/Documents/sre/tedim-bastion/ansible.cfg
  configured module search path = [u'/home/caiotedim/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/local/lib/python2.7/site-packages/ansible
  executable location = /opt/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

**ADDITIONAL INFORMATION**

Playbook used:
```
- name: Test
  hosts: localhost
  become: false
  tasks:
   - name: GET data using lookup etcd3
     debug:
       msg: "{{ lookup('etcd3', key='test').foo }}"
```

Return:
```
PLAY [Test] ************************************************************************************************************************************************************

TASK [GET data using lookup etcd3] *************************************************************************************************************************************
ok
ok: [localhost] => {
    "msg": "bar"
}
```
