### PR TITLE
add support for the --be-name option

### DIFF
--- a/lib/ansible/modules/packaging/os/pkg5.py
+++ b/lib/ansible/modules/packaging/os/pkg5.py
@@ -42,7 +42,7 @@ options:
   be_name:
     description:
       - creates a new boot environment with the given name
-    version_added: "2.7"
+    version_added: "2.8"
     type: str
 '''
 EXAMPLES = '''

--- a/lib/ansible/modules/packaging/os/pkg5.py
+++ b/lib/ansible/modules/packaging/os/pkg5.py
@@ -42,8 +42,8 @@ options:
   be_name:
     description:
       - Name for new BE.
+    version_added: "2.7"
     type: str
-    default: 'no'
 '''
 EXAMPLES = '''
 - name: Install Vim

--- a/lib/ansible/modules/packaging/os/pkg5.py
+++ b/lib/ansible/modules/packaging/os/pkg5.py
@@ -41,7 +41,7 @@ options:
     aliases: [ accept, accept_licences ]
   be_name:
     description:
-      - Name for new BE.
+      - creates a new boot environment with the given name
     version_added: "2.7"
     type: str
 '''

--- a/lib/ansible/modules/packaging/os/pkg5.py
+++ b/lib/ansible/modules/packaging/os/pkg5.py
@@ -39,6 +39,11 @@ options:
     type: bool
     default: 'no'
     aliases: [ accept, accept_licences ]
+  be_name:
+    description:
+      - Name for new BE.
+    type: str
+    default: 'no'
 '''
 EXAMPLES = '''
 - name: Install Vim
@@ -68,6 +73,7 @@ def main():
             name=dict(type='list', required=True),
             state=dict(type='str', default='present', choices=['absent', 'installed', 'latest', 'present', 'removed', 'uninstalled']),
             accept_licenses=dict(type='bool', default=False, aliases=['accept', 'accept_licences']),
+            be_name=dict(type='str'),
         ),
         supports_check_mode=True,
     )
@@ -124,9 +130,14 @@ def ensure(module, state, packages, params):
     else:
         accept_licenses = []
 
+    if params['be_name']:
+        beadm = ['--be-name=' + module.params['be_name']]
+    else:
+        beadm = []
+
     to_modify = filter(behaviour[state]['filter'], packages)
     if to_modify:
-        rc, out, err = module.run_command(['pkg', behaviour[state]['subcommand']] + dry_run + accept_licenses + ['-q', '--'] + to_modify)
+        rc, out, err = module.run_command(['pkg', behaviour[state]['subcommand']] + dry_run + accept_licenses + beadm + ['-q', '--'] + to_modify)
         response['rc'] = rc
         response['results'].append(out)
         response['msg'] += err


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add support for pkg's --be-name option.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
pkg5

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 2ad234f98e) last updated 2018/07/15 16:02:09 (GMT -600)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /var/tmp/ansible/lib/ansible
  executable location = /var/tmp/ansible/bin/ansible
  python version = 2.7.14 (default, Jun 12 2018, 10:49:56) [C]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
% ansible x5a-1 -m pkg5 -a 'be_name=s11.4_patch name=pkg:/entire'
```
