### PR TITLE
httpapi: Split off and save response text contents

### DIFF
--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -206,12 +206,12 @@ class Connection(NetworkConnectionBase):
 
             httpapi = httpapi_loader.get(self._network_os, self)
             if httpapi:
+                display.vvvv('loaded API plugin for network_os %s' % self._network_os, host=self._play_context.remote_addr)
+                self._implementation_plugins.append(httpapi)
                 httpapi.set_become(self._play_context)
                 httpapi.login(self.get_option('remote_user'), self.get_option('password'))
-                display.vvvv('loaded API plugin for network_os %s' % self._network_os, host=self._play_context.remote_addr)
             else:
                 raise AnsibleConnectionFailure('unable to load API plugin for network_os %s' % self._network_os)
-            self._implementation_plugins.append(httpapi)
 
             cliconf = cliconf_loader.get(self._network_os, self)
             if cliconf:

--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -258,7 +258,9 @@ class Connection(NetworkConnectionBase):
                 return self.send(path, data, **kwargs)
             raise AnsibleConnectionFailure('Could not connect to {0}: {1}'.format(self._url, exc.reason))
 
-        # Try to assign a new auth token if one is given
-        self._auth = self.update_auth(response) or self._auth
+        response_text = response.read()
 
-        return response
+        # Try to assign a new auth token if one is given
+        self._auth = self.update_auth(response, response_text) or self._auth
+
+        return response, response_text

--- a/lib/ansible/plugins/httpapi/__init__.py
+++ b/lib/ansible/plugins/httpapi/__init__.py
@@ -36,7 +36,7 @@ class HttpApiBase(AnsiblePlugin):
         """
         pass
 
-    def update_auth(self, response):
+    def update_auth(self, response, response_text):
         """Return per-request auth token.
 
         The response should be a dictionary that can be plugged into the

--- a/lib/ansible/plugins/httpapi/nxos.py
+++ b/lib/ansible/plugins/httpapi/nxos.py
@@ -27,14 +27,13 @@ class HttpApi(HttpApiBase):
         request = request_builder(queue, output)
         headers = {'Content-Type': 'application/json'}
 
-        response = self.connection.send('/ins', request, headers=headers, method='POST')
-        response_text = to_text(response.read())
+        response, response_text = self.connection.send('/ins', request, headers=headers, method='POST')
         try:
-            response = json.loads(response_text)
+            response_text = json.loads(response_text)
         except ValueError:
             raise ConnectionError('Response was not valid JSON, got {0}'.format(response_text))
 
-        results = handle_response(response)
+        results = handle_response(response_text)
 
         if self._become:
             results = results[1:]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
HTTPResponse can only be read once, so save the contents for reuse

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
httpapi

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```