### PR TITLE
Mazer role loader: Enable loading roles from ~/.ansible/content/

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -623,7 +623,10 @@ class CLI(with_metaclass(ABCMeta, object)):
             cpath = "Default w/o overrides"
         else:
             cpath = C.DEFAULT_MODULE_PATH
+        conpath = C.DEFAULT_CONTENT_PATH or "Default w/o overrides"
+
         result = result + "\n  configured module search path = %s" % cpath
+        result = result + "\n  configured galaxy content search path = %s" % conpath
         result = result + "\n  ansible python module location = %s" % ':'.join(ansible.__path__)
         result = result + "\n  executable location = %s" % sys.argv[0]
         result = result + "\n  python version = %s" % ''.join(sys.version.splitlines())

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -510,6 +510,14 @@ DEFAULT_CONNECTION_PLUGIN_PATH:
   - {key: connection_plugins, section: defaults}
   type: pathspec
   yaml: {key: plugins.connection.path}
+DEFAULT_CONTENT_PATH:
+  name: Ansible Galaxy Content Path
+  description: Colon separated paths in which Ansible will search for Roles, Modules and Plugins installed as Galaxy Content.
+  default: ~/.ansible/content
+  env: [{name: ANSIBLE_CONTENT_PATH}]
+  ini:
+  - {key: content_path, section: defaults}
+  type: pathspec
 DEFAULT_DEBUG:
   name: Debug mode
   default: False

--- a/lib/ansible/playbook/role/definition.py
+++ b/lib/ansible/playbook/role/definition.py
@@ -89,7 +89,7 @@ def role_name_to_relative_content_path(role_name):
     try:
         name = name_parts.pop(0)
     except IndexError:
-        display.debug('role name "%s" only had two name parts (namespace="%s", repo="%s") and no role name' %
+        display.debug('ROLE DEFINITION: role name "%s" only had two name parts (namespace="%s", repo="%s") and no role name' %
                       (role_name, namespace, repo))
 
     if name:
@@ -132,7 +132,7 @@ def find_role_in_content_path(role_name, loader, content_search_paths):
         fq_role_path = unfrackpath(fq_role_path)
 
         if loader.path_exists(fq_role_path):
-            display.debug('FOUND:     %s at content path "%s"' % (role_name, fq_role_path))
+            display.debug('ROLE DEFINITION: Found:     %s at content path "%s"' % (role_name, fq_role_path))
             return (role_name, fq_role_path)
 
     return None
@@ -256,7 +256,7 @@ class RoleDefinition(Base, Become, Conditional, Taggable):
         # in the loader (which should be the playbook dir itself) but without
         # the roles/ dir appended
         role_search_paths.append(self._loader.get_basedir())
-        display.debug('role_search_paths: %s' % role_search_paths)
+        display.debug('ROLE DEFINITION: role_search_paths: %s' % role_search_paths)
 
         # create a templar class to template the dependency names, in
         # case they contain variables
@@ -274,7 +274,7 @@ class RoleDefinition(Base, Become, Conditional, Taggable):
                                                     content_search_paths=C.DEFAULT_CONTENT_PATH)
 
         if content_results:
