### PR TITLE
[WIP] Automatically detect interpreters (alternate approach)

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -624,7 +624,7 @@ class TaskExecutor:
                 return failed_when_result
 
             if 'ansible_facts' in result:
-                if self._task.action in ('set_fact', 'include_vars'):
+                if self._task.action in ('set_fact', 'include_vars', 'gather_interpreters'):
                     vars_copy.update(result['ansible_facts'])
                 else:
                     vars_copy.update(namespace_facts(result['ansible_facts']))
@@ -685,7 +685,7 @@ class TaskExecutor:
             variables[self._task.register] = wrap_var(result)
 
         if 'ansible_facts' in result:
-            if self._task.action in ('set_fact', 'include_vars'):
+            if self._task.action in ('set_fact', 'include_vars', 'gather_interpreters'):
                 variables.update(result['ansible_facts'])
             else:
                 variables.update(namespace_facts(result['ansible_facts']))

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -61,6 +61,7 @@ class Play(Base, Taggable, Become):
     _gather_facts = FieldAttribute(isa='bool', default=None, always_post_validate=True)
     _gather_subset = FieldAttribute(isa='barelist', default=None, always_post_validate=True)
     _gather_timeout = FieldAttribute(isa='int', default=None, always_post_validate=True)
+    _gather_interpreters = FieldAttribute(isa='bool', default=None, always_post_validate=True)
 
     # Variable Attributes
     _vars_files = FieldAttribute(isa='list', default=[], priority=99)

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -278,7 +278,7 @@ class Task(Base, Conditional, Taggable, Become):
                 try:
                     env[k] = templar.template(v, convert_bare=False)
                 except AnsibleUndefinedVariable as e:
-                    if self.action in ('setup', 'gather_facts') and 'ansible_env' in to_native(e):
+                    if self.action in ('setup', 'gather_facts', 'gather_interpreters') and 'ansible_env' in to_native(e):
                         # ignore as fact gathering sets ansible_env
                         return
                     raise

--- a/lib/ansible/plugins/action/gather_interpreters.py
+++ b/lib/ansible/plugins/action/gather_interpreters.py
@@ -1,0 +1,67 @@
+# Copyright 2018 Andrew Gaffney <andrew@agaffney.org>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import re
+
+from ansible.module_utils.parsing.convert_bool import boolean
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+
+    TRANSFERS_FILES = False
+
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        facts = {
+            # Used to prevent gathering interpreters on subsequent plays
+            'module_gather_interpreters': True
+        }
+
+        overwrite = boolean(self._task.args.pop('overwrite', False))
+
+        if hasattr(self._connection._shell, 'find_binary'):
+            # TODO: make list of binary names configurable
+            find_result = self._low_level_execute_command(self._connection._shell.find_binary(['python', 'python3', 'foo', 'bar']), sudoable=False)
+            if len(find_result['stdout_lines']) > 0:
+                for interpreter in find_result['stdout_lines']:
+                    basename = os.path.basename(interpreter)
+                    interpreter_vars = ['ansible_' + basename + '_interpreter']
+                    matches = re.match('(.*[^0-9.]+)([0-9.]+)?$', basename)
+                    if matches:
+                        interpreter_vars.append('ansible_' + matches.group(1) + '_interpreter')
+                    for var in interpreter_vars:
+                        if var not in facts and (overwrite or var not in task_vars):
+                            facts[var] = interpreter
+
+        result['changed'] = False
+        result['ansible_facts'] = facts
+        # Setting cacheable to True causes warnings about restricted vars
+        result['_ansible_facts_cacheable'] = False
+        # hack to keep --verbose from showing the results from this action, like
+        # we do with 'setup'
+        result['_ansible_verbose_override'] = True
+        return result

--- a/lib/ansible/plugins/shell/sh.py
+++ b/lib/ansible/plugins/shell/sh.py
@@ -40,6 +40,12 @@ class ShellModule(ShellBase):
     _SHELL_GROUP_LEFT = '('
     _SHELL_GROUP_RIGHT = ')'
 
