### PR TITLE
move the TLS detection block of win_uri before creating WebRequest

### DIFF
--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -68,14 +68,14 @@ if ($status_code) {
 }
 
 # Enable TLS1.1/TLS1.2 if they're available but disabled (eg. .NET 4.5)
-$security_protcols = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::SystemDefault
+$security_protocols = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::SystemDefault
 if ([Net.SecurityProtocolType].GetMember("Tls11").Count -gt 0) {
-    $security_protcols = $security_protcols -bor [Net.SecurityProtocolType]::Tls11
+    $security_protocols = $security_protocols -bor [Net.SecurityProtocolType]::Tls11
 }
 if ([Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
-    $security_protcols = $security_protcols -bor [Net.SecurityProtocolType]::Tls12
+    $security_protocols = $security_protocols -bor [Net.SecurityProtocolType]::Tls12
 }
-[Net.ServicePointManager]::SecurityProtocol = $security_protcols
+[Net.ServicePointManager]::SecurityProtocol = $security_protocols
 
 $client = [System.Net.WebRequest]::Create($url)
 $client.Method = $method

--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -67,6 +67,16 @@ if ($status_code) {
     }
 }
 
+# Enable TLS1.1/TLS1.2 if they're available but disabled (eg. .NET 4.5)
+$security_protcols = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::SystemDefault
+if ([Net.SecurityProtocolType].GetMember("Tls11").Count -gt 0) {
+    $security_protcols = $security_protcols -bor [Net.SecurityProtocolType]::Tls11
+}
+if ([Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
+    $security_protcols = $security_protcols -bor [Net.SecurityProtocolType]::Tls12
+}
+[Net.ServicePointManager]::SecurityProtocol = $security_protcols
+
 $client = [System.Net.WebRequest]::Create($url)
 $client.Method = $method
 $client.Timeout = $timeout * 1000
@@ -97,17 +107,6 @@ if ($maximum_redirection -eq 0) {
 if (-not $validate_certs) {
     [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
 }
-
-# Enable TLS1.1/TLS1.2 if they're available but disabled (eg. .NET 4.5)
-$security_protcols = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::SystemDefault
-if ([Net.SecurityProtocolType].GetMember("Tls11").Count -gt 0) {
-    $security_protcols = $security_protcols -bor [Net.SecurityProtocolType]::Tls11
-}
-if ([Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
-    $security_protcols = $security_protcols -bor [Net.SecurityProtocolType]::Tls12
-}
-[Net.ServicePointManager]::SecurityProtocol = $security_protcols
-
 
 if ($null -ne $content_type) {
     $client.ContentType = $content_type


### PR DESCRIPTION
##### SUMMARY
Beginning in .NET 4.7.3, `win_uri` can fail on systems without default configuration for TLS1.2:

> WebException occurred when sending web request: The request was aborted: Could not create SSL/TLS secure channel.

Moving the code that modifies `[Net.ServicePointManager]::SecurityProtocol` _before_ instantiating the `[System.Net.WebRequest]` object seems to fix the issue

To clarify, the .NET versions affected are enumerated with `[System.Diagnostics.FileVersionInfo]::GetVersionInfo("C:\Windows\Microsoft.NET\Framework\v4.0.30319\mscorlib.dll")

```

ProductVersion   FileVersion      FileName
--------------   -----------      --------
4.7.3130.0       4.7.3130.0 bu... C:\Windows\Microsoft.NET\Framework\v4.0.30319\mscorlib.dll

```

and 
```
ProductVersion   FileVersion      FileName
--------------   -----------      --------
4.7.3062.0       4.7.3062.0 bu... C:\Windows\Microsoft.NET\Framework\v4.0.30319\mscorlib.dll
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_uri

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```