### PR TITLE
Get rid of duplicate status statement

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -402,8 +402,6 @@ Support
 ~~~~~~~
 For more information about Red Hat's support of this @{ plugin_type }@,
 please refer to this `Knowledge Base article <https://access.redhat.com/articles/rhel-top-support-policies/>`_
-{%     else %}
-This @{ plugin_type }@ is flagged as **preview** which means that @{module_states['preview']}@.
 {%     endif %}
 
 {%   endif %}


### PR DESCRIPTION
##### SUMMARY
If a module was in status "preview", but it was not "supported" (core/network) the message about the module being "preview" would be repeated.

As you can see from: https://docs.ansible.com/ansible/devel/modules/aci_tenant_module.html#status

This issue was introduced in https://github.com/ansible/ansible/commit/b21c7c02326ddd87b9454617392c1ddaec002342

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
module docs

##### ANSIBLE VERSION
v2.7