### PR TITLE
Fix spelling; summery -> summary

### DIFF
--- a/lib/ansible/modules/windows/win_uri.py
+++ b/lib/ansible/modules/windows/win_uri.py
@@ -196,7 +196,7 @@ status_code:
   type: int
   sample: 200
 status_description:
-  description: A summery of the status.
+  description: A summary of the status.
   returned: success
   type: string
   sample: OK


### PR DESCRIPTION
Fix the incorrect spelling of "summary".

+label: docsite_pr

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
win_uri

##### ANSIBLE VERSION
```
Docs - i.e. the ansible site.
```
