### PR TITLE
Add example of using loop: with when: statements

### DIFF
--- a/lib/ansible/plugins/lookup/dict.py
+++ b/lib/ansible/plugins/lookup/dict.py
@@ -38,6 +38,12 @@ tasks:
     debug:
       msg: "{{item.key}}: {{item.value}}"
     with_dict: {a: 1, b: 2, c: 3}
+  # Items from loop can be used in when: statements
+  - name: set_fact when alice in key
+    set_fact:
+      alice_exists: true
+    loop: "{{ lookup('dict', users) }}"
+    when: "'alice' in item.key"
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add example for using `when:` with `loop:`. I wasn't aware that this is possible so figured I'd add an example so people can see another example of what you can do with the `loop:` function.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
dict.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /appl/ansible/ansible.cfg
  configured module search path = [u'/appl/ansible/modules', u'/usr/lib/python2.7/site-packages/napalm_ansible/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
N/A
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
N/A
```
