### PR TITLE
Fix all ACI examples to use delegate_to

### DIFF
--- a/lib/ansible/modules/network/aci/aci_aaa_user.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user.py
@@ -101,6 +101,7 @@ EXAMPLES = r'''
     first_name: Dag
     last_name: Wieers
     state: present
+  delegate_to: localhost
 
 - name: Remove a user
   aci_aaa_user:
@@ -109,6 +110,7 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     aaa_user: dag
     state: absent
+  delegate_to: localhost
 
 - name: Query a user
   aci_aaa_user:
@@ -117,6 +119,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     aaa_user: dag
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all users
   aci_aaa_user:
@@ -124,6 +128,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
@@ -62,6 +62,7 @@ EXAMPLES = r'''
     certificate_name: admin
     certificate_data: '{{ lookup("file", "pki/admin.crt") }}'
     state: present
+  delegate_to: localhost
 
 - name: Remove a certificate of a user
   aci_aaa_user_certificate:
@@ -71,6 +72,7 @@ EXAMPLES = r'''
     aaa_user: admin
     certificate_name: admin
     state: absent
+  delegate_to: localhost
 
 - name: Query a certificate of a user
   aci_aaa_user_certificate:
@@ -80,6 +82,8 @@ EXAMPLES = r'''
     aaa_user: admin
     certificate_name: admin
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all certificates of a user
   aci_aaa_user_certificate:
@@ -88,6 +92,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     aaa_user: admin
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -97,6 +97,7 @@ EXAMPLES = r'''
     toi_port: 16
     policy_group: policygroupname
     state: present
+  delegate_to: localhost
 
 - name: Associate an interface access port selector to an Interface Policy Leaf Profile (w/o policy group) (check if this works)
   aci_access_port_to_interface_policy_leaf_profile:
@@ -109,6 +110,7 @@ EXAMPLES = r'''
     from_port: 13
     to_port: 16
     state: present
+  delegate_to: localhost
 
 - name: Remove an interface access port selector associated with an Interface Policy Leaf Profile
   aci_access_port_to_interface_policy_leaf_profile:
@@ -118,6 +120,7 @@ EXAMPLES = r'''
     leaf_interface_profile: leafintprfname
     access_port_selector: accessportselectorname
     state: absent
+  delegate_to: localhost
 
 - name: Query Specific access_port_selector under given leaf_interface_profile
   aci_access_port_to_interface_policy_leaf_profile:
@@ -127,6 +130,8 @@ EXAMPLES = r'''
     leaf_interface_profile: leafintprfname
     access_port_selector: accessportselectorname
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_aep.py
+++ b/lib/ansible/modules/network/aci/aci_aep.py
@@ -60,6 +60,7 @@ EXAMPLES = r'''
     aep: ACI-AEP
     description: default
     state: present
+  delegate_to: localhost
 
 - name: Remove an existing AEP
   aci_aep:
@@ -68,6 +69,7 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     aep: ACI-AEP
     state: absent
+  delegate_to: localhost
 
 - name: Query all AEPs
   aci_aep:
@@ -75,6 +77,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query a specific AEP
   aci_aep:
@@ -83,6 +87,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     aep: ACI-AEP
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_aep_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_aep_to_domain.py
@@ -64,6 +64,7 @@ EXAMPLES = r'''
     domain: phys_dom
     domain_type: phys
     state: present
+  delegate_to: localhost
 
 - name: Remove AEP to domain binding
   aci_aep_to_domain: &binding_absent
@@ -74,6 +75,7 @@ EXAMPLES = r'''
     domain: phys_dom
     domain_type: phys
     state: absent
+  delegate_to: localhost
 
 - name: Query our AEP to domain binding
   aci_aep_to_domain:
@@ -84,6 +86,8 @@ EXAMPLES = r'''
     domain: phys_dom
     domain_type: phys
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all AEP to domain bindings
   aci_aep_to_domain: &binding_query
@@ -91,6 +95,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_ap.py
+++ b/lib/ansible/modules/network/aci/aci_ap.py
@@ -59,6 +59,7 @@ EXAMPLES = r'''
     ap: default
     description: default ap
     state: present
+  delegate_to: localhost
 
 - name: Remove an AP
   aci_ap:
@@ -68,6 +69,7 @@ EXAMPLES = r'''
     tenant: production
     ap: default
     state: absent
+  delegate_to: localhost
 
 - name: Query an AP
   aci_ap:
@@ -77,6 +79,8 @@ EXAMPLES = r'''
     tenant: production
     ap: default
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all APs
   aci_ap:
@@ -84,6 +88,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_bd.py
+++ b/lib/ansible/modules/network/aci/aci_bd.py
@@ -135,11 +135,12 @@ EXAMPLES = r'''
     username: "{{ username }}"
     password: "{{ password }}"
     validate_certs: no
-    state: present
     tenant: prod
     bd: web_servers
     mac_address: 00:22:BD:F8:19:FE
     vrf: prod_vrf
