### PR TITLE
docfix, python-netaddr should be netaddr

### DIFF
--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -1060,8 +1060,8 @@ def macaddr(value, query=''):
 
 
 def _need_netaddr(f_name, *args, **kwargs):
-    raise errors.AnsibleFilterError('The %s filter requires python-netaddr be '
-                                    'installed on the ansible controller' % f_name)
+    raise errors.AnsibleFilterError("The %s filter requires python's netaddr be "
+                                    "installed on the ansible controller" % f_name)
 
 
 def ip4_hex(arg, delimiter=''):
@@ -1100,5 +1100,5 @@ class FilterModule(object):
         if netaddr:
             return self.filter_map
         else:
-            # Need to install python-netaddr for these filters to work
+            # Need to install python's netaddr for these filters to work
             return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)


### PR DESCRIPTION
##### SUMMARY
docfix: "python-netaddr" is an OS package, but "netaddr" is the pypi package needed in python. Suggesting OS packages for python libs seems in bad form. I like the syntax "python's netaddr" to explain what package manager would have it.

Moved to double quotes for consistency- only needed on the first line, but that seems weirder. (I suppose I could escape the quote mark, but that seems strange too, but this is a style choice.)

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
netaddr

##### ANSIBLE VERSION
devel


##### ADDITIONAL INFORMATION
hi.
