### PR TITLE
module_utils/vultr.py: Ensure comparison is accurate

### DIFF
--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -217,7 +217,7 @@ class Vultr:
             return {}
 
         for r_id, r_data in r_list.items():
-            if r_data[key] == value:
+            if str(r_data[key]) == str(value):
                 self.api_cache.update({
                     resource: r_data
                 })


### PR DESCRIPTION
##### SUMMARY

In `query_resource_by_key()`, there is an equal comparison that is made to
know if the object we are looking for is present. Due to type difference
this comparison doesn't always retrieve true, even when it should.

This is due to the fact that the value in r_data dict are of type
unicode, while the other can be of type int, float,... .

```
>>> a = u'1'
>>> type(a)
<type 'unicode'>
>>> b = 1
>>> type(b)
<type 'int'>
>>> a == b
False
>>> str(a) == str(b)
True
>>> a.encode('utf-8')
'1'
>>> a.encode('utf-8') == b
False
```

Hence the values, for comparison purposes, are casted into strings.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

  - vultr.py

##### ANSIBLE VERSION

  - devel

##### ADDITIONAL INFORMATION

  - N/A