### PR TITLE
elb_application_lb purge rules option

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -448,7 +448,7 @@ def create_or_update_elb(elb_obj):
             rules_to_add, rules_to_modify, rules_to_delete = rules_obj.compare_rules()
 
             # Delete rules
-            if not elb_obj.module.params['purge_rules']:
+            if elb_obj.module.params['purge_rules']:
                 for rule in rules_to_delete:
                     rule_obj = ELBListenerRule(elb_obj.connection, elb_obj.module, {'RuleArn': rule}, rules_obj.listener_arn)
                     rule_obj.delete()
@@ -530,7 +530,7 @@ def main():
             tags=dict(type='dict'),
             wait_timeout=dict(type='int'),
             wait=dict(default=False, type='bool'),
-            purge_rules=dict(default=False, type='bool')
+            purge_rules=dict(default=True, type='bool')
         )
     )
 

--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -121,7 +121,7 @@ options:
     version_added: 2.6
   purge_rules:
     description:
-      - Keeps the existing load balancer rules in place. Will modify and add, but will not delete.
+      - When set to no, keep the existing load balancer rules in place. Will modify and add, but will not delete.
     default: yes
     type: bool
     version_added: 2.7

--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -119,7 +119,7 @@ options:
     description:
       - The time in seconds to use in conjunction with I(wait).
     version_added: 2.6
-  keep_rules:
+  purge_rules:
     description:
       - Keeps the existing load balancer rules in place. Will modify and add, but will not delete.
     version_added: 2.7
@@ -448,7 +448,7 @@ def create_or_update_elb(elb_obj):
             rules_to_add, rules_to_modify, rules_to_delete = rules_obj.compare_rules()
 
             # Delete rules
-            if not elb_obj.module.params['keep_rules']:
+            if not elb_obj.module.params['purge_rules']:
                 for rule in rules_to_delete:
                     rule_obj = ELBListenerRule(elb_obj.connection, elb_obj.module, {'RuleArn': rule}, rules_obj.listener_arn)
                     rule_obj.delete()
@@ -530,7 +530,7 @@ def main():
             tags=dict(type='dict'),
             wait_timeout=dict(type='int'),
             wait=dict(default=False, type='bool'),
-            keep_rules=dict(default=False, type='bool')
+            purge_rules=dict(default=False, type='bool')
         )
     )
 

--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -122,6 +122,8 @@ options:
   purge_rules:
     description:
       - Keeps the existing load balancer rules in place. Will modify and add, but will not delete.
+    default: yes
+    type: bool
     version_added: 2.7
 extends_documentation_fragment:
     - aws

--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -448,7 +448,7 @@ def create_or_update_elb(elb_obj):
             rules_to_add, rules_to_modify, rules_to_delete = rules_obj.compare_rules()
 
             # Delete rules
-            if not elb_obj.module.params['purge_rules']:
+            if elb_obj.module.params['purge_rules']:
                 for rule in rules_to_delete:
                     rule_obj = ELBListenerRule(elb_obj.connection, elb_obj.module, {'RuleArn': rule}, rules_obj.listener_arn)
                     rule_obj.delete()

--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -448,7 +448,7 @@ def create_or_update_elb(elb_obj):
             rules_to_add, rules_to_modify, rules_to_delete = rules_obj.compare_rules()
 
             # Delete rules
-            if elb_obj.module.params['purge_rules']:
+            if not elb_obj.module.params['purge_rules']:
                 for rule in rules_to_delete:
                     rule_obj = ELBListenerRule(elb_obj.connection, elb_obj.module, {'RuleArn': rule}, rules_obj.listener_arn)
                     rule_obj.delete()

--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -119,6 +119,10 @@ options:
     description:
       - The time in seconds to use in conjunction with I(wait).
     version_added: 2.6
+  keep_rules:
+    description:
+      - Keeps the existing load balancer rules in place. Will modify and add, but will not delete.
+    version_added: 2.7
 extends_documentation_fragment:
     - aws
     - ec2
@@ -444,10 +448,11 @@ def create_or_update_elb(elb_obj):
             rules_to_add, rules_to_modify, rules_to_delete = rules_obj.compare_rules()
 
             # Delete rules
