### PR TITLE
NCLU Module: Improve performance by not operating on empty lines

### DIFF
--- a/changelogs/fragments/43024-nclu-empty-net-commands.yaml
+++ b/changelogs/fragments/43024-nclu-empty-net-commands.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- nclu - no longer runs net on empty lines in templates (https://github.com/ansible/ansible/pull/43024)

--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.2',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 

--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
+ANSIBLE_METADATA = {'metadata_version': '1.2',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
@@ -185,7 +185,8 @@ def run_nclu(module, command_list, command_string, commit, atomic, abort, descri
     # Run all of the net commands
     output_lines = []
     for line in commands:
-        output_lines += [command_helper(module, line.strip(), "Failed on line %s" % line)]
+        if line.strip():
+          output_lines += [command_helper(module, line.strip(), "Failed on line %s" % line)]
     output = "\n".join(output_lines)
 
     # If pending changes changed, report a change.

--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -186,7 +186,7 @@ def run_nclu(module, command_list, command_string, commit, atomic, abort, descri
     output_lines = []
     for line in commands:
         if line.strip():
-          output_lines += [command_helper(module, line.strip(), "Failed on line %s" % line)]
+            output_lines += [command_helper(module, line.strip(), "Failed on line %s" % line)]
     output = "\n".join(output_lines)
 
     # If pending changes changed, report a change.

--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2016-2017, Cumulus Networks <ce-ceng@cumulusnetworks.com>
+# (c) 2016-2018, Cumulus Networks <ce-ceng@cumulusnetworks.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function


### PR DESCRIPTION
Stop module from running `net` on empty commands.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This fixes a bug where NCLU would run `net` for empty lines produced in Jinja templates. This will check to ensure that the command has content before being passed to `net`, which should improve performance and clean up the `msg` return value.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

nclu

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 577427b1c2) last updated 2018/07/17 15:23:05 (GMT +000)
  config file = None
  configured module search path = [u'/home/cumulus/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/cumulus/ansible/lib/ansible
  executable location = /home/cumulus/ansible/bin/ansible
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Task:
```
- name: Add 2 interfaces and commit the change.
  nclu:
    template: |
        {% for iface in range(1,3) %}
        add int swp{{iface}}

        {% endfor %}
    commit: true
    description: "Ansible - add swps1-2"
```


Output Before
```
TASK [examply : Add 2 interfaces and commit the change.] ************************************************************************************************************************************************************
ok: [leaf01] => {"changed": false, "msg": "\n\nUsage:\n    # net <COMMAND> [<ARGS>] [help]\n    #\n    # net is a command line utility for networking on Cumulus Linux switches.\n    #\n    # COMMANDS are listed below and have context specific arguments which can\n    # be explored by typing \"<TAB>\" or \"help\" anytime while using net.\n    #\n    # Use \"man net\" for a more comprehensive overview.\n\n    net abort\n    net commit [verbose] [confirm [<number-seconds>]] [description <wildcard>]\n    net commit delete (<number>|<number-range>)\n    net commit permanent <wildcard>\n    net del all\n    net help [verbose]\n    net pending [json]\n    net rollback (<number>|last)\n    net rollback description <wildcard-snapshot>\n    net show commit (history|<number>|<number-range>|last)\n    net show rollback (<number>|last)\n    net show rollback description <wildcard-snapshot>\n    net show configuration [commands|files|acl|bgp|multicast|ospf|ospf6]\n    net show configuration interface [<interface>]\n\nOptions:\n\n    # Help commands\n    help     : context sensitive information; see section below\n    example  : detailed examples of common workflows\n\n    # Configuration commands\n    add      : add/modify configuration\n    del      : remove configuration\n\n    # Commit buffer commands\n    abort    : abandon changes in the commit buffer\n    commit   : apply the commit buffer to the system\n    pending  : show changes staged in the commit buffer\n    rollback : revert to a previous configuration state\n\n    # Status commands\n    show     : show command output\n    clear    : clear counters, BGP neighbors, etc\n\n    <number-seconds> : Number of seconds\n\n\n\nUsage:\n    # net <COMMAND> [<ARGS>] [help]\n    #\n    # net is a command line utility for networking on Cumulus Linux switches.\n    #\n    # COMMANDS are listed below and have context specific arguments which can\n    # be explored by typing \"<TAB>\" or \"help\" anytime while using net.\n    #\n    # Use \"man net\" for a more comprehensive overview.\n\n    net abort\n    net commit [verbose] [confirm [<number-seconds>]] [description <wildcard>]\n    net commit delete (<number>|<number-range>)\n    net commit permanent <wildcard>\n    net del all\n    net help [verbose]\n    net pending [json]\n    net rollback (<number>|last)\n    net rollback description <wildcard-snapshot>\n    net show commit (history|<number>|<number-range>|last)\n    net show rollback (<number>|last)\n    net show rollback description <wildcard-snapshot>\n    net show configuration [commands|files|acl|bgp|multicast|ospf|ospf6]\n    net show configuration interface [<interface>]\n\nOptions:\n\n    # Help commands\n    help     : context sensitive information; see section below\n    example  : detailed examples of common workflows\n\n    # Configuration commands\n    add      : add/modify configuration\n    del      : remove configuration\n\n    # Commit buffer commands\n    abort    : abandon changes in the commit buffer\n    commit   : apply the commit buffer to the system\n    pending  : show changes staged in the commit buffer\n    rollback : revert to a previous configuration state\n\n    # Status commands\n    show     : show command output\n    clear    : clear counters, BGP neighbors, etc\n\n    <number-seconds> : Number of seconds\n"}
```

Output AFter
```
TASK [examply : Add 2 interfaces and commit the change.] ************************************************************************************************************************************************************
ok: [leaf01] => {"changed": false, "msg": "\n"}
```
