### PR TITLE
Fix ssl_version default value. (#42955)

### DIFF
--- a/changelogs/fragments/docker-default-ssl.yml
+++ b/changelogs/fragments/docker-default-ssl.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- fix default SSL version for docker modules https://github.com/ansible/ansible/issues/42897

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -80,7 +80,6 @@ DEFAULT_TLS = False
 DEFAULT_TLS_VERIFY = False
 DEFAULT_TLS_HOSTNAME = 'localhost'
 MIN_DOCKER_VERSION = "1.7.0"
-DEFAULT_SSL_VERSION = "1.0"
 DEFAULT_TIMEOUT_SECONDS = 60
 
 DOCKER_COMMON_ARGS = dict(
@@ -91,7 +90,7 @@ DOCKER_COMMON_ARGS = dict(
     cacert_path=dict(type='str', aliases=['tls_ca_cert']),
     cert_path=dict(type='str', aliases=['tls_client_cert']),
     key_path=dict(type='str', aliases=['tls_client_key']),
-    ssl_version=dict(type='str', default=DEFAULT_SSL_VERSION),
+    ssl_version=dict(type='str'),
     tls=dict(type='bool', default=DEFAULT_TLS),
     tls_verify=dict(type='bool', default=DEFAULT_TLS_VERIFY),
     debug=dict(type='bool', default=False)

--- a/lib/ansible/utils/module_docs_fragments/docker.py
+++ b/lib/ansible/utils/module_docs_fragments/docker.py
@@ -61,8 +61,7 @@ options:
             - tls_client_key
     ssl_version:
         description:
-            - Provide a valid SSL version number. Default value determined by docker-py, currently 1.0.
-        default: "1.0"
+            - Provide a valid SSL version number. Default value determined by ssl.py module.
     tls:
         description:
             -  Secure the connection to the API by using TLS without verifying the authenticity of the Docker host


### PR DESCRIPTION
##### SUMMARY
Fixes #42897. Backport

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
docker

##### ANSIBLE VERSION
```
ansible 2.6.1
  config file = None
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
Remove ssl default value. SSL module checks the version.