### PR TITLE
Properly detect credentials for tower_project

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
@@ -147,18 +147,18 @@ def main():
                 except (exc.NotFound) as excinfo:
                     module.fail_json(msg='Failed to update project, organization not found: {0}'.format(organization), changed=False)
 
-                if scm_type:
+                if scm_credential:
                     try:
                         cred_res = tower_cli.get_resource('credential')
                         cred = cred_res.get(name=scm_credential)
+                        scm_credential = cred['id']
                     except (exc.NotFound) as excinfo:
                         module.fail_json(msg='Failed to update project, credential not found: {0}'.format(scm_credential), changed=False)
 
-                credential = cred['id'] if scm_type else None
                 result = project.modify(name=name, description=description,
                                         organization=org['id'],
                                         scm_type=scm_type, scm_url=scm_url, local_path=local_path,
-                                        scm_branch=scm_branch, scm_clean=scm_clean, credential=credential,
+                                        scm_branch=scm_branch, scm_clean=scm_clean, credential=scm_credential,
                                         scm_delete_on_update=scm_delete_on_update,
                                         scm_update_on_launch=scm_update_on_launch,
                                         create_on_missing=True)

--- a/test/integration/targets/tower_project/tasks/main.yml
+++ b/test/integration/targets/tower_project/tasks/main.yml
@@ -40,3 +40,10 @@
 - assert:
     that:
       - "result is changed"
+
+- name: Create a git project without credentials
+  tower_project:
+    name: git project
+    organization: Default
+    scm_type: git
+    scm_url: https://github.com/ansible/ansible


### PR DESCRIPTION
##### SUMMARY
It seemed like it was mostly the wrong variables been looked at, making
it so a git repository could not be created without a credential, for example.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tower_project

##### ANSIBLE VERSION
```
ansible 2.6.1
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
Before:
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_Ovkg7T/ansible_module_tower_project.py", line 174, in <module>
    main()
  File "/tmp/ansible_Ovkg7T/ansible_module_tower_project.py", line 151, in main
    cred = cred_res.get(name=scm_credential)
  File "/usr/lib/python2.7/site-packages/tower_cli/models/base.py", line 486, in get
    response = self.read(pk=pk, fail_on_no_results=True, fail_on_multiple_results=True, **kwargs)
  File "/usr/lib/python2.7/site-packages/tower_cli/models/base.py", line 306, in read
    raise exc.NotFound('The requested object could not be found.')
tower_cli.exceptions.NotFound: The requested object could not be found.

failed: [localhost] (item={u'name': u'bastion-tower', u'scm_clean': True, u'scm_url': u'https://github.com/dmsimard/bastion-tower', u'scm_type': u'git', u'organization': u'default-organization', u'description': u'Repository for infrastructure management'}) => {
    "changed": false, 
    "item": {
        "description": "Repository for infrastructure management", 
        "name": "bastion-tower", 
        "organization": "default-organization", 
        "scm_clean": true, 
        "scm_type": "git", 
        "scm_url": "https://github.com/dmsimard/bastion-tower"
    }, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_Ovkg7T/ansible_module_tower_project.py\", line 174, in <module>\n    main()\n  File \"/tmp/ansible_Ovkg7T/ansible_module_tower_project.py\", line 151, in main\n    cred = cred_res.get(name=scm_credential)\n  File \"/usr/lib/python2.7/site-packages/tower_cli/models/base.py\", line 486, in get\n    response = self.read(pk=pk, fail_on_no_results=True, fail_on_multiple_results=True, **kwargs)\n  File \"/usr/lib/python2.7/site-packages/tower_cli/models/base.py\", line 306, in read\n    raise exc.NotFound('The requested object could not be found.')\ntower_cli.exceptions.NotFound: The requested object could not be found.\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 1
}
```

After:
```
TASK [tower-config : Configure Tower projects] ********************************
Tuesday 24 July 2018  15:18:34 +0000 (0:00:00.846)       0:00:03.225 ********** 
changed: [localhost] => (item={u'name': u'bastion-tower', u'scm_clean': True, u'scm_url': u'https://github.com/dmsimard/bastion-tower', u'scm_type': u'git', u'organization': u'default-organization', u'description': u'Repository for infrastructure management'})
```