### PR TITLE
Resolves bug where existing host_record was deleted when existing record name is used with different IP

### DIFF
--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -238,8 +238,8 @@ class WapiModule(WapiBase):
                     self.create_object(ib_obj_type, proposed_object)
                 result['changed'] = True
             elif modified:
-                # Send POST request if record input name and retrieved ref name is same
-                if 'name' in (obj_filter and ib_obj_ref[0]):
+                # Send POST request if host record input name and retrieved ref name is same
+                if 'name' in (obj_filter and ib_obj_ref[0]) and ib_obj_type == NIOS_HOST_RECORD:
                     obj_host_name = obj_filter['name']
                     ref_host_name = ib_obj_ref[0]['name']
                     if obj_host_name == ref_host_name:

--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -238,6 +238,12 @@ class WapiModule(WapiBase):
                     self.create_object(ib_obj_type, proposed_object)
                 result['changed'] = True
             elif modified:
+                # Send POST request if record input name and retrieved ref name is same
+                if 'name' in (obj_filter and ib_obj_ref[0]):
+                    obj_host_name = obj_filter['name']
+                    ref_host_name = ib_obj_ref[0]['name']
+                    if obj_host_name == ref_host_name:
+                        self.create_object(ib_obj_type, proposed_object)
                 if (ib_obj_type in (NIOS_HOST_RECORD, NIOS_NETWORK_VIEW, NIOS_DNS_VIEW)):
                     proposed_object = self.on_update(proposed_object, ib_spec)
                     res = self.update_object(ref, proposed_object)

--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -238,7 +238,7 @@ class WapiModule(WapiBase):
                     self.create_object(ib_obj_type, proposed_object)
                 result['changed'] = True
             elif modified:
-                self.check_if_hostname_exists(obj_filter, ib_obj_ref, ib_obj_type, current_object, proposed_object)
+                self.check_if_recordname_exists(obj_filter, ib_obj_ref, ib_obj_type, current_object, proposed_object)
 
                 if (ib_obj_type in (NIOS_HOST_RECORD, NIOS_NETWORK_VIEW, NIOS_DNS_VIEW)):
                     proposed_object = self.on_update(proposed_object, ib_spec)
@@ -258,7 +258,7 @@ class WapiModule(WapiBase):
 
         return result
 
-    def check_if_hostname_exists(self, obj_filter, ib_obj_ref, ib_obj_type, current_object, proposed_object):
+    def check_if_recordname_exists(self, obj_filter, ib_obj_ref, ib_obj_type, current_object, proposed_object):
         ''' Send POST request if host record input name and retrieved ref name is same,
             but input IP and retrieved IP is different'''
 
@@ -266,13 +266,13 @@ class WapiModule(WapiBase):
             obj_host_name = obj_filter['name']
             ref_host_name = ib_obj_ref[0]['name']
             if 'ipv4addrs' in (current_object and proposed_object):
-                ref_ip_addr = current_object['ipv4addrs'][0]['ipv4addr']
-                prop_ip_addr = proposed_object['ipv4addrs'][0]['ipv4addr']
+                current_ip_addr = current_object['ipv4addrs'][0]['ipv4addr']
+                proposed_ip_addr = proposed_object['ipv4addrs'][0]['ipv4addr']
             elif 'ipv6addrs' in (current_object and proposed_object):
-                ref_ip_addr = current_object['ipv6addrs'][0]['ipv6addr']
-                prop_ip_addr = proposed_object['ipv6addrs'][0]['ipv6addr']
+                current_ip_addr = current_object['ipv6addrs'][0]['ipv6addr']
+                proposed_ip_addr = proposed_object['ipv6addrs'][0]['ipv6addr']
 
-            if obj_host_name == ref_host_name and ref_ip_addr != prop_ip_addr:
+            if obj_host_name == ref_host_name and current_ip_addr != proposed_ip_addr:
                 self.create_object(ib_obj_type, proposed_object)
 
     def issubset(self, item, objects):

--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -238,12 +238,8 @@ class WapiModule(WapiBase):
                     self.create_object(ib_obj_type, proposed_object)
                 result['changed'] = True
             elif modified:
-                # Send POST request if host record input name and retrieved ref name is same
-                if 'name' in (obj_filter and ib_obj_ref[0]) and ib_obj_type == NIOS_HOST_RECORD:
-                    obj_host_name = obj_filter['name']
-                    ref_host_name = ib_obj_ref[0]['name']
-                    if obj_host_name == ref_host_name:
-                        self.create_object(ib_obj_type, proposed_object)
+                self.check_if_hostname_exists(obj_filter, ib_obj_ref, ib_obj_type, current_object, proposed_object)
+
                 if (ib_obj_type in (NIOS_HOST_RECORD, NIOS_NETWORK_VIEW, NIOS_DNS_VIEW)):
                     proposed_object = self.on_update(proposed_object, ib_spec)
                     res = self.update_object(ref, proposed_object)
@@ -261,6 +257,23 @@ class WapiModule(WapiBase):
                 result['changed'] = True
 
         return result
+
+    def check_if_hostname_exists(self, obj_filter, ib_obj_ref, ib_obj_type, current_object, proposed_object):
+        ''' Send POST request if host record input name and retrieved ref name is same,
+            but input IP and retrieved IP is different'''
+
+        if 'name' in (obj_filter and ib_obj_ref[0]) and ib_obj_type == NIOS_HOST_RECORD:
+            obj_host_name = obj_filter['name']
+            ref_host_name = ib_obj_ref[0]['name']
+            if 'ipv4addrs' in (current_object and proposed_object):
+                ref_ip_addr = current_object['ipv4addrs'][0]['ipv4addr']
+                prop_ip_addr = proposed_object['ipv4addrs'][0]['ipv4addr']
+            elif 'ipv6addrs' in (current_object and proposed_object):
+                ref_ip_addr = current_object['ipv6addrs'][0]['ipv6addr']
+                prop_ip_addr = proposed_object['ipv6addrs'][0]['ipv6addr']
+
+            if obj_host_name == ref_host_name and ref_ip_addr != prop_ip_addr:
+                self.create_object(ib_obj_type, proposed_object)
 
     def issubset(self, item, objects):
         ''' Checks if item is a subset of objects


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR is raised to resolve bug #42937, where existing host_record was getting deleted when the same name on different IP was used because PUT request was being sent which doesn't check for exsting record name. Now, with this change POST request will be sent which has the particular check for checking the existing record name. 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nios

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6 
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
