### PR TITLE
ACI: Add parameter types to module docs

### DIFF
--- a/lib/ansible/modules/network/aci/aci_aaa_user.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user.py
@@ -37,6 +37,7 @@ options:
   aaa_password_lifetime:
     description:
     - The lifetime of the locally-authenticated user password.
+    type: int
   aaa_password_update_required:
     description:
     - Whether this account needs password update.

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -47,22 +47,22 @@ options:
     - The description to assign to the C(leaf_port_blk)
   from_port:
     description:
-    - The beggining (from range) of the port range block for the leaf access port block.
+    - The beginning (from-range) of the port range block for the leaf access port block.
     aliases: [ from, fromPort, from_port_range ]
     required: yes
   to_port:
     description:
-    - The end (to range) of the port range block for the leaf access port block.
+    - The end (to-range) of the port range block for the leaf access port block.
     aliases: [ to, toPort, to_port_range ]
     required: yes
   from_card:
     description:
-    - The beggining (from range) of the card range block for the leaf access port block.
+    - The beginning (from-range) of the card range block for the leaf access port block.
     aliases: [ from_card_range ]
     version_added: '2.6'
   to_card:
     description:
-    - The end (to range) of the card range block for the leaf access port block.
+    - The end (to-range) of the card range block for the leaf access port block.
     aliases: [ to_card_range ]
     version_added: '2.6'
   policy_group:

--- a/lib/ansible/modules/network/aci/aci_filter_entry.py
+++ b/lib/ansible/modules/network/aci/aci_filter_entry.py
@@ -247,7 +247,7 @@ def main():
         ip_protocol=dict(choices=VALID_IP_PROTOCOLS, type='str'),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         stateful=dict(type='bool'),