+    state: present
+  delegate_to: localhost
 
 - name: Add an FC Bridge Domain
   aci_bd:
@@ -147,12 +148,13 @@ EXAMPLES = r'''
     username: "{{ username }}"
     password: "{{ password }}"
     validate_certs: no
-    state: present
     tenant: prod
     bd: storage
     bd_type: fc
     vrf: fc_vrf
     enable_routing: no
+    state: present
+  delegate_to: localhost
 
 - name: Modify a Bridge Domain
   aci_bd:
@@ -160,11 +162,12 @@ EXAMPLES = r'''
     username: "{{ username }}"
     password: "{{ password }}"
     validate_certs: yes
-    state: present
     tenant: prod
     bd: web_servers
     arp_flooding: yes
     l2_unknown_unicast: flood
+    state: present
+  delegate_to: localhost
 
 - name: Query All Bridge Domains
   aci_bd:
@@ -173,6 +176,8 @@ EXAMPLES = r'''
     password: "{{ password }}"
     validate_certs: yes
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query a Bridge Domain
   aci_bd:
@@ -180,9 +185,11 @@ EXAMPLES = r'''
     username: "{{ username }}"
     password: "{{ password }}"
     validate_certs: yes
-    state: query
     tenant: prod
     bd: web_servers
+    state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Delete a Bridge Domain
   aci_bd:
@@ -190,9 +197,10 @@ EXAMPLES = r'''
     username: "{{ username }}"
     password: "{{ password }}"
     validate_certs: yes
-    state: absent
     tenant: prod
     bd: web_servers
+    state: absent
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_bd_subnet.py
+++ b/lib/ansible/modules/network/aci/aci_bd_subnet.py
@@ -113,6 +113,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     tenant: production
+    state: present
+  delegate_to: localhost
 
 - name: Create a bridge domain
   aci_bd:
@@ -121,6 +123,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     tenant: production
     bd: database
+    state: present
+  delegate_to: localhost
 
 - name: Create a subnet
   aci_bd_subnet:
@@ -131,6 +135,8 @@ EXAMPLES = r'''
     bd: database
     gateway: 10.1.1.1
     mask: 24
+    state: present
+  delegate_to: localhost
 
 - name: Create a subnet with options
   aci_bd_subnet:
@@ -146,6 +152,8 @@ EXAMPLES = r'''
     scope: public
     route_profile_l3_out: corp
     route_profile: corp_route_profile
+    state: present
+  delegate_to: localhost
 
 - name: Update a subnets scope to private and shared
   aci_bd_subnet:
@@ -157,6 +165,8 @@ EXAMPLES = r'''
     gateway: 10.1.1.1
     mask: 24
     scope: [private, shared]
+    state: present
+  delegate_to: localhost
 
 - name: Get all subnets
   aci_bd_subnet:
@@ -164,38 +174,44 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
 
 - name: Get all subnets of specific gateway in specified tenant
   aci_bd_subnet:
     host: apic
     username: admin
     password: SomeSecretPassword
-    state: query
     tenant: production
     gateway: 10.1.1.1
     mask: 24
+    state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Get specific subnet
   aci_bd_subnet:
     host: apic
     username: admin
     password: SomeSecretPassword
-    state: query
     tenant: production
     bd: database
     gateway: 10.1.1.1
     mask: 24
+    state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Delete a subnet
   aci_bd_subnet:
     host: apic
     username: admin
     password: SomeSecretPassword
-    state: absent
     tenant: production
     bd: database
     gateway: 10.1.1.1
     mask: 24
+    state: absent
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_config_rollback.py
+++ b/lib/ansible/modules/network/aci/aci_config_rollback.py
@@ -77,44 +77,47 @@ EXAMPLES = r'''
     host: apic
     username: admin
     password: SomeSecretPassword
-    state: present
     export_policy: config_backup
+    state: present
+  delegate_to: localhost
 
 - name: Query Existing Snapshots
   aci_config_snapshot:
     host: apic
     username: admin
     password: SomeSecretPassword
-    state: query
     export_policy: config_backup
+    state: query
+  delegate_to: localhost
 
 - name: Compare Snapshot Files
   aci_config_rollback:
     host: apic
     username: admin
     password: SomeSecretPassword
-    state: preview
     export_policy: config_backup
     snapshot: run-2017-08-28T06-24-01
     compare_export_policy: config_backup
     compare_snapshot: run-2017-08-27T23-43-56
+    state: preview
+  delegate_to: localhost
 
 - name: Rollback Configuration
   aci_config_rollback:
     host: apic
     username: admin
     password: SomeSecretPassword
-    state: rollback
     import_policy: rollback_config
     export_policy: config_backup
     snapshot: run-2017-08-28T06-24-01
+    state: rollback
+  delegate_to: localhost
 
 - name: Rollback Configuration
   aci_config_rollback:
     host: apic
     username: admin
     password: SomeSecretPassword
-    state: rollback
     import_policy: rollback_config
     export_policy: config_backup
     snapshot: run-2017-08-28T06-24-01
@@ -122,6 +125,8 @@ EXAMPLES = r'''
     import_mode: atomic
     import_type: replace
     fail_on_decrypt: yes
