### PR TITLE
Update Shippable integration test groups. (#43118)

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
@@ -13,10 +13,11 @@ Tests must be configured to run in exactly one group. This is done by adding the
 
 The following are examples of some of the available groups:
 
-- ``posix/ci/group1``
-- ``windows/ci/group2``
-- ``posix/ci/cloud/group3/azure``
-- ``posix/ci/cloud/group4/aws``
+- ``shippable/posix/group1``
+- ``shippable/windows/group2``
+- ``shippable/azure/group3``
+- ``shippable/aws/group1``
+- ``shippable/cloud/group1``
 
 Groups are used to balance tests across multiple CI jobs to minimize test run time.
 They also improve efficiency by keeping tests with similar requirements running together.

--- a/shippable.yml
+++ b/shippable.yml
@@ -35,6 +35,12 @@ matrix:
     - env: T=windows/2012-R2/3
     - env: T=windows/2016/3
 
+    - env: T=windows/2008/4
+    - env: T=windows/2008-R2/4
+    - env: T=windows/2012/4
+    - env: T=windows/2012-R2/4
+    - env: T=windows/2016/4
+
     - env: T=network
 
     - env: T=osx/10.11/1
@@ -76,20 +82,35 @@ matrix:
     - env: T=linux/ubuntu1604/3
     - env: T=linux/ubuntu1604py3/3
 
-    - env: T=cloud/default/2.7/1
-    - env: T=cloud/default/3.6/1
+    - env: T=aws/2.7/1
+    - env: T=aws/3.6/1
 
-    - env: T=cloud/default/2.7/2
-    - env: T=cloud/default/3.6/2
+    - env: T=aws/2.7/2
+    - env: T=aws/3.6/2
 
-    - env: T=cloud/default/2.7/3
-    - env: T=cloud/default/3.6/3
+    - env: T=azure/2.7/1
+    - env: T=azure/3.6/1
 
-    - env: T=cloud/default/2.7/4
-    - env: T=cloud/default/3.6/4
+    - env: T=azure/2.7/2
+    - env: T=azure/3.6/2
 
-    - env: T=cloud/default/2.7/5
-    - env: T=cloud/default/3.6/5
+    - env: T=azure/2.7/3
+    - env: T=azure/3.6/3
+
+    - env: T=azure/2.7/4
+    - env: T=azure/3.6/4
+
+    - env: T=vcenter/2.7/1
+    - env: T=vcenter/3.6/1
+
+    - env: T=cs/2.7/1
+    - env: T=cs/3.6/1
+
+    - env: T=tower/2.7/1
+    - env: T=tower/3.6/1
+
+    - env: T=cloud/2.7/1
+    - env: T=cloud/3.6/1
 branches:
   except:
     - "*-patch-*"

--- a/shippable.yml
+++ b/shippable.yml
@@ -105,12 +105,6 @@ matrix:
 
     - env: T=cs/2.7/1
     - env: T=cs/3.6/1
-
-    - env: T=tower/2.7/1
-    - env: T=tower/3.6/1
-
-    - env: T=cloud/2.7/1
-    - env: T=cloud/3.6/1
 branches:
   except:
     - "*-patch-*"

--- a/test/integration/targets/acl/aliases
+++ b/test/integration/targets/acl/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/add_host/aliases
+++ b/test/integration/targets/add_host/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/alternatives/aliases
+++ b/test/integration/targets/alternatives/aliases
@@ -1,4 +1,4 @@
-posix/ci/group3
+shippable/posix/group3
 destructive
 needs/root
 skip/freebsd

--- a/test/integration/targets/ansible-galaxy/aliases
+++ b/test/integration/targets/ansible-galaxy/aliases
@@ -1,2 +1,2 @@
 destructive
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/ansible/aliases
+++ b/test/integration/targets/ansible/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/any_errors_fatal/aliases
+++ b/test/integration/targets/any_errors_fatal/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/apache2_module/aliases
+++ b/test/integration/targets/apache2_module/aliases
@@ -1,2 +1,2 @@
 destructive
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/apt/aliases
+++ b/test/integration/targets/apt/aliases
@@ -1,4 +1,4 @@
-posix/ci/group1
+shippable/posix/group1
 destructive
 skip/freebsd
 skip/osx

--- a/test/integration/targets/apt_key/aliases
+++ b/test/integration/targets/apt_key/aliases
@@ -1,4 +1,4 @@
-posix/ci/group1
+shippable/posix/group1
 skip/freebsd
 skip/osx
 skip/rhel

--- a/test/integration/targets/apt_repository/aliases
+++ b/test/integration/targets/apt_repository/aliases
@@ -1,6 +1,6 @@
 apt_key
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/freebsd
 skip/osx
 skip/rhel

--- a/test/integration/targets/archive/aliases
+++ b/test/integration/targets/archive/aliases
@@ -1,3 +1,3 @@
 needs/root
-posix/ci/group2
+shippable/posix/group2
 destructive

--- a/test/integration/targets/args/aliases
+++ b/test/integration/targets/args/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/assemble/aliases
+++ b/test/integration/targets/assemble/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/async/aliases
+++ b/test/integration/targets/async/aliases
@@ -1,3 +1,3 @@
 async_status
 async_wrapper
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/async_extra_data/aliases
+++ b/test/integration/targets/async_extra_data/aliases
@@ -1,4 +1,4 @@
 needs/ssh
-posix/ci/group3
+shippable/posix/group3
 skip/freebsd
 skip/osx

--- a/test/integration/targets/async_fail/aliases
+++ b/test/integration/targets/async_fail/aliases
@@ -1,3 +1,3 @@
 async_status
 async_wrapper
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/at/aliases
+++ b/test/integration/targets/at/aliases
@@ -1,2 +1,2 @@
-posix/ci/group1
+shippable/posix/group1
 destructive

--- a/test/integration/targets/authorized_key/aliases
+++ b/test/integration/targets/authorized_key/aliases
@@ -1,2 +1,2 @@
 needs/root
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/aws_api_gateway/aliases
+++ b/test/integration/targets/aws_api_gateway/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group1

--- a/test/integration/targets/aws_elasticbeanstalk_app/aliases
+++ b/test/integration/targets/aws_elasticbeanstalk_app/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group1

--- a/test/integration/targets/aws_lambda/aliases
+++ b/test/integration/targets/aws_lambda/aliases
@@ -1,4 +1,4 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group1
 execute_lambda
 lambda

--- a/test/integration/targets/aws_s3/aliases
+++ b/test/integration/targets/aws_s3/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group1

--- a/test/integration/targets/aws_ses_identity/aliases
+++ b/test/integration/targets/aws_ses_identity/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group1

--- a/test/integration/targets/aws_ssm_parameters/aliases
+++ b/test/integration/targets/aws_ssm_parameters/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group1

--- a/test/integration/targets/azure_rm_availabilityset/aliases
+++ b/test/integration/targets/azure_rm_availabilityset/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 destructive

--- a/test/integration/targets/azure_rm_availabilityset_facts/aliases
+++ b/test/integration/targets/azure_rm_availabilityset_facts/aliases
@@ -1,4 +1,4 @@
 cloud/azure
-posix/ci/cloud/group3/azure
-posix/ci/cloud/group3/smoketest
+shippable/azure/group4
+shippable/azure/smoketest
 destructive

--- a/test/integration/targets/azure_rm_containerinstance/aliases
+++ b/test/integration/targets/azure_rm_containerinstance/aliases
@@ -1,4 +1,4 @@
 cloud/azure
 destructive
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 unstable

--- a/test/integration/targets/azure_rm_containerregistry/aliases
+++ b/test/integration/targets/azure_rm_containerregistry/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 destructive

--- a/test/integration/targets/azure_rm_deployment/aliases
+++ b/test/integration/targets/azure_rm_deployment/aliases
@@ -1,3 +1,3 @@
 cloud/azure
 destructive
-posix/ci/cloud/group2/azure
+shippable/azure/group2

--- a/test/integration/targets/azure_rm_dnsrecordset/aliases
+++ b/test/integration/targets/azure_rm_dnsrecordset/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 destructive

--- a/test/integration/targets/azure_rm_dnsrecordset_facts/aliases
+++ b/test/integration/targets/azure_rm_dnsrecordset_facts/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 destructive

--- a/test/integration/targets/azure_rm_dnszone/aliases
+++ b/test/integration/targets/azure_rm_dnszone/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 destructive

--- a/test/integration/targets/azure_rm_dnszone_facts/aliases
+++ b/test/integration/targets/azure_rm_dnszone_facts/aliases
@@ -1,4 +1,4 @@
 cloud/azure
-posix/ci/cloud/group2/azure
-posix/ci/cloud/group2/smoketest
+shippable/azure/group1
+shippable/azure/smoketest
 destructive

--- a/test/integration/targets/azure_rm_functionapp/aliases
+++ b/test/integration/targets/azure_rm_functionapp/aliases
@@ -1,4 +1,4 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 destructive
 unstable

--- a/test/integration/targets/azure_rm_image/aliases
+++ b/test/integration/targets/azure_rm_image/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group5/azure
+shippable/azure/group3
 destructive

--- a/test/integration/targets/azure_rm_keyvault/aliases
+++ b/test/integration/targets/azure_rm_keyvault/aliases
@@ -1,3 +1,3 @@
 cloud/azure
 destructive
-posix/ci/cloud/group2/azure
+shippable/azure/group1

--- a/test/integration/targets/azure_rm_keyvaultkey/aliases
+++ b/test/integration/targets/azure_rm_keyvaultkey/aliases
@@ -1,4 +1,4 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 destructive
 disabled

--- a/test/integration/targets/azure_rm_keyvaultsecret/aliases
+++ b/test/integration/targets/azure_rm_keyvaultsecret/aliases
@@ -1,4 +1,4 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 destructive
 disabled

--- a/test/integration/targets/azure_rm_loadbalancer/aliases
+++ b/test/integration/targets/azure_rm_loadbalancer/aliases
@@ -1,4 +1,4 @@
 cloud/azure
-posix/ci/cloud/group3/azure
+shippable/azure/group4
 unstable
 destructive

--- a/test/integration/targets/azure_rm_managed_disk/aliases
+++ b/test/integration/targets/azure_rm_managed_disk/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group5/azure
+shippable/azure/group3
 destructive

--- a/test/integration/targets/azure_rm_mysqldatabase/aliases
+++ b/test/integration/targets/azure_rm_mysqldatabase/aliases
@@ -1,3 +1,3 @@
 cloud/azure
 destructive
-posix/ci/cloud/group2/azure
+shippable/azure/group4

--- a/test/integration/targets/azure_rm_mysqlserver/aliases
+++ b/test/integration/targets/azure_rm_mysqlserver/aliases
@@ -1,3 +1,3 @@
 cloud/azure
 destructive
-posix/ci/cloud/group2/azure
+shippable/azure/group4

--- a/test/integration/targets/azure_rm_networkinterface/aliases
+++ b/test/integration/targets/azure_rm_networkinterface/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 destructive

--- a/test/integration/targets/azure_rm_postgresqldatabase/aliases
+++ b/test/integration/targets/azure_rm_postgresqldatabase/aliases
@@ -1,4 +1,4 @@
 cloud/azure
 destructive
-posix/ci/cloud/group2/azure
+shippable/azure/group2
 unstable

--- a/test/integration/targets/azure_rm_postgresqlserver/aliases
+++ b/test/integration/targets/azure_rm_postgresqlserver/aliases
@@ -1,4 +1,4 @@
 cloud/azure
 destructive
-posix/ci/cloud/group2/azure
+shippable/azure/group4
 unstable

--- a/test/integration/targets/azure_rm_publicipaddress/aliases
+++ b/test/integration/targets/azure_rm_publicipaddress/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 destructive

--- a/test/integration/targets/azure_rm_securitygroup/aliases
+++ b/test/integration/targets/azure_rm_securitygroup/aliases
@@ -1,5 +1,5 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 unstable
 destructive
 azure_rm_securitygroup_facts

--- a/test/integration/targets/azure_rm_sqldatabase/aliases
+++ b/test/integration/targets/azure_rm_sqldatabase/aliases
@@ -1,4 +1,4 @@
 cloud/azure
 destructive
-posix/ci/cloud/group2/azure
+shippable/azure/group3
 unstable

--- a/test/integration/targets/azure_rm_sqlserver/aliases
+++ b/test/integration/targets/azure_rm_sqlserver/aliases
@@ -1,3 +1,3 @@
 cloud/azure
 destructive
-posix/ci/cloud/group2/azure
+shippable/azure/group4

--- a/test/integration/targets/azure_rm_sqlserver_facts/aliases
+++ b/test/integration/targets/azure_rm_sqlserver_facts/aliases
@@ -1,4 +1,4 @@
 cloud/azure
 destructive
-posix/ci/cloud/group2/azure
+shippable/azure/group3
 unstable

--- a/test/integration/targets/azure_rm_storageaccount/aliases
+++ b/test/integration/targets/azure_rm_storageaccount/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 destructive

--- a/test/integration/targets/azure_rm_storageblob/aliases
+++ b/test/integration/targets/azure_rm_storageblob/aliases
@@ -1,4 +1,4 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 destructive
 unstable

--- a/test/integration/targets/azure_rm_subnet/aliases
+++ b/test/integration/targets/azure_rm_subnet/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 destructive

--- a/test/integration/targets/azure_rm_virtualmachine/aliases
+++ b/test/integration/targets/azure_rm_virtualmachine/aliases
@@ -1,4 +1,4 @@
 cloud/azure
-posix/ci/cloud/group3/azure
+shippable/azure/group2
 unstable
 destructive

--- a/test/integration/targets/azure_rm_virtualmachine_extension/aliases
+++ b/test/integration/targets/azure_rm_virtualmachine_extension/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group5/azure
+shippable/azure/group1
 destructive

--- a/test/integration/targets/azure_rm_virtualmachine_scaleset/aliases
+++ b/test/integration/targets/azure_rm_virtualmachine_scaleset/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group3/azure
+shippable/azure/group4
 destructive

--- a/test/integration/targets/azure_rm_virtualmachineimage_facts/aliases
+++ b/test/integration/targets/azure_rm_virtualmachineimage_facts/aliases
@@ -1,4 +1,4 @@
 cloud/azure
-posix/ci/cloud/group5/azure
-posix/ci/cloud/group5/smoketest
+shippable/azure/group3
+shippable/azure/smoketest
 destructive

--- a/test/integration/targets/azure_rm_virtualnetwork/aliases
+++ b/test/integration/targets/azure_rm_virtualnetwork/aliases
@@ -1,4 +1,4 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+shippable/azure/group1
 destructive
 unstable

--- a/test/integration/targets/become/aliases
+++ b/test/integration/targets/become/aliases
@@ -1,2 +1,2 @@
 destructive
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/binary/aliases
+++ b/test/integration/targets/binary/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/binary_modules_posix/aliases
+++ b/test/integration/targets/binary_modules_posix/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/binary_modules_winrm/aliases
+++ b/test/integration/targets/binary_modules_winrm/aliases
@@ -1,3 +1,3 @@
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group1
+shippable/windows/smoketest
 windows

--- a/test/integration/targets/blockinfile/aliases
+++ b/test/integration/targets/blockinfile/aliases
@@ -1,1 +1,1 @@
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/blocks/aliases
+++ b/test/integration/targets/blocks/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/callback_retry_task_name/aliases
+++ b/test/integration/targets/callback_retry_task_name/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/changed_when/aliases
+++ b/test/integration/targets/changed_when/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/check_mode/aliases
+++ b/test/integration/targets/check_mode/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/command_shell/aliases
+++ b/test/integration/targets/command_shell/aliases
@@ -1,3 +1,3 @@
 command
-posix/ci/group2
+shippable/posix/group2
 shell

--- a/test/integration/targets/conditionals/aliases
+++ b/test/integration/targets/conditionals/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/connection/aliases
+++ b/test/integration/targets/connection/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/connection_chroot/aliases
+++ b/test/integration/targets/connection_chroot/aliases
@@ -1,2 +1,2 @@
 needs/root
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/connection_local/aliases
+++ b/test/integration/targets/connection_local/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/connection_paramiko_ssh/aliases
+++ b/test/integration/targets/connection_paramiko_ssh/aliases
@@ -1,2 +1,2 @@
 needs/ssh
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/connection_ssh/aliases
+++ b/test/integration/targets/connection_ssh/aliases
@@ -1,2 +1,2 @@
 needs/ssh
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/connection_winrm/aliases
+++ b/test/integration/targets/connection_winrm/aliases
@@ -1,2 +1,3 @@
-windows/ci/group1
-windows/ci/smoketest
+windows
+shippable/windows/group1
+shippable/windows/smoketest

--- a/test/integration/targets/copy/aliases
+++ b/test/integration/targets/copy/aliases
@@ -1,2 +1,2 @@
 needs/root
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/cs_account/aliases
+++ b/test/integration/targets/cs_account/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_affinitygroup/aliases
+++ b/test/integration/targets/cs_affinitygroup/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_cluster/aliases
+++ b/test/integration/targets/cs_cluster/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_configuration/aliases
+++ b/test/integration/targets/cs_configuration/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_domain/aliases
+++ b/test/integration/targets/cs_domain/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_firewall/aliases
+++ b/test/integration/targets/cs_firewall/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_host/aliases
+++ b/test/integration/targets/cs_host/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_instance/aliases
+++ b/test/integration/targets/cs_instance/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_instance_facts/aliases
+++ b/test/integration/targets/cs_instance_facts/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_instance_nic/aliases
+++ b/test/integration/targets/cs_instance_nic/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_instance_nic_secondaryip/aliases
+++ b/test/integration/targets/cs_instance_nic_secondaryip/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_instancegroup/aliases
+++ b/test/integration/targets/cs_instancegroup/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_iso/aliases
+++ b/test/integration/targets/cs_iso/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_loadbalancer_rule/aliases
+++ b/test/integration/targets/cs_loadbalancer_rule/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_network/aliases
+++ b/test/integration/targets/cs_network/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_network_acl/aliases
+++ b/test/integration/targets/cs_network_acl/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_network_acl_rule/aliases
+++ b/test/integration/targets/cs_network_acl_rule/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_network_offering/aliases
+++ b/test/integration/targets/cs_network_offering/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_pod/aliases
+++ b/test/integration/targets/cs_pod/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_portforward/aliases
+++ b/test/integration/targets/cs_portforward/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_project/aliases
+++ b/test/integration/targets/cs_project/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_region/aliases
+++ b/test/integration/targets/cs_region/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_resourcelimit/aliases
+++ b/test/integration/targets/cs_resourcelimit/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_role/aliases
+++ b/test/integration/targets/cs_role/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_router/aliases
+++ b/test/integration/targets/cs_router/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_securitygroup/aliases
+++ b/test/integration/targets/cs_securitygroup/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_securitygroup_rule/aliases
+++ b/test/integration/targets/cs_securitygroup_rule/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_service_offering/aliases
+++ b/test/integration/targets/cs_service_offering/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_snapshot_policy/aliases
+++ b/test/integration/targets/cs_snapshot_policy/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_sshkeypair/aliases
+++ b/test/integration/targets/cs_sshkeypair/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_storage_pool/aliases
+++ b/test/integration/targets/cs_storage_pool/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_user/aliases
+++ b/test/integration/targets/cs_user/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_vmsnapshot/aliases
+++ b/test/integration/targets/cs_vmsnapshot/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_volume/aliases
+++ b/test/integration/targets/cs_volume/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_vpc/aliases
+++ b/test/integration/targets/cs_vpc/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_vpc_offering/aliases
+++ b/test/integration/targets/cs_vpc_offering/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_vpn_connection/aliases
+++ b/test/integration/targets/cs_vpn_connection/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_vpn_customer_gateway/aliases
+++ b/test/integration/targets/cs_vpn_customer_gateway/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_vpn_gateway/aliases
+++ b/test/integration/targets/cs_vpn_gateway/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_zone/aliases
+++ b/test/integration/targets/cs_zone/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/cs_zone_facts/aliases
+++ b/test/integration/targets/cs_zone_facts/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/group1/cs
+shippable/cs/group1

--- a/test/integration/targets/debconf/aliases
+++ b/test/integration/targets/debconf/aliases
@@ -1,1 +1,1 @@
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/delegate_to/aliases
+++ b/test/integration/targets/delegate_to/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/deploy_helper/aliases
+++ b/test/integration/targets/deploy_helper/aliases
@@ -1,1 +1,1 @@
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/dnf/aliases
+++ b/test/integration/targets/dnf/aliases
@@ -1,4 +1,4 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/freebsd
 skip/osx

--- a/test/integration/targets/docker_secret/aliases
+++ b/test/integration/targets/docker_secret/aliases
@@ -1,4 +1,4 @@
-posix/ci/group2
+shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/dpkg_selections/aliases
+++ b/test/integration/targets/dpkg_selections/aliases
@@ -1,4 +1,4 @@
-posix/ci/group1
+shippable/posix/group1
 destructive
 skip/freebsd
 skip/osx

--- a/test/integration/targets/ec2_ami/aliases
+++ b/test/integration/targets/ec2_ami/aliases
@@ -1,4 +1,4 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group2
 unstable
 ec2_ami_facts

--- a/test/integration/targets/ec2_elb_lb/aliases
+++ b/test/integration/targets/ec2_elb_lb/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group2

--- a/test/integration/targets/ec2_group/aliases
+++ b/test/integration/targets/ec2_group/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group2
 unstable

--- a/test/integration/targets/ec2_key/aliases
+++ b/test/integration/targets/ec2_key/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group2

--- a/test/integration/targets/ec2_metadata_facts/aliases
+++ b/test/integration/targets/ec2_metadata_facts/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-posix/ci/cloud/group4/aws
-posix/ci/cloud/group4/smoketest
+shippable/aws/group2
+shippable/aws/smoketest

--- a/test/integration/targets/ec2_tag/aliases
+++ b/test/integration/targets/ec2_tag/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group2

--- a/test/integration/targets/ec2_vol/aliases
+++ b/test/integration/targets/ec2_vol/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group2

--- a/test/integration/targets/ec2_vpc_egress_igw/aliases
+++ b/test/integration/targets/ec2_vpc_egress_igw/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group2

--- a/test/integration/targets/ec2_vpc_net/aliases
+++ b/test/integration/targets/ec2_vpc_net/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group2

--- a/test/integration/targets/ec2_vpc_route_table/aliases
+++ b/test/integration/targets/ec2_vpc_route_table/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group2
 unstable

--- a/test/integration/targets/ec2_vpc_subnet/aliases
+++ b/test/integration/targets/ec2_vpc_subnet/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group2
 unstable

--- a/test/integration/targets/ecs_ecr/aliases
+++ b/test/integration/targets/ecs_ecr/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group1

--- a/test/integration/targets/elb_classic_lb/aliases
+++ b/test/integration/targets/elb_classic_lb/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group1

--- a/test/integration/targets/embedded_module/aliases
+++ b/test/integration/targets/embedded_module/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/environment/aliases
+++ b/test/integration/targets/environment/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/etcd3/aliases
+++ b/test/integration/targets/etcd3/aliases
@@ -1,5 +1,5 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/osx
 skip/freebsd
 disabled

--- a/test/integration/targets/expect/aliases
+++ b/test/integration/targets/expect/aliases
@@ -1,2 +1,2 @@
-posix/ci/group2
+shippable/posix/group2
 destructive

--- a/test/integration/targets/facts_d/aliases
+++ b/test/integration/targets/facts_d/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/failed_when/aliases
+++ b/test/integration/targets/failed_when/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/fetch/aliases
+++ b/test/integration/targets/fetch/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/file/aliases
+++ b/test/integration/targets/file/aliases
@@ -1,2 +1,2 @@
-posix/ci/group2
+shippable/posix/group2
 needs/root

--- a/test/integration/targets/filesystem/aliases
+++ b/test/integration/targets/filesystem/aliases
@@ -1,3 +1,3 @@
 destructive
-posix/ci/group3
+shippable/posix/group3
 skip/osx

--- a/test/integration/targets/filters/aliases
+++ b/test/integration/targets/filters/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/find/aliases
+++ b/test/integration/targets/find/aliases
@@ -1,1 +1,1 @@
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/firewalld/aliases
+++ b/test/integration/targets/firewalld/aliases
@@ -1,4 +1,4 @@
 destructive
-posix/ci/group3
+shippable/posix/group3
 skip/freebsd
 skip/osx

--- a/test/integration/targets/fortios_address/aliases
+++ b/test/integration/targets/fortios_address/aliases
@@ -1,3 +1,3 @@
-posix/ci/group1
+shippable/posix/group1
 destructive
 disabled

--- a/test/integration/targets/fortios_ipv4_policy/aliases
+++ b/test/integration/targets/fortios_ipv4_policy/aliases
@@ -1,3 +1,3 @@
-posix/ci/group1
+shippable/posix/group1
 destructive
 disabled

--- a/test/integration/targets/gathering_facts/aliases
+++ b/test/integration/targets/gathering_facts/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/gem/aliases
+++ b/test/integration/targets/gem/aliases
@@ -1,3 +1,3 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/osx

--- a/test/integration/targets/get_url/aliases
+++ b/test/integration/targets/get_url/aliases
@@ -1,3 +1,3 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 needs/httptester

--- a/test/integration/targets/getent/aliases
+++ b/test/integration/targets/getent/aliases
@@ -1,1 +1,1 @@
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/git/aliases
+++ b/test/integration/targets/git/aliases
@@ -1,1 +1,1 @@
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/github_issue/aliases
+++ b/test/integration/targets/github_issue/aliases
@@ -1,3 +1,3 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 disabled

--- a/test/integration/targets/group/aliases
+++ b/test/integration/targets/group/aliases
@@ -1,1 +1,1 @@
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/group_by/aliases
+++ b/test/integration/targets/group_by/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/groupby_filter/aliases
+++ b/test/integration/targets/groupby_filter/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/handlers/aliases
+++ b/test/integration/targets/handlers/aliases
@@ -1,2 +1,2 @@
-posix/ci/group3
+shippable/posix/group3
 handlers

--- a/test/integration/targets/hash/aliases
+++ b/test/integration/targets/hash/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/hg/aliases
+++ b/test/integration/targets/hg/aliases
@@ -1,2 +1,2 @@
-posix/ci/group2
+shippable/posix/group2
 skip/python3

--- a/test/integration/targets/hosts_field/aliases
+++ b/test/integration/targets/hosts_field/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/ignore_errors/aliases
+++ b/test/integration/targets/ignore_errors/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/include_import/aliases
+++ b/test/integration/targets/include_import/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/include_vars/aliases
+++ b/test/integration/targets/include_vars/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/includes/aliases
+++ b/test/integration/targets/includes/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/influxdb_user/aliases
+++ b/test/integration/targets/influxdb_user/aliases
@@ -1,5 +1,5 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 disabled
 skip/osx
 skip/freebsd

--- a/test/integration/targets/ini_file/aliases
+++ b/test/integration/targets/ini_file/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/inventory_path_with_comma/aliases
+++ b/test/integration/targets/inventory_path_with_comma/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/ipify_facts/aliases
+++ b/test/integration/targets/ipify_facts/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/iso_extract/aliases
+++ b/test/integration/targets/iso_extract/aliases
@@ -1,2 +1,2 @@
-posix/ci/group1
+shippable/posix/group1
 destructive

--- a/test/integration/targets/iterators/aliases
+++ b/test/integration/targets/iterators/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/known_hosts/aliases
+++ b/test/integration/targets/known_hosts/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/lambda_policy/aliases
+++ b/test/integration/targets/lambda_policy/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group1

--- a/test/integration/targets/lineinfile/aliases
+++ b/test/integration/targets/lineinfile/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/locale_gen/aliases
+++ b/test/integration/targets/locale_gen/aliases
@@ -1,3 +1,3 @@
 destructive
 needs/root
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/lookup_passwordstore/aliases
+++ b/test/integration/targets/lookup_passwordstore/aliases
@@ -1,2 +1,2 @@
-posix/ci/group2
+shippable/posix/group2
 destructive

--- a/test/integration/targets/lookup_paths/aliases
+++ b/test/integration/targets/lookup_paths/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/lookup_properties/aliases
+++ b/test/integration/targets/lookup_properties/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/lookups/aliases
+++ b/test/integration/targets/lookups/aliases
@@ -1,2 +1,2 @@
-posix/ci/group1
+shippable/posix/group1
 needs/httptester

--- a/test/integration/targets/loops/aliases
+++ b/test/integration/targets/loops/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/module_precedence/aliases
+++ b/test/integration/targets/module_precedence/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/module_utils/aliases
+++ b/test/integration/targets/module_utils/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/mount/aliases
+++ b/test/integration/targets/mount/aliases
@@ -1,3 +1,3 @@
 needs/privileged
 needs/root
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/mysql_db/aliases
+++ b/test/integration/targets/mysql_db/aliases
@@ -1,4 +1,4 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/osx
 skip/freebsd

--- a/test/integration/targets/mysql_user/aliases
+++ b/test/integration/targets/mysql_user/aliases
@@ -1,4 +1,4 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/osx
 skip/freebsd

--- a/test/integration/targets/mysql_variables/aliases
+++ b/test/integration/targets/mysql_variables/aliases
@@ -1,4 +1,4 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/osx
 skip/freebsd

--- a/test/integration/targets/no_log/aliases
+++ b/test/integration/targets/no_log/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/npm/aliases
+++ b/test/integration/targets/npm/aliases
@@ -1,3 +1,3 @@
-posix/ci/group2
+shippable/posix/group2
 destructive
 skip/freebsd

--- a/test/integration/targets/nuage_vspk/aliases
+++ b/test/integration/targets/nuage_vspk/aliases
@@ -1,2 +1,2 @@
-posix/ci/group1
+shippable/posix/group1
 skip/python3

--- a/test/integration/targets/openssl_certificate/aliases
+++ b/test/integration/targets/openssl_certificate/aliases
@@ -1,2 +1,2 @@
-posix/ci/group1
+shippable/posix/group1
 destructive

--- a/test/integration/targets/openssl_csr/aliases
+++ b/test/integration/targets/openssl_csr/aliases
@@ -1,2 +1,2 @@
-posix/ci/group1
+shippable/posix/group1
 destructive

--- a/test/integration/targets/openssl_dhparam/aliases
+++ b/test/integration/targets/openssl_dhparam/aliases
@@ -1,2 +1,2 @@
-posix/ci/group1
+shippable/posix/group1
 destructive

--- a/test/integration/targets/openssl_privatekey/aliases
+++ b/test/integration/targets/openssl_privatekey/aliases
@@ -1,2 +1,2 @@
-posix/ci/group1
+shippable/posix/group1
 destructive

--- a/test/integration/targets/openssl_publickey/aliases
+++ b/test/integration/targets/openssl_publickey/aliases
@@ -1,2 +1,2 @@
-posix/ci/group1
+shippable/posix/group1
 destructive

--- a/test/integration/targets/package/aliases
+++ b/test/integration/targets/package/aliases
@@ -1,2 +1,2 @@
-posix/ci/group1
+shippable/posix/group1
 destructive

--- a/test/integration/targets/package_facts/aliases
+++ b/test/integration/targets/package_facts/aliases
@@ -1,3 +1,3 @@
-posix/ci/group3
+shippable/posix/group3
 skip/freebsd
 skip/osx

--- a/test/integration/targets/parsing/aliases
+++ b/test/integration/targets/parsing/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/pause/aliases
+++ b/test/integration/targets/pause/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/ping/aliases
+++ b/test/integration/targets/ping/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/pip/aliases
+++ b/test/integration/targets/pip/aliases
@@ -1,2 +1,2 @@
 destructive
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/plugin_filtering/aliases
+++ b/test/integration/targets/plugin_filtering/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/postgresql/aliases
+++ b/test/integration/targets/postgresql/aliases
@@ -1,5 +1,5 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 postgresql_db
 postgresql_privs
 postgresql_user

--- a/test/integration/targets/pull/aliases
+++ b/test/integration/targets/pull/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/rabbitmq_user/aliases
+++ b/test/integration/targets/rabbitmq_user/aliases
@@ -1,5 +1,5 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel

--- a/test/integration/targets/raw/aliases
+++ b/test/integration/targets/raw/aliases
@@ -1,1 +1,1 @@
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/rds_param_group/aliases
+++ b/test/integration/targets/rds_param_group/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group1

--- a/test/integration/targets/rpm_key/aliases
+++ b/test/integration/targets/rpm_key/aliases
@@ -1,2 +1,2 @@
 destructive
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/script/aliases
+++ b/test/integration/targets/script/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/seboolean/aliases
+++ b/test/integration/targets/seboolean/aliases
@@ -1,2 +1,2 @@
 needs/root
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/sefcontext/aliases
+++ b/test/integration/targets/sefcontext/aliases
@@ -1,2 +1,2 @@
 needs/root
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/selinux/aliases
+++ b/test/integration/targets/selinux/aliases
@@ -1,2 +1,2 @@
 needs/root
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/sensu_client/aliases
+++ b/test/integration/targets/sensu_client/aliases
@@ -1,1 +1,1 @@
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/sensu_handler/aliases
+++ b/test/integration/targets/sensu_handler/aliases
@@ -1,1 +1,1 @@
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/service/aliases
+++ b/test/integration/targets/service/aliases
@@ -1,5 +1,5 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/freebsd
 skip/osx
 systemd

--- a/test/integration/targets/service_facts/aliases
+++ b/test/integration/targets/service_facts/aliases
@@ -1,3 +1,3 @@
-posix/ci/group3
+shippable/posix/group3
 skip/freebsd
 skip/osx

--- a/test/integration/targets/set_fact/aliases
+++ b/test/integration/targets/set_fact/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/setup_zabbix/aliases
+++ b/test/integration/targets/setup_zabbix/aliases
@@ -1,5 +1,5 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel

--- a/test/integration/targets/slurp/aliases
+++ b/test/integration/targets/slurp/aliases
@@ -1,1 +1,1 @@
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/special_vars/aliases
+++ b/test/integration/targets/special_vars/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/stat/aliases
+++ b/test/integration/targets/stat/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/strategy_linear/aliases
+++ b/test/integration/targets/strategy_linear/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/sts_assume_role/aliases
+++ b/test/integration/targets/sts_assume_role/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-posix/ci/cloud/group4/aws
+shippable/aws/group1
 iam_role

--- a/test/integration/targets/subversion/aliases
+++ b/test/integration/targets/subversion/aliases
@@ -1,2 +1,2 @@
-posix/ci/group2
+shippable/posix/group2
 skip/osx

--- a/test/integration/targets/synchronize/aliases
+++ b/test/integration/targets/synchronize/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/sysctl/aliases
+++ b/test/integration/targets/sysctl/aliases
@@ -1,3 +1,3 @@
-posix/ci/group1
+shippable/posix/group1
 skip/freebsd
 skip/osx

--- a/test/integration/targets/systemd/aliases
+++ b/test/integration/targets/systemd/aliases
@@ -1,1 +1,1 @@
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/tags/aliases
+++ b/test/integration/targets/tags/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/task_ordering/aliases
+++ b/test/integration/targets/task_ordering/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/template/aliases
+++ b/test/integration/targets/template/aliases
@@ -1,2 +1,2 @@
 needs/root
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/templating_settings/aliases
+++ b/test/integration/targets/templating_settings/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/test_infra/aliases
+++ b/test/integration/targets/test_infra/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/timezone/aliases
+++ b/test/integration/targets/timezone/aliases
@@ -1,4 +1,4 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/osx
 systemd

--- a/test/integration/targets/unarchive/aliases
+++ b/test/integration/targets/unarchive/aliases
@@ -1,3 +1,3 @@
 needs/root
-posix/ci/group2
+shippable/posix/group2
 destructive

--- a/test/integration/targets/unicode/aliases
+++ b/test/integration/targets/unicode/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/until/aliases
+++ b/test/integration/targets/until/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/uri/aliases
+++ b/test/integration/targets/uri/aliases
@@ -1,3 +1,3 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 needs/httptester

--- a/test/integration/targets/user/aliases
+++ b/test/integration/targets/user/aliases
@@ -1,2 +1,2 @@
 destructive
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/var_blending/aliases
+++ b/test/integration/targets/var_blending/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/var_precedence/aliases
+++ b/test/integration/targets/var_precedence/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/vault/aliases
+++ b/test/integration/targets/vault/aliases
@@ -1,1 +1,1 @@
-posix/ci/group3
+shippable/posix/group3

--- a/test/integration/targets/vcenter_folder/aliases
+++ b/test/integration/targets/vcenter_folder/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vcenter_license/aliases
+++ b/test/integration/targets/vcenter_license/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_cluster/aliases
+++ b/test/integration/targets/vmware_cluster/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_datacenter/aliases
+++ b/test/integration/targets/vmware_datacenter/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_datastore_facts/aliases
+++ b/test/integration/targets/vmware_datastore_facts/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group1/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_drs_rule_facts/aliases
+++ b/test/integration/targets/vmware_drs_rule_facts/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group1/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_dvs_portgroup/aliases
+++ b/test/integration/targets/vmware_dvs_portgroup/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_dvswitch/aliases
+++ b/test/integration/targets/vmware_dvswitch/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_guest/aliases
+++ b/test/integration/targets/vmware_guest/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_guest_facts/aliases
+++ b/test/integration/targets/vmware_guest_facts/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_guest_find/aliases
+++ b/test/integration/targets/vmware_guest_find/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_guest_powerstate/aliases
+++ b/test/integration/targets/vmware_guest_powerstate/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_guest_tools_wait/aliases
+++ b/test/integration/targets/vmware_guest_tools_wait/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_host/aliases
+++ b/test/integration/targets/vmware_host/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_host_config_facts/aliases
+++ b/test/integration/targets/vmware_host_config_facts/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_host_dns_facts/aliases
+++ b/test/integration/targets/vmware_host_dns_facts/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter
 

--- a/test/integration/targets/vmware_host_facts/aliases
+++ b/test/integration/targets/vmware_host_facts/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter
 

--- a/test/integration/targets/vmware_host_firewall_facts/aliases
+++ b/test/integration/targets/vmware_host_firewall_facts/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter
 

--- a/test/integration/targets/vmware_host_firewall_manager/aliases
+++ b/test/integration/targets/vmware_host_firewall_manager/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_local_role_manager/aliases
+++ b/test/integration/targets/vmware_local_role_manager/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group1/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_maintenancemode/aliases
+++ b/test/integration/targets/vmware_maintenancemode/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group1/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_resource_pool/aliases
+++ b/test/integration/targets/vmware_resource_pool/aliases
@@ -1,2 +1,2 @@
-posix/ci/cloud/group4/vcenter
+shippable/vcenter/group1
 cloud/vcenter

--- a/test/integration/targets/vmware_vm_facts/aliases
+++ b/test/integration/targets/vmware_vm_facts/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group1/vcenter
-posix/ci/cloud/group1/smoketest
+shippable/vcenter/group1
+shippable/vcenter/smoketest
 cloud/vcenter

--- a/test/integration/targets/vyos_banner/aliases
+++ b/test/integration/targets/vyos_banner/aliases
@@ -1,1 +1,1 @@
-network/ci
+shippable/network

--- a/test/integration/targets/vyos_command/aliases
+++ b/test/integration/targets/vyos_command/aliases
@@ -1,1 +1,1 @@
-network/ci
+shippable/network

--- a/test/integration/targets/vyos_config/aliases
+++ b/test/integration/targets/vyos_config/aliases
@@ -1,1 +1,1 @@
-network/ci
+shippable/network

--- a/test/integration/targets/vyos_facts/aliases
+++ b/test/integration/targets/vyos_facts/aliases
@@ -1,1 +1,1 @@
-network/ci
+shippable/network

--- a/test/integration/targets/vyos_lldp/aliases
+++ b/test/integration/targets/vyos_lldp/aliases
@@ -1,1 +1,1 @@
-network/ci
+shippable/network

--- a/test/integration/targets/vyos_static_route/aliases
+++ b/test/integration/targets/vyos_static_route/aliases
@@ -1,1 +1,1 @@
-network/ci
+shippable/network

--- a/test/integration/targets/wait_for/aliases
+++ b/test/integration/targets/wait_for/aliases
@@ -1,2 +1,2 @@
 destructive
-posix/ci/group1
+shippable/posix/group1

--- a/test/integration/targets/wait_for_connection/aliases
+++ b/test/integration/targets/wait_for_connection/aliases
@@ -1,2 +1,2 @@
-posix/ci/group1
-windows/ci/group1
+shippable/posix/group1
+shippable/windows/group1

--- a/test/integration/targets/wakeonlan/aliases
+++ b/test/integration/targets/wakeonlan/aliases
@@ -1,1 +1,1 @@
-posix/ci/group2
+shippable/posix/group2

--- a/test/integration/targets/win_acl_inheritance/aliases
+++ b/test/integration/targets/win_acl_inheritance/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_async_wrapper/aliases
+++ b/test/integration/targets/win_async_wrapper/aliases
@@ -1,3 +1,3 @@
 async_status
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group1
+shippable/windows/smoketest

--- a/test/integration/targets/win_audit_policy_system/aliases
+++ b/test/integration/targets/win_audit_policy_system/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_audit_rule/aliases
+++ b/test/integration/targets/win_audit_rule/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_become/aliases
+++ b/test/integration/targets/win_become/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group4
+shippable/windows/smoketest

--- a/test/integration/targets/win_certificate_store/aliases
+++ b/test/integration/targets/win_certificate_store/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_chocolatey/aliases
+++ b/test/integration/targets/win_chocolatey/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group1

--- a/test/integration/targets/win_command/aliases
+++ b/test/integration/targets/win_command/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group1

--- a/test/integration/targets/win_copy/aliases
+++ b/test/integration/targets/win_copy/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_disk_facts/aliases
+++ b/test/integration/targets/win_disk_facts/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_domain_membership/aliases
+++ b/test/integration/targets/win_domain_membership/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_dotnet_ngen/aliases
+++ b/test/integration/targets/win_dotnet_ngen/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_dsc/aliases
+++ b/test/integration/targets/win_dsc/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group4

--- a/test/integration/targets/win_environment/aliases
+++ b/test/integration/targets/win_environment/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_eventlog/aliases
+++ b/test/integration/targets/win_eventlog/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_eventlog_entry/aliases
+++ b/test/integration/targets/win_eventlog_entry/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group1

--- a/test/integration/targets/win_exec_wrapper/aliases
+++ b/test/integration/targets/win_exec_wrapper/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group1
+shippable/windows/smoketest

--- a/test/integration/targets/win_feature/aliases
+++ b/test/integration/targets/win_feature/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_fetch/aliases
+++ b/test/integration/targets/win_fetch/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_file/aliases
+++ b/test/integration/targets/win_file/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group1
+shippable/windows/smoketest

--- a/test/integration/targets/win_find/aliases
+++ b/test/integration/targets/win_find/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group1

--- a/test/integration/targets/win_firewall/aliases
+++ b/test/integration/targets/win_firewall/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_firewall_rule/aliases
+++ b/test/integration/targets/win_firewall_rule/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group1

--- a/test/integration/targets/win_get_url/aliases
+++ b/test/integration/targets/win_get_url/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group1

--- a/test/integration/targets/win_group/aliases
+++ b/test/integration/targets/win_group/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group1
+shippable/windows/smoketest

--- a/test/integration/targets/win_group_membership/aliases
+++ b/test/integration/targets/win_group_membership/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group4

--- a/test/integration/targets/win_hotfix/aliases
+++ b/test/integration/targets/win_hotfix/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_iis_webapppool/aliases
+++ b/test/integration/targets/win_iis_webapppool/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_iis_webbinding/aliases
+++ b/test/integration/targets/win_iis_webbinding/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_lineinfile/aliases
+++ b/test/integration/targets/win_lineinfile/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_mapped_drive/aliases
+++ b/test/integration/targets/win_mapped_drive/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group1

--- a/test/integration/targets/win_module_utils/aliases
+++ b/test/integration/targets/win_module_utils/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group1
+shippable/windows/smoketest

--- a/test/integration/targets/win_module_utils_legacy/aliases
+++ b/test/integration/targets/win_module_utils_legacy/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group1
+shippable/windows/smoketest

--- a/test/integration/targets/win_msg/aliases
+++ b/test/integration/targets/win_msg/aliases
@@ -1,2 +1,2 @@
-windows/ci/group2
+shippable/windows/group2
 unstable

--- a/test/integration/targets/win_msi/aliases
+++ b/test/integration/targets/win_msi/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group1

--- a/test/integration/targets/win_owner/aliases
+++ b/test/integration/targets/win_owner/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group4
+shippable/windows/smoketest

--- a/test/integration/targets/win_package/aliases
+++ b/test/integration/targets/win_package/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_pagefile/aliases
+++ b/test/integration/targets/win_pagefile/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_path/aliases
+++ b/test/integration/targets/win_path/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group1
+shippable/windows/smoketest

--- a/test/integration/targets/win_ping/aliases
+++ b/test/integration/targets/win_ping/aliases
@@ -1,3 +1,3 @@
-windows/ci/group1
-windows/ci/minimal
-windows/ci/smoketest
+shippable/windows/group1
+shippable/windows/minimal
+shippable/windows/smoketest

--- a/test/integration/targets/win_power_plan/aliases
+++ b/test/integration/targets/win_power_plan/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_product_facts/aliases
+++ b/test/integration/targets/win_product_facts/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_psexec/aliases
+++ b/test/integration/targets/win_psexec/aliases
@@ -1,2 +1,2 @@
-windows/ci/group3
+shippable/windows/group3
 unstable

--- a/test/integration/targets/win_psmodule/aliases
+++ b/test/integration/targets/win_psmodule/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_rabbitmq_plugin/aliases
+++ b/test/integration/targets/win_rabbitmq_plugin/aliases
@@ -1,2 +1,2 @@
-windows/ci/group3
+shippable/windows/group3
 disabled

--- a/test/integration/targets/win_raw/aliases
+++ b/test/integration/targets/win_raw/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group1
+shippable/windows/smoketest

--- a/test/integration/targets/win_reg_stat/aliases
+++ b/test/integration/targets/win_reg_stat/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group1

--- a/test/integration/targets/win_regedit/aliases
+++ b/test/integration/targets/win_regedit/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_region/aliases
+++ b/test/integration/targets/win_region/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group4

--- a/test/integration/targets/win_regmerge/aliases
+++ b/test/integration/targets/win_regmerge/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group1

--- a/test/integration/targets/win_route/aliases
+++ b/test/integration/targets/win_route/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_say/aliases
+++ b/test/integration/targets/win_say/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group1

--- a/test/integration/targets/win_scheduled_task/aliases
+++ b/test/integration/targets/win_scheduled_task/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_scheduled_task_stat/aliases
+++ b/test/integration/targets/win_scheduled_task_stat/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group1

--- a/test/integration/targets/win_script/aliases
+++ b/test/integration/targets/win_script/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group1
+shippable/windows/smoketest

--- a/test/integration/targets/win_security_policy/aliases
+++ b/test/integration/targets/win_security_policy/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_service/aliases
+++ b/test/integration/targets/win_service/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group4
+shippable/windows/smoketest

--- a/test/integration/targets/win_setup/aliases
+++ b/test/integration/targets/win_setup/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_share/aliases
+++ b/test/integration/targets/win_share/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_shell/aliases
+++ b/test/integration/targets/win_shell/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group1
+shippable/windows/smoketest

--- a/test/integration/targets/win_shortcut/aliases
+++ b/test/integration/targets/win_shortcut/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_slurp/aliases
+++ b/test/integration/targets/win_slurp/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_stat/aliases
+++ b/test/integration/targets/win_stat/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+shippable/windows/group1

--- a/test/integration/targets/win_tempfile/aliases
+++ b/test/integration/targets/win_tempfile/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_template/aliases
+++ b/test/integration/targets/win_template/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
-windows/ci/smoketest
+shippable/windows/group1
+shippable/windows/smoketest

--- a/test/integration/targets/win_timezone/aliases
+++ b/test/integration/targets/win_timezone/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_toast/aliases
+++ b/test/integration/targets/win_toast/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
+shippable/windows/group1
 disabled

--- a/test/integration/targets/win_unzip/aliases
+++ b/test/integration/targets/win_unzip/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+shippable/windows/group2

--- a/test/integration/targets/win_updates/aliases
+++ b/test/integration/targets/win_updates/aliases
@@ -1,2 +1,2 @@
-windows/ci/group2
+shippable/windows/group2
 unstable

--- a/test/integration/targets/win_uri/aliases
+++ b/test/integration/targets/win_uri/aliases
@@ -1,2 +1,2 @@
-windows/ci/group3
+shippable/windows/group3
 unstable

--- a/test/integration/targets/win_user/aliases
+++ b/test/integration/targets/win_user/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_user_right/aliases
+++ b/test/integration/targets/win_user_right/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_wait_for/aliases
+++ b/test/integration/targets/win_wait_for/aliases
@@ -1,2 +1,2 @@
-windows/ci/group1
+shippable/windows/group4
 unstable

--- a/test/integration/targets/win_wakeonlan/aliases
+++ b/test/integration/targets/win_wakeonlan/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/win_whoami/aliases
+++ b/test/integration/targets/win_whoami/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+shippable/windows/group3

--- a/test/integration/targets/windows-paths/aliases
+++ b/test/integration/targets/windows-paths/aliases
@@ -1,2 +1,3 @@
-windows/ci/group1
-windows/ci/smoketest
+windows
+shippable/windows/group1
+shippable/windows/smoketest

--- a/test/integration/targets/xattr/aliases
+++ b/test/integration/targets/xattr/aliases
@@ -1,4 +1,4 @@
-posix/ci/group2
+shippable/posix/group2
 skip/freebsd
 skip/osx
 destructive

--- a/test/integration/targets/xml/aliases
+++ b/test/integration/targets/xml/aliases
@@ -1,3 +1,3 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 disabled

--- a/test/integration/targets/yum/aliases
+++ b/test/integration/targets/yum/aliases
@@ -1,4 +1,4 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/freebsd
 skip/osx

--- a/test/integration/targets/yum_repository/aliases
+++ b/test/integration/targets/yum_repository/aliases
@@ -1,2 +1,2 @@
-posix/ci/group1
+shippable/posix/group1
 destructive

--- a/test/integration/targets/zabbix_host/aliases
+++ b/test/integration/targets/zabbix_host/aliases
@@ -1,5 +1,5 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel

--- a/test/integration/targets/zypper/aliases
+++ b/test/integration/targets/zypper/aliases
@@ -1,5 +1,5 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/freebsd
 skip/osx
 skip/rhel

--- a/test/integration/targets/zypper_repository/aliases
+++ b/test/integration/targets/zypper_repository/aliases
@@ -1,5 +1,5 @@
 destructive
-posix/ci/group1
+shippable/posix/group1
 skip/freebsd
 skip/osx
 skip/rhel

--- a/test/runner/lib/classification.py
+++ b/test/runner/lib/classification.py
@@ -648,6 +648,13 @@ class PathMapper(object):
                         test_command: test_target,
                     }
 
