### PR TITLE
Fix one_vm.py DISK_SIZE type

### DIFF
--- a/lib/ansible/modules/cloud/opennebula/one_vm.py
+++ b/lib/ansible/modules/cloud/opennebula/one_vm.py
@@ -815,7 +815,7 @@ def create_disk_str(module, client, template_id, disk_size_str):
         disk[child.tag] = child.text
 
     result = 'DISK = [' + ','.join('{key}="{val}"'.format(key=key, val=val) for key, val in disk.items() if key != 'SIZE')
-    result += ', SIZE=' + str(get_size_in_MB(module, disk_size_str)) + ']\n'
+    result += ', SIZE=' + str(int(get_size_in_MB(module, disk_size_str))) + ']\n'
 
     return result
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
OpenNebula 5.5.8  expects int in DISK_SIZE field when you create a vm, not a float.
For example, "42 GB" should be sent to OpenNebula API as "43088", not as "43088.0". MEMORY you cast to int explicitly, but DISK_SIZE not.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
OpenNebula
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```