### PR TITLE
Idempotent mysql_db dump

### DIFF
--- a/changelogs/fragments/mysql_db-idempotent-dump.yaml
+++ b/changelogs/fragments/mysql_db-idempotent-dump.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mysql_db - Compare checksums of files if dump overwrites an existing file to detect change and use the --compact option in mysqldump to make the dumping of databases idempotent

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -65,6 +65,7 @@ options:
   compact:
     description:
       - When I(state) is C(dump), generate compact dump. Equivalent to C(--compact) flag in C(mysqldump).
+        When this option is disabled, idempotence is lost.
     type: bool
     required: false
     default: 'yes'

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -66,6 +66,7 @@ options:
     description:
       - When I(state) is C(dump), generate compact dump. Equivalent to C(--compact) flag in C(mysqldump).
         When this option is disabled, idempotence is lost.
+        Dumps created with this option enabled cannot be used to overwrite existing tables by using them as a source for importing.
     type: bool
     required: false
     default: 'yes'

--- a/test/integration/targets/mysql_db/tasks/state_dump_import.yml
+++ b/test/integration/targets/mysql_db/tasks/state_dump_import.yml
@@ -70,6 +70,11 @@
     that:
        - "'department' not in result.stdout"
 
+- name: remove database file
+  file:
+    path: '{{ db_file_name}}'
+    state: absent
+
 - name: test state=dump to backup the database of type {{ format_type }} (expect changed=true)
   mysql_db: name={{ db_name }} state=dump target={{ db_file_name }}
   register: result
@@ -77,7 +82,18 @@
 - name: assert output message backup the database
   assert:
     that:
-       - "result.db =='{{ db_name }}'"
+      - "result.changed == true"
+      - "result.db =='{{ db_name }}'"
+
+- name: test state=dump to backup the database of type {{ format_type }} (expect changed=false)
+  mysql_db: name={{ db_name }} state=dump target={{ db_file_name }}
+  register: result
+
+- name: assert idempotence of repeated database dumping
+  assert:
+    that:
+      - "result.changed == false"
+      - "result.db =='{{ db_name }}'"
 
 - name: assert database was backed up successfully
   command: file {{ db_file_name }}

--- a/test/integration/targets/mysql_db/tasks/state_dump_import.yml
+++ b/test/integration/targets/mysql_db/tasks/state_dump_import.yml
@@ -102,6 +102,10 @@
 - name: assert file format type
   assert: { that: "'{{format_msg_type}}' in result.stdout" }
 
+- name: create non-compact dump
+  mysql_db: name={{ db_name }} state=dump target={{ db_file_name }} compact=false
+  register: result
+
 - name: update database table employee
   command: mysql {{ db_name }} "-e update employee set name='John Doe' where id=47;"
 

--- a/test/integration/targets/mysql_db/tasks/state_dump_import.yml
+++ b/test/integration/targets/mysql_db/tasks/state_dump_import.yml
@@ -77,7 +77,6 @@
 - name: assert output message backup the database
   assert:
     that:
-       - "result.changed == true"
        - "result.db =='{{ db_name }}'"
 
 - name: assert database was backed up successfully


### PR DESCRIPTION
##### SUMMARY
Currently using `state: dump` with the `mysql_db` is not idempotent, which I wanted to fix. I don't know whether to mark this as a bug or a feature. It's not doing what it should currently be doing, so in that sense its a bug I guess.

The solution is simple, and comparable to that of the `copy` module for example. If the destination file already exists, then get the checksum, and compare it to the checksum of the new dump. If these are equal then assume that no changes were made. Unfortunately you still have to do the entire dump, so it doesn't really save time, but at least it now reports the proper result (which is useful for applications building on Ansible, it's useful because you can verify the idempotence of your own roles, and most importantly: It's correct)