+                cloud_target = 'cloud/%s/' % name
+
+                if cloud_target in self.integration_targets_by_alias:
+                    return {
+                        'integration': cloud_target,
+                    }
+
             return all_tests(self.args)  # test infrastructure, run all tests
 
         if path.startswith('test/utils/'):

--- a/test/sanity/code-smell/integration-aliases.json
+++ b/test/sanity/code-smell/integration-aliases.json
@@ -1,4 +1,0 @@
-{
-    "always": true,
-    "output": "path-message"
-}

--- a/test/utils/shippable/aws.sh
+++ b/test/utils/shippable/aws.sh
@@ -1,0 +1,1 @@
+cloud.sh

--- a/test/utils/shippable/azure.sh
+++ b/test/utils/shippable/azure.sh
@@ -1,0 +1,1 @@
+cloud.sh

--- a/test/utils/shippable/cloud.sh
+++ b/test/utils/shippable/cloud.sh
@@ -5,13 +5,28 @@ set -o pipefail
 declare -a args
 IFS='/:' read -ra args <<< "$1"
 
-image="${args[1]}"
-python="${args[2]}"
-target="posix/ci/cloud/group${args[3]}/"
+cloud="${args[0]}"
+python="${args[1]}"
+group="${args[2]}"
+
+target="shippable/${cloud}/group${group}/"
 
 stage="${S:-prod}"
