### PR TITLE
make integration tests resilient to upstream distro changes

### DIFF
--- a/test/integration/targets/filesystem/tasks/main.yml
+++ b/test/integration/targets/filesystem/tasks/main.yml
@@ -32,4 +32,5 @@
     # On Ubuntu trusty, blkid (2.20.1) is unable to identify F2FS filesystem. blkid handles F2FS since v2.23, see:
     # https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23-ReleaseNotes
     - 'not (item.key == "f2fs" and ansible_distribution == "Ubuntu" and ansible_distribution_version is version("14.04", "<="))'
+    - 'not (item.key == "btrfs") and (btrfsprogs_installed == false)'
   loop: "{{ lookup('dict', tested_filesystems) }}"

--- a/test/integration/targets/filesystem/tasks/main.yml
+++ b/test/integration/targets/filesystem/tasks/main.yml
@@ -32,5 +32,5 @@
     # On Ubuntu trusty, blkid (2.20.1) is unable to identify F2FS filesystem. blkid handles F2FS since v2.23, see:
     # https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23-ReleaseNotes
     - 'not (item.key == "f2fs" and ansible_distribution == "Ubuntu" and ansible_distribution_version is version("14.04", "<="))'
-    - 'not (item.key == "btrfs") and (btrfsprogs_installed == false)'
+    - 'not (item.key == "btrfs") and (btrfsprogs_installed is defined and btrfsprogs_installed == false)'
   loop: "{{ lookup('dict', tested_filesystems) }}"

--- a/test/integration/targets/filesystem/tasks/setup.yml
+++ b/test/integration/targets/filesystem/tasks/setup.yml
@@ -14,6 +14,11 @@
       name: btrfs-progs
       state: present
     when: ansible_os_family != 'Suse' and not (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('16.04', '<='))
+    ignore_errors: true
+    register: install_btrfs_progs
+
+  - set_fact:
+      btrfsprogs_installed: "{{ install_btrfs_progs is successful }}"
 
   - name: install btrfs progs (Ubuntu <= 16.04)
     package:

--- a/test/integration/targets/filesystem/tasks/setup.yml
+++ b/test/integration/targets/filesystem/tasks/setup.yml
@@ -21,10 +21,6 @@
       btrfsprogs_installed: "{{ install_btrfs_progs is successful }}"
     when: install_btrfs_progs is defined
 
-  - set_fact:
-      btrfsprogs_installed: false
-    when: ansible_system == 'FreeBSD'
-
   - name: install btrfs progs (Ubuntu <= 16.04)
     package:
       name: btrfs-tools

--- a/test/integration/targets/filesystem/tasks/setup.yml
+++ b/test/integration/targets/filesystem/tasks/setup.yml
@@ -19,9 +19,10 @@
 
   - set_fact:
       btrfsprogs_installed: "{{ install_btrfs_progs is successful }}"
+    when: install_btrfs_progs is defined
 
   - set_fact:
-      btrfsprogs_installed: False
+      btrfsprogs_installed: false
     when: ansible_system == 'FreeBSD'
 
   - name: install btrfs progs (Ubuntu <= 16.04)

--- a/test/integration/targets/filesystem/tasks/setup.yml
+++ b/test/integration/targets/filesystem/tasks/setup.yml
@@ -20,6 +20,10 @@
   - set_fact:
       btrfsprogs_installed: "{{ install_btrfs_progs is successful }}"
 
+  - set_fact:
+      btrfsprogs_installed: False
+    when: ansible_system == 'FreeBSD'
+
   - name: install btrfs progs (Ubuntu <= 16.04)
     package:
       name: btrfs-tools

--- a/test/integration/targets/setup_mysql_db/tasks/main.yml
+++ b/test/integration/targets/setup_mysql_db/tasks/main.yml
@@ -34,6 +34,7 @@
         - '{{ ansible_os_family }}-{{ ansible_distribution_major_version }}{{ python_suffix }}.yml'
         - '{{ ansible_distribution }}{{ python_suffix }}.yml'
         - '{{ ansible_os_family }}{{ python_suffix }}.yml'
+        - '{{ ansible_os_family }}.yml'
         - 'default{{ python_suffix }}.yml'
       paths: '../vars'
 

--- a/test/integration/targets/setup_rpm_repo/tasks/main.yml
+++ b/test/integration/targets/setup_rpm_repo/tasks/main.yml
@@ -33,6 +33,17 @@
       - createrepo  # used by el6 version of rpmfluff
     when:
       - ansible_distribution not in ['Fedora']
+      - ansible_python["version"]["major"] == 2
+
+  - name: Install rpmfluff and deps
+    package:
+      name: "{{ item }}"
+    with_items:
+      - python3-rpmfluff
+      - createrepo_c
+      - createrepo  # used by el6 version of rpmfluff
+    when:
+      - ansible_distribution not in ['Fedora']
       - ansible_python["version"]["major"] == 3
 
   - name: Copy script for creating a repo

--- a/test/integration/targets/setup_rpm_repo/tasks/main.yml
+++ b/test/integration/targets/setup_rpm_repo/tasks/main.yml
@@ -33,7 +33,7 @@
       - createrepo  # used by el6 version of rpmfluff
     when:
       - ansible_distribution not in ['Fedora']
-      - ansible_python["version"]["major"] == 2
+      - ansible_python["version"]["major"] == 3
 
   - name: Install rpmfluff and deps
     package:


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
Currently some of the tests don't take into account possible changes in upstream distro behavior, this allows the tests to not break because of distro upgrades in certain scenarios.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (tests/distro_compat 865ece9951) last updated 2018/07/25 11:05:03 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```
