### PR TITLE
SLXOS Cliconf - Missing close "

### DIFF
--- a/lib/ansible/plugins/cliconf/slxos.py
+++ b/lib/ansible/plugins/cliconf/slxos.py
@@ -49,7 +49,7 @@ class Cliconf(CliconfBase):
         if match:
             device_info['network_os_model'] = match.group(2)
 
-        reply = self.get(b'show running-config | inc "switch-attributes host-name')
+        reply = self.get(b'show running-config | inc "switch-attributes host-name"')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
         match = re.search(r'switch-attributes host-name (\S+)', data, re.M)


### PR DESCRIPTION
##### SUMMARY

The slxos Cliconf module (used by `slxos_*` modules) was missing a close `"`. This was still interpreted properly by the switch, and was not breaking anything, but it should be cleaned up.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/cliconf/slxos.py

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (nos_command 2c4ba7a9e9) last updated 2018/07/18 16:26:28 (GMT -700)
  config file = /home/extreme/.ansible.cfg
  configured module search path = [u'/home/extreme/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/extreme/ansible/lib/ansible
  executable location = /home/extreme/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

Note that this works correctly on the switch without the closing `"`:
```
SLX# show running-config | include "switch-attributes host-name
switch-attributes host-name SLX
SLX#
```

The switch automatically interprets it as `show running-config | include switch-attributes\ host-name`.

This is cleaner using the closing `"`:
```
SLX# show running-config | include "switch-attributes host-name"
switch-attributes host-name SLX
SLX#
```