### PR TITLE
Add contains parameter to win_find

### DIFF
--- a/lib/ansible/modules/windows/win_find.ps1
+++ b/lib/ansible/modules/windows/win_find.ps1
@@ -14,6 +14,7 @@ $paths = Get-AnsibleParam -obj $params -name 'paths' -failifempty $true
 
 $age = Get-AnsibleParam -obj $params -name 'age'
 $age_stamp = Get-AnsibleParam -obj $params -name 'age_stamp' -default 'mtime' -ValidateSet 'mtime','ctime','atime'
+$contains = Get-AnsibleParam -obj $params -name 'contains'
 $file_type = Get-AnsibleParam -obj $params -name 'file_type' -default 'file' -ValidateSet 'file','directory'
 $follow = Get-AnsibleParam -obj $params -name 'follow' -type "bool" -default $false
 $hidden = Get-AnsibleParam -obj $params -name 'hidden' -type "bool" -default $false
@@ -172,6 +173,31 @@ Function Assert-Pattern($info) {
     $valid_match
 }
 
+Function Assert-Contains($info) {
+    $valid_match = $false
+
+    if ($contains -ne $null) {
+        $file_contents = [System.IO.File]::ReadAllText((Resolve-Path $info.filename))
+        foreach ($pattern in $contains) {
+            if ($use_regex -eq $true) {
+                # Use -match for regex matching
+                if ($file_contents -match $pattern) {
+                    $valid_match = $true
+                }
+            } else {
+                # Use -like for wildcard matching
+                if ($file_contents -like $pattern) {
+                    $valid_match = $true
+                }
+            }
+        }
+    } else {
+        $valid_match = $true
+    }
+
+    $valid_match
+}
+
 Function Assert-Size($info) {
     $valid_match = $true
 
@@ -211,8 +237,9 @@ Function Assert-FileStat($info) {
     $hidden_match = Assert-Hidden -info $info
     $pattern_match = Assert-Pattern -info $info
     $size_match = Assert-Size -info $info
+    $contains_match = Assert-Contains -info $info
 
-    if ($age_match -and $file_type_match -and $hidden_match -and $pattern_match -and $size_match) {
+    if ($age_match -and $file_type_match -and $hidden_match -and $pattern_match -and $size_match -and  $contains_match) {
         $info
     } else {
         $false

--- a/lib/ansible/modules/windows/win_find.ps1
+++ b/lib/ansible/modules/windows/win_find.ps1
@@ -177,7 +177,7 @@ Function Assert-Contains($info) {
     $valid_match = $false
 
     if ($contains -ne $null) {
-        $file_contents = [System.IO.File]::ReadAllText((Resolve-Path $info.filename))
+        $file_contents = [System.IO.File]::ReadAllText($info.path)
         foreach ($pattern in $contains) {
             if ($use_regex -eq $true) {
                 # Use -match for regex matching
@@ -237,10 +237,13 @@ Function Assert-FileStat($info) {
     $hidden_match = Assert-Hidden -info $info
     $pattern_match = Assert-Pattern -info $info
     $size_match = Assert-Size -info $info
-    $contains_match = Assert-Contains -info $info
+    
 
-    if ($age_match -and $file_type_match -and $hidden_match -and $pattern_match -and $size_match -and  $contains_match) {
-        $info
+    if ($age_match -and $file_type_match -and $hidden_match -and $pattern_match -and $size_match) {
+        # Nest Assert-Contains inside other conditions because it reads the whole file, and there is no sense in reading files which have otherwise failed assert.
+        if ((Assert-Contains -info $info)) {
+            $info
+        }
     } else {
         $false
     }
@@ -358,7 +361,7 @@ foreach ($path in $paths_to_check) {
         $file = Get-Item -Force -Path $path
         $info = Get-FileStat -file $file
     } catch {
-        Add-Warning -obj $result -message "win_find failed to check some files, these files were ignored and will not be part of the result output"
+        Add-Warning -obj $result -message "win_find failed to check some files, these files were ignored and will not be part of the result output: $_"
         break
     }
 


### PR DESCRIPTION
##### SUMMARY
Adds `contains` parameter to `win_find`

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
win_find

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```
