### PR TITLE
Update troubleshooting doc for command timeout

### DIFF
--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -438,7 +438,8 @@ timeout value that can be set on a per task basis.
 The timeout value controls the amount of time in seconds before the
 task will fail if the command has not returned.
 
-* Applicable for local connection type:
+For local connection type:
+
 For example:
 
 .. FIXME: Detail error here
@@ -453,7 +454,8 @@ Suggestions to resolve:
         provider: "{{ cli }}"
         timeout: 30
 
-* Applicable for network_cli, netconf connection type (from 2.7 onwards):
+For network_cli, netconf connection type (applicable from 2.7 onwards):
+
 For example:
 
 .. FIXME: Detail error here

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -440,8 +440,6 @@ task will fail if the command has not returned.
 
 For local connection type:
 
-For example:
-
 .. FIXME: Detail error here
 
 Suggestions to resolve:
@@ -455,8 +453,6 @@ Suggestions to resolve:
         timeout: 30
 
 For network_cli, netconf connection type (applicable from 2.7 onwards):
-
-For example:
 
 .. FIXME: Detail error here
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -418,9 +418,8 @@ For example:
 
 Suggestions to resolve:
 
-Options 1:
+Options 1 (Global command timeout setting):
 Increase value of command timeout in configuration file or by setting environment variable.
-Note: This value should be less than persistent connection idle timeout ie. connect_timeout
 
 .. code-block:: yaml
 
@@ -433,12 +432,13 @@ To make this a permanent change, add the following to your ``ansible.cfg`` file:
    [persistent_connection]
    command_timeout = 30
 
-Option 2:
+Option 2 (Per task command timeout setting):
 Increase command timeout per task basis. All network modules support a
 timeout value that can be set on a per task basis.
 The timeout value controls the amount of time in seconds before the
 task will fail if the command has not returned.
 
+* Applicable for local connection type:
 For example:
 
 .. FIXME: Detail error here
@@ -453,12 +453,26 @@ Suggestions to resolve:
         provider: "{{ cli }}"
         timeout: 30
 
+* Applicable for network_cli, netconf connection type (from 2.7 onwards):
+For example:
+
+.. FIXME: Detail error here
+
+Suggestions to resolve:
+
+.. code-block:: yaml
+
+    - name: save running-config
+      ios_command:
+        commands: copy running-config startup-config
+      vars:
+        ansible_command_timeout: 30
+
 Some operations take longer than the default 10 seconds to complete.  One good
 example is saving the current running config on IOS devices to startup config.
 In this case, changing the timeout value form the default 10 seconds to 30
 seconds will prevent the task from failing before the command completes
 successfully.
-Note: This value should be less than persistent connection idle timeout ie. connect_timeout
 
 Persistent socket connect timeout:
 For example:

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -468,7 +468,7 @@ Suggestions to resolve:
 
 Some operations take longer than the default 10 seconds to complete.  One good
 example is saving the current running config on IOS devices to startup config.
-In this case, changing the timeout value form the default 10 seconds to 30
+In this case, changing the timeout value from the default 10 seconds to 30
 seconds will prevent the task from failing before the command completes
 successfully.
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Update timeout document to reflect the new way to set
  command timeout per task basis for network_cli and netconf
  connection type as per PR #42847
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
network_debug_troubleshooting.rst
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
