### PR TITLE
Provide Kubernetes resource validation to k8s module

### DIFF
--- a/changelogs/fragments/k8s_validate.yml
+++ b/changelogs/fragments/k8s_validate.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - k8s - add validate parameter to k8s module to allow resources to be validated against their specification

--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import, division, print_function
 
 import copy
 from datetime import datetime
+from distutils.version import LooseVersion
 import time
 import sys
 
@@ -80,8 +81,8 @@ class KubernetesRawModule(KubernetesAnsibleModule):
         self.namespace = self.params.get('namespace')
         resource_definition = self.params.get('resource_definition')
         if self.params['validate']:
-            if LooseVersion(self.openshift_version) < LooseVersion("0.7.2"):
-                self.fail_json(msg="openshift >= 0.7.2 is required for validate")
+            if LooseVersion(self.openshift_version) < LooseVersion("0.8.0"):
+                self.fail_json(msg="openshift >= 0.8.0 is required for validate")
         if self.params['merge_type']:
             if LooseVersion(self.openshift_version) < LooseVersion("0.6.2"):
                 self.fail_json(msg="openshift >= 0.6.2 is required for merge_type")
@@ -278,13 +279,9 @@ class KubernetesRawModule(KubernetesAnsibleModule):
             if self.check_mode:
                 k8s_obj = dict_merge(existing.to_dict(), definition)
             else:
-                from distutils.version import LooseVersion
                 if LooseVersion(self.openshift_version) < LooseVersion("0.6.2"):
