### PR TITLE
Only report change when home directory is different on FreeBSD

### DIFF
--- a/changelogs/fragments/user_freebsd_always_changed_bugfix.yaml
+++ b/changelogs/fragments/user_freebsd_always_changed_bugfix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - fix bug that resulted in module always reporting a change when specifiying the home directory on FreeBSD (https://github.com/ansible/ansible/issues/42484)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1010,8 +1010,9 @@ class FreeBsdUser(User):
         if self.home is not None:
             if (info[5] != self.home and self.move_home) or (not os.path.exists(self.home) and self.create_home):
                 cmd.append('-m')
-            cmd.append('-d')
-            cmd.append(self.home)
+            if info[5] != self.home:
+                cmd.append('-d')
+                cmd.append(self.home)
 
             if self.skeleton is not None:
                 cmd.append('-k')

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -65,41 +65,44 @@
       - '"ansibulluser" in user_names.stdout_lines'
 
 # https://github.com/ansible/ansible/issues/42484
-- name: create user specifying home
-  user:
-    name: ansibulluser
-    state: present
-    home: /home/ansibulluser
-  register: user_test3_0
+# Skipping macOS for now since there is a bug when changing home directory
+- block:
+    - name: create user specifying home
+      user:
+        name: ansibulluser
+        state: present
+        home: "{{ user_home_prefix[ansible_system] }}/ansibulluser"
+      register: user_test3_0
 
-- name: create user again specifying home
-  user:
-    name: ansibulluser
-    state: present
-    home: /home/ansibulluser
-  register: user_test3_1
+    - name: create user again specifying home
+      user:
+        name: ansibulluser
+        state: present
+        home: "{{ user_home_prefix[ansible_system] }}/ansibulluser"
+      register: user_test3_1
 
-- name: change user home
-  user:
-    name: ansibulluser
-    state: present
-    home: /home/ansibulluser-mod
-  register: user_test3_2
+    - name: change user home
+      user:
+        name: ansibulluser
+        state: present
+        home: "{{ user_home_prefix[ansible_system] }}/ansibulluser-mod"
+      register: user_test3_2
 
-- name: change user home back
-  user:
-    name: ansibulluser
-    state: present
-    home: /home/ansibulluser
-  register: user_test3_3
+    - name: change user home back
+      user:
+        name: ansibulluser
+        state: present
+        home: "{{ user_home_prefix[ansible_system] }}/ansibulluser"
+      register: user_test3_3
 
-- name: validate results for testcase 3
-  assert:
-    that:
-      - user_test3_0 is not changed
-      - user_test3_1 is not changed
-      - user_test3_2 is changed
-      - user_test3_3 is changed
+    - name: validate results for testcase 3
+      assert:
+        that:
+          - user_test3_0 is not changed
+          - user_test3_1 is not changed
+          - user_test3_2 is changed
+          - user_test3_3 is changed
+  when: ansible_system != 'Darwin'
 
 
 ## user check

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -37,7 +37,13 @@
   user:
     name: ansibulluser
     state: present
-  register: user_test0
+  register: user_test0_0
+
+- name: create the user again
+  user:
+    name: ansibulluser
+    state: present
+  register: user_test0_1
 
 - debug:
     var: user_test0
@@ -54,8 +60,46 @@
 - name: validate results for testcase 0
   assert:
     that:
-      - user_test0 is changed
+      - user_test0_0 is changed
+      - user_test0_1 is not changed
       - '"ansibulluser" in user_names.stdout_lines'
+
+# https://github.com/ansible/ansible/issues/42484
+- name: create user specifying home
+  user:
+    name: ansibulluser
+    state: present
+    home: /home/ansibulluser
+  register: user_test3_0
+
+- name: create user again specifying home
+  user:
+    name: ansibulluser
+    state: present
+    home: /home/ansibulluser
+  register: user_test3_1
+
+- name: change user home
+  user:
+    name: ansibulluser
+    state: present
+    home: /home/ansibulluser-mod
+  register: user_test3_2
+
+- name: change user home back
+  user:
+    name: ansibulluser
+    state: present
+    home: /home/ansibulluser
+  register: user_test3_3
+
+- name: validate results for testcase 3
+  assert:
+    that:
+      - user_test3_0 is not changed
+      - user_test3_1 is not changed
+      - user_test3_2 is changed
+      - user_test3_3 is changed
 
 
 ## user check
@@ -65,7 +109,7 @@
     name: "{{ user_names.stdout_lines | random }}"
     state: present
     create_home: no
-  with_sequence: start=1 end=5
+  loop: "{{ range(1, 5+1) | list }}"
   register: user_test1
 
 - debug:

--- a/test/integration/targets/user/vars/main.yml
+++ b/test/integration/targets/user/vars/main.yml
@@ -1,0 +1,5 @@
+user_home_prefix:
+  Linux: '/home'
+  FreeBSD: '/home'
+  SunOS: '/home'
+  Darwin: '/Users'


### PR DESCRIPTION
##### SUMMARY

Fix regression introduced in c1e4ef39cb8d33dcb59a1b0a4984b16623d2cc01 that resulted in the module always reporting a change if the home directory was specified.

Fixes #42484 

Add tests to cover this scenario.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
`user.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
2.7
```
