### PR TITLE
Adding os_disk_size_gb parameter to Virtual Machine

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -156,7 +156,6 @@ options:
     os_disk_size_gb:
         description:
             - Type of OS disk size in GB.
-        default: 32
         version_added: "2.7"
     os_type:
         description:
@@ -660,7 +659,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             storage_blob_name=dict(type='str', aliases=['storage_blob']),
             os_disk_caching=dict(type='str', aliases=['disk_caching'], choices=['ReadOnly', 'ReadWrite'],
                                  default='ReadOnly'),
-            os_disk_size_gb=dict(type='int', default=32),
+            os_disk_size_gb=dict(type='int'),
             managed_disk_type=dict(type='str', choices=['Standard_LRS', 'Premium_LRS']),
             os_type=dict(type='str', choices=['Linux', 'Windows'], default='Linux'),
             public_ip_allocation_method=dict(type='str', choices=['Dynamic', 'Static', 'Disabled'], default='Static',

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -1121,7 +1121,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                                 create_option=vm_dict['properties']['storageProfile']['osDisk']['createOption'],
                                 os_type=vm_dict['properties']['storageProfile']['osDisk']['osType'],
                                 caching=vm_dict['properties']['storageProfile']['osDisk']['caching'],
-                                disk_size_gb=dict['properties']['storageProfile']['osDisk']['diskSizeGB']
+                                disk_size_gb=vm_dict['properties']['storageProfile']['osDisk']['diskSizeGB']
                             ),
                             image_reference=self.compute_models.ImageReference(
                                 publisher=vm_dict['properties']['storageProfile']['imageReference']['publisher'],

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -153,6 +153,11 @@ options:
         default: ReadOnly
         aliases:
             - disk_caching
+    os_disk_size_gb:
+        description:
+            - Type of OS disk size in GB.
+        default: 32
+        version_added: "2.7"
     os_type:
         description:
             - Base type of operating system.
@@ -655,6 +660,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             storage_blob_name=dict(type='str', aliases=['storage_blob']),
             os_disk_caching=dict(type='str', aliases=['disk_caching'], choices=['ReadOnly', 'ReadWrite'],
                                  default='ReadOnly'),
+            os_disk_size_gb=dict(type='int', default=32),
             managed_disk_type=dict(type='str', choices=['Standard_LRS', 'Premium_LRS']),
             os_type=dict(type='str', choices=['Linux', 'Windows'], default='Linux'),
             public_ip_allocation_method=dict(type='str', choices=['Dynamic', 'Static', 'Disabled'], default='Static',
@@ -690,6 +696,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
         self.storage_blob_name = None
         self.os_type = None
         self.os_disk_caching = None
+        self.os_disk_size_gb = None
         self.managed_disk_type = None
         self.network_interface_names = None
         self.remove_on_absent = set()
@@ -841,6 +848,13 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     changed = True
                     vm_dict['properties']['storageProfile']['osDisk']['caching'] = self.os_disk_caching
 
+                if self.os_disk_size_gb and \
+                   self.os_disk_size_gb != vm_dict['properties']['storageProfile']['osDisk']['diskSizeGB']:
+                    self.log('CHANGED: virtual machine {0} - OS disk size '.format(self.name))
+                    differences.append('OS Disk size')
+                    changed = True
+                    vm_dict['properties']['storageProfile']['osDisk']['diskSizeGB'] = self.os_disk_size_gb
+
                 update_tags, vm_dict['tags'] = self.update_tags(vm_dict.get('tags', dict()))
                 if update_tags:
                     differences.append('Tags')
@@ -976,6 +990,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                                 managed_disk=managed_disk,
                                 create_option=self.compute_models.DiskCreateOptionTypes.from_image,
                                 caching=self.os_disk_caching,
+                                disk_size_gb=self.os_disk_size_gb
                             ),
                             image_reference=image_reference,
                         ),
@@ -1106,6 +1121,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                                 create_option=vm_dict['properties']['storageProfile']['osDisk']['createOption'],
                                 os_type=vm_dict['properties']['storageProfile']['osDisk']['osType'],
                                 caching=vm_dict['properties']['storageProfile']['osDisk']['caching'],
+                                disk_size_gb=dict['properties']['storageProfile']['osDisk']['diskSizeGB']
                             ),
                             image_reference=self.compute_models.ImageReference(
                                 publisher=vm_dict['properties']['storageProfile']['imageReference']['publisher'],

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -86,6 +86,7 @@
       admin_password: Password123!
       short_hostname: testvm
       os_type: Linux
+      os_disk_size_gb: 64
       network_interfaces: testvm001
       availability_set: "avbs{{ resource_group | hash('md5') | truncate(7, True, '') }}"
       image:
@@ -190,6 +191,7 @@
       admin_password: Password123!
       short_hostname: testvm
       os_type: Linux
+      os_disk_size_gb: 64
       network_interfaces: testvm001
       image:
         offer: UbuntuServer

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -86,7 +86,6 @@
       admin_password: Password123!
       short_hostname: testvm
       os_type: Linux
-      os_disk_size_gb: 64
       network_interfaces: testvm001
       availability_set: "avbs{{ resource_group | hash('md5') | truncate(7, True, '') }}"
       image:
@@ -191,7 +190,6 @@
       admin_password: Password123!
       short_hostname: testvm
       os_type: Linux
-      os_disk_size_gb: 64
       network_interfaces: testvm001
       image:
         offer: UbuntuServer
@@ -286,6 +284,7 @@
       admin_password: Password123!
       short_hostname: testvm
       os_type: Linux
+      os_disk_size_gb: 64
       network_interfaces: "{{ niclist }}"
       availability_set: "avbs{{ resource_group | hash('md5') | truncate(7, True, '') }}"
       image:
@@ -314,6 +313,7 @@
       admin_password: Password123!
       short_hostname: testvm
       os_type: Linux
+      os_disk_size_gb: 64
       network_interfaces: "{{ niclist }}"
       availability_set: "avbs{{ resource_group | hash('md5') | truncate(7, True, '') }}"
       image:


### PR DESCRIPTION
##### SUMMARY
Adding os_disk_size_gb parameter to Virtual Machine.
This option appeared to be necessary while working on openshift playbooks.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine

##### ANSIBLE VERSION
2.6

##### ADDITIONAL INFORMATION


