### PR TITLE
Saltstack: fix for getting the current home of user

### DIFF
--- a/lib/ansible/plugins/connection/saltstack.py
+++ b/lib/ansible/plugins/connection/saltstack.py
@@ -65,7 +65,7 @@ class Connection(ConnectionBase):
             raise errors.AnsibleError("Internal Error: this module does not support optimized module pipelining")
 
         # Fixes an issue where tilde '~' is not resolved to the actual user home
-        get_current_user_home = self.client.cmd(self.host, 'cmd.exec_code_all', ['bash', 'echo ~'])[self.host]
+        get_current_user_home = self.client.cmd(self.host, 'cmd.exec_code_all', ['sh', 'echo $HOME'])[self.host]
         if get_current_user_home and get_current_user_home['retcode'] == 0:
             current_user_home = get_current_user_home['stdout']
         else:


### PR DESCRIPTION
The PR should fix an issue with saltstack plugin where tilde `~` is not resolved to the actual user home while using default ansible `remote_tmp` value `~/.ansible/tmp` which makes it fail to continue on **Ubuntu** systems as described in the issue mentioned below

##### SUMMARY
Fixes #40434 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugin: saltstack

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```