### PR TITLE
module_utils_service: Fix glob path of rc.d for SUSE

### DIFF
--- a/changelogs/fragments/service.yml
+++ b/changelogs/fragments/service.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- Fix glob path of rc.d
+  Some distribtuions like SUSE has the rc%.d directories under /etc/init.d

--- a/lib/ansible/module_utils/service.py
+++ b/lib/ansible/module_utils/service.py
@@ -48,8 +48,12 @@ def sysv_is_enabled(name, runlevel=None):
     :kw runlevel: runlevel to check (default: None)
     '''
     if runlevel:
+        if not os.path.isdir('/etc/rc0.d/'):
+            return bool(glob.glob('/etc/init.d/rc%s.d/S??%s' % (runlevel, name)))
         return bool(glob.glob('/etc/rc%s.d/S??%s' % (runlevel, name)))
     else:
+        if not os.path.isdir('/etc/rc0.d/'):
+            return bool(glob.glob('/etc/init.d/rc?.d/S??%s' % name))
         return bool(glob.glob('/etc/rc?.d/S??%s' % name))
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The service module reports always a changed message when you set "enabled: true" for a service e.g. ntp.

FIX:
SUSE has the rc%.d directories under /etc/init.d
Set the glob path to /etc/init.d on SLES.

Quote of /etc/rc.d.README on SLES11.

"Some people expect the system startup scripts in /etc/rc.d/.
We use a slightly different structure for better LSB compliance."
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
module_utils/service.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (service_utils_sysv f8a64807dc) last updated 2018/07/19 12:37:40 (GMT +000)
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
OS / ENVIRONMENT
```
SLES11
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
before:
srv1~] :)$ chkconfig ntp
ntp  on
srv0: ansible -m service -a "name=ntp enabled=true" srv1 -b -D

srv1| SUCCESS => {
    "changed": true,
    "name": "ntp",
    "status": {
        "enabled": {
            "changed": true,
            "rc": 0,
            "stderr": "",
            "stdout": ""
        },
        "null": {
            "changed": false,
            "rc": null,
            "stderr": null,
            "stdout": null
        }
    }
}

after:
srv1~] :)$ chkconfig ntp
srv0: ansible -m service -a "name=ntp enabled=true" srv1 -b -D
srv1| SUCCESS => {
    "changed": false,
    "name": "ntp",
    "status": {
        "enabled": {
            "changed": false,
            "rc": null,
            "stderr": null,
            "stdout": null
        },
        "null": {
            "changed": false,
            "rc": null,
            "stderr": null,
            "stdout": null
        }
    }
}

```
