### PR TITLE
fixed network['vlan'] str / int mismatch

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1109,7 +1109,7 @@ class PyVmomiHelper(PyVmomi):
                 for dvp in dvps:
                     if hasattr(dvp.config.defaultPortConfig, 'vlan') and \
                             isinstance(dvp.config.defaultPortConfig.vlan.vlanId, int) and \
-                            str(dvp.config.defaultPortConfig.vlan.vlanId) == network['vlan']:
+                            str(dvp.config.defaultPortConfig.vlan.vlanId) == str(network['vlan']):
                         network['name'] = dvp.config.name
                         break
                     if 'dvswitch_name' in network and \


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/38398#issuecomment-405893130 & https://github.com/ansible/ansible/pull/40131#issuecomment-406081884

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (fix_40131 2156a24a6c) last updated 2018/07/18 18:58:50 (GMT -400)
  config file = /Users/deric/.ansible.cfg
  configured module search path = [u'/Users/deric/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/deric/ansible/lib/ansible
  executable location = /Users/deric/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:54:19) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION
I'm not exactly sure what's happening with the passed in `vlan` var in terms of `|int` making it a string. Here's some troubleshooting output that lead to this patch.

```yaml
# vars.yaml
network: 1024

# playbook.yaml
networks:
  - vlan: "{{ network }}"
```

```python
# result
sanitize_network_params: type(network['vlan'])=<type 'int'>
```

```yaml
# vars.yaml
network: '1024'

# playbook.yaml
networks:
  - vlan: "{{ network }}"
```

```python
# result
sanitize_network_params: type(network['vlan'])=<type 'str'>
```

```yaml
# vars.yaml
network: 1024

# playbook.yaml
networks:
  - vlan: "{{ network|int }}"
```

```python
# result
sanitize_network_params: type(network['vlan'])=<type 'str'>
```

```yaml
# vars.yaml
network: '1024'

# playbook.yaml
networks:
  - vlan: "{{ network|int }}"
```

```python
# result
sanitize_network_params: type(network['vlan'])=<type 'str'>
```

```yaml
# vars.yaml
network: VLAN1024

# playbook.yaml
networks:
  - vlan: "{{ network }}"
```

```python
# result
sanitize_network_params: type(network['vlan'])=<type 'str'>
```