### PR TITLE
Fix all VMware examples to use delegate_to

### DIFF
--- a/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/_vsphere_guest.py
@@ -176,6 +176,7 @@ EXAMPLES = '''
     esxi:
       datacenter: MyDatacenter
       hostname: esx001.mydomain.local
+  delegate_to: localhost
 
 # Reconfigure the CPU and Memory on the newly created VM
 # Will return the changes made
@@ -208,6 +209,7 @@ EXAMPLES = '''
     esxi:
       datacenter: MyDatacenter
       hostname: esx001.mydomain.local
+  delegate_to: localhost
 
 # Deploy a guest from a template
 - vsphere_guest:
@@ -221,15 +223,16 @@ EXAMPLES = '''
     resource_pool: "/Resources"
     vm_extra_config:
       folder: MyFolder
+  delegate_to: localhost
 
 # Task to gather facts from a vSphere cluster only if the system is a VMware guest
-
 - vsphere_guest:
     vcenter_hostname: vcenter.mydomain.local
     username: myuser
     password: mypass
     guest: newvm001
     vmware_guest_facts: yes
+  delegate_to: localhost
 
 ---
 # Typical output of a vsphere_facts run on a guest
@@ -273,6 +276,7 @@ EXAMPLES = '''
     guest: newvm001
     state: absent
     force: yes
+  delegate_to: localhost
 '''
 
 import os

--- a/lib/ansible/modules/cloud/vmware/vca_vapp.py
+++ b/lib/ansible/modules/cloud/vmware/vca_vapp.py
@@ -97,7 +97,6 @@ extends_documentation_fragment: vca
 '''
 
 EXAMPLES = '''
-
 - name: Creates a new vApp in a VCA instance
   vca_vapp:
     vapp_name: tower
@@ -107,7 +106,7 @@ EXAMPLES = '''
     instance_id: '<your instance id here>'
     username: '<your username here>'
     password: '<your password here>'
-
+  delegate_to: localhost
 '''
 
 from ansible.module_utils.vca import VcaAnsibleModule, VcaError

--- a/lib/ansible/modules/cloud/vmware/vcenter_folder.py
+++ b/lib/ansible/modules/cloud/vmware/vcenter_folder.py
@@ -112,7 +112,6 @@ EXAMPLES = r'''
     folder_type: vm
     state: absent
   register: vm_folder_deletion_result
-
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/cloud/vmware/vmware_about_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_about_facts.py
@@ -37,6 +37,7 @@ EXAMPLES = r'''
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
+  delegate_to: localhost
   register: vcenter_about_info
 
 - name: Provide information about a standalone ESXi server
@@ -44,6 +45,7 @@ EXAMPLES = r'''
     hostname: '{{ esxi_hostname }}'
     username: '{{ esxi_username }}'
     password: '{{ esxu_password }}'
+  delegate_to: localhost
   register: esxi_about_info
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_category_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_category_facts.py
@@ -42,6 +42,7 @@ EXAMPLES = r'''
     hostname: "{{ vcenter_server }}"
     username: "{{ vcenter_user }}"
     password: "{{ vcenter_pass }}"
+  delegate_to: localhost
   register: all_tag_category_facts
 
 - name: Gather category id from given tag category
@@ -49,6 +50,7 @@ EXAMPLES = r'''
     hostname: "{{ vcenter_server }}"
     username: "{{ vcenter_user }}"
     password: "{{ vcenter_pass }}"
+  delegate_to: localhost
   register: tag_category_results
 
 - set_fact:

--- a/lib/ansible/modules/cloud/vmware/vmware_cfg_backup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_cfg_backup.py
@@ -53,24 +53,24 @@ extends_documentation_fragment: vmware.documentation
 EXAMPLES = '''
 # save the ESXi configuration locally by authenticating directly against the ESXi host
 - name: ESXI backup test
-  local_action:
-      module: vmware_cfg_backup
-      hostname: esxi_hostname
-      username: user
-      password: pass
-      state: saved
-      dest: /tmp/
+  vmware_cfg_backup:
+    hostname: esxi_hostname
+    username: user
+    password: pass
+    state: saved
+    dest: /tmp/
+  delegate_to: localhost
 
 # save the ESXi configuration locally by authenticating against the vCenter and selecting the ESXi host
 - name: ESXI backup test
-  local_action:
-      module: vmware_cfg_backup
-      hostname: vCenter
-      esxi_hostname: esxi_hostname
-      username: user
-      password: pass
-      state: saved
-      dest: /tmp/
+  vmware_cfg_backup:
+    hostname: vCenter
+    esxi_hostname: esxi_hostname
+    username: user
+    password: pass
+    state: saved
+    dest: /tmp/
+  delegate_to: localhost
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/vmware/vmware_cluster.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_cluster.py
@@ -57,8 +57,7 @@ extends_documentation_fragment: vmware.documentation
 
 EXAMPLES = r'''
 - name: Create Cluster