+
+if [ "${group}" == "1" ]; then
+    # only run smoketest tests for group1
+    changed_all_target="shippable/${cloud}/smoketest/"
+
+    if ! ansible-test integration "${changed_all_target}" --list-targets > /dev/null 2>&1; then
+        # no smoketest tests are available for this cloud
+        changed_all_target="none"
+    fi
+else
+    # smoketest tests already covered by group1
+    changed_all_target="none"
+fi
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
     --remote-terminate always --remote-stage "${stage}" \
-    --docker "${image}" --python "${python}" --changed-all-target "${target}smoketest/"
+    --docker --python "${python}" --changed-all-target "${changed_all_target}"

--- a/test/utils/shippable/cs.sh
+++ b/test/utils/shippable/cs.sh
@@ -1,0 +1,1 @@
+cloud.sh

--- a/test/utils/shippable/freebsd.sh
+++ b/test/utils/shippable/freebsd.sh
@@ -9,9 +9,9 @@ platform="${args[0]}"
 version="${args[1]}"
 
 if [ "${#args[@]}" -gt 2 ]; then
-    target="posix/ci/group${args[2]}/"
+    target="shippable/posix/group${args[2]}/"
 else
-    target="posix/ci/"
+    target="shippable/posix/"
 fi
 
 stage="${S:-prod}"
