### PR TITLE
Don't get host list for ansible-playbook syntax check

### DIFF
--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -109,7 +109,8 @@ class PlaybookCLI(CLI):
         # limit if only implicit localhost was in inventory to start with.
         #
         # Fix this when we rewrite inventory by making localhost a real host (and thus show up in list_hosts())
-        hosts = CLI.get_host_list(inventory, self.options.subset)
+        if not self.options.syntax:
+            hosts = CLI.get_host_list(inventory, self.options.subset)
 
         # flush fact cache if requested
         if self.options.flush_cache:


### PR DESCRIPTION
##### SUMMARY

The ansible-playbook `--syntax-check` doesn't take host association into
account, but rather checks the full playbook, no matter what.

The most immediate/practical benefit of this change is not having to
provide a (dummy) inventory file to get rid of the "provided hosts
list is empty..." warning.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
syntax-check

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel b02e0c07d8) last updated 2018/07/21 09:55:30 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/labs/ansible/devel/lib/ansible
  executable location = /home/andreas/labs/ansible/devel/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```