### PR TITLE
Update openstack inventory script to keep basic functionality

### DIFF
--- a/contrib/inventory/openstack_inventory.py
+++ b/contrib/inventory/openstack_inventory.py
@@ -57,6 +57,7 @@ import os
 import sys
 import time
 from distutils.version import StrictVersion
+from io import StringIO
 
 try:
     import json
@@ -81,7 +82,8 @@ def get_groups_from_server(server_vars, namegroup=True):
     groups.append(cloud)
 
     # Create a group on region
-    groups.append(region)
+    if region:
+        groups.append(region)
 
     # And one by cloud_region
     groups.append("%s_%s" % (cloud, region))
@@ -235,6 +237,8 @@ def parse_args():
 def main():
     args = parse_args()
     try:
+        # openstacksdk library may write to stdout, so redirect this
+        sys.stdout = StringIO()
         config_files = cloud_config.CONFIG_FILES + CONFIG_FILES
         sdk.enable_logging(debug=args.debug)
         inventory_args = dict(
@@ -255,6 +259,7 @@ def main():
 
         inventory = sdk_inventory.OpenStackInventory(**inventory_args)
 
+        sys.stdout = sys.__stdout__
         if args.list:
             output = get_host_groups(inventory, refresh=args.refresh, cloud=args.cloud)
         elif args.host:


### PR DESCRIPTION
re-applies commit 6667ec447466abf1641787afccf9175369319d1f which
fixed the plugin to the script so that it will work with current
ansible-inventory.

Also redirect stdout before dumping the ouptput, because not doing
so will cause JSON parse errors in some cases.

Resolves https://github.com/ansible/ansible/issues/43427

##### SUMMARY
There are 2 separate issues, first issue is the group with `""` name.

Second issue is that after upgrading the openstack script, I was getting output that looked like the following:

```
Keystone catalog entry not found (service_type=network,service_name=Noneinterface=public,region_name=)
Keystone catalog entry not found (service_type=network,service_name=Noneinterface=public,region_name=)
Keystone catalog entry not found (service_type=network,service_name=Noneinterface=public,region_name=)
Keystone catalog entry not found (service_type=network,service_name=Noneinterface=public,region_name=)
Keystone catalog entry not found (service_type=network,service_name=Noneinterface=public,region_name=)
Keystone catalog entry not found (service_type=network,service_name=Noneinterface=public,region_name=)
Keystone catalog entry not found (service_type=network,service_name=Noneinterface=public,region_name=)
Keystone catalog entry not found (service_type=network,service_name=Noneinterface=public,region_name=)
Keystone catalog entry not found (service_type=network,service_name=Noneinterface=public,region_name=)
Keystone catalog entry not found (service_type=network,service_name=Noneinterface=public,region_name=)
Keystone catalog entry not found (service_type=network,service_name=Noneinterface=public,region_name=)
Keystone catalog entry not found (service_type=network,service_name=Noneinterface=public,region_name=)
{
  "_meta": {
    "hostvars": {
```

So I'm re-directing stdout in this PR. I don't know if this is acceptable, but I don't see any other clear way around this.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/openstack_inventory.py

##### ANSIBLE VERSION
Would like fix cherry-picked to 2.6


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
