### PR TITLE
Add missing QoS and source facts and fix for vVOLs in purefa_facts module

### DIFF
--- a/lib/ansible/modules/storage/purestorage/purefa_facts.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_facts.py
@@ -281,6 +281,7 @@ ansible_facts:
         "subnet": {}
         "volumes": {
             "ansible_data": {
+                "bandwidth": null,
                 "hosts": [
                     [
                         "host1",
@@ -288,7 +289,8 @@ ansible_facts:
                     ]
                 ],
                 "serial": "43BE47C12334399B000114A6",
-                "size": 1099511627776
+                "size": 1099511627776,
+                "source": null
             }
         }
 '''
@@ -450,10 +452,27 @@ def generate_vol_dict(array):
     for vol in range(0, len(vols)):
         volume = vols[vol]['name']
         volume_facts[volume] = {
+            'source': vols[vol]['source'],
             'size': vols[vol]['size'],
             'serial': vols[vol]['serial'],
-            'hosts': []
+            'hosts': [],
+            'bandwidth': ""
         }
+    api_version = array._list_available_rest_versions()
+    if AC_REQUIRED_API_VERSION in api_version:
+        qvols = array.list_volumes(qos=True)
+        for qvol in range(0, len(qvols)):
+            volume = qvols[qvol]['name']
+            qos = qvols[qvol]['bandwidth_limit']
+            volume_facts[volume]['bandwidth'] = qos
+        vvols = array.list_volumes(protocol_endpoint=True)
+        for vvol in range(0, len(vvols)):
+            volume = vvols[vvol]['name']
+            volume_facts[volume] = {
+                'source': vols[vol]['source'],
+                'serial': vols[vol]['serial'],
+                'hosts': []
+            }
     cvols = array.list_volumes(connect=True)
     for cvol in range(0, len(cvols)):
         volume = cvols[cvol]['name']
@@ -541,7 +560,7 @@ def main():
     subset_test = (test in valid_subsets for test in subset)
     if not all(subset_test):
         module.fail_json(msg="value must gather_subset must be one or more of: %s, got: %s"
-                             % (",".join(valid_subsets), ",".join(subset)))
+                         % (",".join(valid_subsets), ",".join(subset)))
 
     facts = {}
 


### PR DESCRIPTION
##### SUMMARY
Add missing QoS fact and source fact, which identifies where a volume was cloned from, for purefa_facts module. Fix error when vVOLs are present on an array which needs to correctly see protocol endpoints for VASA

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
storage/purestorage/purefa_facts

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.7.0.dev0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```