+    state: rollback
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_config_snapshot.py
+++ b/lib/ansible/modules/network/aci/aci_config_snapshot.py
@@ -74,6 +74,7 @@ EXAMPLES = r'''
     export_policy: config_backup
     max_count: 10
     description: Backups taken before new configs are applied.
+  delegate_to: localhost
 
 - name: Query all Snapshots
   aci_config_snapshot:
@@ -81,23 +82,28 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query Snapshots associated with a particular Export Policy
   aci_config_snapshot:
     host: apic
     username: admin
     password: SomeSecretPassword
-    state: query
     export_policy: config_backup
+    state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Delete a Snapshot
   aci_config_snapshot:
     host: apic
     username: admin
     password: SomeSecretPassword
-    state: absent
     export_policy: config_backup
     snapshot: run-2017-08-24T17-20-05
+    state: absent
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_contract.py
+++ b/lib/ansible/modules/network/aci/aci_contract.py
@@ -77,6 +77,7 @@ EXAMPLES = r'''
     description: Communication between web-servers and database
     scope: application-profile
     state: present
+  delegate_to: localhost
 
 - name: Remove an existing contract
   aci_contract:
@@ -86,6 +87,7 @@ EXAMPLES = r'''
     tenant: production
     contract: web_to_db
     state: absent
+  delegate_to: localhost
 
 - name: Query a specific contract
   aci_contract:
@@ -95,6 +97,8 @@ EXAMPLES = r'''
     tenant: production
     contract: web_to_db
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all contracts
   aci_contract:
@@ -102,6 +106,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_contract_subject.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject.py
@@ -92,6 +92,7 @@ EXAMPLES = r'''
     priority: level1
     dscp: unspecified
     state: present
+  register: query_result
 
 - name: Remove a contract subject
   aci_contract_subject:
@@ -102,6 +103,7 @@ EXAMPLES = r'''
     contract: web_to_db
     subject: default
     state: absent
+  delegate_to: localhost
 
 - name: Query a contract subject
   aci_contract_subject:
@@ -112,6 +114,8 @@ EXAMPLES = r'''
     contract: web_to_db
     subject: default
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all contract subjects
   aci_contract_subject:
@@ -119,6 +123,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
@@ -69,6 +69,7 @@ EXAMPLES = r'''
     filter: '{{ filter }}'
     log: '{{ log }}'
     state: present
+  delegate_to: localhost
 
 - name: Remove an existing contract subject to filter binding
   aci_contract_subject_to_filter:
@@ -81,6 +82,7 @@ EXAMPLES = r'''
     filter: '{{ filter }}'
     log: '{{ log }}'
     state: present
+  delegate_to: localhost
 
 - name: Query a specific contract subject to filter binding
   aci_contract_subject_to_filter:
@@ -92,6 +94,8 @@ EXAMPLES = r'''
     subject: test
     filter: '{{ filter }}'
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all contract subject to filter bindings
   aci_contract_subject_to_filter:
@@ -102,6 +106,8 @@ EXAMPLES = r'''
     contract: web_to_db
     subject: test
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_domain.py
+++ b/lib/ansible/modules/network/aci/aci_domain.py
@@ -99,6 +99,7 @@ EXAMPLES = r'''
     domain_type: vmm
     vm_provider: microsoft
     state: present
+  delegate_to: localhost
 
 - name: Remove a VMM domain
   aci_domain:
@@ -109,6 +110,7 @@ EXAMPLES = r'''
     domain_type: vmm
     vm_provider: microsoft
     state: absent
+  delegate_to: localhost
 
 - name: Query a specific physical domain
   aci_domain:
@@ -118,6 +120,8 @@ EXAMPLES = r'''
     domain: phys_dom
     domain_type: phys
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all domains
   aci_domain:
@@ -126,6 +130,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     domain_type: phys
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
@@ -76,6 +76,7 @@ EXAMPLES = r'''
     pool_type: vlan
     pool_allocation_mode: dynamic
     state: present
+  delegate_to: localhost
 
 - name: Remove domain to VLAN pool binding
   aci_domain_to_encap_pool:
@@ -88,6 +89,7 @@ EXAMPLES = r'''
     pool_type: vlan
     pool_allocation_mode: dynamic
     state: absent
+  delegate_to: localhost
 
 - name: Query our domain to VLAN pool binding
   aci_domain_to_encap_pool:
