### PR TITLE
webdocs: Differentiate between type and required

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -117,9 +117,8 @@ Parameters
                 {% endfor %}
                 {# parameter name with required and/or introduced label #}
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
-                    <b>@{ key }@</b>
+                    <b>@{ key }@{% if value.get('required', False) %}<div style="color: red; display:inline">**</div>{% endif %}</b>
                     {% if value.get('type', None) %}<br/><div style="font-size: small; color: red">@{ value.type }@</div>{% endif %}
-                    {% if value.get('required', False) %}<br/><div style="font-size: small; color: red">required</div>{% endif %}
                     {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
                 </td>
                 {# default / choices #}
@@ -201,7 +200,8 @@ Parameters
             {% endif %}
         {% endfor %}
     </table>
-    <br/>
+    <div style="color: red; display:inline"><b>**</b></div> This parameter is required for this @{ plugin_type }@ to work.
+    <br/><br/>
 
 {% endif %}
 

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -200,7 +200,7 @@ Parameters
             {% endif %}
         {% endfor %}
     </table>
-    <div style="color: red; display:inline"><b>**</b></div> This parameter is required for this @{ plugin_type }@ to work.
+    <div style="color: red; display:inline"><b>**</b></div> The parameter is required for this @{ plugin_type }@ to work.
     <br/><br/>
 
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
Now that parameters have their (non-string) type indicated in the module
docs, it becomes harder to tell which parameter is required, and what is
the type. (Mostly because both are red and positioned similarly).

![screenshot from 2018-07-17 13-54-35](https://user-images.githubusercontent.com/388198/42815868-04cee79e-89c9-11e8-8629-b0d6ddaf3734.png)

Furthermore, if a non-string parameter is required, both are now
indicated subsequently.

![screenshot from 2018-07-17 13-56-24](https://user-images.githubusercontent.com/388198/42815930-3cc7e7e0-89c9-11e8-9bb8-978eba3edddc.png)

This change makes required parameters stand out by adding asterisks to
the parameter name (in red) with an explanation at the bottom.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Module docs

##### ANSIBLE VERSION
v2.7