### PR TITLE
Allow DNS bypass for add/remove of host records with nios_host_record

### DIFF
--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -25,7 +25,7 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
+import q
 import os
 from functools import partial
 from ansible.module_utils._text import to_native
@@ -318,9 +318,9 @@ class WapiModule(WapiBase):
             update = True
             return ib_obj, update, new_name
         if (ib_obj_type == NIOS_HOST_RECORD):
-            if 'configure_for_dns' in obj_filter:
-                if not obj_filter['configure_for_dns']:
-                    test_obj_filter = dict([('name', name)])
+            # to check only by name if dns bypassing is set
+            if not obj_filter['configure_for_dns']:
+                test_obj_filter = dict([('name', name)])
             else:
                 test_obj_filter = dict([('name', name), ('view', obj_filter['view'])])
         else:

--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -318,7 +318,11 @@ class WapiModule(WapiBase):
             update = True
             return ib_obj, update, new_name
         if (ib_obj_type == NIOS_HOST_RECORD):
-            test_obj_filter = dict([('name', name), ('view', obj_filter['view'])])
+            if 'configure_for_dns' in obj_filter:
+                if not obj_filter['configure_for_dns']:
+                    test_obj_filter = dict([('name', name)])
+            else:
+                test_obj_filter = dict([('name', name), ('view', obj_filter['view'])])
         else:
             test_obj_filter = dict([('name', name)])
         ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=ib_spec.keys())

--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -25,7 +25,7 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-import q
+
 import os
 from functools import partial
 from ansible.module_utils._text import to_native

--- a/lib/ansible/modules/net_tools/nios/nios_host_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_host_record.py
@@ -39,12 +39,22 @@ options:
     default: default
     aliases:
       - dns_view
+  configure_for_dns:
+  description:
+      - Sets the DNS to particular parent. If user needs to bypass DNS
+        user can make the value to false.
+    required: false
+    default: true
+    aliases:
+      - dns
   ipv4addrs:
     description:
       - Configures the IPv4 addresses for this host record.  This argument
         accepts a list of values (see suboptions)
     aliases:
       - ipv4
+      - dhcp
+      - mac
     suboptions:
       ipv4addr:
         description:
@@ -52,15 +62,27 @@ options:
         required: true
         aliases:
           - address
+      configure_for_dhcp:
+        description:
+          - Configure the host_record over DHCP instead of DNS, if user
+            changes it to true, user need to mention MAC address to configure
+        required: false
+        default: null
+        aliases:
+          - dhcp
       mac:
         description:
-          - Configures the hardware MAC address for the host record
+          - Configures the hardware MAC address for the host record. If user makes
+            DHCP to true, user need to mention MAC address.
+        required: false
+        default: null
   ipv6addrs:
     description:
       - Configures the IPv6 addresses for the host record.  This argument
         accepts a list of values (see options)
     aliases:
       - ipv6
+      - dhcp
     suboptions:
       ipv6addr:
         description:
@@ -68,6 +90,14 @@ options:
         required: true
         aliases:
           - address
+      configure_for_dhcp:
+        description:
+          - Configure the host_record over DHCP instead of DNS, if user
+            changes it to true, user need to mention MAC address to configure
+        required: false
+        default: null
+        aliases:
+          - dhcp
   aliases:
     version_added: "2.6"
     description:
@@ -145,6 +175,31 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
+- name: create an ipv4 host record bypassing DNS
+  nios_host_record:
+    name: new_host
+    ipv4:
+      - address: 192.168.10.1
+    dns: false
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+- name: create an ipv4 host record over DHCP
+  nios_host_record:
+    name: host.ansible.com
+    ipv4:
+      - address: 192.168.10.1
+        dhcp: true
+        mac: 00-80-C8-E3-4C-BD
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
 '''
 
 RETURN = ''' # '''
@@ -174,11 +229,11 @@ def ipaddr(module, key, filtered_keys=None):
 
 
 def ipv4addrs(module):