@@ -99,6 +101,8 @@ EXAMPLES = r'''
     pool_type: vlan
     pool_allocation_mode: dynamic
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all domain to VLAN pool bindings
   aci_domain_to_encap_pool:
@@ -109,6 +113,8 @@ EXAMPLES = r'''
     pool_type: vlan
     pool_allocation_mode: dynamic
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
@@ -71,6 +71,7 @@ EXAMPLES = r'''
     pool_allocation_mode: dynamic
     vm_provider: vmware
     state: present
+  delegate_to: localhost
 
 - name: Remove a VMM domain to VLAN pool binding
   aci_domain_to_vlan_pool:
@@ -83,6 +84,7 @@ EXAMPLES = r'''
     pool_allocation_mode: dynamic
     vm_provider: vmware
     state: absent
+  delegate_to: localhost
 
 - name: Bind a physical domain to VLAN pool
   aci_domain_to_vlan_pool:
@@ -94,6 +96,7 @@ EXAMPLES = r'''
     pool: phys_pool
     pool_allocation_mode: static
     state: present
+  delegate_to: localhost
 
 - name: Bind a physical domain to VLAN pool
   aci_domain_to_vlan_pool:
@@ -105,6 +108,7 @@ EXAMPLES = r'''
     pool: phys_pool
     pool_allocation_mode: static
     state: absent
+  delegate_to: localhost
 
 - name: Query an domain to VLAN pool binding
   aci_domain_to_vlan_pool:
@@ -116,6 +120,8 @@ EXAMPLES = r'''
     pool: phys_pool
     pool_allocation_mode: static
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all domain to VLAN pool bindings
   aci_domain_to_vlan_pool:
@@ -124,6 +130,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     domain_type: phys
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool.py
@@ -62,6 +62,7 @@ EXAMPLES = r'''
     pool_type: vlan
     description: Production VLANs
     state: present
+  delegate_to: localhost
 
 - name: Remove a vlan pool
   aci_encap_pool:
@@ -71,6 +72,7 @@ EXAMPLES = r'''
     pool: production
     pool_type: vlan
     state: absent
+  delegate_to: localhost
 
 - name: Query a vlan pool
   aci_encap_pool:
@@ -80,6 +82,8 @@ EXAMPLES = r'''
     pool: production
     pool_type: vlan
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all vlan pools
   aci_encap_pool:
@@ -88,6 +92,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     pool_type: vlan
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_encap_pool_range.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool_range.py
@@ -74,7 +74,7 @@ extends_documentation_fragment: aci
 '''
 
 EXAMPLES = r'''
-- name: Add a new vlan range
+- name: Add a new VLAN range
   aci_vlan_pool_encap_block:
     host: apic
     username: admin
@@ -84,8 +84,9 @@ EXAMPLES = r'''
     encap_start: 20
     encap_end: 50
     state: present
+  delegate_to: localhost
 
-- name: Remove a vlan range
+- name: Remove a VLAN range
   aci_vlan_pool_encap_block:
     host: apic
     username: admin
@@ -95,8 +96,9 @@ EXAMPLES = r'''
     encap_start: 20
     encap_end: 50
     state: absent
+  delegate_to: localhost
 
-- name: Query a vlan range
+- name: Query a VLAN range
   aci_vlan_pool_encap_block:
     host: apic
     username: admin
@@ -106,8 +108,10 @@ EXAMPLES = r'''
     encap_start: 20
     encap_end: 50
     state: query
+  delegate_to: localhost
+  register: query_result
 
-- name: Query a vlan pool for ranges
+- name: Query a VLAN pool for ranges
   aci_vlan_pool_encap_block:
     host: apic
     username: admin
@@ -115,14 +119,18 @@ EXAMPLES = r'''
     pool: production
     pool_type: vlan
     state: query
+  delegate_to: localhost
+  register: query_result
 
-- name: Query all vlan ranges
+- name: Query all VLAN ranges
   aci_vlan_pool_encap_block:
     host: apic
     username: admin
     password: SomeSecretPassword
     pool_type: vlan
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_epg.py
+++ b/lib/ansible/modules/network/aci/aci_epg.py
@@ -91,6 +91,8 @@ EXAMPLES = r'''
     description: Web Intranet EPG
     bd: prod_bd
     preferred_group: yes
+    state: present
+  delegate_to: localhost
 
 - aci_epg:
     host: apic
@@ -104,6 +106,7 @@ EXAMPLES = r'''
     priority: unspecified
     intra_epg_isolation: unenforced
     state: present
+  delegate_to: localhost
   with_items:
     - epg: web
       bd: web_bd
@@ -120,6 +123,7 @@ EXAMPLES = r'''
     app_profile: intranet
     epg: web_epg
     state: absent
+  delegate_to: localhost
 
 - name: Query an EPG
   aci_epg:
@@ -130,6 +134,8 @@ EXAMPLES = r'''
     ap: ticketing
     epg: web_epg
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all EPGs
   aci_epg:
@@ -137,6 +143,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all EPGs with a Specific Name
   aci_epg:
