### PR TITLE
Update the regex_findall example

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -992,7 +992,7 @@ To search a string with a regex, use the "regex_search" filter::
 To search for all occurrences of regex matches, use the "regex_findall" filter::
 
     # Return a list of all IPv4 addresses in the string
-    {{ 'Some DNS servers are 8.8.8.8 and 8.8.4.4' | regex_findall('\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b') }}
+    {{ 'Some DNS servers are 8.8.8.8 and 8.8.4.4' | regex_findall('\\b(?:[0-9]{1,3}\\.){3}[0-9]{1,3}\\b') }}
 
 
 To replace text in a string with regex, use the "regex_replace" filter::


### PR DESCRIPTION
<!--- Your description here -->
The example has:
`{{ 'Some DNS servers are 8.8.8.8 and 8.8.4.4' | regex_findall('\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b') }}`

It needs be double backslashes to escape the backslashes:
`{{ 'Some DNS servers are 8.8.8.8 and 8.8.4.4' | regex_findall('\\b(?:[0-9]{1,3}\\.){3}[0-9]{1,3}\\b') }}`
+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If you use the example given to find IP addresses, it will find nothing.  By escaping the backslashes it works as it should
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Filters
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /Users/smolz/Dropbox/Programming/Ansible_Projects/ITS-Ansible/ansible.cfg
  configured module search path = [u'/usr/lib/python2.7/dist-packages/ansible/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 16:44:08) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
__Non-Working Playbook:__
- name: get current running-config
  ios_command:
    commands: show running-config | in ntp server
  register: config

- name: get current configured ntp servers
  set_fact: _servers="{{ config.stdout[0] | regex_findall('\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b') }}"

- debug: var=config.stdout[0]
- debug: var=_servers
```
```
OUTPUT:
TASK [ntp : debug] ***********************************************************************************************************************************************************************************************************
ok: [SW01] => {
    "config.stdout[0]": "ntp server 1.1.1.1 key 1 prefer\nntp server 1.1.1.2"
}

TASK [ntp : debug] ***********************************************************************************************************************************************************************************************************
ok: [SW01] => {
    "_servers": []
}
```
```
__Working Playbook:__
---
- name: get current running-config
  ios_command:
    commands: show running-config | in ntp server
  register: config

- name: get current configured ntp servers
  set_fact: _servers="{{ config.stdout[0] | regex_findall('\\b(?:[0-9]{1,3}\\.){3}[0-9]{1,3}\\b') }}"

- debug: var=config.stdout[0]
- debug: var=_servers
```
```
OUTPUT:
TASK [ntp : debug] ***********************************************************************************************************************************************************************************************************
ok: [SW01] => {
    "config.stdout[0]": "ntp server 1.1.1.1 key 1 prefer\nntp server 1.1.1.2"
}

TASK [ntp : debug] ***********************************************************************************************************************************************************************************************************
ok: [SW01] => {
    "_servers": [
        "1.1.1.1", 
        "1.1.1.2"
    ]
}

