### PR TITLE
Added functionality to inspect baud rate

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_logging.py
+++ b/lib/ansible/modules/network/nxos/nxos_logging.py
@@ -130,7 +130,6 @@ def map_obj_to_commands(updates, module):
         state = w['state']
         del w['state']
 
-
         if state == 'absent' and w in have:
             if w['facility'] is not None:
                 if not w['dest']:

--- a/test/integration/targets/nxos_logging/tests/common/basic.yaml
+++ b/test/integration/targets/nxos_logging/tests/common/basic.yaml
@@ -24,6 +24,42 @@
     that:
       - 'result.changed == false'
 
+- name: Set Baud Rate to less than 38400
+  nxos_config:
+    lines:
+      - speed 9600
+    parents: line console
+    provider: "{{ connection }}"
+
+- name: Enable console logging with level 3 (will fail)
+  nxos_logging: &con3
+    dest: console
+    dest_level: 3
+  register: result
+  provider: "{{ connection }}"
+  ignore_errors: yes
+
+- assert:
+    that:
+      - 'result.failed == true'
+      - '"Baud rate of console should be 38400 to increase severity level." in result.msg'
+
+- name: Set Baud Rate to 38400
+  nxos_config:
+    lines:
+      - speed 38400
+    parents: line console
+    provider: "{{ connection }}"
+
+- name: Enable console logging with level 3 (will pass)
+  nxos_logging: *con3
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == true'
+      - '"logging console 3" in result.commands'
+
 - name: Logfile logging with level
   nxos_logging: &llog
     dest: logfile
@@ -122,7 +158,7 @@
 - name: remove logging as collection tearDown
   nxos_logging: &agg
     aggregate:
-      - { dest: console, dest_level: 0 }
+      - { dest: console, dest_level: 3 }
       - { dest: module, dest_level: 2 }
       - { dest: monitor, dest_level: 3 }
       - { dest: logfile, dest_level: 1, name: test }


### PR DESCRIPTION
##### SUMMARY
- Adds functionality for checking _baud rate_ as mentioned in #43072
- If _baud rate_ is less than 38400, and if user is trying to set console logging with severity > 2, it throws an error message on the device, if directly run.
- However, _nxos_logging_ module showed that the command has been executed successfully.
- With this PR, the _nxos_logging_ module checks the _baud rate_ before running the command in this scenario.
- Added integration tests that does the following:
              - Sets baud rate to below 38400
              - Attempts to configure console logging with sev 3
              - Asserts that the above attempt fails with the correct error message
              - Sets baud rate to 38400
              - Attempts to set the same console logging configuration
              - Asserts that it passes now running the correct command on the device

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
nxos_logging.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
