### PR TITLE
infoblox list requirements as infoblox_client and should be infoblox-client 

### DIFF
--- a/lib/ansible/modules/net_tools/nios/nios_a_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_a_record.py
@@ -21,7 +21,7 @@ description:
     Infoblox NIOS servers.  This module manages NIOS C(record:a) objects
     using the Infoblox WAPI interface over REST.
 requirements:
-  - infoblox_client
+  - infoblox-client
 extends_documentation_fragment: nios
 options:
   name:

--- a/lib/ansible/modules/net_tools/nios/nios_aaaa_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_aaaa_record.py
@@ -21,7 +21,7 @@ description:
     Infoblox NIOS servers.  This module manages NIOS C(record:aaaa) objects
     using the Infoblox WAPI interface over REST.
 requirements:
-  - infoblox_client
+  - infoblox-client
 extends_documentation_fragment: nios
 options:
   name:

--- a/lib/ansible/modules/net_tools/nios/nios_cname_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_cname_record.py
@@ -21,7 +21,7 @@ description:
     Infoblox NIOS servers.  This module manages NIOS C(record:cname) objects
     using the Infoblox WAPI interface over REST.
 requirements:
-  - infoblox_client
+  - infoblox-client
 extends_documentation_fragment: nios
 options:
   name:

--- a/lib/ansible/modules/net_tools/nios/nios_dns_view.py
+++ b/lib/ansible/modules/net_tools/nios/nios_dns_view.py
@@ -22,7 +22,7 @@ description:
     using the Infoblox WAPI interface over REST.
   - Updates instances of DNS view object from Infoblox NIOS servers.
 requirements:
-  - infoblox_client
+  - infoblox-client
 extends_documentation_fragment: nios
 options:
   name:

--- a/lib/ansible/modules/net_tools/nios/nios_host_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_host_record.py
@@ -22,7 +22,7 @@ description:
     using the Infoblox WAPI interface over REST.
   - Updates instances of host record object from Infoblox NIOS servers.
 requirements:
-  - infoblox_client
+  - infoblox-client
 extends_documentation_fragment: nios
 options:
   name:

--- a/lib/ansible/modules/net_tools/nios/nios_mx_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_mx_record.py
@@ -21,7 +21,7 @@ description:
     Infoblox NIOS servers.  This module manages NIOS C(record:mx) objects
     using the Infoblox WAPI interface over REST.
 requirements:
-  - infoblox_client
+  - infoblox-client
 extends_documentation_fragment: nios
 options:
   name:

--- a/lib/ansible/modules/net_tools/nios/nios_network.py
+++ b/lib/ansible/modules/net_tools/nios/nios_network.py
@@ -22,7 +22,7 @@ description:
     using the Infoblox WAPI interface over REST.
   - Supports both IPV4 and IPV6 internet protocols
 requirements:
-  - infoblox_client
+  - infoblox-client
 extends_documentation_fragment: nios
 options:
   network:

--- a/lib/ansible/modules/net_tools/nios/nios_network_view.py
+++ b/lib/ansible/modules/net_tools/nios/nios_network_view.py
@@ -22,7 +22,7 @@ description:
     using the Infoblox WAPI interface over REST.
   - Updates instances of network view object from Infoblox NIOS servers.
 requirements:
-  - infoblox_client
+  - infoblox-client
 extends_documentation_fragment: nios
 options:
   name:

--- a/lib/ansible/modules/net_tools/nios/nios_srv_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_srv_record.py
@@ -21,7 +21,7 @@ description:
     Infoblox NIOS servers.  This module manages NIOS C(record:srv) objects
     using the Infoblox WAPI interface over REST.
 requirements:
-  - infoblox_client
+  - infoblox-client
 extends_documentation_fragment: nios
 options:
   name:

--- a/lib/ansible/modules/net_tools/nios/nios_zone.py
+++ b/lib/ansible/modules/net_tools/nios/nios_zone.py
@@ -21,7 +21,7 @@ description:
     Infoblox NIOS servers.  This module manages NIOS C(zone_auth) objects
     using the Infoblox WAPI interface over REST.
 requirements:
-  - infoblox_client
+  - infoblox-client
 extends_documentation_fragment: nios
 options:
   fqdn:

--- a/lib/ansible/plugins/lookup/nios.py
+++ b/lib/ansible/plugins/lookup/nios.py
@@ -30,7 +30,7 @@ description:
     supports adding additional keywords to filter the return data and specify
     the desired set of returned fields.
 requirements:
-  - infoblox_client
+  - infoblox-client
 extends_documentation_fragment: nios
 options:
     _terms:

--- a/lib/ansible/plugins/lookup/nios_next_ip.py
+++ b/lib/ansible/plugins/lookup/nios_next_ip.py
@@ -29,7 +29,7 @@ description:
   - Uses the Infoblox WAPI API to return the next available IP addresses
     for a given network CIDR
 requirements:
-  - infoblox_client
+  - infoblox-client
 extends_documentation_fragment: nios
 options:
     _terms:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
To fix the doc issue raised in #42014, hence changed the name of `infoblox_client` to `infoblox-client` which is the actual name of the WAPI Infoblox client. 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nios
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
