### PR TITLE
Fix rabbitmq_user when create a new user with permissions

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -146,7 +146,7 @@ class RabbitMqUser(object):
             if self.node is not None:
                 cmd.extend(['-n', self.node])
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
-            return out.splitlines()
+            return out.strip().splitlines()
         return list()
 
     def get(self):


### PR DESCRIPTION
Using RabbitMQ 3.7.7


Fail to create a new RabbitMQ user, because it fails when Ansible is retrieving the current user information


 - Bugfix Pull Request


rabbitmq_user_module


```
ansible 2.6.1
  config file = /Users/robinho/.ansible.cfg
  configured module search path = ['/Users/robinho/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/robinho/app/ansible/venv/lib/python3.6/site-packages/ansible
  executable location = /Users/robinho/app/ansible/venv/bin/ansible
  python version = 3.6.6 (default, Jul 19 2018, 19:16:45) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.10.25.5)]
```



```
FAILED! => {
    "changed": false,
    "module_stderr": "OpenSSH_7.7p1, OpenSSL 1.0.2o  27 Mar 2018\r\ndebug1: Reading configuration data /Users/robinho/.ssh/config\r\ndebug1: /Users/robinho/.ssh/config line 1: Applying options for *\r\ndebug1: /Users/robinho/.ssh/config line 45: Applying options for xxx.xx.x.xx\r\ndebug1: Reading configuration data /usr/local/etc/ssh/ssh_config\r\ndebug2: resolve_canonicalize: hostname xxx.xx.x.xx is address\r\ndebug1: auto-mux: Trying existing master\r\ndebug2: fd 3 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_session: entering\r\ndebug3: mux_client_request_alive: entering\r\ndebug3: mux_client_request_alive: done pid = 92522\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session: master session id: 2\r\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 1\r\nShared connection to xxx.xx.x.xx closed.\r\n",
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_oktqZ4/ansible_module_rabbitmq_user.py\", line 316, in <module>\r\n    main()\r\n  File \"/tmp/ansible_oktqZ4/ansible_module_rabbitmq_user.py\", line 285, in main\r\n    if rabbitmq_user.get():\r\n  File \"/tmp/ansible_oktqZ4/ansible_module_rabbitmq_user.py\", line 170, in get\r\n    self._permissions = self._get_permissions()\r\n  File \"/tmp/ansible_oktqZ4/ansible_module_rabbitmq_user.py\", line 179, in _get_permissions\r\n    vhost, configure_priv, write_priv, read_priv = perm.split('\\t')\r\nValueError: need more than 1 value to unpack\r\n",
    "msg": "MODULE FAILURE",
    "rc": 1
```