-  local_action:
-    module: vmware_cluster
+  vmware_cluster:
     hostname: '{{ ansible_ssh_host }}'
     username: root
     password: vmware
@@ -67,6 +66,7 @@ EXAMPLES = r'''
     enable_ha: yes
     enable_drs: yes
     enable_vsan: yes
+  delegate_to: localhost
 '''
 
 try:

--- a/lib/ansible/modules/cloud/vmware/vmware_datacenter.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_datacenter.py
@@ -43,15 +43,14 @@ extends_documentation_fragment: vmware.documentation
 '''
 
 EXAMPLES = '''
-# Example vmware_datacenter command from Ansible Playbooks
 - name: Create Datacenter
-  local_action:
-    module: vmware_datacenter
+  vmware_datacenter:
     hostname: "{{ ansible_ssh_host }}"
     username: root
     password: vmware
     datacenter_name: "datacenter"
     state: present
+  delegate_to: localhost
 
 - name: Delete Datacenter
   vmware_datacenter:
@@ -60,6 +59,7 @@ EXAMPLES = '''
     password: pass
     datacenter_name: DC2
     state: absent
+  delegate_to: localhost
   register: datacenter_delete_result
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_datastore_cluster.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_datastore_cluster.py
@@ -56,6 +56,7 @@ EXAMPLES = '''
     datacenter_name: "datacenter"
     datastore_cluster_name: datacluster0
     state: present
+  delegate_to: localhost
 
 
 - name: Delete datastore cluster
