### PR TITLE
inventory plugins: add test about config API usage (#41888)

### DIFF
--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -67,7 +67,7 @@ class AnsiblePlugin(with_metaclass(ABCMeta, object)):
         Sets the _options attribute with the configuration/keyword information for this plugin
 
         :arg task_keys: Dict with playbook keywords that affect this option
-        :arg var_options: Dict with either 'conneciton variables'
+        :arg var_options: Dict with either 'connection variables'
         :arg direct: Dict with 'direct assignment'
         '''
         self._options = C.config.get_plugin_options(get_plugin_class(self), self._load_name, keys=task_keys, variables=var_options, direct=direct)

--- a/test/integration/targets/inventory_plugin_config/aliases
+++ b/test/integration/targets/inventory_plugin_config/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/inventory_plugin_config/aliases
+++ b/test/integration/targets/inventory_plugin_config/aliases
@@ -1,0 +1,1 @@
+posix/ci/group3

--- a/test/integration/targets/inventory_plugin_config/config_with_parameter.yml
+++ b/test/integration/targets/inventory_plugin_config/config_with_parameter.yml
@@ -1,0 +1,3 @@
+plugin: test_inventory
+departments:
+  - paris

--- a/test/integration/targets/inventory_plugin_config/config_without_parameter.yml
+++ b/test/integration/targets/inventory_plugin_config/config_without_parameter.yml
@@ -1,0 +1,1 @@
+plugin: test_inventory

--- a/test/integration/targets/inventory_plugin_config/runme.sh
+++ b/test/integration/targets/inventory_plugin_config/runme.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o xtrace
+
+export ANSIBLE_INVENTORY_PLUGINS=./
+export ANSIBLE_INVENTORY_ENABLED=test_inventory
+
+# check default values
+ansible-inventory --list -i ./config_without_parameter.yml --export | \
+    env python -c "import json, sys; inv = json.loads(sys.stdin.read()); \
+                   assert set(inv['_meta']['hostvars']['test_host']['departments']) == set(['seine-et-marne', 'haute-garonne'])"
+
+# check values
+ansible-inventory --list -i ./config_with_parameter.yml --export | \
+    env python -c "import json, sys; inv = json.loads(sys.stdin.read()); \
+                   assert set(inv['_meta']['hostvars']['test_host']['departments']) == set(['paris'])"

--- a/test/integration/targets/inventory_plugin_config/test_inventory.py
+++ b/test/integration/targets/inventory_plugin_config/test_inventory.py
@@ -1,0 +1,51 @@
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    name: test_inventory
+    plugin_type: inventory
+    authors:
+      - Pierre-Louis Bonicoli (@pilou-)
+    short_description: test inventory
+    description:
+        - test inventory (fetch parameters using config API)
+    options:
+        departments:
+            description: test parameter
+            type: list
+            default:
+                - seine-et-marne
+                - haute-garonne
+            required: False
+'''
+
+EXAMPLES = '''
+# Example command line: ansible-inventory --list -i test_inventory.yml
+
+plugin: test_inventory
+departments:
+  - paris
+'''
+
+from ansible.plugins.inventory import BaseInventoryPlugin
+
+
+class InventoryModule(BaseInventoryPlugin):
+    NAME = 'test_inventory'
+
+    def verify_file(self, path):
+        return True
+
+    def parse(self, inventory, loader, path, cache=True):
+        super(InventoryModule, self).parse(inventory, loader, path)
+        self._read_config_data(path=path)
+
+        departments = self.get_option('departments')
+
+        group = 'test_group'
+        host = 'test_host'
+
+        self.inventory.add_group(group)
+        self.inventory.add_host(group=group, host=host)
+        self.inventory.set_variable(host, 'departments', departments)


### PR DESCRIPTION
##### SUMMARY

* Check get_option method works with inventory plugins

This use case is already tested by some cloud inventoty plugin but
these tests are slow and aren't always executed, hence this new quick
test.

(cherry picked from commit 06f5e49dfb8b1a1b6e294aff6faea88fea05f9ae)


##### ISSUE TYPE
 - Bugfix Pull Request

