### PR TITLE
Remove unused imports from /bin and lib/ansible/cli

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -23,7 +23,7 @@ import json
 from contextlib import contextmanager
 
 from ansible import constants as C
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import cPickle, StringIO
 from ansible.module_utils.connection import Connection, ConnectionError, send_data, recv_data

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -20,8 +20,6 @@ __metaclass__ = type
 
 ########################################################
 
-import os
-
 from ansible import constants as C
 from ansible.cli import CLI
 from ansible.errors import AnsibleError, AnsibleOptionsError

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -13,7 +13,7 @@ import yaml
 from ansible.cli import CLI
 from ansible.config.manager import ConfigManager, Setting, find_ini_config_file
 from ansible.errors import AnsibleError, AnsibleOptionsError
-from ansible.module_utils._text import to_native, to_text, to_bytes
+from ansible.module_utils._text import to_native, to_text
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.utils.color import stringc
 from ansible.utils.path import unfrackpath


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

As discussed in #43402 this removes unused imports from `/bin` and `lib/ansible/cli`

@abadger 

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request