### PR TITLE
Pass path to GalaxyRole object

### DIFF
--- a/changelogs/fragments/galaxy_list_all_roles.yaml
+++ b/changelogs/fragments/galaxy_list_all_roles.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - properly list all roles in roles_path (https://github.com/ansible/ansible/issues/43010)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -500,7 +500,7 @@ class GalaxyCLI(CLI):
                 path_files = os.listdir(role_path)
                 path_found = True
                 for path_file in path_files:
-                    gr = GalaxyRole(self.galaxy, path_file)
+                    gr = GalaxyRole(self.galaxy, path_file, path=path)
                     if gr.metadata:
                         install_info = gr.install_info
                         version = None


### PR DESCRIPTION
##### SUMMARY

Without passing `roles_path` to the `GalaxyRole` object, only the first path in `roles_path` is used when searching for roles.

Fixes #43010 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
`/lib/ansible/galaxy/role.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
2.6
2.5
```