+    def find_binary(self, bins):
+        if not isinstance(bins, list):
+            bins = [bins]
+        cmd = ['which'] + bins
+        return ' '.join(cmd)
+
     def checksum(self, path, python_interp):
         # In the following test, each condition is a check and logical
         # comparison (|| or &&) that sets the rc value.  Every check is run so

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -602,9 +602,9 @@ class StrategyBase:
                         else:
                             cacheable = result_item.pop('_ansible_facts_cacheable', False)
                             for target_host in host_list:
-                                if not original_task.action == 'set_fact' or cacheable:
+                                if original_task.action not in ('set_fact', 'gather_interpreters') or cacheable:
                                     self._variable_manager.set_host_facts(target_host, result_item['ansible_facts'].copy())
-                                if original_task.action == 'set_fact':
+                                if original_task.action in ('set_fact', 'gather_interpreters'):
                                     self._variable_manager.set_nonpersistent_facts(target_host, result_item['ansible_facts'].copy())
 
                     if 'ansible_stats' in result_item and 'data' in result_item['ansible_stats'] and result_item['ansible_stats']['data']:

--- a/test/units/executor/test_play_iterator.py
+++ b/test/units/executor/test_play_iterator.py
@@ -129,6 +129,7 @@ class TestPlayIterator(unittest.TestCase):
 
         mock_var_manager = MagicMock()
         mock_var_manager._fact_cache = dict()
+        mock_var_manager._nonpersistent_fact_cache = dict()
         mock_var_manager.get_vars.return_value = dict()
 
         p = Playbook.load('test_play.yml', loader=fake_loader, variable_manager=mock_var_manager)
@@ -140,6 +141,7 @@ class TestPlayIterator(unittest.TestCase):
             hosts.append(host)
 
         mock_var_manager._fact_cache['host00'] = dict()
+        mock_var_manager._nonpersistent_fact_cache['host00'] = dict()
 
         inventory = MagicMock()
         inventory.get_hosts.return_value = hosts
@@ -319,6 +321,7 @@ class TestPlayIterator(unittest.TestCase):
 
         mock_var_manager = MagicMock()
         mock_var_manager._fact_cache = dict()
+        mock_var_manager._nonpersistent_fact_cache = dict()
         mock_var_manager.get_vars.return_value = dict()
 
         p = Playbook.load('test_play.yml', loader=fake_loader, variable_manager=mock_var_manager)
@@ -391,6 +394,7 @@ class TestPlayIterator(unittest.TestCase):
 
         mock_var_manager = MagicMock()
         mock_var_manager._fact_cache = dict()
+        mock_var_manager._nonpersistent_fact_cache = dict()
         mock_var_manager.get_vars.return_value = dict()
 
         p = Playbook.load('test_play.yml', loader=fake_loader, variable_manager=mock_var_manager)

--- a/test/units/plugins/strategy/test_strategy_linear.py
+++ b/test/units/plugins/strategy/test_strategy_linear.py
@@ -54,6 +54,7 @@ class TestStrategyLinear(unittest.TestCase):
 
         mock_var_manager = MagicMock()
         mock_var_manager._fact_cache = dict()
+        mock_var_manager._nonpersistent_fact_cache = dict()
         mock_var_manager.get_vars.return_value = dict()
 
         p = Playbook.load('test_play.yml', loader=fake_loader, variable_manager=mock_var_manager)
@@ -65,6 +66,7 @@ class TestStrategyLinear(unittest.TestCase):
             hosts.append(host)
 
         mock_var_manager._fact_cache['host00'] = dict()
+        mock_var_manager._nonpersistent_fact_cache['host00'] = dict()
 
         inventory = MagicMock()
         inventory.get_hosts.return_value = hosts


### PR DESCRIPTION
##### SUMMARY

This commit adds an action plugin called 'gather_interpreters' and runs it automatically as part of play fact gathering. This plugin uses 'which' (on platforms where it's supported) to find the full path of a list of possible interpreter names and sets the appropriate 'ansible_x_interpreter' var.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
interpreter path

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (gather_interpreters 1a60f99df2) last updated 2018/07/14 10:49:22 (GMT -500)
```

##### ADDITIONAL INFORMATION
N/A