### PR TITLE
Preserve setuid/setgid on a directory with an = operator.

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1466,11 +1466,11 @@ class AnsibleModule(object):
         if operator == '=':
             if user == 'u':
                 mask = stat.S_IRWXU
-                if not is_directory or mode_to_apply & stat.ST_ISUID:
+                if not is_directory or (mode_to_apply & stat.ST_ISUID):
                     mask |= stat.ST_ISUID
             elif user == 'g':
                 mask = stat.S_IRWXG
-                if not is_directory or mode_to_apply & stat.ST_ISGID:
+                if not is_directory or (mode_to_apply & stat.ST_ISGID):
                     mask |= stat.ST_ISGID
             elif user == 'o':
                 mask = stat.S_IRWXO | stat.S_ISVTX

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1466,12 +1466,12 @@ class AnsibleModule(object):
         if operator == '=':
             if user == 'u':
                 mask = stat.S_IRWXU
-                if not is_directory or (mode_to_apply & stat.ST_ISUID):
-                    mask |= stat.ST_ISUID
+                if not is_directory or (mode_to_apply & stat.S_ISUID):
+                    mask |= stat.S_ISUID
             elif user == 'g':
                 mask = stat.S_IRWXG
-                if not is_directory or (mode_to_apply & stat.ST_ISGID):
-                    mask |= stat.ST_ISGID
+                if not is_directory or (mode_to_apply & stat.S_ISGID):
+                    mask |= stat.S_ISGID
             elif user == 'o':
                 mask = stat.S_IRWXO | stat.S_ISVTX
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1457,17 +1457,21 @@ class AnsibleModule(object):
 
                 for user in users:
                     mode_to_apply = cls._get_octal_mode_from_symbolic_perms(path_stat, user, perms, use_umask)
-                    new_mode = cls._apply_operation_to_mode(user, opers[idx], mode_to_apply, new_mode)
+                    new_mode = cls._apply_operation_to_mode(user, opers[idx], mode_to_apply, new_mode, stat.S_ISDIR(path_stat.st_mode))
 
         return new_mode
 
     @staticmethod
-    def _apply_operation_to_mode(user, operator, mode_to_apply, current_mode):
+    def _apply_operation_to_mode(user, operator, mode_to_apply, current_mode, is_directory):
         if operator == '=':
             if user == 'u':
-                mask = stat.S_IRWXU | stat.S_ISUID
+                mask = stat.S_IRWXU
+                if not is_directory or mode_to_apply & stat.ST_ISUID:
+                    mask |= stat.ST_ISUID
             elif user == 'g':
-                mask = stat.S_IRWXG | stat.S_ISGID
+                mask = stat.S_IRWXG
+                if not is_directory or mode_to_apply & stat.ST_ISGID:
+                    mask |= stat.ST_ISGID
             elif user == 'o':
                 mask = stat.S_IRWXO | stat.S_ISVTX
 


### PR DESCRIPTION
This behaviour mimics GNU coreutils, which behaviour is dictated by
ease-of-use.
See issue #20852 for details.

Fixes #20852.

##### SUMMARY
See issue #20852 for reference.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Ansible Core Modules

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```
