### PR TITLE
Fix baud rate and nxos_logging default case idempotency bug  

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_logging.py
+++ b/lib/ansible/modules/network/nxos/nxos_logging.py
@@ -285,11 +285,10 @@ def map_config_to_obj(module):
                         'dest_level': parse_dest_level(line, dest, parse_name(line, dest)),
                         'facility_level': parse_facility_level(line, facility)})
 
-    cmd_1 = [{'command': 'show logging | section enabled | section console', 'output': 'text'}]
-    cmd_2 = [{'command': 'show logging | section enabled | section monitor', 'output': 'text'}]
+    cmd = [{'command': 'show logging | section enabled | section console', 'output':'text'},
+             {'command': 'show logging | section enabled | section monitor', 'output':'text'}]
 
-    default_data = run_commands(module, cmd_1)
-    default_data.append(run_commands(module, cmd_2))
+    default_data = run_commands(module, cmd)
 
     for line in default_data:
         flag = False

--- a/lib/ansible/modules/network/nxos/nxos_logging.py
+++ b/lib/ansible/modules/network/nxos/nxos_logging.py
@@ -293,7 +293,7 @@ def map_config_to_obj(module):
 
     for line in default_data:
         flag = False
-        match = re.search('Logging (\w+):(?:\s+) (?:\w+) (?:\W)Severity: (\w+)', str(line), re.M)
+        match = re.search(r'Logging (\w+):(?:\s+) (?:\w+) (?:\W)Severity: (\w+)', str(line), re.M)
         if match:
             if match.group(1) == 'console' and match.group(2) == 'critical':
                 dest_level = '2'

--- a/lib/ansible/modules/network/nxos/nxos_logging.py
+++ b/lib/ansible/modules/network/nxos/nxos_logging.py
@@ -114,8 +114,7 @@ commands:
 
 import re
 
-
-from ansible.module_utils.network.nxos.nxos import get_config, load_config
+from ansible.module_utils.network.nxos.nxos import get_config, load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
 
@@ -285,6 +284,30 @@ def map_config_to_obj(module):
                         'facility': facility,
                         'dest_level': parse_dest_level(line, dest, parse_name(line, dest)),
                         'facility_level': parse_facility_level(line, facility)})
+
+    cmd_1 = [{'command': 'show logging | section enabled | section console', 'output': 'text'}]
+    cmd_2 = [{'command': 'show logging | section enabled | section monitor', 'output': 'text'}]
+
+    default_data = run_commands(module, cmd_1)
+    default_data.append(run_commands(module, cmd_2))
+
+    for line in default_data:
+        flag = False
+        match = re.search('Logging (\w+):(?:\s+) (?:\w+) (?:\W)Severity: (\w+)', str(line), re.M)
+        if match:
+            if match.group(1) == 'console' and match.group(2) == 'critical':
+                dest_level = '2'
+                flag = True
+            elif match.group(1) == 'monitor' and match.group(2) == 'notifications':
+                dest_level = '5'
+                flag = True
+        if flag:
+            obj.append({'dest': match.group(1),
+                        'remote_server': None,
+                        'name': None,
+                        'facility': None,
+                        'dest_level': dest_level,
+                        'facility_level': None})
 
     return obj
 

--- a/lib/ansible/modules/network/nxos/nxos_logging.py
+++ b/lib/ansible/modules/network/nxos/nxos_logging.py
@@ -122,7 +122,7 @@ from ansible.module_utils.basic import AnsibleModule
 DEST_GROUP = ['console', 'logfile', 'module', 'monitor', 'server']
 
 
-def map_obj_to_commands(updates, module):
+def map_obj_to_commands(updates):
     commands = list()
     want, have = updates
 
@@ -285,8 +285,8 @@ def map_config_to_obj(module):
                         'dest_level': parse_dest_level(line, dest, parse_name(line, dest)),
                         'facility_level': parse_facility_level(line, facility)})
 
