### PR TITLE
Allow to use task retries without until block

### DIFF
--- a/docs/docsite/keyword_desc.yml
+++ b/docs/docsite/keyword_desc.yml
@@ -57,7 +57,7 @@ pre_tasks: A list of tasks to execute before :term:`roles`.
 remote_user: User used to log into the target via the connection plugin.
 register: Name of variable that will contain task status and module return data.
 rescue: List of tasks in a :term:`block` that run if there is a task error in the main :term:`block` list.
-retries: "Number of retries before giving up in a :term:`until` loop. This setting is only used in combination with :term:`until`."
+retries: "Number of retries before giving up on a failure. Can be used with :term:`until` or :term:`failed_when` to change failure condition."
 roles: List of roles to be imported into the play
 run_once: Boolean that will bypass the host loop, forcing the task to attempt to execute on the first host available and afterwards apply any results and facts to all active hosts in the same batch.
 serial: |

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -82,7 +82,7 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
     _notify = FieldAttribute(isa='list')
     _poll = FieldAttribute(isa='int', default=C.DEFAULT_POLL_INTERVAL)
     _register = FieldAttribute(isa='string', static=True)
-    _retries = FieldAttribute(isa='int', default=3)
+    _retries = FieldAttribute(isa='int')
     _until = FieldAttribute(isa='list', default=list)
 
     # deprecated, used to be loop and loop_args but loop has been repurposed

--- a/test/integration/targets/until/tasks/main.yml
+++ b/test/integration/targets/until/tasks/main.yml
@@ -1,8 +1,8 @@
-- shell: '{{ ansible_python.executable }} -c "import tempfile; print(tempfile.mkstemp()[1])"'
+- tempfile:
   register: tempfilepath
 
 - set_fact:
-    until_tempfile_path: "{{ tempfilepath.stdout }}"
+    until_tempfile_path: "{{ tempfilepath.path }}"
 
 - name: loop with default retries
   shell: echo "run" >> {{ until_tempfile_path }} && wc -w < {{ until_tempfile_path }} | tr -d ' '
@@ -32,6 +32,31 @@
 - file:
     path: "{{ until_tempfile_path }}"
     state: absent
+
+- name: Test retries without until
+  shell: echo "run" >> {{ until_tempfile_path }}; false
+  retries: 3
+  delay: 0.01
+  ignore_errors: true
+
+- name: validate output
+  shell: wc -l < {{ until_tempfile_path }}
+  register: runcount
+
+- assert:
+    that: runcount.stdout | int == 4 # initial + 3 retries
+
+- name: Test retries with failed_when without until
+  shell: 'true'
+  register: failed_when_retries
+  failed_when: True
+  retries: 3
+  delay: 0.01
+  ignore_errors: true
+
+- assert:
+    that:
+      - failed_when_retries.attempts == 3
 
 - name: Test failed_when impacting until
   shell: 'true'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This change will make task retries work without having an `until` block. This is useful in situations when you are not interested in the output value and/or you simply want to retry on a failure. This allows you to omit `register` and `until` parameters and makes the task easier to read.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
core engine

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (task-retries 7dda294680) last updated 2018/07/22 11:26:54 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/kerny/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/kerny/dev/github/ansible/lib/ansible
  executable location = /home/kerny/dev/github/ansible/bin/ansible
  python version = 3.6.6 (default, Jun 27 2018, 13:11:40) [GCC 8.1.1 20180531]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
The change will allow you to simplify:
```
    - name: Retry URL call up to five times until we get 200 status code
      uri:
         url: https://httpbin.org/status/200
      register: out
      until: out is successful
      retries: 5
```
into:
```
    - name: Retry URL call up to five times until we get 200 status code
      uri:
         url: https://httpbin.org/status/200
      retries: 5
```

This PR also fixes a small bug (inconsistency) whereby having `retries: ` without a value defaults to 2 retries instead of 3.
