### PR TITLE
Raise exception if command timeout is triggered

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -16,6 +16,7 @@ import os
 import signal
 import socket
 import sys
+import time
 import traceback
 import errno
 import json

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -35,7 +35,7 @@ from ansible.utils.path import unfrackpath, makedirs_safe
 from ansible.utils.display import Display
 from ansible.utils.jsonrpc import JsonRpcServer
 
-
+import q
 @contextmanager
 def file_lock(lock_path):
     """
@@ -130,6 +130,7 @@ class ConnectionProcess(object):
 
         except Exception as e:
             # socket.accept() will raise EINTR if the socket.close() is called
+            q("--execption raised--")
             if hasattr(e, 'errno'):
                 if e.errno != errno.EINTR:
                     self.exception = traceback.format_exc()
@@ -137,8 +138,10 @@ class ConnectionProcess(object):
                 self.exception = traceback.format_exc()
 
         finally:
-            # when done, close the connection properly and cleanup
-            # the socket file so it can be recreated
+            # allow time for any exception msg send over socket to receive at other end before shutting down
+            time.sleep(0.1)
+
+            # when done, close the connection properly and cleanup the socket file so it can be recreated
             self.shutdown()
 
     def connect_timeout(self, signum, frame):
@@ -146,27 +149,15 @@ class ConnectionProcess(object):
         display.display(msg, log_only=True)
         raise Exception(msg)
 
-        # allow time for exception msg send over socket to receive at other end before shutting down
-        time.sleep(0.5)
-        self.shutdown()
-
     def command_timeout(self, signum, frame):
         msg = 'command timeout triggered, timeout value is %s secs' % self.connection.get_option('persistent_command_timeout')
         display.display(msg, log_only=True)
         raise Exception(msg)
 
-        # allow time for exception msg send over socket to receive at other end before shutting down
-        time.sleep(0.5)
-        self.shutdown()
-
     def handler(self, signum, frame):
         msg = 'signal handler called with signal %s' % signum
         display.display(msg, log_only=True)
         raise Exception(msg)
-
-        # allow time for exception msg send over socket to receive at other end before shutting down
-        time.sleep(0.5)
-        self.shutdown()
 
     def shutdown(self):
         """ Shuts down the local domain socket

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -141,16 +141,30 @@ class ConnectionProcess(object):
             self.shutdown()
 
     def connect_timeout(self, signum, frame):
-        display.display('persistent connection idle timeout triggered, timeout value is %s secs'
-                        % self.connection.get_option('persistent_connect_timeout'), log_only=True)
+        msg = 'persistent connection idle timeout triggered, timeout value is %s secs' % self.connection.get_option('persistent_connect_timeout')
+        display.display(msg, log_only=True)
+        raise Exception(msg)
+
+        # allow time for exception msg send over socket to receive at other end before shutting down
+        time.sleep(0.5)
         self.shutdown()
 
     def command_timeout(self, signum, frame):
-        display.display('command timeout triggered, timeout value is %s secs' % self.connection.get_option('persistent_command_timeout'), log_only=True)
+        msg = 'command timeout triggered, timeout value is %s secs' % self.connection.get_option('persistent_command_timeout')
+        display.display(msg, log_only=True)
+        raise Exception(msg)
+
+        # allow time for exception msg send over socket to receive at other end before shutting down
+        time.sleep(0.5)
         self.shutdown()
 
     def handler(self, signum, frame):
-        display.display('signal handler called with signal %s' % signum, log_only=True)
+        msg = 'signal handler called with signal %s' % signum
+        display.display(msg, log_only=True)
+        raise Exception(msg)
+
+        # allow time for exception msg send over socket to receive at other end before shutting down
+        time.sleep(0.5)
         self.shutdown()
 
     def shutdown(self):

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -35,7 +35,7 @@ from ansible.utils.path import unfrackpath, makedirs_safe
 from ansible.utils.display import Display
 from ansible.utils.jsonrpc import JsonRpcServer
 
