### PR TITLE
Vultr: Introducing vr_startup_script_facts module

### DIFF
--- a/lib/ansible/modules/cloud/vultr/vr_startup_script_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vr_startup_script_facts.py
@@ -1,0 +1,125 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# (c) 2018, Yanis Guenane <yanis+ansible@guenane.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: vr_startup_script_facts
+short_description: Gather facts about the Vultr startup scripts available.
+description:
+  - Gather facts about vr_startup_scripts available.
+version_added: "2.7"
+author: "Yanis Guenane (@Spredzy)"
+extends_documentation_fragment: vultr
+'''
+
+EXAMPLES = r'''
+- name: Gather Vultr startup scripts facts
+  local_action:
+    module: vr_startup_script_facts
+
+- name: Print the gathered facts
+  debug:
+    var: ansible_facts.vultr_startup_script_facts
+'''
+
+RETURN = r'''
+---
+vultr_api:
+  description: Response from Vultr API with a few additions/modification
+  returned: success
+  type: complex
+  contains:
+    api_account:
+      description: Account used in the ini file to select the key
+      returned: success
+      type: string
+      sample: default
+    api_timeout:
+      description: Timeout used for the API requests
+      returned: success
+      type: int
+      sample: 60
+    api_retries:
+      description: Amount of max retries for the API requests
+      returned: success
+      type: int
+      sample: 5
+    api_endpoint:
+      description: Endpoint used for the API requests
+      returned: success
+      type: string
+      sample: "https://api.vultr.com"
+vultr_startup_script_facts:
+  description: Response from Vultr API
+  returned: success
+  type: complex
+  contains:
+    "vultr_startup_script_facts": [
+      {
+        "date_created": "2018-07-19 08:38:36",
+        "date_modified": "2018-07-19 08:38:36",
+        "id": 327133,
+        "name": "lolo",
+        "script": "#!/bin/bash\necho Hello World > /root/hello",
+        "type": "boot"
+      }
+    ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vultr import (
+    Vultr,
+    vultr_argument_spec,
+)
+
+
+class AnsibleVultrStartupScriptFacts(Vultr):
+
+    def __init__(self, module):
+        super(AnsibleVultrStartupScriptFacts, self).__init__(module, "vultr_startup_script_facts")
+
+        self.returns = {
+            "SCRIPTID": dict(key='id', convert_to='int'),
+            "date_created": dict(),
+            "date_modified": dict(),
+            "name": dict(),
+            "script": dict(),
+            "type": dict(),
+        }
+
+    def get_startupscripts(self):
+        return self.api_query(path="/v1/startupscript/list")
+
+
+def parse_startupscript_list(startupscipts_list):
+    return [startupscript for id, startupscript in startupscipts_list.items()]
+
+
+def main():
+    argument_spec = vultr_argument_spec()
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    startupscript_facts = AnsibleVultrStartupScriptFacts(module)
+    result = startupscript_facts.get_result(parse_startupscript_list(startupscript_facts.get_startupscripts()))
+    ansible_facts = {
+        'vultr_startup_script_facts': result['vultr_startup_script_facts']
+    }
+    module.exit_json(ansible_facts=ansible_facts, **result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/legacy/roles/vr_startup_script_facts/defaults/main.yml
+++ b/test/legacy/roles/vr_startup_script_facts/defaults/main.yml
@@ -1,0 +1,3 @@
+startup_script_name: myteststartupscript
+startup_script_type: boot
+startup_script_content: "#!/bin/bash\necho Hello World > /root/hello"

--- a/test/legacy/roles/vr_startup_script_facts/tasks/main.yml
+++ b/test/legacy/roles/vr_startup_script_facts/tasks/main.yml
@@ -1,0 +1,30 @@
+# Copyright (c) 2018, Yanis Guenane <yanis+ansible@guenane.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Create the script
+  vr_startup_script:
+    name: '{{ startup_script_name }}'
+    script_type: '{{ startup_script_type }}'
+    script: '{{ startup_script_content }}'
+
+- name: test gather vultr startup script facts in check mode
+  vr_startup_script_facts:
+  check_mode: yes
+
+- name: verify test gather vultr startup script facts in check mode
+  assert:
+    that:
+    - ansible_facts.vultr_startup_script_facts|selectattr('name','equalto','{{ startup_script_name }}') | list | count == 1
+
+- name: test gather vultr startup script facts
+  vr_startup_script_facts:
+
+- name: verify test gather vultr startup script facts
+  assert:
+    that:
+    - ansible_facts.vultr_startup_script_facts|selectattr('name','equalto','{{ startup_script_name }}') | list | count == 1
+
+- name: Delete the script
+  vr_startup_script:
+    name: '{{ startup_script_name }}'
+    state: absent

--- a/test/legacy/vultr.yml
+++ b/test/legacy/vultr.yml
@@ -18,5 +18,6 @@
     - { role: vr_ssh_key, tags: test_vr_ssh_key }
     - { role: vr_ssh_key_facts, tags: test_vr_ssh_key_facts }
     - { role: vr_startup_script, tags: test_vr_startup_script }
+    - { role: vr_startup_script_facts, tags: test_vr_startup_script_facts }
     - { role: vr_user, tags: test_vr_user }
     - { role: vr_user_facts, tags: test_vr_user_facts }


### PR DESCRIPTION
##### SUMMARY

This commit introduces a new module called vr_startup_script_facts.

This module aims to return the list of startup scripts avaiable
avaiable in Vultr.

Sample available here:

```
"vultr_startup_script_facts": [
  {
    "date_created": "2018-07-19 08:52:55",
    "date_modified": "2018-07-19 08:52:55",
    "id": 327140,
    "name": "myteststartupscript",
    "script": "#!/bin/bash\necho Hello World > /root/hello",
    "type": "boot"
  }
]
```

##### ISSUE TYPE

 - New Module Pull Request

##### COMPONENT NAME

  - vr_startup_script_facts

##### ANSIBLE VERSION

  - devel

##### ADDITIONAL INFORMATION

  - N/A