### PR TITLE
ios_linkagg: Avoid exiting config mode before configuring port-channel members

### DIFF
--- a/lib/ansible/modules/network/ios/ios_linkagg.py
+++ b/lib/ansible/modules/network/ios/ios_linkagg.py
@@ -130,7 +130,7 @@ def map_obj_to_commands(updates, module):
 
         elif state == 'present':
             cmd = ['interface port-channel {0}'.format(group),
-                   'end']
+                   'exit']
             if not obj_in_have:
                 if not group:
                     module.fail_json(msg='group is a required option')


### PR DESCRIPTION
##### SUMMARY
Fixes #41769

This fix is only required in 2.5.
From 2.6 onwards it is not needed as iOS cliconf will filter 'end' command
https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/cliconf/ios.py#L158

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_linkagg

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.3
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Test
```
ansible-test network-integration --inventory /tmp/inventory ios_linkagg  -vvv

<snip>
TASK [ios_linkagg : debug] *******************************************************************************************************
task path: /macos/ansible/test/integration/targets/ios_linkagg/tests/cli/basic.yaml:171
ok: [iosl201] => {
    "msg": "END cli/basic.yaml on connection=local"
}
META: ran handlers
META: ran handlers

PLAY RECAP ***********************************************************************************************************************
iosl201                    : ok=69   changed=19   unreachable=0    failed=0
<snip>

```
