### PR TITLE
Fix maven_artifact md5 check for archiva repository from issue #43149

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -434,6 +434,14 @@ class MavenDownloader:
                     return "Cannot retrieve a valid md5 from %s: %s" % (remote_url, to_native(e))
                 if(not remote_md5):
                     return "Cannot find md5 from " + remote_url
+            try:
+                # Check if remote md5 only contains md5 or md5 + filename
+                _remote_md5 = remote_md5.split(None)[0]
+                remote_md5 = _remote_md5
+                # remote_md5 is empty so we continue and keep original md5 string
+                # This should not happen since we check for remote_md5 before
+            except IndexError as e:
+                pass
             if local_md5 == remote_md5:
                 return None
             else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix the md5 check when we download the .md5 file from an archiva repository where the .md5 file contain the md5 and the filename inside the .md5 file.


<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This fix #43149
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
maven_artifact

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

All this is included in #43149. In order to test this fix I modified the maven_artifact.py file with the one from the devel branch and everything was working on my side.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
