### PR TITLE
Httpapi : changes to support token based auth methods

### DIFF
--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -258,7 +258,7 @@ class Connection(NetworkConnectionBase):
                 return self.send(path, data, **kwargs)
             raise AnsibleConnectionFailure('Could not connect to {0}: {1}'.format(self._url, exc.reason))
 
-        if self._auth == None:
+        if self._auth is None:
             # Try to assign a new auth token if one is given
             self._auth = self.update_auth(response)
 

--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -206,12 +206,12 @@ class Connection(NetworkConnectionBase):
 
             httpapi = httpapi_loader.get(self._network_os, self)
             if httpapi:
+                self._implementation_plugins.append(httpapi)
                 httpapi.set_become(self._play_context)
                 httpapi.login(self.get_option('remote_user'), self.get_option('password'))
                 display.vvvv('loaded API plugin for network_os %s' % self._network_os, host=self._play_context.remote_addr)
             else:
                 raise AnsibleConnectionFailure('unable to load API plugin for network_os %s' % self._network_os)
-            self._implementation_plugins.append(httpapi)
 
             cliconf = cliconf_loader.get(self._network_os, self)
             if cliconf:
@@ -258,7 +258,8 @@ class Connection(NetworkConnectionBase):
                 return self.send(path, data, **kwargs)
             raise AnsibleConnectionFailure('Could not connect to {0}: {1}'.format(self._url, exc.reason))
 
-        # Try to assign a new auth token if one is given
-        self._auth = self.update_auth(response) or self._auth
+        if self._auth == None:
+            # Try to assign a new auth token if one is given
+            self._auth = self.update_auth(response)
 
         return response


### PR DESCRIPTION
##### SUMMARY
Two issues are fixed by this
1) After #43212, we need httpapi plugin on implementation_plugins before we call plugin's login method as we need method 'update_auth' from 'httpapi' plugin. Call stack is ->  (connection_plugin)_connect -> (httpapi_plugin) ->login -> (connection_plugin)->send -> (httpapi_plugin)->update_auth
 
2) in case of FTD, access_token is in body of http response so to extract token info from http response I need to read from response which reads payload from socket buffer on demand. Now response buffer object can not be read back again in 'send_request' which results in empty response to be sent. Current solution is to update_auth only in case auth was not done earlier or token got expired .

@Qalthos as discussed with you, you wanted better solution to see if we can check or update auth for every possible interaction with device. I think that is fair but it will need some time to think through this. Can we go ahead with this approach for now ?


##### ISSUE TYPE
 - Bugfix Pull Request
 