@@ -146,6 +154,8 @@ EXAMPLES = r'''
     validate_certs: no
     epg: web_epg
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all EPGs of an App Profile
   aci_epg:
@@ -155,6 +165,8 @@ EXAMPLES = r'''
     validate_certs: no
     ap: ticketing
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
+++ b/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
@@ -57,6 +57,7 @@ EXAMPLES = r'''
     monitoring_policy: '{{ monitoring_policy }}'
     description: '{{ description }}'
     tenant: '{{ tenant }}'
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_epg_to_contract.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_contract.py
@@ -77,6 +77,7 @@ EXAMPLES = r'''
     contract: anstest_http
     contract_type: provider
     state: present
+  delegate_to: localhost
 
 - name: Remove an existing contract to EPG binding
   aci_epg_to_contract:
@@ -89,6 +90,7 @@ EXAMPLES = r'''
     contract: anstest_http
     contract_type: provider
     state: absent
+  delegate_to: localhost
 
 - name: Query a specific contract to EPG binding
   aci_epg_to_contract:
@@ -101,6 +103,8 @@ EXAMPLES = r'''
     contract: anstest_http
     contract_type: provider
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all provider contract to EPG bindings
   aci_epg_to_contract:
@@ -109,6 +113,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     contract_type: provider
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_epg_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_domain.py
@@ -112,6 +112,7 @@ EXAMPLES = r'''
     domain: anstest
     domain_type: phys
     state: present
+  delegate_to: localhost
 
 - name: Remove an existing physical domain to EPG binding
   aci_epg_to_domain:
@@ -124,6 +125,7 @@ EXAMPLES = r'''
     domain: anstest
     domain_type: phys
     state: absent
+  delegate_to: localhost
 
 - name: Query a specific physical domain to EPG binding
   aci_epg_to_domain:
@@ -136,6 +138,8 @@ EXAMPLES = r'''
     domain: anstest
     domain_type: phys
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all domain to EPG bindings
   aci_epg_to_domain:
@@ -143,6 +147,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_fabric_node.py
+++ b/lib/ansible/modules/network/aci/aci_fabric_node.py
@@ -68,6 +68,7 @@ EXAMPLES = r'''
     node_id: 1011
     switch: fab4-sw1011
     state: present
+  delegate_to: localhost
 
 - name: Remove fabric node
   aci_fabric_node:
@@ -77,6 +78,7 @@ EXAMPLES = r'''
     serial: FDO2031124L
     node_id: 1011
     state: absent
+  delegate_to: localhost
 
 - name: Query fabric nodes
   aci_fabric_node:
@@ -84,6 +86,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_filter.py
+++ b/lib/ansible/modules/network/aci/aci_filter.py
@@ -59,6 +59,7 @@ EXAMPLES = r'''
     description: Filter for web protocols
     tenant: production
     state: present
+  delegate_to: localhost
 
 - name: Remove a filter for a tenant
   aci_filter:
@@ -68,6 +69,7 @@ EXAMPLES = r'''
     filter: web_filter
     tenant: production
     state: absent
+  delegate_to: localhost
 
 - name: Query a filter of a tenant
   aci_filter:
@@ -77,6 +79,8 @@ EXAMPLES = r'''
     filter: web_filter
     tenant: production
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all filters for a tenant
   aci_filter:
@@ -85,6 +89,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     tenant: production
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_filter_entry.py
+++ b/lib/ansible/modules/network/aci/aci_filter_entry.py
@@ -105,6 +105,7 @@ EXAMPLES = r'''
     icmp_msg_type: "{{ icmp_msg_type }}"
     filter: "{{ filter }}"
     descr: "{{ descr }}"
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_firmware_source.py
+++ b/lib/ansible/modules/network/aci/aci_firmware_source.py
@@ -67,6 +67,7 @@ EXAMPLES = r'''
     url: foo.bar.cisco.com/download/cisco/aci/aci-msft-pkg-3.1.1i.zip
     url_protocol: http
     state: present
+  delegate_to: localhost
 
 - name: Remove firmware source
   aci_firmware_source:
@@ -75,6 +76,7 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     source: aci-msft-pkg-3.1.1i.zip
     state: absent
+  delegate_to: localhost
 
 - name: Query a specific firmware source
   aci_firmware_source:
@@ -83,6 +85,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     source: aci-msft-pkg-3.1.1i.zip
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all firmware sources
   aci_firmware_source:
@@ -90,6 +94,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
@@ -55,6 +55,7 @@ EXAMPLES = r'''
     port_mode: '{{ port_mode }}'
     description: '{{ description }}'
     state: present
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
@@ -64,6 +64,7 @@ EXAMPLES = r'''
     l2_policy: '{{ l2_policy }}'
     vlan_scope: '{{ vlan_policy }}'
     description: '{{ description }}'
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
@@ -116,7 +116,6 @@ options:
 extends_documentation_fragment: aci
 '''
 
-# FIXME: Add query examples
 EXAMPLES = r'''
 - name: Create a Port Channel (PC) Interface Policy Group
   aci_interface_policy_leaf_policy_group:
@@ -129,6 +128,7 @@ EXAMPLES = r'''
     link_level_policy: whateverlinklevelpolicy
     fibre_channel_interface_policy: whateverfcpolicy
     state: present
+  delegate_to: localhost
 
 - name: Create a Virtual Port Channel (VPC) Interface Policy Group (no description)
   aci_interface_policy_leaf_policy_group:
@@ -140,6 +140,7 @@ EXAMPLES = r'''
     link_level_policy: whateverlinklevelpolicy
     fibre_channel_interface_policy: whateverfcpolicy
     state: present
+  delegate_to: localhost
 
 - name: Create a Leaf Access Port Policy Group (no description)
   aci_interface_policy_leaf_policy_group:
@@ -151,6 +152,7 @@ EXAMPLES = r'''
     link_level_policy: whateverlinklevelpolicy
     fibre_channel_interface_policy: whateverfcpolicy
     state: present
+  delegate_to: localhost
 
 - name: Query all Leaf Access Port Policy Groups of type link
   aci_interface_policy_leaf_policy_group:
@@ -159,6 +161,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     lag_type: link
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query a specific Lead Access Port Policy Group
   aci_interface_policy_leaf_policy_group:
@@ -168,6 +172,8 @@ EXAMPLES = r'''
     lag_type: leaf
     policy_group: policygroupname
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Delete an Interface policy Leaf Policy Group
   aci_interface_policy_leaf_policy_group:
@@ -177,6 +183,7 @@ EXAMPLES = r'''
     lag_type: type_name
     policy_group: policygroupname
     state: absent
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
@@ -51,6 +51,7 @@ EXAMPLES = r'''
     leaf_interface_profile: leafintprfname
     description:  leafintprfname description
     state: present
+  delegate_to: localhost
 
 - name: Remove a leaf_interface_profile
   aci_interface_policy_leaf_profile:
@@ -59,6 +60,7 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     leaf_interface_profile: leafintprfname
     state: absent
+  delegate_to: localhost
 
 - name: Remove all leaf_interface_profiles
   aci_interface_policy_leaf_profile:
@@ -66,6 +68,7 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: absent
+  delegate_to: localhost
 
 - name: Query a leaf_interface_profile
   aci_interface_policy_leaf_profile:
@@ -74,6 +77,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     leaf_interface_profile: leafintprfname
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
@@ -61,6 +61,7 @@ EXAMPLES = r'''
     description: '{{ description }}'
     receive_state: '{{ receive_state }}'
     transmit_state: '{{ transmit_state }}'
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
@@ -55,6 +55,7 @@ EXAMPLES = r'''
     mcp: '{{ mcp }}'
     description: '{{ descr }}'
     admin_state: '{{ admin_state }}'
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_interface_policy_ospf.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_ospf.py
@@ -139,6 +139,7 @@ EXAMPLES = r'''
     tenant: production
     ospf: ospf1
     state: present
+  delegate_to: localhost
 
 - name: Ensure ospf interface policy does not exist
   aci_interface_policy_ospf:
@@ -148,6 +149,7 @@ EXAMPLES = r'''
     tenant: production
     ospf: ospf1
     state: present
+  delegate_to: localhost
 
 - name: Query an ospf interface policy
   aci_interface_policy_ospf:
@@ -157,6 +159,8 @@ EXAMPLES = r'''
     tenant: production
     ospf: ospf1
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all ospf interface policies in tenant production
   aci_interface_policy_ospf:
@@ -165,6 +169,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     tenant: production
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
@@ -104,6 +104,7 @@ EXAMPLES = r'''
     min_links: '{{ min_links }}'
     max_links: '{{ max_links }}'
     mode: '{{ mode }}'
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
@@ -56,6 +56,7 @@ EXAMPLES = r'''
     port_security: '{{ port_security }}'
     description: '{{ descr }}'
     max_end_points: '{{ max_end_points }}'
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
@@ -51,6 +51,7 @@ EXAMPLES = r'''
     leaf_profile: sw_name
     interface_selector: interface_profile_name
     state: present
+  delegate_to: localhost
 
 - name: Remove an interface selector profile associated with a switch policy leaf profile
   aci_interface_selector_to_switch_policy_leaf_profile:
@@ -60,6 +61,7 @@ EXAMPLES = r'''
     leaf_profile: sw_name
     interface_selector: interface_profile_name
     state: absent
+  delegate_to: localhost
 
 - name: Query an interface selector profile associated with a switch policy leaf profile
   aci_interface_selector_to_switch_policy_leaf_profile:
@@ -69,6 +71,8 @@ EXAMPLES = r'''
     leaf_profile: sw_name
     interface_selector: interface_profile_name
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_l3out.py
@@ -87,6 +87,8 @@ EXAMPLES = r'''
     domain: l3dom_prod
     vrf: prod
     l3protocol: ospf
+    state: present
+  delegate_to: localhost
 
 - name: Delete L3Out
   aci_l3out:
@@ -96,6 +98,7 @@ EXAMPLES = r'''
     tenant: production
     name: prod_l3out
     state: absent
