### PR TITLE
NetApp: return lun info for na_ontap_lun_map module

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_lun_map.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_lun_map.py
@@ -96,8 +96,8 @@ lun_serial:
     returned: success
     type: string
     sample: 80E7/]LZp1Tt
-lun_naa_id: The Network Address Authority (NAA) identifier for the LUN.
-    description:
+lun_naa_id: 
+    description: The Network Address Authority (NAA) identifier for the LUN.
     returned: success
     type: string
     sample: 600a0980383045372f5d4c5a70315474
@@ -132,8 +132,8 @@ class NetAppOntapLUNMap(object):
             initiator_group_name=dict(required=True, type='str'),
             path=dict(type='str'),
             vserver=dict(required=True, type='str'),
-            lun_id=dict(required=False, type='str', default=None)),
-        )
+            lun_id=dict(required=False, type='str', default=None),
+        ))
 
         self.module = AnsibleModule(
             argument_spec=self.argument_spec,
@@ -142,7 +142,7 @@ class NetAppOntapLUNMap(object):
             ],
             supports_check_mode=True
         )
-      
+
         self.result = dict(
             changed=False,
         )
@@ -233,7 +233,7 @@ class NetAppOntapLUNMap(object):
             self.server.invoke_successfully(lun_map_create, enable_tunneling=True)
         except netapp_utils.zapi.NaApiError as e:
             self.module.fail_json(msg="Error mapping lun %s of initiator_group_name %s: %s" %
-                                      (self.path, self.initiator_group_name, to_native(e)),
+                                  (self.path, self.initiator_group_name, to_native(e)),
                                   exception=traceback.format_exc())
 
     def delete_lun_map(self):
@@ -246,7 +246,7 @@ class NetAppOntapLUNMap(object):
             self.server.invoke_successfully(lun_map_delete, enable_tunneling=True)
         except netapp_utils.zapi.NaApiError as e:
             self.module.fail_json(msg="Error unmapping lun %s of initiator_group_name %s: %s" %
-                                      (self.path, self.initiator_group_name, to_native(e)),
+                                  (self.path, self.initiator_group_name, to_native(e)),
                                   exception=traceback.format_exc())
 
     def apply(self):

--- a/lib/ansible/modules/storage/netapp/na_ontap_lun_map.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_lun_map.py
@@ -80,7 +80,7 @@ EXAMPLES = """
     password: "{{ netapp_password }}"
 """
 
-RETURN = r"""
+RETURN = """
 lun_node:
     description: NetApp controller that is hosting the LUN.
     returned: success

--- a/lib/ansible/modules/storage/netapp/na_ontap_lun_map.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_lun_map.py
@@ -96,7 +96,7 @@ lun_serial:
     returned: success
     type: string
     sample: 80E7/]LZp1Tt
-lun_naa_id: 
+lun_naa_id:
     description: The Network Address Authority (NAA) identifier for the LUN.
     returned: success
     type: string

--- a/lib/ansible/modules/storage/netapp/na_ontap_lun_map.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_lun_map.py
@@ -142,6 +142,10 @@ class NetAppOntapLUNMap(object):
             ],
             supports_check_mode=True
         )
+      
+        self.result = dict(
+            changed=False,
+        )
 
         p = self.module.params
 
@@ -246,21 +250,23 @@ class NetAppOntapLUNMap(object):
                                   exception=traceback.format_exc())
 
     def apply(self):
-        changed = False
         netapp_utils.ems_log_event("na_ontap_lun_map", self.server)
         lun_details = self.get_lun()
         lun_map_details = self.get_lun_map()
 
+        if self.state == 'present' and lun_details:
+            self.result.update(lun_details)
+
         if self.state == 'present' and not lun_map_details:
-            changed = True
+            self.result['changed'] = True
             if not self.module.check_mode:
                 self.create_lun_map()
         elif self.state == 'absent' and lun_map_details:
-            changed = True
+            self.result['changed'] = True
             if not self.module.check_mode:
                 self.delete_lun_map()
 
-        self.module.exit_json(changed=changed, **lun_details)
+        self.module.exit_json(**self.result)
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added return values for the na_ontap_lun_map module. Module will now return useful information about the mapped LUN such as the NAA ID, size, OS type, and state. Also updates documentation.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
na_ontap_lun_map.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Output before:
```
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "hostname": "netapp01",
            "https": "True",
            "initiator_group_name": "esxi_hosts",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "path": "/vol/vol01/lun01",
            "state": "present",
            "username": "admin",
            "vserver": "netapp01_san"
        }
    },
}
```
Output after:
```
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "hostname": "netapp01",
            "https": "True",
            "initiator_group_name": "esxi_hosts",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "path": "/vol/vol01/lun01",
            "state": "present",
            "username": "admin",
            "vserver": "netapp01_san"
        }
    },
    "lun_naa_id": "600a0980383045372f5d4c5a70315474",
    "lun_node": "netapp01b",
    "lun_ostype": "vmware",
    "lun_serial": "80E7/]LZp1Tt",
    "lun_size": "2199023255552",
    "lun_state": "online"
}
```