### PR TITLE
Avoid namespace clash between "real" json and json.py

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import difflib
-import json
+import json as _myjson
 import os
 import sys
 import warnings
@@ -120,7 +120,7 @@ class CallbackBase(AnsiblePlugin):
         if 'exception' in abridged_result:
             del abridged_result['exception']
 
-        return json.dumps(abridged_result, cls=AnsibleJSONEncoder, indent=indent, ensure_ascii=False, sort_keys=sort_keys)
+        return _myjson.dumps(abridged_result, cls=AnsibleJSONEncoder, indent=indent, ensure_ascii=False, sort_keys=sort_keys)
 
     def _handle_warnings(self, res):
         ''' display warnings, if enabled and any exist in the result '''
@@ -170,7 +170,7 @@ class CallbackBase(AnsiblePlugin):
                         # format complex structures into 'files'
                         for x in ['before', 'after']:
                             if isinstance(diff[x], MutableMapping):
-                                diff[x] = json.dumps(diff[x], sort_keys=True, indent=4, separators=(',', ': ')) + '\n'
+                                diff[x] = _myjson.dumps(diff[x], sort_keys=True, indent=4, separators=(',', ': ')) + '\n'
                         if 'before_header' in diff:
                             before_header = "before: %s" % diff['before_header']
                         else:


### PR DESCRIPTION
The story of https://stackoverflow.com/a/46288244/616349 appears to
be incomplete in an __init__.py file, whose namespace will undergo
further tweaking after it is finished loading (if I understand
correctly things such as
https://medium.com/@ramrajchandradevan/python-init-py-modular-imports-81b746e58aae)

* Side-step the clash by importing json under a different name

##### SUMMARY

Running a simple playbook in my environment (described below) with -vvvv results in

```                                                                                                                                                                                                                                                                            [WARNING]: Failure using method (v2_runner_item_on_failed) in callback plugin (<ansible.plugins.callback.default.CallbackModule object at 0x1126716d0>): 'module' object has no attribute 'dumps'

Callback Exception:
  File "/Users/jaep/cede/code/prod_repos/epflstack/src/edx-configuration/.venv/lib/python2.7/site-packages/ansible/executor/task_queue_manager.py", line 374, in send_callback                                                                                                    method(*new_args, **kwargs)                                                                                                                                                                                                                                                  File "/Users/jaep/cede/code/prod_repos/epflstack/src/edx-configuration/.venv/lib/python2.7/site-packages/ansible/plugins/callback/default.py", line 227, in v2_runner_item_on_failed
    self._display.display(msg + " (item=%s) => %s" % (self._get_item_label(result._result), self._dump_results(result._result)), color=C.COLOR_ERROR)
   File "/Users/jaep/cede/code/prod_repos/epflstack/src/edx-configuration/.venv/lib/python2.7/site-packages/ansible/plugins/callback/__init__.py", line 123, in _dump_results
    return json.dumps(abridged_result, cls=AnsibleJSONEncoder, indent=indent, ensure_ascii=False, sort_keys=sort_keys) 
```
                                                                                                                                                                                                                                                                                                                                                                                                                               
##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (detached HEAD 9bf22309b3) last updated 2018/07/25 17:55:55 (GMT +200)
  config file = /Users/jaep/cede/code/prod_repos/epflstack/src/edx-configuration/playbooks/ansible.cfg
  configured module search path = [u'/Users/jaep/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jaep/cede/code/prod_repos/epflstack/src/edx-configuration/playbooks/ansible/lib/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jul 23 2018, 21:27:06) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

On my platform, even a simple "apt" task results in the aforementioned stack trace. (brew install python2 ; pip install --upgrade pip; pip install git+https://github.com/ansible/ansible.git@devel)

<!--- Paste verbatim command output below, e.g. before and after your change -->
Without this change: (See above stack trace)

With this change: "apt" (and the rest of the playbook) completes successfully.
