### PR TITLE
Exorcise Python-2.6

### DIFF
--- a/changelogs/fragments/drop-python-2.6-controller.yaml
+++ b/changelogs/fragments/drop-python-2.6-controller.yaml
@@ -1,6 +1,6 @@
 ---
 major_changes:
-- Support for running an Ansible controller with Python 2.6 has been dropped.
+- Support for running an Ansible controller with Python-2.6 has been dropped.
   You can still manage machines which use Python-2.6 but you will have to
   manage them from a machine which has Python-2.7 or Python-3.5 or greater
   installed.

--- a/changelogs/fragments/drop-python-2.6-controller.yaml
+++ b/changelogs/fragments/drop-python-2.6-controller.yaml
@@ -3,4 +3,5 @@ major_changes:
 - Support for running an Ansible controller with Python-2.6 has been dropped.
   You can still manage machines which use Python-2.6 but you will have to
   manage them from a machine which has Python-2.7 or Python-3.5 or greater
-  installed.
+  installed.  See the `porting guide <https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.7.html>`_
+  if you need more information.

--- a/changelogs/fragments/drop-python-2.6-controller.yaml
+++ b/changelogs/fragments/drop-python-2.6-controller.yaml
@@ -1,0 +1,6 @@
+---
+major_changes:
+- Support for running an Ansible controller with Python 2.6 has been dropped.
+  You can still manage machines which use Python-2.6 but you will have to
+  manage them from a machine which has Python-2.7 or Python-3.5 or greater
+  installed.

--- a/docs/docsite/rst/dev_guide/developing_python_3.rst
+++ b/docs/docsite/rst/dev_guide/developing_python_3.rst
@@ -30,13 +30,15 @@ controller-side section.
 Minimum Version of Python-3.x and Python-2.x
 --------------------------------------------
 
-In both controller side and module code, we support Python-3.5 or greater and Python-2.6 or
-greater.  Python-3.5 was chosen as a minimum because it is the earliest Python-3 version
-adopted as the default Python by a Long Term Support (LTS) Linux distribution (in this case, Ubuntu-16.04).
-Previous LTS Linux distributions shipped with a Python-2 version which users can rely upon instead of the 
-Python-3 version.
+On the controller we support Python-3.5 or greater and Python-2.7 or greater.  Module-side, we
+support Python-3.5 or greater and Python-2.6 or greater.
 
-For Python-2, the default is for modules to run on at least Python-2.6.  This allows
+Python-3.5 was chosen as a minimum because it is the earliest Python-3 version adopted as the
+default Python by a Long Term Support (LTS) Linux distribution (in this case, Ubuntu-16.04).
+Previous LTS Linux distributions shipped with a Python-2 version which users can rely upon instead
+of the Python-3 version.
+
+For Python 2, the default is for modules to run on at least Python-2.6.  This allows
 users with older distributions that are stuck on Python-2.6 to manage their
 machines.  Modules are allowed to drop support for Python-2.6 when one of
 their dependent libraries requires a higher version of Python.  This is not an

--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -531,7 +531,7 @@ A helpful development approach to this should be to ensure that all of the tests
 run under Python 2.6 and that each assertion in the test cases has been checked to work by breaking
 the code in Ansible to trigger that failure.
 
-.. warn:: Maintain Python-2.6 compatibility
+.. warning:: Maintain Python-2.6 compatibility
 
     Please remember that modules need to maintain compatibility with Python-2.6 so the unittests for
     modules should also be compatible with Python-2.6.

--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -531,6 +531,12 @@ A helpful development approach to this should be to ensure that all of the tests
 run under Python 2.6 and that each assertion in the test cases has been checked to work by breaking
 the code in Ansible to trigger that failure.
 
+.. warn:: Maintain Python-2.6 compatibility
+
+    Please remember that modules need to maintain compatibility with Python-2.6 so the unittests for
+    modules should also be compatible with Python-2.6.
+
+
 .. seealso::
 
    :doc:`testing_units`

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -41,7 +41,7 @@ information about running from source.  It's not necessary to install the progra
 Control Machine Requirements
 ````````````````````````````
 
-Currently Ansible can be run from any machine with Python 2 (versions 2.6 or 2.7) or Python 3 (versions 3.5 and higher) installed (Windows isn't supported for the control machine).
+Currently Ansible can be run from any machine with Python 2 (version 2.7) or Python 3 (versions 3.5 and higher) installed (Windows isn't supported for the control machine).
 
 This includes Red Hat, Debian, CentOS, macOS, any of the BSDs, and so on.
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -41,7 +41,7 @@ information about running from source.  It's not necessary to install the progra
 Control Machine Requirements
 ````````````````````````````
 
-Currently Ansible can be run from any machine with Python 2 (version 2.7) or Python 3 (versions 3.5 and higher) installed (Windows isn't supported for the control machine).
+Currently Ansible can be run from any machine with Python 2 (version 2.7) or Python 3 (versions 3.5 and higher) installed. Windows isn't supported for the control machine.
 
 This includes Red Hat, Debian, CentOS, macOS, any of the BSDs, and so on.
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -14,6 +14,14 @@ This document is part of a collection on porting. The complete list of porting g
 
 .. contents:: Topics
 
+Python Compatibility
+====================
+
+Ansible has dropped compatibility with Python-2.6 on the controller (The host where :command:`/usr/bin/ansible`
+or :command:`/usr/bin/ansible-playbook` is run).  Modules shipped with Ansible can still be used to
+manage hosts which only have Python-2.6.  You just need to have a host with Python-2.7 or Python-3.5
+or greater to manage those hosts from.
+
 Playbook
 ========
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -22,6 +22,20 @@ or :command:`/usr/bin/ansible-playbook` is run).  Modules shipped with Ansible c
 manage hosts which only have Python-2.6.  You just need to have a host with Python-2.7 or Python-3.5
 or greater to manage those hosts from.
 
+One thing that this does affect is the ability to use :command:`/usr/bin/ansible-pull` to manage
+a host which has Python-2.6.  ``ansible-pull`` runs on the host being managed but it is a controller
+script, not a module so it will need an updated Python.  Actively developed Linux distros which ship
+with Python-2.6 have some means to install newer Python versions (For instance, you can install
+Python-2.7 via an SCL on RHEL-6) but you may need to also install Python bindings for many common
+modules to work (For RHEL-6, for instance, selinux bindings and yum would have to be installed for
+the updated Python install).
+
+The decision to drop Python-2.6 support on the controller was made because many dependent libraries
+are becoming unavailable there.  In particular, python-cryptography is no longer available for Python-2.6
+and the last release of pycrypto (the alternative to python-cryptography) has known security bugs
+which will never be fixed.
+
+
 Playbook
 ========
 

--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -685,8 +685,8 @@ would an IPv4 address or hostname::
 
 
 .. Note:: The ipaddress library is only included by default in Python 3.x. To
-    use IPv6 addresses in Python 2.6 and 2.7, make sure to run
-    ``pip install ipaddress`` which installs a backported package.
+    use IPv6 addresses in Python 2.7, make sure to run ``pip install ipaddress`` which installs
+    a backported package.
 
 HTTPS Certificate Validation
 ````````````````````````````


### PR DESCRIPTION
##### SUMMARY
Python-2.6 support on the controller is being dropped for Ansible-2.7.  Update docs and add a changelog and porting guide entry for this.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7.0
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