-            for rule in rules_to_delete:
-                rule_obj = ELBListenerRule(elb_obj.connection, elb_obj.module, {'RuleArn': rule}, rules_obj.listener_arn)
-                rule_obj.delete()
-                elb_obj.changed = True
+            if not elb_obj.module.params['keep_rules']:
+                for rule in rules_to_delete:
+                    rule_obj = ELBListenerRule(elb_obj.connection, elb_obj.module, {'RuleArn': rule}, rules_obj.listener_arn)
+                    rule_obj.delete()
+                    elb_obj.changed = True
 
             # Add rules
             for rule in rules_to_add:
@@ -524,7 +529,8 @@ def main():
             state=dict(choices=['present', 'absent'], type='str'),
             tags=dict(type='dict'),
             wait_timeout=dict(type='int'),
-            wait=dict(default=False, type='bool')
+            wait=dict(default=False, type='bool'),
+            keep_rules=dict(default=False, type='bool')
         )
     )
 

--- a/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
+++ b/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
@@ -94,7 +94,7 @@
       subnets: "{{ alb_subnets }}"
       security_groups: "{{ sec_group.group_id }}"
       state: present
-      purge_rules: no
+      purge_listeners: no
       listeners:
         - Protocol: HTTP
           Port: 80

--- a/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
+++ b/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
@@ -88,7 +88,7 @@
         - not alb.changed
         - alb.listeners[0].rules|length == 2
 
-  - name: test a rule can be added and other rules will not be removed when purge_rules is no
+  - name: test a rule can be added and other rules will not be removed when purge_rules is no.
     elb_application_lb:
       name: "{{ alb_name }}"
       subnets: "{{ alb_subnets }}"

--- a/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
+++ b/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
@@ -94,7 +94,7 @@
       subnets: "{{ alb_subnets }}"
       security_groups: "{{ sec_group.group_id }}"
       state: present
-      purge_listeners: no
+      purge_rules: no
       listeners:
         - Protocol: HTTP
           Port: 80

--- a/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
+++ b/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
@@ -88,13 +88,13 @@
         - not alb.changed
         - alb.listeners[0].rules|length == 2
 
-  - name: test a rule can be added and other rules will not be removed without purge_listeners
+  - name: test a rule can be added and other rules will not be removed when purge_rules is no
     elb_application_lb:
       name: "{{ alb_name }}"
       subnets: "{{ alb_subnets }}"
       security_groups: "{{ sec_group.group_id }}"
       state: present
-      purge_rules: no
+      purge_listeners: no
       listeners:
         - Protocol: HTTP
           Port: 80

--- a/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
+++ b/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
@@ -88,6 +88,36 @@
         - not alb.changed
         - alb.listeners[0].rules|length == 2
 
+  - name: test a rule can be added and other rules will not be removed without purge_listeners
+    elb_application_lb:
+      name: "{{ alb_name }}"
+      subnets: "{{ alb_subnets }}"
+      security_groups: "{{ sec_group.group_id }}"
+      state: present
+      purge_rules: no
+      listeners:
+        - Protocol: HTTP
+          Port: 80
+          DefaultActions:
+            - Type: forward
+              TargetGroupName: "{{ tg_name }}"
+          Rules:
+            - Conditions:
+                - Field: path-pattern
+                  Values:
+                    - '/new'
+              Priority: '2'
+              Actions:
+                - TargetGroupName: "{{ tg_name }}"
+                  Type: forward
+      <<: *aws_connection_info
+    register: alb
+
+  - assert:
+      that:
+        - alb.changed
+        - alb.listeners[0].rules|length == 3
+
   - name: remove the rule
     elb_application_lb:
       name: "{{ alb_name }}"


### PR DESCRIPTION
##### SUMMARY
Adds the ability to leave existing rules in place on an ELB.
Fixes #43109

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_application_lb

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (detached HEAD f6160c675d) last updated 2018/07/20 18:28:16 (GMT +000)
  config file = /home/vagrant/.ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible
  python version = 2.7.15 (default, May  9 2018, 11:32:33) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
```

