### PR TITLE
Fix journald unittests

### DIFF
--- a/test/units/module_utils/basic/test_log.py
+++ b/test/units/module_utils/basic/test_log.py
@@ -120,7 +120,7 @@ class TestAnsibleModuleLogJournal:
             assert journal_send.called == 1
             # Message
             # call_args is a 2-tuple of (arg_list, kwarg_dict)
-            assert journal_send.call_args[0][0].endswith('unittest no_log'), 'Message was not sent to log'
+            assert journal_send.call_args[1]['MESSAGE'].endswith('unittest no_log'), 'Message was not sent to log'
             # log adds this journal field
             assert 'MODULE' in journal_send.call_args[1]
             assert 'basic.py' in journal_send.call_args[1]['MODULE']
@@ -133,14 +133,14 @@ class TestAnsibleModuleLogJournal:
         journal_send = mocker.patch('systemd.journal.send')
         am.log(msg)
         assert journal_send.call_count == 1, 'journal.send not called exactly once'
-        assert journal_send.call_args[0][0].endswith(param)
+        assert journal_send.call_args[1]['MESSAGE'].endswith(param)
 
     @pytest.mark.parametrize('stdin', ({},), indirect=['stdin'])
     def test_log_args(self, am, mocker):
         journal_send = mocker.patch('systemd.journal.send')
         am.log('unittest log_args', log_args=dict(TEST='log unittest'))
         assert journal_send.called == 1
-        assert journal_send.call_args[0][0].endswith('unittest log_args'), 'Message was not sent to log'
+        assert journal_send.call_args[1]['MESSAGE'].endswith('unittest log_args'), 'Message was not sent to log'
 
         # log adds this journal field
         assert 'MODULE' in journal_send.call_args[1]


### PR DESCRIPTION
d7df072b9622b4795d50b994d499121bceab1054 changed how we call
journal.send() from positional arguments to keyword arguments.  So we
need to update the test to check for the arguments it was called with in
the keyword args, not in the positional args.

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
I'm not sure why the unittests for this are currently passing.  I only ran across this failure when I started working on changing how Ansiballz is invoked.