@@ -19,5 +19,4 @@ provider="${P:-default}"
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
-    --exclude "posix/ci/cloud/" \
     --remote "${platform}/${version}" --remote-terminate always --remote-stage "${stage}" --remote-provider "${provider}"

--- a/test/utils/shippable/linux.sh
+++ b/test/utils/shippable/linux.sh
@@ -8,12 +8,11 @@ IFS='/:' read -ra args <<< "$1"
 image="${args[1]}"
 
 if [ "${#args[@]}" -gt 2 ]; then
-    target="posix/ci/group${args[2]}/"
+    target="shippable/posix/group${args[2]}/"
 else
-    target="posix/ci/"
+    target="shippable/posix/"
 fi
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
-    --exclude "posix/ci/cloud/" \
     --docker "${image}"

--- a/test/utils/shippable/network.sh
+++ b/test/utils/shippable/network.sh
@@ -11,7 +11,7 @@ if [ "${COVERAGE}" ]; then
     echo "coverage" > /tmp/network.txt
 fi
 
-target="network/ci/"
+target="shippable/network/"
 
 stage="${S:-prod}"
 provider="${P:-default}"

--- a/test/utils/shippable/osx.sh
+++ b/test/utils/shippable/osx.sh
@@ -9,9 +9,9 @@ platform="${args[0]}"
 version="${args[1]}"
 
 if [ "${#args[@]}" -gt 2 ]; then
