### PR TITLE
Detect failed sysvinit module

### DIFF
--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -310,8 +310,8 @@ def main():
                 (rc, out, err) = module.run_command(cmd)
             # FIXME: ERRORS
 
-            if rc != 0:
-                module.fail_json(msg="Failed to %s service: %s" % (action, name))
+            if err != "":
+                module.fail_json(msg="Failed to %s service: %s" % (action, name), rc=rc, out=out, err=err)
 
             return (rc, out, err)
 

--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -310,8 +310,8 @@ def main():
                 (rc, out, err) = module.run_command(cmd)
             # FIXME: ERRORS
 
-            if err != "":
-                module.fail_json(msg="Failed to %s service: %s" % (action, name), rc=rc, out=out, err=err)
+            if rc != 0:
+                module.fail_json(msg="Failed to %s service: %s" % (action, name), rc=rc, stdout=out, stderr=err)
 
             return (rc, out, err)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The rationale for this change was to close #42957

- This checks the stderr instead of the rc to detect whether the
  sysvinit module was successful or not, as even when failing, the
  rc would be 0.

- It immediatly became obvious that the debug info when failing
  was far too little to properly debug the role. To improve this,
  I also added the rc, stderr and stdout to the debug output.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #42957
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
`sysvinit` (module)

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (detect-failed-sysvinit 0f49244c8b) last updated 2018/07/22 12:28:39 (GMT +200)
  config file = None
  configured module search path = ['/home/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/documents/programming/ansible/lib/ansible
  executable location = /home/user/.venv/bin/ansible
  python version = 3.6.6 (default, Jun 27 2018, 13:11:40) [GCC 8.1.1 20180531]
```

