### PR TITLE
add example using peer keepalive vrf and delay restore (#41111)

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vpc.py
+++ b/lib/ansible/modules/network/nxos/nxos_vpc.py
@@ -101,6 +101,18 @@ EXAMPLES = '''
     pkl_src: 10.1.100.2
     pkl_dest: 192.168.100.4
     auto_recovery: true
+
+- name: Configure VPC with delay restore and existing keepalive VRF
+  nxos_vpc:
+    domain: 10
+    role_priority: 28672
+    system_priority: 2000
+    delay_restore: 180
+    peer_gw: true
+    pkl_src: 1.1.1.2
+    pkl_dest: 1.1.1.1
+    pkl_vrf: vpckeepalive
+    auto_recovery: true
 '''
 
 RETURN = '''


### PR DESCRIPTION
* add example using peer keepalive vrf and delay restore

<!--- Your description here -->
add example using peer keepalive vrf and delay restore
+label: docsite_pr
+label: issue ansible/community#311

* Update nxos_vpc.py

update task name to include "existing"

(cherry picked from commit d6fb00e7971be3750faa4dc9d36fee9e2946bbb8)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Backporting PR #41111
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nxos_vpc

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /home/samccann/ansible-tests/ansible.cfg
  configured module search path = [u'/home/samccann/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Followed the verification steps with the playbook in the original PR on nxos9k lab vm, with the initial step of enabling the VPC feature:

```
an-nxos9k-02# config t
Enter configuration commands, one per line. End with CNTL/Z.
an-nxos9k-02(config)# feature vpc
```
Before setting vrf:
```
PLAY [cisco] ***************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************
ok: [test]

TASK [Configure VPC with delay restore and keepalive VRF] ******************************************************
fatal: [test]: FAILED! => {"changed": false, "msg": "The VRF you are trying to use for the peer keepalive link is not on device yet. Add it first, please."}
	to retry, use: --limit @/home/samccann/ansible-tests/nxos-vpc.retry

PLAY RECAP *****************************************************************************************************
test                       : ok=1    changed=0    unreachable=0    failed=1  
```

Then set vrf:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
n-nxos9k-02# config t
Enter configuration commands, one per line. End with CNTL/Z.
an-nxos9k-02(config)# vrf context vpckeepalive
an-nxos9k-02(config-vrf)# exit

```
and rerun the playbook:

```
PLAY [cisco] ***************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************
ok: [test]

TASK [Configure VPC with delay restore and keepalive VRF] ******************************************************
changed: [test]

PLAY RECAP *****************************************************************************************************
test                       : ok=2    changed=1    unreachable=0    failed=0   
```