@@ -66,6 +67,7 @@ EXAMPLES = '''
     datacenter_name: "datacenter"
     datastore_cluster_name: datacluster0
     state: absent
+  delegate_to: localhost
 '''
 
 RETURN = """

--- a/lib/ansible/modules/cloud/vmware/vmware_datastore_maintenancemode.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_datastore_maintenancemode.py
@@ -63,6 +63,7 @@ EXAMPLES = '''
     password: vc_pass
     datastore: datastore1
     state: present
+  delegate_to: localhost
 
 - name: Enter all datastores under cluster into Maintenance Mode
   vmware_datastore_maintenancemode:
@@ -71,6 +72,7 @@ EXAMPLES = '''
     password: vc_pass
     cluster_name: DC0_C0
     state: present
+  delegate_to: localhost
 
 - name: Enter all datastores under datastore cluster into Maintenance Mode
   vmware_datastore_maintenancemode:
@@ -79,6 +81,7 @@ EXAMPLES = '''
     password: vc_pass
     datastore_cluster: DSC_POD0
     state: present
+  delegate_to: localhost
 
 - name: Exit datastore into Maintenance Mode
   vmware_datastore_maintenancemode:
@@ -87,6 +90,7 @@ EXAMPLES = '''
     password: vc_pass
     datastore: datastore1
     state: absent
+  delegate_to: localhost
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
@@ -112,6 +112,7 @@ EXAMPLES = r'''
     password: passw0rd
     ovf: /path/to/ubuntu-16.04-amd64.ovf
     wait_for_ip_address: true
+  delegate_to: localhost
 '''
 
 

--- a/lib/ansible/modules/cloud/vmware/vmware_dns_config.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dns_config.py
@@ -42,10 +42,8 @@ extends_documentation_fragment: vmware.documentation
 '''
 
 EXAMPLES = '''
-# Example vmware_dns_config command from Ansible Playbooks
 - name: Configure ESXi hostname and DNS servers
-  local_action:
-    module: vmware_dns_config
+  vmware_dns_config:
     hostname: esxi_hostname
     username: root
     password: your_password
@@ -54,6 +52,7 @@ EXAMPLES = '''
     dns_servers:
         - 8.8.8.8
         - 8.8.4.4
+  delegate_to: localhost
 '''
 try:
     from pyVmomi import vim, vmodl

--- a/lib/ansible/modules/cloud/vmware/vmware_drs_rule_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_drs_rule_facts.py
@@ -49,6 +49,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     cluster_name: cluster_name
+  delegate_to: localhost
   register: cluster_drs_facts
 
 - name: Gather DRS facts about all Clusters in given datacenter
@@ -57,6 +58,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     datacenter: datacenter_name
+  delegate_to: localhost
   register: datacenter_drs_facts
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_host.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_host.py
@@ -54,8 +54,7 @@ extends_documentation_fragment: vmware.documentation
 
 EXAMPLES = '''
 - name: Add Host to dVS
-  local_action:
-    module: vmware_dvs_host
+  vmware_dvs_host:
     hostname: vcenter_ip_or_hostname
     username: vcenter_username
     password: vcenter_password
@@ -65,6 +64,7 @@ EXAMPLES = '''
         - vmnic0
         - vmnic1
     state: present
+  delegate_to: localhost
 '''
 
 try:

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -151,6 +151,7 @@ EXAMPLES = '''
         num_ports: 120
         portgroup_type: earlyBinding
         state: present
+     delegate_to: localhost
 
    - name: Create vlan trunk portgroup
      connection: local
@@ -165,6 +166,7 @@ EXAMPLES = '''
         num_ports: 120
         portgroup_type: earlyBinding
         state: present
+     delegate_to: localhost
 
    - name: Create no-vlan portgroup
      connection: local
@@ -178,6 +180,7 @@ EXAMPLES = '''
         num_ports: 120
         portgroup_type: earlyBinding
         state: present
+     delegate_to: localhost
 
    - name: Create vlan portgroup with all security and port policies
      connection: local
@@ -207,6 +210,7 @@ EXAMPLES = '''
           uplink_teaming_override: yes
           vendor_config_override: yes
           vlan_override: yes
+     delegate_to: localhost
 '''
 
 try:

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -75,8 +75,7 @@ extends_documentation_fragment: vmware.documentation
 '''
 EXAMPLES = '''
 - name: Create dvswitch
-  local_action:
-    module: vmware_dvswitch
+  vmware_dvswitch:
     hostname: vcenter_ip_or_hostname
     username: vcenter_username
     password: vcenter_password
@@ -88,6 +87,7 @@ EXAMPLES = '''
     discovery_proto: lldp
     discovery_operation: both
     state: present
+  delegate_to: localhost
 '''
 
 try:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -458,6 +458,7 @@ EXAMPLES = r'''
       dns_suffix:
         - example.com
         - example2.com
+  delegate_to: localhost
 
 - name: Rename a virtual machine (requires the virtual machine's uuid)
   vmware_guest:
@@ -496,6 +497,7 @@ EXAMPLES = r'''
         value: 10.10.10.1
       - id: old_property
         operation: remove
+  delegate_to: localhost
 
 - name: Set powerstate of a virtual machine to poweroff by using UUID
   vmware_guest:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
@@ -92,6 +92,7 @@ EXAMPLES = r'''
       - cdrom
       - ethernet
       - disk
+  delegate_to: localhost
   register: vm_boot_order
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
@@ -51,6 +51,7 @@ EXAMPLES = r'''
     password: vmware
     validate_certs: no
     name: testvm
+  delegate_to: localhost
   register: vm_folder
 
 - name: Find Guest's Folder using UUID
@@ -60,6 +61,7 @@ EXAMPLES = r'''
     password: vmware
     validate_certs: no
     uuid: 38c4c89c-b3d7-4ae6-ae4e-43c5118eae49
+  delegate_to: localhost
   register: vm_folder
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
@@ -75,6 +75,7 @@ EXAMPLES = r'''
     validate_certs: False
     name: testvm-1
     dest_folder: datacenter/vm/prodvms
+  delegate_to: localhost
 
 - name: Get VM UUID
   vmware_guest_facts:
@@ -85,6 +86,7 @@ EXAMPLES = r'''
     datacenter: "{{ datacenter }}"
     folder: "/{{datacenter}}/vm"
     name: "{{ vm_name }}"
+  delegate_to: localhost
   register: vm_facts
 
 - name: Get UUID from previous task and pass it to this task
@@ -93,9 +95,9 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: no
+    datacenter: "{{ datacenter }}"
     uuid: "{{ vm_facts.instance.hw_product_uuid }}"
     dest_folder: "/DataCenter/vm/path/to/new/folder/where/we/want"
-  datacenter: "{{ datacenter }}"
   delegate_to: localhost
   register: facts
 '''

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
@@ -69,6 +69,7 @@ EXAMPLES = '''
     datacenter: "{{ datacenter }}"
     folder: "/{{datacenter}}/vm"
     name: "{{ vm_name }}"
+  delegate_to: localhost
   register: vm_facts
 
 - name: Get UUID from previous task and pass it to this task

--- a/lib/ansible/modules/cloud/vmware/vmware_host.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host.py
@@ -112,6 +112,7 @@ EXAMPLES = r'''
     esxi_username: '{{ esxi_username }}'
     esxi_password: '{{ esxi_password }}'
     state: present
+  delegate_to: localhost
 
 - name: Add ESXi Host to vCenter under a specific folder
   vmware_host:
@@ -125,6 +126,7 @@ EXAMPLES = r'''
     esxi_password: '{{ esxi_password }}'
     state: present
     add_connected: True
+  delegate_to: localhost
 
 - name: Reconnect ESXi Host (with username/password set)
   vmware_host:
@@ -137,6 +139,7 @@ EXAMPLES = r'''
     esxi_username: '{{ esxi_username }}'
     esxi_password: '{{ esxi_password }}'
     state: reconnect
+  delegate_to: localhost
 
 - name: Reconnect ESXi Host (with default username/password)
   vmware_host:
@@ -147,6 +150,7 @@ EXAMPLES = r'''
     cluster_name: cluster_name
     esxi_hostname: '{{ esxi_hostname }}'
     state: reconnect
+  delegate_to: localhost
 
 - name: Add ESXi Host with SSL Thumbprint to vCenter
   vmware_host:
@@ -160,6 +164,7 @@ EXAMPLES = r'''
     esxi_password: '{{ esxi_password }}'
     esxi_ssl_thumbprint: "3C:A5:60:6F:7A:B7:C4:6C:48:28:3D:2F:A5:EC:A3:58:13:88:F6:DD"
     state: present
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/cloud/vmware/vmware_host_acceptance.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_acceptance.py
@@ -68,6 +68,7 @@ EXAMPLES = r'''
     cluster_name: cluster_name
     acceptance_level: 'community'
     state: present
+  delegate_to: localhost
   register: cluster_acceptance_level
 
 - name: Set acceptance level to vmware_accepted for the given ESXi Host
@@ -78,6 +79,7 @@ EXAMPLES = r'''
     esxi_hostname: '{{ esxi_hostname }}'
     acceptance_level: 'vmware_accepted'
     state: present
+  delegate_to: localhost
   register: host_acceptance_level
 
 - name: Get acceptance level from the given ESXi Host
@@ -87,6 +89,7 @@ EXAMPLES = r'''
     password: '{{ vcenter_password }}'
     esxi_hostname: '{{ esxi_hostname }}'
     state: list
+  delegate_to: localhost
   register: host_acceptance_level
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_host_capability_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_capability_facts.py
@@ -46,6 +46,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     cluster_name: cluster_name
+  delegate_to: localhost
   register: all_cluster_hosts_facts
 
 - name: Gather capability facts about ESXi Host
@@ -54,6 +55,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     esxi_hostname: '{{ esxi_hostname }}'
+  delegate_to: localhost
   register: hosts_facts
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_host_config_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_config_facts.py
@@ -46,6 +46,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     cluster_name: cluster_name
+  delegate_to: localhost
 
 - name: Gather facts about ESXi Host
   vmware_host_config_facts:
@@ -53,6 +54,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     esxi_hostname: '{{ esxi_hostname }}'
+  delegate_to: localhost
 '''
 
 RETURN = r'''#

--- a/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
@@ -55,6 +55,7 @@ EXAMPLES = r'''
     cluster_name: cluster_name
     options:
         'Config.HostAgent.log.level': 'info'
+  delegate_to: localhost
 
 - name: Manage Log level setting for an ESXi Host
   vmware_host_config_manager:
@@ -64,6 +65,7 @@ EXAMPLES = r'''
     esxi_hostname: '{{ esxi_hostname }}'
     options:
         'Config.HostAgent.log.level': 'verbose'
+  delegate_to: localhost
 
 - name: Manage multiple settings for an ESXi Host
   vmware_host_config_manager:
@@ -75,6 +77,7 @@ EXAMPLES = r'''
         'Config.HostAgent.log.level': 'verbose'
         'Annotations.WelcomeMessage': 'Hello World'
         'Config.HostAgent.plugins.solo.enableMob': false
+  delegate_to: localhost
 '''
 
 RETURN = r'''#

--- a/lib/ansible/modules/cloud/vmware/vmware_host_dns_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_dns_facts.py
@@ -48,6 +48,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     cluster_name: cluster_name
+  delegate_to: localhost
 
 - name: Gather DNS facts about ESXi Host
   vmware_host_dns_facts:
@@ -55,6 +56,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     esxi_hostname: '{{ esxi_hostname }}'
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/cloud/vmware/vmware_host_firewall_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_firewall_facts.py
@@ -46,6 +46,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     cluster_name: cluster_name
+  delegate_to: localhost
 
 - name: Gather firewall facts about ESXi Host
   vmware_host_firewall_facts:
@@ -53,6 +54,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     esxi_hostname: '{{ esxi_hostname }}'
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
@@ -58,6 +58,7 @@ EXAMPLES = r'''
     rules:
         - name: vvold
           enabled: True
+  delegate_to: localhost
 
 - name: Enable vvold rule set for an ESXi Host
   vmware_host_firewall_manager:
@@ -68,6 +69,7 @@ EXAMPLES = r'''
     rules:
         - name: vvold
           enabled: True
+  delegate_to: localhost
 
 - name: Manage multiple rule set for an ESXi Host
   vmware_host_firewall_manager:
@@ -80,6 +82,7 @@ EXAMPLES = r'''
           enabled: True
         - name: CIMHttpServer
           enabled: False
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/cloud/vmware/vmware_host_lockdown.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_lockdown.py
@@ -62,6 +62,7 @@ EXAMPLES = r'''
     password: '{{ vcenter_password }}'
     esxi_hostname: '{{ esxi_hostname }}'
     state: present
+  delegate_to: localhost
 
 - name: Exit host systems from lockdown mode
   vmware_host_lockdown:
@@ -70,6 +71,7 @@ EXAMPLES = r'''
     password: '{{ vcenter_password }}'
     esxi_hostname: '{{ esxi_hostname }}'
     state: absent
+  delegate_to: localhost
 
 - name: Enter host systems into lockdown mode
   vmware_host_lockdown:
@@ -80,6 +82,7 @@ EXAMPLES = r'''
         - '{{ esxi_hostname_1 }}'
         - '{{ esxi_hostname_2 }}'
     state: present
+  delegate_to: localhost
 
 - name: Exit host systems from lockdown mode
   vmware_host_lockdown:
@@ -90,6 +93,7 @@ EXAMPLES = r'''
         - '{{ esxi_hostname_1 }}'
         - '{{ esxi_hostname_2 }}'
     state: absent
+  delegate_to: localhost
 
 - name: Enter all host system from cluster into lockdown mode
   vmware_host_lockdown:
@@ -98,6 +102,7 @@ EXAMPLES = r'''
     password: '{{ vcenter_password }}'
     cluster_name: '{{ cluster_name }}'
     state: present
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
@@ -64,6 +64,7 @@ EXAMPLES = r'''
     ntp_servers:
         - 0.pool.ntp.org
         - 1.pool.ntp.org
+  delegate_to: localhost
 
 - name: Set NTP setting for an ESXi Host
   vmware_host_ntp:
@@ -75,6 +76,7 @@ EXAMPLES = r'''
     ntp_servers:
         - 0.pool.ntp.org
         - 1.pool.ntp.org
+  delegate_to: localhost
 
 - name: Remove NTP setting for an ESXi Host
   vmware_host_ntp:
@@ -85,6 +87,7 @@ EXAMPLES = r'''
     state: absent
     ntp_servers:
         - bad.server.ntp.org
+  delegate_to: localhost
 '''
 
 RETURN = r'''#

--- a/lib/ansible/modules/cloud/vmware/vmware_host_package_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_package_facts.py
@@ -48,6 +48,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     cluster_name: cluster_name
+  delegate_to: localhost
   register: cluster_host_packages
 
 - name: Gather facts about ESXi Host
@@ -56,6 +57,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     esxi_hostname: '{{ esxi_hostname }}'
+  delegate_to: localhost
   register: host_packages
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_host_powerstate.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_powerstate.py
@@ -96,7 +96,6 @@ EXAMPLES = r'''
     state: reboot-host
   delegate_to: localhost
   register: reboot_host
-
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/cloud/vmware/vmware_host_service_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_service_facts.py
@@ -48,6 +48,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     cluster_name: cluster_name
+  delegate_to: localhost
   register: cluster_host_services
 
 - name: Gather facts about ESXi Host
@@ -56,6 +57,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     esxi_hostname: '{{ esxi_hostname }}'
+  delegate_to: localhost
   register: host_services
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_host_service_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_service_manager.py
@@ -71,6 +71,7 @@ EXAMPLES = r'''
     cluster_name: cluster_name
     service_name: ntpd
     state: present
+  delegate_to: localhost
 
 - name: Start ntpd setting for an ESXi Host
   vmware_host_service_manager:
@@ -80,6 +81,7 @@ EXAMPLES = r'''
     esxi_hostname: '{{ esxi_hostname }}'
     service_name: ntpd
     state: present
+  delegate_to: localhost
 
 - name: Start ntpd setting for an ESXi Host with Service policy
   vmware_host_service_manager:
@@ -90,6 +92,7 @@ EXAMPLES = r'''
     service_name: ntpd
     service_policy: on
     state: present
+  delegate_to: localhost
 
 - name: Stop ntpd setting for an ESXi Host
   vmware_host_service_manager:
@@ -99,6 +102,7 @@ EXAMPLES = r'''
     esxi_hostname: '{{ esxi_hostname }}'
     service_name: ntpd
     state: absent
+  delegate_to: localhost
 '''
 
 RETURN = r'''#

--- a/lib/ansible/modules/cloud/vmware/vmware_host_vmnic_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_vmnic_facts.py
@@ -52,6 +52,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     cluster_name: cluster_name
+  delegate_to: localhost
   register: cluster_host_vmnics
 
 - name: Gather facts about vmnics of an ESXi Host
@@ -60,6 +61,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     esxi_hostname: '{{ esxi_hostname }}'
+  delegate_to: localhost
   register: host_vmnics
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_local_role_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_local_role_manager.py
@@ -63,6 +63,7 @@ EXAMPLES = '''
       password: vmware
       local_role_name: vmware_qa
       state: present
+  delegate_to: localhost
 
 - name: Add local role with privileges to ESXi
   vmware_local_role_manager:
@@ -72,6 +73,7 @@ EXAMPLES = '''
       local_role_name: vmware_qa
       local_privilege_ids: [ 'Folder.Create', 'Folder.Delete']
       state: present
+  delegate_to: localhost
 
 - name: Remove local role from ESXi
   vmware_local_role_manager:
@@ -80,6 +82,7 @@ EXAMPLES = '''
       password: vmware
       local_role_name: vmware_qa
       state: absent
+  delegate_to: localhost
 
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_local_user_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_local_user_facts.py
@@ -39,6 +39,7 @@ EXAMPLES = r'''
     hostname: esxi_hostname
     username: root
     password: vmware
+  delegate_to: localhost
   register: all_user_facts
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_local_user_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_local_user_manager.py
@@ -54,14 +54,13 @@ extends_documentation_fragment: vmware.documentation
 '''
 
 EXAMPLES = '''
-# Example vmware_local_user_manager command from Ansible Playbooks
 - name: Add local user to ESXi
-  local_action:
-      module: vmware_local_user_manager
-      hostname: esxi_hostname
-      username: root
-      password: vmware
-      local_user_name: foo
+  vmware_local_user_manager:
+    hostname: esxi_hostname
+    username: root
+    password: vmware
+    local_user_name: foo
+  delegate_to: localhost
 '''
 
 RETURN = '''# '''

--- a/lib/ansible/modules/cloud/vmware/vmware_maintenancemode.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_maintenancemode.py
@@ -78,6 +78,7 @@ EXAMPLES = '''
     evacuate: yes
     timeout: 3600
     state: present
+  delegate_to: localhost
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/vmware/vmware_migrate_vmk.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_migrate_vmk.py
@@ -55,20 +55,18 @@ extends_documentation_fragment: vmware.documentation
 '''
 
 EXAMPLES = '''
-# Example from Ansible playbook
-
-    - name: Migrate Management vmk
-      local_action:
-        module: vmware_migrate_vmk
-        hostname: vcsa_host
-        username: vcsa_user
-        password: vcsa_pass
-        esxi_hostname: esxi_hostname
-        device: vmk1
-        current_switch_name: temp_vswitch
-        current_portgroup_name: esx-mgmt
-        migrate_switch_name: dvSwitch
-        migrate_portgroup_name: Management
+- name: Migrate Management vmk
+  vmware_migrate_vmk:
+    hostname: vcsa_host
+    username: vcsa_user
+    password: vcsa_pass
+    esxi_hostname: esxi_hostname
+    device: vmk1
+    current_switch_name: temp_vswitch
+    current_portgroup_name: esx-mgmt
+    migrate_switch_name: dvSwitch
+    migrate_portgroup_name: Management
+  delegate_to: localhost
 '''
 try:
     from pyVmomi import vim, vmodl

--- a/lib/ansible/modules/cloud/vmware/vmware_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_portgroup.py
@@ -110,6 +110,7 @@ EXAMPLES = r'''
     switch_name: vswitch_name
     portgroup_name: portgroup_name
     vlan_id: vlan_id
+  delegate_to: localhost
 
 - name: Add Portgroup with Promiscuous Mode Enabled
   vmware_portgroup:
@@ -120,6 +121,7 @@ EXAMPLES = r'''
     portgroup_name: portgroup_name
     network_policy:
         promiscuous_mode: True
+  delegate_to: localhost
 
 - name: Add Management Network VM Portgroup to specific hosts
   vmware_portgroup:
@@ -130,6 +132,7 @@ EXAMPLES = r'''
     switch_name: vswitch_name
     portgroup_name: portgroup_name
     vlan_id: vlan_id
+  delegate_to: localhost
 
 - name: Add Management Network VM Portgroup to all hosts in a cluster
   vmware_portgroup:
@@ -140,6 +143,7 @@ EXAMPLES = r'''
     switch_name: vswitch_name
     portgroup_name: portgroup_name
     vlan_id: vlan_id
+  delegate_to: localhost
 
 - name: Remove Management Network VM Portgroup to all hosts in a cluster
   vmware_portgroup:
@@ -151,6 +155,7 @@ EXAMPLES = r'''
     portgroup_name: portgroup_name
     vlan_id: vlan_id
     state: absent
+  delegate_to: localhost
 
 - name: Add Portgroup with teaming policy
   vmware_portgroup:
@@ -162,6 +167,7 @@ EXAMPLES = r'''
     teaming_policy:
       load_balance_policy: 'failover_explicit'
       inbound_policy: True
+  delegate_to: localhost
   register: teaming_result
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_portgroup_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_portgroup_facts.py
@@ -47,6 +47,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     cluster_name: cluster_name
+  delegate_to: localhost
 
 - name: Gather portgroup facts about ESXi Host system
   vmware_portgroup_facts:
@@ -54,6 +55,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     esxi_hostname: '{{ esxi_hostname }}'
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/cloud/vmware/vmware_resource_pool.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_resource_pool.py
@@ -113,6 +113,7 @@ EXAMPLES = '''
       cpu_reservation: 0
       cpu_expandable_reservations: True
       state: present
+    delegate_to: localhost
 '''
 
 RETURN = """