-    target="posix/ci/group${args[2]}/"
+    target="shippable/posix/group${args[2]}/"
 else
-    target="posix/ci/"
+    target="shippable/posix/"
 fi
 
 stage="${S:-prod}"
@@ -19,5 +19,4 @@ provider="${P:-default}"
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
-    --exclude "posix/ci/cloud/" \
     --remote "${platform}/${version}" --remote-terminate always --remote-stage "${stage}" --remote-provider "${provider}"

--- a/test/utils/shippable/rhel.sh
+++ b/test/utils/shippable/rhel.sh
@@ -9,9 +9,9 @@ platform="${args[0]}"
 version="${args[1]}"
 
 if [ "${#args[@]}" -gt 2 ]; then
-    target="posix/ci/group${args[2]}/"
+    target="shippable/posix/group${args[2]}/"
 else
-    target="posix/ci/"
+    target="shippable/posix/"
 fi
 
 stage="${S:-prod}"
@@ -19,5 +19,4 @@ provider="${P:-default}"
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
-    --exclude "posix/ci/cloud/" \
     --remote "${platform}/${version}" --remote-terminate always --remote-stage "${stage}" --remote-provider "${provider}"

--- a/test/utils/shippable/tower.sh
+++ b/test/utils/shippable/tower.sh
@@ -1,0 +1,1 @@
+cloud.sh

