### PR TITLE
Revert "dnf: Call dnf.Base.close() before exit to cleanup. (#41810)"

### DIFF
--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -287,7 +287,6 @@ def list_items(module, base, command):
         packages = dnf.subject.Subject(command).get_best_query(base.sack)
         results = [_package_dict(package) for package in packages]
 
-    base.close()
     module.exit_json(results=results)
 
 
@@ -296,7 +295,6 @@ def _mark_package_install(module, base, pkg_spec):
     try:
         base.install(pkg_spec)
     except dnf.exceptions.MarkingError:
-        base.close()
         module.fail_json(msg="No package {0} available.".format(pkg_spec))
 
 
@@ -355,7 +353,6 @@ def ensure(module, base, state, names, autoremove):
                 if environment:
                     environments.append(environment.id)
                 else:
-                    base.close()
                     module.fail_json(
                         msg="No group {0} available.".format(group_spec))
 
@@ -422,7 +419,6 @@ def ensure(module, base, state, names, autoremove):
                 base.conf.clean_requirements_on_remove = autoremove
 
             if filenames:
-                base.close()
                 module.fail_json(
                     msg="Cannot remove paths -- please specify package name.")
 
@@ -454,20 +450,16 @@ def ensure(module, base, state, names, autoremove):
 
     if not base.resolve(allow_erasing=allow_erasing):
         if failures:
-            base.close()
             module.fail_json(msg='Failed to install some of the '
                                  'specified packages',
                              failures=failures)
-        base.close()
         module.exit_json(msg="Nothing to do")
     else:
         if module.check_mode:
             if failures:
-                base.close()
                 module.fail_json(msg='Failed to install some of the '
                                      'specified packages',
                                  failures=failures)
-            base.close()
             module.exit_json(changed=True)
 
         base.download_packages(base.transaction.install_set)
@@ -479,11 +471,9 @@ def ensure(module, base, state, names, autoremove):
             response['results'].append("Removed: {0}".format(package))
 
         if failures:
-            base.close()
             module.fail_json(msg='Failed to install some of the '
                                  'specified packages',
                              failures=failures)
-        base.close()
         module.exit_json(**response)
 
 


### PR DESCRIPTION
This reverts commit 32436ea9a529841c1f8196dcd28e752c1888f5aa.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The previously merged commit 32436ea9a529841c1f8196dcd28e752c1888f5aa turned out to have unintended and unknown side effects at the time it was merged. It turns out that by closing the base dnf object we cause certain references to state and configuration information to be dereferenced from the `result`, which changes the behavior of the module.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
dnf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (modules/dnf cdca9627f1) last updated 2018/07/20 14:36:54 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


