### PR TITLE
Let called functions use `method` keyword

### DIFF
--- a/lib/ansible/module_utils/connection.py
+++ b/lib/ansible/module_utils/connection.py
@@ -72,9 +72,9 @@ def exec_command(module, command):
     return 0, out, ''
 
 
-def request_builder(method, *args, **kwargs):
+def request_builder(method_, *args, **kwargs):
     reqid = str(uuid.uuid4())
-    req = {'jsonrpc': '2.0', 'method': method, 'id': reqid}
+    req = {'jsonrpc': '2.0', 'method': method_, 'id': reqid}
 
     params = args or kwargs or None
     if params:

--- a/lib/ansible/plugins/action/asa.py
+++ b/lib/ansible/plugins/action/asa.py
@@ -27,7 +27,6 @@ from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network.asa.asa import asa_provider_spec
 from ansible.module_utils.network.common.utils import load_provider
-from ansible.module_utils.connection import request_builder
 
 
 try:


### PR DESCRIPTION
Hopefully we can live without `method_` instead

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
network

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```
