### PR TITLE
zabbix_import module to import zabbix configuration from file

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_import.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_import.py
@@ -18,7 +18,7 @@ module: zabbix_import
 short_description: Import zabbix configuration from xml or json
 description:
    - This module allows you to import zabbix configuration from xml or json file
-version_added: "2.6"
+version_added: "2.7"
 author:
     - "(@kuczko)"
 requirements:
@@ -173,7 +173,7 @@ class Configuration(object):
         f = open(filename, 'r')
         import_string = f.read()
         f.close()
-        import_result = self._zapi.configuration.import_({'format': import_format, 'source': import_string , 'rules': rules})
+        import_result = self._zapi.configuration.import_({'format': import_format, 'source': import_string, 'rules': rules})
         return import_result
 
 
@@ -187,8 +187,8 @@ def main():
             http_login_password=dict(type='str', required=False, default=None, no_log=True),
             validate_certs=dict(type='bool', required=False, default=True),
             import_file=dict(type='str', required=True),
-            rules=dict(type='dict', required=False),
-            import_format=dict(type='str', required=False, default='xml'),
+            rules=dict(type='dict', required=False, default=default_rules),
+            import_format=dict(choices=['xml','json'], required=False, default='xml'),
             timeout=dict(type='int', default=10)
         ),
         supports_check_mode=True
@@ -212,7 +212,7 @@ def main():
     # login to zabbix
     try:
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
-            validate_certs=validate_certs)
+                        validate_certs=validate_certs)
         zbx.login(login_user, login_password)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_import.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_import.py
@@ -32,9 +32,45 @@ options:
     import_format:
         description:
             - Format of zabbix import file
-        choices:
-            - xml
-            - json
+        choices: ['xml','json']
+    rules:
+        description:
+            - Rules for importing items
+        default: 
+            applications:
+                createMissing: true
+                deleteMissing:true
+            discoveryRules:
+                createMissing:true
+                updateExisting:true
+                deleteMissing:true
+            graphs:
+                createMissing:true
+                updateExisting:true
+                deleteMissing:true
+            groups:
+                createMissing:true
+            hosts:
+                createMissing:true
+                updateExisting:true
+            images:
+                createMissing:true
+                updateExisting:true
+            items:
+                createMissing:true
+                updateExisting:true
+                deleteMissing:true
+            maps:
+                createMissing:true
+                updateExisting:true
+            screens:
+                createMissing:true
+                updateExisting:true
+            templateLinkage:
+                createMissing:true
+            templates:
+                createMissing:true
+                updateExisting:true
 extends_documentation_fragment:
     - zabbix
 '''
@@ -134,6 +170,7 @@ class Configuration(object):
     def import_template(self, filename,rules, import_format):
         f = open(filename,'r') 
         import_string = f.read()
+        f.close()
         import_result = self._zapi.configuration.import_({'format': import_format, 'source' : import_string , 'rules' : rules })
         return import_result
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_import.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_import.py
@@ -36,42 +36,54 @@ options:
         default: xml
     rules:
         description:
-            - Rules for importing items
-        default:
-            applications:
-                createMissing:true
-                deleteMissing:true
-            discoveryRules:
-                createMissing:true
-                updateExisting:true
-                deleteMissing:true
-            graphs:
-                createMissing:true
-                updateExisting:true
-                deleteMissing:true
-            groups:
-                createMissing:true
-            hosts:
-                createMissing:true
-                updateExisting:true
-            images:
-                createMissing:true
-                updateExisting:true
-            items:
-                createMissing:true
-                updateExisting:true
-                deleteMissing:true
-            maps:
-                createMissing:true
-                updateExisting:true
-            screens:
-                createMissing:true
-                updateExisting:true
-            templateLinkage:
-                createMissing:true
-            templates:
-                createMissing:true
-                updateExisting:true
+            - "Rules for importing items. By default it will switch all rules to true (overwritting/removing all). It means:"
+            - "applications:"
+            - "  createMissing: true"
+            - "  deleteMissing true"
+            - "discoveryRules:"
+            - "  createMissing: true"
+            - "  updateExisting: true"
+            - "  deleteMissing: true"
+            - "graphs:"
+            - "  createMissing: true"
+            - "  updateExisting: true"
+            - "  deleteMissing: true"
+            - "groups:"
+            - "  createMissing: true"
+            - "hosts:"
+            - "  createMissing: true"
+            - "  updateExisting: true"
+            - "images:"
+            - "  createMissing: true"
+            - "  updateExisting: true"
+            - "items:"
+            - "  createMissing: true"
+            - "  updateExisting: true"
+            - "  deleteMissing: true"
+            - "maps:"
+            - "  createMissing: true"
+            - "  updateExisting: true"
+            - "screens:"
+            - "  createMissing: true"
+            - "  updateExisting': true"
+            - "templateLinkage:"
+            - "  createMissing: true"
+            - "templates:"
+            - "  createMissing: true"
+            - "  updateExisting: true"
+            - "templateScreens:"
+            - "  createMissing: true"
+            - "  updateExisting: true"
+            - "  deleteMissing: true"
+            - "triggers:"
+            - "  createMissing: true"
+            - "  updateExisting: true"
+            - "  deleteMissing: true"
+            - "valueMaps:"
+            - "  createMissing: true"
+            - "  updateExisting: true"
+
+
 extends_documentation_fragment:
     - zabbix
 '''
