### PR TITLE
docker_service: Cast scaling factor to int

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_service.py
@@ -1009,7 +1009,7 @@ class ContainerManager(DockerBaseClass):
                 containers = service.containers(stopped=True)
                 if len(containers) != self.scale[service.name]:
                     result['changed'] = True
-                    service_res['scale'] = self.scale[service.name] - len(containers)
+                    service_res['scale'] = int(self.scale[service.name]) - len(containers)
                     if not self.check_mode:
                         try:
                             service.scale(int(self.scale[service.name]))


### PR DESCRIPTION
Without this patch in 2.5.5, I see a failure similar to ansible/ansible-modules-core#4943. In my case I am using a hostvars variable to specify the value of scale: mycontainer:.

Refiling this PR against devel at the suggestion of #41931.