-            display.debug('returning %s (found a role in content_path="%s" for role_name=%s)' %
+            display.debug('ROLE DEFINITION: returning %s (found a role in content_path="%s" for role_name=%s)' %
                           (repr(content_results), C.DEFAULT_CONTENT_PATH, role_name))
 
             return content_results
@@ -287,7 +287,7 @@ class RoleDefinition(Base, Become, Conditional, Taggable):
             role_path = unfrackpath(os.path.join(path, role_name))
 
             if self._loader.path_exists(role_path):
-                display.debug('FOUND:     %s at role path: "%s"' % (role_name, role_path))
+                display.debug('ROLE DEFINITION: Found:     %s at role path: "%s"' % (role_name, role_path))
 
                 return (role_name, role_path)
 
@@ -297,10 +297,6 @@ class RoleDefinition(Base, Become, Conditional, Taggable):
         if self._loader.path_exists(role_path):
             role_name = os.path.basename(role_name)
             return (role_name, role_path)
-
-        display.debug('Failed to find the role "%s" in content paths %s' % (role_name, C.DEFAULT_CONTENT_PATH))
-        display.debug('Failed to find the role "%s" in any of the roles paths: %s' %
-                      (role_name, ":".join(role_search_paths)))
 
         raise AnsibleError("the role '%s' was not found in %s" % (role_name, ":".join(role_search_paths)), obj=self._ds)
 

--- a/lib/ansible/playbook/role/definition.py
+++ b/lib/ansible/playbook/role/definition.py
@@ -25,7 +25,6 @@ from ansible import constants as C  # noqa
 from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.module_utils.six import iteritems, string_types
 from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject, AnsibleMapping
-# from ansible.playbook.attribute import Attribute
 from ansible.playbook.attribute import FieldAttribute
 from ansible.playbook.base import Base
 from ansible.playbook.become import Become
@@ -283,7 +282,6 @@ class RoleDefinition(Base, Become, Conditional, Taggable):
         for path in role_search_paths:
             path = templar.template(path)
 
-            # fq_role_name = resolve_role_name(role_name)
             role_path = unfrackpath(os.path.join(path, role_name))
 
             if self._loader.path_exists(role_path):

--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -112,7 +112,7 @@ class RoleRequirement(RoleDefinition):
         else:
             role = role.copy()
 
-            if 'src'in role:
+            if 'src' in role:
                 # New style: { src: 'galaxy.role,version,name', other_vars: "here" }
                 if 'github.com' in role["src"] and 'http' in role["src"] and '+' not in role["src"] and not role["src"].endswith('.tar.gz'):
                     role["src"] = "git+" + role["src"]

--- a/test/units/playbook/role/test_definition.py
+++ b/test/units/playbook/role/test_definition.py
@@ -1,0 +1,153 @@
+import logging
+import os.path
+
+import pytest
+
+from ansible import errors
+from ansible.playbook.role import definition
+
+log = logging.getLogger(__name__)
+
+
+def test_role_definition(mocker):
+    res = definition.RoleDefinition(play=None, role_basedir=None, variable_manager=None, loader=None)
+
+    assert isinstance(res, definition.RoleDefinition)
+
+
+def test_role_definition_load_role_path_from_content_path(mocker):
+    mock_loader = mocker.Mock(name='MockDataLoader')
+    mock_loader.get_basedir = mocker.Mock(return_value='/dev/null/roles')
+    mock_loader.path_exists = mocker.Mock(return_value=True)
+
+    content_path = '/dev/null/content/'
+    mocker.patch('ansible.playbook.role.definition.C.DEFAULT_CONTENT_PATH',
+                 [content_path])
+    rd = definition.RoleDefinition(play=None, role_basedir=None, variable_manager=None, loader=mock_loader)
+
+    role_name = 'namespace.repo.role'
+    res = rd._load_role_path(role_name)
+
+    log.debug('res: %s', res)
+    assert isinstance(res, tuple)
+    assert res[0] == role_name
+    assert res[1] == os.path.join(content_path, 'namespace/repo/roles/role')
+
+
+def test_role_definition_load_role_path_from_role_path(mocker):
+    mock_loader = mocker.Mock(name='MockDataLoader')
+    mock_loader.get_basedir = mocker.Mock(return_value='/dev/null/playbook_rel_roles_dir')
+    mock_loader.path_exists = mocker.Mock(return_value=True)
+
+    content_path = '/dev/null/content/'
+    role_path = '/dev/null/the_default_roles_path'
+    mocker.patch('ansible.playbook.role.definition.C.DEFAULT_CONTENT_PATH',
+                 [content_path])
+    mocker.patch('ansible.playbook.role.definition.C.DEFAULT_ROLES_PATH',
+                 [role_path])
+    rd = definition.RoleDefinition(play=None, role_basedir='/dev/null/role_basedir', variable_manager=None, loader=mock_loader)
+
+    role_name = 'some_role'
+    rd.preprocess_data({'role': role_name})
+    res = rd._load_role_path(role_name)
+
+    log.debug('res: %s', res)
+    assert isinstance(res, tuple)
+    # The playbook rel roles/ dir is the first path checked
+    assert res[1] == '/dev/null/playbook_rel_roles_dir/roles/some_role'
+
+
+def test_role_definition_load_role_path_from_role_path_not_found(mocker):
+    mock_loader = mocker.Mock(name='MockDataLoader')
+    mock_loader.get_basedir = mocker.Mock(return_value='/dev/null/playbook_rel_roles_dir')
+    mock_loader.path_exists = mocker.Mock(return_value=False)
+
+    content_path = '/dev/null/content/'
+    role_path = '/dev/null/the_default_roles_path'
+    mocker.patch('ansible.playbook.role.definition.C.DEFAULT_CONTENT_PATH',
+                 [content_path])
+    mocker.patch('ansible.playbook.role.definition.C.DEFAULT_ROLES_PATH',
+                 [role_path])
+    rd = definition.RoleDefinition(play=None, role_basedir='/dev/null/role_basedir', variable_manager=None, loader=mock_loader)
+
+    role_name = 'some_role'
+    with pytest.raises(errors.AnsibleError, match='.'):
+        # pres = rd.preprocess_data({'role': role_name})
+        pres = rd.preprocess_data(role_name)
+        log.debug('pres: %s', pres)
+        rd._load_role_path(role_name)
+
+
+def test_role_definition_load_role_no_name_in_role_ds(mocker):
+    mock_loader = mocker.Mock(name='MockDataLoader')
+    mock_loader.get_basedir = mocker.Mock(return_value='/dev/null/playbook_rel_roles_dir')
+    mock_loader.path_exists = mocker.Mock(return_value=True)
+
+    content_path = '/dev/null/content/'
+    role_path = '/dev/null/the_default_roles_path'
+    mocker.patch('ansible.playbook.role.definition.C.DEFAULT_CONTENT_PATH',
+                 [content_path])
+    mocker.patch('ansible.playbook.role.definition.C.DEFAULT_ROLES_PATH',
+                 [role_path])
+    rd = definition.RoleDefinition(play=None, role_basedir='/dev/null/role_basedir', variable_manager=None, loader=mock_loader)
+
+    role_name = 'some_role'
+    with pytest.raises(errors.AnsibleError, match='role definitions must contain a role name'):
+        rd.preprocess_data({'stuff': role_name,
+                            'things_i_like': ['cheese', 'naps']})
+
+
+@pytest.mark.parametrize("role_name,expected",
+                         [('namespace.repo.role', 'namespace/repo/roles/role'),
+                          ('a.a.a', 'a/a/roles/a'),
+                          ('too.many.dots.lets.assume.extra.dots.are.role.name',
+                           'too/many/roles/dots.lets.assume.extra.dots.are.role.name'),
+                          # valid if role names can include sub paths? should raise an error?
+                          ('ns.repo.role/name/roles/role', 'ns/repo/roles/role/name/roles/role'),
+                          # DWIM
+                          ('geerlingguy.apache', 'geerlingguy/apache/roles/apache'),
+
+                          # these are actually legit 'role_name' inside ansible
+                          # they get used as relative paths
+                          ('../../some_dir/foo', None),
+                          ('../some_dir.foo.bar', None),
+                          ('.', None),
+                          ('/', None),
+                          ('./foo', None),
+                          ('.', None),
+
+                          ('justaname', None),
+                          ('namespace_dot.', None),
+                          ('somenamespace/somerepo/roles/somerole', None),
+
+                          (None, None),
+                          ])
+def test_role_name_to_relative_content_path(role_name, expected):
+    res = definition.role_name_to_relative_content_path(role_name)
+    log.debug('res: %s', res)
+    assert res == expected
+
+
+def test_find_role_in_content_path_invalid_role_name(mocker):
+    mock_loader = mocker.Mock(return_value=False)
+    res = definition.find_role_in_content_path('justaname', mock_loader, '/dev/null/foo')
+
+    assert res is None
+
+
+def test_find_role_in_content_path_loader_cant_find(mocker):
+    mock_loader = mocker.Mock(path_exists=mocker.Mock(return_value=False))
+    res = definition.find_role_in_content_path('namespace.repo.rolename', mock_loader, ['/dev/null/foo'])
+
+    assert res is None
+
+
+def test_find_role_in_content_path_loader(mocker):
+    content_search_path = '/dev/null/foo'
+    role_name = 'namespace.repo.rolename'
+    mock_loader = mocker.Mock(path_exists=mocker.Mock(return_value=True))
+    res = definition.find_role_in_content_path(role_name, mock_loader, [content_search_path])
+
+    assert isinstance(res, tuple)
+    assert res[0] == role_name
+    assert res[1] == os.path.join(content_search_path, 'namespace/repo/roles/rolename')

--- a/test/units/playbook/role/test_metadata.py
+++ b/test/units/playbook/role/test_metadata.py
@@ -1,0 +1,13 @@
+import logging
+
+from ansible.playbook.role import metadata
+
+log = logging.getLogger(__name__)
+
+
+def test_role_metadata():
+    rmd = metadata.RoleMetadata()
+
+    log.debug('rmd: %s', rmd)
+
+    assert isinstance(rmd, metadata.RoleMetadata)

--- a/test/units/playbook/role/test_requirement.py
+++ b/test/units/playbook/role/test_requirement.py
@@ -1,0 +1,87 @@
+import logging
+
+from ansible.playbook.role import definition
+from ansible.playbook.role import requirement
+
+log = logging.getLogger(__name__)
+
+
+def test_role_requirement():
+    rr = requirement.RoleRequirement()
+
+    assert isinstance(rr, requirement.RoleRequirement)
+    assert isinstance(rr, definition.RoleDefinition)
+
+
+def test_repo_url_to_repo_name():
+    repo_url = 'http://git.example.com/repos/repo.git'
+    res = requirement.RoleRequirement.repo_url_to_role_name(repo_url)
+
+    log.debug('res: %s', res)
+
+    assert res == 'repo'
+
+
+def test_role_spec_parse():
+
+    res = requirement.RoleRequirement.role_spec_parse('foo.bar')
+
+    log.debug('res: %s', res)
+
+    assert isinstance(res, dict)
+    assert res['name'] == 'foo.bar'
+    assert res['src'] == 'foo.bar'
+
+
+def test_role_spec_parse_example():
+    role_spec = 'git+http://git.example.com/repos/repo.git,v1.0'
+    res = requirement.RoleRequirement.role_spec_parse(role_spec)
+
+    # {'scm': 'git', 'src': 'http://git.example.com/repos/repo.git',
+    #  'version': 'v1.0', 'name': 'repo'}
+    log.debug('res: %s', res)
+
+    assert isinstance(res, dict)
+    assert res['name'] == 'repo'
+    assert res['scm'] == 'git'
+    assert res['src'] == 'http://git.example.com/repos/repo.git'
+    assert res['version'] == 'v1.0'
+
+
+def test_role_yaml_parse_dict_old_style():
+    role_yaml = {'role': "galaxy.role,v1.2.3,role_name", 'other_vars': "here"}
+    res = requirement.RoleRequirement.role_yaml_parse(role_yaml)
+
+    log.debug('res: %s', res)
+    # {'scm': None, 'src': 'galaxy.role', 'version': 'v1.2.3', 'name': 'role_name'}
+    assert isinstance(res, dict)
+    assert res['name'] == 'role_name'
+    assert res['version'] == 'v1.2.3'
+    assert res['src'] == 'galaxy.role'
+
+#
+# def test_role_yaml_parse_dict_new_style():
+#     # NOTE: the example in the comments for role_yaml_parse fails
+#     role_yaml = {'src': 'git+http://github.com/some_galaxy/some_role,v1.2.3,role_name', 'other_vars': "here"}
+#
+#     res = requirement.RoleRequirement.role_yaml_parse(role_yaml)
+#
+#     log.debug('res: %s', res)
+#     # {'scm': None, 'src': 'galaxy.role', 'version': 'v1.2.3', 'name': 'role_name'}
+#     assert isinstance(res, dict)
+#     assert res['name'] == 'role_name'
+#     assert res['version'] == 'v1.2.3'
+#     assert res['src'] == 'galaxy.role'
+#
+
+
+def test_role_yaml_parse_string():
+    role_yaml = 'galaxy.role,v1.2.3,role_name'
+    res = requirement.RoleRequirement.role_yaml_parse(role_yaml)
+
+    log.debug('res: %s', res)
+
+    assert isinstance(res, dict)
+    assert res['name'] == 'role_name'
+    assert res['version'] == 'v1.2.3'
+    assert res['src'] == 'galaxy.role'

--- a/test/units/playbook/role/test_requirement.py
+++ b/test/units/playbook/role/test_requirement.py
@@ -21,44 +21,6 @@ def test_repo_url_to_repo_name():
 
     assert res == 'repo'
 
-
-def test_role_spec_parse():
-
-    res = requirement.RoleRequirement.role_spec_parse('foo.bar')
-
-    log.debug('res: %s', res)
-
-    assert isinstance(res, dict)
-    assert res['name'] == 'foo.bar'
-    assert res['src'] == 'foo.bar'
-
-
-def test_role_spec_parse_example():
-    role_spec = 'git+http://git.example.com/repos/repo.git,v1.0'
-    res = requirement.RoleRequirement.role_spec_parse(role_spec)
-
-    # {'scm': 'git', 'src': 'http://git.example.com/repos/repo.git',
-    #  'version': 'v1.0', 'name': 'repo'}
-    log.debug('res: %s', res)
-
-    assert isinstance(res, dict)
-    assert res['name'] == 'repo'
-    assert res['scm'] == 'git'
-    assert res['src'] == 'http://git.example.com/repos/repo.git'
-    assert res['version'] == 'v1.0'
-
-
-def test_role_yaml_parse_dict_old_style():
-    role_yaml = {'role': "galaxy.role,v1.2.3,role_name", 'other_vars': "here"}
-    res = requirement.RoleRequirement.role_yaml_parse(role_yaml)
-
-    log.debug('res: %s', res)
-    # {'scm': None, 'src': 'galaxy.role', 'version': 'v1.2.3', 'name': 'role_name'}
-    assert isinstance(res, dict)
-    assert res['name'] == 'role_name'
-    assert res['version'] == 'v1.2.3'
-    assert res['src'] == 'galaxy.role'
-
 #
 # def test_role_yaml_parse_dict_new_style():
 #     # NOTE: the example in the comments for role_yaml_parse fails


### PR DESCRIPTION
##### SUMMARY
A proof of concept of loading roles with dotted namespace.repo.rolename mazer style names.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/playbook/role/

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (mazer_role_loader_logging 13b76db36a) last updated 2018/07/16 15:39:21 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = ['/home/adrian/ansible/my-modules']
  configured galaxy content search path = ['/home/adrian/.ansible/content']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/venvs/ansible-py3/bin/ansible
  python version = 3.6.5 (default, Apr  4 2018, 15:01:18) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]

```


##### ADDITIONAL INFORMATION
Running the test playbook in roletest
```
cd roletest
ANSIBLE_CONFIG=ansible-role-paths.cfg  ansible-playbook -vvv -i hosts ping_roles.yml
```

fixes #12157