### PR TITLE
URL encode the constructed metadata URL to avoid errors for SSH key

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
@@ -423,7 +423,7 @@ import time
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
 from ansible.module_utils.urls import fetch_url
-
+from ansible.module_utils.six.moves.urllib.parse import quote
 
 socket.setdefaulttimeout(5)
 
@@ -444,13 +444,14 @@ class Ec2Metadata(object):
         self._prefix = 'ansible_ec2_%s'
 
     def _fetch(self, url):
-        response, info = fetch_url(self.module, url, force=True)
+        encoded_url = quote(url, safe='%/:=&?~#+!$,;\'@()*[]')
+        response, info = fetch_url(self.module, encoded_url, force=True)
 
         if info.get('status') not in (200, 404):
             time.sleep(3)
             # request went bad, retry once then raise
             self.module.warn('Retrying query to metadata service. First attempt failed: {0}'.format(info['msg']))
-            response, info = fetch_url(self.module, url, force=True)
+            response, info = fetch_url(self.module, encoded_url, force=True)
             if info.get('status') not in (200, 404):
                 # fail out now
                 self.module.fail_json(msg='Failed to retrieve metadata from AWS: {0}'.format(info['msg']), response=info)


### PR DESCRIPTION
##### SUMMARY
Fixes #42371 and #43378.

If a field has a space in it, the resulting constructed URL would be invalid. This change URL encodes the URL correctly so that the metadata service will return a 404 which will be safely ignored (since the field with the SSH key name doesn't actually return any data).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_metadata_facts

##### ANSIBLE VERSION
```
ansible 2.6.0
```

##### ADDITIONAL INFORMATION
Before:
```
localhost | FAILED! => {
    "changed": false,
    "msg": "Failed to retrieve metadata from AWS: HTTP Error 400: Bad Request",
    "response": {
        "body": "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n         \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\n <head>\n  <title>400 - Bad Request</title>\n </head>\n <body>\n  <h1>400 - Bad Request</h1>\n </body>\n</html>\n",
        "connection": "close",
        "content-length": "349",
        "content-type": "text/html",
        "date": "Sat, 28 Jul 2018 17:29:25 GMT",
        "msg": "HTTP Error 400: Bad Request",
        "server": "EC2ws",
        "status": 400,
        "url": "http://169.254.169.254/latest/meta-data/public-keys/0=Test Key"
    }
}
```
After:
Works without error.