### PR TITLE
Lenovo port to persistence 1

### DIFF
--- a/lib/ansible/module_utils/network/cnos/cnos.py
+++ b/lib/ansible/module_utils/network/cnos/cnos.py
@@ -1350,8 +1350,8 @@ def portChannelConfig(module, prompt, answer):
                 command = command + ""
             elif(portChArg3 == "source-interface"):
                 command = command + portChArg3
-            cmd = [{'command': command, 'prompt': None, 'answer': None}]
-            retVal = retVal + str(run_cnos_commands(module, cmd))
+                cmd = [{'command': command, 'prompt': None, 'answer': None}]
+                retVal = retVal + str(run_cnos_commands(module, cmd))
             else:
                 retVal = "Error-231"
                 return retVal

--- a/lib/ansible/module_utils/network/cnos/cnos.py
+++ b/lib/ansible/module_utils/network/cnos/cnos.py
@@ -2554,15 +2554,17 @@ def createVlan(module, prompt, answer):
 # EOM
 
 
-def vlagConfig(
-        obj, deviceType, prompt, timeout, vlagArg1, vlagArg2, vlagArg3,
-        vlagArg4):
+def vlagConfig(module, prompt, answer):
 
-    retVal = ""
-    # Wait time to get response from server
-    timeout = timeout
+    retVal = ''
     # vlag config command happens here.
-    command = "vlag "
+    command = 'vlag '
+
+    vlagArg1 = module.params['vlagArg1']
+    vlagArg2 = module.params['vlagArg2']
+    vlagArg3 = module.params['vlagArg3']
+    vlagArg4 = module.params['vlagArg4']
+    deviceType = module.params['deviceType']
 
     if(vlagArg1 == "enable"):
         # debugOutput("enable")
