### PR TITLE
NCLU - Add example: Changing the hostname and committing on Cumulus Linux

### DIFF
--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -64,7 +64,7 @@ EXAMPLES = '''
         - add int swp1
         - add int swp2
 
-- name: Set hostname to Cumulus-1 and commit the change
+- name: Modify hostname to Cumulus-1 and commit the change
   nclu:
     commands:
         - add hostname Cumulus-1

--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -64,6 +64,12 @@ EXAMPLES = '''
         - add int swp1
         - add int swp2
 
+- name: Set hostname to Cumulus-1 and commit the change
+  nclu:
+    commands:
+        - add hostname Cumulus-1
+    commit: true
+
 - name: Add 48 interfaces and commit the change.
   nclu:
     template: |


### PR DESCRIPTION
##### SUMMARY
This adds a quick example for setting the hostname and commiting the change on Cumulus Linux.

Referring to https://github.com/ansible/community/issues/311
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
cumulus/nclu

##### ANSIBLE VERSION
```
ansible 2.6.1
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.4 (default, Apr  6 2018, 05:23:32) [GCC 6.4.0]
```


##### ADDITIONAL INFORMATION
Playbook output:
```
PLAY [Cumulus test playbook] *********************************************************************

TASK [Set hostname to Cumulus-1 and commit the change] *******************************************
changed: [Cumulus-1]

PLAY RECAP ***************************************************************************************
Cumulus-1                  : ok=1    changed=1    unreachable=0    failed=0   
```

Verification (the PS1 not changing is intentional, updates upon re-login):
```
cumulus@cumulus:~$ net show hostname
cumulus
cumulus@cumulus:~$ # Ansible! 
cumulus@cumulus:~$ net show hostname
Cumulus-1
```