### PR TITLE
Fix win_reboot test and mark win_uri unstable.

### DIFF
--- a/test/integration/targets/win_reboot/tasks/main.yml
+++ b/test/integration/targets/win_reboot/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: make sure win output dir exists
+  win_file:
+    path: "{{win_output_dir}}"
+    state: directory
+
 - name: reboot with defaults
   win_reboot:
 

--- a/test/integration/targets/win_uri/aliases
+++ b/test/integration/targets/win_uri/aliases
@@ -1,1 +1,2 @@
 windows/ci/group3
+unstable


### PR DESCRIPTION
##### SUMMARY

Fix win_reboot test and mark win_uri unstable.

(cherry picked from commit 547f11ad8faf7e35796ed5fcfcc84286107676c5)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

win_reboot and win_uri integration tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1.post0 (win-test-fixes-2.6 ef61e2664b) last updated 2018/07/23 15:31:07 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
