### PR TITLE
make sure to get correct python version for rpmfluff in setup_rpm_repo

### DIFF
--- a/test/integration/targets/setup_rpm_repo/tasks/main.yml
+++ b/test/integration/targets/setup_rpm_repo/tasks/main.yml
@@ -17,7 +17,7 @@
     package:
       name: "{{ item }}"
     with_items:
-      - python-rpmfluff
+      - python{{ ansible_python_version.split(".")[0] }}-rpmfluff
       - createrepo_c
       - createrepo  # used by el6 version of rpmfluff
     when:

--- a/test/integration/targets/setup_rpm_repo/tasks/main.yml
+++ b/test/integration/targets/setup_rpm_repo/tasks/main.yml
@@ -17,11 +17,23 @@
     package:
       name: "{{ item }}"
     with_items:
-      - python{{ ansible_python_version.split(".")[0] }}-rpmfluff
+      - python-rpmfluff
       - createrepo_c
       - createrepo  # used by el6 version of rpmfluff
     when:
       - ansible_distribution not in ['Fedora']
+      - ansible_python["version"]["major"] == 2
+
+  - name: Install rpmfluff and deps
+    package:
+      name: "{{ item }}"
+    with_items:
+      - python3-rpmfluff
+      - createrepo_c
+      - createrepo  # used by el6 version of rpmfluff
+    when:
+      - ansible_distribution not in ['Fedora']
+      - ansible_python["version"]["major"] == 3
 
   - name: Copy script for creating a repo
     copy:


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
Previously if `python3` was the executable, this would cause the incorrect version to be used.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
