### PR TITLE
Fix comparison of priority

### DIFF
--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -688,7 +688,7 @@ class ELBListenerRules(object):
         for current_rule in self.current_rules:
             current_rule_passed_to_module = False
             for new_rule in self.rules[:]:
-                if current_rule['Priority'] == new_rule['Priority']:
+                if current_rule['Priority'] == str(new_rule['Priority']):
                     current_rule_passed_to_module = True
                     # Remove what we match so that what is left can be marked as 'to be added'
                     rules_to_add.remove(new_rule)


### PR DESCRIPTION
##### SUMMARY
The existing rule priority comes from aws as a string. It is then
compared to the new rule priority, which is defined as an int. This change
casts the new rule priority as a string making the comparison work. The
reason to cast it as a string rather than an int is used because a priority
can also be set to 'default'. When trying to case 'default' as an int, it creates
an error.

Fixes #43314 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_application_lb
elbv2

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (priority_compare 3dd05f2c60) last updated 2018/07/26 20:48:24 (GMT +000)
  config file = /home/vagrant/.ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible
  python version = 2.7.15 (default, May  9 2018, 11:32:33) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
```