+  delegate_to: localhost
 
 - name: Query L3Out information
   aci_l3out:
@@ -105,6 +108,8 @@ EXAMPLES = r'''
     tenant: production
     name: prod_l3out
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
+++ b/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
@@ -64,6 +64,7 @@ EXAMPLES = r'''
     tenant: production
     tag: '{{ tag }}'
     description: '{{ description }}'
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_rest.py
+++ b/lib/ansible/modules/network/aci/aci_rest.py
@@ -142,6 +142,7 @@ EXAMPLES = r'''
     method: get
     path: /api/node/class/fvTenant.json
   delegate_to: localhost
+  register: query_result
 
 - name: Configure contracts
   aci_rest:

--- a/lib/ansible/modules/network/aci/aci_static_binding_to_epg.py
+++ b/lib/ansible/modules/network/aci/aci_static_binding_to_epg.py
@@ -125,6 +125,7 @@ EXAMPLES = r'''
     leafs: 101
     interface: '1/7'
     state: present
+  delegate_to: localhost
 
 - name: Remove Static Path binding for given EPG
   aci_static_binding_to_epg:
@@ -139,6 +140,7 @@ EXAMPLES = r'''
     leafs: 101
     interface: '1/7'
     state: absent
+  delegate_to: localhost
 
 - name: Get specific Static Path binding for given EPG
   aci_static_binding_to_epg:
@@ -153,6 +155,8 @@ EXAMPLES = r'''
     leafs: 101
     interface: '1/7'
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
+++ b/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
@@ -80,6 +80,7 @@ EXAMPLES = r'''
     to: 1011
     policy_group: somepolicygroupname
     state: present
+  delegate_to: localhost
 
 - name: adding a switch policy leaf profile selector associated Node Block range (w/o policy group)
   aci_switch_leaf_selector:
@@ -92,6 +93,7 @@ EXAMPLES = r'''
     from: 1011
     to: 1011
     state: present
+  delegate_to: localhost
 
 - name: Removing a switch policy leaf profile selector
   aci_switch_leaf_selector:
@@ -101,6 +103,7 @@ EXAMPLES = r'''
     leaf_profile: sw_name
     leaf: leaf_selector_name
     state: absent
+  delegate_to: localhost
 
 - name: Querying a switch policy leaf profile selector
   aci_switch_leaf_selector:
@@ -110,6 +113,8 @@ EXAMPLES = r'''
     leaf_profile: sw_name
     leaf: leaf_selector_name
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
@@ -50,6 +50,7 @@ EXAMPLES = r'''
     leaf_profile: sw_name
     description: sw_description
     state: present
+  delegate_to: localhost
 
 - name: Deleting a Leaf Profile
   aci_switch_policy_leaf_profile:
@@ -58,6 +59,7 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     leaf_profile: sw_name
     state: absent
+  delegate_to: localhost
 
 - name: Query a Leaf Profile
   aci_switch_policy_leaf_profile:
@@ -66,6 +68,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     leaf_profile: sw_name
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_switch_policy_vpc_protection_group.py
+++ b/lib/ansible/modules/network/aci/aci_switch_policy_vpc_protection_group.py
@@ -69,6 +69,7 @@ EXAMPLES = r'''
     switch_1_id: 1011
     switch_2_id: 1012
     state: present
+  delegate_to: localhost
 
 - name: Remove Explicit vPC Protection Group
   aci_switch_policy_vpc_protection_group:
@@ -77,6 +78,7 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     protection_group: leafPair101-vpcGrp
     state: absent
+  delegate_to: localhost
 
 - name: Query vPC Protection Groups
   aci_switch_policy_vpc_protection_group:
@@ -84,6 +86,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query our vPC Protection Group
   aci_switch_policy_vpc_protection_group:
@@ -92,6 +96,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     protection_group: leafPair101-vpcGrp
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_taboo_contract.py
+++ b/lib/ansible/modules/network/aci/aci_taboo_contract.py
@@ -63,6 +63,7 @@ EXAMPLES = r'''
     tenant: ansible_test
     taboo_contract: taboo_contract_test
     state: present
+  delegate_to: localhost
 
 - name: Remove taboo contract
   aci_taboo_contract:
@@ -72,6 +73,7 @@ EXAMPLES = r'''
     tenant: ansible_test
     taboo_contract: taboo_contract_test
     state: absent
+  delegate_to: localhost
 
 - name: Query all taboo contracts
   aci_taboo_contract:
@@ -79,6 +81,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query a specific taboo contract
   aci_taboo_contract:
