### PR TITLE
Fix cloudflare_dns JSON response error handling

### DIFF
--- a/lib/ansible/modules/net_tools/cloudflare_dns.py
+++ b/lib/ansible/modules/net_tools/cloudflare_dns.py
@@ -354,11 +354,11 @@ class CloudflareAPI(object):
         if content:
             try:
                 result = json.loads(to_text(content, errors='surrogate_or_strict'))
-            except (json.JSONDecodeError, UnicodeError) as e:
+            except (getattr(json, 'JSONDecodeError', ValueError)) as e:
                 error_msg += "; Failed to parse API response with error {0}: {1}".format(to_native(e), content)
 
-        # received an error status but no data with details on what failed
-        if (info['status'] not in [200, 304]) and (result is None):
+        # Without a valid/parsed JSON response no more error processing can be done
+        if result is None:
             self.module.fail_json(msg=error_msg)
 
         if not result['success']:


### PR DESCRIPTION
##### SUMMARY

* The JSONDecodeError exception only exists in Python 3.

* Without a properly parsed JSON response there is no more error
  processing to be done, no matter the http response code.

Relates to #38178

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudflare_dns

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel b6e9df2065) last updated 2018/07/17 14:07:45 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/labs/ansible/devel/lib/ansible
  executable location = /home/andreas/labs/ansible/devel/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```