### PR TITLE
slxos_facts: Fix broken IPv6 regex

### DIFF
--- a/lib/ansible/modules/network/slxos/slxos_facts.py
+++ b/lib/ansible/modules/network/slxos/slxos_facts.py
@@ -291,7 +291,7 @@ class Interfaces(FactsBase):
     # Only gets primary IPv6 addresses
     def populate_ipv6_interfaces(self, data):
         interfaces = re.split('=+', data)[1].strip()
-        matches = re.findall(r'(\S+ \S+) +[\w-]+.+\s+([\d:/]+)', interfaces, re.M)
+        matches = re.findall(r'(\S+ \S+) +[\w-]+.+\s+([\w:/]+/\d+)', interfaces, re.M)
         for match in matches:
             interface = match[0]
             self.facts['interfaces'][interface]['ipv6'] = list()


### PR DESCRIPTION
##### SUMMARY

Regex was wrong for matching IPv6 addresses in `slxos_facts`, and only matched numeric addresses.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

`slxos_facts`

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel afb6c1c532) last updated 2018/07/20 20:03:40 (GMT -700)
  config file = /home/extreme/.ansible.cfg
  configured module search path = [u'/home/extreme/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/extreme/ansible/lib/ansible
  executable location = /home/extreme/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

`show ipv6 int brief` output:

```
SLX# show ipv6 int br

Interface                         Vrf                     Status        Protocol
         IPv6-Address
================================================================================
Ve 1000                           b1                      up            down
         fe80::629c:9fff:fecd:1d01/128
Ve 4000                           b2                      up            up
         2001:db8:1:1::1/64
SLX#
```

If those IPv6 addresses were entirely numeric - e.g. 2001::1/64, this worked fine. But given the above output, this was a typical response:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ValueError: need more than 1 value to unpack
fatal: [slx01]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_oyxgE7/ansible_module_slxos_facts.py\", line 457, in <module>\n    main()\n  File \"/tmp/ansible_oyxgE7/ansible_module_slxos_facts.py\", line 443, in main\n    inst.populate()\n  File \"/tmp/ansible_oyxgE7/ansible_module_slxos_facts.py\", line 254, in populate\n    self.populate_ipv6_interfaces(data)\n  File \"/tmp/ansible_oyxgE7/ansible_module_slxos_facts.py\", line 298, in populate_ipv6_interfaces\n    address, masklen = match[1].split('/')\nValueError: need more than 1 value to unpack\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
```

With these changes, this now provides the correct output (truncated):

```json
        "Ve 4000": {
            "bandwidth": null,
            "description": null,
            "duplex": null,
            "ipv4": [],
            "ipv6": [
                {
                    "address": "2001:db8:1:1::1",
                    "masklen": 64
                }
            ],
            "lineprotocol": "up",
            "macaddress": null,
            "mtu": 9018,
            "operstatus": null,
            "type": null
        }
```