### PR TITLE
Support setting persistent command timeout per task basis

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -146,7 +146,7 @@ class ConnectionProcess(object):
         self.shutdown()
 
     def command_timeout(self, signum, frame):
-        display.display('command timeout triggered, timeout value is %s secs' %  self.connection.get_option('persistent_command_timeout'), log_only=True)
+        display.display('command timeout triggered, timeout value is %s secs' % self.connection.get_option('persistent_command_timeout'), log_only=True)
         self.shutdown()
 
     def handler(self, signum, frame):

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -119,7 +119,7 @@ class ConnectionProcess(object):
                     if not data:
                         break
 
-                    signal.alarm(self.connection._play_context.timeout)
+                    signal.alarm(self.connection.get_option('persistent_command_timeout'))
                     resp = self.srv.handle_request(data)
                     signal.alarm(0)
 
@@ -146,7 +146,7 @@ class ConnectionProcess(object):
         self.shutdown()
 
     def command_timeout(self, signum, frame):
-        display.display('command timeout triggered, timeout value is %s secs' % self.play_context.timeout, log_only=True)
+        display.display('command timeout triggered, timeout value is %s secs' %  self.connection.get_option('persistent_command_timeout'), log_only=True)
         self.shutdown()
 
     def handler(self, signum, frame):
@@ -273,6 +273,7 @@ def main():
             else:
                 messages.append('found existing local domain socket, using it!')
                 conn = Connection(socket_path)
+                conn.set_options(var_options=variables)
                 pc_data = to_text(init_data)
                 try:
                     messages.extend(conn.update_play_context(pc_data))

--- a/lib/ansible/plugins/action/aireos.py
+++ b/lib/ansible/plugins/action/aireos.py
@@ -58,10 +58,11 @@ class ActionModule(_ActionModule):
         pc.port = int(provider['port'] or self._play_context.port or 22)
         pc.remote_user = provider['username'] or self._play_context.connection_user
         pc.password = provider['password'] or self._play_context.password
-        pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+        command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
 
         display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+        connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
         socket_path = connection.run()
         display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/aruba.py
+++ b/lib/ansible/plugins/action/aruba.py
@@ -58,10 +58,11 @@ class ActionModule(_ActionModule):
         pc.remote_user = provider['username'] or self._play_context.connection_user
         pc.password = provider['password'] or self._play_context.password
         pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-        pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+        command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
 
         display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+        connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
         socket_path = connection.run()
         display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/asa.py
+++ b/lib/ansible/plugins/action/asa.py
@@ -52,13 +52,14 @@ class ActionModule(_ActionModule):
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-            pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+            command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
             pc.become = provider['authorize'] or False
             pc.become_pass = provider['auth_pass']
             pc.become_method = 'enable'
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()
 

--- a/lib/ansible/plugins/action/bigip.py
+++ b/lib/ansible/plugins/action/bigip.py
@@ -66,10 +66,12 @@ class ActionModule(_ActionModule):
                 pc.remote_user = provider.get('user', self._play_context.connection_user)
                 pc.password = provider.get('password', self._play_context.password)
                 pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-                pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+                command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
 
                 display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
                 connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+                connection.set_options(direct={'persistent_command_timeout': command_timeout})
+
                 socket_path = connection.run()
                 display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
                 if not socket_path:

--- a/lib/ansible/plugins/action/bigiq.py
+++ b/lib/ansible/plugins/action/bigiq.py
@@ -66,10 +66,12 @@ class ActionModule(_ActionModule):
                 pc.remote_user = provider.get('user', self._play_context.connection_user)
                 pc.password = provider.get('password', self._play_context.password)
                 pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-                pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+                command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
 
                 display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
                 connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+                connection.set_options(direct={'persistent_command_timeout': command_timeout})
+
                 socket_path = connection.run()
                 display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
                 if not socket_path:

--- a/lib/ansible/plugins/action/ce.py
+++ b/lib/ansible/plugins/action/ce.py
@@ -60,7 +60,7 @@ class ActionModule(_ActionModule):
                 pc.port = int(provider['port'] or self._play_context.port or 22)
                 pc.remote_user = provider['username'] or self._play_context.connection_user
                 pc.password = provider['password'] or self._play_context.password
