### PR TITLE
mysql_db: Allow importing database to get `state: present`

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -77,6 +77,12 @@ EXAMPLES = '''
     name: bobdata
     state: present
 
+- name: If it doesn't exist, import database my_db from /tmp/dump.sql.bz2
+  mysql_db:
+    name: my_db
+    state: present
+    target: /tmp/dump.sql.bz2
+
 # Copy database dump file to remote host and restore it to database 'my_db'
 - name: Copy database dump file
   copy:

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -316,6 +316,7 @@ def main():
     else:
         if db == 'all':
             module.fail_json(msg="name is not allowed to equal 'all' unless state equals import, or dump.")
+        all_databases = False
     try:
         cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca,
                                connect_timeout=connect_timeout)
@@ -373,7 +374,7 @@ def main():
             module.exit_json(changed=False, db=db)
 
     else:
-        if state == "present":
+        if state == "present" and target is None:
             if module.check_mode:
                 changed = True
             else:
@@ -384,7 +385,7 @@ def main():
                                      exception=traceback.format_exc())
             module.exit_json(changed=changed, db=db)
 
-        elif state == "import":
+        elif state == "import" or (state == "present" and target is not None):
             if module.check_mode:
                 module.exit_json(changed=True, db=db)
             else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Rationale:

As far as I'm aware, there is currently not really a good way (except for doing an additional check, like first telling it to be present and only importing if asserting presence reported 'changed') to import a database in such a way that running the task again will not repeat the import. One can set `state: import` but this will always run an import, no matter the current state of the database; it's slow, it can give errors, it always reports 'changed (and that of course has implications for handlers and applications using ansible).

The solution:

The solution is simple: If `state: present` provided and the database isn't currently present, then:
- If no `target` set: Create
- If a `target` set: Import

Additional info about the changes:

The reason to set `all_databases` to `False` also when not importing
or dumping, is that now we might need the variable when making the database
present.

I've also added an example of this new behavior

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
`mysql_db`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (mysql-import-if-not-exists 33877cd749) last updated 2018/07/27 14:15:54 (GMT +200)
  config file = None
  configured module search path = ['/home/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/documents/programming/ansible/lib/ansible
  executable location = /home/user/.venv/bin/ansible
  python version = 3.6.6 (default, Jun 27 2018, 13:11:40) [GCC 8.1.1 20180531]
```

##### ADDITIONAL INFORMATION
Here's an example to see the new behavior (tested on ubuntu:18.04 docker container):

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
---
- name: MySQL packages installed
  apt:
    update-cache: true
    state: present
    name:
      - python-mysqldb
      - mysql-client
      - mysql-server
      - unzip

- name: MySQL running
  service:
    name: mysql
    state: started

- name: Sample database dump present
  get_url:
    url: http://sportsdb.org/modules/sd/assets/downloads/mlb-samples-2008.09.19.sql.zip
    dest: /database.sql.zip

- name: Unzip database
  unarchive:
    src: /database.sql.zip
    remote_src: true
    dest: /

- name: Sample database present
  mysql_db:
    name: test-db
    state: present
    target: /mlb-samples-2008.09.19.sql
```

Using the old behavior, the result is that the database is present but empty. Using the new behavior the result is that the database is present and imported from the provided file. On the second run, both old and new behavior are to do nothing.

