### PR TITLE
fix fedora version dnf fact, default pkg_mgr detection per distro family

### DIFF
--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -77,10 +77,12 @@ class PkgMgrFactCollector(BaseFactCollector):
                     for yum in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'yum']:
                         if os.path.exists(yum['path']):
                             pkg_mgr_name = 'yum'
+                            break
                 else:
                     for dnf in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'dnf']:
-                        if os.path.exists(yum['path']):
+                        if os.path.exists(dnf['path']):
                             pkg_mgr_name = 'dnf'
+                            break
             except ValueError:
                 # If there's some new magical Fedora version in the future,
                 # just default to dnf

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -70,13 +70,17 @@ class PkgMgrFactCollector(BaseFactCollector):
     _platform = 'Generic'
     required_facts = set(['distribution'])
 
-    def _check_rh_versions(self, collected_facts):
+    def _check_rh_versions(self, pkg_mgr_name, collected_facts):
         if collected_facts['ansible_distribution'] == 'Fedora':
             try:
-                if int(collected_facts['ansible_distribution_major_version']) < 15:
-                    pkg_mgr_name = 'yum'
+                if int(collected_facts['ansible_distribution_major_version']) < 23:
+                    yum = [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'yum'][0]
+                    if os.path.exists(yum['path']):
+                        pkg_mgr_name = 'yum'
                 else:
-                    pkg_mgr_name = 'dnf'
+                    dnf = [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'dnf'][0]
+                    if os.path.exists(yum['path']):
+                        pkg_mgr_name = 'dnf'
             except ValueError:
                 # If there's some new magical Fedora version in the future,
                 # just default to dnf
@@ -92,14 +96,15 @@ class PkgMgrFactCollector(BaseFactCollector):
             if os.path.exists(pkg['path']):
                 pkg_mgr_name = pkg['name']
 
-        # apt is easily installable and supported by distros other than those
-        # that are debian based, this handles some of those scenarios as they
-        # are reported/requested
-        if pkg_mgr_name == 'apt' and collected_facts['ansible_os_family'] in ["RedHat", "Altlinux"]:
-            if collected_facts['ansible_os_family'] == 'RedHat':
-                pkg_mgr_name = self._check_rh_versions(collected_facts)
 
-            elif collected_facts['ansible_os_family'] == 'Altlinux':
+        # Handle distro family defaults when more than one package manager is
+        # installed, the ansible_fact entry should be the default package
+        # manager provided by the distro.
+        if collected_facts['ansible_os_family'] == "RedHat":
+            if pkg_mgr_name not in ('yum', 'dnf'):
+                pkg_mgr_name = self._check_rh_versions(pkg_mgr_name, collected_facts)
+        elif collected_facts['ansible_os_family'] == 'Altlinux':
+            if pkg_mgr_name == 'apt':
                 pkg_mgr_name = 'apt_rpm'
 
         # pacman has become available by distros other than those that are Arch

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -74,13 +74,13 @@ class PkgMgrFactCollector(BaseFactCollector):
         if collected_facts['ansible_distribution'] == 'Fedora':
             try:
                 if int(collected_facts['ansible_distribution_major_version']) < 23:
-                    yum = [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'yum'][0]
-                    if os.path.exists(yum['path']):
-                        pkg_mgr_name = 'yum'
+                    for yum in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'yum']
+                        if os.path.exists(yum['path']):
+                            pkg_mgr_name = 'yum'
                 else:
-                    dnf = [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'dnf'][0]
-                    if os.path.exists(yum['path']):
-                        pkg_mgr_name = 'dnf'
+                    for dnf in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'dnf']
+                        if os.path.exists(yum['path']):
+                            pkg_mgr_name = 'dnf'
             except ValueError:
                 # If there's some new magical Fedora version in the future,
                 # just default to dnf

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -74,11 +74,11 @@ class PkgMgrFactCollector(BaseFactCollector):
         if collected_facts['ansible_distribution'] == 'Fedora':
             try:
                 if int(collected_facts['ansible_distribution_major_version']) < 23:
-                    for yum in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'yum']
+                    for yum in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'yum']:
                         if os.path.exists(yum['path']):
                             pkg_mgr_name = 'yum'
                 else:
-                    for dnf in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'dnf']
+                    for dnf in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'dnf']:
                         if os.path.exists(yum['path']):
                             pkg_mgr_name = 'dnf'
             except ValueError:
@@ -95,7 +95,6 @@ class PkgMgrFactCollector(BaseFactCollector):
         for pkg in PKG_MGRS:
             if os.path.exists(pkg['path']):
                 pkg_mgr_name = pkg['name']
-
 
         # Handle distro family defaults when more than one package manager is
         # installed, the ansible_fact entry should be the default package


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
Fix the version Fedora switched to `dnf` by default for fact finding and switch the structure for `pkg_mgr` fact finding to detect default distro package manager is more logically grouped by distro family as [suggested](https://github.com/ansible/ansible/pull/40922#pullrequestreview-139950734)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/facts/system/pkg_mgr.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (facts/system/pkg_mgr 25e8534cd0) last updated 2018/07/25 10:51:14 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]

```


