### PR TITLE
[aws] Add suboptions to aws_application_scaling_policy

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
+++ b/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
@@ -483,6 +483,15 @@ def main():
 
     connection = module.client('application-autoscaling')
 
+    # Remove any target_tracking_scaling_policy_configuration suboptions that are None
+    policy_config_options = [
+        'CustomizedMetricSpecification', 'DisableScaleIn', 'PredefinedMetricSpecification', 'ScaleInCooldown', 'ScaleOutCooldown', 'TargetValue'
+    ]
+    if isinstance(module.params['target_tracking_scaling_policy_configuration'], dict):
+        for option in policy_config_options:
+            if module.params['target_tracking_scaling_policy_configuration'][option] is None:
+                module.params['target_tracking_scaling_policy_configuration'].pop(option)
+
     if module.params.get("state") == 'present':
         # A scalable target must be registered prior to creating a scaling policy
         scalable_target_result = create_scalable_target(connection, module)

--- a/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
+++ b/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
@@ -170,7 +170,7 @@ policy_name:
 policy_type:
     description: The policy type.
     returned: when state present
-    type: string    
+    type: string
 min_capacity:
     description: The minimum value to scale to in response to a scale in event. Required if I(state) is C(present).
     returned: when state present
@@ -197,7 +197,7 @@ step_scaling_policy_configuration:
             type: string
             sample: "ChangeInCapacity, PercentChangeInCapacity, ExactCapacity"
         cooldown:
-            description: The amount of time, in seconds, after a scaling activity completes 
+            description: The amount of time, in seconds, after a scaling activity completes
                 where previous trigger-related scaling activities can influence future scaling events
             returned: when state present and the policy type is StepScaling
             type: int
@@ -462,7 +462,18 @@ def main():
                                                         ], type='str'),
         policy_type=dict(required=True, choices=['StepScaling', 'TargetTrackingScaling'], type='str'),
         step_scaling_policy_configuration=dict(required=False, type='dict'),
-        target_tracking_scaling_policy_configuration=dict(required=False, type='dict'),
+        target_tracking_scaling_policy_configuration=dict(
+            required=False,
+            type='dict',
+            options=dict(
+                CustomizedMetricSpecification=dict(type='dict'),
+                DisableScaleIn=dict(type='bool'),
+                PredefinedMetricSpecification=dict(type='dict'),
+                ScaleInCooldown=dict(type='int'),
+                ScaleOutCooldown=dict(type='int'),
+                TargetValue=dict(type='float'),
+            )
+        ),
         minimum_tasks=dict(required=False, type='int'),
         maximum_tasks=dict(required=False, type='int'),
         override_task_capacity=dict(required=False, type=bool)


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
For target policy, options filled in by jinja2 were loaded as strings and not converted to integers before being passed to the scaling policy API. This change adds suboptions to enforce int types on API params requiring integers. 

Fixes #42917

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
aws_application_scaling_policy

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
