### PR TITLE
Don't close persistent connection socket on command timeout

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -147,6 +147,7 @@ class ConnectionProcess(object):
 
     def command_timeout(self, signum, frame):
         display.display('command timeout triggered, timeout value is %s secs' % self.connection.get_option('persistent_command_timeout'), log_only=True)
+        self.shutdown()
 
     def handler(self, signum, frame):
         display.display('signal handler called with signal %s' % signum, log_only=True)

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -147,7 +147,6 @@ class ConnectionProcess(object):
 
     def command_timeout(self, signum, frame):
         display.display('command timeout triggered, timeout value is %s secs' % self.connection.get_option('persistent_command_timeout'), log_only=True)
-        self.shutdown()
 
     def handler(self, signum, frame):
         display.display('signal handler called with signal %s' % signum, log_only=True)

--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -122,7 +122,11 @@ def to_commands(module, commands):
 
 def run_commands(module, commands, check_rc=True):
     connection = get_connection(module)
-    return connection.run_commands(commands=commands, check_rc=check_rc)
+    try:
+        out = connection.run_commands(commands=commands, check_rc=check_rc)
+        return out
+    except ConnectionError as exc:
+        module.fail_json(msg=to_text(exc))
 
 
 def load_config(module, commands):


### PR DESCRIPTION
##### SUMMARY
Fixes  #42340
- If we have a task in a playbook which issues a command which might take long time to respond (e.g. reboot ) and causes command timeout trigger, we will delete the persistent socket and it will cause whole playbook termination. Fix is to not delete pc socket and prevent connection closing when a command timeout has been triggered.

- This will also fix retry functionality in  (*network_os*)_command modules.


##### ISSUE TYPE
 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
all network modules
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
After the fix:
-------------
fatal: [ios_01]: FAILED! => {
    "attempts": 5 ,   <<<<<------- 
    "changed": false, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_veTu8u/ansible_module_ios_command.py\", line 247, in <module>\n    main()\n  File \"/tmp/ansible_veTu8u/ansible_module_ios_command.py\", line 217, in main\n    responses = run_commands(module, commands)\n  File \"/tmp/ansible_veTu8u/ansible_modlib.zip/ansible/module_utils/network/ios/ios.py\", line 124, in run_commands\n  File \"/tmp/ansible_veTu8u/ansible_modlib.zip/ansible/module_utils/network/ios/ios.py\", line 71, in get_connection\n  File \"/tmp/ansible_veTu8u/ansible_modlib.zip/ansible/module_utils/network/ios/ios.py\", line 85, in get_capabilities\n  File \"/tmp/ansible_veTu8u/ansible_modlib.zip/ansible/module_utils/connection.py\", line 149, in __rpc__\nansible.module_utils.connection.ConnectionError: timeout trying to send command: show version\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 1
}

Before the fix:
--------------
The full traceback is:
Traceback (most recent call last):
  File "/macos/ansible/lib/ansible/executor/task_executor.py", line 139, in run
    res = self._execute()
  File "/macos/ansible/lib/ansible/executor/task_executor.py", line 585, in _execute
    result = self._handler.run(task_vars=variables)
  File "/macos/ansible/lib/ansible/plugins/action/ios.py", line 90, in run
    out = conn.get_prompt()
  File "/macos/ansible/lib/ansible/module_utils/connection.py", line 143, in __rpc__
    response = self._exec_jsonrpc(name, *args, **kwargs)
  File "/macos/ansible/lib/ansible/module_utils/connection.py", line 117, in _exec_jsonrpc
    raise ConnectionError('socket_path does not exist or cannot be found. Please check %s' % troubleshoot)
ConnectionError: socket_path does not exist or cannot be found. Please check https://docs.ansible.com/ansible/latest/network/user_guide/network_debug_troubleshooting.html#category-socket-path-issue

fatal: [ios_docker01]: FAILED! => {
    "msg": "Unexpected failure during module execution.", 
    "stdout": ""
}


```