### PR TITLE
Fix typo in ignore_unknown_extensions doc

### DIFF
--- a/lib/ansible/modules/utilities/logic/include_vars.py
+++ b/lib/ansible/modules/utilities/logic/include_vars.py
@@ -56,10 +56,10 @@ options:
     description:
       - List of file extensions to read when using C(dir).
     default: [yaml, yml, json]
-  ignore_unkown_extensions:
+  ignore_unknown_extensions:
     version_added: "2.7"
     description:
-      - Ignore unkown file extensions within the directory. This allows users to specify a directory containing vars files
+      - Ignore unknown file extensions within the directory. This allows users to specify a directory containing vars files
         that are intermingled with non vars files extension types (For example, a directory with a README in it and vars files)
     default: False
   free-form:

--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -103,7 +103,7 @@ class ActionModule(ActionBase):
                 raise AnsibleError('{0} is not a valid option in include_vars'.format(arg))
 
         if dirs and files:
-            raise AnsibleError("Your are mixing file only and dir only arguments, these are incompatible")
+            raise AnsibleError("You are mixing file only and dir only arguments, these are incompatible")
 
         # set internal vars from args
         self._set_args()


### PR DESCRIPTION
##### SUMMARY
Minor typo fix in docs of ignore_unknown_extension 

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/utilities/logic/include_vars.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```