### PR TITLE
Mark win_uri unstable.

### DIFF
--- a/test/integration/targets/win_uri/aliases
+++ b/test/integration/targets/win_uri/aliases
@@ -1,1 +1,2 @@
 windows/ci/group3
+unstable


### PR DESCRIPTION
##### SUMMARY

Mark win_uri unstable.

(cherry picked from commit 547f11ad8faf7e35796ed5fcfcc84286107676c5)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

win_uri integration test

##### ANSIBLE VERSION

```
ansible 2.5.6 (win-test-fixes-2.5 d124fc542f) last updated 2018/07/23 15:33:56 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
