### PR TITLE
JM: allow choco to install 32 bit version

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -194,7 +194,7 @@ Function Choco-Upgrade
         [string] $proxy_url,
         [string] $proxy_username,
         [string] $proxy_password,
-        [bool] $x86
+        [bool] $x86,
     )
 
     if (-not (Choco-IsInstalled $package))
@@ -335,7 +335,7 @@ Function Choco-Install
         [string] $proxy_url,
         [string] $proxy_username,
         [string] $proxy_password,
-        [bool] $x86
+        [bool] $x86,
     )
 
     if (Choco-IsInstalled $package)

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -194,7 +194,7 @@ Function Choco-Upgrade
         [string] $proxy_url,
         [string] $proxy_username,
         [string] $proxy_password,
-        [bool] $x86,
+        [bool] $x86
     )
 
     if (-not (Choco-IsInstalled $package))
@@ -335,7 +335,7 @@ Function Choco-Install
         [string] $proxy_url,
         [string] $proxy_username,
         [string] $proxy_password,
-        [bool] $x86,
+        [bool] $x86
     )
 
     if (Choco-IsInstalled $package)

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -33,7 +33,7 @@ $skipscripts = Get-AnsibleParam -obj $params -name "skip_scripts" -type "bool" -
 $proxy_url = Get-AnsibleParam -obj $params -name "proxy_url" -type "str"
 $proxy_username = Get-AnsibleParam -obj $params -name "proxy_username" -type "str"
 $proxy_password = Get-AnsibleParam -obj $params -name "proxy_password" -type "str" -failifempty ($proxy_username -ne $null)
-$x86 = Get-AnsibleParam -obj $params -name "x86"  -type "bool" -default $false
+$architecture = Get-AnsibleParam -obj $params -name "architecture"  -type "str" -default "default" -validateset "default","x86"
 
 $result = @{
     changed = $false 
@@ -194,7 +194,7 @@ Function Choco-Upgrade
         [string] $proxy_url,
         [string] $proxy_username,
         [string] $proxy_password,
-        [bool] $x86
+        [string] $architecture
     )
 
     if (-not (Choco-IsInstalled $package))
@@ -204,9 +204,8 @@ Function Choco-Upgrade
 
     $options = @( "-y", $package, "--timeout", "$timeout", "--failonunfound" )
 
-    if ($x86)
-    {
-        $options += "--x86"
+    switch ($architecture) {
+      "x86" { $options += "--x86" ; break}
     }
 
     if ($check_mode)
@@ -313,6 +312,7 @@ Function Choco-Upgrade
     $result.failed = $false
 }
 
+
 Function Choco-Install
 {
     [CmdletBinding()]
@@ -335,7 +335,7 @@ Function Choco-Install
         [string] $proxy_url,
         [string] $proxy_username,
         [string] $proxy_password,
-        [bool] $x86
+        [string] $architecture
     )
 
     if (Choco-IsInstalled $package)
@@ -348,7 +348,7 @@ Function Choco-Install
                 -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
                 -allowdowngrade $allowdowngrade -proxy_url $proxy_url `
                 -proxy_username $proxy_username -proxy_password $proxy_password `
-                -allowprerelease $allowprerelease -x86 $x86
+                -allowprerelease $allowprerelease -architecture $architecture
             return
         }
         elseif (-not $force)
@@ -359,9 +359,8 @@ Function Choco-Install
 
     $options = @( "-y", $package, "--timeout", "$timeout", "--failonunfound" )
 
-    if ($x86)
-    {
-        $options += "--x86"
+    switch ($architecture) {
+      "x86" { $options += "--x86" ; break}
     }
 
     if ($check_mode)
@@ -542,7 +541,7 @@ if ($state -in ("downgrade", "latest", "present", "reinstalled")) {
         -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
         -allowdowngrade ($state -eq "downgrade") -proxy_url $proxy_url `
         -proxy_username $proxy_username -proxy_password $proxy_password `
-        -allowprerelease $allowprerelease -x86 $x86
+        -allowprerelease $allowprerelease -architecture $architecture
 }
 
 Exit-Json -obj $result

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -33,6 +33,7 @@ $skipscripts = Get-AnsibleParam -obj $params -name "skip_scripts" -type "bool" -
 $proxy_url = Get-AnsibleParam -obj $params -name "proxy_url" -type "str"
 $proxy_username = Get-AnsibleParam -obj $params -name "proxy_username" -type "str"
 $proxy_password = Get-AnsibleParam -obj $params -name "proxy_password" -type "str" -failifempty ($proxy_username -ne $null)
+$x86 = Get-AnsibleParam -obj $params -name "x86"  -type "bool" -default $false
 
 $result = @{
     changed = $false 
@@ -192,7 +193,8 @@ Function Choco-Upgrade
         [bool] $allowprerelease,
         [string] $proxy_url,
         [string] $proxy_username,
-        [string] $proxy_password
+        [string] $proxy_password,
+        [bool] $x86
     )
 
     if (-not (Choco-IsInstalled $package))
@@ -201,6 +203,11 @@ Function Choco-Upgrade
     }
 
     $options = @( "-y", $package, "--timeout", "$timeout", "--failonunfound" )
