### PR TITLE
Explicitly pass HTTP method to fetch_url

### DIFF
--- a/lib/ansible/modules/monitoring/rollbar_deployment.py
+++ b/lib/ansible/modules/monitoring/rollbar_deployment.py
@@ -120,7 +120,7 @@ def main():
 
     try:
         data = urlencode(params)
-        response, info = fetch_url(module, url, data=data)
+        response, info = fetch_url(module, url, data=data, method='POST')
     except Exception as e:
         module.fail_json(msg='Unable to notify Rollbar: %s' % to_native(e), exception=traceback.format_exc())
     else:


### PR DESCRIPTION
##### SUMMARY

The `rollbar_deployment` module no longer works on the `HEAD` of `devel` due to changes made in the `fetch_url` method, which currently lives in `module_utils/urls.py` (I'm not exactly sure what, but my best guess is the default method was changed from `GET` to `POST` (there were recently non-trivial changes made to this module). 

Explicitly specifying the `method` in the call to `fetch_url` resolves the issue (note: I did not see any open issues referring to rollbar_deployment).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rollbar_deployment

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel cb1396b5be) last updated 2018/07/17 00:40:07 (GMT -400)
  config file = None
  configured module search path = [u'/home/ecoutu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ecoutu/dev/crowdstaffing/deploy/.venv/src/ansible/lib/ansible
  executable location = /home/ecoutu/dev/crowdstaffing/deploy/.venv/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Minimal playbook to reproduce:

```yaml
- hosts: localhost
  connection: local
  tasks:
    - name: notify rollbar of deployment
      rollbar_deployment:
        environment: local
        revision: master
        token: "{{ rollbar_access_token }}"
```

Before patch:

```bash
$ ansible-playbook wat1.yml -i localdev

PLAY [localhost] ***************************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [notify rollbar of deployment] ********************************************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "HTTP result code: 400 connecting to https://api.rollbar.com/api/1/deploy/"}

PLAY RECAP *********************************************************************************************************************************************************************************************************************************************************************************
localhost              : ok=1    changed=0    unreachable=0    failed=1   
```
After patch:

```yaml
$ ansible-playbook wat1.yml -i localdev

PLAY [localhost] ***************************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [notify rollbar of deployment] ********************************************************************************************************************************************************************************************************************************************************
changed: [localhost]

PLAY RECAP *********************************************************************************************************************************************************************************************************************************************************************************
localhost              : ok=2    changed=1    unreachable=0    failed=0  
```