### PR TITLE
[WIP] interfaces_file: Fix potential bad entry

### DIFF
--- a/lib/ansible/modules/system/interfaces_file.py
+++ b/lib/ansible/modules/system/interfaces_file.py
@@ -137,6 +137,7 @@ EXAMPLES = '''
 '''
 
 import os
+import platform
 import re
 import tempfile
 
@@ -194,6 +195,9 @@ def read_interfaces_lines(module, line_strings):
             lines.append(lineDict(line))
             currently_processing = "NONE"
         elif words[0] == "source-directory":
+            os_infos = platform.dist()
+            if os_infos[0] == 'Ubuntu' and os_infos[1] >= '16.04':
+                line = re.sub(r'^source-directory\s(.*)', 'source \\1/*', line)
             lines.append(lineDict(line))
             currently_processing = "NONE"
         elif words[0] == "iface":

--- a/test/units/modules/system/interfaces_file/test_interfaces_file.py
+++ b/test/units/modules/system/interfaces_file/test_interfaces_file.py
@@ -220,3 +220,11 @@ class TestInterfacesFileModule(unittest.TestCase):
                 self.compareInterfacesToFile(ifaces, testfile, "%s_%s.json" % (testfile, testname))
                 # Restore backup
                 move(backupp, path)
+
+    def test_fix_sourcedir(self):
+        for testfile in self.getTestFiles():
+            path = os.path.join(fixture_path, testfile)
+            lines, ifaces = interfaces_file.read_interfaces_file(module, path)
+            # self.compareInterfacesLinesToFile(lines, testfile)
+            # self.compareInterfacesToFile(ifaces, testfile)
+        self.assertTrue(len([]) == 1)


### PR DESCRIPTION
##### SUMMARY

According to http://bit.ly/2HA4oDO and
the official Ubuntu manual
http://manpages.ubuntu.com/manpages/xenial/man5/interfaces.5.html
source-dir support has been removed from Ubuntu >= 16.04/Xenial

this fixes automatically transform such buggy lines into proper ones

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
interfaces_file

##### ANSIBLE VERSION
```
ansible 2.6.0 (work e2aa1155ba) last updated 2018/04/19 09:51:12 (GMT +200)
  config file = None
  configured module search path = [u'/Users/olivierbourdon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/olivierbourdon/Documents/WORK/OpenNext/TECH/CODE/ANSIBLE/0-REF-ansible/lib/ansible
  executable location = /Users/olivierbourdon/Documents/WORK/OpenNext/TECH/CODE/ANSIBLE/0-REF-ansible/bin/ansible
  python version = 2.7.14 (default, Sep 22 2017, 00:06:07) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```

##### ADDITIONAL INFORMATION

Before:
```
source-directory /etc/network/interfaces.d
```

After:
```
source /etc/network/interfaces.d/*
```