### PR TITLE
Backport #42939 for 2.6 - Do not create group with empty name when region (optional argument) is not given in the openstack connection

### DIFF
--- a/changelogs/fragments/42042-inventory_with_no_region.yaml
+++ b/changelogs/fragments/42042-inventory_with_no_region.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- plugins/inventory/openstack.py - Do not create group with empty name if region is not set

--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -254,7 +254,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         groups.append(cloud)
 
         # Create a group on region
-        groups.append(region)
+        if region:
+            groups.append(region)
 
         # And one by cloud_region
         groups.append("%s_%s" % (cloud, region))


### PR DESCRIPTION
##### SUMMARY
Backport of #42939 for Ansible 2.6

Do not create group with empty name when region (optional argument) is
not given in the openstack connection

region is an optional connection parameter in Openstack. Currently group with the region name is created automatically, what results in creation of a group with empty name. According to issue #42042 this creates problems. So before creating a group with a region name - check if region is present.

##### ISSUE TYPE
 - Bugfix Pull Request
 

##### COMPONENT NAME
plugins/inventory/openstack.py