-    return ipaddr(module, 'ipv4addrs', filtered_keys=['address'])
+    return ipaddr(module, 'ipv4addrs', filtered_keys=['address', 'dhcp'])
 
 
 def ipv6addrs(module):
-    return ipaddr(module, 'ipv6addrs', filtered_keys=['address'])
+    return ipaddr(module, 'ipv6addrs', filtered_keys=['address', 'dhcp'])
 
 
 def main():
@@ -186,11 +241,14 @@ def main():
     '''
     ipv4addr_spec = dict(
         ipv4addr=dict(required=True, aliases=['address'], ib_req=True),
-        mac=dict()
+        configure_for_dhcp=dict(type='bool', required=False, aliases=['dhcp'], ib_req=True),
+        mac=dict(required=False, aliases=['mac'], ib_req=True)
     )
 
     ipv6addr_spec = dict(
-        ipv6addr=dict(required=True, aliases=['address'], ib_req=True)
+        ipv6addr=dict(required=True, aliases=['address'], ib_req=True),
+        configure_for_dhcp=dict(type='bool', required=False, aliases=['configure_for_dhcp'], ib_req=True),
+        mac=dict(required=False, aliases=['mac'], ib_req=True)
     )
 
     ib_spec = dict(
@@ -199,6 +257,7 @@ def main():
 
         ipv4addrs=dict(type='list', aliases=['ipv4'], elements='dict', options=ipv4addr_spec, transform=ipv4addrs),
         ipv6addrs=dict(type='list', aliases=['ipv6'], elements='dict', options=ipv6addr_spec, transform=ipv6addrs),
+        configure_for_dns=dict(type='bool', required=False, aliases=['dns'], ib_req=True),
         aliases=dict(type='list'),
 
         ttl=dict(type='int'),

--- a/lib/ansible/modules/net_tools/nios/nios_host_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_host_record.py
@@ -40,9 +40,10 @@ options:
     aliases:
       - dns_view
   configure_for_dns:
-  description:
+    description:
       - Sets the DNS to particular parent. If user needs to bypass DNS
         user can make the value to false.
+    type: bool
     required: false
     default: true
     aliases:
@@ -53,8 +54,6 @@ options:
         accepts a list of values (see suboptions)
     aliases:
       - ipv4
-      - dhcp
-      - mac
     suboptions:
       ipv4addr:
         description:
@@ -67,7 +66,6 @@ options:
           - Configure the host_record over DHCP instead of DNS, if user
             changes it to true, user need to mention MAC address to configure
         required: false
-        default: null
         aliases:
           - dhcp
       mac:
@@ -75,14 +73,14 @@ options:
           - Configures the hardware MAC address for the host record. If user makes
             DHCP to true, user need to mention MAC address.
         required: false
-        default: null
+        aliases:
+          - mac
   ipv6addrs:
     description:
       - Configures the IPv6 addresses for the host record.  This argument
         accepts a list of values (see options)
     aliases:
       - ipv6
-      - dhcp
     suboptions:
       ipv6addr:
         description:
@@ -95,7 +93,6 @@ options:
           - Configure the host_record over DHCP instead of DNS, if user
             changes it to true, user need to mention MAC address to configure
         required: false
-        default: null
         aliases:
           - dhcp
   aliases:
@@ -257,7 +254,7 @@ def main():
 
         ipv4addrs=dict(type='list', aliases=['ipv4'], elements='dict', options=ipv4addr_spec, transform=ipv4addrs),
         ipv6addrs=dict(type='list', aliases=['ipv6'], elements='dict', options=ipv6addr_spec, transform=ipv6addrs),
-        configure_for_dns=dict(type='bool', required=False, aliases=['dns'], ib_req=True),
+        configure_for_dns=dict(type='bool', default=True, required=False, aliases=['dns'], ib_req=True),
         aliases=dict(type='list'),
 
         ttl=dict(type='int'),

--- a/lib/ansible/modules/net_tools/nios/nios_host_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_host_record.py
@@ -40,6 +40,7 @@ options:
     aliases:
       - dns_view
   configure_for_dns:
+    version_added: "2.7"
     description:
       - Sets the DNS to particular parent. If user needs to bypass DNS
         user can make the value to false.

--- a/test/integration/targets/nios_host_record/tasks/nios_host_record_idempotence.yml
+++ b/test/integration/targets/nios_host_record/tasks/nios_host_record_idempotence.yml
@@ -80,6 +80,16 @@
     provider: "{{ nios_provider }}"
   register: ipv4_create3
 
+- name: recreate an ipv4 host record bypassing DNS
+  nios_host_record:
+    name: host
+    ipv4:
+      - address: 192.168.10.1
+    dns: false
+    state: present
+    provider: "{{ nios_provider }}"
+  register: ipv4_create4
+
 - name: create an ipv4 host record via DHCP and MAC
   nios_host_record:
     name: host
@@ -89,7 +99,18 @@
         mac: 00-80-C8-E3-4C-BD
     state: present
     provider: "{{ nios_provider }}"
-  register: ipv4_create4
+  register: ipv4_create5
+
+- name: recreate an ipv4 host record via DHCP and MAC
+  nios_host_record:
+    name: host
+    ipv4:
+      - address: 192.168.10.1
+        dhcp: true
+        mac: 00-80-C8-E3-4C-BD
+    state: present
+    provider: "{{ nios_provider }}"
+  register: ipv4_create6
 
 - assert:
     that:
@@ -100,4 +121,6 @@
       - "ipv4_delete1.changed"
       - "not ipv4_delete2.changed"
       - "ipv4_create3.changed"
-      - "ipv4_create4.changed"
+      - "not ipv4_create4.changed"
+      - "ipv4_create5.changed"
+      - "not ipv4_create6.changed"

--- a/test/integration/targets/nios_host_record/tasks/nios_host_record_idempotence.yml
+++ b/test/integration/targets/nios_host_record/tasks/nios_host_record_idempotence.yml
@@ -75,6 +75,27 @@
     provider: "{{ nios_provider }}"
   register: ipv4_delete2
 
+- name: create an ipv4 host record bypassing DNS
+  nios_host_record:
+    name: host
+    ipv4:
+      - address: 192.168.10.1
+    dns: false
+    state: present
+    provider: "{{ nios_provider }}"
+  register: ipv4_create3
+
+- name: create an ipv4 host record via DHCP and MAC
+  nios_host_record:
+    name: host
+    ipv4:
+      - address: 192.168.10.1
+        dhcp: true
+        mac: 00-80-C8-E3-4C-BD
+    state: present
+    provider: "{{ nios_provider }}"
+  register: ipv4_create4
+
 - assert:
     that:
       - "ipv4_create1.changed"
@@ -83,3 +104,5 @@
       - "not ipv4_update2.changed"
       - "ipv4_delete1.changed"
       - "not ipv4_delete2.changed"
+      - "ipv4_create3.changed"
+      - "ipv4_create4.changed"

--- a/test/integration/targets/nios_host_record/tasks/nios_host_record_idempotence.yml
+++ b/test/integration/targets/nios_host_record/tasks/nios_host_record_idempotence.yml
@@ -36,11 +36,6 @@
     provider: "{{ nios_provider }}"
   register: ipv4_create2
 
-- assert:
-    that:
-      - "ipv4_create1.changed"
-      - "not ipv4_create2.changed"
-
 - name: add a comment to an existing host record
   nios_host_record:
     name: host.ansible.com


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR fixes the behavior raised in #42420. Now, the user can create new host record bypassing DNS and will also be able to delete existing host_record made via bypassing DNS. Also, now user can use the feature of DHCP while creating the new host record.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description, but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nios
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
I have included DHCP support also in this PR, which will help the user to create host_record under DHCP which earlier was not supported and was by default set to False. If the user chooses to create host_record under DHCP, a user will have have to mention the MAC address.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