--- a/test/utils/shippable/vcenter.sh
+++ b/test/utils/shippable/vcenter.sh
@@ -1,0 +1,1 @@
+cloud.sh

--- a/test/utils/shippable/windows.sh
+++ b/test/utils/shippable/windows.sh
@@ -6,7 +6,9 @@ declare -a args
 IFS='/:' read -ra args <<< "$1"
 
 version="${args[1]}"
-target="windows/ci/group${args[2]}/"
+group="${args[2]}"
+
+target="shippable/windows/group${group}/"
 
 stage="${S:-prod}"
 provider="${P:-default}"
@@ -59,9 +61,9 @@ for version in "${python_versions[@]}"; do
             # with change detection enabled run tests for anything changed
             # use the smoketest tests for any change that triggers all tests
             ci="${target}"
-            if [ "${target}" == "windows/ci/group1/" ]; then
+            if [ "${target}" == "shippable/windows/group1/" ]; then
                 # only run smoketest tests for group1
-                changed_all_target="windows/ci/smoketest/"
+                changed_all_target="shippable/windows/smoketest/"
             else
                 # smoketest tests already covered by group1
                 changed_all_target="none"
@@ -72,9 +74,9 @@ for version in "${python_versions[@]}"; do
         fi
     else
         # only run minimal tests for group1
-        if [ "${target}" != "windows/ci/group1/" ]; then continue; fi
+        if [ "${target}" != "shippable/windows/group1/" ]; then continue; fi
         # minimal tests for other python versions
-        ci="windows/ci/minimal/"
+        ci="shippable/windows/minimal/"
     fi
 
     # terminate remote instances on the final python version tested


### PR DESCRIPTION
##### SUMMARY

Update Shippable integration test groups. (#43118)

* Update Shippable integration test groups.
* Update integration test group aliases.
* Rebalance AWS and Azure tests with extra group.
* Rebalance Windows tests with another group.

(cherry picked from commit 4e489d1be86a2e8eafce935d91ba4fe096c1b15e)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

shippable.yml

##### ANSIBLE VERSION

```
ansible 2.5.6 (test-matrix-2.5 1bcb871cd6) last updated 2018/07/23 23:21:22 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
