### PR TITLE
scaleway: initialise auth_token to none

### DIFF
--- a/contrib/inventory/scaleway.py
+++ b/contrib/inventory/scaleway.py
@@ -152,6 +152,7 @@ def generate_inv_from_api(config):
     try:
         inventory['scaleway'] = copy.deepcopy(EMPTY_GROUP)
 
+        auth_token = None
         if config.has_option('auth', 'api_token'):
             auth_token = config.get('auth', 'api_token')
         auth_token = env_or_param('SCALEWAY_TOKEN', param=auth_token)


### PR DESCRIPTION
##### SUMMARY
 
Fixes: #43132

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

scaleway.py inventory script

##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION

https://github.com/ansible/ansible/issues/43132