### PR TITLE
openstack: fix parameter handling when cloud provided as dict

### DIFF
--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -134,11 +134,12 @@ def openstack_cloud_from_module(module, min_version='0.12.0'):
                 " excluded.")
             for param in (
                     'auth', 'region_name', 'verify',
-                    'cacert', 'key', 'api_timeout', 'interface'):
+                    'cacert', 'key', 'api_timeout', 'auth_type'):
                 if module.params[param] is not None:
                     module.fail_json(msg=fail_message.format(param=param))
-            if module.params['auth_type'] != 'password':
-                module.fail_json(msg=fail_message.format(param='auth_type'))
+            # For 'interface' parameter, fail if we receive a non-default value
+            if module.params['interface'] != 'public':
+                module.fail_json(msg=fail_message.format(param='interface'))
             return sdk, sdk.connect(**cloud_config)
         else:
             return sdk, sdk.connect(

--- a/lib/ansible/modules/cloud/openstack/os_user.py
+++ b/lib/ansible/modules/cloud/openstack/os_user.py
@@ -201,11 +201,12 @@ def main():
 
     sdk, cloud = openstack_cloud_from_module(module)
     try:
-        user = cloud.get_user(name)
-
         domain_id = None
         if domain:
             domain_id = _get_domain_id(cloud, domain)
+            user = cloud.get_user(name, domain_id=domain_id)
+        else:
+            user = cloud.get_user(name)
 
         if state == 'present':
             if update_password in ('always', 'on_create'):

--- a/lib/ansible/modules/cloud/openstack/os_user.py
+++ b/lib/ansible/modules/cloud/openstack/os_user.py
@@ -272,7 +272,10 @@ def main():
             if user is None:
                 changed = False
             else:
-                cloud.delete_user(user['id'])
+                if domain:
+                    cloud.delete_user(user['id'], domain_id=domain_id)
+                else:
+                    cloud.delete_user(user['id'])
                 changed = True
             module.exit_json(changed=changed)
 


### PR DESCRIPTION
If a cloud is provided as dictionary:

 * Do not assert that 'interface' parameter is None. Instead,
   assert that it is 'public'.
 * Assert that 'auth_type' parameter is not set.

Fixes #42858

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
For OpenStack modules, if an entire cloud configuration is provided as dictionary
in the "cloud" parameter:

 * Previous code was expecting the `interface` parameter to be unset. However, since
   the module itself will set the `interface` parameter to a default value of `public` if no
   other value is explicitly provided, this check always failed. Updated the code to expect
   the default value instead.

 * Previous code was expecting the `auth_type` parameter to have a value of `password`.
   However, since that parameter has no default value, and the expectation is that the user does
   not specify this parameter when defining a cloud, this check should be removed.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /home/ckoester/.ansible.cfg
  configured module search path = [u'/home/ckoester/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ckoester/ansible26/local/lib/python2.7/site-packages/ansible
  executable location = /home/ckoester/ansible26/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
