### PR TITLE
Allow adhoc to execute includes and imports

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -134,10 +134,6 @@ class AdHocCLI(CLI):
                 err = err + ' (did you mean to run ansible-playbook?)'
             raise AnsibleOptionsError(err)
 
-        # Avoid modules that don't work with ad-hoc
-        if self.options.module_name.startswith(('include', 'import_')):
-            raise AnsibleOptionsError("'%s' is not a valid action for ad-hoc commands" % self.options.module_name)
-
         play_ds = self._play_ds(pattern, self.options.seconds, self.options.poll_interval)
         play = Play().load(play_ds, variable_manager=variable_manager, loader=loader)
 


### PR DESCRIPTION
##### SUMMARY
Allow adhoc to execute includes and imports

I thought I submitted this a while ago, but seem not to have done so.

Addresses https://github.com/ansible/proposals/issues/131

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/cli/adhoc.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
include_tasks:

```
$ ansible localhost -m include_tasks -a include_me.yml
localhost | SUCCESS => {
    "changed": false,
    "include": "include_me.yml",
    "include_variables": {}
}
localhost | SUCCESS => {
    "msg": "here"
}
```

import_tasks:

```
$ ansible localhost -m import_tasks -a include_me.yml
localhost | SUCCESS => {
    "msg": "here"
}
```

include_role:
```
$ ansible localhost -m include_role -a name=bob
localhost | SUCCESS => {
    "changed": false,
    "include_variables": {
        "name": "bob"
    }
}
localhost | SUCCESS => {
    "msg": "bob"
}
```

import_role:

```
$ ansible localhost -m import_role -a name=bob
localhost | SUCCESS => {
    "msg": "bob"
}
```