--- a/lib/ansible/modules/cloud/vmware/vmware_tag.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_tag.py
@@ -73,6 +73,7 @@ EXAMPLES = r'''
     tag_name: Sample_Tag_0002
     tag_description: Sample Description
     state: present
+  delegate_to: localhost
 
 - name: Update tag description
   vmware_tag:
@@ -83,6 +84,7 @@ EXAMPLES = r'''
     tag_name: Sample_Tag_0002
     tag_description: Some fancy description
     state: present
+  delegate_to: localhost
 
 - name: Delete tag
   vmware_tag:
@@ -92,6 +94,7 @@ EXAMPLES = r'''
     validate_certs: False
     tag_name: Sample_Tag_0002
     state: absent
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/cloud/vmware/vmware_tag_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_tag_facts.py
@@ -43,6 +43,7 @@ EXAMPLES = r'''
     username: administrator@vsphere.local
     password: Esxi@123$
     validate_certs: False
+  delegate_to: localhost
 
 - name: Get category id from the given tag
   vmware_tag_facts:
@@ -50,6 +51,7 @@ EXAMPLES = r'''
     username: administrator@vsphere.local
     password: Esxi@123$
     validate_certs: False
+  delegate_to: localhost
   register: tag_details
 
 - debug:

--- a/lib/ansible/modules/cloud/vmware/vmware_target_canonical_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_target_canonical_facts.py
@@ -51,29 +51,29 @@ extends_documentation_fragment: vmware.documentation
 
 EXAMPLES = '''
 - name: Get Canonical name of particular target on particular ESXi host system
