### PR TITLE
Backport #42711 for 2.6 - Incorrect attribute name in FreeBSD class

### DIFF
--- a/changelogs/fragments/user-freebsd-createhome-name-fix.yaml
+++ b/changelogs/fragments/user-freebsd-createhome-name-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - use correct attribute name in FreeBSD for creat_home (https://github.com/ansible/ansible/pull/42711)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1008,7 +1008,7 @@ class FreeBsdUser(User):
             cmd.append(self.comment)
 
         if self.home is not None:
-            if (info[5] != self.home and self.move_home) or (not os.path.exists(self.home) and self.createhome):
+            if (info[5] != self.home and self.move_home) or (not os.path.exists(self.home) and self.create_home):
                 cmd.append('-m')
             cmd.append('-d')
             cmd.append(self.home)


### PR DESCRIPTION
##### SUMMARY
Backport of #42711 for Ansible 2.6

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
`user.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```