This required another change however. In the 'regular' dump there's an additional timestamp of when the dump was completed, which of course ruins checksum comparisons. However, it seemed to me that this information in the database dump is undesired to begin with, and you probably always want to use the `--compact` option. So I added that. It can be disabled easily using `compact: no`.
I wasn't sure whether I should enable it by default, because defaults are often to have things turned off, at least that's my impression, but I think for most uses you want it on, and its needed for the actual feature that this PR is about.
I also wasn't sure what version to mark it as. I thought 2.7 is now in development so I used that.
I couldn't get the generation of docs working, so someone should check that they make some sense.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
`mysql_db`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (idempotent-mysql_db-dump 7b18490b7c) last updated 2018/07/30 11:19:52 (GMT +200)
  config file = None
  configured module search path = ['/home/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/documents/programming/ansible/lib/ansible
  executable location = /home/user/.venv/bin/ansible
  python version = 3.6.6 (default, Jun 27 2018, 13:11:40) [GCC 8.1.1 20180531]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Take a look at the tasks below. The last two tasks are identical, and as such the last task shouldn't report `changed` but just `ok`. Old behavior is to `report changed`, but after this PR the last task will just report `ok`.

Tasks:

```yaml
---
- name: MySQL packages installed
  apt:
    update-cache: true
    state: present
    name:
      - python-mysqldb
      - mysql-client
      - mysql-server
      - unzip

- name: MySQL running
  service:
    name: mysql
    state: started

- name: Sample database dump present
  get_url:
    url: http://sportsdb.org/modules/sd/assets/downloads/mlb-samples-2008.09.19.sql.zip
    dest: /database.sql.zip

- name: Unzip database
  unarchive:
    src: /database.sql.zip
    remote_src: true
    dest: /

- name: Sample database present
  mysql_db:
    name: test-db
    state: import
    target: /mlb-samples-2008.09.19.sql

- name: Dump
  mysql_db:
    name: test-db
    state: dump
    target: /tmp/dump.sql

- name: Dump again
  mysql_db:
    name: test-db
    state: dump
    target: /tmp/dump.sql
```

Old result:

```
    TASK [Gathering Facts] *********************************************************
    ok: [molecule-test-import-changed]
    
    TASK [mysql-import-changed : MySQL packages installed] *************************
    changed: [molecule-test-import-changed]
    
    TASK [mysql-import-changed : MySQL running] ************************************
    changed: [molecule-test-import-changed]
    
    TASK [mysql-import-changed : Sample database dump present] *********************
    changed: [molecule-test-import-changed]
    
    TASK [mysql-import-changed : Unzip database] ***********************************
    changed: [molecule-test-import-changed]
    
    TASK [mysql-import-changed : Sample database present] **************************
    changed: [molecule-test-import-changed]
    
    TASK [mysql-import-changed : Dump] *********************************************
    changed: [molecule-test-import-changed]
    
    TASK [mysql-import-changed : Dump again] ***************************************
    changed: [molecule-test-import-changed]
    
    PLAY RECAP *********************************************************************
    molecule-test-import-changed : ok=8    changed=7    unreachable=0    failed=0
```

New result:

```
    TASK [Gathering Facts] *********************************************************
    ok: [molecule-test-import-changed]
    
    TASK [mysql-import-changed : MySQL packages installed] *************************
    changed: [molecule-test-import-changed]
    
    TASK [mysql-import-changed : MySQL running] ************************************
    changed: [molecule-test-import-changed]
    
    TASK [mysql-import-changed : Sample database dump present] *********************
    changed: [molecule-test-import-changed]
    
    TASK [mysql-import-changed : Unzip database] ***********************************
    changed: [molecule-test-import-changed]
    
    TASK [mysql-import-changed : Sample database present] **************************
    changed: [molecule-test-import-changed]
    
    TASK [mysql-import-changed : Dump] *********************************************
    changed: [molecule-test-import-changed]
    
    TASK [mysql-import-changed : Dump again] ***************************************
    ok: [molecule-test-import-changed]
    
    PLAY RECAP *********************************************************************
    molecule-test-import-changed : ok=8    changed=6    unreachable=0    failed=0
```