### PR TITLE
vault: check dir value before passing

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -927,7 +927,7 @@ class VaultEditor:
         """ create a new encrypted file """
 
         dirname = os.path.dirname(filename)
-        if not os.path.exists(dirname):
+        if dirname and not os.path.exists(dirname):
             display.warning("%s does not exist, creating..." % dirname)
             makedirs_safe(dirname)
 


### PR DESCRIPTION
##### SUMMARY
This fix checks if dirname is not equal to '' before proceeding
to create actual directory with name.

Before fix - 

```
$ ansible-vault create before.yml
New Vault password:
Confirm New Vault password:
 [WARNING]:  does not exist, creating...
```
After fix - 

```
# ansible-vault create after.yml
New Vault password:
Confirm New Vault password:
```
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/parsing/vault/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```