### PR TITLE
ANSIBLE_REMOTE_TMP was an implementation of unified temp that was lat…

### DIFF
--- a/changelogs/fragments/remove-unused-ansible-remote-temp.yaml
+++ b/changelogs/fragments/remove-unused-ansible-remote-temp.yaml
@@ -1,0 +1,10 @@
+---
+minor_changes:
+- In Ansible-2.4 and above, Ansible passes the temporary directory a module
+  should use to the module.  This is done via a module parameter
+  (_ansible_tmpdir).  An earlier version of this which was also prototyped in
+  Ansible-2.4 development used an environment variable, ANSIBLE_REMOTE_TMP to
+  pass this information to the module instead.  When we switched to using
+  a module parameter, the environment variable was left in by mistake.
+  Ansible-2.7 removes that variable.  Any third party modules which relied on
+  it should use the module parameter instead.

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -321,8 +321,6 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
         self._connection._shell.tmpdir = rc
 
-        if not become_unprivileged:
-            self._connection._shell.env.update({'ANSIBLE_REMOTE_TMP': self._connection._shell.tmpdir})
         return rc
 
     def _should_remove_tmp_path(self, tmp_path):


### PR DESCRIPTION
…er changed

One of the earlier implementation of unified temp for 2.4 passed the
temp diretory to the remote side using this environment variable.  We
later changed it to be passed via a module parameter but forgot to
remove the environment variable.

##### ISSUE TYPE

 - Bugfix Pull Request



##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```

