### PR TITLE
Documentation change for resizefs

### DIFF
--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -80,7 +80,7 @@ options:
     description:
     - Resize the underlying filesystem together with the logical volume.
     type: bool
-    default: 'yes'
+    default: 'no'
     version_added: "2.5"
 notes:
   - You must specify lv (when managing the state of logical volumes) or thinpool (when managing a thin provisioned volume).
@@ -138,7 +138,7 @@ EXAMPLES = '''
     lv: test
     size: +100%FREE
 
-- name: Extend the logical volume to take all remaining space of the PVs
+- name: Extend the logical volume to take all remaining space of the PVs and resize the underlying filesystem
   lvol:
     vg: firefly
     lv: test

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -1163,7 +1163,6 @@ lib/ansible/modules/system/iptables.py E326
 lib/ansible/modules/system/java_cert.py E324
 lib/ansible/modules/system/java_cert.py E325
 lib/ansible/modules/system/known_hosts.py E324
-lib/ansible/modules/system/lvol.py E324
 lib/ansible/modules/system/make.py E317
 lib/ansible/modules/system/mount.py E324
 lib/ansible/modules/system/open_iscsi.py E322


### PR DESCRIPTION
Changed documentation to match the default value of resizefs set in the code.
Added a note on the resizefs use on the example utilizing it.

##### SUMMARY
The documentation of the lvol module has the default value for resizefs listed as True when in the code it is set to False and is implied by the example as needing to be set to true for its use.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lvol

##### ANSIBLE VERSION
2.x
