### PR TITLE
katello.py - fix "TypeError: 'SyncPlan' object does not support indexing" error

### DIFF
--- a/lib/ansible/modules/remote_management/foreman/katello.py
+++ b/lib/ansible/modules/remote_management/foreman/katello.py
@@ -345,7 +345,7 @@ class NailGun(object):
             sync_plan.update()
         else:
             response = sync_plan.create()
-            sync_plan.id = response[0].id
+            sync_plan.id = response.id
 
         if products:
             ids = []


### PR DESCRIPTION
##### SUMMARY
When attempting to create a sync plan with the katello module the module fails. The sync plan actually gets created, but the module fails with an error.

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: 'SyncPlan' object does not support indexing
failed: [localhost -> localhost] (item={u'sync_date': u'00:00', u'interval': u'daily', u'products': [u'Red Hat Enterprise Linux Server', u'Red Hat Satellite', u'Red Hat OpenShift Container Platform', u'Red Hat CloudForms', u'Red Hat Ansible Engine'], u'name': u'All - Nightly'}) => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_AMlJTV/ansible_module_katello.py\", line 524, in <module>\n    main()\n  File \"/tmp/ansible_AMlJTV/ansible_module_katello.py\", line 505, in main\n    result = ng.sync_plan(params)\n  File \"/tmp/ansible_AMlJTV/ansible_module_katello.py\", line 352, in sync_plan\n    sync_plan.id = response[0].id\nTypeError: 'SyncPlan' object does not support indexing\n",
    "module_stdout": "",
    "rc": 1,
    "sync_plan": {
        "interval": "daily",
        "name": "All - Nightly",
        "products": [
            "Red Hat Enterprise Linux Server",
            "Red Hat Satellite",
            "Red Hat OpenShift Container Platform",
            "Red Hat CloudForms",
            "Red Hat Ansible Engine"
        ],
        "sync_date": "00:00"
    }
}

MSG:

MODULE FAILURE
```

The issue is:
```
response = sync_plan.create()
sync_plan.id = response[0].id
```

`sync_plan.create()` returns a `SyncPlan` object, not an array.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
katello module

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Before
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```

After
```
changed: [localhost -> localhost] => (item={u'sync_date': u'00:00', u'interval': u'daily', u'products': [u'Red Hat Enterprise Linux Server', u'Red Hat Satellite', u'Red Hat OpenShift Container Platform', u'Red Hat CloudForms', u'Red Hat Ansible Engine'], u'name': u'All - Nightly'})
```
