### PR TITLE
Fix bug preventing coverage of setup module.

### DIFF
--- a/test/runner/lib/cover.py
+++ b/test/runner/lib/cover.py
@@ -39,7 +39,7 @@ def command_coverage_combine(args):
     """
     coverage = initialize_coverage(args)
 
-    modules = dict((t.module, t.path) for t in list(walk_module_targets()))
+    modules = dict((t.module, t.path) for t in list(walk_module_targets()) if t.path.endswith('.py'))
 
     coverage_files = [os.path.join(COVERAGE_DIR, f) for f in os.listdir(COVERAGE_DIR) if '=coverage.' in f]
 


### PR DESCRIPTION
##### SUMMARY

Fix bug preventing coverage of setup module.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (coverage-fix ed78f37422) last updated 2018/07/25 18:22:47 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