+
+    if ($x86)
+    {
+        $options += "--x86"
+    }
 
     if ($check_mode)
     {
@@ -327,7 +334,8 @@ Function Choco-Install
         [bool] $allowprerelease,
         [string] $proxy_url,
         [string] $proxy_username,
-        [string] $proxy_password
+        [string] $proxy_password,
+        [bool] $x86
     )
 
     if (Choco-IsInstalled $package)
@@ -340,7 +348,7 @@ Function Choco-Install
                 -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
                 -allowdowngrade $allowdowngrade -proxy_url $proxy_url `
                 -proxy_username $proxy_username -proxy_password $proxy_password `
-                -allowprerelease $allowprerelease
+                -allowprerelease $allowprerelease -x86 $x86
             return
         }
         elseif (-not $force)
@@ -350,6 +358,11 @@ Function Choco-Install
     }
 
     $options = @( "-y", $package, "--timeout", "$timeout", "--failonunfound" )
+
+    if ($x86)
+    {
+        $options += "--x86"
+    }
 
     if ($check_mode)
     {
@@ -529,7 +542,7 @@ if ($state -in ("downgrade", "latest", "present", "reinstalled")) {
         -ignorechecksums $ignorechecksums -ignoredependencies $ignoredependencies `
         -allowdowngrade ($state -eq "downgrade") -proxy_url $proxy_url `
         -proxy_username $proxy_username -proxy_password $proxy_password `
-        -allowprerelease $allowprerelease
+        -allowprerelease $allowprerelease -x86 $x86
 }
 
 Exit-Json -obj $result

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -166,7 +166,7 @@ EXAMPLES = r'''
 - name: Install notepadplusplus 32 bit version
   win_chocolatey:
     name: notepadplusplus
-    x86: yes
+    architecture: 'x86'
 
 - name: Install git from specified repository
   win_chocolatey:

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -51,12 +51,15 @@ options:
   source:
     description:
       - Specify source rather than using default chocolatey repository.
-  x86:
+  architecture:
     description:
-      - Install 32 bit version.
+      - Allows installation of alternative architecture packages, for example,
+        32bit on 64bit windows.
     version_added: '2.7'
-    type: bool
-    default: 'no'
+    choices:
+      - default
+      - x86
+    default: default
   install_args:
     description:
       - Arguments to pass to the native installer.

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -53,7 +53,7 @@ options:
       - Specify source rather than using default chocolatey repository.
   x86:
     description:
-      - Install 32 bit version
+      - Install 32 bit version.
     version_added: '2.7'
     type: bool
     default: 'no'

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -51,6 +51,12 @@ options:
   source:
     description:
       - Specify source rather than using default chocolatey repository.
+  x86:
+    description:
+      - Install 32 bit version
+    version_added: '2.7'
+    type: bool
+    default: 'no'
   install_args:
     description:
       - Arguments to pass to the native installer.
@@ -153,6 +159,11 @@ EXAMPLES = r'''
   win_chocolatey:
     name: notepadplusplus
     version: '6.6'
+
+- name: Install notepadplusplus 32 bit version
+  win_chocolatey:
+    name: notepadplusplus
+    x86: yes
 
 - name: Install git from specified repository
   win_chocolatey:


### PR DESCRIPTION
##### SUMMARY
This allows you to pass x86:true to win_chocolatey in order to install the 32 bit package instead of 64bit.
It defaults to false (ie 64bit) if not declared/passed.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_chocolatey

##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.7.0.dev0 (install_32bit bfcc6f74fa) last updated 2018/07/18 13:10:06 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/jezm/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/share/sandbox/ansible-source/lib/ansible
  executable location = /home/share/sandbox/ansible-source/bin/ansible
  python version = 3.6.6 (default, Jun 27 2018, 13:11:40) [GCC 8.1.1 20180531]

```


##### ADDITIONAL INFORMATION

This replaces the PR https://github.com/ansible/ansible/pull/40703
I had, in that request had an 'extra-args' flag. Due to the possibility of misuse this is specific to just the 32bit (x86) flag.


```
Without flag (and pre-patch):
Command line: \"C:\\ProgramData\\chocolatey\\choco.exe\" install -dv --no-pro
gress -y notepadplusplus.install --timeout 2700 --failonunfound

With flag set to yes/true:
Command line: \"C:\\ProgramData\\chocolatey\\choco.exe\" install -dv --no-pro
gress -y notepadplusplus.install --timeout 2700 --failonunfound --x86

```
