### PR TITLE
Add tests filters

### DIFF
--- a/test/units/modules/system/interfaces_file/test_interfaces_file.py
+++ b/test/units/modules/system/interfaces_file/test_interfaces_file.py
@@ -17,14 +17,15 @@
 
 from units.compat import unittest
 from ansible.modules.system import interfaces_file
-import os
-import json
-import io
-import inspect
 from shutil import copyfile, move
 import difflib
-import tempfile
+import inspect
+import io
+import json
+import os
+import re
 import shutil
+import tempfile
 
 
 class AnsibleFailJson(Exception):
@@ -50,8 +51,13 @@ golden_output_path = os.path.join(os.path.dirname(__file__), 'fixtures', 'golden
 
 
 class TestInterfacesFileModule(unittest.TestCase):
-    def getTestFiles(self):
-        return next(os.walk(fixture_path))[2]
+    def getTestFiles(self, include_filter=None, exclude_filter=None):
+        flist = next(os.walk(fixture_path))[2]
+        if include_filter:
+            flist = filter(lambda x: re.match(include_filter, x), flist)
+        if exclude_filter:
+            flist = filter(lambda x: not re.match(exclude_filter, x), flist)
+        return flist
 
     def compareFileToBackup(self, path, backup):
         with open(path) as f1:


### PR DESCRIPTION
##### SUMMARY
This will allow tests to be carried out condtionally if necessary
using regexp include and/or exclude filters
Reorganize imports into alphabetical order for easier insertion

##### ISSUE TYPE
 - Feature Pull Request
 
##### COMPONENT NAME
interfaces_file

##### ANSIBLE VERSION
```
ansible 2.6.0 (work e2aa1155ba) last updated 2018/04/19 09:51:12 (GMT +200)
  config file = None
  configured module search path = [u'/Users/olivierbourdon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/olivierbourdon/Documents/WORK/OpenNext/TECH/CODE/ANSIBLE/0-REF-ansible/lib/ansible
  executable location = /Users/olivierbourdon/Documents/WORK/OpenNext/TECH/CODE/ANSIBLE/0-REF-ansible/bin/ansible
  python version = 2.7.14 (default, Sep 22 2017, 00:06:07) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```

##### ADDITIONAL INFORMATION
None