-  local_action:
-    module: vmware_target_canonical_facts
+  vmware_target_canonical_facts:
     hostname: vcenter_hostname
     username: vcenter_user
     password: vcenter_pass
     target_id: 7
     esxi_hostname: esxi_hostname
+  delegate_to: localhost
 
 - name: Get Canonical name of all target on particular ESXi host system
-  local_action:
-    module: vmware_target_canonical_facts
+  vmware_target_canonical_facts:
     hostname: vcenter_hostname
     username: vcenter_user
     password: vcenter_pass
     esxi_hostname: esxi_hostname
+  delegate_to: localhost
 
 - name: Get Canonical name of all ESXi hostname on particular Cluster
-  local_action:
-    module: vmware_target_canonical_facts
+  vmware_target_canonical_facts:
     hostname: vcenter_hostname
     username: vcenter_user
     password: vcenter_pass
     cluster_name: cluster_name
+  delegate_to: localhost
 '''
 
 RETURN = r"""

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_vm_drs_rule.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_vm_drs_rule.py
@@ -85,6 +85,7 @@ EXAMPLES = r'''
     enabled: True
     mandatory: True
     affinity_rule: True
+  delegate_to: localhost
 
 - name: Create DRS Anti-Affinity Rule for VM-VM
   vmware_vm_vm_drs_rule:
@@ -100,6 +101,7 @@ EXAMPLES = r'''
     enabled: True
     mandatory: True
     affinity_rule: False
+  delegate_to: localhost
 
 - name: Delete DRS Affinity Rule for VM-VM
   vmware_vm_vm_drs_rule:
@@ -110,6 +112,7 @@ EXAMPLES = r'''
     validate_certs: no
     drs_rule_name: vm1-vm2-affinity-rule-001
     state: absent
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_vss_dvs_migrate.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_vss_dvs_migrate.py
@@ -39,13 +39,13 @@ extends_documentation_fragment: vmware.documentation
 
 EXAMPLES = '''
 - name: Migrate VCSA to vDS
-  local_action:
-    module: vmware_vm_vss_dvs_migrate
+  vmware_vm_vss_dvs_migrate:
     hostname: vcenter_ip_or_hostname
     username: vcenter_username
     password: vcenter_password
     vm_name: virtual_machine_name
     dvportgroup_name: distributed_portgroup_name
+  delegate_to: localhost
 '''
 
 try:

--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
@@ -128,6 +128,7 @@ EXAMPLES = '''
         subnet_mask: 255.255.255.0
       state: present
       enable_mgmt: True
+   delegate_to: localhost
 
 -  name: Add Management vmkernel port using DHCP network type
    vmware_vmkernel:
@@ -141,6 +142,7 @@ EXAMPLES = '''
       network:
         type: 'dhcp'
       enable_mgmt: True
