### PR TITLE
Autoselect datastore only from the given cluster/ESXi

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -139,7 +139,7 @@ def find_object_by_name(content, name, obj_type, folder=None, recurse=True):
 
 def find_cluster_by_name(content, cluster_name, datacenter=None):
 
-    if datacenter:
+    if datacenter and hasattr(datacenter, 'hostFolder'):
         folder = datacenter.hostFolder
     else:
         folder = content.rootFolder

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -2158,10 +2158,24 @@ class PyVmomiHelper(PyVmomi):
         if len(self.params['disk']) != 0:
             # TODO: really use the datastore for newly created disks
             if 'autoselect_datastore' in self.params['disk'][0] and self.params['disk'][0]['autoselect_datastore']:
-                datastores = self.cache.get_all_objs(self.content, [vim.Datastore])
-                datastores = [x for x in datastores if self.cache.get_parent_datacenter(x).name == self.params['datacenter']]
-                if datastores is None or len(datastores) == 0:
-                    self.module.fail_json(msg="Unable to find a datastore list when autoselecting")
+                datastores = []
+
+                if self.params['cluster']:
+                    cluster = self.find_cluster_by_name(self.params['cluster'], self.content)
+
+                    for host in cluster.host:
+                        for mi in host.configManager.storageSystem.fileSystemVolumeInfo.mountInfo:
+                            if mi.volume.type == "VMFS":
+                                datastores.append(self.cache.find_obj(self.content, [vim.Datastore], mi.volume.name))
+                elif self.params['esxi_hostname']:
+                    host = self.find_hostsystem_by_name(self.params['esxi_hostname'])
+
+                    for mi in host.configManager.storageSystem.fileSystemVolumeInfo.mountInfo:
+                        if mi.volume.type == "VMFS":
+                            datastores.append(self.cache.find_obj(self.content, [vim.Datastore], mi.volume.name))
+                else:
+                    datastores = self.cache.get_all_objs(self.content, [vim.Datastore])
+                    datastores = [x for x in datastores if self.cache.get_parent_datacenter(x).name == self.params['datacenter']]
 
                 datastore_freespace = 0
                 for ds in datastores:

--- a/test/integration/targets/vmware_guest/tasks/clone_resize_disks.yml
+++ b/test/integration/targets/vmware_guest/tasks/clone_resize_disks.yml
@@ -2,74 +2,76 @@
 # Copyright: (c) 2019, Noe Gonzalez <noe.a.gonzalez@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: create new VM
-  vmware_guest:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    name: clone_resize_disks_original
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    folder: "{{ f0 }}"
-    hardware:
-      num_cpus: 1
-      memory_mb: 128
-    guest_id: centos7_64Guest
-    disk:
-      - size_gb: 1
-        type: thin
-        datastore: "{{ rw_datastore }}"
-    state: poweredoff
+- when: vcsim is not defined
+  block:
+    - name: create new VM
+      vmware_guest:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        name: clone_resize_disks_original
+        datacenter: "{{ dc1 }}"
+        cluster: "{{ ccr1 }}"
+        folder: "{{ f0 }}"
+        hardware:
+          num_cpus: 1
+          memory_mb: 128
+        guest_id: centos7_64Guest
+        disk:
+          - size_gb: 1
+            type: thin
+            datastore: "{{ rw_datastore }}"
+        state: poweredoff
 
-- name: convert to VM template
-  vmware_guest:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    name: clone_resize_disks_original
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    folder: "{{ f0 }}"
-    is_template: True
+    - name: convert to VM template
+      vmware_guest:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        name: clone_resize_disks_original
+        datacenter: "{{ dc1 }}"
+        cluster: "{{ ccr1 }}"
+        folder: "{{ f0 }}"
+        is_template: True
 
-- name: clone template and modify disks
-  vmware_guest:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    name: clone_resize_disks_clone
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    folder: "{{ f0 }}"
-    disk:
-      - size_gb: 2
-        type: thin
-        datastore: "{{ rw_datastore }}"
-      - size_gb: 3
-        type: thin
-        datastore: "{{ rw_datastore }}"
-    template: clone_resize_disks_original
-    state: poweredoff
-  register: l_clone_template_modify_disks
+    - name: clone template and modify disks
+      vmware_guest:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        name: clone_resize_disks_clone
+        datacenter: "{{ dc1 }}"
+        cluster: "{{ ccr1 }}"
+        folder: "{{ f0 }}"
+        disk:
+          - size_gb: 2
+            type: thin
+            datastore: "{{ rw_datastore }}"
+          - size_gb: 3
+            type: thin
+            datastore: "{{ rw_datastore }}"
+        template: clone_resize_disks_original
+        state: poweredoff
+      register: l_clone_template_modify_disks
 
-- assert:
-    that:
-      - l_clone_template_modify_disks.changed | bool
+    - assert:
+        that:
+          - l_clone_template_modify_disks.changed | bool
 
-- name: delete VM clone & original template
-  vmware_guest:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    name: "{{ item }}"
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    folder: "{{ f0 }}"
-    state: absent
-  with_items:
-    - clone_resize_disks_original
-    - clone_resize_disks_clone
+    - name: delete VM clone & original template
+      vmware_guest:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        name: "{{ item }}"
+        datacenter: "{{ dc1 }}"
+        cluster: "{{ ccr1 }}"
+        folder: "{{ f0 }}"
+        state: absent
+      with_items:
+        - clone_resize_disks_original
+        - clone_resize_disks_clone


### PR DESCRIPTION
##### SUMMARY
In the `vmware_guest` module, when `autoselect_datastore` is set with any of the disks, the biggest datastore is chosen from all available datastores in that datacenter. This can be problematic if there is multiple clusters in the same datacenter because not all datastores might be available across all clusters.

This PR adding is addressing the issue and allow to auto-select datastores only from the specified cluster or ESXi host.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
`vmware_guest`

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.6 (default, Jun 27 2018, 13:11:40) [GCC 8.1.1 20180531]
```

##### ADDITIONAL INFORMATION
None