### PR TITLE
ssh - skip connection reset if controlpath does not exist

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1102,7 +1102,19 @@ class Connection(ConnectionBase):
         # If we have a persistent ssh connection (ControlPersist), we can ask it to stop listening.
         cmd = self._build_command(self._play_context.ssh_executable, '-O', 'stop', self.host)
         controlpersist, controlpath = self._persistence_controls(cmd)
-        if controlpersist:
+        cp_arg = [a for a in cmd if a.startswith(b"ControlPath=")]
+
+        # only run the reset if the ControlPath already exists or if it isn't
+        # configured and ControlPersist is set
+        run_reset = False
+        if controlpersist and len(cp_arg) > 0:
+            cp_path = cp_arg[0].split(b"=", 1)[-1]
+            if os.path.exists(cp_path):
+                run_reset = True
+        elif controlpersist:
+            run_reset = True
+
+        if run_reset:
             display.vvv(u'sending stop: %s' % cmd)
             p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()


### PR DESCRIPTION
##### SUMMARY
When running `wait_for_connection` as the first task, the ControlPath is defined but as no connection occurred it may not exist. This adds a conditional check on the ssh reset method to skip the reset if ControlPath exists but the path does not exist.

Fixes https://github.com/ansible/ansible/issues/42991

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ssh

##### ANSIBLE VERSION
```
devel
```