### PR TITLE
Allow routes to be created if the CIDR already exists but its 'Origin…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -432,8 +432,9 @@ def index_of_matching_route(route_spec, routes_to_match):
     for i, route in enumerate(routes_to_match):
         if route_spec_matches_route(route_spec, route):
             return "exact", i
-        elif route_spec_matches_route_cidr(route_spec, route):
-            return "replace", i
+        elif 'Origin' in route_spec and route_spec['Origin'] != 'EnableVgwRoutePropagation':
+            if route_spec_matches_route_cidr(route_spec, route):
+                return "replace", i
 
 
 def ensure_routes(connection=None, module=None, route_table=None, route_specs=None,


### PR DESCRIPTION
…' is 'EnableVgwRoutePropagation' (which cannot be replaced).

Fixes #43415

##### SUMMARY
Allows a route to be added to a route table if there is already a route with the same CIDR, but whose origin is 'EnableVgwRoutePropagation' (these cannot be replaced).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_route_table

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/dse09/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
