### PR TITLE
Fileglob: support wildcard directories

### DIFF
--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -55,6 +55,6 @@ class LookupModule(LookupBase):
 
         ret = []
         for term in terms:
-            globbed = glob.glob(to_bytes(term), errors='surrogate_or_strict'))
+            globbed = glob.glob(to_bytes(term, errors='surrogate_or_strict'))
             ret.extend(to_text(g, errors='surrogate_or_strict') for g in globbed if os.path.isfile(g))
         return ret

--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -55,9 +55,6 @@ class LookupModule(LookupBase):
 
         ret = []
         for term in terms:
-            term_file = os.path.basename(term)
-            dwimmed_path = self.find_file_in_search_path(variables, 'files', os.path.dirname(term))
-            if dwimmed_path:
-                globbed = glob.glob(to_bytes(os.path.join(dwimmed_path, term_file), errors='surrogate_or_strict'))
-                ret.extend(to_text(g, errors='surrogate_or_strict') for g in globbed if os.path.isfile(g))
+            globbed = glob.glob(to_bytes(term), errors='surrogate_or_strict'))
+            ret.extend(to_text(g, errors='surrogate_or_strict') for g in globbed if os.path.isfile(g))
         return ret


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Modified `run` so that fileglob supports wildcards in directories.
Accomplished by removing `find_file_in_search_path` from `run`.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes ansible/ansible#17136

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
fileglob (lookup plugin)
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/monoflo/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```