### PR TITLE
user - add min and max UID options

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -951,20 +951,18 @@ class FreeBsdUser(User):
         # looking for first lower uid from range
         file_obj = (self.SHADOWFILE, 'r')
 
-        uidminmax = [x for x in range(self.uid_min,self.uid_max+1)]
+        uidminmax = [x for x in range(self.uid_min, self.uid_max)]
         uids = []
         for pwdline in file_obj:
             pwdline = pwdline.strip()
             fields = pwdline.split(":")
             uid = int(fields[2])
 
-            if uid >= uid_min and uid <= uid_max:
+            if uid >= self.uid_min and uid <= self.uid_max:
                             uids.append(uid)
 
         file_obj.close()
-        
         uids.sort()
-
         listoffreeuids = (set(uids) ^ set(uidminmax))
 
         if len(listoffreeuids) > 0:
@@ -1205,9 +1203,6 @@ class OpenBSDUser(User):
     def create_user(self):
         cmd = [self.module.get_bin_path('useradd', True)]
 
-        if self.rawoptions is not None:
-            cmd.append(self.rawoptions)
-
         if self.uid is not None:
             cmd.append('-u')
             cmd.append(self.uid)
@@ -1381,9 +1376,6 @@ class NetBSDUser(User):
 
     def create_user(self):
         cmd = [self.module.get_bin_path('useradd', True)]
-
-        if self.rawoptions is not None:
-            cmd.append(self.rawoptions)
 
         if self.uid is not None:
             cmd.append('-u')
@@ -1577,9 +1569,6 @@ class SunOS(User):
 
     def create_user(self):
         cmd = [self.module.get_bin_path('useradd', True)]
-
-        if self.rawoptions is not None:
-            cmd.append(self.rawoptions)
 
         if self.uid is not None:
             cmd.append('-u')
@@ -2031,7 +2020,6 @@ class DarwinUser(User):
         if self.uid is None:
             self.uid = str(self._get_next_uid(self.system))
 
-
         # Homedir is not created by default
         if self.create_home:
             if self.home is None:
@@ -2140,9 +2128,6 @@ class AIX(User):
 
     def create_user_useradd(self, command_name='useradd'):
         cmd = [self.module.get_bin_path(command_name, True)]
-
-        if self.rawoptions is not None:
-            cmd.append(self.rawoptions)
 
         if self.uid is not None:
             cmd.append('-u')
@@ -2285,9 +2270,6 @@ class HPUX(User):
 
     def create_user(self):
         cmd = ['/usr/sam/lbin/useradd.sam']
-
-        if self.rawoptions is not None:
-            cmd.append(self.rawoptions)
 
         if self.uid is not None:
             cmd.append('-u')
@@ -2462,7 +2444,6 @@ def main():
             expires=dict(type='float'),
             password_lock=dict(type='bool'),
             local=dict(type='bool'),
-            rawoptions=dict(type='str'),
             uid_min=dict(type='int'),
             uid_max=dict(type='int'),
         ),

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1053,8 +1053,11 @@ class FreeBsdUser(User):
             cmd.append(self.comment)
 
         if self.home is not None:
-            if (info[5] != self.home and self.move_home) or (not os.path.exists(self.home) and self.createhome):
+            if (info[5] != self.home and self.move_home) or (not os.path.exists(self.home) and self.create_home):
                 cmd.append('-m')
+            if info[5] != self.home:
+                cmd.append('-d')
+                cmd.append(self.home)
             cmd.append('-d')
             cmd.append(self.home)
 

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -197,11 +197,11 @@ options:
     uid_min:
         description:
             - Minimal UID
-        version_added: "2.6"
+        version_added: "2.7"
     uid_max:
         description:
             - Max UID
-        version_added: "2.6"
+        version_added: "2.7"
 
 '''
 

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1,4 +1,4 @@
-  #!/usr/bin/python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2012, Stephen Fromm <sfromm@gmail.com>

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -949,24 +949,25 @@ class FreeBsdUser(User):
         ]
 
         # looking for first lower uid from range
-        file_obj = (self.SHADOWFILE, 'r')
+        if self.uid_min is not None and self.uid_max is not None:
+          file_obj = (self.SHADOWFILE, 'r')
 
-        uidminmax = [x for x in range(self.uid_min, self.uid_max)]
-        uids = []
-        for pwdline in file_obj:
-            pwdline = pwdline.strip()
-            fields = pwdline.split(":")
-            uid = int(fields[2])
+          uidminmax = [x for x in range(self.uid_min, self.uid_max)]
+          uids = []
+          for pwdline in file_obj:
+              pwdline = pwdline.strip()
+              fields = pwdline.split(":")
+              uid = int(fields[2])
 
-            if uid >= self.uid_min and uid <= self.uid_max:
-                            uids.append(uid)
+              if uid >= self.uid_min and uid <= self.uid_max:
+                              uids.append(uid)
 
-        file_obj.close()
-        uids.sort()
-        listoffreeuids = (set(uids) ^ set(uidminmax))
+          file_obj.close()
+          uids.sort()
+          listoffreeuids = (set(uids) ^ set(uidminmax))
 
-        if len(listoffreeuids) > 0:
-            self.uid = next(iter(listoffreeuids))
+          if len(listoffreeuids) > 0:
+              self.uid = next(iter(listoffreeuids))
 
         if self.uid is not None:
             cmd.append('-u')

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -948,27 +948,6 @@ class FreeBsdUser(User):
             self.name,
         ]
 
-        # looking for first lower uid from range
-        if self.uid_min is not None and self.uid_max is not None:
-          file_obj = (self.SHADOWFILE, 'r')
-
-          uidminmax = [x for x in range(self.uid_min, self.uid_max)]
-          uids = []
-          for pwdline in file_obj:
-              pwdline = pwdline.strip()
-              fields = pwdline.split(":")
-              uid = int(fields[2])
-
-              if uid >= self.uid_min and uid <= self.uid_max:
-                              uids.append(uid)
-
-          file_obj.close()
-          uids.sort()
-          listoffreeuids = (set(uids) ^ set(uidminmax))
-
-          if len(listoffreeuids) > 0:
-              self.uid = next(iter(listoffreeuids))
-
         if self.uid is not None:
             cmd.append('-u')
             cmd.append(self.uid)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+  #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2012, Stephen Fromm <sfromm@gmail.com>
@@ -993,6 +993,8 @@ class FreeBsdUser(User):
             cmd.append('-e')
             cmd.append(time.strftime(self.DATE_FORMAT, self.expires))
 
+        # system cannot be handled currently - should we error if its requested?
+        # create the user
         (rc, out, err) = self.execute_command(cmd)
         if rc is not None and rc != 0:
             self.module.fail_json(name=self.name, msg=err, rc=rc)
@@ -1036,8 +1038,6 @@ class FreeBsdUser(User):
             if info[5] != self.home:
                 cmd.append('-d')
                 cmd.append(self.home)
-            cmd.append('-d')
-            cmd.append(self.home)
 
             if self.skeleton is not None:
                 cmd.append('-k')


### PR DESCRIPTION
##### SUMMARY
New option for module 'user' allow define uid range within new user will be create. This is option can be use in any way, when service/application uid account maybe defined in specific uid range.


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module user
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /home/madej/.ansible.cfg
  configured module search path = [u'/home/madej/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
user module allow define new value: uid_min and uid_max and new user UID will be assigned from this, user defined range. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
