### PR TITLE
fix for special case of last element of url

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_resource.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resource.py
@@ -210,6 +210,7 @@ class AzureRMResource(AzureRMModuleBase):
             self.status_code.append(204)
 
         if self.url is None:
+            orphan = None
             rargs = dict()
             rargs['subscription'] = self.subscription_id
             rargs['resource_group'] = self.resource_group

--- a/lib/ansible/modules/cloud/azure/azure_rm_resource.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resource.py
@@ -227,6 +227,15 @@ class AzureRMResource(AzureRMModuleBase):
 
             self.url = resource_id(**rargs)
 
+            # resource_id doesn't append last element, when it doesn't have name
+            # if it happens it should be appended manually
+            if len(self.subresource) > 0:
+                last = self.subresource[-1]
+                if last.get('name', None) is None and last.get('type', None) is not None:
+                    self.url = self.url + "/" + last['type']
+            elif self.resource_type is not None and self.resource_name is None:
+                self.url += '/' + self.resource_type
+
         query_parameters = {}
         query_parameters['api-version'] = self.api_version
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_resource_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resource_facts.py
@@ -169,8 +169,13 @@ class AzureRMResourceFacts(AzureRMModuleBase):
 
             self.url = resource_id(**rargs)
 
-            # this is to fix a problem with resource_id implementation, when resource_name is not specified
-            if self.resource_type is not None and self.resource_name is None:
+            # resource_id doesn't append last element, when it doesn't have name
+            # if it happens it should be appended manually
+            if len(self.subresource) > 0:
+                last = self.subresource[-1]
+                if last.get('name', None) is None and last.get('type', None) is not None:
+                    self.url = self.url + "/" + last['type']
+            elif self.resource_type is not None and self.resource_name is None:
                 self.url += '/' + self.resource_type
 
         self.results['url'] = self.url

--- a/lib/ansible/modules/cloud/azure/azure_rm_resource_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resource_facts.py
@@ -152,6 +152,7 @@ class AzureRMResourceFacts(AzureRMModuleBase):
                                                     base_url=self._cloud_environment.endpoints.resource_manager)
 
         if self.url is None:
+            orphan = None
             rargs = dict()
             rargs['subscription'] = self.subscription_id
             rargs['resource_group'] = self.resource_group
@@ -159,24 +160,27 @@ class AzureRMResourceFacts(AzureRMModuleBase):
                 rargs['namespace'] = "Microsoft." + self.provider
             else:
                 rargs['namespace'] = self.provider
-            rargs['type'] = self.resource_type
-            rargs['name'] = self.resource_name
 
-            for i in range(len(self.subresource)):
-                rargs['child_namespace_' + str(i + 1)] = self.subresource[i].get('namespace', None)
-                rargs['child_type_' + str(i + 1)] = self.subresource[i].get('type', None)
-                rargs['child_name_' + str(i + 1)] = self.subresource[i].get('name', None)
+            if self.resource_type is not None and self.resource_name is not None:
+                rargs['type'] = self.resource_type
+                rargs['name'] = self.resource_name
+                for i in range(len(self.subresource)):
+                    resource_ns = self.subresource[i].get('namespace', None)
+                    resource_type = self.subresource[i].get('type', None)
+                    resource_name = self.subresource[i].get('name', None)
+                    if resource_type is not None and resource_name is not None:
+                        rargs['child_namespace_' + str(i + 1)] = resource_ns
+                        rargs['child_type_' + str(i + 1)] = resource_type
+                        rargs['child_name_' + str(i + 1)] = resource_name
+                    else:
+                        orphan = resource_type
+            else:
+                orphan = self.resource_type
 
             self.url = resource_id(**rargs)
 
-            # resource_id doesn't append last element, when it doesn't have name
-            # if it happens it should be appended manually
-            if len(self.subresource) > 0:
-                last = self.subresource[-1]
-                if last.get('name', None) is None and last.get('type', None) is not None:
-                    self.url = self.url + "/" + last['type']
-            elif self.resource_type is not None and self.resource_name is None:
-                self.url += '/' + self.resource_type
+            if orphan is not None:
+                self.url += '/' + orphan
 
         self.results['url'] = self.url
 

--- a/test/integration/targets/azure_rm_resource/tasks/main.yml
+++ b/test/integration/targets/azure_rm_resource/tasks/main.yml
@@ -82,6 +82,6 @@
     method: POST
   register: keys
 
-- name: Assert that something has changed
+- name: Assert that key was returned
   assert:
     that: keys['response']['keys'][0]['value'] | length > 0

--- a/test/integration/targets/azure_rm_resource/tasks/main.yml
+++ b/test/integration/targets/azure_rm_resource/tasks/main.yml
@@ -1,6 +1,7 @@
 - name: Prepare random number
   set_fact:
     nsgname: "{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+    storageaccountname: "stacc{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
   run_once: yes
 
 - name: Call REST API
@@ -54,7 +55,6 @@
   assert:
     that: output.changed
 
-
 - name: Try to get information about account
   azure_rm_resource_facts:
     api_version: '2018-02-01'
@@ -63,3 +63,25 @@
     resource_type: networksecuritygroups
     resource_name: "{{ nsgname }}"
   register: output
+
+- name: Create storage account for Registry
+  azure_rm_storageaccount:
+    resource_group: "{{ resource_group }}"
+    name: "{{ storageaccountname }}"
+    type: Standard_LRS
+
+- name: Try to storage keys -- special case when subresource part has no name
+  azure_rm_resource:
+    resource_group: "{{ resource_group }}"
+    provider: storage
+    resource_type: "{{ storageaccountname }}"
+    resource_name: "{{ registry_storage_account }}"
+    subresource:
+      - type: listkeys
+    api_version: '2018-03-01-preview'
+    method: POST
+  register: keys
+
+- name: Assert that something has changed
+  assert:
+    that: keys['response']['keys'][0]['value'] | length > 0

--- a/test/integration/targets/azure_rm_resource/tasks/main.yml
+++ b/test/integration/targets/azure_rm_resource/tasks/main.yml
@@ -74,8 +74,8 @@
   azure_rm_resource:
     resource_group: "{{ resource_group }}"
     provider: storage
-    resource_type: "{{ storageaccountname }}"
-    resource_name: "{{ registry_storage_account }}"
+    resource_type: storageAccounts
+    resource_name: "{{ storageaccountname }}"
     subresource:
       - type: listkeys
     api_version: '2018-03-01-preview'


### PR DESCRIPTION
##### SUMMARY
When last element or URL contains only type (name is not present), underlying library will ignore it and won't include it in URL. Therefore we need to handle such special case.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_resource
azure_rm_resource_facts

##### ANSIBLE VERSION
2.6

##### ADDITIONAL INFORMATION


