### PR TITLE
Clarify usage of encrypt arg

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -246,7 +246,7 @@ def _format_content(password, salt, encrypt=None):
     .. warning:: Passwords are saved in clear.  This is because the playbooks
         expect to get cleartext passwords from this lookup.
     """
-    if encrypt is None and not salt:
+    if not encrypt and not salt:
         return password
 
     # At this point, the calling code should have assured us that there is a salt value.
@@ -286,7 +286,7 @@ class LookupModule(LookupBase):
             else:
                 plaintext_password, salt = _parse_content(content)
 
-            if params['encrypt'] is not None and not salt:
+            if params['encrypt'] and not salt:
                 changed = True
                 salt = _random_salt()
 
@@ -294,7 +294,7 @@ class LookupModule(LookupBase):
                 content = _format_content(plaintext_password, salt, encrypt=params['encrypt'])
                 _write_password_file(b_path, content)
 
-            if params['encrypt'] is not None:
+            if params['encrypt']:
                 password = do_encrypt(plaintext_password, params['encrypt'], salt=salt)
                 ret.append(password)
             else:

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -32,6 +32,7 @@ DOCUMENTATION = """
            - If not provided, the password will be returned in plain text.
            - Note that the password is always stored as plain text, only the returning password is encrypted.
            - Encrypt also forces saving the salt value for idempotence.
+           - Note that before 2.6 this option was incorrectly labeled as a boolean for a long time.
         default: None
       chars:
         version_added: "1.4"

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -28,11 +28,11 @@ DOCUMENTATION = """
          required: True
       encrypt:
         description:
-           - Whether the user requests that this password is returned encrypted or in plain text.
-           - Note that the password is always stored as plain text.
+           - Which hash scheme to encrypt the returning password, should be one hash scheme from C(passlib.hash).
+           - If not provided, the password will be returned in plain text.
+           - Note that the password is always stored as plain text, only the returning password is encrypted.
            - Encrypt also forces saving the salt value for idempotence.
-        type: boolean
-        default: True
+        default: None
       chars:
         version_added: "1.4"
         description:
@@ -234,19 +234,19 @@ def _parse_content(content):
     return password, salt
 
 
-def _format_content(password, salt, encrypt=True):
+def _format_content(password, salt, encrypt=None):
     """Format the password and salt for saving
     :arg password: the plaintext password to save
     :arg salt: the salt to use when encrypting a password
-    :arg encrypt: Whether the user requests that this password is encrypted.
+    :arg encrypt: Which method the user requests that this password is encrypted.
         Note that the password is saved in clear.  Encrypt just tells us if we
-        must save the salt value for idempotence.  Defaults to True.
+        must save the salt value for idempotence.  Defaults to None.
     :returns: a text string containing the formatted information
 
     .. warning:: Passwords are saved in clear.  This is because the playbooks
         expect to get cleartext passwords from this lookup.
     """
-    if not encrypt and not salt:
+    if encrypt is None and not salt:
         return password
 
     # At this point, the calling code should have assured us that there is a salt value.
@@ -286,7 +286,7 @@ class LookupModule(LookupBase):
             else:
                 plaintext_password, salt = _parse_content(content)
 
-            if params['encrypt'] and not salt:
+            if params['encrypt'] is not None and not salt:
                 changed = True
                 salt = _random_salt()
 
@@ -294,7 +294,7 @@ class LookupModule(LookupBase):
                 content = _format_content(plaintext_password, salt, encrypt=params['encrypt'])
                 _write_password_file(b_path, content)
 
-            if params['encrypt']:
+            if params['encrypt'] is not None:
                 password = do_encrypt(plaintext_password, params['encrypt'], salt=salt)
                 ret.append(password)
             else:

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -333,7 +333,7 @@ class TestFormatContent(unittest.TestCase):
         self.assertEqual(
             password._format_content(password=u'hunter42',
                                      salt=None,
-                                     encrypt=False),
+                                     encrypt=None),
             u'hunter42')
 
     def test_encrypt(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
According to the `do_encrypt` interface, `encrypt` arg should be the hash method name used for encrypting returning password. But in the doc and lookup code it's a boolean flag. This PR change clarifies the usage of `encrypt`.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fix #41383
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
/lib/ansible/lookup/password.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (issue_41383 b1b3ea60fa) last updated 2018/07/26 16:56:32 (GMT -400)
  config file = None
  configured module search path = [u'/home/zhikangzhang/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/zhikangzhang/Desktop/ansible/lib/ansible
  executable location = /home/zhikangzhang/Desktop/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```