### PR TITLE
fix ip address tokenization bug in eos_static_route module

### DIFF
--- a/lib/ansible/modules/network/eos/eos_static_route.py
+++ b/lib/ansible/modules/network/eos/eos_static_route.py
@@ -162,13 +162,13 @@ def map_config_to_obj(module):
         lines = out.splitlines()
         for line in lines:
             obj = {}
-            add_match = re.search(r'ip route (\S+)', line, re.M)
+            add_match = re.search(r'ip route ([\d\./]+)', line, re.M)
             if add_match:
                 address = add_match.group(1)
                 if is_address(address):
                     obj['address'] = address
 
-                hop_match = re.search(r'ip route {0} (\S+)'.format(address), line, re.M)
+                hop_match = re.search(r'ip route {0} ([\d\./]+)'.format(address), line, re.M)
                 if hop_match:
                     hop = hop_match.group(1)
                     if is_hop(hop):


### PR DESCRIPTION
##### SUMMARY
Changed ip subnet matching regex in module eos_static_route to fix issue with VRF-associated routes not being parsed correctly.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
eos_static_route module

##### ANSIBLE VERSION
```
  config file = /home/xxx/.ansible.cfg
  configured module search path = [u'/home/xxx/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/xxx/.venv/ansible/lib/python2.7/site-packages/ansible
  executable location = /home/xxx/.venv/ansible/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```


##### ADDITIONAL INFORMATION
Tokenization of ip static route commands in the map_config_to_obj function in the eos_static_route module fail and raise an IndexError exception if the device has VRF's with static routes configured (e.g., ip route vrf FOO 1.2.3.4/24 5.6.7.8). The tokenization expression was changed to match only characters that appear in a valid IP/CIDR mask string, which will cause static routes associated with VRF's to be ignored.

```
before:

{
    "_ansible_parsed": false,
    "exception": "Traceback (most recent call last):\n  File \"/tmp/ansible_m2i_hN/ansible_module_eos_static_route.py\", line 253, in <module>\n    main()\n  File \"/tmp/ansible_m2i_hN/ansible_module_eos_static_route.py\", line 238, in main\n    have = map_config_to_obj(module)\n  File \"/tmp/ansible_m2i_hN/ansible_module_eos_static_route.py\", line 168, in map_config_to_obj\n    if is_address(address):\n  File \"/tmp/ansible_m2i_hN/ansible_module_eos_static_route.py\", line 98, in is_address\n    if is_masklen(address[1]) and validate_ip_address(address[0]):\nIndexError: list index out of range\n",
    "changed": false,
    "_ansible_no_log": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_m2i_hN/ansible_module_eos_static_route.py\", line 253, in <module>\n    main()\n  File \"/tmp/ansible_m2i_hN/ansible_module_eos_static_route.py\", line 238, in main\n    have = map_config_to_obj(module)\n  File \"/tmp/ansible_m2i_hN/ansible_module_eos_static_route.py\", line 168, in map_config_to_obj\n    if is_address(address):\n  File \"/tmp/ansible_m2i_hN/ansible_module_eos_static_route.py\", line 98, in is_address\n    if is_masklen(address[1]) and validate_ip_address(address[0]):\nIndexError: list index out of range\n",
    "_ansible_item_result": true,
    "module_stdout": "",
    "item": [
        "x.x.x.x/x",
        "x.x.x.x"
    ],
    "rc": 1,
    "msg": "MODULE FAILURE",
    "_ansible_ignore_errors": null
}

after:

{
    "_ansible_parsed": true,
    "commands": [
        "no ip route x.x.x.x/x x.x.x.x"
    ],
    "changed": true,
    "_ansible_no_log": false,
    "_ansible_item_result": true,
    "item": [
        "x.x.x.x/x",
        "x.x.x.x"
    ],
    "invocation": {
        "module_args": {
            "username": null,
            "authorize": null,
            "ssh_keyfile": null,
            "address": "x.x.x.x/x",
            "auth_pass": null,
            "host": null,
            "admin_distance": 1,
            "state": "absent",
            "next_hop": "x.x.x.x",
            "timeout": null,
            "provider": null,
            "aggregate": null,
            "use_ssl": null,
            "password": null,
            "validate_certs": null,
            "port": null,
            "transport": null
        }
    },
    "session_name": "ansible_1532353971",
    "_ansible_ignore_errors": null
}

```