@@ -189,7 +201,7 @@ def main():
             http_login_password=dict(type='str', required=False, default=None, no_log=True),
             validate_certs=dict(type='bool', required=False, default=True),
             import_file=dict(type='str', required=True),
-            rules=dict(type='dict', required=False, default=DEFAULT_RULES),
+            rules=dict(type='dict', required=False),
             import_format=dict(choices=['xml', 'json'], required=False, default='xml'),
             timeout=dict(type='int', default=10)
         ),

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_import.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_import.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
@@ -91,6 +91,8 @@ EXAMPLES = '''
     timeout: 10
 '''
 
+RETURN = ''' # '''
+
 from ansible.module_utils.basic import AnsibleModule
 
 try:
@@ -101,7 +103,7 @@ except ImportError:
     HAS_ZABBIX_API = False
 
 
-default_rules = ({
+DEFAULT_RULES = ({
     'applications': {
         'createMissing': True,
         'deleteMissing': True
@@ -187,8 +189,8 @@ def main():
             http_login_password=dict(type='str', required=False, default=None, no_log=True),
             validate_certs=dict(type='bool', required=False, default=True),
             import_file=dict(type='str', required=True),
-            rules=dict(type='dict', required=False, default=default_rules),
-            import_format=dict(choices=['xml','json'], required=False, default='xml'),
+            rules=dict(type='dict', required=False, default=DEFAULT_RULES),
+            import_format=dict(choices=['xml', 'json'], required=False, default='xml'),
             timeout=dict(type='int', default=10)
         ),
         supports_check_mode=True
@@ -225,16 +227,16 @@ def main():
         rules = {}
 
     # Set default values for all empty rules
-    for rule_group in default_rules:
+    for rule_group in DEFAULT_RULES:
         try:
             rules[rule_group]
         except KeyError:
             rules[rule_group] = {}
-        for rule in default_rules[rule_group]:
+        for rule in DEFAULT_RULES[rule_group]:
             try:
                 rules[rule_group][rule]
             except KeyError:
-                rules[rule_group][rule] = default_rules[rule_group][rule]
+                rules[rule_group][rule] = DEFAULT_RULES[rule_group][rule]
 
     # Execute import
     conf = Configuration(module, zbx)

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_import.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_import.py
@@ -33,6 +33,7 @@ options:
         description:
             - Format of zabbix import file
         choices: ['xml','json']
+        default: xml
     rules:
         description:
             - Rules for importing items
@@ -232,6 +233,8 @@ def main():
                 rules[rule_group][rule]
             except KeyError:
                 rules[rule_group][rule]=default_rules[rule_group][rule]
+
+    # Execute import
     conf = Configuration(module, zbx)
     import_task = conf.import_template(import_file,rules,import_format)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_import.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_import.py
@@ -1,0 +1,130 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) mateusz@sysadmins.pl
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+RETURN = '''
+---
+host_groups:
+  description: List of Zabbix groups.
+  returned: success
+  type: dict
+  sample: [ { "flags": "0", "groupid": "33", "internal": "0", "name": "Hostgruup A" } ]
+'''
+
+DOCUMENTATION = '''
+---
+module: zabbix_group_facts
+short_description: Gather facts about Zabbix hostgroup
+description:
+   - This module allows you to search for Zabbix hostgroup entries.
+version_added: "2.6"
+author:
+    - "(@redwhitemiko)"
+requirements:
+    - "python >= 2.6"
+    - zabbix-api
+options:
+    hostgroup_name:
+        description:
+            - Name of the hostgroup in Zabbix.
+            - hostgroup is the unique identifier used and cannot be updated using this module.
+        required: true
+extends_documentation_fragment:
+    - zabbix
+'''
+
+EXAMPLES = '''
+- name: Get hostgroup info
+  local_action:
+    module: zabbix_group_facts
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    hostgroup_name:
+      - ExampleHostgroup
+    timeout: 10
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from zabbix_api import ZabbixAPI, ZabbixAPISubClass
+
+    HAS_ZABBIX_API = True
+except ImportError:
+    HAS_ZABBIX_API = False
+
+class Configuration(object):
+    def __init__(self, module, zbx):
+        self._module = module
+        self._zapi = zbx
+
+    def import_template(self, filename,rules):
+        f = open(filename,'r') 
+        import_string = f.read()
+        import_result = self._zapi.configuration.import_({'format': 'xml', 'source' : import_string , 'rules' : rules })
+        return import_result
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            server_url=dict(type='str', required=True, aliases=['url']),
+            login_user=dict(type='str', required=True),
+            login_password=dict(type='str', required=True, no_log=True),
+            http_login_user=dict(type='str', required=False, default=None),
+            http_login_password=dict(type='str', required=False, default=None, no_log=True),
+            validate_certs=dict(type='bool', required=False, default=True),
+            import_file=dict(type='str', required=True),
+            rules=dict(type='dict', required=True),
+            timeout=dict(type='int', default=10)
+        ),
+        supports_check_mode=True
+    )
+
+    if not HAS_ZABBIX_API:
+        module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
+
+    server_url = module.params['server_url']
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
+    http_login_user = module.params['http_login_user']
+    http_login_password = module.params['http_login_password']
+    validate_certs = module.params['validate_certs']
+    import_file = module.params['import_file']
+    timeout = module.params['timeout']
+    rules = module.params['rules']
+
+    zbx = None
+    # login to zabbix
+    try:
+        zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
+                               validate_certs=validate_certs)
+        zbx.login(login_user, login_password)
+    except Exception as e:
+        module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
+
+    # Validate parameters
+    if 'application' not in rules:
+         rules['applications']={}
+    if 'createMissing' not in rules['applications']:
+        rules['applications']['createMissing'] = True
+    if 'deleteMissing' not in rules['applications']:
+        rules['applications']['deleteMissing'] = True
+        
+    conf = Configuration(module, zbx)
+    import_task = conf.import_template(import_file,rules)
+
+    module.exit_json(import_task=import_task)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_import.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_import.py
@@ -37,9 +37,9 @@ options:
     rules:
         description:
             - Rules for importing items
-        default: 
+        default:
             applications:
-                createMissing: true
+                createMissing:true
                 deleteMissing:true
             discoveryRules:
                 createMissing:true
@@ -101,79 +101,81 @@ except ImportError:
     HAS_ZABBIX_API = False
 
 
-default_rules=({
-    'applications':{
-        'createMissing':True,
-        'deleteMissing':True
+default_rules = ({
+    'applications': {
+        'createMissing': True,
+        'deleteMissing': True
     },
-    'discoveryRules':{
-        'createMissing':True,
-        'updateExisting':True,
-        'deleteMissing':True
+    'discoveryRules': {
+        'createMissing': True,
+        'updateExisting': True,
+        'deleteMissing': True
     },
-    'graphs':{
-        'createMissing':True,
-        'updateExisting':True,
-        'deleteMissing':True
+    'graphs': {
+        'createMissing': True,
+        'updateExisting': True,
+        'deleteMissing': True
     },
-    'groups':{
-        'createMissing':True
+    'groups': {
+        'createMissing': True
     },
-    'hosts':{
-        'createMissing':True,
-        'updateExisting':True
+    'hosts': {
+        'createMissing': True,
+        'updateExisting': True
     },
-    'images':{
-        'createMissing':True,
-        'updateExisting':True
+    'images': {
+        'createMissing': True,
+        'updateExisting': True
     },
-    'items':{
-        'createMissing':True,
-        'updateExisting':True,
-        'deleteMissing':True
+    'items': {
+        'createMissing': True,
+        'updateExisting': True,
+        'deleteMissing': True
     },
-    'maps':{
-        'createMissing':True,
-        'updateExisting':True
+    'maps': {
+        'createMissing': True,
+        'updateExisting': True
     },
-    'screens':{
-        'createMissing':True,
-        'updateExisting':True
+    'screens': {
+        'createMissing': True,
+        'updateExisting': True
     },
-    'templateLinkage':{
-        'createMissing':True
+    'templateLinkage': {
+        'createMissing': True
     },
-    'templates':{
-        'createMissing':True,
-        'updateExisting':True
+    'templates': {
+        'createMissing': True,
+        'updateExisting': True
     },
-    'templateScreens':{
-        'createMissing':True,
-        'updateExisting':True,
-        'deleteMissing':True
+    'templateScreens': {
+        'createMissing': True,
+        'updateExisting': True,
+        'deleteMissing': True
     },
-    'triggers':{
-        'createMissing':True,
-        'updateExisting':True,
-        'deleteMissing':True
+    'triggers': {
+        'createMissing': True,
+        'updateExisting': True,
+        'deleteMissing': True
     },
-    'valueMaps':{
-        'createMissing':True,
-        'updateExisting':True
+    'valueMaps': {
+        'createMissing': True,
+        'updateExisting': True
     }
 })
+
 
 class Configuration(object):
     def __init__(self, module, zbx):
         self._module = module
         self._zapi = zbx
 
-    def import_template(self, filename,rules, import_format):
-        f = open(filename,'r') 
+    def import_template(self, filename, rules, import_format):
+        f = open(filename, 'r')
         import_string = f.read()
         f.close()
-        import_result = self._zapi.configuration.import_({'format': import_format, 'source' : import_string , 'rules' : rules })
+        import_result = self._zapi.configuration.import_({'format': import_format, 'source': import_string , 'rules': rules})
         return import_result
+
 
 def main():
     module = AnsibleModule(
@@ -210,33 +212,33 @@ def main():
     # login to zabbix
     try:
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
-                               validate_certs=validate_certs)
+            validate_certs=validate_certs)
         zbx.login(login_user, login_password)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 
-    # Validate format 
-    if import_format.lower() not in ['xml','json']:
-        self._module.fail_json(msg="import_format value incorrect: %s" % import_format)
+    # Validate format
+    if import_format.lower() not in ['xml', 'json']:
+        module.fail_json(msg="import_format value incorrect: %s" % import_format)
 
     if rules is None:
-       rules={}
+        rules = {}
 
     # Set default values for all empty rules
     for rule_group in default_rules:
         try:
             rules[rule_group]
         except KeyError:
-            rules[rule_group]={}
+            rules[rule_group] = {}
         for rule in default_rules[rule_group]:
             try:
                 rules[rule_group][rule]
             except KeyError:
-                rules[rule_group][rule]=default_rules[rule_group][rule]
+                rules[rule_group][rule] = default_rules[rule_group][rule]
 
     # Execute import
     conf = Configuration(module, zbx)
-    import_task = conf.import_template(import_file,rules,import_format)
+    import_task = conf.import_template(import_file, rules, import_format)
 
     module.exit_json(import_task=import_task)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There is zabbix_import functionality, which can be used for bulk zabbix updates and i needed it. Hence i have created module using othere zabbix modules as a base - zabbix-api library already supports this api call.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
zabbix_import
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 34d004c068) last updated 2018/07/26 09:04:57 (GMT +200)
  config file = /home/kuczko/.ansible.cfg
  configured module search path = [u'/home/kuczko/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/kuczko/Dropbox/SysAdmin/tools/ansible/lib/ansible
  executable location = /home/kuczko/Dropbox/SysAdmin/tools/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
