### PR TITLE
fix regex parse for total memory in slxos_facts.py

### DIFF
--- a/lib/ansible/modules/network/slxos/slxos_facts.py
+++ b/lib/ansible/modules/network/slxos/slxos_facts.py
@@ -208,7 +208,7 @@ class Hardware(FactsBase):
             self.facts['memfree_mb'] = int(round(int(self.parse_memfree(data)) / 1024, 0))
 
     def parse_memtotal(self, data):
-        match = re.search(r'TotalMemory: (\d+)\s', data, re.M)
+        match = re.search(r'Total Memory: (\d+)\s', data, re.M)
         if match:
             return match.group(1)
 

--- a/lib/ansible/modules/network/slxos/slxos_facts.py
+++ b/lib/ansible/modules/network/slxos/slxos_facts.py
@@ -208,7 +208,7 @@ class Hardware(FactsBase):
             self.facts['memfree_mb'] = int(round(int(self.parse_memfree(data)) / 1024, 0))
 
     def parse_memtotal(self, data):
-        match = re.search(r'Total Memory: (\d+)\s', data, re.M)
+        match = re.search(r'Total\s*Memory: (\d+)\s', data, re.M)
         if match:
             return match.group(1)
 


### PR DESCRIPTION
##### SUMMARY
In `slxos_facts.py`, `parse_memtotal()` does a regex search for "TotalMemory" - this fix adds a space, making the search string "Total Memory" which then prevents SLX-OS facts gathering from returning an error because `parse_memtotal()` returns `NoneType`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
"slxos" module:

`lib/ansible/modules/network/slxos/slxos_facts.py`

##### ANSIBLE VERSION
```
ansible 2.6.1
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Dec 14 2017, 15:51:29) [GCC 6.4.0]
```


##### ADDITIONAL INFORMATION
I'm running a customized version of https://github.com/jmal98/ansiblecm which runs an Ansible control machine in a Docker container and exposes `ansible-playbook` via its entrypoint. Below is output from a vanilla install of Ansible 2.6.1 (via `pip`) running the container against two of my SLX'es in my work lab. One is running 17r.1.01a and the other is running 17r.1.01b.

Playbook:
```
---
- hosts: slx
  gather_facts: no

  tasks:

  - name: Gather facts
    slxos_facts:
      gather_subset: all
    register: result

#  - debug: var=result
```

Command output of `ansible-playbook` via the container:
```
jjensen@host:~/netops-ansible/playbooks$ docker run -it --rm -v $PWD:/tmp/playbook:Z -e ANSIBLE_HOST_KEY_CHECKING=False ansible-cm test_slx.yml -i inventory/brocade/lab.ini

PLAY [slx] *************************************************************************************************************************************************************************************************

TASK [Gather facts] ****************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: int() argument must be a string or a number, not 'NoneType'
fatal: [LAB.01.SLX.COR.02]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_yEGfmh/ansible_module_slxos_facts.py\", line 457, in <module>\n    main()\n  File \"/tmp/ansible_yEGfmh/ansible_module_slxos_facts.py\", line 443, in main\n    inst.populate()\n  File \"/tmp/ansible_yEGfmh/ansible_module_slxos_facts.py\", line 207, in populate\n    self.facts['memtotal_mb'] = int(round(int(self.parse_memtotal(data)) / 1024, 0))\nTypeError: int() argument must be a string or a number, not 'NoneType'\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: int() argument must be a string or a number, not 'NoneType'
fatal: [LAB.01.SLX.COR.01]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_8oKxhW/ansible_module_slxos_facts.py\", line 457, in <module>\n    main()\n  File \"/tmp/ansible_8oKxhW/ansible_module_slxos_facts.py\", line 443, in main\n    inst.populate()\n  File \"/tmp/ansible_8oKxhW/ansible_module_slxos_facts.py\", line 207, in populate\n    self.facts['memtotal_mb'] = int(round(int(self.parse_memtotal(data)) / 1024, 0))\nTypeError: int() argument must be a string or a number, not 'NoneType'\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
	to retry, use: --limit @/tmp/playbook/test_slx.retry

PLAY RECAP *************************************************************************************************************************************************************************************************
LAB.01.SLX.COR.01 : ok=0    changed=0    unreachable=0    failed=1
LAB.01.SLX.COR.02 : ok=0    changed=0    unreachable=0    failed=1
```

Re-running the same command after patching `slxos_facts.py` via the Dockerfile:

```
# patch slxos_facts.py
RUN cd /usr/lib/python2.7/site-packages/ansible/modules/network/slxos \
    && rm slxos_facts.py && rm slxos_facts.pyc
COPY patch_files/slxos_facts.py /usr/lib/python2.7/site-packages/ansible/modules/network/slxos/
```

Command output again:
```
jjensen@host:~/netops-ansible/playbooks$ docker run -it --rm -v $PWD:/tmp/playbook:Z -e ANSIBLE_HOST_KEY_CHECKING=False ansible-cm test_slx.yml -i inventory/brocade/lab.ini

PLAY [slx] *************************************************************************************************************************************************************************************************

TASK [Gather facts] ****************************************************************************************************************************************************************************************
ok: [LAB.01.SLX.COR.02]
ok: [LAB.01.SLX.COR.01]

PLAY RECAP *************************************************************************************************************************************************************************************************
LAB.01.SLX.COR.01 : ok=1    changed=0    unreachable=0    failed=0
LAB.01.SLX.COR.02 : ok=1    changed=0    unreachable=0    failed=0
```

Here are the outputs for `memtotal_mb` and `memfree_mb` on each device:

```
LAB.01.SLX.COR.01:
    "ansible_net_memfree_mb": 5590
    "ansible_net_memtotal_mb": 7958

LAB.01.SLX.COR.02:
    "ansible_net_memfree_mb": 5621
    "ansible_net_memtotal_mb": 7958
```