-                pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+                command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
                 self._task.args['provider'] = provider.update(
                     host=pc.remote_addr,
                     port=pc.port,
@@ -71,6 +71,7 @@ class ActionModule(_ActionModule):
                     pc.connection = 'netconf'
                 display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
                 connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+                connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
                 socket_path = connection.run()
                 display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/cnos.py
+++ b/lib/ansible/plugins/action/cnos.py
@@ -51,13 +51,15 @@ class ActionModule(_ActionModule):
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-            pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+            command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
             pc.become = provider['authorize'] or True
             pc.become_pass = provider['auth_pass']
             pc.become_method = 'enable'
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection.set_options(direct={'persistent_command_timeout': command_timeout})
+
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
             if not socket_path:

--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -60,7 +60,7 @@ class ActionModule(_ActionModule):
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-            pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+            command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
             pc.become = provider['authorize'] or False
             if pc.become:
                 pc.become_method = 'enable'
@@ -68,6 +68,7 @@ class ActionModule(_ActionModule):
 
             display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -60,7 +60,7 @@ class ActionModule(_ActionModule):
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-            pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+            command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
             pc.become = provider['authorize'] or False
             if pc.become:
                 pc.become_method = 'enable'
@@ -68,6 +68,7 @@ class ActionModule(_ActionModule):
 
             display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -60,7 +60,7 @@ class ActionModule(_ActionModule):
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-            pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+            command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
             pc.become = provider['authorize'] or False
             if pc.become:
                 pc.become_method = 'enable'
@@ -68,6 +68,7 @@ class ActionModule(_ActionModule):
 
             display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/enos.py
+++ b/lib/ansible/plugins/action/enos.py
@@ -51,13 +51,15 @@ class ActionModule(_ActionModule):
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-            pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+            command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
             pc.become = provider['authorize'] or True
             pc.become_pass = provider['auth_pass']
             pc.become_method = 'enable'
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection.set_options(direct={'persistent_command_timeout': command_timeout})
+
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
             if not socket_path:

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -66,7 +66,6 @@ class ActionModule(_ActionModule):
                 pc.remote_user = provider['username'] or self._play_context.connection_user
                 pc.password = provider['password'] or self._play_context.password
                 pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-                pc.timeout = int(provider['timeout']) if provider['timeout'] else None
                 pc.become = provider['authorize'] or False
                 if pc.become:
                     pc.become_method = 'enable'
@@ -75,8 +74,8 @@ class ActionModule(_ActionModule):
                 display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
                 connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 
-                if connection._play_context.timeout is None:
-                    connection._play_context.timeout = connection.get_option('persistent_command_timeout')
+                command_timeout = int(provider['timeout']) if provider['timeout'] else connection.get_option('persistent_command_timeout')
+                connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
                 socket_path = connection.run()
                 display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -58,7 +58,6 @@ class ActionModule(_ActionModule):
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-            pc.timeout = int(provider['timeout']) if provider['timeout'] else None
             pc.become = provider['authorize'] or False
             if pc.become:
                 pc.become_method = 'enable'
@@ -67,8 +66,8 @@ class ActionModule(_ActionModule):
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 
-            if connection._play_context.timeout is None:
-                connection._play_context.timeout = connection.get_option('persistent_command_timeout')
+            command_timeout = int(provider['timeout']) if provider['timeout'] else connection.get_option('persistent_command_timeout')
+            connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -61,13 +61,12 @@ class ActionModule(_ActionModule):
             pc.port = int(provider['port'] or self._play_context.port or 22)
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
-            pc.timeout = int(provider['timeout']) if provider['timeout'] else None
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 
-            if connection._play_context.timeout is None:
-                connection._play_context.timeout = connection.get_option('persistent_command_timeout')
+            command_timeout = int(provider['timeout']) if provider['timeout'] else connection.get_option('persistent_command_timeout')
+            connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/ironware.py
+++ b/lib/ansible/plugins/action/ironware.py
@@ -59,7 +59,7 @@ class ActionModule(_ActionModule):
         pc.remote_user = provider['username'] or self._play_context.connection_user
         pc.password = provider['password'] or self._play_context.password
         pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-        pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+        command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
         pc.become = provider['authorize'] or False
         if pc.become:
             pc.become_method = 'enable'
@@ -67,6 +67,7 @@ class ActionModule(_ActionModule):
 
         display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+        connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
         socket_path = connection.run()
 

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -72,13 +72,12 @@ class ActionModule(_ActionModule):
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-            pc.timeout = int(provider['timeout']) if provider['timeout'] else None
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 
-            if connection._play_context.timeout is None:
-                connection._play_context.timeout = connection.get_option('persistent_command_timeout')
+            command_timeout = int(provider['timeout']) if provider['timeout'] else connection.get_option('persistent_command_timeout')
+            connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/net_base.py
+++ b/lib/ansible/plugins/action/net_base.py
@@ -151,6 +151,8 @@ class ActionModule(ActionBase):
         connection = self._shared_loader_obj.connection_loader.get('persistent',
                                                                    play_context, sys.stdin)
 
+        connection.set_options(direct={'persistent_command_timeout': play_context.timeout})
+
         socket_path = connection.run()
         display.vvvv('socket_path: %s' % socket_path, play_context.remote_addr)
         if not socket_path:

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -85,7 +85,6 @@ class ActionModule(_ActionModule):
                 pc.remote_user = provider['username'] or self._play_context.connection_user
                 pc.password = provider['password'] or self._play_context.password
                 pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-                pc.timeout = int(provider['timeout']) if provider['timeout'] else None
                 pc.become = provider['authorize'] or False
                 if pc.become:
                     pc.become_method = 'enable'
@@ -94,8 +93,8 @@ class ActionModule(_ActionModule):
                 display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
                 connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 
-                if connection._play_context.timeout is None:
-                    connection._play_context.timeout = connection.get_option('persistent_command_timeout')
+                command_timeout = int(provider['timeout']) if provider['timeout'] else connection.get_option('persistent_command_timeout')
+                connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
                 socket_path = connection.run()
                 display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/sros.py
+++ b/lib/ansible/plugins/action/sros.py
@@ -55,10 +55,11 @@ class ActionModule(_ActionModule):
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-            pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+            command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -58,13 +58,12 @@ class ActionModule(_ActionModule):
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-            pc.timeout = int(provider['timeout']) if provider['timeout'] else None
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 
-            if connection._play_context.timeout is None:
-                connection._play_context.timeout = connection.get_option('persistent_command_timeout')
+            command_timeout = int(provider['timeout']) if provider['timeout'] else connection.get_option('persistent_command_timeout')
+            connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()
             display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -152,6 +152,8 @@ options:
         key: command_timeout
     env:
       - name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT
+    vars:
+      - name: ansible_command_timeout
 """
 
 import os

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -155,6 +155,8 @@ options:
         key: command_timeout
     env:
       - name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT
+    vars:
+      - name: ansible_command_timeout
 """
 
 import getpass

--- a/lib/ansible/plugins/connection/persistent.py
+++ b/lib/ansible/plugins/connection/persistent.py
@@ -26,6 +26,8 @@ options:
         key: command_timeout
     env:
       - name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT
+    vars:
+      - name: ansible_command_timeout
 """
 import os
 import pty
@@ -119,7 +121,7 @@ class Connection(ConnectionBase):
         stdin.write(src)
         stdin.write(b'\n#END_INIT#\n')
 
-        src = cPickle.dumps({}, protocol=0)
+        src = cPickle.dumps({'ansible_command_timeout': self.get_option('persistent_command_timeout')}, protocol=0)
         stdin.write(src)
         stdin.write(b'\n#END_VARS#\n')
 

--- a/test/integration/targets/ios_smoke/tests/cli/misc_tests.yaml
+++ b/test/integration/targets/ios_smoke/tests/cli/misc_tests.yaml
@@ -19,4 +19,22 @@
     provider: "{{ cli }}"
   register: result
 
+- name: run ios commands to test command_timeout
+  ios_command:
+    commands:
+    - show running-config all
+    - show interfaces
+    - show running-config all
+  vars:
+    ansible_command_timeout: 1
+  ignore_errors: True
+  register: result
+  when: ansible_connection == 'network_cli'
+
+- assert:
+    that:
+      - 'result.failed == true'
+      - "'timeout trying to send command' in result.module_stderr"
+  when: ansible_connection == 'network_cli'
+
 - debug: msg="END ios_smoke cli/misc_tests.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #42200

*  Add variable `ansible_command_timeout` to `persistent_command_timeout`
   option for `network_cli` and `netconf` connection plugin so that the
   command_timeout can be set per task basis while using `connection=network_cli`
   or `connection=netconf`
   eg:
   ```
   - name: run command
     ios_command:
       commands:
       - show version
     vars:
      ansible_command_timeout: 40
   ```

* Modify `ansible-connection` to read command_timeout value from
  connection plugin options.

* Add `ansible_command_timeout` to `persistent_command_timeout`
  option in `persistent` to support `connection=local` so that
  it is backward compatibilty

* To support `connection=local` pass the timeout value as variables
  from persistent connection to `ansible-connection` instead of sending
  it in playcontext
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bin/ansible-connection
plugins/action/aruba.py
plugins/action/asa.py
plugins/action/bigip.py
plugins/action/bigiq.py
plugins/action/ce.py
plugins/action/cnos.py
plugins/action/dellos10.py
plugins/action/dellos6.py
plugins/action/dellos9.py
plugins/action/enos.py
plugins/action/eos.py
plugins/action/ios.py
plugins/action/iosxr.py
plugins/action/ironware.py
plugins/action/junos.py
plugins/action/dellos10.py
plugins/action/net_base.py
plugins/action/nxos.py
plugins/action/sros.py
plugins/action/vyos.py
plugins/connection/netconf.py
plugins/connection/network_cli.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
