### PR TITLE
Fix for creation and removal of swap record in fstab

### DIFF
--- a/changelogs/fragments/fix-swap-mount-module.yaml
+++ b/changelogs/fragments/fix-swap-mount-module.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- Fix the mount module's handling of swap entries in fstab
+  (https://github.com/ansible/ansible/pull/42837)

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -218,7 +218,13 @@ def set_mount(module, args):
             ) = line.split()
 
         # Check if we found the correct line
-        if ld['name'] != escaped_args['name']:
+        if (
+                ld['name'] != escaped_args['name'] or (
+                    # In the case of swap, check the src instead
+                    'src' in args and
+                    ld['name'] == 'none' and
+                    ld['fstype'] == 'swap' and
+                    ld['src'] != args['src'])):
             to_write.append(line)
 
             continue
@@ -299,7 +305,13 @@ def unset_mount(module, args):
                 ld['passno']
             ) = line.split()
 
-        if ld['name'] != escaped_name:
+        if (
+                ld['name'] != escaped_name or (
+                    # In the case of swap, check the src instead
+                    'src' in args and
+                    ld['name'] == 'none' and
+                    ld['fstype'] == 'swap' and
+                    ld['src'] != args['src'])):
             to_write.append(line)
 
             continue

--- a/test/integration/targets/mount/tasks/main.yml
+++ b/test/integration/targets/mount/tasks/main.yml
@@ -148,3 +148,103 @@
       - "unmount_result['changed']"
       - "not dest_stat['stat']['exists']"
   when: ansible_system in ('FreeBSD', 'Linux')
+
+- name: Create fstab record for the first swap file
+  mount:
+    name: none
+    src: /tmp/swap1
+    opts: sw
+    fstype: swap
+    state: present
+  register: swap1_created
+  when: ansible_system in ('Linux')
+
+- name: Try to create fstab record for the first swap file again
+  mount:
+    name: none
+    src: /tmp/swap1
+    opts: sw
+    fstype: swap
+    state: present
+  register: swap1_created_again
+  when: ansible_system in ('Linux')
+
+- name: Check that we created the swap1 record
+  assert:
+    that:
+      - "swap1_created['changed']"
+      - "not swap1_created_again['changed']"
+  when: ansible_system in ('Linux')
+
+- name: Create fstab record for the second swap file
+  mount:
+    name: none
+    src: /tmp/swap2
+    opts: sw
+    fstype: swap
+    state: present
+  register: swap2_created
+  when: ansible_system in ('Linux')
+
+- name: Try to create fstab record for the second swap file again
+  mount:
+    name: none
+    src: /tmp/swap1
+    opts: sw
+    fstype: swap
+    state: present
+  register: swap2_created_again
+  when: ansible_system in ('Linux')
+
+- name: Check that we created the swap2 record
+  assert:
+    that:
+      - "swap2_created['changed']"
+      - "not swap2_created_again['changed']"
+  when: ansible_system in ('Linux')
+
+- name: Remove the fstab record for the first swap file
+  mount:
+    name: none
+    src: /tmp/swap1
+    state: absent
+  register: swap1_removed
+  when: ansible_system in ('Linux')
+
+- name: Try to remove the fstab record for the first swap file again
+  mount:
+    name: none
+    src: /tmp/swap1
+    state: absent
+  register: swap1_removed_again
+  when: ansible_system in ('Linux')
+
+- name: Check that we removed the swap1 record
+  assert:
+    that:
+      - "swap1_removed['changed']"
+      - "not swap1_removed_again['changed']"
+  when: ansible_system in ('Linux')
+
+- name: Remove the fstab record for the second swap file
+  mount:
+    name: none
+    src: /tmp/swap2
+    state: absent
+  register: swap2_removed
+  when: ansible_system in ('Linux')
+
+- name: Try to remove the fstab record for the second swap file again
+  mount:
+    name: none
+    src: /tmp/swap2
+    state: absent
+  register: swap2_removed_again
+  when: ansible_system in ('Linux')
+
+- name: Check that we removed the swap2 record
+  assert:
+    that:
+      - "swap2_removed['changed']"
+      - "not swap2_removed_again['changed']"
+  when: ansible_system in ('Linux')


### PR DESCRIPTION
This PR is trying to fix creation and removal of `fstab` records done by the `mount` module. This should fix issues  #42706, #31437 and #30090.

##### SUMMARY
The problem was that the module was only checking for destination path which is the same (`none`) for all swap partitions/files. This is why removal of one swap record removed all other records as well.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
`mount`

##### ANSIBLE VERSION
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.6 (default, Jun 27 2018, 13:11:40) [GCC 8.1.1 20180531]
```

##### ADDITIONAL INFORMATION
None