### PR TITLE
elasticache_parameter_group.py: add parameter group compatibility with redis4.0

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -37,7 +37,7 @@ options:
     description:
       - The name of the cache parameter group family that the cache parameter group can be used with.
         Required when creating a cache parameter group.
-    choices: ['memcached1.4', 'redis2.6', 'redis2.8', 'redis3.2']
+    choices: ['memcached1.4', 'redis2.6', 'redis2.8', 'redis3.2','redis4.0']
   name:
     description:
      - A user-specified name for the cache parameter group.
@@ -285,7 +285,7 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(
         dict(
-            group_family=dict(type='str', choices=['memcached1.4', 'redis2.6', 'redis2.8', 'redis3.2']),
+            group_family=dict(type='str', choices=['memcached1.4', 'redis2.6', 'redis2.8', 'redis3.2', 'redis4.0']),
             name=dict(required=True, type='str'),
             description=dict(default='', type='str'),
             state=dict(required=True),

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -37,7 +37,7 @@ options:
     description:
       - The name of the cache parameter group family that the cache parameter group can be used with.
         Required when creating a cache parameter group.
-    choices: ['memcached1.4', 'redis2.6', 'redis2.8', 'redis3.2','redis4.0']
+    choices: ['memcached1.4', 'redis2.6', 'redis2.8', 'redis3.2', 'redis4.0']
   name:
     description:
      - A user-specified name for the cache parameter group.


### PR DESCRIPTION
##### SUMMARY

Fix issue #42717 

##### ISSUE TYPE

Parameter group now support redis4.0

```python
response = ecache.create_cache_parameter_group(CacheParameterGroupFamily="redis4.0", CacheParameterGroupName='valid',Description='test')

response
{u'CacheParameterGroup': {u'CacheParameterGroupFamily': 'redis4.0',
  u'CacheParameterGroupName': 'valid',
  u'Description': 'test'},
 'ResponseMetadata': {'HTTPHeaders': {'content-length': '534',
   'content-type': 'text/xml',
   'date': 'Wed, 18 Jul 2018 20:11:57 GMT',
   'x-amzn-requestid': '87dd2508-8a94-11e8-XXXXXXXXXX'},
  'HTTPStatusCode': 200,
  'RequestId': '87dd2508-8a94-11e8-83b5-XXXXXXX',
  'RetryAttempts': 0}}
```

API definition is not updated though:
https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateCacheParameterGroup.html

Same then for boto3:
https://boto3.readthedocs.io/en/latest/reference/services/elasticache.html#ElastiCache.Client.create_cache_parameter_group

I have opened a request to update it.

##### COMPONENT NAME

lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py