@@ -88,6 +92,8 @@ EXAMPLES = r'''
     tenant: ansible_test
     taboo_contract: taboo_contract_test
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_tenant.py
+++ b/lib/ansible/modules/network/aci/aci_tenant.py
@@ -50,6 +50,7 @@ EXAMPLES = r'''
     tenant: production
     description: Production tenant
     state: present
+  delegate_to: localhost
 
 - name: Remove a tenant
   aci_tenant:
@@ -58,6 +59,7 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     tenant: production
     state: absent
+  delegate_to: localhost
 
 - name: Query a tenant
   aci_tenant:
@@ -66,6 +68,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     tenant: production
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all tenants
   aci_tenant:
@@ -73,6 +77,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
@@ -55,6 +55,7 @@ EXAMPLES = r'''
     action_rule: '{{ action_rule }}'
     description: '{{ descr }}'
     tenant: '{{ tenant }}'
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
@@ -96,6 +96,7 @@ EXAMPLES = r'''
     move_frequency: 256
     description: test
     state: present
+  delegate_to: localhost
 
 - name: Remove an EPR policy
   aci_epr_policy:
@@ -105,6 +106,7 @@ EXAMPLES = r'''
     tenant: production
     epr_policy: EPRPol1
     state: absent
+  delegate_to: localhost
 
 - name: Query an EPR policy
   aci_epr_policy:
@@ -114,6 +116,8 @@ EXAMPLES = r'''
     tenant: production
     epr_policy: EPRPol1
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all EPR policies
   aci_epr_policy:
@@ -121,6 +125,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
@@ -57,6 +57,7 @@ EXAMPLES = r'''
     dst_group: '{{ dst_group }}'
     description: '{{ descr }}'
     tenant: '{{ tenant }}'
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
@@ -64,6 +64,7 @@ EXAMPLES = r'''
     dst_group: "{{ dst_group }}"
     admin_state: "{{ admin_state }}"
     description: "{{ description }}"
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
@@ -57,6 +57,7 @@ EXAMPLES = r'''
     src_group: "{{ src_group }}"
     dst_group: "{{ dst_group }}"
     description: "{{ description }}"
+  delegate_to: localhost
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool.py
@@ -58,6 +58,7 @@ EXAMPLES = r'''
     pool_allocation_mode: dynamic
     description: Production VLANs
     state: present
+  delegate_to: localhost
 
 - name: Remove a VLAN pool
   aci_vlan_pool:
@@ -67,6 +68,7 @@ EXAMPLES = r'''
     pool: production
     pool_allocation_mode: dynamic
     state: absent
+  delegate_to: localhost
 
 - name: Query a VLAN pool
   aci_vlan_pool:
@@ -76,6 +78,8 @@ EXAMPLES = r'''
     pool: production
     pool_allocation_mode: dynamic
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all VLAN pools
   aci_vlan_pool:
@@ -83,6 +87,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
@@ -78,6 +78,7 @@ EXAMPLES = r'''
     block_start: 20
     block_end: 50
     state: present
+  delegate_to: localhost
 
 - name: Remove a VLAN encap block
   aci_vlan_pool_encap_block:
@@ -88,6 +89,7 @@ EXAMPLES = r'''
     block_start: 20
     block_end: 50
     state: absent
+  delegate_to: localhost
 
 - name: Query a VLAN encap block
   aci_vlan_pool_encap_block:
@@ -98,6 +100,8 @@ EXAMPLES = r'''
     block_start: 20
     block_end: 50
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query a VLAN pool for encap blocks
   aci_vlan_pool_encap_block:
@@ -106,6 +110,8 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     pool: production
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all VLAN encap blocks
   aci_vlan_pool_encap_block:
@@ -113,6 +119,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/network/aci/aci_vrf.py
+++ b/lib/ansible/modules/network/aci/aci_vrf.py
@@ -67,6 +67,7 @@ EXAMPLES = r'''
     policy_control_preference: enforced
     policy_control_direction: ingress
     state: present
+  delegate_to: localhost
 
 - name: Remove a VRF for a tenant
   aci_vrf:
@@ -76,6 +77,7 @@ EXAMPLES = r'''
     vrf: vrf_lab
     tenant: lab_tenant
     state: absent
+  delegate_to: localhost
 
 - name: Query a VRF of a tenant
   aci_vrf:
@@ -85,6 +87,8 @@ EXAMPLES = r'''
     vrf: vrf_lab
     tenant: lab_tenant
     state: query
+  delegate_to: localhost
+  register: query_result
 
 - name: Query all VRFs
   aci_vrf:
@@ -92,6 +96,8 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     state: query
+  delegate_to: localhost
+  register: query_result
 '''
 
 RETURN = r'''


### PR DESCRIPTION
##### SUMMARY
This is to avoid users connecting to the APIC using SSH, which is likely
to fail. In the ACI documentation (linked from every module) we go into
more details on how people are supposed to work with the modules..

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
ACI modules

##### ANSIBLE VERSION
v2.7 and earlier