### PR TITLE
vultr.py: query_resource_by_key Handle list and dict  

### DIFF
--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -219,13 +219,20 @@ class Vultr:
 
         if not r_list:
             return {}
-
-        for r_id, r_data in r_list.items():
-            if str(r_data[key]) == str(value):
-                self.api_cache.update({
-                    resource: r_data
-                })
-                return r_data
+        elif isinstance(r_list, list):
+            for r_data in r_list:
+                if str(r_data[key]) == str(value):
+                    self.api_cache.update({
+                        resource: r_data
+                    })
+                    return r_data
+        elif isinstance(r_list, dict):
+            for r_id, r_data in r_list.items():
+                if str(r_data[key]) == str(value):
+                    self.api_cache.update({
+                        resource: r_data
+                    })
+                    return r_data
 
         self.module.fail_json(msg="Could not find %s with %s: %s" % (resource, key, value))
 


### PR DESCRIPTION
##### SUMMARY
                
The Vultr API is inconsistent in the type of the value it returns           
based on the resources. While most of the time it will be a dict, for       
some resources it will be a list (`/v1/user/list`, `/v1/block/list`).           
                                                                            
`query_resource_by_key()` fails if the return value isn't a dict (.items() 
does not exist on list). This patch aims to support both list and dict.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

  - module_utils/vultr.py

##### ANSIBLE VERSION

  - devel

##### ADDITIONAL INFORMATION

  - N/A