### PR TITLE
Fixed incompatible unicode and int comparison in zabbix_host module w…

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -396,7 +396,7 @@ class Host(object):
         if len(proxy_list) < 1:
             self._module.fail_json(msg="Proxy not found: %s" % proxy_name)
         else:
-            return proxy_list[0]['proxyid']
+            return int(proxy_list[0]['proxyid'])
 
     # get group ids by group names
     def get_group_ids_by_group_names(self, group_names):
@@ -763,7 +763,7 @@ def main():
 
         # If proxy is not specified as a module parameter, use the existing setting
         if proxy is None:
-            proxy_id = zabbix_host_obj['proxy_hostid']
+            proxy_id = int(zabbix_host_obj['proxy_hostid'])
 
         if state == "absent":
             # remove host


### PR DESCRIPTION
…hen using proxy option

##### SUMMARY
zabbix_host module ignores comparison restrictions enforced in Python 3. It tries to compare unicode string (returned from zabbix-api) with integer. This action results in error when ansible is used with Python 3:

```python3
The full traceback is:
  File "/tmp/user/0/ansible_1uuzvwdi/ansible_module_zabbix_host.py", line 324, in update_host
    if proxy_id >= 0:

"'>=' not supported between instances of 'str' and 'int'"
```



Fixes #42617

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
zabbix_host

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (zabbix-host-py3-comparison-fix 3272188170) last updated 2018/07/20 16:14:19 (GMT +200)
  config file = None
  configured module search path = [u'/home/dusan.matejka/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/dusan.matejka/projects/ansible/ansible-upstream/lib/ansible
  executable location = /home/dusan.matejka/projects/ansible/ansible-upstream/bin/ansible
  python version = 2.7.14 (default, Oct 31 2017, 21:12:13) [GCC 6.4.0]
```