### PR TITLE
win_wait_for: add a bit more stability to the tests

### DIFF
--- a/test/integration/targets/win_wait_for/tasks/main.yml
+++ b/test/integration/targets/win_wait_for/tasks/main.yml
@@ -272,6 +272,12 @@
     that:
     - wait_for_port_already_started.wait_attempts == 1
 
+# add a manual wait to make sure the port is truly offline for next test
+- name: wait for port to be offline
+  win_wait_for:
+    port: '{{test_win_wait_for_port}}'
+    state: stopped
+
 - name: wait for port that is already offline
   win_wait_for:
     port: '{{test_win_wait_for_port}}'


### PR DESCRIPTION
##### SUMMARY
This adds an extra step to make sure the port is truly offline before testing win_wait_for on a port that is offline before it starts so it returns immediately.

##### ISSUE TYPE
 - Test Pull Request

##### COMPONENT NAME
win_wait_for

##### ANSIBLE VERSION
```
devel
```