-                    if self.params['merge_type']:
-                        self.fail_json(msg="openshift >= 0.6.2 is required for merge_type")
-                    else:
-                        k8s_obj, error = self.patch_resource(resource, definition, existing, name,
-                                                             namespace)
+                    k8s_obj, error = self.patch_resource(resource, definition, existing, name,
+                                                         namespace)
                 else:
                     for merge_type in self.params['merge_type'] or ['strategic-merge', 'merge']:
                         k8s_obj, error = self.patch_resource(resource, definition, existing, name,

--- a/lib/ansible/modules/clustering/k8s/k8s.py
+++ b/lib/ansible/modules/clustering/k8s/k8s.py
@@ -73,6 +73,22 @@ options:
     - How long in seconds to wait for the resource to end up in the desired state. Ignored if C(wait) is not set.
     default: 120
     version_added: "2.8"
+  validate:
+    description:
+      - how (if at all) to validate the resource definition against the kubernetes schema.
+        Requires the kubernetes-validate python module
+    suboptions:
+      fail_on_error:
+        description: whether to fail on validation errors.
+        required: yes
+        type: bool
+      version:
+        description: version of Kubernetes to validate against. defaults to Kubernetes server version
+      strict:
+        description: whether to fail when passing unexpected properties
+        default: no
+        type: bool
+    version_added: "2.8"
 
 requirements:
   - "python >= 2.7"
@@ -141,6 +157,21 @@ EXAMPLES = '''
   k8s:
     state: present
     definition: "{{ lookup('template', '/testing/deployment.yml') }}"
+
+- name: fail on validation errors
+  k8s:
+    state: present
+    definition: "{{ lookup('template', '/testing/deployment.yml') }}"
+    validate:
+      fail_on_error: yes
+
+- name: warn on validation errors, check for unexpected properties
+  k8s:
+    state: present
+    definition: "{{ lookup('template', '/testing/deployment.yml') }}"
+    validate:
+      fail_on_error: no
+      strict: yes
 '''
 
 RETURN = '''

--- a/test/integration/targets/k8s/playbooks/older_openshift_fail.yml
+++ b/test/integration/targets/k8s/playbooks/older_openshift_fail.yml
@@ -1,0 +1,61 @@
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  vars:
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
+    recreate_crd_default_merge_expectation: recreate_crd is failed
+    playbook_namespace: ansible-test-k8s-older-openshift
+
+  tasks:
+    - python_requirements_facts:
+        dependencies:
+          - openshift==0.6.0
+          - kubernetes==6.0.0
+
+    # append_hash
+    - name: use append_hash with ConfigMap
+      k8s:
+        definition:
+          metadata:
+            name: config-map-test
+            namespace: "{{ playbook_namespace }}"
+          apiVersion: v1
+          kind: ConfigMap
+          data:
+            hello: world
+        append_hash: yes
+      ignore_errors: yes
+      register: k8s_append_hash
+
+    - name: assert that append_hash fails gracefully
+      assert:
+        that:
+          - k8s_append_hash is failed
+          - "k8s_append_hash.msg == 'openshift >= 0.7.FIXME is required for append_hash'"
+
+    # merge_type
+    - include_role:
+        name: k8s
+        tasks_from: crd
+
+    # validate
+    - name: attempt to use validate with older openshift
+      k8s:
+        definition:
+          metadata:
+            name: config-map-test
+            namespace: "{{ playbook_namespace }}"
+          apiVersion: v1
+          kind: ConfigMap
+          data:
+            hello: world
+        validate:
+          fail_on_error: yes
+      ignore_errors: yes
+      register: k8s_validate
+
+    - name: assert that validate fails gracefully
+      assert:
+        that:
+          - k8s_validate is failed
+          - "k8s_validate.msg == 'openshift >= 0.7.FIXME is required for validate'"

--- a/test/integration/targets/k8s/playbooks/roles/k8s/files/kuard-extra-property.yml
+++ b/test/integration/targets/k8s/playbooks/roles/k8s/files/kuard-extra-property.yml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: kuard
+  name: kuard
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: kuard
+    unwanted: value
+  template:
+    metadata:
+      labels:
+        app: kuard
+    spec:
+      containers:
+      - image: gcr.io/kuar-demo/kuard-amd64:1
+        name: kuard

--- a/test/integration/targets/k8s/playbooks/roles/k8s/files/kuard-invalid-type.yml
+++ b/test/integration/targets/k8s/playbooks/roles/k8s/files/kuard-invalid-type.yml
@@ -1,0 +1,20 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: kuard
+  name: kuard
+  namespace: default
+spec:
+  replicas: hello
+  selector:
+    matchLabels:
+      app: kuard
+  template:
+    metadata:
+      labels:
+        app: kuard
+    spec:
+      containers:
+      - image: gcr.io/kuar-demo/kuard-amd64:1
+        name: kuard

--- a/test/integration/targets/k8s/playbooks/roles/k8s/tasks/validate_installed.yml
+++ b/test/integration/targets/k8s/playbooks/roles/k8s/tasks/validate_installed.yml
@@ -1,0 +1,102 @@
+- block:
+    - name: Create a namespace
+      k8s:
+        name: "{{ playbook_namespace }}"
+        kind: namespace
+
+    - name: incredibly simple ConfigMap
+      k8s:
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: hello
+            namespace: "{{ playbook_namespace }}"
+        validate:
+          fail_on_error: yes
+      register: k8s_with_validate
+
+    - name: assert that k8s_with_validate succeeds
+      assert:
+        that:
+          - k8s_with_validate is successful
+
+    - name: extra property does not fail without strict
+      k8s:
+        src: "{{ role_path }}/files/kuard-extra-property.yml"
+        namespace: "{{ playbook_namespace }}"
+        validate:
+          fail_on_error: yes
+          strict: no
+
+    - name: extra property fails with strict
+      k8s:
+        src: "{{ role_path }}/files/kuard-extra-property.yml"
+        namespace: "{{ playbook_namespace }}"
+        validate:
+          fail_on_error: yes
+          strict: yes
+      ignore_errors: yes
+      register: extra_property
+
+    - name: check that extra property fails with strict
+      assert:
+        that:
+          - extra_property is failed
+
+    - name: invalid type fails
+      k8s:
+        src: "{{ role_path }}/files/kuard-invalid-type.yml"
+        namespace: "{{ playbook_namespace }}"
+        validate:
+          fail_on_error: yes
+          strict: no
+      ignore_errors: yes
+      register: invalid_type
+
+    - name: check that invalid type fails
+      assert:
+        that:
+          - invalid_type is failed
+
+    - name: setup custom resource definition
+      k8s:
+        src: "{{ role_path }}/files/setup-crd.yml"
+
+    - name: add custom resource definition
+      k8s:
+        src: "{{ role_path }}/files/crd-resource.yml"
+        namespace: "{{ playbook_namespace }}"
+        validate:
+          fail_on_error: yes
+          strict: yes
+      register: unknown_kind
+
+    - name: check that unknown kind warns
+      assert:
+        that:
+          - unknown_kind is successful
+          - "'warnings' in unknown_kind"
+
+  always:
+    - name: remove custom resource
+      k8s:
+        definition: "{{ lookup('file', role_path + '/files/crd-resource.yml') }}"
+        namespace: "{{ playbook_namespace }}"
+        state: absent
+      ignore_errors: yes
+
+    - name: remove custom resource definitions
+      k8s:
+        definition: "{{ lookup('file', role_path + '/files/setup-crd.yml') }}"
+        state: absent
+
+    - name: Delete namespace
+      k8s:
+        state: absent
+        definition:
+          - kind: Namespace
+            apiVersion: v1
+            metadata:
+              name: "{{ playbook_namespace }}"
+      ignore_errors: yes

--- a/test/integration/targets/k8s/playbooks/roles/k8s/tasks/validate_installed.yml
+++ b/test/integration/targets/k8s/playbooks/roles/k8s/tasks/validate_installed.yml
@@ -44,7 +44,7 @@
         that:
           - extra_property is failed
 
-    - name: invalid type fails
+    - name: invalid type fails at validation stage
       k8s:
         src: "{{ role_path }}/files/kuard-invalid-type.yml"
         namespace: "{{ playbook_namespace }}"
@@ -58,6 +58,21 @@
       assert:
         that:
           - invalid_type is failed
+
+    - name: invalid type fails with warnings when fail_on_error is False
+      k8s:
+        src: "{{ role_path }}/files/kuard-invalid-type.yml"
+        namespace: "{{ playbook_namespace }}"
+        validate:
+          fail_on_error: no
+          strict: no
+      ignore_errors: yes
+      register: invalid_type_no_fail
+
+    - name: check that invalid type fails
+      assert:
+        that:
+          - invalid_type_no_fail is failed
 
     - name: setup custom resource definition
       k8s:

--- a/test/integration/targets/k8s/playbooks/validate_installed.yml
+++ b/test/integration/targets/k8s/playbooks/validate_installed.yml
@@ -1,0 +1,9 @@
+- hosts: localhost
+  connection: local
+  vars:
+    playbook_namespace: ansible-test-k8s-validate
+
+  tasks:
+  - include_role:
+      name: k8s
+      tasks_from: validate_installed

--- a/test/integration/targets/k8s/playbooks/validate_not_installed.yml
+++ b/test/integration/targets/k8s/playbooks/validate_not_installed.yml
@@ -1,0 +1,21 @@
+- hosts: localhost
+  connection: local
+
+  tasks:
+  - k8s:
+      definition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: hello
+          namespace: default
+      validate:
+        fail_on_error: yes
+    ignore_errors: yes
+    register: k8s_no_validate
+
+  - name: assert that k8s_no_validate fails gracefully
+    assert:
+      that:
+        - k8s_no_validate is failed
+        - "k8s_no_validate.msg == 'kubernetes-validate python library is required to validate resources'"

--- a/test/integration/targets/k8s/runme.sh
+++ b/test/integration/targets/k8s/runme.sh
@@ -12,16 +12,16 @@ MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 # but for the python3 tests we need virtualenv to use python3
 PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
 
-# Test graceful failure for missing kubernetes-validate
+# Test graceful failure for missing all_the_merges
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/openshift-validate-not-installed"
 source "${MYTMPDIR}/openshift-validate-not-installed/bin/activate"
-$PYTHON -m pip install git+https://github.com/willthames/openshift-restclient-python@kubernetes-validate
+$PYTHON -m pip install git+https://github.com/willthames/openshift-restclient-python@all_the_merges
 ansible-playbook -v playbooks/validate_not_installed.yml "$@"
 
-# Test graceful failure for missing kubernetes-validate
+# Test graceful failure for missing all_the_merges
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/openshift-validate-installed"
 source "${MYTMPDIR}/openshift-validate-installed/bin/activate"
-$PYTHON -m pip install git+https://github.com/willthames/openshift-restclient-python@kubernetes-validate 'kubernetes-validate>=1.11.5'
+$PYTHON -m pip install git+https://github.com/willthames/openshift-restclient-python@all_the_merges 'all_the_merges>=1.11.5'
 ansible-playbook -v playbooks/validate_installed.yml "$@"
 
 # Test graceful failure for older versions of openshift

--- a/test/integration/targets/k8s/runme.sh
+++ b/test/integration/targets/k8s/runme.sh
@@ -12,6 +12,18 @@ MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 # but for the python3 tests we need virtualenv to use python3
 PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
 
+# Test graceful failure for missing kubernetes-validate
+virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/openshift-validate-not-installed"
+source "${MYTMPDIR}/openshift-validate-not-installed/bin/activate"
+$PYTHON -m pip install git+https://github.com/willthames/openshift-restclient-python@kubernetes-validate
+ansible-playbook -v playbooks/validate_not_installed.yml "$@"
+
+# Test graceful failure for missing kubernetes-validate
+virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/openshift-validate-installed"
+source "${MYTMPDIR}/openshift-validate-installed/bin/activate"
+$PYTHON -m pip install git+https://github.com/willthames/openshift-restclient-python@kubernetes-validate 'kubernetes-validate>=1.11.5'
+ansible-playbook -v playbooks/validate_installed.yml "$@"
+
 # Test graceful failure for older versions of openshift
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/openshift-0.6.0"
 source "${MYTMPDIR}/openshift-0.6.0/bin/activate"

--- a/test/integration/targets/k8s/runme.sh
+++ b/test/integration/targets/k8s/runme.sh
@@ -12,26 +12,26 @@ MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 # but for the python3 tests we need virtualenv to use python3
 PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
 
-# Test graceful failure for missing all_the_merges
+# Test graceful failure for missing kubernetes-validate
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/openshift-validate-not-installed"
 source "${MYTMPDIR}/openshift-validate-not-installed/bin/activate"
-$PYTHON -m pip install git+https://github.com/willthames/openshift-restclient-python@all_the_merges
+$PYTHON -m pip install openshift==0.8.1
 ansible-playbook -v playbooks/validate_not_installed.yml "$@"
 
-# Test graceful failure for missing all_the_merges
+# Test validate with kubernetes-validate
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/openshift-validate-installed"
 source "${MYTMPDIR}/openshift-validate-installed/bin/activate"
-$PYTHON -m pip install git+https://github.com/willthames/openshift-restclient-python@all_the_merges 'all_the_merges>=1.11.5'
+$PYTHON -m pip install openshift==0.8.1 kubernetes-validate==1.12.0
 ansible-playbook -v playbooks/validate_installed.yml "$@"
 
 # Test graceful failure for older versions of openshift
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/openshift-0.6.0"
 source "${MYTMPDIR}/openshift-0.6.0/bin/activate"
-$PYTHON -m pip install 'openshift==0.6.0' 'kubernetes==6.0.0'
+$PYTHON -m pip install openshift==0.6.0 kubernetes==6.0.0
 ansible-playbook -v playbooks/merge_type_fail.yml "$@"
 
 # Run full test suite
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/openshift-recent"
 source "${MYTMPDIR}/openshift-recent/bin/activate"
-$PYTHON -m pip install 'openshift==0.7.2'
+$PYTHON -m pip install openshift==0.8.1
 ansible-playbook -v playbooks/full_test.yml "$@"

--- a/test/runner/lib/cloud/openshift.py
+++ b/test/runner/lib/cloud/openshift.py
@@ -44,7 +44,7 @@ class OpenShiftCloudProvider(CloudProvider):
         super(OpenShiftCloudProvider, self).__init__(args, config_extension='.kubeconfig')
 
         # The image must be pinned to a specific version to guarantee CI passes with the version used.
-        self.image = 'openshift/origin:v3.7.1'
+        self.image = 'openshift/origin:v3.9.0'
         self.container_name = ''
 
     def filter(self, targets, exclude):


### PR DESCRIPTION
##### SUMMARY

Use kubernetes-validate to validate Kubernetes resource
definitions against the published schema

Note that `fail_on_error` is compulsory to use `validate` because otherwise the default to obtain some validation would be `validate: {}` which isn't particularly Ansiblish. Better suggestions for a nicer default case are welcome. 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
k8s

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 0b77262288) last updated 2018/07/27 21:11:54 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
e.g. with

```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  labels:
    app: kuard
  name: kuard
  namespace: default
spec:
  replicas: 3
  selector:
    matchLabels:
      app: kuard
    unwanted: value
  template:
    metadata:
      labels:
        app: kuard
    spec:
      containers:
      - image: gcr.io/kuar-demo/kuard-amd64:1
        name: kuard
```

and

```
- hosts: localhost

  tasks:
    - k8s:
        definition: "{{ lookup('file', 'kuard-extra-property.yml') }}"
        validate:
          fail_on_error: no
```

the result includes

```
 [WARNING]: resource validation error at spec.selector: Additional properties are not allowed ('unwanted' was unexpected)
```


