### PR TITLE
Add from_yaml_all to support multi document yaml strings

### DIFF
--- a/changelogs/fragments/from_yaml_all_filter_plugin.yaml
+++ b/changelogs/fragments/from_yaml_all_filter_plugin.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Added the from_yaml_all filter to parse multi-document yaml strings.
+    Refer to the appropriate entry which as been added to user_guide
+    playbooks_filters.rst document.

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -47,6 +47,22 @@ for example::
     - set_fact:
         myvar: "{{ result.stdout | from_json }}"
 
+
+.. versionadded:: 2.7
+
+To parse multi-document yaml strings, the ``from_yaml_all`` filter is provided.
+The ``from_yaml_all`` filter will return a generator of parsed yaml documents.
+
+for example::
+
+  tasks:
+    - shell: cat /some/path/to/multidoc-file.yaml
+      register: result
+   - debug:
+       msg: '{{ item }}'
+    loop: '{{ result.stdout | from_yaml_all | list }}'
+
+
 .. _forcing_variables_to_be_defined:
 
 Forcing Variables To Be Defined

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -204,11 +204,14 @@ def regex_escape(string):
     return re.escape(string)
 
 
-def from_yaml(data, multidoc=False):
+def from_yaml(data):
     if isinstance(data, string_types):
-        if multidoc:
-            return yaml.safe_load_all(data)
-        return yaml.safe_load(data)
+        try:
+            return yaml.safe_load(data)
+        except yaml.composer.ComposerError as e:
+            if e.context == 'expected a single document in the stream':
+                return yaml.safe_load_all(data)
+            raise
     return data
 
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -206,12 +206,10 @@ def regex_escape(string):
 
 def from_yaml(data):
     if isinstance(data, string_types):
-        try:
-            return yaml.safe_load(data)
-        except yaml.composer.ComposerError as e:
-            if e.context == 'expected a single document in the stream':
-                return yaml.safe_load_all(data)
-            raise
+        parsed = list(yaml.safe_load_all(data))
+        if len(parsed) == 1:
+            return parsed[1]
+        return parsed
     return data
 
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -204,8 +204,10 @@ def regex_escape(string):
     return re.escape(string)
 
 
-def from_yaml(data):
+def from_yaml(data, multidoc=False):
     if isinstance(data, string_types):
+        if multidoc:
+            return yaml.safe_load_all(data)
         return yaml.safe_load(data)
     return data
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -206,10 +206,13 @@ def regex_escape(string):
 
 def from_yaml(data):
     if isinstance(data, string_types):
-        parsed = list(yaml.safe_load_all(data))
-        if len(parsed) == 1:
-            return parsed[1]
-        return parsed
+        return yaml.safe_load(data)
+    return data
+
+
+def from_yaml_all(data):
+    if isinstance(data, string_types):
+        return yaml.safe_load_all(data)
     return data
 
 
@@ -603,6 +606,7 @@ class FilterModule(object):
             'to_yaml': to_yaml,
             'to_nice_yaml': to_nice_yaml,
             'from_yaml': from_yaml,
+            'from_yaml_all': from_yaml_all,
 
             # path
             'basename': partial(unicode_wrap, os.path.basename),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If yaml parsing fails because the source is a multi-document yaml string, it will load it as a multidocument yaml file instead of erroring out.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
from_yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (from-yaml-multi-doc 6f20e88472) last updated 2018/07/19 13:12:13 (GMT -400)
  config file = /home/fabian/tmp/reproducer/ansible/ansible.cfg
  configured module search path = [u'/home/fabian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/fabian/tmp/reproducer/ansible/lib/ansible
  executable location = /home/fabian/tmp/reproducer/ansible/bin/ansible
  python version = 2.7.15 (default, May 15 2018, 15:37:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```
