### PR TITLE
make lockfile destination settable and update doc

### DIFF
--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -101,12 +101,18 @@ class FileLock:
 
     def unlock(self):
         '''
-        Unlock the file descriptor locked by set_lock
+        Make sure lock file is available for everyone and Unlock the file descriptor
+        locked by set_lock
 
         :returns: True
         '''
         if not self.lockfd:
             return True
+
+        try:
+            os.chmod(self.lockfd.name, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)
+        except OSError:  # ignore failed chmod
+            pass
 
         try:
             fcntl.flock(self.lockfd, fcntl.LOCK_UN)

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -12,7 +12,6 @@ import pwd
 import grp
 import time
 import shutil
-import tempfile
 import traceback
 import fcntl
 import sys
@@ -43,30 +42,32 @@ class FileLock:
         self.lockfd = None
 
     @contextmanager
-    def lock_file(self, path, lock_timeout=None):
+    def lock_file(self, path, tmpdir, lock_timeout=None):
         '''
         Context for lock acquisition
         '''
         try:
-            self.set_lock(path, lock_timeout)
+            self.set_lock(path, tmpdir, lock_timeout)
             yield
         finally:
             self.unlock()
 
-    def set_lock(self, path, lock_timeout=None):
+    def set_lock(self, path, tmpdir, lock_timeout=None):
         '''
         Create a lock file based on path with flock to prevent other processes
-        using given path
+        using given path.
+        Please note that currently file locking only works when it's executed by
+        the same user, I.E single user scenarios
 
         :kw path: Path (file) to lock
+        :kw tmpdir: Path where to place the temporary .lock file
         :kw lock_timeout:
             Wait n seconds for lock acquisition, fail if timeout is reached.
             0 = Do not wait, fail if lock cannot be acquired immediately,
             Default is None, wait indefinitely until lock is released.
         :returns: True
         '''
-        tmp_dir = tempfile.gettempdir()
-        lock_path = os.path.join(tmp_dir, 'ansible-{0}.lock'.format(os.path.basename(path)))
+        lock_path = os.path.join(tmpdir, 'ansible-{0}.lock'.format(os.path.basename(path)))
         l_wait = 0.1
         r_exception = IOError
         if sys.version_info[0] == 3:
@@ -108,11 +109,6 @@ class FileLock:
         '''
         if not self.lockfd:
             return True
-
-        try:
-            os.chmod(self.lockfd.name, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)
-        except OSError:  # ignore failed chmod
-            pass
 
         try:
             fcntl.flock(self.lockfd, fcntl.LOCK_UN)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Chmod lock file before unlocking and closing the file descriptor to make it available for other users 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
module_utils.common.file
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (fix-lockfile-cleanup d840c4daeb) last updated 2018/07/15 22:40:26 (GMT +200)
  config file = None
  configured module search path = ['/home/acalm/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/acalm/venv/ansible/lib/python3.6/site-packages/ansible
  executable location = /home/acalm/venv/ansible/bin/ansible
  python version = 3.6.5 (default, Apr 20 2018, 08:08:06) [GCC 6.4.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Currently the unlock() function will leave the .lock file read/writeable for the current user, leaving it inaccessible for other users, this PR fixes this by setting permissions to 777, unlock the file descriptor and close it.