-        tenant=dict(type="str", aliases=['tenant_name']),  # Not required for querying all objects
+        tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
     )
 
     module = AnsibleModule(

--- a/lib/ansible/modules/network/aci/aci_firmware_source.py
+++ b/lib/ansible/modules/network/aci/aci_firmware_source.py
@@ -32,6 +32,7 @@ options:
   polling_interval:
     description:
     - Polling interval in minutes.
+    type: int
   url_protocol:
     description:
     - The Firmware download protocol.

--- a/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
@@ -40,8 +40,8 @@ options:
   vepa:
     description:
     - Determines if Virtual Ethernet Port Aggregator is disabled or enabled.
-    - The APIC defaults to C(disabled) when unset during creation.
-    choices: [ disabled, enabled ]
+    - The APIC defaults to C(no) when unset during creation.
+    type: bool
   vlan_scope:
     description:
     - The scope of the VLAN.

--- a/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
@@ -35,13 +35,13 @@ options:
   receive_state:
     description:
     - Enable or disable Receive state.
-    - The APIC defaults to C(enabled) when unset during creation.
-    choices: [ disabled, enabled ]
+    - The APIC defaults to C(yes) when unset during creation.
+    type: bool
   transmit_state:
     description:
     - Enable or Disable Transmit state.
-    - The APIC defaults to C(enabled) when unset during creation.
-    choices: [ disabled, enabled ]
+    - The APIC defaults to C(yes) when unset during creation.
+    type: bool
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.

--- a/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
@@ -35,8 +35,8 @@ options:
   admin_state:
     description:
     - Enable or disable admin state.
-    - The APIC defaults to C(enable) when unset during creation.
-    choices: [ disable, enable ]
+    - The APIC defaults to C(yes) when unset during creation.
+    type: bool
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.

--- a/lib/ansible/modules/network/aci/aci_interface_policy_ospf.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_ospf.py
@@ -73,6 +73,7 @@ options:
     - C(passive) -- The interface does not participate in the OSPF protocol and
       will not establish adjacencies or send routing updates. However the
       interface is announced as part of the routing network.
+    type: list
     choices: [ advert-subnet, bfd, mtu-ignore, passive ]
   dead_interval:
     description:
@@ -84,6 +85,7 @@ options:
       routing instability.
     - Accepted values range between C(1) and C(65535).
     - The APIC defaults to C(40) when unset during creation.
+    type: int
   hello_interval:
     description:
     - The interval between hello packets that OSPF sends on the interface.
@@ -91,6 +93,7 @@ options:
     - This value must be the same for all routers and access servers on a specific network.
     - Accepted values range between C(1) and C(65535).
     - The APIC defaults to C(10) when unset during creation.
+    type: int
   prefix_suppression:
     description:
     - Whether prefix suppressions is enabled or disabled.
@@ -101,6 +104,7 @@ options:
     - The priority for the OSPF interface profile.
     - Accepted values ranges between C(0) and C(255).
     - The APIC defaults to C(1) when unset during creation.
+    type: int
   retransmit_interval:
     description:
     - The interval between LSA retransmissions.
@@ -108,6 +112,7 @@ options:
     - If no acknowlegment is received at the end of the interval, then the LSA is resent.
     - Accepted values range between C(1) and C(65535).
     - The APIC defaults to C(5) when unset during creation.
+    type: int
   transmit_delay:
     description:
     - The delay time needed to send an LSA update packet.
@@ -115,6 +120,7 @@ options:
     - You should take into account the transmission and propagation delays for the interface when you set this value.
     - Accepted values range between C(1) and C(450).
     - The APIC defaults to C(1) when unset during creation.
+    type: int
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
@@ -34,13 +34,13 @@ options:
     aliases: [ descr ]
   max_links:
     description:
-    - Maximum links (range 1-16).
+    - Maximum links.
     - Accepted values range between 1 and 16.
     - The APIC defaults to C(16) when unset during creation.
     type: int
   min_links:
     description:
-    - Minimum links (range 1-16).
+    - Minimum links.
     - Accepted values range between 1 and 16.
     - The APIC defaults to C(1) when unset during creation.
     type: int

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
@@ -34,8 +34,10 @@ options:
     aliases: [ descr ]
   max_end_points:
     description:
-    - Maximum number of end points (range 0-12000).
+    - Maximum number of end points.
+    - Accepted values range between C(0) and C(12000).
     - The APIC defaults to C(0) when unset during creation.
+    type: int
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.

--- a/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
+++ b/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
@@ -41,8 +41,10 @@ options:
     aliases: [ tenant_name ]
   tag:
     description:
-    - The value of the route tag (range 0-4294967295).
+    - The value of the route tag.
+    - Accepted values range between C(0) and C(4294967295).
     - The APIC defaults to C(4294967295) when unset during creation.
+    type: int
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.

--- a/lib/ansible/modules/network/aci/aci_rest.py
+++ b/lib/ansible/modules/network/aci/aci_rest.py
@@ -63,6 +63,7 @@ options:
       of the HTTP request being sent to the ACI fabric.
     - If you require a templated payload, use the C(content) parameter
       together with the C(template) lookup plugin, or use M(template).
+    type: path
     aliases: [ config_file ]
 extends_documentation_fragment: aci
 '''

--- a/lib/ansible/modules/network/aci/aci_switch_policy_vpc_protection_group.py
+++ b/lib/ansible/modules/network/aci/aci_switch_policy_vpc_protection_group.py
@@ -32,9 +32,9 @@ options:
   protection_group_id:
     description:
     - The Explicit vPC Protection Group ID.
+    required: yes
     type: int
     aliases: [ id ]
-    required: yes
   vpc_domain_policy:
     description:
     - The vPC domain policy to be associated with the Explicit vPC Protection Group.
@@ -42,13 +42,13 @@ options:
   switch_1_id:
     description:
     - The ID of the first Leaf Switch for the Explicit vPC Protection Group.
-    type: int
     required: yes
+    type: int
   switch_2_id:
     description:
     - The ID of the Second Leaf Switch for the Explicit vPC Protection Group.
-    type: int
     required: yes
+    type: int
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.

--- a/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
@@ -35,8 +35,8 @@ options:
     aliases: [ epr_name, name ]
   bounce_age:
     description:
-    - Bounce Entry Aging Interval (range 150secs - 65535secs)
-    - 0 is used for infinite.
+    - Bounce entry aging interval in seconds.
+    - Accepted values range between C(150) and C(65535); 0 is used for infinite.
     - The APIC defaults to C(630) when unset during creation.
     type: int
   bounce_trigger:
@@ -46,25 +46,26 @@ options:
     choices: [ coop, flood ]
   hold_interval:
     description:
-    - Hold Interval (range 5secs - 65535secs).
+    - Hold interval in seconds.
+    - Accepted values range between C(5) and C(65535).
     - The APIC defaults to C(300) when unset during creation.
     type: int
   local_ep_interval:
     description:
-    - Local end point Aging Interval (range 120secs - 65535secs).
-    - 0 is used for infinite.
+    - Local end point aging interval in seconds.
+    - Accepted values range between C(120) and C(65535); 0 is used for infinite.
     - The APIC defaults to C(900) when unset during creation.
     type: int
   remote_ep_interval:
     description:
-    - Remote end point Aging Interval (range 120secs - 65535secs).
-    - O is used for infinite.
+    - Remote end point aging interval in seconds.
+    - Accepted values range between C(120) and C(65535); 0 is used for infinite.
     - The APIC defaults to C(300) when unset during creation.
     type: int
   move_frequency:
     description:
-    - Move frequency per second (range 0secs - 65535secs).
-    - 0 is used for none.
+    - Move frequency per second.
+    - Accepted values range between C(0) and C(65535); 0 is used for none.
     - The APIC defaults to C(256) when unset during creation.
     type: int
   description:

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
@@ -28,8 +28,8 @@ options:
   admin_state:
     description:
     - Enable or disable the span sources.
-    - The APIC defaults to C(enabled) when unset during creation.
-    choices: [ enabled, disabled ]
+    - The APIC defaults to C(yes) when unset during creation.
+    type: bool
   description:
     description:
     - The description for Span source group.

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -675,10 +675,6 @@ lib/ansible/modules/net_tools/snmp_facts.py E322
 lib/ansible/modules/net_tools/snmp_facts.py E324
 lib/ansible/modules/network/a10/a10_server_axapi3.py E326
 lib/ansible/modules/network/a10/a10_virtual_server.py E324
-lib/ansible/modules/network/aci/aci_interface_policy_l2.py E326
-lib/ansible/modules/network/aci/aci_interface_policy_lldp.py E326
-lib/ansible/modules/network/aci/aci_interface_policy_mcp.py E326
-lib/ansible/modules/network/aci/aci_tenant_span_src_group.py E326
 lib/ansible/modules/network/aos/_aos_blueprint_param.py E325
 lib/ansible/modules/network/asa/asa_config.py E324
 lib/ansible/modules/network/bigswitch/bigmon_policy.py E324


### PR DESCRIPTION
##### SUMMARY
This is a continuation of #42572

This PR also includes:
- Updates to old enabled/disabled now promoting the use of booleans
- Documenting range values more consistently

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ACI modules

##### ANSIBLE VERSION
v2.7