### PR TITLE
VMware: provide appropriate error if NICs missing

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vswitch.py
@@ -177,7 +177,7 @@ class VMwareHostVirtualSwitch(PyVmomi):
 
     def process_state(self):
         """
-        Function to manage internal state of vSwitch
+        Manage internal state of vSwitch
         """
         vswitch_states = {
             'absent': {
@@ -201,7 +201,7 @@ class VMwareHostVirtualSwitch(PyVmomi):
 
     def state_create_vswitch(self):
         """
-        Function to create a virtual switch
+        Create a virtual switch
 
         Source from
         https://github.com/rreubenur/pyvmomi-community-samples/blob/patch-1/samples/create_vswitch.py
@@ -252,13 +252,13 @@ class VMwareHostVirtualSwitch(PyVmomi):
 
     def state_exit_unchanged(self):
         """
-        Function to declare exit without unchanged
+        Declare exit without unchanged
         """
         self.module.exit_json(changed=False)
 
     def state_destroy_vswitch(self):
         """
-        Function to remove vSwitch from configuration
+        Remove vSwitch from configuration
 
         """
         results = dict(changed=False, result="")
@@ -288,7 +288,7 @@ class VMwareHostVirtualSwitch(PyVmomi):
 
     def state_update_vswitch(self):
         """
-        Function to update vSwitch
+        Update vSwitch
 
         """
         results = dict(changed=False, result="No change in vSwitch '%s'" % self.switch)
@@ -305,19 +305,23 @@ class VMwareHostVirtualSwitch(PyVmomi):
             all_nics += remain_pnic
             diff = True
 
-        # vSwitch needs every parameter again while updating,
-        # even if we are updating any one of them
-        vss_spec = vim.host.VirtualSwitch.Specification()
-        vss_spec.bridge = vim.host.VirtualSwitch.BondBridge(nicDevice=all_nics)
-        vss_spec.numPorts = self.number_of_ports
-        vss_spec.mtu = self.mtu
-
         if vswitch_pnic_info['mtu'] != self.mtu or \
                 vswitch_pnic_info['num_ports'] != self.number_of_ports:
             diff = True
 
+        if not all_nics:
+            diff = False
+            results['result'] += " as no NICs provided / found which are required while updating vSwitch."
+
         try:
             if diff:
+                # vSwitch needs every parameter again while updating,
+                # even if we are updating any one of them
+                vss_spec = vim.host.VirtualSwitch.Specification()
+                vss_spec.bridge = vim.host.VirtualSwitch.BondBridge(nicDevice=all_nics)
+                vss_spec.numPorts = self.number_of_ports
+                vss_spec.mtu = self.mtu
+
                 network_mgr = self.host_system.configManager.networkSystem
                 if network_mgr:
                     network_mgr.UpdateVirtualSwitch(vswitchName=self.switch,
@@ -361,7 +365,7 @@ class VMwareHostVirtualSwitch(PyVmomi):
 
     def check_vswitch_configuration(self):
         """
-        Function to check if vSwitch exists
+        Check if vSwitch exists
         Returns: 'present' if vSwitch exists or 'absent' if not
 
         """
@@ -374,7 +378,7 @@ class VMwareHostVirtualSwitch(PyVmomi):
     @staticmethod
     def find_vswitch_by_name(host, vswitch_name):
         """
-        Function to find and return vSwitch managed object
+        Find and return vSwitch managed object
         Args:
             host: Host system managed object
             vswitch_name: Name of vSwitch to find


### PR DESCRIPTION
##### SUMMARY
While creating/reconfiguring vSwitch without NICs check if nics details
are gathered or not.

Fixes: #42619

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_vswitch.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```