### PR TITLE
Fix ignoring of 'Login Profile cannot be found' errors in iam

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam.py
+++ b/lib/ansible/modules/cloud/amazon/iam.py
@@ -254,7 +254,7 @@ def delete_dependencies_first(module, iam, name):
         changed = True
     except boto.exception.BotoServerError as err:
         error_msg = boto_exception(err)
-        if 'Cannot find Login Profile' not in error_msg:
+        if 'Login Profile for User ' + name + ' cannot be found.' not in error_msg:
             module.fail_json(changed=changed, msg="Failed to delete login profile: %s" % err, exception=traceback.format_exc())
 
     # try to detach policies


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This simply changes an error check. Closes #43197

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
`iam`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```ansible 2.7.0.dev0 (devel 54a20f64fc) last updated 2018/07/24 13:40:56 (GMT +200)
  config file = None
  configured module search path = ['/home/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/documents/programming/ansible/lib/ansible
  executable location = /home/user/.venv-asf/bin/ansible
  python version = 3.6.5 (default, May 11 2018, 04:00:52) [GCC 8.1.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Please refer to #43197 for an explanation.