### PR TITLE
Add missing s3 permissions for s3 module testing.

### DIFF
--- a/hacking/aws_config/testing_policies/storage-policy.json
+++ b/hacking/aws_config/testing_policies/storage-policy.json
@@ -26,6 +26,14 @@
                 "arn:aws:s3:::ansible-test-*",
                 "arn:aws:s3:::ansible-test-*/*"
             ]
+        },
+        {
+            "Sid": "AllowListingS3Buckets",
+            "Action": [
+                "s3:ListAllMyBuckets"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
         }
     ]
 }


### PR DESCRIPTION
##### SUMMARY

Add the missing ListAllMyBuckets permission to the iam testing policies so that s3 tests run with the restricted permissions.

Fixes #43124

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aws testing policies

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (test-permissions-for-s3 48c9ffd4db) last updated 2018/07/25 20:45:22 (GMT +1300)
  config file = None
  configured module search path = [u'USER_HOME/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ANSIBLE_HOME/lib/ansible
  executable location = ANSIBLE_HOME/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

