### PR TITLE
Fix referenced before assignment in role requirements

### DIFF
--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -189,8 +189,8 @@ class RoleRequirement(RoleDefinition):
 
         def run_scm_cmd(cmd, tempdir):
             try:
-                stdout = None
-                stderr = None
+                stdout = ''
+                stderr = ''
                 popen = Popen(cmd, cwd=tempdir, stdout=PIPE, stderr=PIPE)
                 stdout, stderr = popen.communicate()
             except Exception as e:

--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -189,6 +189,8 @@ class RoleRequirement(RoleDefinition):
 
         def run_scm_cmd(cmd, tempdir):
             try:
+                stdout = None
+                stderr = None
                 popen = Popen(cmd, cwd=tempdir, stdout=PIPE, stderr=PIPE)
                 stdout, stderr = popen.communicate()
             except Exception as e:


### PR DESCRIPTION
##### SUMMARY
If the SCM provider is missing during role require, `run_scm_cmd()` throws an uncaught Unbound exception error:

```
ERROR! Unexpected Exception, this is probably a bug: local variable 'stdout' referenced before assignment
the full traceback was:

Traceback (most recent call last):
  File "/usr/bin/ansible-galaxy", line 118, in <module>
    exit_code = cli.run()
  File "/usr/lib/python2.7/site-packages/ansible/cli/galaxy.py", line 152, in run
    self.execute()
  File "/usr/lib/python2.7/site-packages/ansible/cli/__init__.py", line 155, in execute
    fn()
  File "/usr/lib/python2.7/site-packages/ansible/cli/galaxy.py", line 395, in execute_install
    installed = role.install()
  File "/usr/lib/python2.7/site-packages/ansible/galaxy/role.py", line 200, in install
    tmp_file = RoleRequirement.scm_archive_role(keep_scm_meta=self.options.keep_scm_meta, **self.spec)
  File "/usr/lib/python2.7/site-packages/ansible/playbook/role/requirement.py", line 208, in scm_archive_role
    run_scm_cmd(clone_cmd, tempdir)
  File "/usr/lib/python2.7/site-packages/ansible/playbook/role/requirement.py", line 197, in run_scm_cmd
    display.debug("\tstdout: " + stdout)
UnboundLocalError: local variable 'stdout' referenced before assignment
```

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/role/requirement.py

##### ANSIBLE VERSION
```
2.6.1
```


##### ADDITIONAL INFORMATION
```

```
fixes #43312