### PR TITLE
Don't perform string to bool conversion in set_fact when jinja2 native types is enabled

### DIFF
--- a/lib/ansible/plugins/action/set_fact.py
+++ b/lib/ansible/plugins/action/set_fact.py
@@ -23,6 +23,8 @@ from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import isidentifier
 
+import ansible.constants as C
+
 
 class ActionModule(ActionBase):
 
@@ -49,7 +51,7 @@ class ActionModule(ActionBase):
                                      "letters, numbers and underscores." % k)
                     return result
 
-                if isinstance(v, string_types) and v.lower() in ('true', 'false', 'yes', 'no'):
+                if not C.DEFAULT_JINJA2_NATIVE and isinstance(v, string_types) and v.lower() in ('true', 'false', 'yes', 'no'):
                     v = boolean(v, strict=False)
                 facts[k] = v
 

--- a/test/integration/targets/set_fact/runme.sh
+++ b/test/integration/targets/set_fact/runme.sh
@@ -17,3 +17,7 @@ export ANSIBLE_CACHE_PLUGIN=jsonfile ANSIBLE_CACHE_PLUGIN_CONNECTION="${MYTMPDIR
 ansible-playbook -i ../../inventory "$@" set_fact_cached_1.yml
 ansible-playbook -i ../../inventory "$@" set_fact_cached_2.yml
 ansible-playbook -i ../../inventory --flush-cache "$@" set_fact_no_cache.yml
+
+# Test boolean conversions in set_fact
+ansible-playbook -v set_fact_bool_conv.yml
+ANSIBLE_JINJA2_NATIVE=1 ansible-playbook -v set_fact_bool_conv_jinja2_native.yml

--- a/test/integration/targets/set_fact/set_fact_bool_conv.yml
+++ b/test/integration/targets/set_fact/set_fact_bool_conv.yml
@@ -1,0 +1,20 @@
+- hosts: localhost
+  gather_facts: false
+  vars:
+    string_var: "no"
+  tasks:
+    - set_fact:
+        this_is_string: "yes"
+        this_is_not_string: yes
+        this_is_also_string: "{{ string_var }}"
+        this_is_another_string: !!str "{% set thing = '' + string_var + '' %}{{ thing }}"
+        this_is_more_strings: '{{ string_var + "" }}'
+
+    - assert:
+        that:
+          - string_var == 'no'
+          - this_is_string == True
+          - this_is_not_string == True
+          - this_is_also_string == False
+          - this_is_another_string == False
+          - this_is_more_strings == False

--- a/test/integration/targets/set_fact/set_fact_bool_conv_jinja2_native.yml
+++ b/test/integration/targets/set_fact/set_fact_bool_conv_jinja2_native.yml
@@ -1,0 +1,20 @@
+- hosts: localhost
+  gather_facts: false
+  vars:
+    string_var: "no"
+  tasks:
+    - set_fact:
+        this_is_string: "yes"
+        this_is_not_string: yes
+        this_is_also_string: "{{ string_var }}"
+        this_is_another_string: !!str "{% set thing = '' + string_var + '' %}{{ thing }}"
+        this_is_more_strings: '{{ string_var + "" }}'
+
+    - assert:
+        that:
+          - string_var == 'no'
+          - this_is_string == 'yes'
+          - this_is_not_string == True
+          - this_is_also_string == 'no'
+          - this_is_another_string == 'no'
+          - this_is_more_strings == 'no'


### PR DESCRIPTION
##### SUMMARY

Don't perform string to bool conversion in set_fact when jinja2 native types is enabled. Fixes #42599

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/set_fact.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```