### PR TITLE
docker_container: fix working_dir

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1294,7 +1294,7 @@ class Container(DockerBaseClass):
             expected_binds=host_config.get('Binds'),
             volumes_from=host_config.get('VolumesFrom'),
             volume_driver=host_config.get('VolumeDriver'),
-            working_dir=host_config.get('WorkingDir')
+            working_dir=config.get('WorkingDir')
         )
 
         differences = []


### PR DESCRIPTION
##### SUMMARY

docker_container with `working_dir` always get recreated, because `config_mapping["working_dir"]` is always empty.

`WorkingDir` should be read from `Config` instead of `HostConfig`, check
https://docs.docker.com/engine/api/v1.37/#operation/ContainerInspect

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

docker_container

##### ANSIBLE VERSION

```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/.local/lib/python2.7/site-packages/ansible
  executable location = /home/user/.local/bin/ansible
  python version = 2.7.15 (default, May  9 2018, 11:32:33) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
```

##### ADDITIONAL INFORMATION