+   delegate_to: localhost
 
 -  name: Delete VMkernel port using DHCP network type
    vmware_vmkernel:
@@ -151,7 +153,7 @@ EXAMPLES = '''
       portgroup_name: PG_0002
       vlan_id: vlan_id
       state: absent
-
+   delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel_facts.py
@@ -48,6 +48,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     cluster_name: cluster_name
+  delegate_to: localhost
   register: cluster_host_vmks
 
 - name: Gather VMKernel facts about ESXi Host
@@ -56,6 +57,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     esxi_hostname: '{{ esxi_hostname }}'
+  delegate_to: localhost
   register: host_vmks
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel_ip_config.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel_ip_config.py
@@ -46,14 +46,14 @@ EXAMPLES = '''
 # Example command from Ansible Playbook
 
 - name: Configure IP address on ESX host
-  local_action:
-    module: vmware_vmkernel_ip_config
+  vmware_vmkernel_ip_config:
     hostname: esxi_hostname
     username: esxi_username
     password: esxi_password
     vmk_name: vmk0
     ip_address: 10.0.0.10
     subnet_mask: 255.255.255.0
+  delegate_to: localhost
 '''
 
 try:

--- a/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -69,6 +69,7 @@ EXAMPLES = '''
     validate_certs: False
     vm_name: 'vm_name_as_per_vcenter'
     destination_host: 'destination_host_as_per_vcenter'