-import q
+
 @contextmanager
 def file_lock(lock_path):
     """
@@ -130,7 +130,6 @@ class ConnectionProcess(object):
 
         except Exception as e:
             # socket.accept() will raise EINTR if the socket.close() is called
-            q("--execption raised--")
             if hasattr(e, 'errno'):
                 if e.errno != errno.EINTR:
                     self.exception = traceback.format_exc()

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -35,8 +35,6 @@ from ansible.utils.path import unfrackpath, makedirs_safe
 from ansible.utils.display import Display
 from ansible.utils.jsonrpc import JsonRpcServer
 
-TIMEOUT_TROUBLESHOOT_URL = "https://docs.ansible.com/ansible/latest/network/user_guide/network_debug_troubleshooting.html#timeout-issues"
-
 
 @contextmanager
 def file_lock(lock_path):
@@ -146,19 +144,19 @@ class ConnectionProcess(object):
             self.shutdown()
 
     def connect_timeout(self, signum, frame):
-        msg = 'persistent connection idle timeout triggered, timeout value is %s secs.\nFor more details refer %s' %\
-              (self.connection.get_option('persistent_connect_timeout'), TIMEOUT_TROUBLESHOOT_URL)
+        msg = 'persistent connection idle timeout triggered, timeout value is %s secs.\nSee the timeout setting options in the Network Debug and ' \
+              'Troubleshooting Guide.' % self.connection.get_option('persistent_connect_timeout')
         display.display(msg, log_only=True)
         raise Exception(msg)
 
     def command_timeout(self, signum, frame):
-        msg = 'command timeout triggered, timeout value is %s secs.\nFor more details refer %s' %\
-              (self.connection.get_option('persistent_command_timeout'), TIMEOUT_TROUBLESHOOT_URL)
+        msg = 'command timeout triggered, timeout value is %s secs.\nSee the timeout setting options in the Network Debug and Troubleshooting Guide.'\
+              % self.connection.get_option('persistent_command_timeout')
         display.display(msg, log_only=True)
         raise Exception(msg)
 
     def handler(self, signum, frame):
-        msg = 'signal handler called with signal %s.\nFor more details refer %s' % (signum, TIMEOUT_TROUBLESHOOT_URL)
+        msg = 'signal handler called with signal %s.' % signum
         display.display(msg, log_only=True)
         raise Exception(msg)
 

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -35,6 +35,8 @@ from ansible.utils.path import unfrackpath, makedirs_safe
 from ansible.utils.display import Display
 from ansible.utils.jsonrpc import JsonRpcServer
 
+TIMEOUT_TROUBLESHOOT_URL = "https://docs.ansible.com/ansible/latest/network/user_guide/network_debug_troubleshooting.html#timeout-issues"
+
 
 @contextmanager
 def file_lock(lock_path):
@@ -144,17 +146,19 @@ class ConnectionProcess(object):
             self.shutdown()
 
     def connect_timeout(self, signum, frame):
-        msg = 'persistent connection idle timeout triggered, timeout value is %s secs' % self.connection.get_option('persistent_connect_timeout')
+        msg = 'persistent connection idle timeout triggered, timeout value is %s secs.\nFor more details refer %s' %\
+              (self.connection.get_option('persistent_connect_timeout'), TIMEOUT_TROUBLESHOOT_URL)
         display.display(msg, log_only=True)
         raise Exception(msg)
 
     def command_timeout(self, signum, frame):
-        msg = 'command timeout triggered, timeout value is %s secs' % self.connection.get_option('persistent_command_timeout')
+        msg = 'command timeout triggered, timeout value is %s secs.\nFor more details refer %s' %\
+              (self.connection.get_option('persistent_command_timeout'), TIMEOUT_TROUBLESHOOT_URL)
         display.display(msg, log_only=True)
         raise Exception(msg)
 
     def handler(self, signum, frame):
-        msg = 'signal handler called with signal %s' % signum
+        msg = 'signal handler called with signal %s.\nFor more details refer %s' % (signum, TIMEOUT_TROUBLESHOOT_URL)
         display.display(msg, log_only=True)
         raise Exception(msg)
 

--- a/lib/ansible/module_utils/connection.py
+++ b/lib/ansible/module_utils/connection.py
@@ -111,10 +111,9 @@ class Connection(object):
         req = request_builder(name, *args, **kwargs)
         reqid = req['id']
 
-        troubleshoot = 'https://docs.ansible.com/ansible/latest/network/user_guide/network_debug_troubleshooting.html#category-socket-path-issue'
-
         if not os.path.exists(self.socket_path):
-            raise ConnectionError('socket_path does not exist or cannot be found. Please check %s' % troubleshoot)
+            raise ConnectionError('socket_path does not exist or cannot be found.'
+                                  '\nSee the socket_path issue catergory in Network Debug and Troubleshooting Guide')
 
         try:
             data = json.dumps(req)
@@ -122,8 +121,8 @@ class Connection(object):
             response = json.loads(out)
 
         except socket.error as e:
-            raise ConnectionError('unable to connect to socket. Please check %s' % troubleshoot, err=to_text(e, errors='surrogate_then_replace'),
-                                  exception=traceback.format_exc())
+            raise ConnectionError('unable to connect to socket. See the socket_path issue catergory in Network Debug and Troubleshooting Guide',
+                                  err=to_text(e, errors='surrogate_then_replace'), exception=traceback.format_exc())
 
         if response['id'] != reqid:
             raise ConnectionError('invalid json-rpc id received')


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #43076

If persistent connection timeout is triggered, riase
exception which will be send over socket to module code
instead of silently shutting down the socket.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bin/ansible-connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
ok: [ios] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "auth_pass": null,
            "authorize": null,
            "commands": [
                "show running-config all"
            ],
            "host": null,
            "interval": 1,
            "match": "all",
            "password": null,
            "port": null,
            "provider": null,
            "retries": 10,
            "ssh_keyfile": null,
            "timeout": null,
            "username": null,
            "wait_for": null
        }
    },
    "stdout": [
        "None"
    ],
    "stdout_lines": [
        [
            "None"
        ]
    ]
}
```
After:
```
[ios]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/8l/27cd4l3n2vnc2cpk3498__680000gn/T/ansible_BoEKEj/ansible_module_ios_command.py\", line 247, in <module>\n    main()\n  File \"/var/folders/8l/27cd4l3n2vnc2cpk3498__680000gn/T/ansible_BoEKEj/ansible_module_ios_command.py\", line 217, in main\n    responses = run_commands(module, commands)\n  File \"/var/folders/8l/27cd4l3n2vnc2cpk3498__680000gn/T/ansible_BoEKEj/ansible_modlib.zip/ansible/module_utils/network/ios/ios.py\", line 125, in run_commands\n  File \"/var/folders/8l/27cd4l3n2vnc2cpk3498__680000gn/T/ansible_BoEKEj/ansible_modlib.zip/ansible/module_utils/connection.py\", line 149, in __rpc__\nansible.module_utils.connection.ConnectionError: command timeout triggered, timeout value is 1 secs\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 1
}
```
