### PR TITLE
Add enable_ip_forwarding option to azure_rm_networkinterface; Fixes #43276

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -190,8 +190,9 @@ options:
             - Whether to enable IP forwarding
         aliases:
             - ip_forwarding
-        version_added: 2.7
+        type: bool
         default: False
+        version_added: 2.7
 extends_documentation_fragment:
     - azure
     - azure_tags

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -532,6 +532,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                     self.log("CHANGED: Accelerated Networking set to {0} (previously {1})".format(
                         self.enable_accelerated_networking,
                         results.get('enable_accelerated_networking')))
+                    changed = True
 
                 if self.enable_ip_forwarding != bool(results.get('enable_ip_forwarding')):
                     self.log("CHANGED: IP forwarding set to {0} (previously {1})".format(

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -185,6 +185,13 @@ options:
             - When a default security group is created for a Linux host a rule will be added allowing inbound TCP
               connections to the default SSH port 22, and for a Windows host rules will be added allowing inbound
               access to RDP ports 3389 and 5986. Override the default ports by providing a list of open ports.
+    enable_ip_forwarding:
+        description:
+            - Whether to enable IP forwarding
+        aliases:
+            - ip_forwarding
+        version_added: 2.7
+        default: False
 extends_documentation_fragment:
     - azure
     - azure_tags
@@ -270,6 +277,18 @@ EXAMPLES = '''
         virtual_network_name: vnet001
         subnet_name: subnet001
         enable_accelerated_networking: True
+
+    - name: Create a network interface with IP forwarding
+      azure_rm_networkinterface:
+        name: nic001
+        resource_group: Testing
+        virtual_network: vnet001
+        subnet_name: subnet001
+        ip_forwarding: True
+        ip_configurations:
+          - name: ipconfig1
+            public_ip_address_name: publicip001
+            primary: True
 
     - name: Delete network interface
       azure_rm_networkinterface:
@@ -415,6 +434,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             ip_configurations=dict(type='list', default=None, elements='dict', options=ip_configuration_spec),
             os_type=dict(type='str', choices=['Windows', 'Linux'], default='Linux'),
             open_ports=dict(type='list'),
+            enable_ip_forwarding=dict(type='bool', aliases=['ip_forwarding'], default=False),
         )
 
         required_if = [
@@ -438,6 +458,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
         self.tags = None
         self.os_type = None
         self.open_ports = None
+        self.enable_ip_forwarding = None
         self.ip_configurations = None
 
         self.results = dict(
@@ -510,6 +531,11 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                     self.log("CHANGED: Accelerated Networking set to {0} (previously {1})".format(
                         self.enable_accelerated_networking,
                         results.get('enable_accelerated_networking')))
+
+                if self.enable_ip_forwarding != bool(results.get('enable_ip_forwarding')):
+                    self.log("CHANGED: IP forwarding set to {0} (previously {1})".format(
+                        self.enable_ip_forwarding,
+                        results.get('enable_ip_forwarding')))
                     changed = True
 
                 if not changed:
@@ -591,6 +617,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                     tags=self.tags,
                     ip_configurations=nic_ip_configurations,
                     enable_accelerated_networking=self.enable_accelerated_networking,
+                    enable_ip_forwarding=self.enable_ip_forwarding,
                     network_security_group=nsg
                 )
                 self.results['state'] = self.create_or_update_nic(nic)

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -5,17 +5,17 @@
 
 - name: Create virtual network
   azure_rm_virtualnetwork:
-    resource_group: "{{ resource_group_secondary }}"
-    name: "tn{{ rpfx }}"
-    address_prefixes: "10.10.0.0/16"
+      resource_group: "{{ resource_group_secondary }}"
+      name: "tn{{ rpfx }}"
+      address_prefixes: "10.10.0.0/16"
   register: vn
 
 - name: Add subnet
   azure_rm_subnet:
-    resource_group: "{{ resource_group_secondary }}"
-    name: "tn{{ rpfx }}"
-    address_prefix: "10.10.0.0/24"
-    virtual_network: "tn{{ rpfx }}"
+      resource_group: "{{ resource_group_secondary }}"
+      name: "tn{{ rpfx }}"
+      address_prefix: "10.10.0.0/24"
+      virtual_network: "tn{{ rpfx }}"
 
 - name: create public ip
   azure_rm_publicipaddress:
@@ -58,13 +58,13 @@
 
 - name: Create NIC (check mode)
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}"
-    virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
-    public_ip_name: "tn{{ rpfx }}"
-    public_ip_allocation_method: Static
-    security_group: "tn{{ rpfx }}"
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
+      public_ip_allocation_method: Static
+      security_group: "tn{{ rpfx }}"
   register: output
   check_mode: yes
 
@@ -74,28 +74,28 @@
 
 - name: Create NIC using virtual_network resource_group parameter
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}rg"
-    virtual_network:
-      name: "tn{{ rpfx }}"
-      resource_group: "{{ resource_group_secondary }}"
-    subnet: "tn{{ rpfx }}"
-    public_ip_name: "tn{{ rpfx }}rg"
-    public_ip_allocation_method: Static
-    security_group: "tn{{ rpfx }}"
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}rg"
+      virtual_network:
+        name: "tn{{ rpfx }}"
+        resource_group: "{{ resource_group_secondary }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}rg"
+      public_ip_allocation_method: Static
+      security_group: "tn{{ rpfx }}"
   register: output
 
 - name: Create NIC using virtual_network resource_group parameter (idempotent)
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}rg"
-    virtual_network:
-      name: "tn{{ rpfx }}"
-      resource_group: "{{ resource_group_secondary }}"
-    subnet: "tn{{ rpfx }}"
-    public_ip_name: "tn{{ rpfx }}rg"
-    public_ip_allocation_method: Static
-    security_group: "tn{{ rpfx }}"
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}rg"
+      virtual_network:
+        name: "tn{{ rpfx }}"
+        resource_group: "{{ resource_group_secondary }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}rg"
+      public_ip_allocation_method: Static
+      security_group: "tn{{ rpfx }}"
   register: output
 
 - assert:
@@ -104,21 +104,21 @@
 
 - name: Delete NIC
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}rg"
-    state: absent
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}rg"
+      state: absent
 
 - name: Create NIC
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}"
-    virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
-    public_ip_name: "tn{{ rpfx }}"
-    public_ip_allocation_method: Static
-    security_group:
-      name: "tn{{ rpfx }}2"
-      resource_group: "{{ resource_group_secondary }}"
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      public_ip_name: "tn{{ rpfx }}"
+      public_ip_allocation_method: Static
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
   register: output
 
 - assert:
@@ -128,22 +128,22 @@
 
 - name: Update the NIC with mutilple ip configurations (check mode)
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}"
-    security_group:
-      name: "tn{{ rpfx }}2"
-      resource_group: "{{ resource_group_secondary }}"
-    virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
-    ip_configurations:
-      - name: ipconfig-add
-        public_ip_name: "tn{{ rpfx }}2"
-      - name: default
-        public_ip_name: "tn{{ rpfx }}"
-        primary: True
-        public_ip_allocation_method: Static
-      - name: ipconfig1
-        public_ip_name: "tn{{ rpfx }}3"
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      ip_configurations:
+        - name: ipconfig-add
+          public_ip_name: "tn{{ rpfx }}2"
+        - name: default
+          public_ip_name: "tn{{ rpfx }}"
+          primary: True
+          public_ip_allocation_method: Static
+        - name: ipconfig1
+          public_ip_name: "tn{{ rpfx }}3"
   register: output
   check_mode: yes
 
@@ -153,26 +153,26 @@
 
 - name: Update the NIC with mutilple ip configurations
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}"
-    security_group: 
-      name: "tn{{ rpfx }}2"
-      resource_group: "{{ resource_group_secondary }}"
-    virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
-    ip_configurations:
-      - name: ipconfig-add
-        public_ip_name: "tn{{ rpfx }}2"
-      - name: default
-        public_ip_name: "tn{{ rpfx }}"
-        primary: True
-        public_ip_allocation_method: Static
-      - name: ipconfig1
-        public_ip_name: "tn{{ rpfx }}3"
-        load_balancer_backend_address_pools:
-        - "{{ lb.state.backend_address_pools[0].id }}"
-        - name: backendaddrpool1
-          load_balancer: "lb{{ rpfx }}"
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      security_group: 
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      ip_configurations:
+        - name: ipconfig-add
+          public_ip_name: "tn{{ rpfx }}2"
+        - name: default
+          public_ip_name: "tn{{ rpfx }}"
+          primary: True
+          public_ip_allocation_method: Static
+        - name: ipconfig1
+          public_ip_name: "tn{{ rpfx }}3"
+          load_balancer_backend_address_pools:
+          - "{{ lb.state.backend_address_pools[0].id }}"
+          - name: backendaddrpool1
+            load_balancer: "lb{{ rpfx }}"
   register: output
 
 - assert:
@@ -184,24 +184,24 @@
 
 - name: Update the NIC with mutilple ip configurations (idempotent)
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}"
-    security_group: "{{ output.state.network_security_group.id }}"
-    virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
-    ip_configurations:
-      - name: ipconfig-add
-        public_ip_name: "tn{{ rpfx }}2"
-      - name: default
-        public_ip_name: "tn{{ rpfx }}"
-        primary: True
-        public_ip_allocation_method: Static
-      - name: ipconfig1
-        public_ip_name: "tn{{ rpfx }}3"
-        load_balancer_backend_address_pools:
-        - "{{ lb.state.backend_address_pools[0].id }}"
-        - name: backendaddrpool1
-          load_balancer: "lb{{ rpfx }}"
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      security_group: "{{ output.state.network_security_group.id }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      ip_configurations:
+        - name: ipconfig-add
+          public_ip_name: "tn{{ rpfx }}2"
+        - name: default
+          public_ip_name: "tn{{ rpfx }}"
+          primary: True
+          public_ip_allocation_method: Static
+        - name: ipconfig1
+          public_ip_name: "tn{{ rpfx }}3"
+          load_balancer_backend_address_pools:
+          - "{{ lb.state.backend_address_pools[0].id }}"
+          - name: backendaddrpool1
+            load_balancer: "lb{{ rpfx }}"
   register: output
 
 - assert:
@@ -210,24 +210,24 @@
 
 - name: Remove one ip configuration
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}"
-    security_group:
-      name: "tn{{ rpfx }}2"
-      resource_group: "{{ resource_group_secondary }}"
-    virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
-    ip_configurations:
-      - name: ipconfig1
-        public_ip_name: "tn{{ rpfx }}3"
-        load_balancer_backend_address_pools:
-        - "{{ lb.state.backend_address_pools[0].id }}"
-        - name: backendaddrpool1
-          load_balancer: "lb{{ rpfx }}"
-      - name: default
-        public_ip_name: "tn{{ rpfx }}"
-        public_ip_allocation_method: Static
-        primary: True
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      security_group:
+        name: "tn{{ rpfx }}2"
+        resource_group: "{{ resource_group_secondary }}"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      ip_configurations:
+        - name: ipconfig1
+          public_ip_name: "tn{{ rpfx }}3"
+          load_balancer_backend_address_pools:
+          - "{{ lb.state.backend_address_pools[0].id }}"
+          - name: backendaddrpool1
+            load_balancer: "lb{{ rpfx }}"
+        - name: default
+          public_ip_name: "tn{{ rpfx }}"
+          public_ip_allocation_method: Static
+          primary: True
   register: output
 
 - assert:
@@ -237,14 +237,14 @@
 
 - name: IP configuration without public IP and NSG
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}noip"
-    create_with_security_group: False
-    virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
-    ip_configurations:
-      - name: ipconfig1
-        primary: True
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}noip"
+      create_with_security_group: False
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      ip_configurations:
+        - name: ipconfig1
+          primary: True
   register: output
 
 - assert:
@@ -254,11 +254,11 @@
 
 - name: NIC with Accelerated networking enabled
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}an"
-    virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
-    enable_accelerated_networking: True
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}an"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      enable_accelerated_networking: True
   register: output
 
 - assert:
@@ -268,11 +268,11 @@
 
 - name: NIC with Accelerated networking enabled (check idempotent)
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}an"
-    virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
-    enable_accelerated_networking: True
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}an"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      enable_accelerated_networking: True
   register: output
 
 - assert:
@@ -281,12 +281,12 @@
       - not output.changed
 
 - name: Disable (previously enabled) Accelerated networking
-  azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}an"
-    virtual_network: "{{ vn.state.id }}"
-    subnet: "tn{{ rpfx }}"
-    enable_accelerated_networking: False
+    azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}an"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      enable_accelerated_networking: False
   register: output
 
 - assert:
@@ -296,9 +296,9 @@
 
 - name: Delete AN NIC
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}an"
-    state: absent
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}an"
+      state: absent
   register: output
 
 - assert:
@@ -360,9 +360,9 @@
 
 - name: Delete the NIC (check mode)
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}"
-    state: absent
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      state: absent
   check_mode: yes
   register: output
 
@@ -372,9 +372,9 @@
 
 - name: Delete the NIC
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "{{ item }}"
-    state: absent
+      resource_group: "{{ resource_group }}"
+      name: "{{ item }}"
+      state: absent
   with_items:
     - "tn{{ rpfx }}"
     - "tn{{ rpfx }}noip"
@@ -386,9 +386,9 @@
 
 - name: Delete the NIC (idempotent)
   azure_rm_networkinterface:
-    resource_group: "{{ resource_group }}"
-    name: "tn{{ rpfx }}"
-    state: absent
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}"
+      state: absent
   register: output
 
 - assert:

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -281,7 +281,7 @@
       - not output.changed
 
 - name: Disable (previously enabled) Accelerated networking
-    azure_rm_networkinterface:
+  azure_rm_networkinterface:
       resource_group: "{{ resource_group }}"
       name: "tn{{ rpfx }}an"
       virtual_network: "{{ vn.state.id }}"

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -1,29 +1,34 @@
 - name: Prepare random number
   set_fact:
     rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+    auth_source: auto
   run_once: yes
 
 - name: Create virtual network
   azure_rm_virtualnetwork:
-      resource_group: "{{ resource_group_secondary }}"
-      name: "tn{{ rpfx }}"
-      address_prefixes: "10.10.0.0/16"
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group_secondary }}"
+    name: "tn{{ rpfx }}"
+    address_prefixes: "10.10.0.0/16"
   register: vn
 
 - name: Add subnet
   azure_rm_subnet:
-      resource_group: "{{ resource_group_secondary }}"
-      name: "tn{{ rpfx }}"
-      address_prefix: "10.10.0.0/24"
-      virtual_network: "tn{{ rpfx }}"
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group_secondary }}"
+    name: "tn{{ rpfx }}"
+    address_prefix: "10.10.0.0/24"
+    virtual_network: "tn{{ rpfx }}"
 
 - name: create public ip
   azure_rm_publicipaddress:
+    auth_source: "{{ auth_source }}"
     name: "pip{{ rpfx }}"
     resource_group: '{{ resource_group }}'
 
 - name: create load balancer with multiple parameters
   azure_rm_loadbalancer:
+    auth_source: "{{ auth_source }}"
     resource_group: '{{ resource_group }}'
     name: "lb{{ rpfx }}"
     frontend_ip_configurations:
@@ -53,18 +58,20 @@
 
 - name: create public ip
   azure_rm_publicipaddress:
+    auth_source: "{{ auth_source }}"
     name: "pip{{ rpfx }}"
     resource_group: '{{ resource_group }}'
 
 - name: Create NIC (check mode)
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}"
-      virtual_network: "{{ vn.state.id }}"
-      subnet: "tn{{ rpfx }}"
-      public_ip_name: "tn{{ rpfx }}"
-      public_ip_allocation_method: Static
-      security_group: "tn{{ rpfx }}"
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    public_ip_name: "tn{{ rpfx }}"
+    public_ip_allocation_method: Static
+    security_group: "tn{{ rpfx }}"
   register: output
   check_mode: yes
 
@@ -74,28 +81,30 @@
 
 - name: Create NIC using virtual_network resource_group parameter
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}rg"
-      virtual_network:
-        name: "tn{{ rpfx }}"
-        resource_group: "{{ resource_group_secondary }}"
-      subnet: "tn{{ rpfx }}"
-      public_ip_name: "tn{{ rpfx }}rg"
-      public_ip_allocation_method: Static
-      security_group: "tn{{ rpfx }}"
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}rg"
+    virtual_network:
+      name: "tn{{ rpfx }}"
+      resource_group: "{{ resource_group_secondary }}"
+    subnet: "tn{{ rpfx }}"
+    public_ip_name: "tn{{ rpfx }}rg"
+    public_ip_allocation_method: Static
+    security_group: "tn{{ rpfx }}"
   register: output
 
 - name: Create NIC using virtual_network resource_group parameter (idempotent)
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}rg"
-      virtual_network:
-        name: "tn{{ rpfx }}"
-        resource_group: "{{ resource_group_secondary }}"
-      subnet: "tn{{ rpfx }}"
-      public_ip_name: "tn{{ rpfx }}rg"
-      public_ip_allocation_method: Static
-      security_group: "tn{{ rpfx }}"
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}rg"
+    virtual_network:
+      name: "tn{{ rpfx }}"
+      resource_group: "{{ resource_group_secondary }}"
+    subnet: "tn{{ rpfx }}"
+    public_ip_name: "tn{{ rpfx }}rg"
+    public_ip_allocation_method: Static
+    security_group: "tn{{ rpfx }}"
   register: output
 
 - assert:
@@ -104,21 +113,23 @@
 
 - name: Delete NIC
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}rg"
-      state: absent
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}rg"
+    state: absent
 
 - name: Create NIC
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}"
-      virtual_network: "{{ vn.state.id }}"
-      subnet: "tn{{ rpfx }}"
-      public_ip_name: "tn{{ rpfx }}"
-      public_ip_allocation_method: Static
-      security_group:
-        name: "tn{{ rpfx }}2"
-        resource_group: "{{ resource_group_secondary }}"
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    public_ip_name: "tn{{ rpfx }}"
+    public_ip_allocation_method: Static
+    security_group:
+      name: "tn{{ rpfx }}2"
+      resource_group: "{{ resource_group_secondary }}"
   register: output
 
 - assert:
@@ -128,22 +139,23 @@
 
 - name: Update the NIC with mutilple ip configurations (check mode)
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}"
-      security_group:
-        name: "tn{{ rpfx }}2"
-        resource_group: "{{ resource_group_secondary }}"
-      virtual_network: "{{ vn.state.id }}"
-      subnet: "tn{{ rpfx }}"
-      ip_configurations:
-        - name: ipconfig-add
-          public_ip_name: "tn{{ rpfx }}2"
-        - name: default
-          public_ip_name: "tn{{ rpfx }}"
-          primary: True
-          public_ip_allocation_method: Static
-        - name: ipconfig1
-          public_ip_name: testnic003
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}"
+    security_group:
+      name: "tn{{ rpfx }}2"
+      resource_group: "{{ resource_group_secondary }}"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    ip_configurations:
+      - name: ipconfig-add
+        public_ip_name: "tn{{ rpfx }}2"
+      - name: default
+        public_ip_name: "tn{{ rpfx }}"
+        primary: True
+        public_ip_allocation_method: Static
+      - name: ipconfig1
+        public_ip_name: testnic003
   register: output
   check_mode: yes
 
@@ -153,26 +165,27 @@
 
 - name: Update the NIC with mutilple ip configurations
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}"
-      security_group: 
-        name: "tn{{ rpfx }}2"
-        resource_group: "{{ resource_group_secondary }}"
-      virtual_network: "{{ vn.state.id }}"
-      subnet: "tn{{ rpfx }}"
-      ip_configurations:
-        - name: ipconfig-add
-          public_ip_name: "tn{{ rpfx }}2"
-        - name: default
-          public_ip_name: "tn{{ rpfx }}"
-          primary: True
-          public_ip_allocation_method: Static
-        - name: ipconfig1
-          public_ip_name: testnic003
-          load_balancer_backend_address_pools:
-          - "{{ lb.state.backend_address_pools[0].id }}"
-          - name: backendaddrpool1
-            load_balancer: "lb{{ rpfx }}"
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}"
+    security_group: 
+      name: "tn{{ rpfx }}2"
+      resource_group: "{{ resource_group_secondary }}"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    ip_configurations:
+      - name: ipconfig-add
+        public_ip_name: "tn{{ rpfx }}2"
+      - name: default
+        public_ip_name: "tn{{ rpfx }}"
+        primary: True
+        public_ip_allocation_method: Static
+      - name: ipconfig1
+        public_ip_name: testnic003
+        load_balancer_backend_address_pools:
+        - "{{ lb.state.backend_address_pools[0].id }}"
+        - name: backendaddrpool1
+          load_balancer: "lb{{ rpfx }}"
   register: output
 
 - assert:
@@ -184,24 +197,25 @@
 
 - name: Update the NIC with mutilple ip configurations (idempotent)
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}"
-      security_group: "{{ output.state.network_security_group.id }}"
-      virtual_network: "{{ vn.state.id }}"
-      subnet: "tn{{ rpfx }}"
-      ip_configurations:
-        - name: ipconfig-add
-          public_ip_name: "tn{{ rpfx }}2"
-        - name: default
-          public_ip_name: "tn{{ rpfx }}"
-          primary: True
-          public_ip_allocation_method: Static
-        - name: ipconfig1
-          public_ip_name: testnic003
-          load_balancer_backend_address_pools:
-          - "{{ lb.state.backend_address_pools[0].id }}"
-          - name: backendaddrpool1
-            load_balancer: "lb{{ rpfx }}"
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}"
+    security_group: "{{ output.state.network_security_group.id }}"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    ip_configurations:
+      - name: ipconfig-add
+        public_ip_name: "tn{{ rpfx }}2"
+      - name: default
+        public_ip_name: "tn{{ rpfx }}"
+        primary: True
+        public_ip_allocation_method: Static
+      - name: ipconfig1
+        public_ip_name: testnic003
+        load_balancer_backend_address_pools:
+        - "{{ lb.state.backend_address_pools[0].id }}"
+        - name: backendaddrpool1
+          load_balancer: "lb{{ rpfx }}"
   register: output
 
 - assert:
@@ -210,24 +224,25 @@
 
 - name: Remove one ip configuration
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}"
-      security_group:
-        name: "tn{{ rpfx }}2"
-        resource_group: "{{ resource_group_secondary }}"
-      virtual_network: "{{ vn.state.id }}"
-      subnet: "tn{{ rpfx }}"
-      ip_configurations:
-        - name: ipconfig1
-          public_ip_name: testnic003
-          load_balancer_backend_address_pools:
-          - "{{ lb.state.backend_address_pools[0].id }}"
-          - name: backendaddrpool1
-            load_balancer: "lb{{ rpfx }}"
-        - name: default
-          public_ip_name: "tn{{ rpfx }}"
-          public_ip_allocation_method: Static
-          primary: True
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}"
+    security_group:
+      name: "tn{{ rpfx }}2"
+      resource_group: "{{ resource_group_secondary }}"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    ip_configurations:
+      - name: ipconfig1
+        public_ip_name: testnic003
+        load_balancer_backend_address_pools:
+        - "{{ lb.state.backend_address_pools[0].id }}"
+        - name: backendaddrpool1
+          load_balancer: "lb{{ rpfx }}"
+      - name: default
+        public_ip_name: "tn{{ rpfx }}"
+        public_ip_allocation_method: Static
+        primary: True
   register: output
 
 - assert:
@@ -237,14 +252,15 @@
 
 - name: IP configuration without public IP and NSG
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}noip"
-      create_with_security_group: False
-      virtual_network: "{{ vn.state.id }}"
-      subnet: "tn{{ rpfx }}"
-      ip_configurations:
-        - name: ipconfig1
-          primary: True
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}noip"
+    create_with_security_group: False
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    ip_configurations:
+      - name: ipconfig1
+        primary: True
   register: output
 
 - assert:
@@ -254,11 +270,12 @@
 
 - name: NIC with Accelerated networking enabled
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}an"
-      virtual_network: "{{ vn.state.id }}"
-      subnet: "tn{{ rpfx }}"
-      enable_accelerated_networking: True
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}an"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    enable_accelerated_networking: True
   register: output
 
 - assert:
@@ -268,11 +285,12 @@
 
 - name: NIC with Accelerated networking enabled (check idempotent)
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}an"
-      virtual_network: "{{ vn.state.id }}"
-      subnet: "tn{{ rpfx }}"
-      enable_accelerated_networking: True
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}an"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    enable_accelerated_networking: True
   register: output
 
 - assert:
@@ -282,28 +300,94 @@
 
 - name: Disable (previously enabled) Accelerated networking
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}an"
-      virtual_network: "{{ vn.state.id }}"
-      subnet: "tn{{ rpfx }}"
-      enable_accelerated_networking: False
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}an"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    enable_accelerated_networking: False
   register: output
 
 - assert:
     that:
       - not output.state.enable_accelerated_networking
+      - output.changed
 
 - name: Delete AN NIC
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}an"
-      state: absent
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}an"
+    state: absent
+  register: output
+
+- assert:
+    that:
+      - output.changed
+
+- name: NIC with IP forwarding networking enabled
+  azure_rm_networkinterface:
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}ipf"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    enable_ip_forwarding: True
+  register: output
+
+- assert:
+    that:
+      - output.state.enable_ip_forwarding
+      - output.changed
+
+- name: NIC with IP forwarding enabled (check idempotent)
+  azure_rm_networkinterface:
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}ipf"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    enable_ip_forwarding: True
+  register: output
+
+- assert:
+    that:
+      - output.state.enable_ip_forwarding
+      - not output.changed
+
+- name: Disable (previously enabled) IP forwarding
+  azure_rm_networkinterface:
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}ipf"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    enable_ip_forwarding: False
+  register: output
+
+- assert:
+    that:
+      - not output.state.enable_ip_forwarding
+      - output.changed
+
+- name: Delete IP forwarding NIC
+  azure_rm_networkinterface:
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}ipf"
+    state: absent
+  register: output
+
+- assert:
+    that:
+      - output.changed
 
 - name: Delete the NIC (check mode)
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}"
-      state: absent
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}"
+    state: absent
   check_mode: yes
   register: output
 
@@ -313,9 +397,10 @@
 
 - name: Delete the NIC
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "{{ item }}"
-      state: absent
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "{{ item }}"
+    state: absent
   with_items:
     - "tn{{ rpfx }}"
     - "tn{{ rpfx }}noip"
@@ -327,9 +412,10 @@
 
 - name: Delete the NIC (idempotent)
   azure_rm_networkinterface:
-      resource_group: "{{ resource_group }}"
-      name: "tn{{ rpfx }}"
-      state: absent
+    auth_source: "{{ auth_source }}"
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}"
+    state: absent
   register: output
 
 - assert:
@@ -338,6 +424,7 @@
 
 - name: delete load balancer
   azure_rm_loadbalancer:
+    auth_source: "{{ auth_source }}"
     resource_group: '{{ resource_group }}'
     name: "lb{{ rpfx }}"
     frontend_ip_configurations:
@@ -367,6 +454,7 @@
 
 - name: delete public ip
   azure_rm_publicipaddress:
+    auth_source: "{{ auth_source }}"
     name: "pip{{ rpfx }}"
     resource_group: '{{ resource_group }}'
     state: absent

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Prepare random number
   set_fact:
     rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
-    auth_source: auto
+    auth_source: cli
   run_once: yes
 
 - name: Create virtual network
@@ -155,7 +155,7 @@
         primary: True
         public_ip_allocation_method: Static
       - name: ipconfig1
-        public_ip_name: testnic003
+        public_ip_name: "tn{{ rpfx }}3"
   register: output
   check_mode: yes
 
@@ -181,7 +181,7 @@
         primary: True
         public_ip_allocation_method: Static
       - name: ipconfig1
-        public_ip_name: testnic003
+        public_ip_name: "tn{{ rpfx }}3"
         load_balancer_backend_address_pools:
         - "{{ lb.state.backend_address_pools[0].id }}"
         - name: backendaddrpool1
@@ -211,7 +211,7 @@
         primary: True
         public_ip_allocation_method: Static
       - name: ipconfig1
-        public_ip_name: testnic003
+        public_ip_name: "tn{{ rpfx }}3"
         load_balancer_backend_address_pools:
         - "{{ lb.state.backend_address_pools[0].id }}"
         - name: backendaddrpool1
@@ -234,7 +234,7 @@
     subnet: "tn{{ rpfx }}"
     ip_configurations:
       - name: ipconfig1
-        public_ip_name: testnic003
+        public_ip_name: "tn{{ rpfx }}3"
         load_balancer_backend_address_pools:
         - "{{ lb.state.backend_address_pools[0].id }}"
         - name: backendaddrpool1

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -1,12 +1,11 @@
 - name: Prepare random number
   set_fact:
     rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
-    auth_source: auto
   run_once: yes
 
 - name: Create virtual network
   azure_rm_virtualnetwork:
-    auth_source: "{{ auth_source }}"
+    auth_source: "cli"
     resource_group: "{{ resource_group_secondary }}"
     name: "tn{{ rpfx }}"
     address_prefixes: "10.10.0.0/16"
@@ -14,7 +13,6 @@
 
 - name: Add subnet
   azure_rm_subnet:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group_secondary }}"
     name: "tn{{ rpfx }}"
     address_prefix: "10.10.0.0/24"
@@ -22,13 +20,11 @@
 
 - name: create public ip
   azure_rm_publicipaddress:
-    auth_source: "{{ auth_source }}"
     name: "pip{{ rpfx }}"
     resource_group: '{{ resource_group }}'
 
 - name: create load balancer with multiple parameters
   azure_rm_loadbalancer:
-    auth_source: "{{ auth_source }}"
     resource_group: '{{ resource_group }}'
     name: "lb{{ rpfx }}"
     frontend_ip_configurations:
@@ -58,13 +54,11 @@
 
 - name: create public ip
   azure_rm_publicipaddress:
-    auth_source: "{{ auth_source }}"
     name: "pip{{ rpfx }}"
     resource_group: '{{ resource_group }}'
 
 - name: Create NIC (check mode)
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     virtual_network: "{{ vn.state.id }}"
@@ -81,7 +75,6 @@
 
 - name: Create NIC using virtual_network resource_group parameter
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}rg"
     virtual_network:
@@ -95,7 +88,6 @@
 
 - name: Create NIC using virtual_network resource_group parameter (idempotent)
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}rg"
     virtual_network:
@@ -113,14 +105,12 @@
 
 - name: Delete NIC
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}rg"
     state: absent
 
 - name: Create NIC
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     virtual_network: "{{ vn.state.id }}"
@@ -139,7 +129,6 @@
 
 - name: Update the NIC with mutilple ip configurations (check mode)
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     security_group:
@@ -165,7 +154,6 @@
 
 - name: Update the NIC with mutilple ip configurations
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     security_group: 
@@ -197,7 +185,6 @@
 
 - name: Update the NIC with mutilple ip configurations (idempotent)
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     security_group: "{{ output.state.network_security_group.id }}"
@@ -224,7 +211,6 @@
 
 - name: Remove one ip configuration
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     security_group:
@@ -252,7 +238,6 @@
 
 - name: IP configuration without public IP and NSG
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}noip"
     create_with_security_group: False
@@ -270,7 +255,6 @@
 
 - name: NIC with Accelerated networking enabled
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}an"
     virtual_network: "{{ vn.state.id }}"
@@ -285,7 +269,6 @@
 
 - name: NIC with Accelerated networking enabled (check idempotent)
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}an"
     virtual_network: "{{ vn.state.id }}"
@@ -300,7 +283,6 @@
 
 - name: Disable (previously enabled) Accelerated networking
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}an"
     virtual_network: "{{ vn.state.id }}"
@@ -315,7 +297,6 @@
 
 - name: Delete AN NIC
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}an"
     state: absent
@@ -327,7 +308,6 @@
 
 - name: NIC with IP forwarding networking enabled
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}ipf"
     virtual_network: "{{ vn.state.id }}"
@@ -342,7 +322,6 @@
 
 - name: NIC with IP forwarding enabled (check idempotent)
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}ipf"
     virtual_network: "{{ vn.state.id }}"
@@ -357,7 +336,6 @@
 
 - name: Disable (previously enabled) IP forwarding
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}ipf"
     virtual_network: "{{ vn.state.id }}"
@@ -372,7 +350,6 @@
 
 - name: Delete IP forwarding NIC
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}ipf"
     state: absent
@@ -384,7 +361,6 @@
 
 - name: Delete the NIC (check mode)
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     state: absent
@@ -397,7 +373,6 @@
 
 - name: Delete the NIC
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "{{ item }}"
     state: absent
@@ -412,7 +387,6 @@
 
 - name: Delete the NIC (idempotent)
   azure_rm_networkinterface:
-    auth_source: "{{ auth_source }}"
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}"
     state: absent
@@ -424,7 +398,6 @@
 
 - name: delete load balancer
   azure_rm_loadbalancer:
-    auth_source: "{{ auth_source }}"
     resource_group: '{{ resource_group }}'
     name: "lb{{ rpfx }}"
     frontend_ip_configurations:
@@ -454,7 +427,6 @@
 
 - name: delete public ip
   azure_rm_publicipaddress:
-    auth_source: "{{ auth_source }}"
     name: "pip{{ rpfx }}"
     resource_group: '{{ resource_group }}'
     state: absent

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -5,7 +5,6 @@
 
 - name: Create virtual network
   azure_rm_virtualnetwork:
-    auth_source: "cli"
     resource_group: "{{ resource_group_secondary }}"
     name: "tn{{ rpfx }}"
     address_prefixes: "10.10.0.0/16"

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Prepare random number
   set_fact:
     rpfx: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
-    auth_source: cli
+    auth_source: auto
   run_once: yes
 
 - name: Create virtual network


### PR DESCRIPTION
##### SUMMARY
Add `enable_ip_forwarding` to `azure_rm_networkinterface`

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
azure_rm_networkinterface

##### ANSIBLE VERSION
```
2.7
```


##### ADDITIONAL INFORMATION
Fixes #43276 
