### PR TITLE
sysvinit: Fix for false changed messages (#42956)

### DIFF
--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -221,6 +221,7 @@ def main():
         if not worked:
             # hail mary
             if rc == 0:
+                is_started = True
                 worked = True
             # ps for luck, can only assure positive match
             elif get_ps(module, name):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
 Fix for false changed messages
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #42956 

Add missing "is_started = True" when return code of the service check is 0.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
sysvinit

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (detached HEAD 8ce3bd6dea) last updated 2018/07/03 10:43:54 (GMT +200)
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Have a look into #42956 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
