### PR TITLE
Fix support for SubnetMappings and EIPs in NLB

### DIFF
--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -152,27 +152,31 @@ class ElasticLoadBalancerV2(object):
         :return: bool True if they match otherwise False
         """
 
-        subnet_id_list = []
-        subnets = []
+        subnet_mapping_id_list = []
+        subnet_mappings = []
 
         # Check if we're dealing with subnets or subnet_mappings
         if self.subnets is not None:
-            # We need to first get the subnet ID from the list
-            subnets = self.subnets
+            # Convert subnets to subnet_mappings format for comparison
+            for subnet in self.subnets:
+                subnet_mappings.append({ 'SubnetId': subnet })
 
         if self.subnet_mappings is not None:
-            # Make a list from the subnet_mappings dict
-            subnets_from_mappings = []
-            for subnet_mapping in self.subnet_mappings:
-                subnets.append(subnet_mapping['SubnetId'])
+            # Use this directly since we're comparing as a mapping
+            subnet_mappings = self.subnet_mappings
 
+        # Build a subnet_mapping style struture of what's currently
+        # on the load balancer
         for subnet in self.elb['AvailabilityZones']:
-            subnet_id_list.append(subnet['SubnetId'])
+            this_mapping = { 'SubnetId': subnet['SubnetId'] }
+            for address in subnet['LoadBalancerAddresses']:
+                if 'AllocationId' in address:
+                    this_mapping['AllocationId'] = address['AllocationId']
+                    break
 
-        if set(subnet_id_list) != set(subnets):
-            return False
-        else:
-            return True
+            subnet_mapping_id_list.append(this_mapping)
+
+        return set(frozenset(mapping.items()) for mapping in subnet_mapping_id_list) == set(frozenset(mapping.items()) for mapping in subnet_mappings)
 
     def modify_subnets(self):
         """
@@ -359,6 +363,8 @@ class NetworkLoadBalancer(ElasticLoadBalancerV2):
         # Other parameters
         if self.subnets is not None:
             params['Subnets'] = self.subnets
+        if self.subnet_mappings is not None:
+            params['SubnetMappings'] = self.subnet_mappings
         params['Scheme'] = self.scheme
         if self.tags:
             params['Tags'] = self.tags
@@ -399,6 +405,15 @@ class NetworkLoadBalancer(ElasticLoadBalancerV2):
                 if self.new_load_balancer:
                     AWSRetry.jittered_backoff()(self.connection.delete_load_balancer)(LoadBalancerArn=self.elb['LoadBalancerArn'])
                 self.module.fail_json_aws(e)
+
+    def modify_subnets(self):
+        """
+        Modify elb subnets to match module parameters (unsupported for NLB)
+        :return:
+        """
+
+        self.module.fail_json(msg='Modifying subnets and elastic IPs is not supported for Network Load Balancer')
+
 
 
 class ELBListeners(object):

--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -159,7 +159,7 @@ class ElasticLoadBalancerV2(object):
         if self.subnets is not None:
             # Convert subnets to subnet_mappings format for comparison
             for subnet in self.subnets:
-                subnet_mappings.append({ 'SubnetId': subnet })
+                subnet_mappings.append({'SubnetId': subnet})
 
         if self.subnet_mappings is not None:
             # Use this directly since we're comparing as a mapping
@@ -168,7 +168,7 @@ class ElasticLoadBalancerV2(object):
         # Build a subnet_mapping style struture of what's currently
         # on the load balancer
         for subnet in self.elb['AvailabilityZones']:
-            this_mapping = { 'SubnetId': subnet['SubnetId'] }
+            this_mapping = {'SubnetId': subnet['SubnetId']}
             for address in subnet['LoadBalancerAddresses']:
                 if 'AllocationId' in address:
                     this_mapping['AllocationId'] = address['AllocationId']
@@ -413,7 +413,6 @@ class NetworkLoadBalancer(ElasticLoadBalancerV2):
         """
 
         self.module.fail_json(msg='Modifying subnets and elastic IPs is not supported for Network Load Balancer')
-
 
 
 class ELBListeners(object):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #42977

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
`lib/ansible/module_utils/aws/elbv2.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
See #42977

New and existing NLBs work after this change when using subnet mappings, with or without EIPs attached.

I also improved the error handling for an existing NLB that doesn't match the requests subnets (that operation is not supported, sending it to boto anyway doesn't give the best error message).

Note that the change in #42060 does not address comparison of EIPs, so while it may work on initial creation with EIPs, it will fail to detect that requested EIPs on existing NLBs are different from the current state.