### PR TITLE
fix firewalld permanent zone operations

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -498,7 +498,9 @@ class ZoneTransaction(FirewallTransaction):
         self.module.fail_json(msg=self.tx_not_permanent_error_msg)
 
     def get_enabled_permanent(self):
-        if self.zone in self.fw.config().getZoneNames():
+        zones = self.fw.config().listZones()
+        zone_names = [self.fw.config().getZone(z).get_property("name") for z in zones]
+        if self.zone in zone_names:
             return True
         else:
             return False


### PR DESCRIPTION
Fixes #42310

Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY

Previously, the firewalld module was making a call to
FirewallClientConfig.getZoneNames() which doesn't exist in versions
of firwalld older than 0.4.2, this patch implements the same logic
with older API calls to not require a newer version of firewalld.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
firewalld

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (modules/firewalld 9b5f0b58a4) last updated 2018/07/16 15:46:41 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Before change:
```
$ ansible ubuntu1604 -m firewalld -a "zone=test state=present permanent=True" -i ~/inventory
192.168.86.109 | FAILED! => {
    "changed": false,
    "msg": "ERROR: Exception caught: 'FirewallClientConfig' object has no attribute 'getZoneNames'"
}
```

After change:
```
$(ansible)  ansible ubuntu1604 -m firewalld -a "zone=test state=present permanent=True" -i ~/inventory
192.168.86.109 | CHANGED => {
    "changed": true,
    "msg": "Permanent operation, Added zone test, Changed zone test to present"
}
$(ansible)  ansible ubuntu1604 -m firewalld -a "zone=test state=present permanent=True" -i ~/inventory
192.168.86.109 | SUCCESS => {
    "changed": false,
    "msg": "Permanent operation"
}
```
