### PR TITLE
Correcting conditionals looping (#43331)

### DIFF
--- a/changelogs/fragments/vyos_command_retry.yml
+++ b/changelogs/fragments/vyos_command_retry.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vyos_command correcting conditionals looping (https://github.com/ansible/ansible/pull/43331).

--- a/lib/ansible/modules/network/vyos/vyos_command.py
+++ b/lib/ansible/modules/network/vyos/vyos_command.py
@@ -212,10 +212,10 @@ def main():
                     break
                 conditionals.remove(item)
 
-            if not conditionals:
-                break
+        if not conditionals:
+            break
 
-            time.sleep(interval)
+        time.sleep(interval)
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Empty conditionals would not break out of the loop, causing every command to be run for the same number of times as retries is defined (10 by default)

(cherry picked from commit e215f842bab59b15bfbe64dd5409cc1d4a27dbd5)
Merged to devel https://github.com/ansible/ansible/pull/43331
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
vyos_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
