### PR TITLE
Enable setting options for cliconf and other implementation plugins (if set to configurable)

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -85,6 +85,11 @@ class ConnectionProcess(object):
                                                     ansible_playbook_pid=self._ansible_playbook_pid)
             self.connection.set_options(var_options=variables)
             self.connection._connect()
+
+            # implementation plugins are updated while connection initialization
+            if hasattr(self.connection, 'set_implementation_plugin_options'):
+                self.connection.set_implementation_plugin_options(var_options=variables)
+
             self.connection._socket_path = self.socket_path
             self.srv.register(self.connection)
             messages.extend(sys.stdout.getvalue().splitlines())

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -346,7 +346,6 @@ class NetworkConnectionBase(ConnectionBase):
         super(NetworkConnectionBase, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
         self.set_implementation_plugin_options(task_keys=task_keys, var_options=var_options, direct=direct)
 
-
     def set_implementation_plugin_options(self, task_keys=None, var_options=None, direct=None):
         '''
         initialize implementation plugin options

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -342,6 +342,18 @@ class NetworkConnectionBase(ConnectionBase):
             self._connected = False
         self._implementation_plugins = []
 
+    def set_options(self, task_keys=None, var_options=None, direct=None):
+        super(NetworkConnectionBase, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
+        self.set_implementation_plugin_options(task_keys=task_keys, var_options=var_options, direct=direct)
+
+
+    def set_implementation_plugin_options(self, task_keys=None, var_options=None, direct=None):
+        '''
+        initialize implementation plugin options
+        '''
+        for plugin in self._implementation_plugins:
+            plugin.set_options(task_keys=task_keys, var_options=var_options, direct=direct)
+
     def _update_connection_state(self):
         '''
         Reconstruct the connection socket_path and check if it exists

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -297,7 +297,6 @@ class Connection(NetworkConnectionBase):
             if self.cliconf:
                 display.vvvv('loaded cliconf plugin for network_os %s' % self._network_os, host=host)
                 self._implementation_plugins.append(self.cliconf)
-                self.cliconf.set_options()
             else:
                 display.vvvv('unable to load cliconf for network_os %s' % self._network_os)
 

--- a/test/integration/targets/eos_config/tests/cli/check_mode.yaml
+++ b/test/integration/targets/eos_config/tests/cli/check_mode.yaml
@@ -69,5 +69,6 @@
 - assert:
    that:
    - "result.changed == true"
+   - "'session' not in result"
 
 - debug: msg="END cli/check_mode.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #43367

* Add support to set configuration options for implementation plugins (eg: cliconf)
  from `ansible-connection`. This also enables setting configuration options in eos cliconf plugins

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bin/ansible-connection
plugins/connection/__init__.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