-    cmd = [{'command': 'show logging | section enabled | section console', 'output':'text'},
-             {'command': 'show logging | section enabled | section monitor', 'output':'text'}]
+    cmd = [{'command': 'show logging | section enabled | section console', 'output': 'text'},
+           {'command': 'show logging | section enabled | section monitor', 'output': 'text'}]
 
     default_data = run_commands(module, cmd)
 

--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -47,7 +47,8 @@ class TerminalModule(TerminalBase):
         re.compile(br"syntax error"),
         re.compile(br"unknown command"),
         re.compile(br"user not present"),
-        re.compile(br"invalid (.+?)at '\^' marker", re.I)
+        re.compile(br"invalid (.+?)at '\^' marker", re.I),
+        re.compile(br"baud rate of console should be (\d*) to increase severity level", re.I)
     ]
 
     def on_become(self, passwd=None):

--- a/test/integration/targets/nxos_logging/tests/common/basic.yaml
+++ b/test/integration/targets/nxos_logging/tests/common/basic.yaml
@@ -24,6 +24,60 @@
     that:
       - 'result.changed == false'
 
+- name: Set up console logging with level 2 (edge case)
+  nxos_logging: &clog2
+    dest: console
+    dest_level: 2
+    provider: "{{ connection }}"
+    state: present
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == true'
+      - '"logging console 2" in result.commands'
+
+- name: Set up console logging with level 2 (edge case) (idempotent)
+  nxos_logging: *clog2
+  register: result
+
+- assert: *false
+
+- name: Set Baud Rate to less than 38400
+  nxos_config:
+    lines:
+      - speed 9600
+    parents: line console
+    provider: "{{ connection }}"
+
+- name: Enable console logging with level 3 (will fail)
+  nxos_logging: &con3
+    dest: console
+    dest_level: 3
+  register: result
+  provider: "{{ connection }}"
+  ignore_errors: yes
+
+- assert:
+    that:
+      - 'result.failed == true'
+
+- name: Set Baud Rate to 38400
+  nxos_config:
+    lines:
+      - speed 38400
+    parents: line console
+    provider: "{{ connection }}"
+
+- name: Enable console logging with level 3 (will pass)
+  nxos_logging: *con3
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == true'
+      - '"logging console 3" in result.commands'
+
 - name: Logfile logging with level
   nxos_logging: &llog
     dest: logfile
@@ -80,6 +134,24 @@
 
 - assert: *false
 
+- name: Configure monitor with level 5 (edge case)
+  nxos_logging: &mlog5
+    dest: monitor
+    dest_level: 5
+    provider: "{{ connection }}"
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == true'
+      - '"logging monitor 5" in result.commands'
+
+- name: Configure monitor with level 5 (edge case) (idempotent)
+  nxos_logging: *mlog5
+  register: result
+
+- assert: *false
+
 - name: Configure facility with level
   nxos_logging: &flog
     facility: daemon
@@ -122,9 +194,9 @@
 - name: remove logging as collection tearDown
   nxos_logging: &agg
     aggregate:
-      - { dest: console, dest_level: 0 }
+      - { dest: console, dest_level: 3 }
       - { dest: module, dest_level: 2 }
-      - { dest: monitor, dest_level: 3 }
+      - { dest: monitor, dest_level: 5 }
       - { dest: logfile, dest_level: 1, name: test }
       - { facility: daemon, facility_level: 4 }
       - { dest: server, remote_server: test-syslogserver.com, facility: auth, dest_level: 1 }


### PR DESCRIPTION
##### SUMMARY
- Fixes #43072 
- Added regex in nxos terminal plugin to detect baud rate error messages while configuring console logging with level > 2
- Added more code to detect monitor and console logging configurations with default levels, that doesn't show up in running-config
- Added integration tests for the above fixes 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_logging.py

##### ANSIBLE VERSION
```
devel
```
