### PR TITLE
Stop throwing TypeErrors

### DIFF
--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -327,7 +327,7 @@ def format_disk_size(size_bytes, unit):
 
     # Shortcut
     if size_bytes == 0:
-        return 0.0
+        return 0.0, 'b'
 
     # Cases where we default to 'compact'
     if unit in ['', 'compact', 'cyl', 'chs']:


### PR DESCRIPTION
##### SUMMARY
parted on unlabeled empty volumes throws a type error, when shortcut return 0.0

```
File "/tmp/ansible_zEcr6b/ansible_module_parted.py", line 412, in get_device_info
    return get_unlabeled_device_info(device, unit)
  File "/tmp/ansible_zEcr6b/ansible_module_parted.py", line 384, in get_unlabeled_device_info
    size, unit = format_disk_size(size_bytes, unit)
TypeError: 'float' object is not iterable
```
This fixes the shortcut, by also returning a unit.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
parted

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /Users/docker/.ansible.cfg
  configured module search path = [u'/Users/docker/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.5.0/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Apr  9 2018, 11:21:50) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```