### PR TITLE
Catch errors raised when deleting objects remaining in a bucket

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -444,6 +444,14 @@ def destroy_bucket(s3_client, module):
         try:
             for key_version_pairs in paginated_versions_list(s3_client, Bucket=name):
                 formatted_keys = [{'Key': key, 'VersionId': version} for key, version in key_version_pairs]
+                for fk in formatted_keys:
+                    # remove VersionId from cases where they are `None` so that
+                    # unversioned objects are deleted using `DeleteObject`
+                    # rather than `DeleteObjectVersion`, improving backwards
+                    # compatibility with older IAM policies.
+                    if not fk.get('VersionId'):
+                        fk.pop('VersionId')
+
                 if formatted_keys:
                     resp = s3_client.delete_objects(Bucket=name, Delete={'Objects': formatted_keys})
                     if resp.get('Errors'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
When emptying a bucket, if the calling user lacks `s3:DeleteObject` permissions, they currently get an error related to the bucket not being empty:

```
    "msg": "Failed to delete bucket: An error occurred (BucketNotEmpty) when calling the DeleteBucket operation: The bucket you tried to delete is not empty",
```

This is somewhat useful, but when `force: yes` is used, that error doesn't say why the bucket still contains items, even though `s3_bucket` should be deleting those objects. This change checks the response from the multiple-delete API call and checks for any errors returned, including which keys/versions were affected.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
s3_bucket

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
After the change, the message for the same bucket shows which keys could not be deleted, and a list-of-dicts for the objects that failed with the failure message, version, and other info. 
```
    "msg": "Failed to delete objects: foo/bar/AWSLogs/515220891604/Config/ConfigWritabilityCheckFile, AWSLogs/515220891604/Config/ConfigWritabilityCheckFile",
    "errors": [
        {
            "Code": "AccessDenied",                                                                                                                           
            "Key": "foo/bar/AWSLogs/515220891604/Config/ConfigWritabilityCheckFile",                                                                         
            "Message": "Access Denied",                                                                                                                      
            "VersionId": "null"                                                                                                                              
        },                                                                                                                                                   
        {                                                                                                                                                    
            "Code": "AccessDenied",                                                                                                                          
            "Key": "AWSLogs/515220891604/Config/ConfigWritabilityCheckFile",
            "Message": "Access Denied",                                                                                                                      
            "VersionId": "null"
        }                              
    ],
```
