### PR TITLE
vultr.py: fix env var handling (#42659)

### DIFF
--- a/changelogs/fragments/vultr-parameters-parsing.yaml
+++ b/changelogs/fragments/vultr-parameters-parsing.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vultr - Do not fail trying to load configuration from ini files if required variables have been set as environment variables.

--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -43,9 +43,9 @@ class Vultr:
         # For caching HTTP API responses
         self.api_cache = dict()
 
-        # Reads the config from vultr.ini
         try:
-            config = self.read_ini_config()
+            config = self.read_env_variables()
+            config.update(self.read_ini_config())
         except KeyError:
             config = {}
 
@@ -60,6 +60,9 @@ class Vultr:
             self.fail_json(msg="One of the following settings, "
                                "in section '%s' in the ini config file has not an int value: timeout, retries. "
                                "Error was %s" % (self.module.params.get('api_account'), to_native(e)))
+
+        if not self.api_config.get('api_key'):
+            self.module.fail_json(msg="The API key is not speicied. Please refer to the documentation.")
 
         # Common vultr returns
         self.result['vultr_api'] = {
@@ -76,18 +79,18 @@ class Vultr:
             'Accept': 'application/json',
         }
 
-    def read_ini_config(self):
-        ini_group = self.module.params.get('api_account')
-
+    def read_env_variables(self):
         keys = ['key', 'timeout', 'retries', 'endpoint']
         env_conf = {}
         for key in keys:
             if 'VULTR_API_%s' % key.upper() not in os.environ:
-                break
-            else:
-                env_conf[key] = os.environ['VULTR_API_%s' % key.upper()]
-        else:
-            return env_conf
+                continue
+            env_conf[key] = os.environ['VULTR_API_%s' % key.upper()]
+
+        return env_conf
+
+    def read_ini_config(self):
+        ini_group = self.module.params.get('api_account')
 
         paths = (
             os.path.join(os.path.expanduser('~'), '.vultr.ini'),
@@ -95,11 +98,13 @@ class Vultr:
         )
         if 'VULTR_API_CONFIG' in os.environ:
             paths += (os.path.expanduser(os.environ['VULTR_API_CONFIG']),)
-        if not any((os.path.exists(c) for c in paths)):
-            self.module.fail_json(msg="Config file not found. Tried : %s" % ", ".join(paths))
 
         conf = configparser.ConfigParser()
         conf.read(paths)
+
+        if not conf._sections.get(ini_group):
+            return dict()
+
         return dict(conf.items(ini_group))
 
     def fail_json(self, **kwargs):


### PR DESCRIPTION
##### SUMMARY

In its current behavior, `read_ini_config()` tries to read ini file,
even thought `$VULTR_API_KEY` environment file has been specified.

This is due to the fact that if not *all* the keys (key, timeout,
retries and endpoint) are specified in the environment, then the method
goes and look for the vultr.ini file.

Since timeout, retries and endpoint have default value, it is a
perfectly valid use case to only specify key.

Before patch:

`VULTR_API_KEY=XXXX ansible -m vr_ssh_key ...`  fails with Config file is
missing

After patch:

`VULTR_API_KEY=XXXX ansible -m vr_ssh_key ...` goes all the way

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

  - module_utils/vultr.py

##### ANSIBLE VERSION

 - devel

##### ADDITIONAL INFORMATION

  - N/A