+  delegate_to: localhost
 
 - name: Perform storage vMotion of of virtual machine
   vmware_vmotion:
@@ -78,6 +79,7 @@ EXAMPLES = '''
     validate_certs: False
     vm_name: 'vm_name_as_per_vcenter'
     destination_datastore: 'destination_datastore_as_per_vcenter'
+  delegate_to: localhost
 
 - name: Perform storage vMotion and host vMotion of virtual machine
   vmware_vmotion:
@@ -88,6 +90,7 @@ EXAMPLES = '''
     vm_name: 'vm_name_as_per_vcenter'
     destination_host: 'destination_host_as_per_vcenter'
     destination_datastore: 'destination_datastore_as_per_vcenter'
+  delegate_to: localhost
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/vmware/vmware_vsan_cluster.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vsan_cluster.py
@@ -47,6 +47,7 @@ EXAMPLES = '''
          hostname: "{{ groups['esxi'][0] }}"
          username: "{{ esxi_username }}"
          password: "{{ site_password }}"
+      delegate_to: localhost
       register: vsan_cluster
 
     - name: Configure VSAN on remaining hosts
@@ -55,8 +56,8 @@ EXAMPLES = '''
          username: "{{ esxi_username }}"
          password: "{{ site_password }}"
          cluster_uuid: "{{ vsan_cluster.cluster_uuid }}"
+      delegate_to: localhost
       with_items: "{{ groups['esxi'][1:] }}"
-
 '''
 
 try:

--- a/lib/ansible/modules/cloud/vmware/vmware_vswitch_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vswitch_facts.py
@@ -46,6 +46,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     cluster_name: cluster_name
+    delegate_to: localhost
   register: all_hosts_vswitch_facts
 
 - name: Gather firewall facts about ESXi Host
@@ -54,6 +55,7 @@ EXAMPLES = r'''
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     esxi_hostname: '{{ esxi_hostname }}'
+    delegate_to: localhost
   register: all_vswitch_facts
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vsphere_copy.py
+++ b/lib/ansible/modules/cloud/vmware/vsphere_copy.py
@@ -74,7 +74,7 @@ EXAMPLES = '''
     datacenter: DC1 Someplace
     datastore: datastore1
     path: some/remote/file
-  transport: local
+  delegate_to: localhost
 
 - vsphere_copy:
     host: vhost


### PR DESCRIPTION
##### SUMMARY
Some users have problems using the VMware modules because they use the vCenter as target, and Ansible uses SSH to connect to the targets.

(We should backport to v2.6 and v2.5 too)

The reason for preferring `delegate_to: localhost` over `connection: local` or an inventory-based solution is that this makes it very obvious from the examples that the modules are not run on the target. Which is fundamental to understand how it currently works.

Obviously at some point we want to:
- Document this in the VMware guide (explain `connection` vs `delegate_to`) with examples #43430
- Document how this can be done from the inventory #43430
- Link the VMware guide from every VMware-related module #43433
- Implement a VMware connection plugin and retire the `hostname`, `port`, `username`, `password` and  `validate_certs` parameters #43428 

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
VMware modules

##### ANSIBLE VERSION
v2.7 and older