### PR TITLE
Fix lvg module read issue with symbolic link on dev

### DIFF
--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -154,10 +154,6 @@ def main():
     elif state == 'present':
         module.fail_json(msg="No physical volumes given.")
 
-    # LVM always uses real paths not symlinks so replace symlinks with actual path
-    for idx, dev in enumerate(dev_list):
-        dev_list[idx] = os.path.realpath(dev)
-
     if state == 'present':
         # check given devices
         for test_dev in dev_list:
@@ -235,7 +231,7 @@ def main():
                     module.fail_json(msg="Refuse to remove non-empty volume group %s without force=yes" % (vg))
 
         # resize VG
-        current_devs = [os.path.realpath(pv['name']) for pv in pvs if pv['vg_name'] == vg]
+        current_devs = [pv['name'] for pv in pvs if pv['vg_name'] == vg]
         devs_to_remove = list(set(current_devs) - set(dev_list))
         devs_to_add = list(set(dev_list) - set(current_devs))
 


### PR DESCRIPTION
Fix #43159

##### SUMMARY
As explained on the issue, the module lvg can't read the physical
volume correctly from a device with a symbolic link if it already
exists. The problem, I guess, is that the comment line 157 of the module
file is wrong. pvcreate uses the "finale" name of the device from udev
rules and not the original one. Example:

Let's assume that I have got a new instance with a secondary EBS volume
named /dev/sdb as a symlink to /dev/nvme1n1. If I want to create a new
physical volume, I should execute that:

```bash
sudo pvcreate /dev/sdb
  Physical volume "/dev/sdb" successfully created.
sudo pvdisplay
  "/dev/sdb" is a new physical volume of "8.00 GiB"
  --- NEW Physical volume ---
  PV Name               /dev/sdb
  VG Name
  PV Size               8.00 GiB
  Allocatable           NO
  PE Size               0
  Total PE              0
  Free PE               0
  Allocated PE          0
  PV UUID               hn17WV-wcKs-0QcT-iqTD-WfbE-22p2-JQm4HQ
```

We can see that the name is still /dev/sdb and not /dev/nvme1n1 in
contrary to the comment. And if the "original" name is used, here is the
result:

```bash
sudo pvcreate /dev/nvme1n1
  Physical volume "/dev/nvme1n1" successfully created.
sudo pvdisplay
  "/dev/sdb" is a new physical volume of "8.00 GiB"
  --- NEW Physical volume ---
  PV Name               /dev/sdb
  VG Name
  PV Size               8.00 GiB
  Allocatable           NO
  PE Size               0
  Total PE              0
  Free PE               0
  Allocated PE          0
  PV UUID               y2UyOK-qey0-rF1A-V0mf-cplg-9nqr-6yQoRd
```

As you can see, the PV name is /dev/sdb instead of /dev/nvme1n1.

So I propose to remove the comment and its associated code to use
directly the name passed by the task. The only problem with that is if
someone uses the /dev/nvme1n1 as device name instead of its symlink, the
issue will be the same. But in both cases, the point is the same if we
change nothing.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
lvg

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (fix-lvg d556e6c79a) last updated 2018/07/23 14:30:28 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/erouan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/erouan/Documents/ansible/lib/ansible
  executable location = /home/erouan/Documents/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```