### PR TITLE
Update yum_repository.py

### DIFF
--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -23,6 +23,7 @@ version_added: '2.1'
 short_description: Add or remove YUM repositories
 description:
   - Add or remove YUM repositories in RPM-based Linux distributions.
+  - If you wish to update an existing repository definition use ini_file instead
 
 options:
   async:

--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -23,7 +23,7 @@ version_added: '2.1'
 short_description: Add or remove YUM repositories
 description:
   - Add or remove YUM repositories in RPM-based Linux distributions.
-  - If you wish to update an existing repository definition use ini_file instead
+  - If you wish to update an existing repository definition use M(ini_file) instead.
 
 options:
   async:


### PR DESCRIPTION
Having spent some time trying and googling how to enable an installed repo with this, I discovered that the thread at https://github.com/ansible/ansible-modules-extras/issues/2384 had decided that this would not be supported and recommended use of ini_file instead.  Since I am sure I'm not alone in expecting yum-repository to support enabling/disabling a configured repo, I suggest adding a note so people find this easier.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
