### PR TITLE
Fix author name in the documentation

### DIFF
--- a/lib/ansible/plugins/inventory/auto.py
+++ b/lib/ansible/plugins/inventory/auto.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
     name: auto
     plugin_type: inventory
-    authors:
+    author:
       - Matt Davis <@nitzmahone>
     short_description: Loads and executes an inventory plugin specified in a YAML config
     description:

--- a/lib/ansible/plugins/inventory/k8s.py
+++ b/lib/ansible/plugins/inventory/k8s.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
     name: k8s
     plugin_type: inventory
-    authors:
+    author:
       - Chris Houseknecht <@chouseknecht>
       - Fabian von Feilitzsch <@fabianvf>
 

--- a/lib/ansible/plugins/inventory/openshift.py
+++ b/lib/ansible/plugins/inventory/openshift.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
     name: openshift
     plugin_type: inventory
-    authors:
+    author:
       - Chris Houseknecht <@chouseknecht>
 
     short_description: OpenShift inventory source

--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
     name: openstack
     plugin_type: inventory
-    authors:
+    author:
       - Marco Vito Moscaritolo <marco@agavee.com>
       - Jesse Keating <jesse.keating@rackspace.com>
     short_description: OpenStack inventory source

--- a/lib/ansible/plugins/inventory/scaleway.py
+++ b/lib/ansible/plugins/inventory/scaleway.py
@@ -8,8 +8,8 @@ __metaclass__ = type
 DOCUMENTATION = '''
     name: scaleway
     plugin_type: inventory
-    authors:
-      - Remy Leone <rleone@online.net>
+    author:
+      - Remy Leone (@sieben)
     short_description: Scaleway inventory source
     description:
         - Get inventory hosts from Scaleway


### PR DESCRIPTION
##### SUMMARY

Fix author rendering in the documentation website

https://docs.ansible.com/ansible/devel/plugins/inventory/scaleway.html

UNKNOWN author error

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

`lib/ansible/plugins/inventory/scaleway.py`

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (specify_author aab3c11413) last updated 2018/07/24 11:01:56 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]

```