@@ -2718,10 +2720,8 @@ def vlagConfig(
         return retVal
 
     # debugOutput(command)
-    command = command + "\n"
-    # debugOutput(command)
-    retVal = retVal + waitForDeviceResponse(command, "(config)#", timeout, obj)
-
+    cmd = [{'command': command, 'prompt': None, 'answer': None}]
+    retVal = retVal + str(run_cnos_commands(module, cmd))
     return retVal
 # EOM
 

--- a/lib/ansible/module_utils/network/cnos/cnos.py
+++ b/lib/ansible/module_utils/network/cnos/cnos.py
@@ -212,128 +212,95 @@ def get_defaults_flag(module):
         return 'full'
 
 
-def interfaceConfig(
-    obj, deviceType, prompt, timeout, interfaceArg1,
-        interfaceArg2, interfaceArg3, interfaceArg4, interfaceArg5,
-        interfaceArg6, interfaceArg7, interfaceArg8, interfaceArg9):
+def interfaceConfig(module, prompt, functionality, answer):
     retVal = ""
     command = "interface "
     newPrompt = prompt
-    if(interfaceArg1 == "port-aggregation"):
-        command = command + " " + interfaceArg1 + " " + interfaceArg2 + "\n"
+    interfaceArg1 = functionality
+    interfaceArg2 = module.params['interfaceRange']
+    interfaceArg3 = module.params['interfaceArg1']
+    interfaceArg4 = module.params['interfaceArg2']
+    interfaceArg5 = module.params['interfaceArg3']
+    interfaceArg6 = module.params['interfaceArg4']
+    interfaceArg7 = module.params['interfaceArg5']
+    interfaceArg8 = module.params['interfaceArg6']
+    interfaceArg9 = module.params['interfaceArg7']
+    deviceType = module.params['deviceType']
+    
+    if(interfaceArg1 == "port-channel"):
+        command = command + " " + interfaceArg1 + " " + interfaceArg2
         # debugOutput(command)
         value = checkSanityofVariable(
             deviceType, "portchannel_interface_value", interfaceArg2)
         if(value == "ok"):
-            newPrompt = "(config-if)#"
-            retVal = retVal + \
-                waitForDeviceResponse(command, newPrompt, timeout, obj)
+            cmd = [{'command': command, 'prompt': None, 'answer': None}]
         else:
             value = checkSanityofVariable(
                 deviceType, "portchannel_interface_range", interfaceArg2)
             if(value == "ok"):
-                newPrompt = "(config-if-range)#"
-                retVal = retVal + \
-                    waitForDeviceResponse(command, newPrompt, timeout, obj)
+                cmd = [{'command': command, 'prompt': None, 'answer': None}]
             else:
                 value = checkSanityofVariable(
                     deviceType, "portchannel_interface_string", interfaceArg2)
                 if(value == "ok"):
-                    newPrompt = "(config-if-range)#"
-                    if '/' in interfaceArg2:
-                        newPrompt = "(config-if)#"
-                    retVal = retVal + \
-                        waitForDeviceResponse(command, newPrompt, timeout, obj)
+                    cmd = [{'command': command, 'prompt': None, 'answer': None}]
                 else:
                     retVal = "Error-102"
                     return retVal
-
-        retVal = retVal + interfaceLevel2Config(
-            obj, deviceType, newPrompt, timeout, interfaceArg3, interfaceArg4,
-            interfaceArg5, interfaceArg6, interfaceArg7, interfaceArg8,
-            interfaceArg9)
+        retVal = retVal + interfaceLevel2Config(module, cmd, prompt, answer)
     elif(interfaceArg1 == "ethernet"):
-        # command = command + interfaceArg1 + " 1/"
         value = checkSanityofVariable(
             deviceType, "ethernet_interface_value", interfaceArg2)
         if(value == "ok"):
-            newPrompt = "(config-if)#"
-            command = command + interfaceArg1 + " 1/" + interfaceArg2 + " \n"
-            retVal = retVal + \
-                waitForDeviceResponse(command, newPrompt, timeout, obj)
+            command = command + interfaceArg1 + " 1/" + interfaceArg2
+            cmd = [{'command': command, 'prompt': None, 'answer': None}]
         else:
             value = checkSanityofVariable(
                 deviceType, "ethernet_interface_range", interfaceArg2)
             if(value == "ok"):
-                command = command + \
-                    interfaceArg1 + " 1/" + interfaceArg2 + " \n"
-                newPrompt = "(config-if-range)#"
-                retVal = retVal + \
-                    waitForDeviceResponse(command, newPrompt, timeout, obj)
+                command = command + interfaceArg1 + " 1/" + interfaceArg2
+                cmd = [{'command': command, 'prompt': None, 'answer': None}]
             else:
                 value = checkSanityofVariable(
                     deviceType, "ethernet_interface_string", interfaceArg2)
                 if(value == "ok"):
-                    command = command + \
-                        interfaceArg1 + " " + interfaceArg2 + "\n"
-                    newPrompt = "(config-if-range)#"
-                    if '/' in interfaceArg2:
-                        newPrompt = "(config-if)#"
-                    retVal = retVal + \
-                        waitForDeviceResponse(command, newPrompt, timeout, obj)
+                    command = command + interfaceArg1 + " " + interfaceArg2
+                    cmd = [{'command': command, 'prompt': None, 'answer': None}]
                 else:
                     retVal = "Error-102"
                     return retVal
 
-        retVal = retVal + interfaceLevel2Config(
-            obj, deviceType, newPrompt, timeout, interfaceArg3, interfaceArg4,
-            interfaceArg5, interfaceArg6, interfaceArg7, interfaceArg8,
-            interfaceArg9)
+        retVal = retVal + interfaceLevel2Config(module, cmd, prompt, answer)	
     elif(interfaceArg1 == "loopback"):
         value = checkSanityofVariable(
             deviceType, "loopback_interface_value", interfaceArg2)
         if(value == "ok"):
-            newPrompt = "(config-if)#"
-            command = command + interfaceArg1 + " " + interfaceArg2 + "\n"
-            retVal = retVal + \
-                waitForDeviceResponse(command, newPrompt, timeout, obj)
+            command = command + interfaceArg1 + " " + interfaceArg2
+            cmd = [{'command': command, 'prompt': None, 'answer': None}]
         else:
             retVal = "Error-102"
             return retVal
-        retVal = retVal + interfaceLevel2Config(
-            obj, deviceType, newPrompt, timeout, interfaceArg3, interfaceArg4,
-            interfaceArg5, interfaceArg6, interfaceArg7, interfaceArg8,
-            interfaceArg9)
+        retVal = retVal + interfaceLevel2Config(module, cmd, prompt, answer)
     elif(interfaceArg1 == "mgmt"):
         value = checkSanityofVariable(
             deviceType, "mgmt_interface_value", interfaceArg2)
         if(value == "ok"):
-            newPrompt = "(config-if)#"
-            command = command + interfaceArg1 + " " + interfaceArg2 + "\n"
-            retVal = retVal + \
-                waitForDeviceResponse(command, newPrompt, timeout, obj)
+            command = command + interfaceArg1 + " " + interfaceArg2
+            cmd = [{'command': command, 'prompt': None, 'answer': None}]
         else:
             retVal = "Error-102"
             return retVal
-        retVal = retVal + interfaceLevel2Config(
-            obj, deviceType, newPrompt, timeout, interfaceArg3, interfaceArg4,
-            interfaceArg5, interfaceArg6, interfaceArg7, interfaceArg8,
-            interfaceArg9)
+        retVal = retVal + interfaceLevel2Config(module, cmd, prompt, answer)
     elif(interfaceArg1 == "vlan"):
         value = checkSanityofVariable(
             deviceType, "vlan_interface_value", interfaceArg2)
         if(value == "ok"):
-            newPrompt = "(config-if)#"
-            command = command + interfaceArg1 + " " + interfaceArg2 + "\n"
-            retVal = retVal + \
-                waitForDeviceResponse(command, newPrompt, timeout, obj)
+            command = command + interfaceArg1 + " " + interfaceArg2
+            cmd = [{'command': command, 'prompt': None, 'answer': None}]
         else:
             retVal = "Error-102"
             return retVal
-        retVal = retVal + interfaceLevel2Config(
-            obj, deviceType, newPrompt, timeout, interfaceArg3, interfaceArg4,
-            interfaceArg5, interfaceArg6, interfaceArg7, interfaceArg8,
-            interfaceArg9)
+        retVal = retVal + interfaceLevel2Config(module, cmd, prompt, answer)
     else:
         retVal = "Error-102"
 
@@ -341,14 +308,20 @@ def interfaceConfig(
 # EOM
 
 
-def interfaceLevel2Config(
-    obj, deviceType, prompt, timeout, interfaceL2Arg1, interfaceL2Arg2,
-    interfaceL2Arg3, interfaceL2Arg4, interfaceL2Arg5, interfaceL2Arg6,
-        interfaceL2Arg7):
+def interfaceLevel2Config(module, cmd, prompt, answer):
     retVal = ""
     command = ""
-    if(interfaceL2Arg1 == "aggregation-group"):
-        # debugOutput("aggregation-group")
+    interfaceL2Arg1 = module.params['interfaceArg1']
+    interfaceL2Arg2 = module.params['interfaceArg2']
+    interfaceL2Arg3 = module.params['interfaceArg3']
+    interfaceL2Arg4 = module.params['interfaceArg4']
+    interfaceL2Arg5 = module.params['interfaceArg5']
+    interfaceL2Arg6 = module.params['interfaceArg6']
+    interfaceL2Arg7 = module.params['interfaceArg7']
+    deviceType = module.params['deviceType']
+
+    if(interfaceL2Arg1 == "channel-group"):
+        # debugOutput("channel-group")
         command = interfaceL2Arg1 + " "
         value = checkSanityofVariable(
             deviceType, "aggregation_group_no", interfaceL2Arg2)
@@ -583,8 +556,8 @@ def interfaceLevel2Config(
             retVal = "Error-205"
             return retVal
 
-    elif (interfaceL2Arg1 == "bridge-port"):
-        # debugOutput("bridge-port")
+    elif (interfaceL2Arg1 == "switchport"):
+        # debugOutput("switchport")
         command = interfaceL2Arg1 + " "
         if(interfaceL2Arg2 is None):
             command = command.strip()
@@ -1335,26 +1308,25 @@ def interfaceLevel2Config(
         retVal = "Error-233"
         return retVal
 
-    command = command + "\n"
     # debugOutput(command)
-    retVal = retVal + waitForDeviceResponse(command, prompt, timeout, obj)
+    inner_cmd = [{'command': command, 'prompt': None, 'answer': None}]
+    cmd.extend(inner_cmd)
+    retVal = retVal + str(run_cnos_commands(module, cmd))
     # Come back to config mode
     if((prompt == "(config-if)#") or (prompt == "(config-if-range)#")):
-        command = "exit \n"
+        command = "exit"
         # debugOutput(command)
-        retVal = retVal + \
-            waitForDeviceResponse(command, "(config)#", timeout, obj)
-
+        cmd = [{'command': command, 'prompt': None, 'answer': None}]
+        #retVal = retVal + str(run_cnos_commands(module, cmd))
     return retVal
 # EOM
 
 
-def portChannelConfig(
-        obj, deviceType, prompt, timeout, portChArg1, portChArg2, portChArg3,
-        portChArg4, portChArg5, portChArg6, portChArg7):
-    retVal = ""
-    command = ""
-    if(portChArg1 == "port-aggregation" and prompt == "(config)#"):
+def portChannelConfig((module, prompt, answer)
+        
+    retVal = ''
+    command = ''
+    if(portChArg1 == "port-channel" and prompt == "(config)#"):
         command = command + portChArg1 + " load-balance ethernet "
         if(portChArg2 == "destination-ip" or
            portChArg2 == "destination-mac" or
@@ -1373,6 +1345,8 @@ def portChannelConfig(
                 command = command + ""
             elif(portChArg3 == "source-interface"):
                 command = command + portChArg3
+            cmd = [{'command': command, 'prompt': None, 'answer': None}]
+            retVal = retVal + str(run_cnos_commands(module, cmd))
             else:
                 retVal = "Error-231"
                 return retVal
@@ -2594,7 +2568,7 @@ def vlagConfig(module, prompt, answer):
 
     elif(vlagArg1 == "isl"):
         # debugOutput("isl")
-        command = command + vlagArg1 + " port-aggregation "
+        command = command + vlagArg1 + " port-channel "
         value = checkSanityofVariable(
             deviceType, "vlag_port_aggregation", vlagArg2)
         if(value == "ok"):
@@ -2653,7 +2627,7 @@ def vlagConfig(module, prompt, answer):
         if(value == "ok"):
             command = command + vlagArg2
             if(vlagArg3 is not None):
-                command = command + " port-aggregation "
+                command = command + " port-channel "
                 value = checkSanityofVariable(
                     deviceType, "vlag_port_aggregation", vlagArg3)
                 if(value == "ok"):

--- a/lib/ansible/module_utils/network/cnos/cnos.py
+++ b/lib/ansible/module_utils/network/cnos/cnos.py
@@ -164,7 +164,8 @@ def run_commands(module, commands, check_rc=True):
 
 def run_cnos_commands(module, commands, check_rc=True):
     retVal = ''
-    enter_config = {'command': 'configure terminal', 'prompt': None, 'answer': None}
+    enter_config = {'command': 'configure terminal', 'prompt': None,
+                    'answer': None}
     exit_config = {'command': 'end', 'prompt': None, 'answer': None}
     commands.insert(0, enter_config)
     commands.append(exit_config)
@@ -226,7 +227,7 @@ def interfaceConfig(module, prompt, functionality, answer):
     interfaceArg8 = module.params['interfaceArg6']
     interfaceArg9 = module.params['interfaceArg7']
     deviceType = module.params['deviceType']
-    
+
     if(interfaceArg1 == "port-channel"):
         command = command + " " + interfaceArg1 + " " + interfaceArg2
         # debugOutput(command)
@@ -243,7 +244,8 @@ def interfaceConfig(module, prompt, functionality, answer):
                 value = checkSanityofVariable(
                     deviceType, "portchannel_interface_string", interfaceArg2)
                 if(value == "ok"):
-                    cmd = [{'command': command, 'prompt': None, 'answer': None}]
+                    cmd = [{'command': command, 'prompt': None,
+                            'answer': None}]
                 else:
                     retVal = "Error-102"
                     return retVal
@@ -265,12 +267,13 @@ def interfaceConfig(module, prompt, functionality, answer):
                     deviceType, "ethernet_interface_string", interfaceArg2)
                 if(value == "ok"):
                     command = command + interfaceArg1 + " " + interfaceArg2
-                    cmd = [{'command': command, 'prompt': None, 'answer': None}]
+                    cmd = [{'command': command, 'prompt': None,
+                            'answer': None}]
                 else:
                     retVal = "Error-102"
                     return retVal
 
-        retVal = retVal + interfaceLevel2Config(module, cmd, prompt, answer)	
+        retVal = retVal + interfaceLevel2Config(module, cmd, prompt, answer)
     elif(interfaceArg1 == "loopback"):
         value = checkSanityofVariable(
             deviceType, "loopback_interface_value", interfaceArg2)
@@ -1317,15 +1320,17 @@ def interfaceLevel2Config(module, cmd, prompt, answer):
         command = "exit"
         # debugOutput(command)
         cmd = [{'command': command, 'prompt': None, 'answer': None}]
-        #retVal = retVal + str(run_cnos_commands(module, cmd))
+        # retVal = retVal + str(run_cnos_commands(module, cmd))
     return retVal
 # EOM
 
 
-def portChannelConfig((module, prompt, answer)
-        
+def portChannelConfig(module, prompt, answer):
     retVal = ''
     command = ''
+    portChArg1 = module.params['interfaceArg1']
+    portChArg2 = module.params['interfaceArg2']
+    portChArg3 = module.params['interfaceArg3']
     if(portChArg1 == "port-channel" and prompt == "(config)#"):
         command = command + portChArg1 + " load-balance ethernet "
         if(portChArg2 == "destination-ip" or
@@ -1353,7 +1358,6 @@ def portChannelConfig((module, prompt, answer)
         else:
             retVal = "Error-232"
             return retVal
-
 # EOM
 
 

--- a/lib/ansible/module_utils/network/cnos/cnos_devicerules.py
+++ b/lib/ansible/module_utils/network/cnos/cnos_devicerules.py
@@ -1356,7 +1356,7 @@ g8272_cnos = {'vlan_id': 'INTEGER_VALUE:1-3999',
               'portchannel_ipv6_address': 'IPV6Address:',
               'portchannel_ipv6_options': 'TEXT_OPTIONS:address,dhcp,\
               link-local,nd,neighbor',
-              'interface_speed': 'TEXT_OPTIONS:1000,10000,40000,auto',
+              'interface_speed': 'TEXT_OPTIONS:1000,10000,40000',
               'stormcontrol_options': 'TEXT_OPTIONS:broadcast,multicast,\
               unicast',
               'stormcontrol_level': 'FLOAT:',

--- a/lib/ansible/modules/network/cnos/cnos_interface.py
+++ b/lib/ansible/modules/network/cnos/cnos_interface.py
@@ -57,7 +57,7 @@ extends_documentation_fragment: cnos
 options:
     interfaceRange:
         description:
-            - This specifies the interface range in which the port aggregation is envisaged
+            - This specifies the interface range in which the port channel is envisaged
         required: Yes
         default: Null
     interfaceOption:
@@ -65,21 +65,21 @@ options:
             - This specifies the attribute you specify subsequent to interface command
         required: Yes
         default: Null
-        choices: [None, ethernet, loopback, mgmt, port-aggregation, vlan]
+        choices: [None, ethernet, loopback, mgmt, port-channel, vlan]
     interfaceArg1:
         description:
             - This is an overloaded interface first argument. Usage of this argument can be found is the User Guide referenced above.
         required: Yes
         default: Null
-        choices: [aggregation-group, bfd, bridgeport, description, duplex, flowcontrol, ip, ipv6, lacp, lldp,
+        choices: [channel-group, bfd, switchport, description, duplex, flowcontrol, ip, ipv6, lacp, lldp,
         load-interval, mac, mac-address, mac-learn, microburst-detection, mtu, service, service-policy,
-        shutdown, snmp, spanning-tree, speed, storm-control, vlan, vrrp, port-aggregation]
+        shutdown, snmp, spanning-tree, speed, storm-control, vlan, vrrp, port-channel]
     interfaceArg2:
         description:
             - This is an overloaded interface second argument. Usage of this argument can be found is the User Guide referenced above.
         required: No
         default: Null
-        choices: [aggregation-group number, access or mode or trunk, description, auto or full or half,
+        choices: [channel-group number, access or mode or trunk, description, auto or full or half,
         receive or send, port-priority, suspend-individual, timeout, receive or transmit or trap-notification,
         tlv-select, Load interval delay in seconds, counter, Name for the MAC Access List, mac-address in HHHH.HHHH.HHHH format,
         THRESHOLD  Value in unit of buffer cell, <64-9216>  MTU in bytes-<64-9216> for L2 packet,<576-9216> for L3 IPv4 packet,
@@ -132,7 +132,7 @@ options:
 EXAMPLES = '''
 Tasks : The following are examples of using the module cnos_interface. These are written in the main.yml file of the tasks directory.
 ---
-- name: Test Interface Ethernet - aggregation-group
+- name: Test Interface Ethernet - channel-group
   cnos_interface:
       host: "{{ inventory_hostname }}"
       username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
@@ -142,11 +142,11 @@ Tasks : The following are examples of using the module cnos_interface. These are
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
       interfaceOption: 'ethernet'
       interfaceRange: 1
-      interfaceArg1: "aggregation-group"
+      interfaceArg1: "channel-group"
       interfaceArg2: 33
       interfaceArg3: "on"
 
-- name: Test Interface Ethernet - bridge-port
+- name: Test Interface Ethernet - switchport
   cnos_interface:
       host: "{{ inventory_hostname }}"
       username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
@@ -156,11 +156,11 @@ Tasks : The following are examples of using the module cnos_interface. These are
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
       interfaceOption: 'ethernet'
       interfaceRange: 33
-      interfaceArg1: "bridge-port"
+      interfaceArg1: "switchport"
       interfaceArg2: "access"
       interfaceArg3: 33
 
-- name: Test Interface Ethernet - bridgeport mode
+- name: Test Interface Ethernet - switchport mode
   cnos_interface:
       host: "{{ inventory_hostname }}"
       username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
@@ -170,7 +170,7 @@ Tasks : The following are examples of using the module cnos_interface. These are
       outputfile: "./results/test_interface_{{ inventory_hostname }}_output.txt"
       interfaceOption: 'ethernet'
       interfaceRange: 33
-      interfaceArg1: "bridge-port"
+      interfaceArg1: "switchport"
       interfaceArg2: "mode"
       interfaceArg3: "access"
 
@@ -505,70 +505,23 @@ def main():
             interfaceArg7=dict(required=False),),
         supports_check_mode=False)
 
-    username = module.params['username']
-    password = module.params['password']
-    enablePassword = module.params['enablePassword']
-    interfaceRange = module.params['interfaceRange']
     interfaceOption = module.params['interfaceOption']
-    interfaceArg1 = module.params['interfaceArg1']
-    interfaceArg2 = module.params['interfaceArg2']
-    interfaceArg3 = module.params['interfaceArg3']
-    interfaceArg4 = module.params['interfaceArg4']
-    interfaceArg5 = module.params['interfaceArg5']
-    interfaceArg6 = module.params['interfaceArg6']
-    interfaceArg7 = module.params['interfaceArg7']
     outputfile = module.params['outputfile']
-    hostIP = module.params['host']
-    deviceType = module.params['deviceType']
 
-    output = ""
-    if not HAS_PARAMIKO:
-        module.fail_json(msg='paramiko is required for this module')
-
-    # Create instance of SSHClient object
-    remote_conn_pre = paramiko.SSHClient()
-
-    # Automatically add untrusted hosts (make sure okay for security policy in your environment)
-    remote_conn_pre.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
-    # initiate SSH connection with the switch
-    remote_conn_pre.connect(hostIP, username=username, password=password)
-    time.sleep(2)
-
-    # Use invoke_shell to establish an 'interactive session'
-    remote_conn = remote_conn_pre.invoke_shell()
-    time.sleep(2)
-
-    # Enable and enter configure terminal then send command
-    output = output + cnos.waitForDeviceResponse("\n", ">", 2, remote_conn)
-
-    output = output + cnos.enterEnableModeForDevice(enablePassword, 3, remote_conn)
-
-    # Make terminal length = 0
-    output = output + cnos.waitForDeviceResponse("terminal length 0\n", "#", 2, remote_conn)
-
-    # Go to config mode
-    output = output + cnos.waitForDeviceResponse("configure device\n", "(config)#", 2, remote_conn)
-
+    output = ''
     # Send the CLi command
     if(interfaceOption is None or interfaceOption == ""):
-        output = output + cnos.interfaceConfig(remote_conn, deviceType, "(config)#", 2, None, interfaceRange,
-                                               interfaceArg1, interfaceArg2, interfaceArg3, interfaceArg4, interfaceArg5, interfaceArg6, interfaceArg7)
+        output = output + cnos.interfaceConfig(module, "(config)#", None, None)
     elif(interfaceOption == "ethernet"):
-        output = output + cnos.interfaceConfig(remote_conn, deviceType, "(config)#", 2, "ethernet", interfaceRange,
-                                               interfaceArg1, interfaceArg2, interfaceArg3, interfaceArg4, interfaceArg5, interfaceArg6, interfaceArg7)
+        output = output + cnos.interfaceConfig(module, "(config)#", "ethernet", None)
     elif(interfaceOption == "loopback"):
-        output = output + cnos.interfaceConfig(remote_conn, deviceType, "(config)#", 2, "loopback", interfaceRange,
-                                               interfaceArg1, interfaceArg2, interfaceArg3, interfaceArg4, interfaceArg5, interfaceArg6, interfaceArg7)
+        output = output + cnos.interfaceConfig(module, "(config)#", "loopback", None)
     elif(interfaceOption == "mgmt"):
-        output = output + cnos.interfaceConfig(remote_conn, deviceType, "(config)#", 2, "mgmt", interfaceRange,
-                                               interfaceArg1, interfaceArg2, interfaceArg3, interfaceArg4, interfaceArg5, interfaceArg6, interfaceArg7)
-    elif(interfaceOption == "port-aggregation"):
-        output = output + cnos.interfaceConfig(remote_conn, deviceType, "(config)#", 2, "port-aggregation", interfaceRange,
-                                               interfaceArg1, interfaceArg2, interfaceArg3, interfaceArg4, interfaceArg5, interfaceArg6, interfaceArg7)
+        output = output + cnos.interfaceConfig(module, "(config)#", "mgmt", None)
+    elif(interfaceOption == "port-channel"):
+        output = output + cnos.interfaceConfig(module, "(config)#", "port-channel", None)
     elif(interfaceOption == "vlan"):
-        output = output + cnos.interfaceConfig(remote_conn, deviceType, "(config)#", 2, "vlan", interfaceRange,
-                                               interfaceArg1, interfaceArg2, interfaceArg3, interfaceArg4, interfaceArg5, interfaceArg6, interfaceArg7)
+        output = output + cnos.interfaceConfig(module, "(config)#", "vlan", None)
     else:
         output = "Invalid interface option \n"
     # Save it into the file
@@ -579,7 +532,7 @@ def main():
     # Logic to check when changes occur or not
     errorMsg = cnos.checkOutputForError(output)
     if(errorMsg is None):
-        module.exit_json(changed=True, msg="Interface Configuration is done")
+        module.exit_json(changed=True, msg="Interface Configuration is Accomplished")
     else:
         module.fail_json(msg=errorMsg)
 

--- a/lib/ansible/modules/network/cnos/cnos_portchannel.py
+++ b/lib/ansible/modules/network/cnos/cnos_portchannel.py
@@ -32,10 +32,10 @@ DOCUMENTATION = '''
 ---
 module: cnos_portchannel
 author: "Anil Kumar Muraleedharan (@amuraleedhar)"
-short_description: Manage portchannel (port aggregation) configuration on devices running Lenovo CNOS
+short_description: Manage portchannel (port channel) configuration on devices running Lenovo CNOS
 description:
-    - This module allows you to work with port aggregation related configurations. The operators
-     used are overloaded to ensure control over switch port aggregation configurations. Apart
+    - This module allows you to work with port channel related configurations. The operators
+     used are overloaded to ensure control over switch port channel configurations. Apart
      from the regular device connection related attributes, there are five LAG arguments which are
      overloaded variables that will perform further configurations. They are interfaceArg1, interfaceArg2,
      interfaceArg3, interfaceArg4, and interfaceArg5. For more details on how to use these arguments, see
@@ -50,7 +50,7 @@ extends_documentation_fragment: cnos
 options:
     interfaceRange:
         description:
-            - This specifies the interface range in which the port aggregation is envisaged
+            - This specifies the interface range in which the port channel is envisaged
         required: Yes
         default: Null
     interfaceArg1:
@@ -58,15 +58,15 @@ options:
             - This is an overloaded Port Channel first argument. Usage of this argument can be found is the User Guide referenced above.
         required: Yes
         default: Null
-        choices: [aggregation-group, bfd, bridgeport, description, duplex, flowcontrol, ip, ipv6, lacp, lldp,
+        choices: [channel-group, bfd, bridgeport, description, duplex, flowcontrol, ip, ipv6, lacp, lldp,
         load-interval, mac, mac-address, mac-learn, microburst-detection, mtu, service, service-policy,
-        shutdown, snmp, spanning-tree, speed, storm-control, vlan, vrrp, port-aggregation]
+        shutdown, snmp, spanning-tree, speed, storm-control, vlan, vrrp, port-channel]
     interfaceArg2:
         description:
             - This is an overloaded Port Channel second argument. Usage of this argument can be found is the User Guide referenced above.
         required: No
         default: Null
-        choices: [aggregation-group number, access or mode or trunk, description, auto or full or half,
+        choices: [channel-group number, access or mode or trunk, description, auto or full or half,
         receive or send, port-priority, suspend-individual, timeout,     receive or transmit or trap-notification,
         tlv-select, Load interval delay in seconds, counter, Name for the MAC Access List, mac-address in HHHH.HHHH.HHHH format,
         THRESHOLD  Value in unit of buffer cell, <64-9216>  MTU in bytes-<64-9216> for L2 packet,<576-9216> for
@@ -118,7 +118,7 @@ options:
 EXAMPLES = '''
 Tasks : The following are examples of using the module cnos_portchannel. These are written in the main.yml file of the tasks directory.
 ---
-- name: Test Port Channel - aggregation-group
+- name: Test Port Channel - channel-group
   cnos_portchannel:
     host: "{{ inventory_hostname }}"
     username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
@@ -126,11 +126,11 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
     deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
     outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
     interfaceRange: 33
-    interfaceArg1: "aggregation-group"
+    interfaceArg1: "channel-group"
     interfaceArg2: 33
     interfaceArg3: "on"
 
-- name: Test Port Channel - aggregation-group - Interface Range
+- name: Test Port Channel - channel-group - Interface Range
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
   username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
@@ -138,7 +138,7 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
   deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
   outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
   interfaceRange: "1/1-2"
-  interfaceArg1: "aggregation-group"
+  interfaceArg1: "channel-group"
   interfaceArg2: 33
   interfaceArg3: "on"
 
@@ -305,16 +305,16 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
   interfaceArg2: "broadcast"
   interfaceArg3: 12.5
 
-#- name: Test Port Channel - vlan
-#  cnos_portchannel:
-#  host: "{{ inventory_hostname }}"
-#  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
-#  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
-#  deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
-#  outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
-#  interfaceRange: 33
-#  interfaceArg1: "vlan"
-#  interfaceArg2: "disable"
+- name: Test Port Channel - vlan
+  cnos_portchannel:
+  host: "{{ inventory_hostname }}"
+  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
+  deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
+  outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
+  interfaceRange: 33
+  interfaceArg1: "vlan"
+  interfaceArg2: "disable"
 
 - name: Test Port Channel - vrrp
   cnos_portchannel:
@@ -378,34 +378,34 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
   interfaceArg2: "port"
   interfaceArg3: "anil"
 
-- name: Test Port Channel - bfd
-  cnos_portchannel:
-  host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
-  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
-  deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
-  outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
-  interfaceRange: 33
-  interfaceArg1: "bfd"
-  interfaceArg2: "interval"
-  interfaceArg3: 55
-  interfaceArg4: 55
-  interfaceArg5: 33
+#- name: Test Port Channel - bfd
+#  cnos_portchannel:
+#  host: "{{ inventory_hostname }}"
+#  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+#  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
+#  deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
+#  outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
+#  interfaceRange: 33
+#  interfaceArg1: "bfd"
+#  interfaceArg2: "interval"
+#  interfaceArg3: 55
+#  interfaceArg4: 55
+#  interfaceArg5: 33
 
-- name: Test Port Channel - bfd
-  cnos_portchannel:
-  host: "{{ inventory_hostname }}"
-  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
-  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
-  deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
-  outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
-  interfaceRange: 33
-  interfaceArg1: "bfd"
-  interfaceArg2: "ipv4"
-  interfaceArg3: "authentication"
-  interfaceArg4: "meticulous-keyed-md5"
-  interfaceArg5: "key-chain"
-  interfaceArg6: "mychain"
+#- name: Test Port Channel - bfd
+#  cnos_portchannel:
+#  host: "{{ inventory_hostname }}"
+#  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
+#  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
+#  deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
+#  outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
+#  interfaceRange: 33
+#  interfaceArg1: "bfd"
+#  interfaceArg2: "ipv4"
+#  interfaceArg3: "authentication"
+#  interfaceArg4: "meticulous-keyed-md5"
+#  interfaceArg5: "key-chain"
+#  interfaceArg6: "mychain"
 
 '''
 RETURN = '''
@@ -417,11 +417,6 @@ msg:
 '''
 
 import sys
-try:
-    import paramiko
-    HAS_PARAMIKO = True
-except ImportError:
-    HAS_PARAMIKO = False
 import time
 import socket
 import array
@@ -457,56 +452,13 @@ def main():
             interfaceArg7=dict(required=False),),
         supports_check_mode=False)
 
-    username = module.params['username']
-    password = module.params['password']
-    enablePassword = module.params['enablePassword']
-    interfaceRange = module.params['interfaceRange']
-    interfaceArg1 = module.params['interfaceArg1']
-    interfaceArg2 = module.params['interfaceArg2']
-    interfaceArg3 = module.params['interfaceArg3']
-    interfaceArg4 = module.params['interfaceArg4']
-    interfaceArg5 = module.params['interfaceArg5']
-    interfaceArg6 = module.params['interfaceArg6']
-    interfaceArg7 = module.params['interfaceArg7']
     outputfile = module.params['outputfile']
-    hostIP = module.params['host']
-    deviceType = module.params['deviceType']
-    output = ""
-    if not HAS_PARAMIKO:
-        module.fail_json(msg='paramiko is required for this module')
-
-    # Create instance of SSHClient object
-    remote_conn_pre = paramiko.SSHClient()
-
-    # Automatically add untrusted hosts (make sure okay for security policy in your environment)
-    remote_conn_pre.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
-    # initiate SSH connection with the switch
-    remote_conn_pre.connect(hostIP, username=username, password=password)
-    time.sleep(2)
-
-    # Use invoke_shell to establish an 'interactive session'
-    remote_conn = remote_conn_pre.invoke_shell()
-    time.sleep(2)
-
-    # Enable and enter configure terminal then send command
-    output = output + cnos.waitForDeviceResponse("\n", ">", 2, remote_conn)
-
-    output = output + cnos.enterEnableModeForDevice(enablePassword, 3, remote_conn)
-
-    # Make terminal length = 0
-    output = output + cnos.waitForDeviceResponse("terminal length 0\n", "#", 2, remote_conn)
-
-    # Go to config mode
-    output = output + cnos.waitForDeviceResponse("configure device\n", "(config)#", 2, remote_conn)
-
+    output = ''
     # Send the CLi command
-    if(interfaceArg1 == "port-aggregation"):
-        output = output + cnos.portChannelConfig(remote_conn, deviceType, "(config)#", 2, interfaceArg1,
-                                                 interfaceArg2, interfaceArg3, interfaceArg4, interfaceArg5, interfaceArg6, interfaceArg7)
+    if(module.params['interfaceArg1'] == "port-channel"):
+        output = output + cnos.portChannelConfig(module, "(config)#", None)
     else:
-        output = output + cnos.interfaceConfig(remote_conn, deviceType, "(config)#", 2, "port-aggregation", interfaceRange,
-                                               interfaceArg1, interfaceArg2, interfaceArg3, interfaceArg4, interfaceArg5, interfaceArg6, interfaceArg7)
+        output = output + cnos.interfaceConfig(module, "(config)#", "port-channel", None)
 
     # Save it into the file
     file = open(outputfile, "a")
@@ -516,7 +468,7 @@ def main():
     # Logic to check when changes occur or not
     errorMsg = cnos.checkOutputForError(output)
     if(errorMsg is None):
-        module.exit_json(changed=True, msg="Port Aggregation configuration is done")
+        module.exit_json(changed=True, msg="Port Channel Configuration is done")
     else:
         module.fail_json(msg=errorMsg)
 

--- a/lib/ansible/modules/network/cnos/cnos_portchannel.py
+++ b/lib/ansible/modules/network/cnos/cnos_portchannel.py
@@ -237,17 +237,6 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
   interfaceArg3: 2
   interfaceArg4: 33
 
-#- name: Test Port Channel - mac
-#  cnos_portchannel:
-#  host: "{{ inventory_hostname }}"
-#  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
-#  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
-#  deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
-#  outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
-#  interfaceRange: 33,
-#  interfaceArg1: "mac"
-#  interfaceArg2: "copp-system-acl-vlag-hc"
-
 - name: Test Port Channel - microburst-detection
   cnos_portchannel:
   host: "{{ inventory_hostname }}"
@@ -377,35 +366,6 @@ Tasks : The following are examples of using the module cnos_portchannel. These a
   interfaceArg1: "ip"
   interfaceArg2: "port"
   interfaceArg3: "anil"
-
-#- name: Test Port Channel - bfd
-#  cnos_portchannel:
-#  host: "{{ inventory_hostname }}"
-#  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
-#  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
-#  deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
-#  outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
-#  interfaceRange: 33
-#  interfaceArg1: "bfd"
-#  interfaceArg2: "interval"
-#  interfaceArg3: 55
-#  interfaceArg4: 55
-#  interfaceArg5: 33
-
-#- name: Test Port Channel - bfd
-#  cnos_portchannel:
-#  host: "{{ inventory_hostname }}"
-#  username: "{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}"
-#  password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
-#  deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
-#  outputfile: "./results/test_portchannel_{{ inventory_hostname }}_output.txt"
-#  interfaceRange: 33
-#  interfaceArg1: "bfd"
-#  interfaceArg2: "ipv4"
-#  interfaceArg3: "authentication"
-#  interfaceArg4: "meticulous-keyed-md5"
-#  interfaceArg5: "key-chain"
-#  interfaceArg6: "mychain"
 
 '''
 RETURN = '''

--- a/lib/ansible/modules/network/cnos/cnos_vlag.py
+++ b/lib/ansible/modules/network/cnos/cnos_vlag.py
@@ -252,11 +252,6 @@ msg:
 '''
 
 import sys
-try:
-    import paramiko
-    HAS_PARAMIKO = True
-except ImportError:
-    HAS_PARAMIKO = False
 import time
 import socket
 import array
@@ -291,54 +286,11 @@ def main():
             vlagArg4=dict(required=False),),
         supports_check_mode=False)
 
-    username = module.params['username']
-    password = module.params['password']
-    enablePassword = module.params['enablePassword']
     outputfile = module.params['outputfile']
-    hostIP = module.params['host']
-    deviceType = module.params['deviceType']
-    vlagArg1 = module.params['vlagArg1']
-    vlagArg2 = module.params['vlagArg2']
-    vlagArg3 = module.params['vlagArg3']
-    vlagArg4 = module.params['vlagArg4']
     output = ""
-    if not HAS_PARAMIKO:
-        module.fail_json(msg='paramiko is required for this module')
-
-    # Create instance of SSHClient object
-    remote_conn_pre = paramiko.SSHClient()
-
-    # Automatically add untrusted hosts (make sure okay for security policy in
-    # your environment)
-    remote_conn_pre.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
-    # initiate SSH connection with the switch
-    remote_conn_pre.connect(hostIP, username=username, password=password)
-    time.sleep(2)
-
-    # Use invoke_shell to establish an 'interactive session'
-    remote_conn = remote_conn_pre.invoke_shell()
-    time.sleep(2)
-
-    # Enable and enter configure terminal then send command
-    output = output + cnos.waitForDeviceResponse("\n", ">", 2, remote_conn)
-
-    output = output + \
-        cnos.enterEnableModeForDevice(enablePassword, 3, remote_conn)
-
-    # Make terminal length = 0
-    output = output + \
-        cnos.waitForDeviceResponse("terminal length 0\n", "#", 2, remote_conn)
-
-    # Go to config mode
-    output = output + \
-        cnos.waitForDeviceResponse(
-            "configure device\n", "(config)#", 2, remote_conn)
 
     # Send the CLi command
-    output = output + cnos.vlagConfig(
-        remote_conn, deviceType, "(config)#", 2, vlagArg1, vlagArg2, vlagArg3,
-        vlagArg4)
+    output = output + str(cnos.vlagConfig(module, '(config)#', None))
 
     # Save it into the file
     file = open(outputfile, "a")

--- a/lib/ansible/modules/network/cnos/cnos_vlag.py
+++ b/lib/ansible/modules/network/cnos/cnos_vlag.py
@@ -300,7 +300,7 @@ def main():
     # need to add logic to check when changes occur or not
     errorMsg = cnos.checkOutputForError(output)
     if(errorMsg is None):
-        module.exit_json(changed=True, msg="vlag configurations accomplished")
+        module.exit_json(changed=True, msg="VLAG configurations accomplished")
     else:
         module.fail_json(msg=errorMsg)
 

--- a/test/units/modules/network/cnos/fixtures/cnos_ethernet_config.cfg
+++ b/test/units/modules/network/cnos/fixtures/cnos_ethernet_config.cfg
@@ -1,0 +1,96 @@
+
+--------------------------------------------------------------------------------
+Ethernet        PVID   Type Mode   Status  Reason                  Speed    Port
+Interface       NVLAN                                                       Ch#
+--------------------------------------------------------------------------------
+Ethernet1/1     33     eth  access down    Link not connected      10000    33
+Ethernet1/2     1      eth  access down    Link not connected      10000    1001
+Ethernet1/3     1      eth  trunk  down    Link not connected      10000    1003
+Ethernet1/4     1      eth  trunk  down    Link not connected      10000    1004
+Ethernet1/5     --     eth  routed down    Link not connected      10000    --
+Ethernet1/6     --     eth  routed down    Link not connected      10000    --
+Ethernet1/7     --     eth  routed down    Link not connected      10000    --
+Ethernet1/8     --     eth  routed down    Link not connected      10000    --
+Ethernet1/9     1      eth  access down    Link not connected      10000    --
+Ethernet1/10    1      eth  access down    Link not connected      10000    --
+Ethernet1/11    --     eth  routed down    Link not connected      10000    --
+Ethernet1/12    --     eth  routed down    Link not connected      10000    --
+Ethernet1/13    --     eth  routed down    Link not connected      10000    --
+Ethernet1/14    1      eth  access down    Link not connected      10000    --
+Ethernet1/15    1      eth  access down    Link not connected      10000    --
+Ethernet1/16    1      eth  access down    Link not connected      10000    --
+Ethernet1/17    1      eth  access down    Link not connected      10000    --
+Ethernet1/18    1      eth  access down    Link not connected      10000    --
+Ethernet1/19    1      eth  access down    Link not connected      10000    --
+Ethernet1/20    1      eth  access down    Link not connected      10000    --
+Ethernet1/21    1      eth  access down    Link not connected      10000    --
+Ethernet1/22    1      eth  access down    Link not connected      10000    --
+Ethernet1/23    1      eth  access down    Link not connected      10000    11
+Ethernet1/24    1      eth  access down    Link not connected      10000    --
+Ethernet1/25    1      eth  access down    Link not connected      10000    --
+Ethernet1/26    1      eth  access down    Link not connected      10000    --
+Ethernet1/27    1      eth  access down    Link not connected      10000    --
+Ethernet1/28    1      eth  access down    Link not connected      10000    --
+Ethernet1/29    1      eth  access down    Link not connected      10000    --
+Ethernet1/30    1      eth  access down    Link not connected      10000    --
+Ethernet1/31    1      eth  access down    Link not connected      10000    --
+Ethernet1/32    1      eth  access down    Link not connected      10000    --
+Ethernet1/33    --     eth  routed down    Link not connected      10000    --
+Ethernet1/34    1      eth  access down    Link not connected      10000    --
+Ethernet1/35    1      eth  access down    Link not connected      10000    --
+Ethernet1/36    1      eth  access down    Link not connected      10000    --
+Ethernet1/37    1      eth  access down    Link not connected      10000    --
+Ethernet1/38    1      eth  access down    Link not connected      10000    --
+Ethernet1/39    1      eth  access down    Link not connected      10000    --
+Ethernet1/40    1      eth  access down    Link not connected      10000    --
+Ethernet1/41    1      eth  access down    Link not connected      10000    --
+Ethernet1/42    1      eth  access down    Link not connected      10000    --
+Ethernet1/43    1      eth  access down    Link not connected      10000    --
+Ethernet1/44    1      eth  access down    Link not connected      10000    --
+Ethernet1/45    1      eth  access down    Link not connected      10000    --
+Ethernet1/46    1      eth  access down    Link not connected      10000    --
+Ethernet1/47    1      eth  access down    Link not connected      10000    --
+Ethernet1/48    1      eth  access down    Link not connected      10000    --
+Ethernet1/49    1      eth  access down    Link not connected      40000    --
+Ethernet1/50    1      eth  access down    Link not connected      40000    --
+Ethernet1/51    1      eth  access down    Link not connected      40000    --
+Ethernet1/52    1      eth  access down    Link not connected      40000    --
+Ethernet1/53    1      eth  access down    Link not connected      40000    --
+Ethernet1/54    1      eth  access down    Link not connected      40000    --
+
+--------------------------------------------------------------------------------
+Port-channel     PVID Type Mode   Status  Reason                 Speed  Protocol
+Interface        NVLAN
+--------------------------------------------------------------------------------
+po1              1    eth  access down    No link up members     NA     none
+po2              1    eth  access down    No link up members     NA     none
+po11             1    eth  access down    No link up members     NA     lacp
+po12             1    eth  access down    No link up members     NA     none
+po13             1    eth  trunk  down    No link up members     NA     none
+po14             1    eth  access down    No link up members     NA     none
+po15             1    eth  access down    No link up members     NA     none
+po17             1    eth  trunk  down    No link up members     NA     none
+po20             1    eth  access down    No link up members     NA     none
+po33             33   eth  access down    No link up members     NA     none
+po100            1    eth  trunk  down    No link up members     NA     none
+po1001           1    eth  access down    No link up members     NA     lacp
+po1002           1    eth  access down    No link up members     NA     none
+po1003           1    eth  trunk  down    No link up members     NA     lacp
+po1004           1    eth  trunk  down    No link up members     NA     lacp
+
+--------------------------------------------------------------------------------
+Port   VRF          Status IP Address                              Speed    MTU
+--------------------------------------------------------------------------------
+mgmt0  management   up     10.241.107.39                           1000     1500
+
+-------------------------------------------------------------------------------
+Interface Secondary VLAN(Type)                    Status Reason
+-------------------------------------------------------------------------------
+Vlan1     --                                      down   VLAN is down
+
+--------------------------------------------------------------------------------
+Interface     Status     Description
+--------------------------------------------------------------------------------
+loopback0     up         --
+loopback3     up         --
+

--- a/test/units/modules/network/cnos/fixtures/cnos_portchannel_config.cfg
+++ b/test/units/modules/network/cnos/fixtures/cnos_portchannel_config.cfg
@@ -1,0 +1,25 @@
+Flags:
+D - Down        P - Up in port-channel (members)
+S - Switched    R - Routed
+I - Individual  s - Suspended
+U - Up (port-channel)
+B - standBy (members)
+------+----------------+--------+-----------------------------------------------
+Group  Port-Channel     Protocol Member Ports
+------+----------------+--------+-----------------------------------------------
+1      po1         (SD)  NONE
+2      po2         (SD)  NONE
+11     po11        (SD)  LACP     Ethernet1/23(D)
+12     po12        (SD)  NONE
+13     po13        (SD)  NONE
+14     po14        (SD)  NONE
+15     po15        (SD)  NONE
+17     po17        (SD)  NONE
+20     po20        (SD)  NONE
+33     po33        (SD)  NONE     Ethernet1/1(D)
+100    po100       (SD)  NONE
+1001   po1001      (SD)  LACP     Ethernet1/2(D)
+1002   po1002      (SD)  NONE
+1003   po1003      (SD)  LACP     Ethernet1/3(D)
+1004   po1004      (SD)  LACP     Ethernet1/4(D)
+

--- a/test/units/modules/network/cnos/fixtures/cnos_vlag_config.cfg
+++ b/test/units/modules/network/cnos/fixtures/cnos_vlag_config.cfg
@@ -1,0 +1,63 @@
+  Global State            : enabled
+  VRRP active/active mode : enabled
+  vLAG system MAC         : 08:17:f4:c3:de:38
+  ISL Information:
+    PCH     Ifindex     State       Previous State
+    -------+-----------+-----------+---------------------------------
+    33      100033      Down        Down
+
+  Mis-Match Information:
+                   Local                      Peer
+    -------------+---------------------------+-----------------------
+    Match Result : Mis-match                  Mis-match
+    Tier ID      : 313                        0
+    System Type  : G8272
+    OS Version   : 10.8.x.x                   0.0.x.x
+
+  Role Information:
+                   Local                      Peer
+    -------------+---------------------------+-----------------------
+    Admin Role   : Primary                    Unselected
+    Oper Role    : Primary                    Unselected
+    Priority     : 1313                       0
+    System MAC   : a4:8c:db:33:bc:01          00:00:00:00:00:00
+
+  Consistency Checking Information:
+    State             : enabled
+    Strict Mode       : enabled
+    Final Result      : pass
+
+  FDB refresh Information:
+  FDB is doing refresh with below setting:
+    FDB refresh is configured
+    Bridge FDB aging timer is 1800 second(s)
+
+  FDB synchronization Information:
+  FDB is NOT being synchronized.
+
+ Auto Recovery Interval 266s (Finished)
+
+ Startup Delay Interval 323s (Finished)
+
+ Health Check Information:
+  Health check Peer IP Address: 1.2.3.4
+  Health check Local IP Address: 0.0.0.0
+  Health check retry interval: 133 seconds
+  Health check number of keepalive attempts: 13
+  Health check keepalive interval: 131 seconds
+  Health check status: DOWN
+
+  Peer Gateway State    : enabled
+
+  VLAG instance 1 : enabled
+  Instance Information
+    PCH        ifindex     State          Previous State    Cons Res
+    ----------+-----------+--------------+-----------------+--------
+    1003       101003      Down           Down              pass
+
+  VLAG instance 33 : enabled
+  Instance Information
+    PCH        ifindex     State          Previous State    Cons Res
+    ----------+-----------+--------------+-----------------+--------
+    333        0           Down           Down              pass
+

--- a/test/units/modules/network/cnos/test_cnos_ethernet.py
+++ b/test/units/modules/network/cnos/test_cnos_ethernet.py
@@ -1,0 +1,87 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+from ansible.compat.tests.mock import patch
+from ansible.modules.network.cnos import cnos_interface
+from units.modules.utils import set_module_args
+from .cnos_module import TestCnosModule, load_fixture
+
+
+class TestCnosEthernetModule(TestCnosModule):
+
+    module = cnos_interface
+
+    def setUp(self):
+        super(TestCnosEthernetModule, self).setUp()
+
+        self.mock_run_cnos_commands = patch('ansible.module_utils.network.cnos.cnos.run_cnos_commands')
+        self.run_cnos_commands = self.mock_run_cnos_commands.start()
+
+    def tearDown(self):
+        super(TestCnosEthernetModule, self).tearDown()
+        self.mock_run_cnos_commands.stop()
+
+    def load_fixtures(self, commands=None, transport='cli'):
+        self.run_cnos_commands.return_value = [load_fixture('cnos_ethernet_config.cfg')]
+
+    def test_ethernet_channelgroup(self):
+        set_module_args({'username': 'admin', 'password': 'pass',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'interfaceOption': 'ethernet', 'interfaceRange': '33',
+                         'interfaceArg1': 'channel-group', 'interfaceArg2': '33', 'interfaceArg3': 'on'})
+        result = self.execute_module(changed=True)
+        file = open('Anil.txt', "a")
+        file.write(str(result))
+        file.close()
+        expected_result = 'Interface Configuration is Accomplished'
+        self.assertEqual(result['msg'], expected_result)
+
+    def test_cnos_ethernet_lacp(self):
+        set_module_args({'username': 'admin', 'password': 'pass',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'interfaceOption': 'ethernet', 'interfaceRange': '33',
+                         'interfaceArg1': 'lacp', 'interfaceArg2': 'port-priority', 'interfaceArg3': '33'})
+        result = self.execute_module(changed=True)
+        expected_result = 'Interface Configuration is Accomplished'
+        self.assertEqual(result['msg'], expected_result)
+
+    def test_cnos_ethernet_duplex(self):
+        set_module_args({'username': 'admin', 'password': 'pass',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'interfaceOption': 'ethernet', 'interfaceRange': '33',
+                         'interfaceArg1': 'duplex', 'interfaceArg2': 'auto'})
+        result = self.execute_module(changed=True)
+        expected_result = 'Interface Configuration is Accomplished'
+        self.assertEqual(result['msg'], expected_result)
+
+    def test_cnos_ethernet_mtu(self):
+        set_module_args({'username': 'admin', 'password': 'pass',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'interfaceOption': 'ethernet', 'interfaceRange': '33',
+                         'interfaceArg1': 'mtu', 'interfaceArg2': '1300'})
+        result = self.execute_module(changed=True)
+        expected_result = 'Interface Configuration is Accomplished'
+        self.assertEqual(result['msg'], expected_result)
+
+    def test_cnos_ethernet_spanningtree(self):
+        set_module_args({'username': 'admin', 'password': 'pass',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'interfaceOption': 'ethernet', 'interfaceRange': '33',
+                         'interfaceArg1': 'spanning-tree', 'interfaceArg2': 'mst',
+                         'interfaceArg3': '33-35', 'interfaceArg4': 'cost',
+                         'interfaceArg5': '33'})
+        result = self.execute_module(changed=True)
+        expected_result = 'Interface Configuration is Accomplished'
+        self.assertEqual(result['msg'], expected_result)
+
+    def test_cnos_ethernet_ip(self):
+        set_module_args({'username': 'admin', 'password': 'pass',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'interfaceOption': 'ethernet', 'interfaceRange': '33',
+                         'interfaceArg1': 'ip', 'interfaceArg2': 'port',
+                         'interfaceArg3': 'anil'})
+        result = self.execute_module(changed=True)
+        expected_result = 'Interface Configuration is Accomplished'
+        self.assertEqual(result['msg'], expected_result)
+

--- a/test/units/modules/network/cnos/test_cnos_ethernet.py
+++ b/test/units/modules/network/cnos/test_cnos_ethernet.py
@@ -84,4 +84,3 @@ class TestCnosEthernetModule(TestCnosModule):
         result = self.execute_module(changed=True)
         expected_result = 'Interface Configuration is Accomplished'
         self.assertEqual(result['msg'], expected_result)
-

--- a/test/units/modules/network/cnos/test_cnos_portchannel.py
+++ b/test/units/modules/network/cnos/test_cnos_portchannel.py
@@ -1,0 +1,87 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+from ansible.compat.tests.mock import patch
+from ansible.modules.network.cnos import cnos_portchannel
+from units.modules.utils import set_module_args
+from .cnos_module import TestCnosModule, load_fixture
+
+
+class TestCnosPortchannelModule(TestCnosModule):
+
+    module = cnos_portchannel
+
+    def setUp(self):
+        super(TestCnosPortchannelModule, self).setUp()
+
+        self.mock_run_cnos_commands = patch('ansible.module_utils.network.cnos.cnos.run_cnos_commands')
+        self.run_cnos_commands = self.mock_run_cnos_commands.start()
+
+    def tearDown(self):
+        super(TestCnosPortchannelModule, self).tearDown()
+        self.mock_run_cnos_commands.stop()
+
+    def load_fixtures(self, commands=None, transport='cli'):
+        self.run_cnos_commands.return_value = [load_fixture('cnos_portchannel_config.cfg')]
+
+    def test_portchannel_channelgroup(self):
+        set_module_args({'username': 'admin', 'password': 'pass',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'interfaceRange': '33',
+                         'interfaceArg1': 'channel-group', 'interfaceArg2': '33', 'interfaceArg3': 'on'})
+        result = self.execute_module(changed=True)
+        file = open('Anil.txt', "a")
+        file.write(str(result))
+        file.close()
+        expected_result = 'Port Channel Configuration is done'
+        self.assertEqual(result['msg'], expected_result)
+
+    def test_cnos_portchannel_lacp(self):
+        set_module_args({'username': 'admin', 'password': 'pass',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'interfaceRange': '33',
+                         'interfaceArg1': 'lacp', 'interfaceArg2': 'port-priority', 'interfaceArg3': '33'})
+        result = self.execute_module(changed=True)
+        expected_result = 'Port Channel Configuration is done'
+        self.assertEqual(result['msg'], expected_result)
+
+    def test_cnos_portchannel_duplex(self):
+        set_module_args({'username': 'admin', 'password': 'pass',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'interfaceRange': '2',
+                         'interfaceArg1': 'duplex', 'interfaceArg2': 'auto'})
+        result = self.execute_module(changed=True)
+        expected_result = 'Port Channel Configuration is done'
+        self.assertEqual(result['msg'], expected_result)
+
+    def test_cnos_portchannel_mtu(self):
+        set_module_args({'username': 'admin', 'password': 'pass',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'interfaceRange': '33',
+                         'interfaceArg1': 'mtu', 'interfaceArg2': '1300'})
+        result = self.execute_module(changed=True)
+        expected_result = 'Port Channel Configuration is done'
+        self.assertEqual(result['msg'], expected_result)
+
+    def test_cnos_portchannel_spanningtree(self):
+        set_module_args({'username': 'admin', 'password': 'pass',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'interfaceRange': '33',
+                         'interfaceArg1': 'spanning-tree', 'interfaceArg2': 'mst',
+                         'interfaceArg3': '33-35', 'interfaceArg4': 'cost',
+                         'interfaceArg5': '33'})
+        result = self.execute_module(changed=True)
+        expected_result = 'Port Channel Configuration is done'
+        self.assertEqual(result['msg'], expected_result)
+
+    def test_cnos_portchannel_ip(self):
+        set_module_args({'username': 'admin', 'password': 'pass',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'interfaceRange': '33',
+                         'interfaceArg1': 'ip', 'interfaceArg2': 'port',
+                         'interfaceArg3': 'anil'})
+        result = self.execute_module(changed=True)
+        expected_result = 'Port Channel Configuration is done'
+        self.assertEqual(result['msg'], expected_result)
+

--- a/test/units/modules/network/cnos/test_cnos_portchannel.py
+++ b/test/units/modules/network/cnos/test_cnos_portchannel.py
@@ -84,4 +84,3 @@ class TestCnosPortchannelModule(TestCnosModule):
         result = self.execute_module(changed=True)
         expected_result = 'Port Channel Configuration is done'
         self.assertEqual(result['msg'], expected_result)
-

--- a/test/units/modules/network/cnos/test_cnos_vlag.py
+++ b/test/units/modules/network/cnos/test_cnos_vlag.py
@@ -53,4 +53,3 @@ class TestCnosVlagModule(TestCnosModule):
         result = self.execute_module(changed=True)
         expected_result = 'VLAG configurations accomplished'
         self.assertEqual(result['msg'], expected_result)
-

--- a/test/units/modules/network/cnos/test_cnos_vlag.py
+++ b/test/units/modules/network/cnos/test_cnos_vlag.py
@@ -1,0 +1,56 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+from ansible.compat.tests.mock import patch
+from ansible.modules.network.cnos import cnos_vlag
+from units.modules.utils import set_module_args
+from .cnos_module import TestCnosModule, load_fixture
+
+
+class TestCnosVlagModule(TestCnosModule):
+
+    module = cnos_vlag
+
+    def setUp(self):
+        super(TestCnosVlagModule, self).setUp()
+
+        self.mock_run_cnos_commands = patch('ansible.module_utils.network.cnos.cnos.run_cnos_commands')
+        self.run_cnos_commands = self.mock_run_cnos_commands.start()
+
+    def tearDown(self):
+        super(TestCnosVlagModule, self).tearDown()
+        self.mock_run_cnos_commands.stop()
+
+    def load_fixtures(self, commands=None, transport='cli'):
+        self.run_cnos_commands.return_value = [load_fixture('cnos_vlag_config.cfg')]
+
+    def test_cnos_vlag_enable(self):
+        set_module_args({'username': 'admin', 'password': 'admin',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'vlagArg1': 'enable'})
+        result = self.execute_module(changed=True)
+        file = open('Anil.txt', "a")
+        file.write(str(result))
+        file.close()
+        expected_result = 'VLAG configurations accomplished'
+        self.assertEqual(result['msg'], expected_result)
+
+    def test_cnos_vlag_instance(self):
+        set_module_args({'username': 'admin', 'password': 'pass',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'vlagArg1': 'instance',
+                         'vlagArg2': '33', 'vlagArg3': '333'})
+        result = self.execute_module(changed=True)
+        expected_result = 'VLAG configurations accomplished'
+        self.assertEqual(result['msg'], expected_result)
+
+    def test_cnos_vlag_hlthchk(self):
+        set_module_args({'username': 'admin', 'password': 'pass',
+                         'host': '10.241.107.39', 'deviceType': 'g8272_cnos',
+                         'outputfile': 'test.log', 'vlagArg1': 'hlthchk',
+                         'vlagArg2': 'keepalive-interval', 'vlagArg3': '131'})
+        result = self.execute_module(changed=True)
+        expected_result = 'VLAG configurations accomplished'
+        self.assertEqual(result['msg'], expected_result)
+


### PR DESCRIPTION
SUMMARY
CNOS Modules were originally using Paramiko. Here this is an attempt to change from paramiko to persistence connection of Ansible. More over along with this I am taking care of the new CLI changes happend on CNOS. I am adding UT cases for this module also along with

ISSUE TYPE
Bugfix Pull Request

COMPONENT NAME
lib\ansible\modules\network\cnos\cnos_portchannel.py
lib\ansible\modules\network\cnos\cnos_interface.py
lib\ansible\module_utils\network\cnos.cnos.py
test\units\modules\network\cnos\fixtures\cnos_portchannel_config.cfg
test\units\modules\network\cnos\fixtures\cnos_ethernet_config.cfg
test\units\modules\network\cnos\test_cnos_ethernet.py
test\units\modules\network\cnos\test_cnos_portchannel.py

ANSIBLE VERSION
ansible 2.7.0.dev0 (devel f9cbdcd) last updated 2018/07/03 14:55:43 (GMT +550)
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /home/ansible/sheru/ansible/lib/ansible
executable location = /home/ansible/sheru/ansible/bin/ansible
python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]

ADDITIONAL INFORMATION
After successful review and merging of these module, I will change rest of the modules