### PR TITLE
Update nclu.py (#40369)

### DIFF
--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -79,6 +79,15 @@ EXAMPLES = '''
         - add int swp1
     atomic: true
     description: "Ansible - add swp1"
+
+- name: Configure BGP AS and add 2 EBGP neighbors using BGP Unnumbered
+  nclu:
+    commands:
+        - add bgp autonomous-system 65000
+        - add bgp neighbor swp51 interface remote-as external
+        - add bgp neighbor swp52 interface remote-as external
+    commit: true
+
 '''
 
 RETURN = '''


### PR DESCRIPTION
* Update nclu.py

Added NCLU BGP Unnumbered Example
+label: ansible/ansible#40323

* Update nclu.py

* Adding AS number example

(cherry picked from commit a9dc79e07b9ac0d16d90e52f8ee65a6ee9a1f954)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Backported PR 40369 to 2.6.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
nclu

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1.post0 (test-2.6 aee1d42fe7) last updated 2018/07/27 18:33:44 (GMT +000)
  config file = None
  configured module search path = [u'/home/cumulus/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/cumulus/ansible/lib/ansible
  executable location = /home/cumulus/ansible/bin/ansible
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Followed example playbook in original PR:
---
- name: test playbook for cumulus
  hosts: leaf02
  gather_facts: false
  tasks:
    - name: Configure BGP AS and add 2 EBGP neighbors using BGP Unnumbered
      nclu:
        commands:
            - add bgp autonomous-system 65000
            - add bgp neighbor swp51 interface remote-as external
            - add bgp neighbor swp52 interface remote-as external
        commit: true

PLAY [test playbook for cumulus] ***********************************************

TASK [Configure BGP AS and add 2 EBGP neighbors using BGP Unnumbered] **********
The authenticity of host '192.168.0.12 (192.168.0.12)' can't be established.
ECDSA key fingerprint is 68:eb:85:89:de:2a:50:0e:74:ff:d0:e4:48:46:32:2e.
Are you sure you want to continue connecting (yes/no)? yes
changed: [leaf02]

PLAY RECAP *********************************************************************
leaf02                     : ok=1    changed=1    unreachable=0    failed=0   



<!--- Paste verbatim command output below, e.g. before and after your change -->
```
cumulus@leaf02:~$ net show bgp neighbor
BGP neighbor on swp51: None, remote AS 0, local AS 65000, external link
  BGP version 4, remote router ID 0.0.0.0
  BGP state = Idle
  Last read 00:02:02, Last write never
  Hold time is 9, keepalive interval is 3 seconds
  Message statistics:
    Inq depth is 0
    Outq depth is 0
                         Sent       Rcvd
    Opens:                  0          0
    Notifications:          0          0
    Updates:                0          0
    Keepalives:             0          0
    Route Refresh:          0          0
    Capability:             0          0
    Total:                  0          0
  Minimum time between advertisement runs is 0 seconds

 For address family: IPv4 Unicast
  Not part of any update group
  Community attribute sent to this neighbor(all)
  0 accepted prefixes

  Connections established 0; dropped 0
  Last reset never
BGP Connect Retry Timer in Seconds: 10
Read thread: off  Write thread: off

BGP neighbor on swp52: None, remote AS 0, local AS 65000, external link
  BGP version 4, remote router ID 0.0.0.0
  BGP state = Idle
  Last read 00:02:02, Last write never
  Hold time is 9, keepalive interval is 3 seconds
<...output omitted...>
```
