### PR TITLE
powershell: support recursive requires statements

### DIFF
--- a/test/integration/targets/win_module_utils/library/recursive_requires.ps1
+++ b/test/integration/targets/win_module_utils/library/recursive_requires.ps1
@@ -1,0 +1,13 @@
+#!powershell
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+#Requires -Module Ansible.ModuleUtils.Recursive3
+#Requires -Version 2
+
+$ErrorActionPreference = "Stop"
+
+$result = @{
+    changed = $false
+    value = Get-Test3
+}
+Exit-Json -obj $result

--- a/test/integration/targets/win_module_utils/module_utils/Ansible.ModuleUtils.Recursive1.psm1
+++ b/test/integration/targets/win_module_utils/module_utils/Ansible.ModuleUtils.Recursive1.psm1
@@ -1,0 +1,9 @@
+Function Get-Test1 {
+    <#
+    .SYNOPSIS
+    Test function
+    #>
+    return "Get-Test1"
+}
+
+Export-ModuleMember -Function Get-Test1

--- a/test/integration/targets/win_module_utils/module_utils/Ansible.ModuleUtils.Recursive2.psm1
+++ b/test/integration/targets/win_module_utils/module_utils/Ansible.ModuleUtils.Recursive2.psm1
@@ -1,0 +1,12 @@
+#Requires -Module Ansible.ModuleUtils.Recursive1
+#Requires -Module Ansible.ModuleUtils.Recursive3
+
+Function Get-Test2 {
+    <#
+    .SYNOPSIS
+    Test function
+    #>
+    return "Get-Test2, 1: $(Get-Test1), 3: $(Get-NewTest3)"
+}
+
+Export-ModuleMember -Function Get-Test2

--- a/test/integration/targets/win_module_utils/module_utils/Ansible.ModuleUtils.Recursive3.psm1
+++ b/test/integration/targets/win_module_utils/module_utils/Ansible.ModuleUtils.Recursive3.psm1
@@ -1,0 +1,20 @@
+#Requires -Module Ansible.ModuleUtils.Recursive2
+#Requires -Version 3.0
+
+Function Get-Test3 {
+    <#
+    .SYNOPSIS
+    Test function
+    #>
+    return "Get-Test3: 2: $(Get-Test2)"
+}
+
+Function Get-NewTest3 {
+    <#
+    .SYNOPSIS
+    Test function
+    #>
+    return "Get-NewTest3"
+}
+
+Export-ModuleMember -Function Get-Test3, Get-NewTest3

--- a/test/integration/targets/win_module_utils/tasks/main.yml
+++ b/test/integration/targets/win_module_utils/tasks/main.yml
@@ -48,6 +48,14 @@
     - bogus_utils is failed
     - bogus_utils.msg is search("Could not find")
 
+- name: call module that imports module_utils with further imports
+  recursive_requires:
+  register: recursive_requires
+
+- assert:
+    that:
+    - 'recursive_requires.value == "Get-Test3: 2: Get-Test2, 1: Get-Test1, 3: Get-NewTest3"'
+
 - name: call module with camel conversion tests
   camel_conversion_test:
   register: camel_conversion


### PR DESCRIPTION
##### SUMMARY
Support recursive module utils imports in PowerShell. This allows a module util in PowerShell to reference another one. Nothing uses this right now but I plan on utilising this for the long path support in PowerShell.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_common

##### ANSIBLE VERSION
```
devel
```