### PR TITLE
os_user_role: Include domain parameter in user lookup

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_user_role.py
+++ b/lib/ansible/modules/cloud/openstack/os_user_role.py
@@ -136,8 +136,17 @@ def main():
             module.fail_json(msg="Role %s is not valid" % role)
         filters['role'] = r['id']
 
+        if domain:
+            d = cloud.get_domain(domain)
+            if d is None:
+                module.fail_json(msg="Domain %s is not valid" % domain)
+            filters['domain'] = d['id']
         if user:
-            u = cloud.get_user(user)
+            if domain:
+                u = cloud.get_user(user, domain_id=filters['domain'])
+            else:
+                u = cloud.get_user(user)
+
             if u is None:
                 module.fail_json(msg="User %s is not valid" % user)
             filters['user'] = u['id']
@@ -146,14 +155,14 @@ def main():
             if g is None:
                 module.fail_json(msg="Group %s is not valid" % group)
             filters['group'] = g['id']
-        if domain:
-            d = cloud.get_domain(domain)
-            if d is None:
-                module.fail_json(msg="Domain %s is not valid" % domain)
-            filters['domain'] = d['id']
         if project:
             if domain:
                 p = cloud.get_project(project, domain_id=filters['domain'])
+                # OpenStack won't allow us to use both a domain and project as
+                # filter. Once we identified the project (using the domain as
+                # a filter criteria), we need to remove the domain itself from
+                # the filters list.
+                filters.pop('domain')
             else:
                 p = cloud.get_project(project)
 


### PR DESCRIPTION
If a "domain" parameter is provided, use it in looking up the user ID.

Additionally, if both a domain and project parameter are provided, then
remove the domain ID from the list of filter criteria after having used
it to look up both the user and the project. OpenStack will not allow us
to apply both a project ID (which implies a domain) and a domain ID as a
search filter.

Fixes #42911

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
os_user_role

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /home/ckoester/.ansible.cfg
  configured module search path = [u'/home/ckoester/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ckoester/ansible26/local/lib/python2.7/site-packages/ansible
  executable location = /home/ckoester/ansible26/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
