### PR TITLE
ACI: Rewrite construct_url framework

### DIFF
--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -78,46 +78,6 @@ def aci_argument_spec():
     )
 
 
-'''
-URL_MAPPING = dict(
-    action_rule=dict(aci_class='rtctrlAttrP', mo='attr-', key='name'),
-    aep=dict(aci_class='infraAttEntityP', mo='infra/attentp-', key='name'),
-    ap=dict(aci_class='fvAp', mo='ap-', key='name'),
-    bd=dict(aci_class='fvBD', mo='BD-', key='name'),
-    bd_l3out=dict(aci_class='fvRsBDToOut', mo='rsBDToOut-', key='tnL3extOutName'),
-    contract=dict(aci_class='vzBrCP', mo='brc-', key='name'),
-    entry=dict(aci_class='vzEntry', mo='e-', key='name'),
-    epg=dict(aci_class='fvAEPg', mo='epg-', key='name'),
-    epg_consumer=dict(aci_class='fvRsCons', mo='rscons-', key='tnVzBrCPName'),
-    epg_domain=dict(aci_class='fvRsDomAtt', mo='rsdomAtt-', key='tDn'),
-    epg_provider=dict(aci_class='fvRsProv', mo='rsprov-', key='tnVzBrCPName'),
-    epr_policy=dict(aci_class='fvEpRetPol', mo='epRPol-', key='name'),
-    export_policy=dict(aci_class='configExportP', mo='fabric/configexp-', key='name'),
-    fc_policy=dict(aci_class='fcIfPol', mo='infra/fcIfPol-', key='name'),
-    filter=dict(aci_class='vzFilter', mo='flt-', key='name'),
-    gateway_addr=dict(aci_class='fvSubnet', mo='subnet-', key='ip'),
-    import_policy=dict(aci_class='configImportP', mo='fabric/configimp-', key='name'),
-    l2_policy=dict(aci_class='l2IfPol', mo='infra/l2IfP-', key='name'),
-    lldp_policy=dict(aci_class='lldpIfPol', mo='infra/lldpIfP-', key='name'),
-    mcp=dict(aci_class='mcpIfPol', mo='infra/mcpIfP-', key='name'),
-    monitoring_policy=dict(aci_class='monEPGPol', mo='monepg-', key='name'),
-    port_channel=dict(aci_class='lacpLagPol', mo='infra/lacplagp-', key='name'),
-    port_security=dict(aci_class='l2PortSecurityPol', mo='infra/portsecurityP-', key='name'),
-    rtp=dict(aci_class='l3extRouteTagPol', mo='rttag-', key='name'),
-    snapshot=dict(aci_class='configSnapshot', mo='snapshot-', key='name'),
-    snapshot_container=dict(aci_class='configSnapshotCont', mo='backupst/snapshots-', key='name'),
-    subject=dict(aci_class='vzSubj', mo='subj-', key='name'),
-    subject_filter=dict(aci_class='vzRsSubjFiltAtt', mo='rssubjFiltAtt-', key='tnVzFilterName'),
-    taboo_contract=dict(aci_class='vzTaboo', mo='taboo-', key='name'),
-    tenant=dict(aci_class='fvTenant', mo='tn-', key='name'),
-    tenant_span_dst_grp=dict(aci_class='spanDestGrp', mo='destgrp-', key='name'),
-    tenant_span_src_grp=dict(aci_class='spanSrcGrp', mo='srcgrp-', key='name'),
-    tenant_span_src_grp_dst_grp=dict(aci_class='spanSpanLbl', mo='spanlbl-', key='name'),
-    vrf=dict(aci_class='fvCtx', mo='ctx-', key='name'),
-)
-'''
-
-
 class ACIModule(object):
 
     def __init__(self, module):
@@ -125,6 +85,7 @@ class ACIModule(object):
         self.params = module.params
         self.result = dict(changed=False)
         self.headers = dict()
+        self.child_classes = set()
 
         # error output
         self.error = dict(code=None, text=None)
@@ -423,14 +384,34 @@ class ACIModule(object):
         if self.result['diff']['before'] != self.result['diff']['after']:
             self.result['changed'] = True
 
+    # TODO: This could be designed to update existing keys
+    def update_qs(self, params):
+        ''' Append key-value pairs to self.filter_string '''
+        accepted_params = dict((k, v) for (k, v) in params.items() if v)
+        if accepted_params:
+            if self.filter_string:
+                self.filter_string += '&'
+            else:
+                self.filter_string = '?'
+            self.filter_string += '&'.join(['%s=%s' % (k, v) for (k, v) in accepted_params.items()])
+
+    # TODO: This could be designed to accept multiple obj_classes and keys
+    def build_filter(self, obj_class, params):
+        ''' Build an APIC filter based on obj_class and key-value pairs '''
+        accepted_params = dict((k, v) for (k, v) in params.items() if v is not None)
+        if len(accepted_params) == 1:
+            return ','.join('eq({0}.{1}, "{2}")'.format(obj_class, k, v) for (k, v) in accepted_params.items())
+        elif len(accepted_params) > 1:
+            return 'and(' + ','.join(['eq({0}.{1}, "{2}")'.format(obj_class, k, v) for (k, v) in accepted_params.items()]) + ')'
+
     def construct_url(self, root_class, subclass_1=None, subclass_2=None, subclass_3=None, child_classes=None):
         """
         This method is used to retrieve the appropriate URL path and filter_string to make the request to the APIC.
 
-        :param root_class: The top-level class dictionary containing aci_class, aci_rn, filter_target, and module_object keys.
-        :param sublass_1: The second-level class dictionary containing aci_class, aci_rn, filter_target, and module_object keys.
-        :param sublass_2: The third-level class dictionary containing aci_class, aci_rn, filter_target, and module_object keys.
-        :param sublass_3: The fourth-level class dictionary containing aci_class, aci_rn, filter_target, and module_object keys.
+        :param root_class: The top-level class dictionary containing aci_class, aci_rn, target_filter, and module_object keys.
+        :param sublass_1: The second-level class dictionary containing aci_class, aci_rn, target_filter, and module_object keys.
+        :param sublass_2: The third-level class dictionary containing aci_class, aci_rn, target_filter, and module_object keys.
+        :param sublass_3: The fourth-level class dictionary containing aci_class, aci_rn, target_filter, and module_object keys.
         :param child_classes: The list of child classes that the module supports along with the object.
         :type root_class: dict
         :type subclass_1: dict
@@ -439,207 +420,203 @@ class ACIModule(object):
         :type child_classes: list
         :return: The path and filter_string needed to build the full URL.
         """
+        self.filter_string = ''
+
         if child_classes is None:
-            child_includes = ''
+            self.child_classes = set()
         else:
-            child_includes = ','.join(child_classes)
-            child_includes = '&rsp-subtree=full&rsp-subtree-class=' + child_includes
+            self.child_classes = set(child_classes)
 
         if subclass_3 is not None:
-            path, filter_string = self._construct_url_4(root_class, subclass_1, subclass_2, subclass_3, child_includes)
+            self._construct_url_4(root_class, subclass_1, subclass_2, subclass_3)
         elif subclass_2 is not None:
-            path, filter_string = self._construct_url_3(root_class, subclass_1, subclass_2, child_includes)
+            self._construct_url_3(root_class, subclass_1, subclass_2)
         elif subclass_1 is not None:
-            path, filter_string = self._construct_url_2(root_class, subclass_1, child_includes)
+            self._construct_url_2(root_class, subclass_1)
         else:
-            path, filter_string = self._construct_url_1(root_class, child_includes)
+            self._construct_url_1(root_class)
 
-        self.path = path
         if 'port' in self.params and self.params['port'] is not None:
-            self.url = '{protocol}://{host}:{port}/{path}'.format(path=path, **self.module.params)
+            self.url = '{protocol}://{host}:{port}/{path}'.format(path=self.path, **self.module.params)
         else:
-            self.url = '{protocol}://{host}/{path}'.format(path=path, **self.module.params)
-        self.filter_string = filter_string
+            self.url = '{protocol}://{host}/{path}'.format(path=self.path, **self.module.params)
 
-    def _construct_url_1(self, obj, child_includes):
+        if self.child_classes:
+            # Append child_classes to filter_string if filter string is empty
+            self.update_qs({'rsp-subtree': 'full', 'rsp-subtree-class': ','.join(self.child_classes)})
+
+    def _construct_url_1(self, obj):
         """
-        This method is used by get_url when the object is the top-level class.
+        This method is used by construct_url when the object is the top-level class.
         """
         obj_class = obj['aci_class']
         obj_rn = obj['aci_rn']
+        obj_filter = obj['target_filter']
         mo = obj['module_object']
 
-        # State is present or absent
-        if self.module.params['state'] != 'query':
-            path = 'api/mo/uni/{0}.json'.format(obj_rn)
-            filter_string = '?rsp-prop-include=config-only' + child_includes
-        # Query for all objects of the module's class
+        if self.module.params['state'] in ('absent', 'present'):
+            # State is absent or present
+            self.path = 'api/mo/uni/{0}.json'.format(obj_rn)
+            self.update_qs({'rsp-prop-include': 'config-only'})
         elif mo is None:
-            path = 'api/class/{0}.json'.format(obj_class)
-            filter_string = ''
-        # Query for a specific object in the module's class
+            # Query for all objects of the module's class (filter by properties)
+            self.path = 'api/class/{0}.json'.format(obj_class)
         else:
-            path = 'api/mo/uni/{0}.json'.format(obj_rn)
-            filter_string = ''
+            # Query for a specific object in the module's class
+            self.path = 'api/mo/uni/{0}.json'.format(obj_rn)
 
-        # Append child_includes to filter_string if filter string is empty
-        if child_includes is not None and filter_string == '':
-            filter_string = child_includes.replace('&', '?', 1)
-
-        return path, filter_string
-
-    def _construct_url_2(self, parent, obj, child_includes):
+    def _construct_url_2(self, parent, obj):
         """
-        This method is used by get_url when the object is the second-level class.
+        This method is used by construct_url when the object is the second-level class.
         """
+        parent_class = parent['aci_class']
         parent_rn = parent['aci_rn']
+        parent_filter = parent['target_filter']
         parent_obj = parent['module_object']
         obj_class = obj['aci_class']
         obj_rn = obj['aci_rn']
-        obj_filter = obj['filter_target']
+        obj_filter = obj['target_filter']
         mo = obj['module_object']
 
-        if not child_includes:
-            self_child_includes = '?rsp-subtree=full&rsp-subtree-class=' + obj_class
-        else:
-            self_child_includes = child_includes.replace('&', '?', 1) + ',' + obj_class
-
-        # State is present or absent
-        if self.module.params['state'] != 'query':
-            path = 'api/mo/uni/{0}/{1}.json'.format(parent_rn, obj_rn)
-            filter_string = '?rsp-prop-include=config-only' + child_includes
-        # Query for all objects of the module's class
-        elif mo is None and parent_obj is None:
-            path = 'api/class/{0}.json'.format(obj_class)
-            filter_string = ''
-        # Queries when parent object is provided
-        elif parent_obj is not None:
-            # Query for specific object in the module's class
-            if mo is not None:
-                path = 'api/mo/uni/{0}/{1}.json'.format(parent_rn, obj_rn)
-                filter_string = ''
+        if self.module.params['state'] in ('absent', 'present'):
+            # State is absent or present
+            self.path = 'api/mo/uni/{0}/{1}.json'.format(parent_rn, obj_rn)
+            self.update_qs({'rsp-prop-include': 'config-only'})
+        elif parent_obj is None and mo is None:
+            # Query for all objects of the module's class
+            self.path = 'api/class/{0}.json'.format(obj_class)
+        elif parent_obj is None:  # mo is known
+            # Query for all objects of the module's class that match the provided ID value
+            self.path = 'api/class/{0}.json'.format(obj_class)
+            self.update_qs({'query-target-filter': self.build_filter(obj_class, obj_filter)})
+        elif mo is None:  # parent_obj is known
             # Query for all object's of the module's class that belong to a specific parent object
-            else:
-                path = 'api/mo/uni/{0}.json'.format(parent_rn)
-                filter_string = self_child_includes
-        # Query for all objects of the module's class that match the provided ID value
+            self.child_classes.add(obj_class)
+            self.path = 'api/mo/uni/{0}.json'.format(parent_rn)
         else:
-            path = 'api/class/{0}.json'.format(obj_class)
-            filter_string = '?query-target-filter={0}'.format(obj_filter) + child_includes
+            # Query for specific object in the module's class
+            self.path = 'api/mo/uni/{0}/{1}.json'.format(parent_rn, obj_rn)
 
-        # Append child_includes to filter_string if filter string is empty
-        if child_includes is not None and filter_string == '':
-            filter_string = child_includes.replace('&', '?', 1)
-
-        return path, filter_string
-
-    def _construct_url_3(self, root, parent, obj, child_includes):
+    def _construct_url_3(self, root, parent, obj):
         """
-        This method is used by get_url when the object is the third-level class.
+        This method is used by construct_url when the object is the third-level class.
         """
+        root_class = root['aci_class']
         root_rn = root['aci_rn']
+        root_filter = root['target_filter']
         root_obj = root['module_object']
         parent_class = parent['aci_class']
         parent_rn = parent['aci_rn']
-        parent_filter = parent['filter_target']
+        parent_filter = parent['target_filter']
         parent_obj = parent['module_object']
         obj_class = obj['aci_class']
         obj_rn = obj['aci_rn']
-        obj_filter = obj['filter_target']
+        obj_filter = obj['target_filter']
         mo = obj['module_object']
 
-        if not child_includes:
-            self_child_includes = '&rsp-subtree=full&rsp-subtree-class=' + obj_class
-        else:
-            self_child_includes = '{0},{1}'.format(child_includes, obj_class)
-
-        if not child_includes:
-            parent_self_child_includes = '&rsp-subtree=full&rsp-subtree-class={0},{1}'.format(parent_class, obj_class)
-        else:
-            parent_self_child_includes = '{0},{1},{2}'.format(child_includes, parent_class, obj_class)
-
-        # State is ablsent or present
-        if self.module.params['state'] != 'query':
-            path = 'api/mo/uni/{0}/{1}/{2}.json'.format(root_rn, parent_rn, obj_rn)
-            filter_string = '?rsp-prop-include=config-only' + child_includes
-        # Query for all objects of the module's class
-        elif mo is None and parent_obj is None and root_obj is None:
-            path = 'api/class/{0}.json'.format(obj_class)
-            filter_string = ''
-        # Queries when root object is provided
-        elif root_obj is not None:
-            # Queries when parent object is provided
-            if parent_obj is not None:
-                # Query for a specific object of the module's class
-                if mo is not None:
-                    path = 'api/mo/uni/{0}/{1}/{2}.json'.format(root_rn, parent_rn, obj_rn)
-                    filter_string = ''
-                # Query for all objects of the module's class that belong to a specific parent object
-                else:
-                    path = 'api/mo/uni/{0}/{1}.json'.format(root_rn, parent_rn)
-                    filter_string = self_child_includes.replace('&', '?', 1)
-            # Query for all objects of the module's class that match the provided ID value and belong to a specefic root object
-            elif mo is not None:
-                path = 'api/mo/uni/{0}.json'.format(root_rn)
-                filter_string = '?rsp-subtree-filter={0}{1}'.format(obj_filter, self_child_includes)
-            # Query for all objects of the module's class that belong to a specific root object
-            else:
-                path = 'api/mo/uni/{0}.json'.format(root_rn)
-                filter_string = '?' + parent_self_child_includes
-        # Queries when parent object is provided but root object is not provided
-        elif parent_obj is not None:
-            # Query for all objects of the module's class that belong to any parent class
-            # matching the provided ID values for both object and parent object
-            if mo is not None:
-                path = 'api/class/{0}.json'.format(parent_class)
-                filter_string = '?query-target-filter={0}{1}&rsp-subtree-filter={2}'.format(
-                    parent_filter, self_child_includes, obj_filter)
+        if self.module.params['state'] in ('absent', 'present'):
+            # State is absent or present
+            self.path = 'api/mo/uni/{0}/{1}/{2}.json'.format(root_rn, parent_rn, obj_rn)
+            self.update_qs({'rsp-prop-include': 'config-only'})
+        elif root_obj is None and parent_obj is None and mo is None:
+            # Query for all objects of the module's class
+            self.path = 'api/class/{0}.json'.format(obj_class)
+        elif root_obj is None and parent_obj is None:  # mo is known
+            # Query for all objects of the module's class matching the provided ID value of the object
+            self.path = 'api/class/{0}.json'.format(obj_class)
+            self.update_qs({'query-target-filter': self.build_filter(obj_class, obj_filter)})
+        elif root_obj is None and mo is None:  # parent_obj is known
             # Query for all objects of the module's class that belong to any parent class
             # matching the provided ID value for the parent object
-            else:
-                path = 'api/class/{0}.json'.format(parent_class)
-                filter_string = '?query-target-filter={0}{1}'.format(parent_filter, self_child_includes)
-        # Query for all objects of the module's class matching the provided ID value of the object
+            self.child_classes.add(obj_class)
+            self.path = 'api/class/{0}.json'.format(parent_class)
+            self.update_qs({'query-target-filter': self.build_filter(parent_class, parent_filter)})
+        elif parent_obj is None and mo is None:  # root_obj is known
+            # Query for all objects of the module's class that belong to a specific root object
+            self.child_classes.update([parent_class, obj_class])
+            self.path = 'api/mo/uni/{0}.json'.format(root_rn)
+            # NOTE: No need to select by root_filter
+            # self.update_qs({'query-target-filter': self.build_filter(root_class, root_filter)})
+        elif root_obj is None:  # mo and parent_obj are known
+            # Query for all objects of the module's class that belong to any parent class
+            # matching the provided ID values for both object and parent object
+            self.child_classes.add(obj_class)
+            self.path = 'api/class/{0}.json'.format(parent_class)
+            self.update_qs({'query-target-filter': self.build_filter(parent_class, parent_filter)})
+            self.update_qs({'rsp-subtree-filter': self.build_filter(obj_class, obj_filter)})
+        elif parent_obj is None:  # mo and root_obj are known
+            # Query for all objects of the module's class that match the provided ID value and belong to a specific root object
+            self.child_classes.add(obj_class)
+            self.path = 'api/mo/uni/{0}.json'.format(root_rn)
+            # NOTE: No need to select by root_filter
+            # self.update_qs({'query-target-filter': self.build_filter(root_class, root_filter)})
+            # TODO: Filter by parent_filter and obj_filter
+            self.update_qs({'rsp-subtree-filter': self.build_filter(obj_class, obj_filter)})
+        elif mo is None:  # root_obj and parent_obj are known
+            # Query for all objects of the module's class that belong to a specific parent object
+            self.child_classes.add(obj_class)
+            self.path = 'api/mo/uni/{0}/{1}.json'.format(root_rn, parent_rn)
+            # NOTE: No need to select by parent_filter
+            # self.update_qs({'query-target-filter': self.build_filter(parent_class, parent_filter)})
         else:
-            path = 'api/class/{0}.json'.format(obj_class)
-            filter_string = '?query-target-filter={0}'.format(obj_filter) + child_includes
+            # Query for a specific object of the module's class
+            self.path = 'api/mo/uni/{0}/{1}/{2}.json'.format(root_rn, parent_rn, obj_rn)
 
-        # append child_includes to filter_string if filter string is empty
-        if child_includes is not None and filter_string == '':
-            filter_string = child_includes.replace('&', '?', 1)
-
-        return path, filter_string
-
-    def _construct_url_4(self, root, sec, parent, obj, child_includes):
+    def _construct_url_4(self, root, sec, parent, obj):
         """
-        This method is used by get_url when the object is the third-level class.
+        This method is used by construct_url when the object is the fourth-level class.
         """
-        # root_class = root['aci_class']
+        root_class = root['aci_class']
         root_rn = root['aci_rn']
-        # root_filter = root['filter_target']
-        # root_obj = root['module_object']
-        # sec_class = sec['aci_class']
+        root_filter = root['target_filter']
+        root_obj = root['module_object']
+        sec_class = sec['aci_class']
         sec_rn = sec['aci_rn']
-        # sec_filter = sec['filter_target']
-        # sec_obj = sec['module_object']
-        # parent_class = parent['aci_class']
+        sec_filter = sec['target_filter']
+        sec_obj = sec['module_object']
+        parent_class = parent['aci_class']
         parent_rn = parent['aci_rn']
-        # parent_filter = parent['filter_target']
-        # parent_obj = parent['module_object']
+        parent_filter = parent['target_filter']
+        parent_obj = parent['module_object']
         obj_class = obj['aci_class']
         obj_rn = obj['aci_rn']
-        # obj_filter = obj['filter_target']
-        # mo = obj['module_object']
+        obj_filter = obj['target_filter']
+        mo = obj['module_object']
 
-        # State is ablsent or present
-        if self.module.params['state'] != 'query':
-            path = 'api/mo/uni/{0}/{1}/{2}/{3}.json'.format(root_rn, sec_rn, parent_rn, obj_rn)
-            filter_string = '?rsp-prop-include=config-only' + child_includes
+        if self.child_classes is None:
+            self.child_classes = [obj_class]
+
+        if self.module.params['state'] in ('absent', 'present'):
+            # State is absent or present
+            self.path = 'api/mo/uni/{0}/{1}/{2}/{3}.json'.format(root_rn, sec_rn, parent_rn, obj_rn)
+            self.update_qs({'rsp-prop-include': 'config-only'})
+        # TODO: Add all missing cases
+        elif root_obj is None:
+            self.child_classes.add(obj_class)
+            self.path = 'api/class/{0}.json'.format(obj_class)
+            self.update_qs({'query-target-filter': self.build_filter(obj_class, obj_filter)})
+        elif sec_obj is None:
+            self.child_classes.add(obj_class)
+            self.path = 'api/mo/uni/{0}.json'.format(root_rn)
+            # NOTE: No need to select by root_filter
+            # self.update_qs({'query-target-filter': self.build_filter(root_class, root_filter)})
+            # TODO: Filter by sec_filter, parent and obj_filter
+            self.update_qs({'rsp-subtree-filter': self.build_filter(obj_class, obj_filter)})
+        elif parent_obj is None:
+            self.child_classes.add(obj_class)
+            self.path = 'api/mo/uni/{0}/{1}.json'.format(root_rn, sec_rn)
+            # NOTE: No need to select by sec_filter
+            # self.update_qs({'query-target-filter': self.build_filter(sec_class, sec_filter)})
+            # TODO: Filter by parent_filter and obj_filter
+            self.update_qs({'rsp-subtree-filter': self.build_filter(obj_class, obj_filter)})
+        elif mo is None:
+            self.child_classes.add(obj_class)
+            self.path = 'api/mo/uni/{0}/{1}/{2}.json'.format(root_rn, sec_rn, parent_rn)
+            # NOTE: No need to select by parent_filter
+            # self.update_qs({'query-target-filter': self.build_filter(parent_class, parent_filter)})
         else:
-            path = 'api/class/{0}.json'.format(obj_class)
-            filter_string = child_includes
-
-        return path, filter_string
+            # Query for a specific object of the module's class
+            self.path = 'api/mo/uni/{0}/{1}/{2}/{3}.json'.format(root_rn, sec_rn, parent_rn, obj_rn)
 
     def delete_config(self):
         """

--- a/lib/ansible/modules/network/aci/aci_aaa_user.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user.py
@@ -301,8 +301,8 @@ def main():
         root_class=dict(
             aci_class='aaaUser',
             aci_rn='userext/user-{0}'.format(aaa_user),
-            filter_target='eq(aaaUser.name, "{0}")'.format(aaa_user),
             module_object=aaa_user,
+            target_filter={'name': aaa_user},
         ),
     )
     aci.get_existing()

--- a/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
@@ -240,14 +240,14 @@ def main():
         root_class=dict(
             aci_class=ACI_MAPPING[aaa_user_type]['aci_class'],
             aci_rn=ACI_MAPPING[aaa_user_type]['aci_mo'] + aaa_user,
-            filter_target='eq({0}.name, "{1}")'.format(ACI_MAPPING[aaa_user_type]['aci_class'], aaa_user),
             module_object=aaa_user,
+            target_filter={'name': aaa_user},
         ),
         subclass_1=dict(
             aci_class='aaaUserCert',
             aci_rn='usercert-{0}'.format(certificate_name),
-            filter_target='eq(aaaUserCert.name, "{0}")'.format(certificate_name),
             module_object=certificate_name,
+            target_filter={'name': certificate_name},
         ),
     )
     aci.get_existing()

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -282,15 +282,15 @@ def main():
         root_class=dict(
             aci_class='infraAccPortP',
             aci_rn='infra/accportprof-{0}'.format(leaf_interface_profile),
-            filter_target='eq(infraAccPortP.name, "{0}")'.format(leaf_interface_profile),
             module_object=leaf_interface_profile,
+            target_filter={'name': leaf_interface_profile},
         ),
         subclass_1=dict(
             aci_class='infraHPortS',
             # NOTE: normal rn: hports-{name}-typ-{type}, hence here hardcoded to range for purposes of module
             aci_rn='hports-{0}-typ-range'.format(access_port_selector),
-            filter_target='eq(infraHPortS.name, "{0}")'.format(access_port_selector),
             module_object=access_port_selector,
+            target_filter={'name': access_port_selector},
         ),
         child_classes=['infraPortBlk', 'infraRsAccBaseGrp'],
     )

--- a/lib/ansible/modules/network/aci/aci_aep.py
+++ b/lib/ansible/modules/network/aci/aci_aep.py
@@ -229,8 +229,8 @@ def main():
         root_class=dict(
             aci_class='infraAttEntityP',
             aci_rn='infra/attentp-{0}'.format(aep),
-            filter_target='eq(infraAttEntityP.name, "{0}")'.format(aep),
             module_object=aep,
+            target_filter={'name': aep},
         ),
     )
     aci.get_existing()

--- a/lib/ansible/modules/network/aci/aci_aep_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_aep_to_domain.py
@@ -264,14 +264,14 @@ def main():
         root_class=dict(
             aci_class='infraAttEntityP',
             aci_rn='infra/attentp-{0}'.format(aep),
-            filter_target='eq(infraAttEntityP.name, "{0}")'.format(aep),
             module_object=aep,
+            target_filter={'name': aep},
         ),
         subclass_1=dict(
             aci_class='infraRsDomP',
             aci_rn='rsdomP-[{0}]'.format(domain_mo),
-            filter_target='eq(infraRsDomP.tDn, "{0}")'.format(domain_mo),
             module_object=domain_mo,
+            target_filter={'tDn': domain_mo},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_ap.py
+++ b/lib/ansible/modules/network/aci/aci_ap.py
@@ -223,14 +223,14 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='fvAp',
             aci_rn='ap-{0}'.format(ap),
-            filter_target='eq(fvAp.name, "{0}")'.format(ap),
             module_object=ap,
+            target_filter={'name': ap},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_bd.py
+++ b/lib/ansible/modules/network/aci/aci_bd.py
@@ -381,14 +381,14 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='fvBD',
             aci_rn='BD-{0}'.format(bd),
-            filter_target='eq(fvBD.name, "{0}")'.format(bd),
             module_object=bd,
+            target_filter={'name': bd},
         ),
         child_classes=['fvRsCtx', 'fvRsIgmpsn', 'fvRsBDToNdP', 'fvRsBdToEpRet'],
     )

--- a/lib/ansible/modules/network/aci/aci_bd_subnet.py
+++ b/lib/ansible/modules/network/aci/aci_bd_subnet.py
@@ -372,20 +372,20 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='fvBD',
             aci_rn='BD-{0}'.format(bd),
-            filter_target='eq(fvBD.name, "{0}")'.format(bd),
             module_object=bd,
+            target_filter={'name': bd},
         ),
         subclass_2=dict(
             aci_class='fvSubnet',
             aci_rn='subnet-[{0}]'.format(gateway),
-            filter_target='eq(fvSubnet.ip, "{0}")'.format(gateway),
             module_object=gateway,
+            target_filter={'ip': gateway},
         ),
         child_classes=['fvRsBDSubnetToProfile', 'fvRsNdPfxPol'],
     )

--- a/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
@@ -188,20 +188,20 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='fvBD',
             aci_rn='BD-{0}'.format(bd),
-            filter_target='eq(fvBD.name, "{0}")'.format(bd),
             module_object=bd,
+            target_filter={'name': bd},
         ),
         subclass_2=dict(
             aci_class='fvRsBDToOut',
             aci_rn='rsBDToOut-{0}'.format(l3out),
-            filter_target='eq(fvRsBDToOut.tnL3extOutName, "{0}")'.format(l3out),
             module_object=l3out,
+            target_filter={'tnL3extOutName': l3out},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_config_rollback.py
+++ b/lib/ansible/modules/network/aci/aci_config_rollback.py
@@ -232,8 +232,8 @@ def main():
             root_class=dict(
                 aci_class='configImportP',
                 aci_rn='fabric/configimp-{0}'.format(import_policy),
-                filter_target='eq(configImportP.name, "{0}")'.format(import_policy),
                 module_object=import_policy,
+                target_filter={'name': import_policy},
             ),
         )
 

--- a/lib/ansible/modules/network/aci/aci_config_snapshot.py
+++ b/lib/ansible/modules/network/aci/aci_config_snapshot.py
@@ -252,8 +252,8 @@ def main():
             root_class=dict(
                 aci_class='configExportP',
                 aci_rn='fabric/configexp-{0}'.format(export_policy),
-                filter_target='eq(configExportP.name, "{0}")'.format(export_policy),
                 module_object=export_policy,
+                target_filter={'name': export_policy},
             ),
         )
 
@@ -286,14 +286,14 @@ def main():
             root_class=dict(
                 aci_class='configSnapshotCont',
                 aci_rn='backupst/snapshots-[{0}]'.format(export_policy),
-                filter_target='(configSnapshotCont.name, "{0}")'.format(export_policy),
                 module_object=export_policy,
+                target_filter={'name': export_policy},
             ),
             subclass_1=dict(
                 aci_class='configSnapshot',
                 aci_rn='snapshot-{0}'.format(snapshot),
-                filter_target='eq(configSnapshot.name, "{0}")'.format(snapshot),
                 module_object=snapshot,
+                target_filter={'name': snapshot},
             ),
         )
 

--- a/lib/ansible/modules/network/aci/aci_contract.py
+++ b/lib/ansible/modules/network/aci/aci_contract.py
@@ -250,14 +250,14 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='vzBrCP',
             aci_rn='brc-{0}'.format(contract),
-            filter_target='eq(vzBrCP.name, "{0}")'.format(contract),
             module_object=contract,
+            target_filter={'name': contract},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_contract_subject.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject.py
@@ -286,20 +286,20 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='vzBrCP',
             aci_rn='brc-{0}'.format(contract),
-            filter_target='eq(vzBrCP.name, "{0}")'.format(contract),
             module_object=contract,
+            target_filter={'name': contract},
         ),
         subclass_2=dict(
             aci_class='vzSubj',
             aci_rn='subj-{0}'.format(subject),
-            filter_target='eq(vzSubj.name, "{0}")'.format(subject),
             module_object=subject,
+            target_filter={'name': subject},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
@@ -252,26 +252,26 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='vzBrCP',
             aci_rn='brc-{0}'.format(contract),
-            filter_target='eq(vzBrCP.name, "{0}")'.format(contract),
             module_object=contract,
+            target_filter={'name': contract},
         ),
         subclass_2=dict(
             aci_class='vzSubj',
             aci_rn='subj-{0}'.format(subject),
-            filter_target='eq(vzSubj.name, "{0}")'.format(subject),
             module_object=subject,
+            target_filter={'name': subject},
         ),
         subclass_3=dict(
             aci_class='vzRsSubjFiltAtt',
             aci_rn='rssubjFiltAtt-{0}'.format(filter_name),
-            filter_target='eq(vzRsSubjFiltAtt.tnVzFilterName, "{0}")'.format(filter_name),
             module_object=filter_name,
+            target_filter={'tnVzFilterName': filter_name},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_domain.py
+++ b/lib/ansible/modules/network/aci/aci_domain.py
@@ -334,8 +334,8 @@ def main():
         root_class=dict(
             aci_class=domain_class,
             aci_rn=domain_rn,
-            filter_target='eq({0}.name, "{1}")'.format(domain_class, domain),
             module_object=domain_mo,
+            target_filter={'name': domain},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
@@ -325,8 +325,8 @@ def main():
         root_class=dict(
             aci_class=domain_class,
             aci_rn=domain_rn,
-            filter_target='eq({0}.name, "{1}")'.format(domain_class, domain),
             module_object=domain_mo,
+            target_filter={'name': domain},
         ),
         child_classes=[child_class],
     )

--- a/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
@@ -315,8 +315,8 @@ def main():
         root_class=dict(
             aci_class=domain_class,
             aci_rn=domain_rn,
-            filter_target='eq({0}.name, "{1}")'.format(domain_class, domain),
             module_object=domain_mo,
+            target_filter={'name': domain},
         ),
         child_classes=['infraRsVlanNs'],
     )

--- a/lib/ansible/modules/network/aci/aci_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool.py
@@ -259,8 +259,8 @@ def main():
         root_class=dict(
             aci_class=aci_class,
             aci_rn='{0}{1}'.format(aci_mo, pool_name),
-            filter_target='eq({0}.name, "{1}")'.format(aci_class, pool),
             module_object=pool,
+            target_filter={'name': pool},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_encap_pool_range.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool_range.py
@@ -327,33 +327,15 @@ def main():
                 if not 1 <= encap_id <= 4093:
                     module.fail_json(msg='vsan pools must have "range_start" and "range_end" values between 1 and 4093')
 
-    # Build proper proper filter_target based on range_start, range_end, and range_name
     if range_end is not None and range_start is not None:
         # Validate range_start is less than range_end
         if range_start > range_end:
             module.fail_json(msg='The "range_start" must be less than or equal to the "range_end"')
 
-        if range_name is None:
-            range_filter_target = 'and(eq({0}.from, "{1}"),eq({0}.to, "{2}"))'.format(aci_range_class, encap_start, encap_end)
-        else:
-            range_filter_target = 'and(eq({0}.from, "{1}"),eq({0}.to, "{2}"),eq({0}.name, "{3}"))'.format(aci_range_class, encap_start, encap_end, range_name)
     elif range_end is None and range_start is None:
         if range_name is None:
             # Reset range managed object to None for aci util to properly handle query
             aci_range_mo = None
-            range_filter_target = ''
-        else:
-            range_filter_target = 'eq({0}.name, "{1}")'.format(aci_range_class, range_name)
-    elif range_start is not None:
-        if range_name is None:
-            range_filter_target = 'eq({0}.from, "{1}")'.format(aci_range_class, encap_start)
-        else:
-            range_filter_target = 'and(eq({0}.from, "{1}"),eq({0}.name, "{2}"))'.format(aci_range_class, encap_start, range_name)
-    else:
-        if range_name is None:
-            range_filter_target = 'eq({0}.to, "{1}")'.format(aci_range_class, encap_end)
-        else:
-            range_filter_target = 'and(eq({0}.to, "{1}"),eq({0}.name, "{2}"))'.format(aci_range_class, encap_end, range_name)
 
     # Vxlan does not support setting the allocation mode
     if pool_type == 'vxlan' and allocation_mode is not None:
@@ -371,14 +353,14 @@ def main():
         root_class=dict(
             aci_class=aci_pool_class,
             aci_rn='{0}{1}'.format(aci_pool_mo, pool_name),
-            filter_target='eq({0}.name, "{1}")'.format(aci_pool_class, pool),
             module_object=pool,
+            target_filter={'name': pool},
         ),
         subclass_1=dict(
             aci_class=aci_range_class,
             aci_rn='{0}'.format(aci_range_mo),
-            filter_target=range_filter_target,
             module_object=aci_range_mo,
+            target_filter={'from': encap_start, 'to': encap_end, 'name': range_name},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_epg.py
+++ b/lib/ansible/modules/network/aci/aci_epg.py
@@ -307,20 +307,20 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='fvAp',
             aci_rn='ap-{0}'.format(ap),
-            filter_target='eq(fvAp.name, "{0}")'.format(ap),
             module_object=ap,
+            target_filter={'name': ap},
         ),
         subclass_2=dict(
             aci_class='fvAEPg',
             aci_rn='epg-{0}'.format(epg),
-            filter_target='eq(fvAEPg.name, "{0}")'.format(epg),
             module_object=epg,
+            target_filter={'name': epg},
         ),
         child_classes=['fvRsBd'],
     )

--- a/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
+++ b/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
@@ -196,14 +196,14 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='monEPGPol',
             aci_rn='monepg-{0}'.format(monitoring_policy),
-            filter_target='eq(monEPGPol.name, "{0}")'.format(monitoring_policy),
             module_object=monitoring_policy,
+            target_filter={'name': monitoring_policy},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_epg_to_contract.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_contract.py
@@ -267,26 +267,26 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='fvAp',
             aci_rn='ap-{0}'.format(ap),
-            filter_target='eq(fvAp.name, "{0}")'.format(ap),
             module_object=ap,
+            target_filter={'name': ap},
         ),
         subclass_2=dict(
             aci_class='fvAEPg',
             aci_rn='epg-{0}'.format(epg),
-            filter_target='eq(fvAEPg.name, "{0}")'.format(epg),
             module_object=epg,
+            target_filter={'name': epg},
         ),
         subclass_3=dict(
             aci_class=aci_class,
             aci_rn='{0}{1}'.format(aci_rn, contract),
-            filter_target='eq({0}.tnVzBrCPName, "{1}'.format(aci_class, contract),
             module_object=contract,
+            target_filter={'tnVzBrCPName': contract},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_epg_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_domain.py
@@ -335,26 +335,26 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='fvAp',
             aci_rn='ap-{0}'.format(ap),
-            filter_target='eq(fvAp.name, "{0}")'.format(ap),
             module_object=ap,
+            target_filter={'name': ap},
         ),
         subclass_2=dict(
             aci_class='fvAEPg',
             aci_rn='epg-{0}'.format(epg),
-            filter_target='eq(fvTenant.name, "{0}")'.format(epg),
             module_object=epg,
+            target_filter={'name': epg},
         ),
         subclass_3=dict(
             aci_class='fvRsDomAtt',
             aci_rn='rsdomAtt-[{0}]'.format(epg_domain),
-            filter_target='eq(fvRsDomAtt.tDn, "{0}")'.format(epg_domain),
             module_object=epg_domain,
+            target_filter={'tDn': epg_domain},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_fabric_node.py
+++ b/lib/ansible/modules/network/aci/aci_fabric_node.py
@@ -232,8 +232,8 @@ def main():
         root_class=dict(
             aci_class='fabricNodeIdentP',
             aci_rn='controller/nodeidentpol/nodep-{0}'.format(serial),
-            filter_target='eq(fabricNodeIdentP.serial, "{0}")'.format(serial),
             module_object=serial,
+            target_filter={'serial': serial},
         )
     )
 

--- a/lib/ansible/modules/network/aci/aci_filter.py
+++ b/lib/ansible/modules/network/aci/aci_filter.py
@@ -224,14 +224,14 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='vzFilter',
             aci_rn='flt-{0}'.format(filter_name),
-            filter_target='eq(vzFilter.name, "{0}")'.format(filter_name),
             module_object=filter_name,
+            target_filter={'name': filter_name},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_filter_entry.py
+++ b/lib/ansible/modules/network/aci/aci_filter_entry.py
@@ -299,20 +299,20 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='vzFilter',
             aci_rn='flt-{0}'.format(filter_name),
-            filter_target='eq(vzFilter.name, "{0}")'.format(filter_name),
             module_object=filter_name,
+            target_filter={'name': filter_name},
         ),
         subclass_2=dict(
             aci_class='vzEntry',
             aci_rn='e-{0}'.format(entry),
-            filter_target='eq(vzEntry.name, "{0}")'.format(entry),
-            module_object=entry
+            module_object=entry,
+            target_filter={'name': entry},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_firmware_source.py
+++ b/lib/ansible/modules/network/aci/aci_firmware_source.py
@@ -236,8 +236,8 @@ def main():
         root_class=dict(
             aci_class='firmwareOSource',
             aci_rn='fabric/fwrepop',
-            filter_target='eq(firmwareOSource.name, "{0}")'.format(source),
             module_object=source,
+            target_filter={'name': source},
         ),
     )
     aci.get_existing()

--- a/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
@@ -194,8 +194,8 @@ def main():
         root_class=dict(
             aci_class='fcIfPol',
             aci_rn='infra/fcIfPol-{0}'.format(fc_policy),
-            filter_target='eq(fcIfPol.name, "{0}")'.format(fc_policy),
             module_object=fc_policy,
+            target_filter={'name': fc_policy},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
@@ -213,8 +213,8 @@ def main():
         root_class=dict(
             aci_class='l2IfPol',
             aci_rn='infra/l2IfP-{0}'.format(l2_policy),
-            filter_target='eq(l2IfPol.name, "{0}")'.format(l2_policy),
             module_object=l2_policy,
+            target_filter={'name': l2_policy},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
@@ -352,6 +352,8 @@ def main():
             name=policy_group,
             descr=description,
         )
+        # Reset for target_filter
+        lag_type = None
     elif lag_type in ('link', 'node'):
         aci_class_name = 'infraAccBndlGrp'
         dn_name = 'accbundle'
@@ -366,8 +368,8 @@ def main():
         root_class=dict(
             aci_class=aci_class_name,
             aci_rn='infra/funcprof/{0}-{1}'.format(dn_name, policy_group),
-            filter_target='eq({0}.name, "{1}")'.format(aci_class_name, policy_group),
             module_object=policy_group,
+            target_filter={'name': policy_group, 'lagT': lag_type},
         ),
         child_classes=[
             'infraRsAttEntP',

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
@@ -211,8 +211,8 @@ def main():
         root_class=dict(
             aci_class='infraAccPortP',
             aci_rn='infra/accportprof-{0}'.format(leaf_interface_profile),
-            filter_target='eq(infraAccPortP.name, "{0}")'.format(leaf_interface_profile),
-            module_object=leaf_interface_profile
+            module_object=leaf_interface_profile,
+            target_filter={'name': leaf_interface_profile},
         ),
     )
     aci.get_existing()

--- a/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
@@ -203,8 +203,8 @@ def main():
         root_class=dict(
             aci_class='lldpIfPol',
             aci_rn='infra/lldpIfP-{0}'.format(lldp_policy),
-            filter_target='eq(lldpIfPol.name, "{0}")'.format(lldp_policy),
             module_object=lldp_policy,
+            target_filter={'name': lldp_policy},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
@@ -195,8 +195,8 @@ def main():
         root_class=dict(
             aci_class='mcpIfPol',
             aci_rn='infra/mcpIfP-{0}'.format(mcp),
-            filter_target='eq(mcpIfPol.name, "{0}")'.format(mcp),
             module_object=mcp,
+            target_filter={'name': mcp},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_interface_policy_ospf.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_ospf.py
@@ -346,8 +346,8 @@ def main():
         root_class=dict(
             aci_class='ospfIfPol',
             aci_rn='tn-{0}/ospfIfPol-{1}'.format(tenant, ospf),
-            filter_target='eq(ospfIfPol.name, "{0}")'.format(ospf),
             module_object=ospf,
+            target_filter={'name': ospf},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
@@ -273,8 +273,8 @@ def main():
         root_class=dict(
             aci_class='lacpLagPol',
             aci_rn='infra/lacplagp-{0}'.format(port_channel),
-            filter_target='eq(lacpLagPol.name, "{0}")'.format(port_channel),
             module_object=port_channel,
+            target_filter={'name': port_channel},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
@@ -197,8 +197,8 @@ def main():
         root_class=dict(
             aci_class='l2PortSecurityPol',
             aci_rn='infra/portsecurityP-{0}'.format(port_security),
-            filter_target='eq(l2PortSecurityPol.name, "{0}")'.format(port_security),
             module_object=port_security,
+            target_filter={'name': port_security},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
@@ -210,14 +210,14 @@ def main():
         root_class=dict(
             aci_class='infraNodeP',
             aci_rn='infra/nprof-{0}'.format(leaf_profile),
-            filter_target='eq(infraNodeP.name, "{0}")'.format(leaf_profile),
-            module_object=leaf_profile
+            module_object=leaf_profile,
+            target_filter={'name': leaf_profile},
         ),
         subclass_1=dict(
             aci_class='infraRsAccPortP',
             aci_rn='rsaccPortP-[{0}]'.format(interface_selector_tDn),
-            filter_target='eq(infraRsAccPortP.name, "{0}")'.format(interface_selector),
             module_object=interface_selector,
+            target_filter={'name': interface_selector},
         )
     )
 

--- a/lib/ansible/modules/network/aci/aci_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_l3out.py
@@ -269,14 +269,14 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='l3extOut',
             aci_rn='out-{0}'.format(l3out),
-            filter_target='eq(l3extOut.name, "{0}")'.format(l3out),
             module_object=l3out,
+            target_filter={'name': l3out},
         ),
         child_classes=child_classes,
     )

--- a/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
+++ b/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
@@ -205,14 +205,14 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='l3extRouteTagPol',
             aci_rn='rttag-{0}'.format(rtp),
-            filter_target='eq(l3extRouteTagPol.name, "{0}")'.format(rtp),
             module_object=rtp,
+            target_filter={'name': rtp},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_static_binding_to_epg.py
+++ b/lib/ansible/modules/network/aci/aci_static_binding_to_epg.py
@@ -358,6 +358,11 @@ def main():
     )
 
     static_path = INTERFACE_TYPE_MAPPING[interface_type]
+
+    path_target_filter = {}
+    if pod_id is not None and leafs is not None and interface is not None and (interface_type != 'fex' or extpaths is not None):
+        path_target_filter = {'tDn': static_path}
+
     if interface_mode is not None:
         interface_mode = INTERFACE_MODE_MAPPING[interface_mode]
 
@@ -366,26 +371,26 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='fvAp',
             aci_rn='ap-{0}'.format(ap),
-            filter_target='eq(fvAp.name, "{0}")'.format(ap),
             module_object=ap,
+            target_filter={'name': ap},
         ),
         subclass_2=dict(
             aci_class='fvAEPg',
             aci_rn='epg-{0}'.format(epg),
-            filter_target='eq(fvAEPg.name, "{0}")'.format(epg),
             module_object=epg,
+            target_filter={'name': epg},
         ),
         subclass_3=dict(
             aci_class='fvRsPathAtt',
             aci_rn='rspathAtt-[{0}]'.format(static_path),
-            filter_target='eq(fvRsPathAtt.tDn, "{0}"'.format(static_path),
             module_object=static_path,
+            target_filter=path_target_filter,
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
+++ b/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
@@ -260,15 +260,15 @@ def main():
         root_class=dict(
             aci_class='infraNodeP',
             aci_rn='infra/nprof-{0}'.format(leaf_profile),
-            filter_target='eq(infraNodeP.name, "{0}")'.format(leaf_profile),
-            module_object=leaf_profile
+            module_object=leaf_profile,
+            target_filter={'name': leaf_profile},
         ),
         subclass_1=dict(
             aci_class='infraLeafS',
             # NOTE: normal rn: leaves-{name}-typ-{type}, hence here hardcoded to range for purposes of module
             aci_rn='leaves-{0}-typ-range'.format(leaf),
-            filter_target='eq(infraLeafS.name, "{0}")'.format(leaf),
             module_object=leaf,
+            target_filter={'name': leaf},
         ),
         # NOTE: infraNodeBlk is not made into a subclass because there is a 1-1 mapping between node block and leaf selector name
         child_classes=['infraNodeBlk', 'infraRsAccNodePGrp'],

--- a/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
@@ -203,8 +203,8 @@ def main():
         root_class=dict(
             aci_class='infraNodeP',
             aci_rn='infra/nprof-{0}'.format(leaf_profile),
-            filter_target='eq(infraNodeP.name, "{0}")'.format(leaf_profile),
             module_object=leaf_profile,
+            target_filter={'name': leaf_profile},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_switch_policy_vpc_protection_group.py
+++ b/lib/ansible/modules/network/aci/aci_switch_policy_vpc_protection_group.py
@@ -235,8 +235,8 @@ def main():
         root_class=dict(
             aci_class='fabricExplicitGEp',
             aci_rn='fabric/protpol/expgep-{0}'.format(protection_group),
-            filter_target='eq(fabricExplicitGEp.name, "{0}")'.format(protection_group),
             module_object=protection_group,
+            target_filter={'name': protection_group},
         ),
         child_classes=['fabricNodePEp', 'fabricNodePEp', 'fabricRsVpcInstPol'],
     )

--- a/lib/ansible/modules/network/aci/aci_taboo_contract.py
+++ b/lib/ansible/modules/network/aci/aci_taboo_contract.py
@@ -229,14 +229,14 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='vzTaboo',
             aci_rn='taboo-{0}'.format(taboo_contract),
-            filter_target='eq(vzTaboo.name, "{0}")'.format(taboo_contract),
             module_object=taboo_contract,
+            target_filter={'name': taboo_contract},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_tenant.py
+++ b/lib/ansible/modules/network/aci/aci_tenant.py
@@ -210,8 +210,8 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
     )
     aci.get_existing()

--- a/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
@@ -194,14 +194,14 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='rtctrlAttrP',
             aci_rn='attr-{0}'.format(action_rule),
-            filter_target='eq(rtctrlAttrP.name, "{0}")'.format(action_rule),
             module_object=action_rule,
+            target_filter={'name': action_rule},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
@@ -294,14 +294,14 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='fvEpRetPol',
             aci_rn='epRPol-{0}'.format(epr_policy),
-            filter_target='eq(fvEpRetPol.name, "{0}")'.format(epr_policy),
             module_object=epr_policy,
+            target_filter={'name': epr_policy},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
@@ -196,14 +196,14 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='spanDestGrp',
             aci_rn='destgrp-{0}'.format(dst_group),
-            filter_target='eq(spanDestGrp.name, "{0}")'.format(dst_group),
             module_object=dst_group,
+            target_filter={'name': dst_group},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
@@ -208,14 +208,14 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='spanSrcGrp',
             aci_rn='srcgrp-{0}'.format(src_group),
-            filter_target='eq(spanSrcGrp.name, "{0}")'.format(src_group),
             module_object=src_group,
+            target_filter={'name': src_group},
         ),
         child_classes=['spanSpanLbl'],
     )

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
@@ -198,20 +198,20 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='spanSrcGrp',
             aci_rn='srcgrp-{0}'.format(src_group),
-            filter_target='eq(spanSrcGrp.name, "{0}")'.format(src_group),
             module_object=src_group,
+            target_filter={'name': src_group},
         ),
         subclass_2=dict(
             aci_class='spanSpanLbl',
             aci_rn='spanlbl-{0}'.format(dst_group),
-            filter_target='eq(spanSpanLbl.name, "{0}")'.format(dst_group),
             module_object=dst_group,
+            target_filter={'name': dst_group},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool.py
@@ -231,8 +231,8 @@ def main():
         root_class=dict(
             aci_class='fvnsVlanInstP',
             aci_rn='infra/vlanns-{0}'.format(pool_name),
-            filter_target='eq(fvnsVlanInstP.name, "{0}")'.format(pool),
             module_object=pool,
+            target_filter={'name': pool},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
@@ -275,33 +275,15 @@ def main():
             if not 1 <= encap_id <= 4094:
                 module.fail_json(msg="vlan pools must have 'block_start' and 'block_end' values between 1 and 4094")
 
-    # Build proper proper filter_target based on block_start, block_end, and block_name
     if block_end is not None and block_start is not None:
         # Validate block_start is less than block_end
         if block_start > block_end:
             module.fail_json(msg="The 'block_start' must be less than or equal to the 'block_end'")
 
-        if block_name is None:
-            block_filter_target = 'and(eq({0}.from, "{1}"),eq({0}.to, "{2}"))'.format('fvnsEncapBlk', encap_start, encap_end)
-        else:
-            block_filter_target = 'and(eq({0}.from, "{1}"),eq({0}.to, "{2}"),eq({0}.name, "{3}"))'.format('fvnsEncapBlk', encap_start, encap_end, block_name)
     elif block_end is None and block_start is None:
         if block_name is None:
             # Reset range managed object to None for aci util to properly handle query
             aci_block_mo = None
-            block_filter_target = ''
-        else:
-            block_filter_target = 'eq({0}.name, "{1}")'.format('fvnsEncapBlk', block_name)
-    elif block_start is not None:
-        if block_name is None:
-            block_filter_target = 'eq({0}.from, "{1}")'.format('fvnsEncapBlk', encap_start)
-        else:
-            block_filter_target = 'and(eq({0}.from, "{1}"),eq({0}.name, "{2}"))'.format('fvnsEncapBlk', encap_start, block_name)
-    else:
-        if block_name is None:
-            block_filter_target = 'eq({0}.to, "{1}")'.format('fvnsEncapBlk', encap_end)
-        else:
-            block_filter_target = 'and(eq({0}.to, "{1}"),eq({0}.name, "{2}"))'.format('fvnsEncapBlk', encap_end, block_name)
 
     # ACI Pool URL requires the allocation mode (ex: uni/infra/vlanns-[poolname]-static)
     if pool is not None:
@@ -315,14 +297,14 @@ def main():
         root_class=dict(
             aci_class='fvnsVlanInstP',
             aci_rn='infra/vlanns-{0}'.format(pool_name),
-            filter_target='eq(fvnsVlanInstP.name, "{0}")'.format(pool),
             module_object=pool,
+            target_filter={'name': pool},
         ),
         subclass_1=dict(
             aci_class='fvnsEncapBlk',
             aci_rn=aci_block_mo,
-            filter_target=block_filter_target,
             module_object=aci_block_mo,
+            target_filter={'from': encap_start, 'to': encap_end, 'name': block_name},
         ),
     )
 

--- a/lib/ansible/modules/network/aci/aci_vrf.py
+++ b/lib/ansible/modules/network/aci/aci_vrf.py
@@ -235,14 +235,14 @@ def main():
         root_class=dict(
             aci_class='fvTenant',
             aci_rn='tn-{0}'.format(tenant),
-            filter_target='eq(fvTenant.name, "{0}")'.format(tenant),
             module_object=tenant,
+            target_filter={'name': tenant},
         ),
         subclass_1=dict(
             aci_class='fvCtx',
             aci_rn='ctx-{0}'.format(vrf),
-            filter_target='eq(fvCtx.name, "{0}")'.format(vrf),
             module_object=vrf,
+            target_filter={'name': vrf},
         ),
     )
 

--- a/test/integration/targets/aci_aaa_user/tasks/main.yml
+++ b/test/integration/targets/aci_aaa_user/tasks/main.yml
@@ -64,8 +64,10 @@
 - name: Verify add user
   assert:
     that:
-    - cm_add_user.changed == nm_add_user.changed == true
-    - cm_add_user_again.changed == nm_add_user_again.changed == false
+    - cm_add_user is changed
+    - nm_add_user is changed
+    - cm_add_user_again is not changed
+    - nm_add_user_again is not changed
 
 
 # MODIFY USER
@@ -103,8 +105,10 @@
 - name: Verify modify user
   assert:
     that:
-    - cm_modify_user.changed == nm_modify_user.changed == true
-    - cm_modify_user_again.changed == nm_modify_user_again.changed == false
+    - cm_modify_user is changed
+    - nm_modify_user is changed
+    - cm_modify_user_again is not changed
+    - nm_modify_user_again is not changed
 
 
 # QUERY ALL USERS
@@ -129,7 +133,8 @@
 - name: Verify query_all_users
   assert:
     that:
-    - cm_query_all_users.changed == nm_query_all_users.changed == false
+    - cm_query_all_users is not changed
+    - nm_query_all_users is not changed
     # NOTE: Order of users is not stable between calls
     #- cm_query_all_users == nm_query_all_users
 
@@ -149,7 +154,8 @@
 - name: Verify query_user
   assert:
     that:
-    - cm_query_user.changed == nm_query_user.changed == false
+    - cm_query_user is not changed
+    - nm_query_user is not changed
     - cm_query_user == nm_query_user
 
 
@@ -175,5 +181,7 @@
 - name: Verify remove_user
   assert:
     that:
-    - cm_remove_user.changed == nm_remove_user.changed == true
-    - cm_remove_user_again.changed == nm_remove_user_again.changed == false
+    - cm_remove_user is changed
+    - nm_remove_user is changed
+    - cm_remove_user_again is not changed
+    - nm_remove_user_again is not changed

--- a/test/integration/targets/aci_aaa_user_certificate/tasks/main.yml
+++ b/test/integration/targets/aci_aaa_user_certificate/tasks/main.yml
@@ -57,8 +57,10 @@
 - name: Verify add_cert
   assert:
     that:
-    - cm_add_cert.changed == nm_add_cert.changed == true
-    - cm_add_cert_again.changed == nm_add_cert_again.changed == false
+    - cm_add_cert is changed
+    - nm_add_cert is change
+    - cm_add_cert_again is not changed
+    - nm_add_cert_again is not changed
 
 
 # QUERY ALL USER CERTIFICATES
@@ -84,7 +86,8 @@
 - name: Verify query_all_certs
   assert:
     that:
-    - cm_query_all_certs.changed == nm_query_all_certs.changed == false
+    - cm_query_all_certs is not changed
+    - nm_query_all_certs is not changed
     # NOTE: Order of certs is not stable between calls
     #- cm_query_all_certs == nm_query_all_certs
 
@@ -106,7 +109,8 @@
 - name: Verify query_cert
   assert:
     that:
-    - cm_query_cert.changed == nm_query_cert.changed == false
+    - cm_query_cert is not changed
+    - nm_query_cert is not changed
     - cm_query_cert == nm_query_cert
 
 
@@ -132,5 +136,7 @@
 - name: Verify remove_cert
   assert:
     that:
-    - cm_remove_cert.changed == nm_remove_cert.changed == true
-    - cm_remove_cert_again.changed == nm_remove_cert_again.changed == false
+    - cm_remove_cert is changed
+    - nm_remove_cert is changed
+    - cm_remove_cert_again is not changed
+    - nm_remove_cert_again is not changed

--- a/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
@@ -53,13 +53,13 @@
 - name: present assertions
   assert:
     that:
-    - accessport_to_intf_check_mode_present.changed == true
-    - accessport_to_intf_present.changed == true
+    - accessport_to_intf_check_mode_present is changed
+    - accessport_to_intf_present is changed
     - accessport_to_intf_present.previous == []
     - 'accessport_to_intf_present.sent == {"infraHPortS": {"attributes": {"name": "anstest_accessportselector"}, "children": [{"infraPortBlk": {"attributes": {"fromPort": "13", "name": "anstest_leafportblkname", "toPort": "16"}}}, {"infraRsAccBaseGrp": {"attributes": {"tDn": "uni/infra/funcprof/accportgrp-None"}}}]}}'
-    - accessport_to_intf_idempotent.changed == false
+    - accessport_to_intf_idempotent is not changed
     - accessport_to_intf_idempotent.sent == {}
-    - accessport_to_intf_update.changed == true
+    - accessport_to_intf_update is changed
     - 'accessport_to_intf_update.sent == {"infraHPortS": {"attributes": {},"children": [{"infraRsAccBaseGrp": {"attributes": {"tDn": "uni/infra/funcprof/accportgrp-anstest_policygroupname"}}}]}}'
 
 - name: Query Specific access_port_selector and leaf_interface_profile binding
@@ -72,7 +72,7 @@
 - name: present assertions
   assert:
     that:
-      - binding_query.changed == false
+      - binding_query is not changed
       - binding_query.current | length >= 1
       - '"api/mo/uni/infra/accportprof-leafintprftest/hports-anstest_accessportselector-typ-range.json" in binding_query.url'
 
@@ -105,13 +105,13 @@
 - name: absent assertions
   assert:
     that:
-      - accessport_to_intf_check_mode_absent.changed == true
+      - accessport_to_intf_check_mode_absent is changed
       - accessport_to_intf_check_mode_absent.previous != []
-      - accessport_to_intf_absent.changed == true
+      - accessport_to_intf_absent is changed
       - accessport_to_intf_absent.previous == accessport_to_intf_check_mode_absent.previous
-      - accessport_to_intf_absent_idempotent.changed == false
+      - accessport_to_intf_absent_idempotent is not changed
       - accessport_to_intf_absent_idempotent.previous == []
-      - accessport_to_intf_absent_missing_param.failed == true
+      - accessport_to_intf_absent_missing_param is failed
       - 'accessport_to_intf_absent_missing_param.msg == "state is absent but all of the following are missing: access_port_selector"'
 
 

--- a/test/integration/targets/aci_aep/tasks/main.yml
+++ b/test/integration/targets/aci_aep/tasks/main.yml
@@ -45,7 +45,8 @@
 - name: Verify add_aep
   assert:
     that:
-    - cm_add_aep.changed == nm_add_aep.changed == true
+    - cm_add_aep is changed
+    - nm_add_aep is changed
     - nm_add_aep.previous == nm_add_aep.previous == cm_add_aep.current == []
     - 'nm_add_aep.current == [{"infraAttEntityP": {"attributes": {"descr": "", "dn": "uni/infra/attentp-ansible_test", "name": "ansible_test", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
     - 'cm_add_aep.proposed == nm_add_aep.proposed == cm_add_aep.sent == nm_add_aep.sent == {"infraAttEntityP": {"attributes": {"name": "ansible_test"}}}'
@@ -62,7 +63,8 @@
 - name: Verify add_aep_again
   assert:
     that:
-    - cm_add_aep_again.changed == nm_add_aep_again.changed == false
+    - cm_add_aep_again is not changed
+    - nm_add_aep_again is not changed
     - 'nm_add_aep_again.previous == nm_add_aep_again.previous == cm_add_aep_again.current == nm_add_aep_again.current == [{"infraAttEntityP": {"attributes": {"descr": "", "dn": "uni/infra/attentp-ansible_test", "name": "ansible_test", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
     - 'cm_add_aep_again.proposed == nm_add_aep_again.proposed == {"infraAttEntityP": {"attributes": {"name": "ansible_test"}}}'
     - cm_add_aep_again.sent == nm_add_aep_again.sent == {}
@@ -85,7 +87,8 @@
 - name: Verify add_aep_descr
   assert:
     that:
-    - cm_add_aep_descr.changed == nm_add_aep_descr.changed == true
+    - cm_add_aep_descr is changed
+    - nm_add_aep_descr is changed
     - 'cm_add_aep_descr.proposed == nm_add_aep_descr.proposed == {"infraAttEntityP": {"attributes": {"descr": "Ansible test AEP", "name": "ansible_test"}}}'
     - 'cm_add_aep_descr.sent == nm_add_aep_descr.sent == {"infraAttEntityP": {"attributes": {"descr": "Ansible test AEP"}}}'
     - 'cm_add_aep_descr.previous == nm_add_aep_descr.previous == cm_add_aep_descr.current == [{"infraAttEntityP": {"attributes": {"descr": "", "dn": "uni/infra/attentp-ansible_test", "name": "ansible_test", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
@@ -107,7 +110,8 @@
 - name: Verify add_aep_descr_again
   assert:
     that:
-    - cm_add_aep_descr_again.changed == nm_add_aep_descr_again.changed == false
+    - cm_add_aep_descr_again is not changed
+    - nm_add_aep_descr_again is not changed
     - 'cm_add_aep_descr_again.proposed == nm_add_aep_descr_again.proposed == {"infraAttEntityP": {"attributes": {"descr": "Ansible test AEP", "name": "ansible_test"}}}'
     - 'cm_add_aep_descr_again.sent == nm_add_aep_descr_again.sent == {}'
     - 'cm_add_aep_descr_again.previous == nm_add_aep_descr_again.previous == cm_add_aep_descr_again.current == nm_add_aep_descr_again.current == [{"infraAttEntityP": {"attributes": {"descr": "Ansible test AEP", "dn": "uni/infra/attentp-ansible_test", "name": "ansible_test", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
@@ -126,7 +130,8 @@
 - name: Verify add_aep_again_no_descr
   assert:
     that:
-    - cm_add_aep_again_no_descr.changed == nm_add_aep_again_no_descr.changed == false
+    - cm_add_aep_again_no_descr is not changed
+    - nm_add_aep_again_no_descr is not changed
     - 'cm_add_aep_again_no_descr.proposed == nm_add_aep_again_no_descr.proposed == {"infraAttEntityP": {"attributes": {"name": "ansible_test"}}}'
     - cm_add_aep_again_no_descr.sent == nm_add_aep_again_no_descr.sent == {}
     - 'cm_add_aep_again_no_descr.previous == nm_add_aep_again_no_descr.previous == cm_add_aep_again_no_descr.current == nm_add_aep_again_no_descr.current == [{"infraAttEntityP": {"attributes": {"descr": "Ansible test AEP", "dn": "uni/infra/attentp-ansible_test", "name": "ansible_test", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
@@ -153,7 +158,8 @@
 - name: Verify query_all_aeps
   assert:
     that:
-    - cm_query_all_aeps.changed == nm_query_all_aeps.changed == false
+    - cm_query_all_aeps is not changed
+    - nm_query_all_aeps is not changed
     - cm_query_all_aeps == nm_query_all_aeps
     - nm_query_all_aeps.current|length >= 1
 
@@ -175,7 +181,8 @@
 - name: Verify query_aep
   assert:
     that:
-    - cm_query_aep.changed == nm_query_aep.changed == false
+    - cm_query_aep is not changed
+    - nm_query_aep is not changed
     - cm_query_aep == nm_query_aep
     - nm_query_aep.current.0.infraAttEntityP.attributes.descr == "Ansible test AEP"
     - nm_query_aep.current.0.infraAttEntityP.attributes.dn == "uni/infra/attentp-ansible_test"
@@ -195,7 +202,8 @@
 - name: Verify remove_aep
   assert:
     that:
-    - cm_remove_aep.changed == nm_remove_aep.changed == true
+    - cm_remove_aep is changed
+    - nm_remove_aep is changed
     - cm_remove_aep.proposed == nm_remove_aep.proposed == {}
     - cm_remove_aep.sent == nm_remove_aep.sent == {}
     - 'cm_remove_aep.previous == nm_remove_aep.previous == cm_remove_aep.current == [{"infraAttEntityP": {"attributes": {"descr": "Ansible test AEP", "dn": "uni/infra/attentp-ansible_test", "name": "ansible_test", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
@@ -213,7 +221,8 @@
 - name: Verify remove_aep_again
   assert:
     that:
-    - cm_remove_aep_again.changed == nm_remove_aep_again.changed == false
+    - cm_remove_aep_again is not changed
+    - nm_remove_aep_again is not changed
     - cm_remove_aep_again.proposed == nm_remove_aep_again.proposed == {}
     - cm_remove_aep_again.sent == nm_remove_aep_again.sent == {}
     - cm_remove_aep_again.previous == nm_remove_aep_again.previous == cm_remove_aep_again.current == nm_remove_aep_again.current == []
@@ -236,7 +245,8 @@
 - name: Verify query_non_aep
   assert:
     that:
-    - cm_query_non_aep.changed == nm_query_non_aep.changed == false
+    - cm_query_non_aep is not changed
+    - nm_query_non_aep is not changed
     - cm_query_non_aep == nm_query_non_aep
     - cm_query_non_aep.current == nm_query_non_aep.current == []
 
@@ -258,5 +268,5 @@
 - name: Verify error_on_missing_required_param
   assert:
     that:
-    - error_on_missing_required_param.failed == true
+    - error_on_missing_required_param is failed
     - 'error_on_missing_required_param.msg == "state is present but all of the following are missing: aep"'

--- a/test/integration/targets/aci_aep_to_domain/tasks/main.yml
+++ b/test/integration/targets/aci_aep_to_domain/tasks/main.yml
@@ -70,7 +70,8 @@
 - name: Verify add_binding
   assert:
     that:
-    - cm_add_binding.changed == nm_add_binding.changed == true
+    - cm_add_binding is changed
+    - nm_add_binding is changed
     - 'cm_add_binding.sent == nm_add_binding.sent == {"infraRsDomP": {"attributes": {"tDn": "uni/phys-phys_dom"}}}'
     - 'cm_add_binding.proposed == nm_add_binding.proposed == {"infraRsDomP": {"attributes": {"tDn": "uni/phys-phys_dom"}}}'
     - cm_add_binding.current == cm_add_binding.previous == nm_add_binding.previous == []
@@ -88,7 +89,8 @@
 - name: Verify add_binding_again
   assert:
     that:
-    - cm_add_binding_again.changed == nm_add_binding_again.changed == false
+    - cm_add_binding_again is not changed
+    - nm_add_binding_again is not changed
 
 
 # QUERY ALL BINDINGS
@@ -112,7 +114,8 @@
 - name: Verify query_all_bindings
   assert:
     that:
-    - cm_query_all_bindings.changed == nm_query_all_bindings.changed == false
+    - cm_query_all_bindings is not changed
+    - nm_query_all_bindings is not changed
     - cm_query_all_bindings == nm_query_all_bindings
     - nm_query_all_bindings.current|length >= 1
 
@@ -138,7 +141,8 @@
 - name: Verify query_binding
   assert:
     that:
-    - cm_query_binding.changed == nm_query_binding.changed == false
+    - cm_query_binding is not changed
+    - nm_query_binding is not changed
     - cm_query_binding == nm_query_binding
     - nm_query_binding.current.0.infraRsDomP.attributes.dn == 'uni/infra/attentp-test_aep/rsdomP-[uni/phys-phys_dom]'
     - nm_query_binding.current.0.infraRsDomP.attributes.tCl == 'physDomP'
@@ -158,7 +162,8 @@
 - name: Verify remove_binding
   assert:
     that:
-    - cm_remove_binding.changed == nm_remove_binding.changed == true
+    - cm_remove_binding is changed
+    - nm_remove_binding is changed
     - 'cm_remove_binding.current == cm_remove_binding.previous == nm_remove_binding.previous == [{"infraRsDomP": {"attributes": {"dn": "uni/infra/attentp-test_aep/rsdomP-[uni/phys-phys_dom]", "tDn": "uni/phys-phys_dom"}}}]'
     - nm_remove_binding.current == []
 
@@ -174,7 +179,8 @@
 - name: Verify remove_binding_again
   assert:
     that:
-    - cm_remove_binding_again.changed == nm_remove_binding_again.changed == false
+    - cm_remove_binding_again is not changed
+    - nm_remove_binding_again is not changed
 
 
 # QUERY NON-EXISTING BINDING
@@ -198,6 +204,7 @@
 - name: Verify query_non_binding
   assert:
     that:
-    - cm_query_non_binding.changed == nm_query_non_binding.changed == false
+    - cm_query_non_binding is not changed
+    - nm_query_non_binding is not changed
     - cm_query_non_binding == nm_query_non_binding
     - nm_query_non_binding.current == []

--- a/test/integration/targets/aci_ap/tasks/main.yml
+++ b/test/integration/targets/aci_ap/tasks/main.yml
@@ -65,17 +65,17 @@
 - name: present asserts
   assert:
     that:
-      - ap_present_check_mode.changed == true
-      - ap_present.changed == true
+      - ap_present_check_mode is changed
+      - ap_present is changed
       - ap_present.previous == []
       - ap_present.sent == ap_present_check_mode.sent
       - 'ap_present.sent == {"fvAp": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
-      - ap_present_idempotent.changed == false
+      - ap_present_idempotent is not changed
       - ap_present_idempotent.previous != []
       - ap_present_idempotent.sent == {}
-      - ap_present_update.changed == true
+      - ap_present_update is changed
       - 'ap_present_update.sent.fvAp.attributes == {"descr": "Ansible Test Update"}'
-      - ap_present_missing_param.failed == true
+      - ap_present_missing_param is failed
       - 'ap_present_missing_param.msg == "state is present but all of the following are missing: ap"'
 
 - name: get ap - query specific ap
@@ -106,21 +106,21 @@
 - name: query assertions
   assert:
     that:
-      - query_ap.changed == false
+      - query_ap is not changed
       - query_ap.current | length == 1
-      - 'query_ap.current.0.fvAp.attributes.name == "anstest"'
+      - query_ap.current.0.fvAp.attributes.name == "anstest"
       - '"tn-anstest/ap-anstest.json" in query_ap.url'
-      - query_ap_tenant.changed == false
+      - query_ap_tenant is not changed
       - query_ap_tenant.current | length == 1
       - query_ap_tenant.current.0.fvTenant.children | length == 2
       - '"rsp-subtree-class=fvAp" in query_ap_tenant.filter_string'
       - '"tn-anstest.json" in query_ap_tenant.url'
-      - query_ap_ap.changed == false
+      - query_ap_ap is not changed
       - query_ap_ap.current != []
       - query_ap_ap.current.0.fvAp is defined
       - '"query-target-filter=eq(fvAp.name, \"anstest\")" in query_ap_ap.filter_string'
       - '"class/fvAp.json" in query_ap_ap.url'
-      - query_all.changed == false
+      - query_all is not changed
       - query_all.current | length > 1
       - '"class/fvAp.json" in query_all.url'
 
@@ -156,18 +156,18 @@
 - name: absent assertions
   assert:
     that:
-      - ap_delete_check_mode.changed == true
+      - ap_delete_check_mode is changed
       - ap_delete_check_mode.previous != []
       - '"tn-anstest/ap-anstest.json" in ap_delete_check_mode.url'
-      - ap_delete.changed == true
+      - ap_delete is changed
       - ap_delete.previous == ap_delete_check_mode.previous
-      - ap_delete_idempotent.changed == false
+      - ap_delete_idempotent is not changed
       - ap_delete_idempotent.previous == []
-      - ap_delete_missing_param.failed == true
+      - ap_delete_missing_param is failed
       - 'ap_delete_missing_param.msg == "state is absent but all of the following are missing: tenant"'
 
 - name: delete tenant - cleanup before ending tests
   aci_tenant:
     <<: *aci_tenant_present
     state: absent
-  when: tenant_present.changed == true
+  when: tenant_present is changed

--- a/test/integration/targets/aci_bd/tasks/main.yml
+++ b/test/integration/targets/aci_bd/tasks/main.yml
@@ -27,6 +27,18 @@
     vrf: anstest
   register: vrf_present
 
+- name: ensure bd anstest does not exist
+  aci_bd:
+    <<: *aci_tenant_present
+    bd: anstest
+    state: absent
+
+- name: ensure bd anstest2 does not exist
+  aci_bd:
+    <<: *aci_tenant_present
+    bd: anstest2
+    state: absent
+
 - name: create bd - check mode works
   aci_bd: &aci_bd_present
     <<: *aci_tenant_present
@@ -74,20 +86,20 @@
 - name: present asserts
   assert:
     that:
-      - bd_present_check_mode.changed == true
+      - bd_present_check_mode is changed
       - 'bd_present_check_mode.sent == {"fvBD": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
-      - bd_present.changed == true
+      - bd_present is changed
       - bd_present.sent == bd_present_check_mode.sent
       - bd_present.previous == []
-      - bd_present_idempotent.changed == false
+      - bd_present_idempotent is not changed
       - bd_present_idempotent.previous != []
-      - bd_update.changed == true
+      - bd_update is changed
       - bd_update.previous != []
-      - bd_update.changed != bd_update.proposed
+      - bd_update.sent != bd_update.proposed
       - 'bd_update.sent == {"fvBD": {"attributes": {"descr": "Ansible Test Update"}, "children": [{"fvRsCtx": {"attributes": {"tnFvCtxName": "anstest"}}}]}}'
       - 'bd_present_2.sent.fvBD.attributes == {"arpFlood": "yes", "descr": "Ansible Test", "ipLearning": "no", "multiDstPktAct": "drop", "name": "anstest2",
       "unicastRoute": "no", "unkMacUcastAct": "flood", "unkMcastAct": "opt-flood"}'
-      - bd_present_missing_param.failed == true
+      - bd_present_missing_param is failed
       - 'bd_present_missing_param.msg == "state is present but all of the following are missing: tenant"'
 
 - name: get all bd
@@ -118,25 +130,25 @@
 - name: query asserts
   assert:
     that:
-      - query_all.changed == false
+      - query_all is not changed
       - query_all.current | length > 1
       - query_all.current.0.fvBD is defined
-      - '"rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet" in query_all.filter_string'
+      - '"rsp-subtree-class=fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn,fvRsBDToNdP" in query_all.filter_string'
       - '"class/fvBD.json" in query_all.url'
-      - query_tenant.changed == false
+      - query_tenant is not changed
       - query_tenant.current | length == 1
       - query_tenant.current.0.fvTenant.children | length == 2
-      - '"rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet,fvBD" in query_tenant.filter_string'
+      - '"rsp-subtree-class=fvRsBdToEpRet,fvBD,fvRsCtx,fvRsIgmpsn,fvRsBDToNdP" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
-      - query_bd_bd.changed == false
+      - query_bd_bd is not changed
       - query_bd_bd.current != []
       - '"query-target-filter=eq(fvBD.name, \"anstest\")" in query_bd_bd.filter_string'
-      - '"rsp-subtree=full&rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet" in query_bd_bd.filter_string'
+      - '"rsp-subtree-class=fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn,fvRsBDToNdP" in query_bd_bd.filter_string'
       - '"class/fvBD.json" in query_bd_bd.url'
-      - query_bd.changed == false
+      - query_bd is not changed
       - query_bd.current | length == 1
-      - 'query_bd.current.0.fvBD.attributes.name == "anstest"'
-      - '"rsp-subtree-class=fvRsCtx,fvRsIgmpsn,fvRsBDToNdP,fvRsBdToEpRet" in query_bd.filter_string'
+      - query_bd.current.0.fvBD.attributes.name == "anstest"
+      - '"rsp-subtree-class=fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn,fvRsBDToNdP" in query_bd.filter_string'
       - '"tn-anstest/BD-anstest.json" in query_bd.url'
 
 - name: delete bd - check mode works
@@ -171,23 +183,23 @@
 - name: asserts for deletion task
   assert:
     that:
-      - bd_absent_check_mode.changed == true
+      - bd_absent_check_mode is changed
       - bd_absent_check_mode.proposed == {}
-      - bd_absent.changed == true
+      - bd_absent is changed
       - bd_absent.previous != []
-      - bd_absent_idempotent.changed == false
+      - bd_absent_idempotent is not changed
       - bd_absent_idempotent.previous == []
-      - bd_absent_missing_param.failed == true
+      - bd_absent_missing_param is failed
       - 'bd_absent_missing_param.msg == "state is absent but all of the following are missing: bd"'
 
 - name: delete vrf - cleanup before ending tests
   aci_vrf:
     <<: *aci_vrf_present
     state: absent
-  when: vrf_present.changed == true
+  when: vrf_present is changed
 
 - name: delete tenant - cleanup before ending tests
   aci_tenant:
     <<: *aci_tenant_present
     state: absent
-  when: tenant_present.changed == true
+  when: tenant_present is changed

--- a/test/integration/targets/aci_bd_subnet/tasks/main.yml
+++ b/test/integration/targets/aci_bd_subnet/tasks/main.yml
@@ -93,24 +93,24 @@
 - name: asserts for subnet creation tasks
   assert:
     that:
-      - create_check_mode.changed == true
+      - create_check_mode is changed
       - 'create_check_mode.sent == {"fvSubnet": {"attributes": {"descr": "Ansible Test", "ip": "10.100.100.1/24", "name": "anstest"}}}'
-      - create_subnet.changed == true
+      - create_subnet is changed
       - 'create_subnet.sent == {"fvSubnet": {"attributes": {"descr": "Ansible Test", "ip": "10.100.100.1/24", "name": "anstest"}}}'
-      - 'create_subnet.previous == []'
-      - create_subnet2.changed == true
+      - create_subnet.previous == []
+      - create_subnet2 is changed
       - create_subnet2.sent == create_subnet2.proposed
-      - 'create_subnet2.sent.fvSubnet.attributes.scope == "private,shared"'
+      - create_subnet2.sent.fvSubnet.attributes.scope == "private,shared"
       - 'create_subnet2.sent.fvSubnet.children.0.fvRsBDSubnetToProfile.attributes == {"tnL3extOutName": "default", "tnRtctrlProfileName": "default"}'
-      - create_idempotency.changed == false
+      - create_idempotency is not changed
       - create_idempotency.previous != []
-      - modify_subnet.changed == true
+      - modify_subnet is changed
       - modify_subnet.previous != []
-      - modify_subnet.changed != modify_subnet.proposed
+      - modify_subnet.sent != modify_subnet.proposed
       - 'modify_subnet.sent == {"fvSubnet": {"attributes": {"ctrl": "querier", "scope": "public,shared"}}}'
-      - create_bad_scope.failed == true
+      - create_bad_scope is failed
       - create_bad_scope.msg.startswith("Parameter 'scope' cannot be both 'private' and 'public'")
-      - create_incomplete_data.failed == true
+      - create_incomplete_data is failed
       - 'create_incomplete_data.msg == "state is present but all of the following are missing: bd"'
 
 - name: get all subnets
@@ -169,26 +169,27 @@
 - name: asserts for query tasks
   assert:
     that:
-      - get_all.changed == false
+      - get_all is not changed
       - get_all.current | length > 1
-      - get_all_tenant.changed == false
+      - get_all_tenant is not changed
       - '"tn-anstest.json" in get_all_tenant.url'
-      - get_all_bd.changed == false
+      - get_all_bd is not changed
       - '"query-target-filter=eq(fvBD.name, \"anstest\")" in get_all_bd.filter_string'
       - '"class/fvBD.json" in get_all_bd.url'
-      - get_all_tenant_bd.changed == false
+      - get_all_tenant_bd is not changed
       - '"tn-anstest/BD-anstest.json" in get_all_tenant_bd.url'
       - get_all_tenant_bd.current.0.fvBD.children | length > 1
-      - get_subnet_tenant.changed == false
+      - get_subnet_tenant is not changed
       - '"rsp-subtree-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnet_tenant.filter_string'
       - '"tn-anstest.json" in get_subnet_tenant.url'
-      - get_subnet_bd.changed == false
-      - '"query-target-filter=eq(fvBD.name, \"anstest\")" and "rsp-subtree-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnet_bd.filter_string'
+      - get_subnet_bd is not changed
+      - '"query-target-filter=eq(fvBD.name, \"anstest\")"'
+      - '"rsp-subtree-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnet_bd.filter_string'
       - '"class/fvBD.json" in get_subnet_bd.url'
-      - get_subnet.changed == false
+      - get_subnet is not changed
       - get_subnet.current | length == 1
       - '"tn-anstest/BD-anstest/subnet-[10.100.100.1/24].json" in get_subnet.url'
-      - get_subnets_gateway.changed == false
+      - get_subnets_gateway is not changed
       - '"query-target-filter=eq(fvSubnet.ip, \"10.100.100.1/24\")" in get_subnets_gateway.filter_string'
       - '"class/fvSubnet.json" in get_subnets_gateway.url'
 
@@ -215,22 +216,22 @@
 - name: asserts for deletion task
   assert:
     that:
-      - delete_check_mode.changed == true
+      - delete_check_mode is changed
       - delete_check_mode.proposed == {}
-      - delete_subnet.changed == true
+      - delete_subnet is changed
       - delete_subnet.previous != []
-      - 'delete_subnet.method == "DELETE"'
-      - delete_idempotency.changed == false
+      - delete_subnet.method == "DELETE"
+      - delete_idempotency is not changed
       - delete_idempotency.previous == []
 
 - name: delete bd - cleanup before ending tests
   aci_bd:
     <<: *aci_bd_present
     state: absent
-  when: bd_present.changed == true
+  when: bd_present is changed
 
 - name: delete tenant - cleanup before ending tests
   aci_tenant:
     <<: *aci_tenant_present
     state: absent
-  when: tenant_present.changed == true
+  when: tenant_present is changed

--- a/test/integration/targets/aci_config_rollback/tasks/main.yml
+++ b/test/integration/targets/aci_config_rollback/tasks/main.yml
@@ -81,14 +81,14 @@
 - name: rollback assertions
   assert:
     that:
-      - rollback_preview.changed == false
+      - rollback_preview is not changed
       - '"<fvTenant name=\"anstest\" rn=\"tn-anstest\" status=\"deleted\">" in rollback_preview.diff'
       - '"snapshots.diff.xml" in rollback_preview.url'
-      - rollback_missing_param.failed == true
+      - rollback_missing_param is failed
       - 'rollback_missing_param.msg == "state is rollback but all of the following are missing: import_policy"'
-      - rollback_rollback.changed == true
+      - rollback_rollback is changed
       - '"ce2_" in rollback_rollback.sent.configImportP.attributes.fileName'
       - '".tar.gz" in rollback_rollback.sent.configImportP.attributes.fileName'
       - '"fabric/configimp-anstest.json" in rollback_rollback.url'
-      - tenant_removed.changed == false
+      - tenant_removed is not changed
       - tenant_removed.previous == []

--- a/test/integration/targets/aci_config_snapshot/tasks/main.yml
+++ b/test/integration/targets/aci_config_snapshot/tasks/main.yml
@@ -48,15 +48,15 @@
 - name: present assertion tests
   assert:
     that:
-      - create.failed == false
-      - create.changed == true
-      - 'create.sent.configExportP.attributes.adminSt == "triggered"'
-      - create_update.failed == false
-      - create_update.changed == true
+      - create is not failed
+      - create is changed
+      - create.sent.configExportP.attributes.adminSt == "triggered"
+      - create_update is not failed
+      - create_update is changed
       - 'create_update.sent == {"configExportP": {"attributes": {"adminSt": "triggered", "format": "xml", "includeSecureFields": "yes"}}}'
-      - invalid_max_count.failed == true
+      - invalid_max_count is failed
       - invalid_max_count.msg == "Parameter 'max_count' must be a number between 1 and 10"
-      - missing_param.failed == true
+      - missing_param is failed
       - 'missing_param.msg == "state is present but all of the following are missing: export_policy"'
 
 - name: query with export_policy
@@ -91,21 +91,21 @@
 - name: query assertion tests
   assert:
     that:
-      - query_export.failed == false
-      - query_export.changed == false
+      - query_export is not failed
+      - query_export is not changed
       - '"snapshots-[uni/fabric/configexp-anstest].json" in query_export.url'
       - query_export.current.0.configSnapshotCont.attributes.name == "anstest"
       - query_export.current.0.configSnapshotCont.children | length > 1
-      - query_export_snapshot.failed == false
-      - query_export_snapshot.changed == false
+      - query_export_snapshot is not failed
+      - query_export_snapshot is not changed
       - '"snapshots-[uni/fabric/configexp-anstest]/snapshot-{{ test_snapshot }}.json" in query_export_snapshot.url'
       - query_export_snapshot.current | length == 1
-      - query_snapshot.failed == false
-      - query_snapshot.changed == false
+      - query_snapshot is not failed
+      - query_snapshot is not changed
       - '"class/configSnapshot.json" in query_snapshot.url'
       - '"configSnapshot.name, \"{{ test_snapshot }}\"" in query_snapshot.filter_string'
-      - query_all.failed == false
-      - query_all.changed == false
+      - query_all is not failed
+      - query_all is not changed
       - '"class/configSnapshot.json" in query_all.url'
       - query_all.current | length > 1
 
@@ -130,13 +130,13 @@
 - name: absent assertion tests
   assert:
     that:
-      - delete_snapshot.failed == false
-      - delete_snapshot.changed == true
+      - delete_snapshot is not failed
+      - delete_snapshot is changed
       - 'delete_snapshot.sent == {"configSnapshot": {"attributes": {"retire": "yes"}}}'
       - delete_snapshot.previous != []
       - delete_snapshot.previous.0.configSnapshot.attributes.name == test_snapshot
-      - delete_idempotent.failed == false
-      - delete_idempotent.changed == false
+      - delete_idempotent is not failed
+      - delete_idempotent is not changed
       - delete_idempotent.previous == []
-      - delete_missing_param.failed == true
+      - delete_missing_param is failed
       - 'delete_missing_param.msg == "state is absent but all of the following are missing: snapshot"'

--- a/test/integration/targets/aci_contract/tasks/main.yml
+++ b/test/integration/targets/aci_contract/tasks/main.yml
@@ -59,16 +59,16 @@
 - name: present assertions
   assert:
     that:
-      - present_check_mode.changed == true
+      - present_check_mode is changed
       - present_check_mode.previous == []
       - 'present_check_mode.sent == {"vzBrCP": {"attributes": {"name": "anstest", "descr": "Ansible Test"}}}'
-      - contract_present.changed == true
+      - contract_present is changed
       - contract_present.sent == present_check_mode.sent
-      - present_idempotent.changed == false
-      - present_update.changed == true
+      - present_idempotent is not changed
+      - present_update is changed
       - present_update.sent != present_update.proposed
-      - 'present_update.sent.vzBrCP.attributes.scope == "application-profile"'
-      - present_missing_param.failed == true
+      - present_update.sent.vzBrCP.attributes.scope == "application-profile"
+      - present_missing_param is failed
       - 'present_missing_param.msg == "state is present but all of the following are missing: contract"'
 
 - name: query contract
@@ -99,19 +99,19 @@
 - name: query assertions
   assert:
     that:
-      - query_contract.changed == false
+      - query_contract is not changed
       - query_contract.current | length == 1
       - '"tn-anstest/brc-anstest.json" in query_contract.url'
-      - query_tenant.changed == false
+      - query_tenant is not changed
       - query_tenant.current | length == 1
       - query_tenant.current.0.fvTenant.children | length > 1
       - '"rsp-subtree-class=vzBrCP" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
-      - query_name.changed == false
+      - query_name is not changed
       - query_name.current != []
       - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_name.filter_string'
       - '"class/vzBrCP.json" in query_name.url'
-      - query_all.changed == false
+      - query_all is not changed
       - query_all.current | length > 1
       - '"class/vzBrCP.json" in query_all.url'
 
@@ -147,17 +147,17 @@
 - name: absent assertions
   assert:
     that:
-      - absent_check_mode.changed == true
+      - absent_check_mode is changed
       - absent_check_mode.previous != []
-      - contract_absent.changed == true
+      - contract_absent is changed
       - contract_absent.previous == absent_check_mode.previous
-      - absent_idempotent.changed == false
+      - absent_idempotent is not changed
       - absent_idempotent.previous == []
-      - absent_missing_param.failed == true
+      - absent_missing_param is failed
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: tenant"'
 
 - name: cleanup tenant
   aci_tenant:
     <<: *aci_tenant_present
     state: absent
-  when: tenant_present.changed == true
+  when: tenant_present is changed

--- a/test/integration/targets/aci_contract_subject/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject/tasks/main.yml
@@ -72,19 +72,19 @@
 - name: present assertions
   assert:
     that:
-      - subject_present_check_mode.changed == true
+      - subject_present_check_mode is changed
       - 'subject_present_check_mode.sent == {"vzSubj": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
-      - subject_present.changed == true
+      - subject_present is changed
       - subject_present.previous == []
       - subject_present.sent == subject_present_check_mode.sent
-      - subject_present_idempotent.changed == false
+      - subject_present_idempotent is not changed
       - subject_present_idempotent.previous != []
-      - subject_update.changed == true
+      - subject_update is changed
       - subject_update.sent != subject_update.proposed
       - 'subject_update.sent.vzSubj.attributes == {"prio": "level2", "provMatchT": "AtmostOne"}'
-      - subject_present_2.changed == true
+      - subject_present_2 is changed
       - 'subject_present_2.sent.vzSubj.attributes == {"consMatchT": "All", "name": "anstest2", "prio": "level3", "revFltPorts": "no"}'
-      - present_missing_param.failed == true
+      - present_missing_param is failed
       - 'present_missing_param.msg == "state is present but all of the following are missing: contract, subject"'
 
 - name: query tenant contract subject
@@ -141,47 +141,47 @@
 - name: query assertions
   assert:
     that:
-      - query_tenant_contract_subject.changed == false
+      - query_tenant_contract_subject is not changed
       - query_tenant_contract_subject.current | length == 1
-      - 'query_tenant_contract_subject.current.0.vzSubj.attributes.name == "anstest"'
+      - query_tenant_contract_subject.current.0.vzSubj.attributes.name == "anstest"
       - '"tn-anstest/brc-anstest/subj-anstest.json" in query_tenant_contract_subject.url'
-      - query_tenant_contract.changed == false
+      - query_tenant_contract is not changed
       - query_tenant_contract.current | length == 1
-      - 'query_tenant_contract.current.0.vzBrCP.attributes.name == "anstest"'
+      - query_tenant_contract.current.0.vzBrCP.attributes.name == "anstest"
       - query_tenant_contract.current.0.vzBrCP.children | length == 2
       - '"rsp-subtree-class=vzSubj" in query_tenant_contract.filter_string'
       - '"tn-anstest/brc-anstest.json" in query_tenant_contract.url'
-      - query_tenant_subject.changed == false
+      - query_tenant_subject is not changed
       - query_tenant_subject.current | length == 1
-      - 'query_tenant_subject.current.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant_subject.current.0.fvTenant.attributes.name == "anstest"
       - query_tenant_subject.current.0.fvTenant.children.0.vzBrCP.children | length == 1
-      - 'query_tenant_subject.current.0.fvTenant.children.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"'
+      - query_tenant_subject.current.0.fvTenant.children.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"
       - '"rsp-subtree-filter=eq(vzSubj.name, \"anstest\")" in query_tenant_subject.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_tenant_subject.filter_string'
       - '"tn-anstest.json" in query_tenant_subject.url'
-      - query_contract_subject.changed == false
-      - 'query_contract_subject.current.0.vzBrCP.attributes.name == "anstest"'
+      - query_contract_subject is not changed
+      - query_contract_subject.current.0.vzBrCP.attributes.name == "anstest"
       - query_contract_subject.current.0.vzBrCP.children | length == 1
-      - 'query_contract_subject.current.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"'
+      - query_contract_subject.current.0.vzBrCP.children.0.vzSubj.attributes.name == "anstest"
       - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_contract_subject.filter_string'
       - '"rsp-subtree-filter=eq(vzSubj.name, \"anstest\")" in query_contract_subject.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_contract_subject.filter_string'
       - '"class/vzBrCP.json" in query_contract_subject.url'
-      - query_tenant.changed == false
+      - query_tenant is not changed
       - query_tenant.current | length == 1
-      - 'query_tenant.current.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant.current.0.fvTenant.attributes.name == "anstest"
       - '"rsp-subtree-class=vzBrCP,vzSubj" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
-      - query_contract.changed == false
-      - 'query_contract.current.0.vzBrCP.attributes.name == "anstest"'
+      - query_contract is not changed
+      - query_contract.current.0.vzBrCP.attributes.name == "anstest"
       - '"query-target-filter=eq(vzBrCP.name, \"anstest\")" in query_contract.filter_string'
       - '"rsp-subtree-class=vzSubj" in query_contract.filter_string'
       - '"class/vzBrCP.json" in query_contract.url'
-      - query_subject.changed == false
-      - 'query_subject.current.0.vzSubj.attributes.name == "anstest"'
+      - query_subject is not changed
+      - query_subject.current.0.vzSubj.attributes.name == "anstest"
       - '"query-target-filter=eq(vzSubj.name, \"anstest\")" in query_subject.filter_string'
       - '"class/vzSubj.json" in query_subject.url'
-      - query_all.changed == false
+      - query_all is not changed
       - query_all.current > 1
       - query_all.current.0.vzSubj is defined
       - '"class/vzSubj.json" in query_all.url'
@@ -218,24 +218,24 @@
 - name: absent assertions
   assert:
     that:
-      - subject_absent_check_mode.changed == true
+      - subject_absent_check_mode is changed
       - subject_absent_check_mode.previous != []
       - subject_absent_check_mode.proposed == {}
-      - subject_absent.changed == true
+      - subject_absent is changed
       - subject_absent.previous == subject_absent_check_mode.previous
-      - subject_absent_idempotent.changed == false
+      - subject_absent_idempotent is not changed
       - subject_absent_idempotent.previous == []
-      - absent_missing_param.failed == true
+      - absent_missing_param is failed
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: subject"'
 
 - name: cleanup contract
   aci_contract:
     <<: *aci_contract_present
     state: absent
-  when: contract_present.changed == true
+  when: contract_present is changed
 
 - name: cleanup tenant
   aci_tenant:
     <<: *aci_tenant_present
     state: absent
-  when: tenant_present.changed == true
+  when: tenant_present is changed

--- a/test/integration/targets/aci_contract_subject_to_filter/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject_to_filter/tasks/main.yml
@@ -84,18 +84,18 @@
 - name: present assertions
   assert:
     that:
-      - subject_filter_present_check_mode.changed == true
+      - subject_filter_present_check_mode is changed
       - subject_filter_present_check_mode.previous == []
       - 'subject_filter_present_check_mode.sent == {"vzRsSubjFiltAtt": {"attributes": {"directives": "log", "tnVzFilterName": "anstest"}}}'
-      - subject_filter_present.changed == true
+      - subject_filter_present is changed
       - subject_filter_present.previous == []
       - subject_filter_present.sent == subject_filter_present_check_mode.sent
-      - subject_filter_present_2.changed == true
-      - subject_filter_present_idempotent.changed == false
+      - subject_filter_present_2 is changed
+      - subject_filter_present_idempotent is not changed
       - subject_filter_present_idempotent.previous != []
-      - subject_filter_update.changed == true
+      - subject_filter_update is changed
       - 'subject_filter_update.sent.vzRsSubjFiltAtt.attributes == {"directives": ""}'
-      - present_missing_param.failed == true
+      - present_missing_param is failed
       - 'present_missing_param.msg == "state is present but all of the following are missing: contract, filter, subject"'
 
 - name: query all
@@ -114,10 +114,10 @@
 - name: query assertions
   assert:
     that:
-      - query_all.changed == false
+      - query_all is not changed
       - query_all.current | length > 1
       - query_all.current.0.vzRsSubjFiltAtt is defined
-      - query_binding.changed == false
+      - query_binding is not changed
       - query_binding.current != []
 
 - name: delete subject filter binding - check mode works
@@ -152,42 +152,42 @@
 - name: absent assertions
   assert:
     that:
-      - subject_filter_absent_check_mode.changed == true
+      - subject_filter_absent_check_mode is changed
       - subject_filter_absent_check_mode.proposed == {}
       - subject_filter_absent_check_mode.previous != []
-      - subject_filter_absent.changed == true
+      - subject_filter_absent is changed
       - subject_filter_absent.previous != []
-      - subject_filter_absent_idempotent.changed == false
+      - subject_filter_absent_idempotent is not changed
       - subject_filter_absent_idempotent.previous == []
-      - absent_missing_param.failed == true
+      - absent_missing_param is failed
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: filter"'
 
 - name: cleanup subject
   aci_contract_subject:
     <<: *aci_subject_present
     state: absent
-  when: subject_present.changed == true
+  when: subject_present is changed
 
 - name: cleanup contract
   aci_contract:
     <<: *aci_contract_present
     state: absent
-  when: contract_present.changed == true
+  when: contract_present is changed
 
 - name: cleanup filter
   aci_filter:
     <<: *aci_filter_present
     state: absent
-  when: filter_present.changed == true
+  when: filter_present is changed
 
 - name: cleanup filter
   aci_filter:
     <<: *aci_filter_present_2
     state: absent
-  when: filter_present_2.changed == true
+  when: filter_present_2 is changed
 
 - name: cleanup tenant
   aci_tenant:
     <<: *aci_tenant_present
     state: absent
-  when: tenant_present.changed == true
+  when: tenant_present is changed

--- a/test/integration/targets/aci_domain/tasks/fc.yml
+++ b/test/integration/targets/aci_domain/tasks/fc.yml
@@ -42,7 +42,8 @@
 - name: Verify add_domain
   assert:
     that:
-    - cm_add_domain.changed == nm_add_domain.changed == true
+    - cm_add_domain is changed
+    - nm_add_domain is changed
     - 'cm_add_domain.sent == nm_add_domain.sent == {"fcDomP": {"attributes": {"name": "fc_dom"}}}'
     - 'cm_add_domain.proposed == nm_add_domain.proposed == {"fcDomP": {"attributes": {"name": "fc_dom"}}}'
     - cm_add_domain.current == cm_add_domain.previous == nm_add_domain.previous == []
@@ -60,7 +61,8 @@
 - name: Verify add_domain_again
   assert:
     that:
-    - cm_add_domain_again.changed == nm_add_domain_again.changed == false
+    - cm_add_domain_again is not changed
+    - nm_add_domain_again is not changed
 
 
 # QUERY ALL DOMAINS
@@ -85,7 +87,8 @@
 - name: Verify query_all_domains
   assert:
     that:
-    - cm_query_all_domains.changed == nm_query_all_domains.changed == false
+    - cm_query_all_domains is not changed
+    - nm_query_all_domains is not changed
     - cm_query_all_domains == nm_query_all_domains
     - nm_query_all_domains.current|length >= 1
 
@@ -107,7 +110,8 @@
 - name: Verify query_domain
   assert:
     that:
-    - cm_query_domain.changed == nm_query_domain.changed == false
+    - cm_query_domain is not changed
+    - nm_query_domain is not changed
     - cm_query_domain == nm_query_domain
     - nm_query_domain.current.0.fcDomP.attributes.dn == 'uni/fc-fc_dom'
     - nm_query_domain.current.0.fcDomP.attributes.name == 'fc_dom'
@@ -126,7 +130,8 @@
 - name: Verify remove_domain
   assert:
     that:
-    - cm_remove_domain.changed == nm_remove_domain.changed == true
+    - cm_remove_domain is changed
+    - nm_remove_domain is changed
     - 'cm_remove_domain.current == cm_remove_domain.previous == nm_remove_domain.previous == [{"fcDomP": {"attributes": {"dn": "uni/fc-fc_dom", "name": "fc_dom", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
     - nm_remove_domain.current == []
 
@@ -142,7 +147,8 @@
 - name: Verify remove_domain_again
   assert:
     that:
-    - cm_remove_domain_again.changed == nm_remove_domain_again.changed == false
+    - cm_remove_domain_again is not changed
+    - nm_remove_domain_again is not changed
 
 
 # QUERY NON-EXISTING DOMAIN
@@ -162,6 +168,7 @@
 - name: Verify query_non_domain
   assert:
     that:
-    - cm_query_non_domain.changed == nm_query_non_domain.changed == false
+    - cm_query_non_domain is not changed
+    - nm_query_non_domain is not changed
     - cm_query_non_domain == nm_query_non_domain
     - nm_query_non_domain.current == []

--- a/test/integration/targets/aci_domain/tasks/l2dom.yml
+++ b/test/integration/targets/aci_domain/tasks/l2dom.yml
@@ -42,7 +42,8 @@
 - name: Verify add_domain
   assert:
     that:
-    - cm_add_domain.changed == nm_add_domain.changed == true
+    - cm_add_domain is changed
+    - nm_add_domain is changed
     - 'cm_add_domain.sent == nm_add_domain.sent == {"l2extDomP": {"attributes": {"name": "l2_dom"}}}'
     - 'cm_add_domain.proposed == nm_add_domain.proposed == {"l2extDomP": {"attributes": {"name": "l2_dom"}}}'
     - cm_add_domain.current == cm_add_domain.previous == nm_add_domain.previous == []
@@ -60,7 +61,8 @@
 - name: Verify add_domain_again
   assert:
     that:
-    - cm_add_domain_again.changed == nm_add_domain_again.changed == false
+    - cm_add_domain_again is not changed
+    - nm_add_domain_again is not changed
 
 
 # QUERY ALL DOMAINS
@@ -85,7 +87,8 @@
 - name: Verify query_all_domains
   assert:
     that:
-    - cm_query_all_domains.changed == nm_query_all_domains.changed == false
+    - cm_query_all_domains is not changed
+    - nm_query_all_domains is not changed
     - cm_query_all_domains == nm_query_all_domains
     - nm_query_all_domains.current|length >= 1
 
@@ -107,7 +110,8 @@
 - name: Verify query_domain
   assert:
     that:
-    - cm_query_domain.changed == nm_query_domain.changed == false
+    - cm_query_domain is not changed
+    - nm_query_domain is not changed
     - cm_query_domain == nm_query_domain
     - nm_query_domain.current.0.l2extDomP.attributes.dn == 'uni/l2dom-l2_dom'
     - nm_query_domain.current.0.l2extDomP.attributes.name == 'l2_dom'
@@ -126,7 +130,8 @@
 - name: Verify remove_domain
   assert:
     that:
-    - cm_remove_domain.changed == nm_remove_domain.changed == true
+    - cm_remove_domain is changed
+    - nm_remove_domain is changed
     - 'cm_remove_domain.current == cm_remove_domain.previous == nm_remove_domain.previous == [{"l2extDomP": {"attributes": {"dn": "uni/l2dom-l2_dom", "name": "l2_dom", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
     - nm_remove_domain.current == []
 
@@ -142,7 +147,8 @@
 - name: Verify remove_domain_again
   assert:
     that:
-    - cm_remove_domain_again.changed == nm_remove_domain_again.changed == false
+    - cm_remove_domain_again is not changed
+    - nm_remove_domain_again is not changed
 
 
 # QUERY NON-EXISTING DOMAIN
@@ -162,6 +168,7 @@
 - name: Verify query_non_domain
   assert:
     that:
-    - cm_query_non_domain.changed == nm_query_non_domain.changed == false
+    - cm_query_non_domain is not changed
+    - nm_query_non_domain is not changed
     - cm_query_non_domain == nm_query_non_domain
     - nm_query_non_domain.current == []

--- a/test/integration/targets/aci_domain/tasks/l3dom.yml
+++ b/test/integration/targets/aci_domain/tasks/l3dom.yml
@@ -42,7 +42,8 @@
 - name: Verify add_domain
   assert:
     that:
-    - cm_add_domain.changed == nm_add_domain.changed == true
+    - cm_add_domain is changed
+    - nm_add_domain is changed
     - 'cm_add_domain.sent == nm_add_domain.sent == {"l3extDomP": {"attributes": {"name": "l3_dom"}}}'
     - 'cm_add_domain.proposed == nm_add_domain.proposed == {"l3extDomP": {"attributes": {"name": "l3_dom"}}}'
     - cm_add_domain.current == cm_add_domain.previous == nm_add_domain.previous == []
@@ -60,7 +61,8 @@
 - name: Verify add_domain_again
   assert:
     that:
-    - cm_add_domain_again.changed == nm_add_domain_again.changed == false
+    - cm_add_domain_again is not changed
+    - nm_add_domain_again is not changed
 
 
 # QUERY ALL DOMAINS
@@ -85,7 +87,8 @@
 - name: Verify query_all_domains
   assert:
     that:
-    - cm_query_all_domains.changed == nm_query_all_domains.changed == false
+    - cm_query_all_domains is not changed
+    - nm_query_all_domains is not changed
     - cm_query_all_domains == nm_query_all_domains
     - nm_query_all_domains.current|length >= 1
 
@@ -107,7 +110,8 @@
 - name: Verify query_domain
   assert:
     that:
-    - cm_query_domain.changed == nm_query_domain.changed == false
+    - cm_query_domain is not changed
+    - nm_query_domain is not changed
     - cm_query_domain == nm_query_domain
     - nm_query_domain.current.0.l3extDomP.attributes.dn == 'uni/l3dom-l3_dom'
     - nm_query_domain.current.0.l3extDomP.attributes.name == 'l3_dom'
@@ -126,7 +130,8 @@
 - name: Verify remove_domain
   assert:
     that:
-    - cm_remove_domain.changed == nm_remove_domain.changed == true
+    - cm_remove_domain is changed
+    - nm_remove_domain is changed
     - 'cm_remove_domain.current == cm_remove_domain.previous == nm_remove_domain.previous == [{"l3extDomP": {"attributes": {"dn": "uni/l3dom-l3_dom", "name": "l3_dom", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
     - nm_remove_domain.current == []
 
@@ -142,7 +147,8 @@
 - name: Verify remove_domain_again
   assert:
     that:
-    - cm_remove_domain_again.changed == nm_remove_domain_again.changed == false
+    - cm_remove_domain_again is not changed
+    - nm_remove_domain_again is not changed
 
 
 # QUERY NON-EXISTING DOMAIN
@@ -162,6 +168,7 @@
 - name: Verify query_non_domain
   assert:
     that:
-    - cm_query_non_domain.changed == nm_query_non_domain.changed == false
+    - cm_query_non_domain is not changed
+    - nm_query_non_domain is not changed
     - cm_query_non_domain == nm_query_non_domain
     - nm_query_non_domain.current == []

--- a/test/integration/targets/aci_domain/tasks/phys.yml
+++ b/test/integration/targets/aci_domain/tasks/phys.yml
@@ -42,7 +42,8 @@
 - name: Verify add_domain
   assert:
     that:
-    - cm_add_domain.changed == nm_add_domain.changed == true
+    - cm_add_domain is changed
+    - nm_add_domain is changed
     - 'cm_add_domain.sent == nm_add_domain.sent == {"physDomP": {"attributes": {"name": "phys_dom"}}}'
     - 'cm_add_domain.proposed == nm_add_domain.proposed == {"physDomP": {"attributes": {"name": "phys_dom"}}}'
     - cm_add_domain.current == cm_add_domain.previous == nm_add_domain.previous == []
@@ -60,7 +61,8 @@
 - name: Verify add_domain_again
   assert:
     that:
-    - cm_add_domain_again.changed == nm_add_domain_again.changed == false
+    - cm_add_domain_again is not changed
+    - nm_add_domain_again is not changed
 
 
 # QUERY ALL DOMAINS
@@ -85,7 +87,8 @@
 - name: Verify query_all_domains
   assert:
     that:
-    - cm_query_all_domains.changed == nm_query_all_domains.changed == false
+    - cm_query_all_domains is not changed
+    - nm_query_all_domains is not changed
     - cm_query_all_domains == nm_query_all_domains
     - nm_query_all_domains.current|length >= 1
 
@@ -107,7 +110,8 @@
 - name: Verify query_domain
   assert:
     that:
-    - cm_query_domain.changed == nm_query_domain.changed == false
+    - cm_query_domain is not changed
+    - nm_query_domain is not changed
     - cm_query_domain == nm_query_domain
     - nm_query_domain.current.0.physDomP.attributes.dn == 'uni/phys-phys_dom'
     - nm_query_domain.current.0.physDomP.attributes.name == 'phys_dom'
@@ -126,7 +130,8 @@
 - name: Verify remove_domain
   assert:
     that:
-    - cm_remove_domain.changed == nm_remove_domain.changed == true
+    - cm_remove_domain is changed
+    - nm_remove_domain is changed
     - 'cm_remove_domain.current == cm_remove_domain.previous == nm_remove_domain.previous == [{"physDomP": {"attributes": {"dn": "uni/phys-phys_dom", "name": "phys_dom", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
     - nm_remove_domain.current == []
 
@@ -142,7 +147,8 @@
 - name: Verify remove_domain_again
   assert:
     that:
-    - cm_remove_domain_again.changed == nm_remove_domain_again.changed == false
+    - cm_remove_domain_again is not changed
+    - nm_remove_domain_again is not changed
 
 
 # QUERY NON-EXISTING DOMAIN
@@ -162,6 +168,7 @@
 - name: Verify query_non_domain
   assert:
     that:
-    - cm_query_non_domain.changed == nm_query_non_domain.changed == false
+    - cm_query_non_domain is not changed
+    - nm_query_non_domain is not changed
     - cm_query_non_domain == nm_query_non_domain
     - nm_query_non_domain.current == []

--- a/test/integration/targets/aci_domain/tasks/vmm-vmware.yml
+++ b/test/integration/targets/aci_domain/tasks/vmm-vmware.yml
@@ -44,7 +44,8 @@
 - name: Verify add_domain
   assert:
     that:
-    - cm_add_domain.changed == nm_add_domain.changed == true
+    - cm_add_domain is changed
+    - nm_add_domain is changed
     - 'cm_add_domain.sent == nm_add_domain.sent == {"vmmDomP": {"attributes": {"name": "vmm_dom"}}}'
     - 'cm_add_domain.proposed == nm_add_domain.proposed == {"vmmDomP": {"attributes": {"name": "vmm_dom"}}}'
     - cm_add_domain.current == cm_add_domain.previous == nm_add_domain.previous == []
@@ -63,7 +64,8 @@
 - name: Verify add_domain_again
   assert:
     that:
-    - cm_add_domain_again.changed == nm_add_domain_again.changed == false
+    - cm_add_domain_again is not changed
+    - nm_add_domain_again is not changed
 
 
 # QUERY ALL DOMAINS
@@ -89,7 +91,8 @@
 - name: Verify query_all_domains
   assert:
     that:
-    - cm_query_all_domains.changed == nm_query_all_domains.changed == false
+    - cm_query_all_domains is not changed
+    - nm_query_all_domains is not changed
     - cm_query_all_domains == nm_query_all_domains
     - nm_query_all_domains.current|length >= 1
 
@@ -113,7 +116,8 @@
 - name: Verify query_domain
   assert:
     that:
-    - cm_query_domain.changed == nm_query_domain.changed == false
+    - cm_query_domain is not changed
+    - nm_query_domain is not changed
     - cm_query_domain == nm_query_domain
     - nm_query_domain.current.0.vmmDomP.attributes.dn == 'uni/vmmp-VMware/dom-vmm_dom'
     - nm_query_domain.current.0.vmmDomP.attributes.name == 'vmm_dom'
@@ -132,7 +136,8 @@
 - name: Verify remove_domain
   assert:
     that:
-    - cm_remove_domain.changed == nm_remove_domain.changed == true
+    - cm_remove_domain is changed
+    - nm_remove_domain is changed
     - cm_remove_domain.current == cm_remove_domain.previous == nm_remove_domain.previous
     - nm_remove_domain.previous.0.vmmDomP.attributes.dn == 'uni/vmmp-VMware/dom-vmm_dom'
     - nm_remove_domain.previous.0.vmmDomP.attributes.name == 'vmm_dom'
@@ -150,7 +155,8 @@
 - name: Verify remove_domain_again
   assert:
     that:
-    - cm_remove_domain_again.changed == nm_remove_domain_again.changed == false
+    - cm_remove_domain_again is not changed
+    - nm_remove_domain_again is not changed
 
 
 # QUERY NON-EXISTING DOMAIN
@@ -172,6 +178,7 @@
 - name: Verify query_non_domain
   assert:
     that:
-    - cm_query_non_domain.changed == nm_query_non_domain.changed == false
+    - cm_query_non_domain is not changed
+    - nm_query_non_domain is not changed
     - cm_query_non_domain == nm_query_non_domain
     - nm_query_non_domain.current == []

--- a/test/integration/targets/aci_domain_to_vlan_pool/tasks/main.yml
+++ b/test/integration/targets/aci_domain_to_vlan_pool/tasks/main.yml
@@ -73,7 +73,8 @@
 - name: Verify add_binding
   assert:
     that:
-    - cm_add_binding.changed == nm_add_binding.changed == true
+    - cm_add_binding is changed
+    - nm_add_binding is changed
     - 'cm_add_binding.sent == nm_add_binding.sent == {"physDomP": {"attributes": {"name": "phys_dom"}, "children": [{"infraRsVlanNs": {"attributes": {"tDn": "uni/infra/vlanns-[test_pool]-dynamic"}}}]}}'
     - 'cm_add_binding.proposed == nm_add_binding.proposed == {"physDomP": {"attributes": {"name": "phys_dom"}, "children": [{"infraRsVlanNs": {"attributes": {"tDn": "uni/infra/vlanns-[test_pool]-dynamic"}}}]}}'
     - cm_add_binding.current == cm_add_binding.previous == nm_add_binding.previous == []
@@ -91,7 +92,8 @@
 - name: Verify add_binding_again
   assert:
     that:
-    - cm_add_binding_again.changed == nm_add_binding_again.changed == false
+    - cm_add_binding_again is not changed
+    - nm_add_binding_again is not changed
 
 
 # QUERY ALL BINDINGS
@@ -117,7 +119,8 @@
 - name: Verify query_all_bindings
   assert:
     that:
-    - cm_query_all_bindings.changed == nm_query_all_bindings.changed == false
+    - cm_query_all_bindings is not changed
+    - nm_query_all_bindings is not changed
     - cm_query_all_bindings == nm_query_all_bindings
     - nm_query_all_bindings.current|length >= 1
 
@@ -143,7 +146,8 @@
 - name: Verify query_binding
   assert:
     that:
-    - cm_query_binding.changed == nm_query_binding.changed == false
+    - cm_query_binding is not changed
+    - nm_query_binding is not changed
     - cm_query_binding == nm_query_binding
     - nm_query_binding.current.0.physDomP.attributes.dn == 'uni/phys-phys_dom'
     - nm_query_binding.current.0.physDomP.attributes.name == 'phys_dom'
@@ -164,7 +168,8 @@
 - name: Verify remove_binding
   assert:
     that:
-    - cm_remove_binding.changed == nm_remove_binding.changed == true
+    - cm_remove_binding is changed
+    - nm_remove_binding is changed
     - 'cm_remove_binding.current == cm_remove_binding.previous == nm_remove_binding.previous == [{"physDomP": {"attributes": {"dn": "uni/phys-phys_dom", "name": "phys_dom", "nameAlias": "", "ownerKey": "", "ownerTag": ""}, "children": [{"infraRsVlanNs": {"attributes": {"tDn": "uni/infra/vlanns-[test_pool]-dynamic"}}}]}}]'
     - nm_remove_binding.current == []
 
@@ -180,7 +185,8 @@
 - name: Verify remove_binding_again
   assert:
     that:
-    - cm_remove_binding_again.changed == nm_remove_binding_again.changed == false
+    - cm_remove_binding_again is not changed
+    - nm_remove_binding_again is not changed
 
 
 # QUERY NON-EXISTING BINDING
@@ -204,6 +210,7 @@
 - name: Verify query_non_binding
   assert:
     that:
-    - cm_query_non_binding.changed == nm_query_non_binding.changed == false
+    - cm_query_non_binding is not changed
+    - nm_query_non_binding is not changed
     - cm_query_non_binding == nm_query_non_binding
     - nm_query_non_binding.current == []

--- a/test/integration/targets/aci_encap_pool/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool/tasks/vlan.yml
@@ -29,7 +29,7 @@
 - name: assertion test - present
   assert:
     that:
-      - create_check_mode.changed == true
+      - create_check_mode is changed
       - 'create_check_mode.sent == {"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "name": "anstest"}}}'
 
 - name: create static vlan pool - creation works
@@ -40,7 +40,7 @@
 - name: assertion test - present
   assert:
     that:
-      - create_static.changed == true
+      - create_static is changed
       - create_static.previous == []
       - create_static.sent == create_check_mode.sent
 
@@ -54,7 +54,7 @@
 - name: assertion test - present
   assert:
     that:
-      - create_dynamic.changed == true
+      - create_dynamic is changed
       - create_dynamic.previous == []
       - 'create_dynamic.sent == {"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "name": "anstest"}}}'
 
@@ -66,7 +66,7 @@
 - name: assertion test - present
   assert:
     that:
-      - idempotent_static.changed == false
+      - idempotent_static is not changed
       - 'idempotent_static.previous == [{"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-static", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
       - idempotent_static.sent == {}
 
@@ -78,7 +78,7 @@
 - name: assertion test - present
   assert:
     that:
-      - idempotent_dynamic.changed == false
+      - idempotent_dynamic is not changed
       - 'idempotent_dynamic.previous == [{"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible Test", "dn": "uni/infra/vlanns-[anstest]-dynamic", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
       - idempotent_dynamic.sent == {}
  
@@ -91,7 +91,7 @@
 - name: assertion test - present
   assert:
     that:
-      - update_static.changed == true
+      - update_static is changed
       - 'update_static.sent == {"fvnsVlanInstP": {"attributes": {"descr": "Ansible Test Change"}}}'
 
 - name: update dynamic vlan pool - update works
@@ -103,7 +103,7 @@
 - name: assertion test - present
   assert:
     that:
-      - update_dynamic.changed == true
+      - update_dynamic is changed
       - 'update_dynamic.sent == {"fvnsVlanInstP": {"attributes": {"descr": "Ansible Test Change"}}}'
 
 - name: missing param - failure message works
@@ -116,7 +116,7 @@
 - name: assertion test - present
   assert:
     that:
-      - vlan_alloc_fail.failed == true
+      - vlan_alloc_fail is failed
       - "vlan_alloc_fail.msg == 'ACI requires parameter \\'pool_allocation_mode\\' for \\'pool_type\\' of \\'vlan\\' and \\'vsan\\' when parameter \\'pool\\' is provided'"
 
 - name: missing param - failure message works
@@ -129,7 +129,7 @@
 - name: assertion test - present
   assert:
     that:
-      - vlan_pool_fail.failed == true
+      - vlan_pool_fail is failed
       - 'vlan_pool_fail.msg == "state is present but all of the following are missing: pool"'
  
 - name: missing param - failure message works
@@ -142,7 +142,7 @@
 - name: assertion test - present
   assert:
     that:
-      - vlan_pool_type_fail.failed == true
+      - vlan_pool_type_fail is failed
       - 'vlan_pool_type_fail.msg == "missing required arguments: pool_type"'
 
 - name: get all vlan pools - get class works
@@ -156,7 +156,7 @@
 - name: assertion test - query
   assert:
     that:
-      - get_all_pools.changed == false
+      - get_all_pools is not changed
       - get_all_pools.method == "GET"
       - get_all_pools.current | length > 1
 
@@ -169,7 +169,7 @@
 - name: assertion test - query
   assert:
     that:
-      - get_static_pool.changed == false
+      - get_static_pool is not changed
       - get_static_pool.method == "GET"
       - get_static_pool.current | length == 1
       - get_static_pool.current.0.fvnsVlanInstP.attributes.allocMode == "static"
@@ -184,7 +184,7 @@
 - name: assertion test - query
   assert:
     that:
-      - get_dynamic_pool.changed == false
+      - get_dynamic_pool is not changed
       - get_dynamic_pool.method == "GET"
       - get_dynamic_pool.current | length == 1
       - get_dynamic_pool.current.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
@@ -201,7 +201,7 @@
 - name: assertion test - query
   assert:
     that:
-      - vlan_query_pool_type_fail.failed == true
+      - vlan_query_pool_type_fail is failed
       - 'vlan_query_pool_type_fail.msg == "missing required arguments: pool_type"'
 
 - name: delete static vlan pool - deletion works
@@ -212,7 +212,7 @@
 - name: assertion test - absent
   assert:
     that:
-      - delete_static.changed == true
+      - delete_static is changed
       - delete_static.method == "DELETE"
       - delete_static.previous.0.fvnsVlanInstP.attributes.allocMode == "static"
       - delete_static.previous.0.fvnsVlanInstP.attributes.name == "anstest"
@@ -226,7 +226,7 @@
 - name: assertion test - absent
   assert:
     that:
-      - delete_check_mode.changed == true
+      - delete_check_mode is changed
 
 - name: delete dynamic vlan pool - deletion works
   aci_encap_pool:
@@ -236,7 +236,7 @@
 - name: assertion test - absent
   assert:
     that:
-      - delete_dynamic.changed == true
+      - delete_dynamic is changed
       - delete_dynamic.method == "DELETE"
       - delete_dynamic.previous.0.fvnsVlanInstP.attributes.allocMode == "dynamic"
       - delete_dynamic.previous.0.fvnsVlanInstP.attributes.name == "anstest"
@@ -249,7 +249,7 @@
 - name: assertion test - absent
   assert:
     that:
-      - idempotent_delete_static.changed == false
+      - idempotent_delete_static is not changed
       - idempotent_delete_static.previous == []
 
 - name: delete dynamic vlan pool again - idempotency works
@@ -260,5 +260,5 @@
 - name: assertion test - absent
   assert:
     that:
-      - idempotent_delete_dynamic.changed == false
+      - idempotent_delete_dynamic is not changed
       - idempotent_delete_dynamic.previous == []

--- a/test/integration/targets/aci_encap_pool/tasks/vxlan.yml
+++ b/test/integration/targets/aci_encap_pool/tasks/vxlan.yml
@@ -33,7 +33,7 @@
 - name: assertion test - present
   assert:
     that:
-      - create_vxlan_check_mode.changed == true
+      - create_vxlan_check_mode is changed
       - 'create_vxlan_check_mode.sent == {"fvnsVxlanInstP": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
 
 - name: create vxlan pool - creation works
@@ -44,7 +44,7 @@
 - name: assertion test - present
   assert:
     that:
-      - create_vxlan.changed == true
+      - create_vxlan is changed
       - create_vxlan.previous == []
       - create_vxlan.sent == create_vxlan_check_mode.sent
 
@@ -56,7 +56,7 @@
 - name: assertion test - present
   assert:
     that:
-      - idempotent_vxlan.changed == false
+      - idempotent_vxlan is not changed
       - 'idempotent_vxlan.previous.0.fvnsVxlanInstP.attributes.name == "anstest"'
       - idempotent_vxlan.sent == {}
 
@@ -69,7 +69,7 @@
 - name: assertion test - present
   assert:
     that:
-      - update_vxlan.changed == true
+      - update_vxlan is changed
       - 'update_vxlan.sent == {"fvnsVxlanInstP": {"attributes": {"descr": "Ansible Test Change"}}}'
 
 - name: create vxlan pool - used for query
@@ -81,7 +81,7 @@
 - name: assertion test - present
   assert:
     that:
-      - create_vxlan_2.changed == true
+      - create_vxlan_2 is changed
 
 - name: create vxlan pool with pool allocation mode - failure message works
   aci_encap_pool:
@@ -94,7 +94,7 @@
 - name: assertion test - present
   assert:
     that:
-      - create_vxlan_alloc_mode.failed == true
+      - create_vxlan_alloc_mode is failed
       - "create_vxlan_alloc_mode.msg == 'vxlan pools do not support setting the \\'pool_allocation_mode\\'; please remove this parameter from the task'"
 
 - name: get vxlan pool - get object works
@@ -106,7 +106,7 @@
 - name: assertion test - query
   assert:
     that:
-      - query_vxlan.changed == false
+      - query_vxlan is not changed
       - query_vxlan.current | length == 1
       - '"infra/vxlanns-anstest.json" in query_vxlan.url'
 
@@ -119,7 +119,7 @@
 - name: assertion test - query
   assert:
     that:
-      - query_vxlan_all.changed == false
+      - query_vxlan_all is not changed
       - query_vxlan_all.current | length > 1
       - '"class/fvnsVxlanInstP.json" in query_vxlan_all.url'
 
@@ -132,7 +132,7 @@
 - name: assertion test - absent
   assert:
     that:
-      - delete_vxlan_check_mode.changed == true
+      - delete_vxlan_check_mode is changed
       - delete_vxlan_check_mode.previous != []
 
 - name: delete vxlan pool - deletion works
@@ -143,7 +143,7 @@
 - name: assertion test - absent
   assert:
     that:
-      - delete_vxlan.changed == true
+      - delete_vxlan is changed
       - delete_vxlan.previous == delete_vxlan_check_mode.previous
       - delete_vxlan.previous.0.fvnsVxlanInstP.attributes.name == "anstest"
 
@@ -162,7 +162,7 @@
 - name: assertion test - absent
   assert:
     that:
-      - delete_vxlan_idempotent.changed == false
+      - delete_vxlan_idempotent is not changed
       - delete_vxlan_idempotent.previous == []
 
 - name: delete vxlan pool - cleanup
@@ -173,5 +173,5 @@
 - name: assertion test - absent
   assert:
     that:
-      - delete_vxlan_pool_fail.failed == true
+      - delete_vxlan_pool_fail is failed
       - 'delete_vxlan_pool_fail.msg == "state is absent but all of the following are missing: pool"'

--- a/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
@@ -45,7 +45,7 @@
 - name: present assertions
   assert:
     that:
-      - range_present_check_mode.changed == true
+      - range_present_check_mode is changed
       - 'range_present_check_mode.sent == {"fvnsEncapBlk": {"attributes": {"allocMode": "inherit", "descr": "Ansible Test", "from": "vlan-20", "name": "anstest", "to": "vlan-40"}}}'
 
 - name: create vlan pool range - creation works
@@ -56,7 +56,7 @@
 - name: present assertions
   assert:
     that:
-      - range_present.changed == true
+      - range_present is changed
       - range_present.previous == []
       - range_present.sent == range_present_check_mode.sent
       - range_present.sent == range_present.proposed
@@ -69,8 +69,8 @@
 - name: present assertions
   assert:
     that:
-      - range_present_idempotent.changed == false
-      - 'range_present_idempotent.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - range_present_idempotent is not changed
+      - range_present_idempotent.previous.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: update vlan pool range - update works
   aci_encap_pool_range:
@@ -82,7 +82,7 @@
 - name: present assertions
   assert:
     that:
-      - range_present_update.changed == true
+      - range_present_update is changed
       - range_present_update.previous != []
       - range_present_update.sent != range_present.sent
 
@@ -97,7 +97,7 @@
 - name: present assertions
   assert:
     that:
-      - range_present_2.changed == true
+      - range_present_2 is changed
       - range_present_2.previous == []
 
 - name: invalid range_start - error message works
@@ -110,8 +110,8 @@
 - name: present assertions
   assert:
     that:
-      - range_start_low.failed == true
-      - 'range_start_low.msg == "vlan pools must have \"range_start\" and \"range_end\" values between 1 and 4094"'
+      - range_start_low is failed
+      - range_start_low.msg == 'vlan pools must have "range_start" and "range_end" values between 1 and 4094'
 
 - name: invalid range_start - error message works
   aci_encap_pool_range:
@@ -123,8 +123,8 @@
 - name: present assertions
   assert:
     that:
-      - range_start_high.failed == true
-      - 'range_start_high.msg == "vlan pools must have \"range_start\" and \"range_end\" values between 1 and 4094"'
+      - range_start_high is failed
+      - range_start_high.msg == 'vlan pools must have "range_start" and "range_end" values between 1 and 4094'
 
 - name: invalid range_end - error message works
   aci_encap_pool_range:
@@ -136,8 +136,8 @@
 - name: present assertions
   assert:
     that:
-      - range_end_low.failed == true
-      - 'range_end_low.msg == "vlan pools must have \"range_start\" and \"range_end\" values between 1 and 4094"'
+      - range_end_low is failed
+      - range_end_low.msg == 'vlan pools must have "range_start" and "range_end" values between 1 and 4094'
 
 - name: invalid range_end - error message works
   aci_encap_pool_range:
@@ -149,8 +149,8 @@
 - name: present assertions
   assert:
     that:
-      - range_end_high.failed == true
-      - 'range_end_high.msg == "vlan pools must have \"range_start\" and \"range_end\" values between 1 and 4094"'
+      - range_end_high is failed
+      - range_end_high.msg == 'vlan pools must have "range_start" and "range_end" values between 1 and 4094'
 
 - name: range start higher than range end - error message works
   aci_encap_pool_range:
@@ -162,8 +162,8 @@
 - name: present assertions
   assert:
     that:
-      - range_start_end.failed == true
-      - 'range_start_end.msg == "The \"range_start\" must be less than or equal to the \"range_end\""'
+      - range_start_end is failed
+      - range_start_end.msg == 'The "range_start" must be less than or equal to the "range_end"'
 
 - name: missing required param - error message works
   aci_encap_pool_range:
@@ -175,8 +175,8 @@
 - name: present assertions
   assert:
     that:
-      - range_present_pool_type.failed == true
-      - 'range_present_pool_type.msg == "missing required arguments: pool_type"'
+      - range_present_pool_type is failed
+      - "range_present_pool_type.msg == 'missing required arguments: pool_type'"
 
 - name: missing required param - error message works
   aci_encap_pool_range:
@@ -187,8 +187,8 @@
 - name: present assertions
   assert:
     that:
-      - range_present_missing_param.failed == true
-      - 'range_present_missing_param.msg == "state is present but all of the following are missing: range_end, range_name, range_start"'
+      - range_present_missing_param is failed
+      - "range_present_missing_param.msg == 'state is present but all of the following are missing: range_end, range_name, range_start'"
 
 - name: missing required param - error message works
   aci_encap_pool_range:
@@ -200,8 +200,8 @@
 - name: present assertions
   assert:
     that:
-      - range_present_allocation.failed == true
-      - 'range_present_allocation.msg == "ACI requires the \"pool_allocation_mode\" for \"pool_type\" of \"vlan\" and \"vsan\" when the \"pool\" is provided"'
+      - range_present_allocation is failed
+      - range_present_allocation.msg == 'ACI requires the "pool_allocation_mode" for "pool_type" of "vlan" and "vsan" when the "pool" is provided'
 
 - name: query specific vlan pool range
   aci_encap_pool_range: &aci_range_query
@@ -212,10 +212,10 @@
 - name: query assertions
   assert:
     that:
-      - range_query.changed == false
+      - range_query is not changed
       - range_query.url.endswith("infra/vlanns-[anstest]-static/from-[vlan-20]-to-[vlan-40].json")
       - range_query.current | length == 1
-      - 'range_query.current.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - range_query.current.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: query vlan pool range - from, to, and name are filtered
   aci_encap_pool_range: &aci_range_query_filter
@@ -226,12 +226,14 @@
 - name: query assertions
   assert:
     that:
-      - range_query_from_to_name.changed == false
-      - 'range_query_from_to_name.url.endswith("class/fvnsEncapBlk.json")'
-      - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in range_query_from_to_name.filter_string'
-      - 'range_query_from_to_name.current.0.fvnsEncapBlk.attributes.name == "anstest"'
-      - 'range_query_from_to_name.current.0.fvnsEncapBlk.attributes.from == "vlan-20"'
-      - 'range_query_from_to_name.current.0.fvnsEncapBlk.attributes.to == "vlan-40"'
+      - range_query_from_to_name is not changed
+      - range_query_from_to_name.url.endswith("class/fvnsEncapBlk.json")
+      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in range_query_from_to_name.filter_string'
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in range_query_from_to_name.filter_string'
+      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in range_query_from_to_name.filter_string'
+      - range_query_from_to_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
+      - range_query_from_to_name.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
+      - range_query_from_to_name.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
 - name: query vlan pool range - from and name are filtered
   aci_encap_pool_range:
@@ -242,11 +244,12 @@
 - name: query assertions
   assert:
     that:
-      - range_query_from_name.changed == false
-      - 'range_query_from_name.url.endswith("class/fvnsEncapBlk.json")'
-      - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.name, \"anstest\"))" in range_query_from_name.filter_string'
-      - 'range_query_from_name.current.0.fvnsEncapBlk.attributes.name == "anstest"'
-      - 'range_query_from_name.current.0.fvnsEncapBlk.attributes.from == "vlan-20"'
+      - range_query_from_name is not changed
+      - range_query_from_name.url.endswith("class/fvnsEncapBlk.json")
+      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in range_query_from_name.filter_string'
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in range_query_from_name.filter_string'
+      - range_query_from_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
+      - range_query_from_name.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
 
 - name: query vlan pool range - to and name are filtered
   aci_encap_pool_range:
@@ -257,11 +260,12 @@
 - name: query assertions
   assert:
     that:
-      - range_query_to_name.changed == false
-      - 'range_query_to_name.url.endswith("class/fvnsEncapBlk.json")'
-      - '"query-target-filter=and(eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in range_query_to_name.filter_string'
-      - 'range_query_to_name.current.0.fvnsEncapBlk.attributes.name == "anstest"'
-      - 'range_query_to_name.current.0.fvnsEncapBlk.attributes.to == "vlan-40"'
+      - range_query_to_name is not changed
+      - range_query_to_name.url.endswith('class/fvnsEncapBlk.json')
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in range_query_to_name.filter_string'
+      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in range_query_to_name.filter_string'
+      - range_query_to_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
+      - range_query_to_name.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
 - name: query vlan pool range - name is filtered
   aci_encap_pool_range:
@@ -273,10 +277,10 @@
 - name: query assertions
   assert:
     that:
-      - range_query_name.changed == false
-      - 'range_query_name.url.endswith("class/fvnsEncapBlk.json")'
-      - '"query-target-filter=eq(fvnsEncapBlk.name, \"anstest\")" in range_query_name.filter_string'
-      - 'range_query_name.current.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - range_query_name is not changed
+      - range_query_name.url.endswith("class/fvnsEncapBlk.json")
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in range_query_name.filter_string'
+      - range_query_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: query vlan pool range - from and to are filtered
   aci_encap_pool_range:
@@ -287,11 +291,12 @@
 - name: query assertions
   assert:
     that:
-      - range_query_from_to.changed == false
-      - 'range_query_from_to.url.endswith("class/fvnsEncapBlk.json")'
-      - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"))" in range_query_from_to.filter_string'
-      - 'range_query_from_to.current.0.fvnsEncapBlk.attributes.from == "vlan-20"'
-      - 'range_query_from_to.current.0.fvnsEncapBlk.attributes.to == "vlan-40"'
+      - range_query_from_to is not changed
+      - range_query_from_to.url.endswith("class/fvnsEncapBlk.json")
+      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in range_query_from_to.filter_string'
+      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in range_query_from_to.filter_string'
+      - range_query_from_to.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
+      - range_query_from_to.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
 - name: query all ranges in a vlan pool
   aci_encap_pool_range:
@@ -304,9 +309,9 @@
   assert:
     that:
       - range_query_pool.current | length == 1
-      - 'range_query_pool.current.0.fvnsVlanInstP.attributes.name == "anstest"'
+      - range_query_pool.current.0.fvnsVlanInstP.attributes.name == "anstest"
       - range_query_pool.current.0.fvnsVlanInstP.children | length > 1
-      - 'range_query_pool.url.endswith("infra/vlanns-[anstest]-static.json")'
+      - range_query_pool.url.endswith("infra/vlanns-[anstest]-static.json")
 
 - name: query all ranges
   aci_encap_pool_range:
@@ -318,10 +323,10 @@
 - name: query assertions
   assert:
     that:
-      - range_query_all.changed == false
+      - range_query_all is not changed
       - range_query_all.current | length > 1
       - range_query_all.current.0.fvnsEncapBlk is defined
-      - 'range_query_all.url.endswith("class/fvnsEncapBlk.json")'
+      - range_query_all.url.endswith("class/fvnsEncapBlk.json")
 
 - name: delete vlan pool range - deletion works
   aci_encap_pool_range:
@@ -332,9 +337,9 @@
 - name: absent assertions
   assert:
     that:
-      - delete_range.changed == true
+      - delete_range is changed
       - delete_range.proposed == {}
-      - 'delete_range.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - delete_range.previous.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: delete vlan pool range - check mode works
   aci_encap_pool_range: &aci_range_absent
@@ -346,7 +351,7 @@
 - name: absent assertions
   assert:
     that:
-      - delete_check_mode.changed == true
+      - delete_check_mode is changed
       - delete_check_mode.previous != []
 
 - name: delete vlan pool range - deletion works
@@ -357,7 +362,7 @@
 - name: absent assertions
   assert:
     that:
-      - delete_range_2.changed == true
+      - delete_range_2 is changed
       - delete_range_2.previous == delete_check_mode.previous
 
 - name: delete vlan pool range again - idempotency works
@@ -368,11 +373,11 @@
 - name: absent assertions
   assert:
     that:
-      - delete_idempotent.changed == false
+      - delete_idempotent is not changed
       - delete_idempotent.previous == []
 
 - name: cleanup vlan pool
   aci_encap_pool:
     <<: *aci_pool_present
     state: absent
-  when: pool_present.changed == true
+  when: pool_present is changed

--- a/test/integration/targets/aci_encap_pool_range/tasks/vsan.yml
+++ b/test/integration/targets/aci_encap_pool_range/tasks/vsan.yml
@@ -17,4 +17,4 @@
   aci_encap_pool:
     <<: *aci_pool_present
     state: absent
-  when: pool_present.changed == true
+  when: pool_present is changed

--- a/test/integration/targets/aci_encap_pool_range/tasks/vxlan.yml
+++ b/test/integration/targets/aci_encap_pool_range/tasks/vxlan.yml
@@ -16,4 +16,4 @@
   aci_encap_pool:
     <<: *aci_pool_present
     state: absent
-  when: pool_present.changed == true
+  when: pool_present is changed

--- a/test/integration/targets/aci_epg/tasks/main.yml
+++ b/test/integration/targets/aci_epg/tasks/main.yml
@@ -73,17 +73,17 @@
 - name: present assertions
   assert:
     that:
-      - epg_present_check_mode.changed == true
+      - epg_present_check_mode is changed
       - epg_present_check_mode.previous == []
       - epg_present_check_mode.sent.fvAEPg.attributes != {}
-      - 'epg_present_check_mode.sent.fvAEPg.children.0.fvRsBd.attributes.tnFvBDName == "anstest"'
-      - epg_present.changed == true
+      - epg_present_check_mode.sent.fvAEPg.children.0.fvRsBd.attributes.tnFvBDName == "anstest"
+      - epg_present is changed
       - epg_present.sent == epg_present_check_mode.sent
-      - epg_present_idempotent.changed == false
+      - epg_present_idempotent is not changed
       - epg_present_idempotent.sent == {}
-      - epg_present_update.changed == true
+      - epg_present_update is changed
       - 'epg_present_update.sent == {"fvAEPg": {"attributes": {"descr": "Ansible Test Update"}}}'
-      - epg_present_missing_param.failed == true
+      - epg_present_missing_param is failed
       - 'epg_present_missing_param.msg == "state is present but all of the following are missing: ap"'
 
 - name: get specific epg
@@ -102,11 +102,11 @@
 - name: query assertions
   assert:
     that:
-      - epg_query.changed == false
+      - epg_query is not changed
       - epg_query.current | length == 1
-      - 'epg_query.current.0.fvAEPg.attributes.name == "anstest"'
+      - epg_query.current.0.fvAEPg.attributes.name == "anstest"
       - '"tn-anstest/ap-anstest/epg-anstest.json" in epg_query.url'
-      - epg_query_all.changed == false
+      - epg_query_all is not changed
       - epg_query_all.current | length > 1
       - '"rsp-subtree-class=fvRsBd" in epg_query_all.filter_string'
       - '"class/fvAEPg.json" in epg_query_all.url'
@@ -143,13 +143,13 @@
 - name: query assertions
   assert:
     that:
-      - delete_epg_check_mode.changed == true
+      - delete_epg_check_mode is changed
       - delete_epg_check_mode.previous != []
-      - delete_epg.changed == true
+      - delete_epg is changed
       - delete_epg.previous == delete_epg_check_mode.previous
-      - delete_epg_idempotent.changed == false
+      - delete_epg_idempotent is not changed
       - delete_epg_idempotent.previous == []
-      - delete_epg_missing_param.failed == true
+      - delete_epg_missing_param is failed
       - 'delete_epg_missing_param.msg == "state is absent but all of the following are missing: tenant"'
 
 - name: cleanup bd

--- a/test/integration/targets/aci_epg_to_contract/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_contract/tasks/main.yml
@@ -8,6 +8,22 @@
     msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
   when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
 
+- name: Ensure contract binding does not exist prior to testing
+  aci_epg_to_contract:
+    host: "{{ aci_hostname }}"
+    username: "{{ aci_username }}"
+    password: "{{ aci_password }}"
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
+    tenant: anstest
+    ap: anstest
+    epg: anstest
+    contract_type: provider
+    contract: "anstest_http"
+    state: absent
+
 - name: ensure tenant exists for tests to kick off
   aci_tenant: &aci_tenant_present
     host: "{{ aci_hostname }}"
@@ -43,7 +59,7 @@
   aci_epg_to_contract: &aci_epg_provide_present
     <<: *aci_epg_present
     contract_type: provider
-    contract: "anstest_http"
+    contract: anstest_http
   check_mode: yes
   register: provide_present_check_mode
 
@@ -94,21 +110,21 @@
 - name: present assertions
   assert:
     that:
-      - provide_present_check_mode.changed == true
+      - provide_present_check_mode is changed
       - 'provide_present_check_mode.sent == {"fvRsProv": {"attributes": {"tnVzBrCPName": "anstest_http"}}}'
-      - provide_present.changed == true
+      - provide_present is changed
       - provide_present.sent == provide_present_check_mode.sent
       - provide_present.previous == []
-      - consume_present.changed == true
+      - consume_present is changed
       - consume_present.previous == []
       - 'consume_present.sent == {"fvRsCons": {"attributes": {"tnVzBrCPName": "anstest_db"}}}'
-      - provide_present2.changed == true
+      - provide_present2 is changed
       - provide_present2.previous == []
-      - missing_param_present.failed == true
+      - missing_param_present is failed
       - 'missing_param_present.msg == "state is present but all of the following are missing: ap, contract, epg"'
-      - missing_required_present.failed == true
+      - missing_required_present is failed
       - 'missing_required_present.msg == "missing required arguments: contract_type"'
-      - incompatible_present.failed == true
+      - incompatible_present is failed
       - incompatible_present.msg == "the 'provider_match' is only configurable for Provided Contracts"
 
 - name: get binding
@@ -141,15 +157,15 @@
 - name: query assertions
   assert:
     that:
-      - query_provide_contract.changed == false
+      - query_provide_contract is not changed
       - query_provide_contract.current != []
-      - '"class/fvRsProv.json" in query_provide_contract.url'
-      - query_consume_contract.changed == false
+      - '"uni/tn-anstest/ap-anstest/epg-anstest/rsprov-anstest_https.json" in query_provide_contract.url'
+      - query_consume_contract is not changed
       - query_consume_contract.current != []
-      - '"class/fvRsCons.json" in query_consume_contract.url'
-      - query_all.changed == false
+      - '"uni/tn-anstest/ap-anstest/epg-anstest/rscons-anstest_db.json" in query_consume_contract.url'
+      - query_all is not changed
       - '"class/fvRsProv.json" in query_all.url'
-      - missing_required_query.failed == true
+      - missing_required_query is failed
       - 'missing_required_query.msg == "missing required arguments: contract_type"'
 
 - name: delete consume binding - check mode works
@@ -198,18 +214,18 @@
 - name: absent assertions
   assert:
     that:
-      - consume_absent_check_mode.changed == true
+      - consume_absent_check_mode is changed
       - consume_absent_check_mode.previous.0.fvRsCons is defined
-      - consume_absent.changed == true
+      - consume_absent is changed
       - consume_absent.previous == consume_absent_check_mode.previous
-      - provide_absent.changed == true
+      - provide_absent is changed
       - provide_absent.previous.0.fvRsProv is defined
-      - provide_absent2.changed == true
-      - consume_absent_idempotent.changed == false
+      - provide_absent2 is changed
+      - consume_absent_idempotent is not changed
       - consume_absent_idempotent.previous == []
-      - missing_param_absent.failed == true
+      - missing_param_absent is failed
       - 'missing_param_absent.msg == "state is absent but all of the following are missing: contract"'
-      - missing_required_absent.failed == true
+      - missing_required_absent is failed
       - 'missing_required_absent.msg == "missing required arguments: contract_type"'
 
 - name: cleanup contracts
@@ -223,16 +239,16 @@
   aci_epg:
     <<: *aci_epg_present
     state: absent
-  when: epg_present.changed == true
+  when: epg_present is changed
 
 - name: cleanup ap
   aci_ap:
     <<: *aci_ap_present
     state: absent
-  when: ap_present.changed == true
+  when: ap_present is changed
 
 - name: cleanup tenant
   aci_tenant:
     <<: *aci_tenant_present
     state: absent
-  when: tenant_present.changed == true
+  when: tenant_present is changed

--- a/test/integration/targets/aci_epg_to_domain/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_domain/tasks/main.yml
@@ -110,23 +110,23 @@
 - name: present assertions
   assert:
     that:
-      - phys_check_mode_present.changed == true
-      - phys_present.changed == true
+      - phys_check_mode_present is changed
+      - phys_present is changed
       - phys_present.previous == []
       - 'phys_present.sent == {"fvRsDomAtt": {"attributes": {}}}'
       - '"[uni/phys-anstest].json" in phys_present.url'
-      - phys_idempotent.changed == false
+      - phys_idempotent is not changed
       - phys_idempotent.sent == {}
-      - phys_update.changed == true
+      - phys_update is changed
       - 'phys_update.sent == {"fvRsDomAtt": {"attributes": {"instrImedcy": "immediate"}}}'
-      - vmm_present.changed == true
+      - vmm_present is changed
       - 'vmm_present.sent == {"fvRsDomAtt": {"attributes": {"resImedcy": "pre-provision"}}}'
       - '"[uni/vmmp-VMware/dom-anstest].json" in vmm_present.url'
-      - present_missing_params.failed == true
+      - present_missing_params is failed
       - 'present_missing_params.msg == "domain_type is vmm but all of the following are missing: vm_provider"'
-      - invalid_vlan.failed == true
-      - 'invalid_vlan.msg == "Valid VLAN assigments are from 1 to 4096"'
-      - incompatible_params.failed == true
+      - invalid_vlan is failed
+      - invalid_vlan.msg == "Valid VLAN assigments are from 1 to 4096"
+      - incompatible_params is failed
       - incompatible_params.msg == "Domain type 'phys' cannot have a 'vm_provider'"
 
 - name: get domain epg binding
@@ -139,7 +139,7 @@
 - name: query assertions
   assert:
     that:
-      - binding_query.changed == false
+      - binding_query is not changed
       - binding_query.current | length > 1
       - '"class/fvRsDomAtt.json" in binding_query.url'
 
@@ -176,42 +176,42 @@
 - name: absent assertions
   assert:
     that:
-      - epg_domain_check_mode_absent.changed == true
+      - epg_domain_check_mode_absent is changed
       - epg_domain_check_mode_absent.previous != []
-      - epg_domain_absent.changed == true
+      - epg_domain_absent is changed
       - epg_domain_absent.previous == epg_domain_check_mode_absent.previous
-      - epg_vmm_domain_absent.changed == true
-      - idempotency_absent.changed == false
+      - epg_vmm_domain_absent is changed
+      - idempotency_absent is not changed
       - idempotency_absent.previous == []
-      - absent_missing_param.failed == true
+      - absent_missing_param is failed
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: ap, domain, domain_type, epg"'
 
 - name: remove vmm domain - cleanup
   aci_rest:
     <<: *aci_rest_vmm_domain
     method: delete
-  when: vmm_domain_post.changed == true
+  when: vmm_domain_post is changed
 
 - name: remove phys domain - cleanup
   aci_rest:
     <<: *aci_rest_phys_domain
     method: delete
-  when: phys_domain_post.changed == true
+  when: phys_domain_post is changed
 
 - name: remove epg - cleanup
   aci_epg:
     <<: *aci_epg_present
     state: absent
-  when: epg_present.changed == true
+  when: epg_present is changed
 
 - name: remove ap - cleanup
   aci_ap:
     <<: *aci_ap_present
     state: absent
-  when: ap_present.changed == true
+  when: ap_present is changed
 
 - name: remove tenant - cleanup
   aci_tenant:
     <<: *aci_tenant_present
     state: absent
-  when: tenant_present.changed == true
+  when: tenant_present is changed

--- a/test/integration/targets/aci_fabric_node/tasks/main.yml
+++ b/test/integration/targets/aci_fabric_node/tasks/main.yml
@@ -57,9 +57,11 @@
 - name: Verify add_fabric_node
   assert:
     that:
-    - cm_add_fabric_node.changed == nm_add_fabric_node.changed == true
+    - cm_add_fabric_node is changed
+    - nm_add_fabric_node is changed
     # FIXME: Module is not idempotent
-    - cm_add_fabric_node_again.changed == nm_add_fabric_node_again.changed == false
+    - cm_add_fabric_node_again is not changed
+    - nm_add_fabric_node_again is not changed
 
 
 # CHANGE FABRIC NODE
@@ -92,9 +94,11 @@
 - name: Verify add_fabric_node_descr
   assert:
     that:
-    - cm_add_fabric_node_descr.changed == nm_add_fabric_node_descr.changed == true
+    - cm_add_fabric_node_descr is changed
+    - nm_add_fabric_node_descr is changed
     # FIXME: Module is not idempotent
-    - cm_add_fabric_node_descr_again.changed == nm_add_fabric_node_descr_again.changed == false
+    - cm_add_fabric_node_descr_again is not changed
+    - nm_add_fabric_node_descr_again is not changed
 
 
 # ADD FABRIC NODE AGAIN
@@ -111,7 +115,8 @@
   assert:
     that:
     # FIXME: Module is not idempotent
-    - cm_add_fabric_node_again_no_descr.changed == nm_add_fabric_node_again_no_descr.changed == false
+    - cm_add_fabric_node_again_no_descr is not changed
+    - nm_add_fabric_node_again_no_descr is not changed
 
 
 # QUERY ALL FABRIC NODES
@@ -135,7 +140,8 @@
 - name: Verify query_all_fabric_nodes
   assert:
     that:
-    - cm_query_all_fabric_nodes.changed == nm_query_all_fabric_nodes.changed == false
+    - cm_query_all_fabric_nodes is not changed
+    - nm_query_all_fabric_nodes is not changed
     - cm_query_all_fabric_nodes == nm_query_all_fabric_nodes
 
 
@@ -156,7 +162,8 @@
 - name: Verify query_fabric_node
   assert:
     that:
-    - cm_query_fabric_node.changed == nm_query_fabric_node.changed == false
+    - cm_query_fabric_node is not changed
+    - nm_query_fabric_node is not changed
     - cm_query_fabric_node == nm_query_fabric_node
 
 
@@ -182,8 +189,10 @@
 - name: Verify remove_fabric_node
   assert:
     that:
-    - cm_remove_fabric_node.changed == nm_remove_fabric_node.changed == true
-    - cm_remove_fabric_node_again.changed == nm_remove_fabric_node_again.changed == false
+    - cm_remove_fabric_node is changed
+    - nm_remove_fabric_node is changed
+    - cm_remove_fabric_node_again is not changed
+    - nm_remove_fabric_node_again is not changed
 
 
 # QUERY NON-EXISTING LEAF PROFILE
@@ -203,5 +212,6 @@
 - name: Verify query_non_fabric_node
   assert:
     that:
-    - cm_query_non_fabric_node.changed == nm_query_non_fabric_node.changed == false
+    - cm_query_non_fabric_node is not changed
+    - nm_query_non_fabric_node is not changed
     - cm_query_non_fabric_node == nm_query_non_fabric_node

--- a/test/integration/targets/aci_filter/tasks/main.yml
+++ b/test/integration/targets/aci_filter/tasks/main.yml
@@ -66,10 +66,10 @@
 - name: Verify add_filter
   assert:
     that:
-    - cm_add_filter.changed == true
-    - cm_add_filter_again.changed == true
-    - nm_add_filter.changed == true
-    - nm_add_filter_again.changed == false
+    - cm_add_filter is changed
+    - cm_add_filter_again is changed
+    - nm_add_filter is changed
+    - nm_add_filter_again is not changed
 
 # CHANGE FILTER
 - name: Change description of filter (check_mode)
@@ -101,10 +101,10 @@
 - name: Verify add_filter_descr
   assert:
     that:
-    - cm_add_filter_descr.changed == true
-    - cm_add_filter_descr_again.changed == true
-    - nm_add_filter_descr.changed == true
-    - nm_add_filter_descr_again.changed == false
+    - cm_add_filter_descr is changed
+    - cm_add_filter_descr_again is changed
+    - nm_add_filter_descr is changed
+    - nm_add_filter_descr_again is not changed
 
 # ADD FILTER AGAIN
 - name: Add filter again with no description (check_mode)
@@ -119,8 +119,8 @@
 - name: Verify add_filter_again_no_descr
   assert:
     that:
-    - cm_add_filter_again_no_descr.changed == false
-    - nm_add_filter_again_no_descr.changed == false
+    - cm_add_filter_again_no_descr is not changed
+    - nm_add_filter_again_no_descr is not changed
 
 # QUERY ALL FILTERS
 - name: Query all filters (check_mode)
@@ -143,8 +143,8 @@
 - name: Verify query_all_filters
   assert:
     that:
-    - cm_query_all_filters.changed == false
-    - nm_query_all_filters.changed == false
+    - cm_query_all_filters is not changed
+    - nm_query_all_filters is not changed
     # NOTE: Order of filters is not stable between calls
     #- cm_query_all_filters == nm_query_all_filters
 
@@ -167,8 +167,8 @@
 - name: Verify query_filter
   assert:
     that:
-    - cm_query_filter.changed == false
-    - nm_query_filter.changed == false
+    - cm_query_filter is not changed
+    - nm_query_filter is not changed
     - cm_query_filter == nm_query_filter
 
 # REMOVE FILTER
@@ -193,10 +193,10 @@
 - name: Verify remove_filter
   assert:
     that:
-    - cm_remove_filter.changed == true
-    - cm_remove_filter_again.changed == true
-    - nm_remove_filter.changed == true
-    - nm_remove_filter_again.changed == false
+    - cm_remove_filter is changed
+    - cm_remove_filter_again is changed
+    - nm_remove_filter is changed
+    - nm_remove_filter_again is not changed
 
 # QUERY NON-EXISTING FILTER
 # FIXME: Should this fail or return empty values ?
@@ -218,6 +218,6 @@
 - name: Verify query_non_filter
   assert:
     that:
-    - cm_query_non_filter.changed == false
-    - nm_query_non_filter.changed == false
+    - cm_query_non_filter is not changed
+    - nm_query_non_filter is not changed
     - cm_query_non_filter == nm_query_non_filter

--- a/test/integration/targets/aci_filter_entry/tasks/main.yml
+++ b/test/integration/targets/aci_filter_entry/tasks/main.yml
@@ -111,27 +111,27 @@
 - name: present assertions
   assert:
     that:
-      - entry_present_check_mode.changed == true
+      - entry_present_check_mode is changed
       - entry_present_check_mode.previous == []
       - 'entry_present_check_mode.sent == {"vzEntry": {"attributes": {"dFromPort": "http","dToPort": "88","descr": "Ansible Test","etherT": "ip","name": "anstest","prot": "tcp"}}}'
-      - entry_present.changed == true
+      - entry_present is changed
       - entry_present.previous == []
       - entry_present.sent == entry_present_check_mode.sent
-      - entry_present_idempotent.changed == false
+      - entry_present_idempotent is not changed
       - entry_present_idempotent.previous != []
       - entry_present_idempotent.sent == {}
-      - entry_present_update.changed == true
+      - entry_present_update is changed
       - entry_present_update.previous != []
       - entry_present_update.sent != entry_present_update.proposed
-      - entry_present_2.changed == true
+      - entry_present_2 is changed
       - 'entry_present_2.sent.vzEntry.attributes == {"arpOpc": "reply",  "etherT": "arp", "name": "anstest2"}'
-      - entry_present_3.changed == true
+      - entry_present_3 is changed
       - 'entry_present_3.sent.vzEntry.attributes == {"etherT": "ip", "icmpv4T": "echo", "name": "anstest3", "prot": "icmp"}'
-      - entry_present_4.changed == true
+      - entry_present_4 is changed
       - 'entry_present_4.sent.vzEntry.attributes == {"dFromPort": "1000", "dToPort": "1000", "etherT": "ip", "name": "anstest4", "prot": "udp"}'
-      - present_missing_param.failed == true
+      - present_missing_param is failed
       - 'present_missing_param.msg == "state is present but all of the following are missing: entry"'
-      - present_incompatible_params.failed == true
+      - present_incompatible_params is failed
       - present_incompatible_params.msg.startswith("Parameter")
 
 - name: query tenant filter entry
@@ -188,43 +188,43 @@
 - name: query assertions
   assert:
     that:
-      - query_tenant_filter_entry.changed == false
+      - query_tenant_filter_entry is not changed
       - query_tenant_filter_entry.current | length == 1
-      - 'query_tenant_filter_entry.current.0.vzEntry.attributes.name == "anstest"'
+      - query_tenant_filter_entry.current.0.vzEntry.attributes.name == "anstest"
       - '"tn-anstest/flt-anstest/e-anstest.json" in query_tenant_filter_entry.url'
-      - query_filter_entry.changed == false
-      - 'query_filter_entry.current.0.vzFilter.attributes.name == "anstest"'
+      - query_filter_entry is not changed
+      - query_filter_entry.current.0.vzFilter.attributes.name == "anstest"
       - query_filter_entry.current.0.vzFilter.children | length == 1
       - '"query-target-filter=eq(vzFilter.name, \"anstest\")" in query_filter_entry.filter_string'
       - '"rsp-subtree-filter=eq(vzEntry.name, \"anstest\")" in query_filter_entry.filter_string'
       - '"class/vzFilter.json" in query_filter_entry.url'
-      - query_tenant_entry.changed == false
+      - query_tenant_entry is not changed
       - query_tenant_entry.current | length == 1
-      - 'query_tenant_entry.current.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant_entry.current.0.fvTenant.attributes.name == "anstest"
       - '"rsp-subtree-filter=eq(vzEntry.name, \"anstest\")" in query_tenant_entry.filter_string'
       - '"rsp-subtree-class=vzEntry" in query_tenant_entry.filter_string'
       - '"tn-anstest.json" in query_tenant_entry.url'
-      - query_tenant_filter.changed == false
+      - query_tenant_filter is not changed
       - query_tenant_filter.current | length == 1
-      - 'query_tenant_filter.current.0.vzFilter.attributes.name == "anstest"'
+      - query_tenant_filter.current.0.vzFilter.attributes.name == "anstest"
       - query_tenant_filter.current.0.vzFilter.children | length == 4
       - '"rsp-subtree-class=vzEntry" in query_tenant_filter.filter_string'
       - '"tn-anstest/flt-anstest.json" in query_tenant_filter.url'
-      - query_entry.changed == false
-      - 'query_entry.current.0.vzEntry.attributes.name == "anstest"'
+      - query_entry is not changed
+      - query_entry.current.0.vzEntry.attributes.name == "anstest"
       - '"query-target-filter=eq(vzEntry.name, \"anstest\")" in query_entry.filter_string'
       - '"class/vzEntry.json" in query_entry.url'
-      - query_filter.changed == false
-      - 'query_filter.current.0.vzFilter.attributes.name == "anstest"'
+      - query_filter is not changed
+      - query_filter.current.0.vzFilter.attributes.name == "anstest"
       - '"query-target-filter=eq(vzFilter.name, \"anstest\")" in query_filter.filter_string'
       - '"rsp-subtree-class=vzEntry" in query_filter.filter_string'
       - '"class/vzFilter.json" in query_filter.url'
-      - query_tenant.changed == false
+      - query_tenant is not changed
       - query_tenant.current | length == 1
-      - 'query_tenant.current.0.fvTenant.attributes.name == "anstest"'
-      - '"rsp-subtree-class=vzFilter,vzEntry" in query_tenant.filter_string'
+      - query_tenant.current.0.fvTenant.attributes.name == "anstest"
+      - '"rsp-subtree-class=vzEntry,vzFilter" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
-      - query_all.changed == false
+      - query_all is not changed
       - query_all.current | length > 1
       - query_all.current.0.vzEntry is defined
       - '"class/vzEntry.json" in query_all.url'
@@ -262,24 +262,24 @@
 - name: absent assertions
   assert:
     that:
-      - entry_absent_check_mode.changed == true
+      - entry_absent_check_mode is changed
       - entry_absent_check_mode.previous != []
-      - entry_absent.changed == true
+      - entry_absent is changed
       - entry_absent.previous == entry_absent_check_mode.previous
       - entry_absent.proposed == {}
-      - entry_absent_idempotent.changed == false
+      - entry_absent_idempotent is not changed
       - entry_absent_idempotent.previous == []
-      - absent_missing_param.failed == true
+      - absent_missing_param is failed
       - 'absent_missing_param.msg == "state is absent but all of the following are missing: entry, filter"'
 
 - name: cleanup filter
   aci_filter:
     <<: *aci_filter_present
     state: absent
-  when: filter_present.changed == true
+  when: filter_present is changed
 
 - name: cleanup tenant
   aci_tenant:
     <<: *aci_tenant_present
     state: absent
-  when: tenant_present.changed == true
+  when: tenant_present is changed

--- a/test/integration/targets/aci_firmware_source/tasks/main.yml
+++ b/test/integration/targets/aci_firmware_source/tasks/main.yml
@@ -42,7 +42,8 @@
 #- name: Verify add_source
 #  assert:
 #    that:
-#    - cm_add_source.changed == nm_add_source.changed == true
+#    - cm_add_source is changed
+#    - nm_add_source is changed
 #    - 'cm_add_source.sent == nm_add_source.sent == {"firmwareOSource": {"attributes": {"name": "aci-msft-pkg-3.1.1i.zip", "proto": "http", "url": "foobar.cisco.com/download/cisco/aci/aci-msft-pkg-3.1.1i.zip"}}}'
 #    - 'cm_add_source.proposed == nm_add_source.proposed == {"firmwareOSource": {"attributes": {"name": "aci-msft-pkg-3.1.1i.zip", "proto": "http", "url": "foobar.cisco.com/download/cisco/aci/aci-msft-pkg-3.1.1i.zip"}}}'
 #    - cm_add_source.current == cm_add_source.previous == nm_add_source.previous == []
@@ -62,7 +63,8 @@
 #- name: Verify add_source_again
 #  assert:
 #    that:
-#    - cm_add_source_again.changed == nm_add_source_again.changed == false
+#    - cm_add_source_again is not changed
+#    - nm_add_source_again is not changed
 
 
 # QUERY ALL SOURCES
@@ -86,7 +88,8 @@
 - name: Verify query_all_sources
   assert:
     that:
-    - cm_query_all_sources.changed == nm_query_all_sources.changed == false
+    - cm_query_all_sources is not changed
+    - nm_query_all_sources is not changed
     - cm_query_all_sources == nm_query_all_sources
 #    - nm_query_all_sources.current|length >= 1
 
@@ -108,7 +111,8 @@
 #- name: Verify query_source
 #  assert:
 #    that:
-#    - cm_query_source.changed == nm_query_source.changed == false
+#    - cm_query_source is not changed
+#    -  nm_query_source is not changed
 #    - cm_query_source == nm_query_source
 #    - nm_query_source.current.0.infraRsDomP.attributes.dn == 'uni/infra/attentp-test_aep/rsdomP-[uni/phys-phys_dom]'
 #    - nm_query_source.current.0.infraRsDomP.attributes.tCl == 'physDomP'
@@ -128,7 +132,8 @@
 #- name: Verify remove_source
 #  assert:
 #    that:
-#    - cm_remove_source.changed == nm_remove_source.changed == true
+#    - cm_remove_source is changed
+#    - nm_remove_source is changed
 #    - 'cm_remove_source.current == cm_remove_source.previous == nm_remove_source.previous == [{"infraRsDomP": {"attributes": {"dn": "uni/infra/attentp-test_aep/rsdomP-[uni/phys-phys_dom]", "tDn": "uni/phys-phys_dom"}}}]'
 #    - nm_remove_source.current == []
 #
@@ -144,7 +149,8 @@
 #- name: Verify remove_source_again
 #  assert:
 #    that:
-#    - cm_remove_source_again.changed == nm_remove_source_again.changed == false
+#    - cm_remove_source_again is not changed
+#    - nm_remove_source_again is not changed
 
 
 # QUERY NON-EXISTING SOURCE
@@ -164,7 +170,8 @@
 #- name: Verify query_non_source
 #  assert:
 #    that:
-#    - cm_query_non_source.changed == nm_query_non_source.changed == false
+#    - cm_query_non_source is not changed
+#    - nm_query_non_source is not changed
 #    - cm_query_non_source == nm_query_non_source
 #    - nm_query_non_source.current == []
 
@@ -186,5 +193,5 @@
 - name: Verify error_on_missing_required_param
   assert:
     that:
-    - error_on_missing_required_param.failed == true
+    - error_on_missing_required_param is failed
     - 'error_on_missing_required_param.msg == "state is present but all of the following are missing: source, url"'

--- a/test/integration/targets/aci_interface_policy_leaf_policy_group/tasks/main.yml
+++ b/test/integration/targets/aci_interface_policy_leaf_policy_group/tasks/main.yml
@@ -8,7 +8,7 @@
     msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
   when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
 
-- name: Making sure interface_policy_leaf_policy_group doesn't exist at beggining of test (PC)
+- name: Making sure interface_policy_leaf_policy_group doesn't exist at beginning of test (PC)
   aci_interface_policy_leaf_policy_group: &aci_interface_policy_leaf_policy_group_link_absent
     host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
@@ -17,11 +17,11 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    policy_group: policygroupname
+    policy_group: policygroupname_link
     lag_type: link
     state: absent
 
-- name: Making sure interface_policy_leaf_policy_group doesn't exist at beggining of test (VPC)
+- name: Making sure interface_policy_leaf_policy_group doesn't exist at beginning of test (VPC)
   aci_interface_policy_leaf_policy_group: &aci_interface_policy_leaf_policy_group_node_absent
     host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
@@ -30,11 +30,11 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    policy_group: policygroupname
+    policy_group: policygroupname_node
     lag_type: node
     state: absent
 
-- name: Making sure interface_policy_leaf_policy_group doesn't exist at beggining of test (Leaf Access Port)
+- name: Making sure interface_policy_leaf_policy_group doesn't exist at beginning of test (Leaf Access Port)
   aci_interface_policy_leaf_policy_group: &aci_interface_policy_leaf_policy_group_leaf_absent
     host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
@@ -43,7 +43,7 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    policy_group: policygroupname
+    policy_group: policygroupname_leaf
     lag_type: leaf
     state: absent
 
@@ -59,7 +59,7 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    policy_group: policygroupname
+    policy_group: policygroupname_link
     lag_type: link
     link_level_policy: linklevelpolicy
     fibre_channel_interface_policy: fiberchannelpolicy
@@ -87,13 +87,13 @@
 - name: present assertions
   assert:
     that:
-    - intf_policy_leaf_polgrp_check_mode_present.changed == true
-    - intf_policy_leaf_polgrp_present.changed == true
+    - intf_policy_leaf_polgrp_check_mode_present is changed
+    - intf_policy_leaf_polgrp_present is changed
     - intf_policy_leaf_polgrp_present.previous == []
-    - 'intf_policy_leaf_polgrp_present.sent ==  {"infraAccBndlGrp": {"attributes": {"lagT": "link","name": "policygroupname"},"children": [{"infraRsAttEntP": {"attributes": {"tDn": "uni/infra/attentp-None"}}},{"infraRsFcIfPol": {"attributes": {"tnFcIfPolName": "fiberchannelpolicy"}}},{"infraRsHIfPol": {"attributes": {"tnFabricHIfPolName": "linklevelpolicy"}}}]}}'
-    - intf_policy_leaf_polgrp_idempotent.changed == false
+    - 'intf_policy_leaf_polgrp_present.sent ==  {"infraAccBndlGrp": {"attributes": {"lagT": "link","name": "policygroupname_link"},"children": [{"infraRsAttEntP": {"attributes": {"tDn": "uni/infra/attentp-None"}}},{"infraRsFcIfPol": {"attributes": {"tnFcIfPolName": "fiberchannelpolicy"}}},{"infraRsHIfPol": {"attributes": {"tnFabricHIfPolName": "linklevelpolicy"}}}]}}'
+    - intf_policy_leaf_polgrp_idempotent is not changed
     - intf_policy_leaf_polgrp_idempotent.sent == {}
-    - intf_policy_leaf_polgrp_update.changed == true
+    - intf_policy_leaf_polgrp_update is changed
     - 'intf_policy_leaf_polgrp_update.sent == {"infraAccBndlGrp": {"attributes": {"descr": "policygroup description"}}}'
 
 - name: Query interface policy leaf policy group (PC)
@@ -105,7 +105,7 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    policy_group: policygroupname
+    policy_group: policygroupname_link
     lag_type: link
     state: query
   register: binding_query
@@ -113,9 +113,9 @@
 - name: present assertions
   assert:
     that:
-      - binding_query.changed == false
+      - binding_query is not changed
       - binding_query.current | length >= 1
-      - '"/api/mo/uni/infra/funcprof/accbundle-policygroupname.json" in binding_query.url'
+      - '"/api/mo/uni/infra/funcprof/accbundle-policygroupname_link.json" in binding_query.url'
 
 - name: Remove interface policy leaf policy group (PC) - check mode
   aci_interface_policy_leaf_policy_group:
@@ -142,7 +142,7 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    policy_group: policygroupname
+    policy_group: policygroupname_link
     #lag_type: link
     state: absent
   ignore_errors: yes
@@ -151,21 +151,21 @@
 - name: absent assertions
   assert:
     that:
-      - intf_policy_leaf_polgrp_check_mode_absent.changed == true
+      - intf_policy_leaf_polgrp_check_mode_absent is changed
       - intf_policy_leaf_polgrp_check_mode_absent.previous != []
-      - intf_policy_leaf_polgrp_absent.changed == true
+      - intf_policy_leaf_polgrp_absent is changed
       - intf_policy_leaf_polgrp_absent.previous == intf_policy_leaf_polgrp_absent.previous
-      - intf_policy_leaf_polgrp_absent_idempotent.changed == false
+      - intf_policy_leaf_polgrp_absent_idempotent is not changed
       - intf_policy_leaf_polgrp_absent_idempotent.previous == []
-      - intf_policy_leaf_polgrp_absent_missing_param.failed == true
-      - 'intf_policy_leaf_polgrp_absent_missing_param.msg == "state is absent but all of the following are missing: lag_type"'
+      - intf_policy_leaf_polgrp_absent_missing_param is failed
+      - 'intf_policy_leaf_polgrp_absent_missing_param.msg == "missing required arguments: lag_type"'
 
 # ==== END TESTING Port Channel (PC), lag_type: link ====
 
 
 # ==== START TESTING Virtual Port Channel (VPC), lag_type: node ====
 
-- name: Making sure interface_policy_leaf_policy_group doesn't exist at beggining of test (VPC)
+- name: Making sure interface_policy_leaf_policy_group doesn't exist at beginning of test (VPC)
   aci_interface_policy_leaf_policy_group:
     <<: *aci_interface_policy_leaf_policy_group_node_absent
 
@@ -178,7 +178,7 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    policy_group: policygroupname
+    policy_group: policygroupname_node
     lag_type: node
     link_level_policy: linklevelpolicy
     fibre_channel_interface_policy: fiberchannelpolicy
@@ -206,13 +206,13 @@
 - name: present assertions
   assert:
     that:
-    - intf_policy_leaf_polgrp_check_mode_present.changed == true
-    - intf_policy_leaf_polgrp_present.changed == true
+    - intf_policy_leaf_polgrp_check_mode_present is changed
+    - intf_policy_leaf_polgrp_present is changed
     - intf_policy_leaf_polgrp_present.previous == []
-    - 'intf_policy_leaf_polgrp_present.sent ==  {"infraAccBndlGrp": {"attributes": {"lagT": "node","name": "policygroupname"},"children": [{"infraRsAttEntP": {"attributes": {"tDn": "uni/infra/attentp-None"}}},{"infraRsFcIfPol": {"attributes": {"tnFcIfPolName": "fiberchannelpolicy"}}},{"infraRsHIfPol": {"attributes": {"tnFabricHIfPolName": "linklevelpolicy"}}}]}}'
-    - intf_policy_leaf_polgrp_idempotent.changed == false
+    - 'intf_policy_leaf_polgrp_present.sent ==  {"infraAccBndlGrp": {"attributes": {"lagT": "node","name": "policygroupname_node"},"children": [{"infraRsAttEntP": {"attributes": {"tDn": "uni/infra/attentp-None"}}},{"infraRsFcIfPol": {"attributes": {"tnFcIfPolName": "fiberchannelpolicy"}}},{"infraRsHIfPol": {"attributes": {"tnFabricHIfPolName": "linklevelpolicy"}}}]}}'
+    - intf_policy_leaf_polgrp_idempotent is not changed
     - intf_policy_leaf_polgrp_idempotent.sent == {}
-    - intf_policy_leaf_polgrp_update.changed == true
+    - intf_policy_leaf_polgrp_update is changed
     - 'intf_policy_leaf_polgrp_update.sent == {"infraAccBndlGrp": {"attributes": {"descr": "policygroup description"}}}'
 
 - name: Query interface policy leaf policy group (VPC)
@@ -224,7 +224,7 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    policy_group: policygroupname
+    policy_group: policygroupname_node
     lag_type: node
     state: query
   register: binding_query
@@ -232,9 +232,35 @@
 - name: present assertions
   assert:
     that:
-      - binding_query.changed == false
+      - binding_query is not changed
       - binding_query.current | length >= 1
-      - '"/api/mo/uni/infra/funcprof/accbundle-policygroupname.json" in binding_query.url'
+      - '"/api/mo/uni/infra/funcprof/accbundle-policygroupname_node.json" in binding_query.url'
+
+# Add lag_type link to see what we get back
+- name: Adding a interface policy leaf policy group (PC) - creation works
+  aci_interface_policy_leaf_policy_group:
+    <<: *aci_interface_policy_leaf_policy_group_link_present
+  register: intf_policy_leaf_polgrp_present
+
+- name: Query interface policy leaf policy group (VPC)
+  aci_interface_policy_leaf_policy_group:
+    host: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: debug
+    lag_type: node
+    state: query
+  register: binding_query_node_all
+
+- name: present assertions
+  assert:
+    that:
+      - binding_query_node_all is not changed
+      - binding_query_node_all.current | length >= 1
+      - '"/api/class/infraAccBndlGrp.json" in binding_query_node_all.url'
 
 - name: Remove interface policy leaf policy group (VPC) - check mode
   aci_interface_policy_leaf_policy_group:
@@ -261,7 +287,7 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    policy_group: policygroupname
+    policy_group: policygroupname_node
     #lag_type: node
     state: absent
   ignore_errors: yes
@@ -270,21 +296,21 @@
 - name: absent assertions
   assert:
     that:
-      - intf_policy_leaf_polgrp_check_mode_absent.changed == true
+      - intf_policy_leaf_polgrp_check_mode_absent is changed
       - intf_policy_leaf_polgrp_check_mode_absent.previous != []
-      - intf_policy_leaf_polgrp_absent.changed == true
+      - intf_policy_leaf_polgrp_absent is changed
       - intf_policy_leaf_polgrp_absent.previous == intf_policy_leaf_polgrp_absent.previous
-      - intf_policy_leaf_polgrp_absent_idempotent.changed == false
+      - intf_policy_leaf_polgrp_absent_idempotent is not changed
       - intf_policy_leaf_polgrp_absent_idempotent.previous == []
-      - intf_policy_leaf_polgrp_absent_missing_param.failed == true
-      - 'intf_policy_leaf_polgrp_absent_missing_param.msg == "state is absent but all of the following are missing: lag_type"'
+      - intf_policy_leaf_polgrp_absent_missing_param is failed
+      - 'intf_policy_leaf_polgrp_absent_missing_param.msg == "missing required arguments: lag_type"'
 
 # ==== END TESTING Virtual Port Channel (VPC), lag_type: node ====
 
 
 # ==== START TESTING Virtual Port Channel (VPC), lag_type: leaf ====
 
-- name: Making sure interface_policy_leaf_policy_group doesn't exist at beggining of test (Leaf Access Port)
+- name: Making sure interface_policy_leaf_policy_group doesn't exist at beginning of test (Leaf Access Port)
   aci_interface_policy_leaf_policy_group:
     <<: *aci_interface_policy_leaf_policy_group_leaf_absent
 
@@ -297,7 +323,7 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    policy_group: policygroupname
+    policy_group: policygroupname_leaf
     lag_type: leaf
     link_level_policy: linklevelpolicy
     fibre_channel_interface_policy: fiberchannelpolicy
@@ -333,13 +359,13 @@
 - name: present assertions
   assert:
     that:
-    - intf_policy_leaf_polgrp_check_mode_present.changed == true
-    - intf_policy_leaf_polgrp_present.changed == true
+    - intf_policy_leaf_polgrp_check_mode_present is changed
+    - intf_policy_leaf_polgrp_present is changed
     - intf_policy_leaf_polgrp_present.previous == []
-    - 'intf_policy_leaf_polgrp_present.sent ==  {"infraAccPortGrp": {"attributes": {"name": "policygroupname"},"children": [{"infraRsAttEntP": {"attributes": {"tDn": "uni/infra/attentp-None"}}},{"infraRsFcIfPol": {"attributes": {"tnFcIfPolName": "fiberchannelpolicy"}}},{"infraRsHIfPol": {"attributes": {"tnFabricHIfPolName": "linklevelpolicy"}}}]}}'
-    - intf_policy_leaf_polgrp_idempotent.changed == false
+    - 'intf_policy_leaf_polgrp_present.sent ==  {"infraAccPortGrp": {"attributes": {"name": "policygroupname_leaf"},"children": [{"infraRsAttEntP": {"attributes": {"tDn": "uni/infra/attentp-None"}}},{"infraRsFcIfPol": {"attributes": {"tnFcIfPolName": "fiberchannelpolicy"}}},{"infraRsHIfPol": {"attributes": {"tnFabricHIfPolName": "linklevelpolicy"}}}]}}'
+    - intf_policy_leaf_polgrp_idempotent is not changed
     - intf_policy_leaf_polgrp_idempotent.sent == {}
-    - intf_policy_leaf_polgrp_update.changed == true
+    - intf_policy_leaf_polgrp_update is changed
     - 'intf_policy_leaf_polgrp_update.sent == {"infraAccPortGrp": {"attributes": {"descr": "policygroup description"}}}'
 
 - name: Query interface policy leaf policy group (Leaf Access Port)
@@ -351,7 +377,7 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    policy_group: policygroupname
+    policy_group: policygroupname_leaf
     lag_type: leaf
     state: query
   register: binding_query
@@ -359,9 +385,9 @@
 - name: present assertions
   assert:
     that:
-      - binding_query.changed == false
+      - binding_query is not changed
       - binding_query.current | length >= 1
-      - '"/api/mo/uni/infra/funcprof/accportgrp-policygroupname.json" in binding_query.url'
+      - '"/api/mo/uni/infra/funcprof/accportgrp-policygroupname_leaf.json" in binding_query.url'
 
 - name: Remove interface policy leaf policy group (Leaf Access Port) - check mode
   aci_interface_policy_leaf_policy_group:
@@ -388,7 +414,7 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    policy_group: policygroupname
+    policy_group: policygroupname_leaf
     #lag_type: leaf
     state: absent
   ignore_errors: yes
@@ -397,13 +423,13 @@
 - name: absent assertions
   assert:
     that:
-      - intf_policy_leaf_polgrp_check_mode_absent.changed == true
+      - intf_policy_leaf_polgrp_check_mode_absent is changed
       - intf_policy_leaf_polgrp_check_mode_absent.previous != []
-      - intf_policy_leaf_polgrp_absent.changed == true
+      - intf_policy_leaf_polgrp_absent is changed
       - intf_policy_leaf_polgrp_absent.previous == intf_policy_leaf_polgrp_absent.previous
-      - intf_policy_leaf_polgrp_absent_idempotent.changed == false
+      - intf_policy_leaf_polgrp_absent_idempotent is not changed
       - intf_policy_leaf_polgrp_absent_idempotent.previous == []
-      - intf_policy_leaf_polgrp_absent_missing_param.failed == true
-      - 'intf_policy_leaf_polgrp_absent_missing_param.msg == "state is absent but all of the following are missing: lag_type"'
+      - intf_policy_leaf_polgrp_absent_missing_param is failed
+      - 'intf_policy_leaf_polgrp_absent_missing_param.msg == "missing required arguments: lag_type"'
 
 # ==== END TESTING Virtual Port Channel (VPC), lag_type: leaf ====

--- a/test/integration/targets/aci_interface_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_interface_policy_leaf_profile/tasks/main.yml
@@ -54,8 +54,10 @@
 - name: Verify add_leaf_interface_profile
   assert:
     that:
-    - cm_add_leaf_interface_profile.changed == nm_add_leaf_interface_profile.changed == true
-    - cm_add_leaf_interface_profile_again.changed == nm_add_leaf_interface_profile_again.changed == false
+    - cm_add_leaf_interface_profile is changed
+    - nm_add_leaf_interface_profile is changed
+    - cm_add_leaf_interface_profile_again is not changed
+    - nm_add_leaf_interface_profile_again is not changed
 
 
 # CHANGE LEAF INTERFACE PROFILE
@@ -88,8 +90,10 @@
 - name: Verify add_leaf_interface_profile_descr
   assert:
     that:
-    - cm_add_leaf_interface_profile_descr.changed == nm_add_leaf_interface_profile_descr.changed == true
-    - cm_add_leaf_interface_profile_descr_again.changed == nm_add_leaf_interface_profile_descr_again.changed == false
+    - cm_add_leaf_interface_profile_descr is changed
+    - nm_add_leaf_interface_profile_descr is changed
+    - cm_add_leaf_interface_profile_descr_again is not changed
+    - nm_add_leaf_interface_profile_descr_again is not changed
 
 
 # ADD LEAF INTERFACE PROFILE AGAIN
@@ -105,7 +109,8 @@
 - name: Verify add_leaf_interface_profile_again_no_descr
   assert:
     that:
-    - cm_add_leaf_interface_profile_again_no_descr.changed == nm_add_leaf_interface_profile_again_no_descr.changed == false
+    - cm_add_leaf_interface_profile_again_no_descr is not changed
+    - nm_add_leaf_interface_profile_again_no_descr is not changed
 
 
 # QUERY ALL LEAF INTERFACE PROFILES
@@ -129,7 +134,8 @@
 - name: Verify query_all_leaf_interface_profiles
   assert:
     that:
-    - cm_query_all_leaf_interface_profiles.changed == nm_query_all_leaf_interface_profiles.changed == false
+    - cm_query_all_leaf_interface_profiles is not changed
+    - nm_query_all_leaf_interface_profiles is not changed
     # NOTE: Order of leaf_interface_profiles is not stable between calls
     #- cm_query_all_leaf_interface_profiles == nm_query_all_leaf_interface_profiles
 
@@ -151,7 +157,8 @@
 - name: Verify query_leaf_interface_profile
   assert:
     that:
-    - cm_query_leaf_interface_profile.changed == nm_query_leaf_interface_profile.changed == false
+    - cm_query_leaf_interface_profile is not changed
+    - nm_query_leaf_interface_profile is not changed
     - cm_query_leaf_interface_profile == nm_query_leaf_interface_profile
 
 
@@ -177,8 +184,10 @@
 - name: Verify remove_leaf_interface_profile
   assert:
     that:
-    - cm_remove_leaf_interface_profile.changed == nm_remove_leaf_interface_profile.changed == true
-    - cm_remove_leaf_interface_profile_again.changed == nm_remove_leaf_interface_profile_again.changed == false
+    - cm_remove_leaf_interface_profile is changed
+    - nm_remove_leaf_interface_profile is changed
+    - cm_remove_leaf_interface_profile_again is not changed
+    - nm_remove_leaf_interface_profile_again is not changed
 
 
 # QUERY NON-EXISTING LEAF INTERFACE PROFILE
@@ -199,5 +208,6 @@
 - name: Verify query_non_leaf_interface_profile
   assert:
     that:
-    - cm_query_non_leaf_interface_profile.changed == nm_query_non_leaf_interface_profile.changed == false
+    - cm_query_non_leaf_interface_profile is not changed
+    - nm_query_non_leaf_interface_profile is not changed
     - cm_query_non_leaf_interface_profile == nm_query_non_leaf_interface_profile

--- a/test/integration/targets/aci_interface_policy_ospf/tasks/main.yml
+++ b/test/integration/targets/aci_interface_policy_ospf/tasks/main.yml
@@ -69,8 +69,10 @@
 - name: Verify add_ospf_interface_policy
   assert:
     that:
-    - cm_add_ospf_interface_policy.changed == nm_add_ospf_interface_policy.changed == true
-    - cm_add_ospf_interface_policy_again.changed == nm_add_ospf_interface_policy_again.changed == false
+    - cm_add_ospf_interface_policy is changed
+    - nm_add_ospf_interface_policy is changed
+    - cm_add_ospf_interface_policy_again is not changed
+    - nm_add_ospf_interface_policy_again is not changed
 
 
 # CHANGE OSPF INTERFACE POLICY
@@ -103,8 +105,10 @@
 - name: Verify add_ospf_descr
   assert:
     that:
-    - cm_add_ospf_descr.changed == nm_add_ospf_descr.changed == true
-    - cm_add_ospf_descr_again.changed == nm_add_ospf_descr_again.changed == false
+    - cm_add_ospf_descr is changed
+    - nm_add_ospf_descr is changed
+    - cm_add_ospf_descr_again is not changed
+    - nm_add_ospf_descr_again is not changed
 
 
 # ADD OSPF INTERFACE POLICY AGAIN
@@ -120,7 +124,8 @@
 - name: Verify add_ospf_again_no_descr
   assert:
     that:
-    - cm_add_ospf_again_no_descr.changed == nm_add_ospf_again_no_descr.changed == false
+    - cm_add_ospf_again_no_descr is not changed
+    - nm_add_ospf_again_no_descr is not changed
 
 
 # QUERY ALL OSPF INTERFACE POLICIES
@@ -145,7 +150,8 @@
 - name: Verify query_all_ospfs
   assert:
     that:
-    - cm_query_all_ospfs.changed == nm_query_all_ospfs.changed == false
+    - cm_query_all_ospfs is not changed
+    - nm_query_all_ospfs is not changed
     # NOTE: Order of ospfs is not stable between calls
     #- cm_query_all_ospfs == nm_query_all_ospfs
 
@@ -169,7 +175,8 @@
 - name: Verify query_ospf
   assert:
     that:
-    - cm_query_ospf.changed == nm_query_ospf.changed == false
+    - cm_query_ospf is not changed
+    - nm_query_ospf is not changed
     - cm_query_ospf == nm_query_ospf
 
 
@@ -195,8 +202,10 @@
 - name: Verify remove_ospf
   assert:
     that:
-    - cm_remove_ospf.changed == nm_remove_ospf.changed == true
-    - cm_remove_ospf_again.changed == nm_remove_ospf_again.changed == false
+    - cm_remove_ospf is changed
+    - nm_remove_ospf is changed
+    - cm_remove_ospf_again is not changed
+    - nm_remove_ospf_again is not changed
 
 
 # QUERY NON-EXISTING OSPF INTERFACE POLICY
@@ -217,5 +226,6 @@
 - name: Verify query_non_ospf
   assert:
     that:
-    - cm_query_non_ospf.changed == nm_query_non_ospf.changed == false
+    - cm_query_non_ospf is not changed
+    - nm_query_non_ospf is not changed
     - cm_query_non_ospf == nm_query_non_ospf

--- a/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
@@ -79,11 +79,11 @@
 - name: present assertions
   assert:
     that:
-    - intftoleaf_check_mode_present.changed == true
-    - intftoleaf_present.changed == true
+    - intftoleaf_check_mode_present is changed
+    - intftoleaf_present is changed
     - intftoleaf_present.previous == []
     - 'intftoleaf_present.sent == {"infraRsAccPortP": {"attributes": {"tDn": "uni/infra/accportprof-leafintprftest"}}}'
-    - intftoleaf_idempotent.changed == false
+    - intftoleaf_idempotent is not changed
     - intftoleaf_idempotent.sent == {}
 
 - name: Query an interface selector profile associated with a switch policy leaf profile
@@ -96,7 +96,7 @@
 - name: query assertions
   assert:
     that:
-      - binding_query.changed == false
+      - binding_query is not changed
       - binding_query.current | length >= 1
       - '"api/mo/uni/infra/nprof-swleafprftest/rsaccPortP-[uni/infra/accportprof-leafintprftest].json" in binding_query.url'
 
@@ -128,13 +128,13 @@
 - name: absent assertions
   assert:
     that:
-      - intftoleaf_check_mode_absent.changed == true
+      - intftoleaf_check_mode_absent is changed
       - intftoleaf_check_mode_absent.previous != []
-      - intftoleaf_absent.changed == true
+      - intftoleaf_absent is changed
       - intftoleaf_absent.previous == intftoleaf_check_mode_absent.previous
-      - intftoleaf_absent_idempotent.changed == false
+      - intftoleaf_absent_idempotent is not changed
       - intftoleaf_absent_idempotent.previous == []
-      - intftoleaf_absent_missing_param.failed == true
+      - intftoleaf_absent_missing_param is failed
       - 'intftoleaf_absent_missing_param.msg == "state is absent but all of the following are missing: interface_selector"'
 
 - name: Remove an interface selector associated with a Switch Policy Leaf Profile - Clean up

--- a/test/integration/targets/aci_rest/tasks/error_handling.yml
+++ b/test/integration/targets/aci_rest/tasks/error_handling.yml
@@ -26,7 +26,7 @@
 - name: Verify error_on_name_resolution
   assert:
     that:
-    - error_on_name_resolution.failed == true
+    - error_on_name_resolution is failed
     - "error_on_name_resolution.msg == 'Connection failed for https://foo.bar.cisco.com/api/aaaLogin.json. Request failed: <urlopen error [Errno -2] Name or service not known>'"
     - "'current' not in error_on_name_resolution"
     - "'previous' not in error_on_name_resolution"
@@ -54,7 +54,7 @@
 - name: Verify error_on_missing_required_param
   assert:
     that:
-    - error_on_missing_required_param.failed == true
+    - error_on_missing_required_param is failed
     - 'error_on_missing_required_param.msg == "missing required arguments: path"'
     - "'current' not in error_on_missing_required_param"
     - "'previous' not in error_on_missing_required_param"
@@ -82,7 +82,7 @@
 - name: Verify error_on_missing_attributes
   assert:
     that:
-    - error_on_missing_attributes.failed == true
+    - error_on_missing_attributes is failed
     - error_on_missing_attributes.method == 'POST'
     - "error_on_missing_attributes.msg == 'APIC Error 400: invalid data at line \\'1\\'. Attributes are missing, tag \\'attributes\\' must be specified first, before any other tag'"
     - 'error_on_missing_attributes.response == "HTTP Error 400: Bad Request"'
@@ -115,7 +115,7 @@
 - name: Verify error_on_input_validation
   assert:
     that:
-    - error_on_input_validation.failed == true
+    - error_on_input_validation is failed
     - error_on_input_validation.method == 'POST'
     - "error_on_input_validation.msg == 'APIC Error 801: property descr of tn-ansible_test failed validation for value \\'This is an [invalid] description\\''"
     - 'error_on_input_validation.response == "HTTP Error 400: Bad Request"'
@@ -148,7 +148,7 @@
 - name: Verify error_on_invalid_attributes
   assert:
     that:
-    - error_on_invalid_attributes.failed == true
+    - error_on_invalid_attributes is failed
     - error_on_invalid_attributes.method == 'POST'
     - "error_on_invalid_attributes.msg == 'APIC Error 400: unknown attribute \\'description\\' in element \\'fvTenant\\''"
     - 'error_on_invalid_attributes.response == "HTTP Error 400: Bad Request"'
@@ -180,7 +180,7 @@
 - name: Verify error_on_invalid_object
   assert:
     that:
-    - error_on_invalid_object.failed == true
+    - error_on_invalid_object is failed
     - error_on_invalid_object.method == 'POST'
     - "error_on_invalid_object.msg == 'APIC Error 122: unknown managed object class fvFoobar'"
     - 'error_on_invalid_object.response == "HTTP Error 400: Bad Request"'

--- a/test/integration/targets/aci_rest/tasks/json_inline.yml
+++ b/test/integration/targets/aci_rest/tasks/json_inline.yml
@@ -48,8 +48,8 @@
 - name: Verify add_tenant
   assert:
     that:
-    - nm_add_tenant.changed == true
-    - nm_add_tenant_again.changed == false
+    - nm_add_tenant is changed
+    - nm_add_tenant_again is not changed
 
 # CHANGE TENANT
 - name: Change description of tenant (normal mode)
@@ -83,8 +83,8 @@
 - name: Verify add_tenant_descr
   assert:
     that:
-    - nm_add_tenant_descr.changed == true
-    - nm_add_tenant_descr_again.changed == false
+    - nm_add_tenant_descr is changed
+    - nm_add_tenant_descr_again is not changed
 
 # ADD TENANT AGAIN
 - name: Add tenant again with no description (normal mode)
@@ -95,7 +95,7 @@
 - name: Verify add_tenant_again_no_descr
   assert:
     that:
-    - nm_add_tenant_again_no_descr.changed == false
+    - nm_add_tenant_again_no_descr is not changed
 
 # QUERY ALL TENANTS
 - name: Query all tenants (normal mode)
@@ -115,7 +115,7 @@
 - name: Verify query_all_tenants
   assert:
     that:
-    - nm_query_all_tenants.changed == false
+    - nm_query_all_tenants is not changed
 
 # QUERY A TENANT
 - name: Query our tenant
@@ -135,7 +135,7 @@
 - name: Verify query_tenant
   assert:
     that:
-    - nm_query_tenant.changed == false
+    - nm_query_tenant is not changed
 
 # REMOVE TENANT
 - name: Remove tenant (normal mode)
@@ -151,8 +151,8 @@
 - name: Verify remove_tenant
   assert:
     that:
-    - nm_remove_tenant.changed == true
-    - nm_remove_tenant_again.changed == false
+    - nm_remove_tenant is changed
+    - nm_remove_tenant_again is not changed
 
 # QUERY NON-EXISTING TENANT
 - name: Query non-existing tenant (normal mode)
@@ -163,4 +163,4 @@
 - name: Verify query_non_tenant
   assert:
     that:
-    - nm_query_non_tenant.changed == false
+    - nm_query_non_tenant is not changed

--- a/test/integration/targets/aci_rest/tasks/json_string.yml
+++ b/test/integration/targets/aci_rest/tasks/json_string.yml
@@ -46,8 +46,8 @@
 - name: Verify add_tenant
   assert:
     that:
-    - nm_add_tenant.changed == true
-    - nm_add_tenant_again.changed == false
+    - nm_add_tenant is changed
+    - nm_add_tenant_again is not changed
 
 # CHANGE TENANT
 - name: Change description of tenant (normal mode)
@@ -79,8 +79,8 @@
 - name: Verify add_tenant_descr
   assert:
     that:
-    - nm_add_tenant_descr.changed == true
-    - nm_add_tenant_descr_again.changed == false
+    - nm_add_tenant_descr is changed
+    - nm_add_tenant_descr_again is not changed
 
 # ADD TENANT AGAIN
 - name: Add tenant again with no description (normal mode)
@@ -90,7 +90,7 @@
 - name: Verify add_tenant_again_no_descr
   assert:
     that:
-    - nm_add_tenant_again_no_descr.changed == false
+    - nm_add_tenant_again_no_descr is not changed
 
 # QUERY ALL TENANTS
 - name: Query all tenants (normal mode)
@@ -109,7 +109,7 @@
 - name: Verify query_all_tenants
   assert:
     that:
-    - nm_query_all_tenants.changed == false
+    - nm_query_all_tenants is not changed
 
 # QUERY A TENANT
 - name: Query our tenant
@@ -128,7 +128,7 @@
 - name: Verify query_tenant
   assert:
     that:
-    - nm_query_tenant.changed == false
+    - nm_query_tenant is not changed
 
 # REMOVE TENANT
 - name: Remove tenant (normal mode)
@@ -142,8 +142,8 @@
 - name: Verify remove_tenant
   assert:
     that:
-    - nm_remove_tenant.changed == true
-    - nm_remove_tenant_again.changed == false
+    - nm_remove_tenant is changed
+    - nm_remove_tenant_again is not changed
 
 # QUERY NON-EXISTING TENANT
 - name: Query non-existing tenant (normal mode)
@@ -153,4 +153,4 @@
 - name: Verify query_non_tenant
   assert:
     that:
-    - nm_query_non_tenant.changed == false
+    - nm_query_non_tenant is not changed

--- a/test/integration/targets/aci_rest/tasks/xml_string.yml
+++ b/test/integration/targets/aci_rest/tasks/xml_string.yml
@@ -40,8 +40,8 @@
 - name: Verify add_tenant
   assert:
     that:
-    - nm_add_tenant.changed == true
-    - nm_add_tenant_again.changed == false
+    - nm_add_tenant is changed
+    - nm_add_tenant_again is not changed
 
 # CHANGE TENANT
 - name: Change description of tenant (normal mode)
@@ -66,8 +66,8 @@
 - name: Verify add_tenant_descr
   assert:
     that:
-    - nm_add_tenant_descr.changed == true
-    - nm_add_tenant_descr_again.changed == false
+    - nm_add_tenant_descr is changed
+    - nm_add_tenant_descr_again is not changed
 
 # ADD TENANT AGAIN
 - name: Add tenant again with no description (normal mode)
@@ -77,7 +77,7 @@
 - name: Verify add_tenant_again_no_descr
   assert:
     that:
-    - nm_add_tenant_again_no_descr.changed == false
+    - nm_add_tenant_again_no_descr is not changed
 
 # QUERY ALL TENANTS
 - name: Query all tenants (normal mode)
@@ -96,7 +96,7 @@
 - name: Verify query_all_tenants
   assert:
     that:
-    - nm_query_all_tenants.changed == false
+    - nm_query_all_tenants is not changed
 
 # QUERY A TENANT
 - name: Query our tenant
@@ -115,7 +115,7 @@
 - name: Verify query_tenant
   assert:
     that:
-    - nm_query_tenant.changed == false
+    - nm_query_tenant is not changed
 
 # REMOVE TENANT
 - name: Remove tenant (normal mode)
@@ -129,8 +129,8 @@
 - name: Verify remove_tenant
   assert:
     that:
-    - nm_remove_tenant.changed == true
-    - nm_remove_tenant_again.changed == false
+    - nm_remove_tenant is changed
+    - nm_remove_tenant_again is not changed
 
 # QUERY NON-EXISTING TENANT
 - name: Query non-existing tenant (normal mode)
@@ -140,4 +140,4 @@
 - name: Verify query_non_tenant
   assert:
     that:
-    - nm_query_non_tenant.changed == false
+    - nm_query_non_tenant is not changed

--- a/test/integration/targets/aci_rest/tasks/yaml_inline.yml
+++ b/test/integration/targets/aci_rest/tasks/yaml_inline.yml
@@ -42,8 +42,8 @@
 - name: Verify add_tenant
   assert:
     that:
-    - nm_add_tenant.changed == true
-    - nm_add_tenant_again.changed == false
+    - nm_add_tenant is changed
+    - nm_add_tenant_again is not changed
 
 # CHANGE TENANT
 - name: Change description of tenant (normal mode)
@@ -71,8 +71,8 @@
 - name: Verify add_tenant_descr
   assert:
     that:
-    - nm_add_tenant_descr.changed == true
-    - nm_add_tenant_descr_again.changed == false
+    - nm_add_tenant_descr is changed
+    - nm_add_tenant_descr_again is not changed
 
 # ADD TENANT AGAIN
 - name: Add tenant again with no description (normal mode)
@@ -82,7 +82,7 @@
 - name: Verify add_tenant_again_no_descr
   assert:
     that:
-    - nm_add_tenant_again_no_descr.changed == false
+    - nm_add_tenant_again_no_descr is not changed
 
 # QUERY ALL TENANTS
 - name: Query all tenants (normal mode)
@@ -101,7 +101,7 @@
 - name: Verify query_all_tenants
   assert:
     that:
-    - nm_query_all_tenants.changed == false
+    - nm_query_all_tenants is not changed
 
 # QUERY A TENANT
 - name: Query our tenant
@@ -120,7 +120,7 @@
 - name: Verify query_tenant
   assert:
     that:
-    - nm_query_tenant.changed == false
+    - nm_query_tenant is not changed
 
 # REMOVE TENANT
 - name: Remove tenant (normal mode)
@@ -134,8 +134,8 @@
 - name: Verify remove_tenant
   assert:
     that:
-    - nm_remove_tenant.changed == true
-    - nm_remove_tenant_again.changed == false
+    - nm_remove_tenant is changed
+    - nm_remove_tenant_again is not changed
 
 # QUERY NON-EXISTING TENANT
 - name: Query non-existing tenant (normal mode)
@@ -145,4 +145,4 @@
 - name: Verify query_non_tenant
   assert:
     that:
-    - nm_query_non_tenant.changed == false
+    - nm_query_non_tenant is not changed

--- a/test/integration/targets/aci_rest/tasks/yaml_string.yml
+++ b/test/integration/targets/aci_rest/tasks/yaml_string.yml
@@ -42,8 +42,8 @@
 - name: Verify add_tenant
   assert:
     that:
-    - nm_add_tenant.changed == true
-    - nm_add_tenant_again.changed == false
+    - nm_add_tenant is changed
+    - nm_add_tenant_again is not changed
 
 # CHANGE TENANT
 - name: Change description of tenant (normal mode)
@@ -71,8 +71,8 @@
 - name: Verify add_tenant_descr
   assert:
     that:
-    - nm_add_tenant_descr.changed == true
-    - nm_add_tenant_descr_again.changed == false
+    - nm_add_tenant_descr is changed
+    - nm_add_tenant_descr_again is not changed
 
 # ADD TENANT AGAIN
 - name: Add tenant again with no description (normal mode)
@@ -82,7 +82,7 @@
 - name: Verify add_tenant_again_no_descr
   assert:
     that:
-    - nm_add_tenant_again_no_descr.changed == false
+    - nm_add_tenant_again_no_descr is not changed
 
 # QUERY ALL TENANTS
 - name: Query all tenants (normal mode)
@@ -101,7 +101,7 @@
 - name: Verify query_all_tenants
   assert:
     that:
-    - nm_query_all_tenants.changed == false
+    - nm_query_all_tenants is not changed
 
 # QUERY A TENANT
 - name: Query our tenant
@@ -120,7 +120,7 @@
 - name: Verify query_tenant
   assert:
     that:
-    - nm_query_tenant.changed == false
+    - nm_query_tenant is not changed
 
 # REMOVE TENANT
 - name: Remove tenant (normal mode)
@@ -134,8 +134,8 @@
 - name: Verify remove_tenant
   assert:
     that:
-    - nm_remove_tenant.changed == true
-    - nm_remove_tenant_again.changed == false
+    - nm_remove_tenant is changed
+    - nm_remove_tenant_again is not changed
 
 # QUERY NON-EXISTING TENANT
 - name: Query non-existing tenant (normal mode)
@@ -145,4 +145,4 @@
 - name: Verify query_non_tenant
   assert:
     that:
-    - nm_query_non_tenant.changed == false
+    - nm_query_non_tenant is not changed

--- a/test/integration/targets/aci_static_binding_to_epg/tasks/main.yml
+++ b/test/integration/targets/aci_static_binding_to_epg/tasks/main.yml
@@ -115,20 +115,20 @@
 - name: Present assertions
   assert:
     that:
-      - provide_present_check_mode.changed == true
+      - provide_present_check_mode is changed
       - 'provide_present_check_mode.sent == {"fvRsPathAtt": {"attributes": { "encap": "vlan-222", "instrImedcy": "lazy", "mode": "regular", "tDn": "topology/pod-1/paths-101/pathep-[eth1/7]"}}}'
-      - provide_present.changed == true
+      - provide_present is changed
       - provide_present.sent == provide_present_check_mode.sent
       - provide_present.previous == []
-      - primary_ecap_id_present.changed == true
+      - primary_ecap_id_present is changed
       - 'primary_ecap_id_present.sent == {"fvRsPathAtt": {"attributes": {"primaryEncap": "vlan-50"}}}'
-      - description_cm.changed == true
-      - description.changed == true
-      - idempotent_description_cm.changed == false
-      - idempotent_description.changed == false
-      - missing_required_present.failed == true
+      - description_cm is changed
+      - description is changed
+      - idempotent_description_cm is not changed
+      - idempotent_description is not changed
+      - missing_required_present is failed
       - 'missing_required_present.msg == "state is present but all of the following are missing: ap, encap_id, epg, interface, leafs, pod_id"'
-      - missing_required_present.failed == true
+      - missing_required_present is failed
 
 
 - name: Query specific binding
@@ -146,11 +146,11 @@
 - name: Query assertions
   assert:
     that:
-      - query_static_binding.changed == false
+      - query_static_binding is not changed
       - query_static_binding.current != []
-      - '"class/fvRsPathAtt.json" in query_static_binding.url'
-      - query_all.changed == false
-      - '"class/fvRsPathAtt.json" in query_all.url'
+      - '"uni/tn-anstest/ap-anstest/epg-anstest/rspathAtt-[topology/pod-1/paths-101/pathep-[eth1/7]]" in query_static_binding.url'
+      - query_all is not changed
+      - '"uni/tn-anstest.json" in query_all.url'
 
 
 - name: Delete provide binding - deletion works
@@ -175,12 +175,12 @@
 - name: Absent assertions
   assert:
     that:
-      - provide_absent.changed == true
+      - provide_absent is changed
       - provide_absent.previous.0.fvRsPathAtt is defined
-      - provide_absent_idempotent.changed == false
+      - provide_absent_idempotent is not changed
       - provide_absent_idempotent.previous == []
-      - missing_param_absent.failed == true
-      - missing_param_absent.failed == true
+      - missing_param_absent is failed
+      - missing_param_absent is failed
       - 'missing_param_absent.msg == "state is absent but all of the following are missing: ap, epg, interface, leafs, pod_id"'
 
 - name: Cleanup binding

--- a/test/integration/targets/aci_switch_leaf_policy_profile/tasks/main.yml
+++ b/test/integration/targets/aci_switch_leaf_policy_profile/tasks/main.yml
@@ -54,8 +54,10 @@
 - name: Verify add_switch_leaf_profile
   assert:
     that:
-    - cm_add_switch_leaf_profile.changed == nm_add_switch_leaf_profile.changed == true
-    - cm_add_switch_leaf_profile_again.changed == nm_add_switch_leaf_profile_again.changed == false
+    - cm_add_switch_leaf_profile is changed
+    - nm_add_switch_leaf_profile is changed
+    - cm_add_switch_leaf_profile_again is not changed
+    - nm_add_switch_leaf_profile_again is not changed
 
 
 # CHANGE SWITCH LEAF PROFILE
@@ -88,8 +90,10 @@
 - name: Verify add_switch_leaf_profile_descr
   assert:
     that:
-    - cm_add_switch_leaf_profile_descr.changed == nm_add_switch_leaf_profile_descr.changed == true
-    - cm_add_switch_leaf_profile_descr_again.changed == nm_add_switch_leaf_profile_descr_again.changed == false
+    - cm_add_switch_leaf_profile_descr is changed
+    - nm_add_switch_leaf_profile_descr is changed
+    - cm_add_switch_leaf_profile_descr_again is not changed
+    - nm_add_switch_leaf_profile_descr_again is not changed
 
 
 # ADD LEAF PROFILE AGAIN
@@ -105,7 +109,8 @@
 - name: Verify add_switch_leaf_profile_again_no_descr
   assert:
     that:
-    - cm_add_switch_leaf_profile_again_no_descr.changed == nm_add_switch_leaf_profile_again_no_descr.changed == false
+    - cm_add_switch_leaf_profile_again_no_descr is not changed
+    - nm_add_switch_leaf_profile_again_no_descr is not changed
 
 
 # QUERY ALL LEAF PROFILES
@@ -129,7 +134,8 @@
 - name: Verify query_all_switch_leaf_profiles
   assert:
     that:
-    - cm_query_all_switch_leaf_profiles.changed == nm_query_all_switch_leaf_profiles.changed == false
+    - cm_query_all_switch_leaf_profiles is not changed
+    - nm_query_all_switch_leaf_profiles is not changed
     # NOTE: Order of switch_leaf_profiles is not stable between calls
     #- cm_query_all_switch_leaf_profiles == nm_query_all_switch_leaf_profiles
 
@@ -151,7 +157,8 @@
 - name: Verify query_switch_leaf_profile
   assert:
     that:
-    - cm_query_switch_leaf_profile.changed == nm_query_switch_leaf_profile.changed == false
+    - cm_query_switch_leaf_profile is not changed
+    - nm_query_switch_leaf_profile is not changed
     - cm_query_switch_leaf_profile == nm_query_switch_leaf_profile
 
 
@@ -177,8 +184,10 @@
 - name: Verify remove_switch_leaf_profile
   assert:
     that:
-    - cm_remove_switch_leaf_profile.changed == nm_remove_switch_leaf_profile.changed == true
-    - cm_remove_switch_leaf_profile_again.changed == nm_remove_switch_leaf_profile_again.changed == false
+    - cm_remove_switch_leaf_profile is changed
+    - nm_remove_switch_leaf_profile is changed
+    - cm_remove_switch_leaf_profile_again is not changed
+    - nm_remove_switch_leaf_profile_again is not changed
 
 
 # QUERY NON-EXISTING LEAF PROFILE
@@ -199,5 +208,6 @@
 - name: Verify query_non_switch_leaf_profile
   assert:
     that:
-    - cm_query_non_switch_leaf_profile.changed == nm_query_non_switch_leaf_profile.changed == false
+    - cm_query_non_switch_leaf_profile is not changed
+    - nm_query_non_switch_leaf_profile is not changed
     - cm_query_non_switch_leaf_profile == nm_query_non_switch_leaf_profile

--- a/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
+++ b/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
@@ -65,13 +65,13 @@
 - name: present assertions
   assert:
     that:
-    - sw_leaf_selec_check_mode_present.changed == true
-    - sw_leaf_selec_present.changed == true
+    - sw_leaf_selec_check_mode_present is changed
+    - sw_leaf_selec_present is changed
     - sw_leaf_selec_present.previous == []
     - 'sw_leaf_selec_present.sent ==  {"infraLeafS": {"attributes": {"name": "leaf_selector_name"}, "children": [{"infraNodeBlk": {"attributes": {"from_": "1011", "name": "node_blk_name", "to_": "1011"}}},{"infraRsAccNodePGrp": {"attributes": {"tDn": "uni/infra/funcprof/accnodepgrp-None"}}}]}}'
-    - sw_leaf_selec_idempotent.changed == false
+    - sw_leaf_selec_idempotent is not changed
     - sw_leaf_selec_idempotent.sent == {}
-    - sw_leaf_selec_update.changed == true
+    - sw_leaf_selec_update is changed
     - 'sw_leaf_selec_update.sent == {"infraLeafS": {"attributes": {},"children": [{"infraRsAccNodePGrp": {"attributes": {"tDn": "uni/infra/funcprof/accnodepgrp-anstest_policygroupname"}}}]}}'
 
 - name: Query Specific switch policy leaf profile selector
@@ -84,7 +84,7 @@
 - name: present assertions
   assert:
     that:
-      - binding_query.changed == false
+      - binding_query is not changed
       - binding_query.current | length >= 1
       - '"api/mo/uni/infra/nprof-sw_name_test/leaves-leaf_selector_name-typ-range.json" in binding_query.url'
 
@@ -117,13 +117,13 @@
 - name: absent assertions
   assert:
     that:
-      - sw_leaf_selec_check_mode_absent.changed == true
+      - sw_leaf_selec_check_mode_absent is changed
       - sw_leaf_selec_check_mode_absent.previous != []
-      - sw_leaf_selec_absent.changed == true
+      - sw_leaf_selec_absent is changed
       - sw_leaf_selec_absent.previous == sw_leaf_selec_check_mode_absent.previous
-      - sw_leaf_selec_absent_idempotent.changed == false
+      - sw_leaf_selec_absent_idempotent is not changed
       - sw_leaf_selec_absent_idempotent.previous == []
-      - sw_leaf_selec_absent_missing_param.failed == true
+      - sw_leaf_selec_absent_missing_param is failed
       - 'sw_leaf_selec_absent_missing_param.msg == "state is absent but all of the following are missing: leaf"'
 
 

--- a/test/integration/targets/aci_switch_policy_vpc_protection_group/tasks/main.yml
+++ b/test/integration/targets/aci_switch_policy_vpc_protection_group/tasks/main.yml
@@ -56,9 +56,11 @@
 - name: Verify add_vpc_prot_grp_again
   assert:
     that:
-    - cm_add_vpc_prot_grp.changed == nm_add_vpc_prot_grp.changed == true
+    - cm_add_vpc_prot_grp is changed
+    - nm_add_vpc_prot_grp is changed
     # FIXME: Not idempotent !
-    #- cm_add_vpc_prot_grp_again.changed == nm_add_vpc_prot_grp_again.changed == false
+    #- cm_add_vpc_prot_grp_again is not changed
+    #- nm_add_vpc_prot_grp_again is not changed
 
 
 # CHANGE VPC PROTECTION GROUP
@@ -91,13 +93,15 @@
 - name: Verify add_vpc_prot_grp_pol
   assert:
     that:
-    - cm_add_vpc_prot_grp_pol.changed == nm_add_vpc_prot_grp_pol.changed == true
+    - cm_add_vpc_prot_grp_pol is changed
+    - nm_add_vpc_prot_grp_pol is changed
     # FIXME: Not idempotent !!
-    #- cm_add_vpc_prot_grp_pol_again.changed == nm_add_vpc_prot_grp_pol_again.changed == false
+    #- cm_add_vpc_prot_grp_pol_again is not changed
+    #- nm_add_vpc_prot_grp_pol_again is not changed
 
 
 # ADD FABRIC NODE AGAIN
-- name: Add vpc protectio group again with no domain policy (check_mode)
+- name: Add vpc protection group again with no domain policy (check_mode)
   aci_switch_policy_vpc_protection_group: *aci_switch_policy_vpc_protection_group_present
   check_mode: yes
   register: cm_add_vpc_prot_grp_again_no_pol
@@ -110,7 +114,8 @@
   assert:
     that:
     # FIXME: Not idempoten !!
-    #- cm_add_vpc_prot_grp_again_no_pol.changed == nm_add_vpc_prot_grp_again_no_pol.changed == false
+    #- cm_add_vpc_prot_grp_again_no_pol is not changed
+    #- nm_add_vpc_prot_grp_again_no_pol is not changed
 
 
 # QUERY ALL VPC PROTECTION GROUPS
@@ -134,7 +139,8 @@
 - name: Verify query_all_vpc_prot_grps
   assert:
     that:
-    - cm_query_all_vpc_prot_grps.changed == nm_query_all_vpc_prot_grps.changed == false
+    - cm_query_all_vpc_prot_grps is not changed
+    - nm_query_all_vpc_prot_grps is not changed
     - cm_query_all_vpc_prot_grps == nm_query_all_vpc_prot_grps
 
 
@@ -155,7 +161,8 @@
 - name: Verify query_vpc_prot_grp
   assert:
     that:
-    - cm_query_vpc_prot_grp.changed == nm_query_vpc_prot_grp.changed == false
+    - cm_query_vpc_prot_grp is not changed
+    - nm_query_vpc_prot_grp is not changed
     - cm_query_vpc_prot_grp == nm_query_vpc_prot_grp
 
 
@@ -181,8 +188,10 @@
 - name: Verify remove_vpc_prot_grp
   assert:
     that:
-    - cm_remove_vpc_prot_grp.changed == nm_remove_vpc_prot_grp.changed == true
-    - cm_remove_vpc_prot_grp_again.changed == nm_remove_vpc_prot_grp_again.changed == false
+    - cm_remove_vpc_prot_grp is changed
+    - nm_remove_vpc_prot_grp is changed
+    - cm_remove_vpc_prot_grp_again is not changed
+    - nm_remove_vpc_prot_grp_again is not changed
 
 
 # QUERY NON-EXISTING LEAF PROFILE
@@ -202,5 +211,6 @@
 - name: Verify query_non_vpc_prot_grp
   assert:
     that:
-    - cm_query_non_vpc_prot_grp.changed == nm_query_non_vpc_prot_grp.changed == false
+    - cm_query_non_vpc_prot_grp is not changed
+    - nm_query_non_vpc_prot_grp is not changed
     - cm_query_non_vpc_prot_grp == nm_query_non_vpc_prot_grp

--- a/test/integration/targets/aci_taboo_contract/tasks/main.yml
+++ b/test/integration/targets/aci_taboo_contract/tasks/main.yml
@@ -54,7 +54,8 @@
 - name: Verify add_taboo_contract
   assert:
     that:
-    - cm_add_taboo_contract.changed == nm_add_taboo_contract.changed == true
+    - cm_add_taboo_contract is changed
+    - nm_add_taboo_contract is changed
     - 'cm_add_taboo_contract.sent == nm_add_taboo_contract.sent == {"vzTaboo": {"attributes": {"name": "taboo_contract_test"}}}'
     - 'cm_add_taboo_contract.proposed == nm_add_taboo_contract.proposed == {"vzTaboo": {"attributes": {"name": "taboo_contract_test"}}}'
     - cm_add_taboo_contract.previous == nm_add_taboo_contract.previous == []
@@ -76,7 +77,8 @@
 - name: Verify add_taboo_contract_again
   assert:
     that:
-    - cm_add_taboo_contract_again.changed == nm_add_taboo_contract_again.changed == false
+    - cm_add_taboo_contract_again is not changed
+    - nm_add_taboo_contract_again is not changed
     - cm_add_taboo_contract_again.current == nm_add_taboo_contract_again.current == nm_add_taboo_contract.current
 
 
@@ -97,7 +99,8 @@
 - name: Verify add_taboo_contract_descr
   assert:
     that:
-    - cm_add_taboo_contract_descr.changed == nm_add_taboo_contract_descr.changed == true
+    - cm_add_taboo_contract_descr is changed
+    - nm_add_taboo_contract_descr is changed
     - 'cm_add_taboo_contract_descr.sent == nm_add_taboo_contract_descr.sent == {"vzTaboo": {"attributes": {"descr": "Ansible test taboo contract"}}}'
     - 'cm_add_taboo_contract_descr.proposed == nm_add_taboo_contract_descr.proposed == {"vzTaboo": {"attributes": {"descr": "Ansible test taboo contract", "name": "taboo_contract_test"}}}'
     - cm_add_taboo_contract_descr.previous == nm_add_taboo_contract_descr.previous == cm_add_taboo_contract_descr.current == nm_add_taboo_contract.current
@@ -121,7 +124,8 @@
 - name: Verify add_taboo_contract_descr_again
   assert:
     that:
-    - cm_add_taboo_contract_descr_again.changed == nm_add_taboo_contract_descr_again.changed == false
+    - cm_add_taboo_contract_descr_again is not changed
+    - nm_add_taboo_contract_descr_again is not changed
     - cm_add_taboo_contract_descr_again.current == nm_add_taboo_contract_descr_again.current == nm_add_taboo_contract_descr.current
 
 
@@ -138,7 +142,8 @@
 - name: Verify add_taboo_contract_again_no_descr
   assert:
     that:
-    - cm_add_taboo_contract_again_no_descr.changed == nm_add_taboo_contract_again_no_descr.changed == false
+    - cm_add_taboo_contract_again_no_descr is not changed
+    - nm_add_taboo_contract_again_no_descr is not changed
     - cm_add_taboo_contract_again_no_descr.current == nm_add_taboo_contract_again_no_descr.current == nm_add_taboo_contract_descr.current
 
 
@@ -163,7 +168,8 @@
 - name: Verify query_all_taboo_contracts
   assert:
     that:
-    - cm_query_all_taboo_contracts.changed == nm_query_all_taboo_contracts.changed == false
+    - cm_query_all_taboo_contracts is not changed
+    - nm_query_all_taboo_contracts is not changed
     - cm_query_all_taboo_contracts == nm_query_all_taboo_contracts
     - cm_query_all_taboo_contracts.current|length >= 1
 
@@ -187,7 +193,8 @@
 - name: Verify query_taboo_contract
   assert:
     that:
-    - cm_query_taboo_contract.changed == nm_query_taboo_contract.changed == false
+    - cm_query_taboo_contract is not changed
+    - nm_query_taboo_contract is not changed
     - cm_query_taboo_contract == nm_query_taboo_contract
     - nm_query_taboo_contract.current.0.vzTaboo.attributes.descr == 'Ansible test taboo contract'
     - nm_query_taboo_contract.current.0.vzTaboo.attributes.dn == 'uni/tn-ansible_test/taboo-taboo_contract_test'
@@ -207,7 +214,8 @@
 - name: Verify remove_taboo_contract
   assert:
     that:
-    - cm_remove_taboo_contract.changed == nm_remove_taboo_contract.changed == true
+    - cm_remove_taboo_contract is changed
+    - nm_remove_taboo_contract is changed
     - 'cm_remove_taboo_contract.current == cm_remove_taboo_contract.previous == nm_remove_taboo_contract.previous == [{"vzTaboo": {"attributes": {"descr": "Ansible test taboo contract", "dn": "uni/tn-ansible_test/taboo-taboo_contract_test", "name": "taboo_contract_test", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
     - nm_remove_taboo_contract.current == []
 
@@ -223,7 +231,8 @@
 - name: Verify remove_taboo_contract_again
   assert:
     that:
-    - cm_remove_taboo_contract_again.changed == nm_remove_taboo_contract_again.changed == false
+    - cm_remove_taboo_contract_again is not changed
+    - nm_remove_taboo_contract_again is not changed
     - cm_remove_taboo_contract_again.proposed == nm_remove_taboo_contract_again.proposed == {}
     - cm_remove_taboo_contract_again.sent == nm_remove_taboo_contract_again.sent == {}
     - cm_remove_taboo_contract_again.previous == nm_remove_taboo_contract_again.previous == []
@@ -250,7 +259,8 @@
 - name: Verify query_non_taboo_contract
   assert:
     that:
-    - cm_query_non_taboo_contract.changed == nm_query_non_taboo_contract.changed == false
+    - cm_query_non_taboo_contract is not changed
+    - nm_query_non_taboo_contract is not changed
     - cm_remove_taboo_contract_again.previous == nm_remove_taboo_contract_again.previous == []
     - cm_remove_taboo_contract_again.current == nm_remove_taboo_contract_again.current == []
 
@@ -272,5 +282,5 @@
 - name: Verify error_on_missing_required_param
   assert:
     that:
-    - error_on_missing_required_param.failed == true
+    - error_on_missing_required_param is failed
     - 'error_on_missing_required_param.msg == "state is present but all of the following are missing: tenant, taboo_contract"'

--- a/test/integration/targets/aci_tenant/tasks/main.yml
+++ b/test/integration/targets/aci_tenant/tasks/main.yml
@@ -54,8 +54,10 @@
 - name: Verify add_tenant
   assert:
     that:
-    - cm_add_tenant.changed == nm_add_tenant.changed == true
-    - cm_add_tenant_again.changed == nm_add_tenant_again.changed == false
+    - cm_add_tenant is changed
+    - nm_add_tenant is changed
+    - cm_add_tenant_again is not changed
+    - nm_add_tenant_again is not changed
 
 
 # CHANGE TENANT
@@ -88,8 +90,10 @@
 - name: Verify add_tenant_descr
   assert:
     that:
-    - cm_add_tenant_descr.changed == nm_add_tenant_descr.changed == true
-    - cm_add_tenant_descr_again.changed == nm_add_tenant_descr_again.changed == false
+    - cm_add_tenant_descr is changed
+    - nm_add_tenant_descr is changed
+    - cm_add_tenant_descr_again is not changed
+    - nm_add_tenant_descr_again is not changed
 
 
 # ADD TENANT AGAIN
@@ -105,7 +109,8 @@
 - name: Verify add_tenant_again_no_descr
   assert:
     that:
-    - cm_add_tenant_again_no_descr.changed == nm_add_tenant_again_no_descr.changed == false
+    - cm_add_tenant_again_no_descr is not changed
+    - nm_add_tenant_again_no_descr is not changed
 
 
 # QUERY ALL TENANTS
@@ -129,7 +134,8 @@
 - name: Verify query_all_tenants
   assert:
     that:
-    - cm_query_all_tenants.changed == nm_query_all_tenants.changed == false
+    - cm_query_all_tenants is not changed
+    - nm_query_all_tenants is not changed
     # NOTE: Order of tenants is not stable between calls
     #- cm_query_all_tenants == nm_query_all_tenants
 
@@ -151,7 +157,8 @@
 - name: Verify query_tenant
   assert:
     that:
-    - cm_query_tenant.changed == nm_query_tenant.changed == false
+    - cm_query_tenant is not changed
+    - nm_query_tenant is not changed
     - cm_query_tenant == nm_query_tenant
 
 
@@ -177,8 +184,10 @@
 - name: Verify remove_tenant
   assert:
     that:
-    - cm_remove_tenant.changed == nm_remove_tenant.changed == true
-    - cm_remove_tenant_again.changed == nm_remove_tenant_again.changed == false
+    - cm_remove_tenant is changed
+    - nm_remove_tenant is changed
+    - cm_remove_tenant_again is not changed
+    - nm_remove_tenant_again is not changed
 
 
 # QUERY NON-EXISTING TENANT
@@ -199,5 +208,6 @@
 - name: Verify query_non_tenant
   assert:
     that:
-    - cm_query_non_tenant.changed == nm_query_non_tenant.changed == false
+    - cm_query_non_tenant is not changed
+    - nm_query_non_tenant is not changed
     - cm_query_non_tenant == nm_query_non_tenant

--- a/test/integration/targets/aci_vlan_pool/tasks/dynamic.yml
+++ b/test/integration/targets/aci_vlan_pool/tasks/dynamic.yml
@@ -41,7 +41,8 @@
 - name: Verify add_dynamic_vlan_pool
   assert:
     that:
-    - cm_add_dynamic_vlan_pool.changed == nm_add_dynamic_vlan_pool.changed == true
+    - cm_add_dynamic_vlan_pool is changed
+    - nm_add_dynamic_vlan_pool is changed
     - 'cm_add_dynamic_vlan_pool.sent == nm_add_dynamic_vlan_pool.sent == {"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "name": "anstest"}}}'
     - 'cm_add_dynamic_vlan_pool.proposed == nm_add_dynamic_vlan_pool.proposed == {"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "name": "anstest"}}}'
     - cm_add_dynamic_vlan_pool.previous == nm_add_dynamic_vlan_pool.previous == []
@@ -64,7 +65,8 @@
 - name: Verify add_dynamic_vlan_pool_again
   assert:
     that:
-    - cm_add_dynamic_vlan_pool_again.changed == nm_add_dynamic_vlan_pool_again.changed == false
+    - cm_add_dynamic_vlan_pool_again is not changed
+    - nm_add_dynamic_vlan_pool_again is not changed
     - cm_add_dynamic_vlan_pool_again.current == nm_add_dynamic_vlan_pool_again.current == nm_add_dynamic_vlan_pool.current
 
 
@@ -85,7 +87,8 @@
 - name: Verify add_dynamic_vlan_pool_descr
   assert:
     that:
-    - cm_add_dynamic_vlan_pool_descr.changed == nm_add_dynamic_vlan_pool_descr.changed == true
+    - cm_add_dynamic_vlan_pool_descr is changed
+    - nm_add_dynamic_vlan_pool_descr is changed
     - 'cm_add_dynamic_vlan_pool_descr.sent == nm_add_dynamic_vlan_pool_descr.sent == {"fvnsVlanInstP": {"attributes": {"descr": "Ansible test dynamic vlan pool"}}}'
     - 'cm_add_dynamic_vlan_pool_descr.proposed == nm_add_dynamic_vlan_pool_descr.proposed == {"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible test dynamic vlan pool", "name": "anstest"}}}'
     - cm_add_dynamic_vlan_pool_descr.previous == nm_add_dynamic_vlan_pool_descr.previous == cm_add_dynamic_vlan_pool_descr.current == nm_add_dynamic_vlan_pool.current
@@ -110,7 +113,8 @@
 - name: Verify add_dynamic_vlan_pool_descr_again
   assert:
     that:
-    - cm_add_dynamic_vlan_pool_descr_again.changed == nm_add_dynamic_vlan_pool_descr_again.changed == false
+    - cm_add_dynamic_vlan_pool_descr_again is not changed
+    - nm_add_dynamic_vlan_pool_descr_again is not changed
     - cm_add_dynamic_vlan_pool_descr_again.current == nm_add_dynamic_vlan_pool_descr_again.current == nm_add_dynamic_vlan_pool_descr.current
 
 
@@ -127,7 +131,8 @@
 - name: Verify add_dynamic_vlan_pool_again_no_descr
   assert:
     that:
-    - cm_add_dynamic_vlan_pool_again_no_descr.changed == nm_add_dynamic_vlan_pool_again_no_descr.changed == false
+    - cm_add_dynamic_vlan_pool_again_no_descr is not changed
+    - nm_add_dynamic_vlan_pool_again_no_descr is not changed
     - cm_add_dynamic_vlan_pool_again_no_descr.current == nm_add_dynamic_vlan_pool_again_no_descr.current == nm_add_dynamic_vlan_pool_descr.current
 
 
@@ -152,7 +157,8 @@
 - name: Verify query_all_dynamic_vlan_pools
   assert:
     that:
-    - cm_query_all_dynamic_vlan_pools.changed == nm_query_all_dynamic_vlan_pools.changed == false
+    - cm_query_all_dynamic_vlan_pools is not changed
+    - nm_query_all_dynamic_vlan_pools is not changed
     - cm_query_all_dynamic_vlan_pools == nm_query_all_dynamic_vlan_pools
     - cm_query_all_dynamic_vlan_pools.current|length >= 1
 
@@ -176,7 +182,8 @@
 - name: Verify query_dynamic_vlan_pool
   assert:
     that:
-    - cm_query_dynamic_vlan_pool.changed == nm_query_dynamic_vlan_pool.changed == false
+    - cm_query_dynamic_vlan_pool is not changed
+    - nm_query_dynamic_vlan_pool is not changed
     - cm_query_dynamic_vlan_pool == nm_query_dynamic_vlan_pool
     - nm_query_dynamic_vlan_pool.current.0.fvnsVlanInstP.attributes.allocMode == 'dynamic'
     - nm_query_dynamic_vlan_pool.current.0.fvnsVlanInstP.attributes.descr == 'Ansible test dynamic vlan pool'
@@ -197,7 +204,8 @@
 - name: Verify remove_dynamic_vlan_pool
   assert:
     that:
-    - cm_remove_dynamic_vlan_pool.changed == nm_remove_dynamic_vlan_pool.changed == true
+    - cm_remove_dynamic_vlan_pool is changed
+    - nm_remove_dynamic_vlan_pool is changed
     - 'cm_remove_dynamic_vlan_pool.current == cm_remove_dynamic_vlan_pool.previous == nm_remove_dynamic_vlan_pool.previous == [{"fvnsVlanInstP": {"attributes": {"allocMode": "dynamic", "descr": "Ansible test dynamic vlan pool", "dn": "uni/infra/vlanns-[anstest]-dynamic", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
     - nm_remove_dynamic_vlan_pool.current == []
 
@@ -213,7 +221,8 @@
 - name: Verify remove_dynamic_vlan_pool_again
   assert:
     that:
-    - cm_remove_dynamic_vlan_pool_again.changed == nm_remove_dynamic_vlan_pool_again.changed == false
+    - cm_remove_dynamic_vlan_pool_again is not changed
+    - nm_remove_dynamic_vlan_pool_again is not changed
     - cm_remove_dynamic_vlan_pool_again.proposed == nm_remove_dynamic_vlan_pool_again.proposed == {}
     - cm_remove_dynamic_vlan_pool_again.sent == nm_remove_dynamic_vlan_pool_again.sent == {}
     - cm_remove_dynamic_vlan_pool_again.previous == nm_remove_dynamic_vlan_pool_again.previous == []
@@ -240,7 +249,8 @@
 - name: Verify query_non_dynamic_vlan_pool
   assert:
     that:
-    - cm_query_non_dynamic_vlan_pool.changed == nm_query_non_dynamic_vlan_pool.changed == false
+    - cm_query_non_dynamic_vlan_pool is not changed
+    - nm_query_non_dynamic_vlan_pool is not changed
     - cm_remove_dynamic_vlan_pool_again.previous == nm_remove_dynamic_vlan_pool_again.previous == []
     - cm_remove_dynamic_vlan_pool_again.current == nm_remove_dynamic_vlan_pool_again.current == []
 
@@ -262,7 +272,7 @@
 - name: Verify error_on_missing_required_param
   assert:
     that:
-    - error_on_missing_required_param.failed == true
+    - error_on_missing_required_param is failed
     - 'error_on_missing_required_param.msg == "state is present but all of the following are missing: pool"'
 
 - name: Error when together parameter is missing
@@ -282,5 +292,5 @@
 - name: Verify error_on_missing_together_param
   assert:
     that:
-    - error_on_missing_together_param.failed == true
+    - error_on_missing_together_param is failed
     - error_on_missing_together_param.msg == "ACI requires the 'pool_allocation_mode' when 'pool' is provided"

--- a/test/integration/targets/aci_vlan_pool/tasks/static.yml
+++ b/test/integration/targets/aci_vlan_pool/tasks/static.yml
@@ -41,7 +41,8 @@
 - name: Verify add_static_vlan_pool
   assert:
     that:
-    - cm_add_static_vlan_pool.changed == nm_add_static_vlan_pool.changed == true
+    - cm_add_static_vlan_pool is changed
+    - nm_add_static_vlan_pool is changed
     - 'cm_add_static_vlan_pool.sent == nm_add_static_vlan_pool.sent == {"fvnsVlanInstP": {"attributes": {"allocMode": "static", "name": "anstest"}}}'
     - 'cm_add_static_vlan_pool.proposed == nm_add_static_vlan_pool.proposed == {"fvnsVlanInstP": {"attributes": {"allocMode": "static", "name": "anstest"}}}'
     - cm_add_static_vlan_pool.previous == nm_add_static_vlan_pool.previous == []
@@ -64,7 +65,8 @@
 - name: Verify add_static_vlan_pool_again
   assert:
     that:
-    - cm_add_static_vlan_pool_again.changed == nm_add_static_vlan_pool_again.changed == false
+    - cm_add_static_vlan_pool_again is not changed
+    - nm_add_static_vlan_pool_again is not changed
     - cm_add_static_vlan_pool_again.current == nm_add_static_vlan_pool_again.current == nm_add_static_vlan_pool.current
 
 
@@ -85,7 +87,8 @@
 - name: Verify add_static_vlan_pool_descr
   assert:
     that:
-    - cm_add_static_vlan_pool_descr.changed == nm_add_static_vlan_pool_descr.changed == true
+    - cm_add_static_vlan_pool_descr is changed
+    - nm_add_static_vlan_pool_descr is changed
     - 'cm_add_static_vlan_pool_descr.sent == nm_add_static_vlan_pool_descr.sent == {"fvnsVlanInstP": {"attributes": {"descr": "Ansible test static vlan pool"}}}'
     - 'cm_add_static_vlan_pool_descr.proposed == nm_add_static_vlan_pool_descr.proposed == {"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible test static vlan pool", "name": "anstest"}}}'
     - cm_add_static_vlan_pool_descr.previous == nm_add_static_vlan_pool_descr.previous == cm_add_static_vlan_pool_descr.current == nm_add_static_vlan_pool.current
@@ -110,7 +113,8 @@
 - name: Verify add_static_vlan_pool_descr_again
   assert:
     that:
-    - cm_add_static_vlan_pool_descr_again.changed == nm_add_static_vlan_pool_descr_again.changed == false
+    - cm_add_static_vlan_pool_descr_again is not changed
+    - nm_add_static_vlan_pool_descr_again is not changed
     - cm_add_static_vlan_pool_descr_again.current == nm_add_static_vlan_pool_descr_again.current == nm_add_static_vlan_pool_descr.current
 
 
@@ -127,7 +131,8 @@
 - name: Verify add_static_vlan_pool_again_no_descr
   assert:
     that:
-    - cm_add_static_vlan_pool_again_no_descr.changed == nm_add_static_vlan_pool_again_no_descr.changed == false
+    - cm_add_static_vlan_pool_again_no_descr is not changed
+    - nm_add_static_vlan_pool_again_no_descr is not changed
     - cm_add_static_vlan_pool_again_no_descr.current == nm_add_static_vlan_pool_again_no_descr.current == nm_add_static_vlan_pool_descr.current
 
 
@@ -152,7 +157,8 @@
 - name: Verify query_all_static_vlan_pools
   assert:
     that:
-    - cm_query_all_static_vlan_pools.changed == nm_query_all_static_vlan_pools.changed == false
+    - cm_query_all_static_vlan_pools is not changed
+    - nm_query_all_static_vlan_pools is not changed
     - cm_query_all_static_vlan_pools == nm_query_all_static_vlan_pools
     - cm_query_all_static_vlan_pools.current|length >= 1
 
@@ -176,7 +182,8 @@
 - name: Verify query_static_vlan_pool
   assert:
     that:
-    - cm_query_static_vlan_pool.changed == nm_query_static_vlan_pool.changed == false
+    - cm_query_static_vlan_pool is not changed
+    - nm_query_static_vlan_pool is not changed
     - cm_query_static_vlan_pool == nm_query_static_vlan_pool
     - nm_query_static_vlan_pool.current.0.fvnsVlanInstP.attributes.allocMode == 'static'
     - nm_query_static_vlan_pool.current.0.fvnsVlanInstP.attributes.descr == 'Ansible test static vlan pool'
@@ -197,7 +204,8 @@
 - name: Verify remove_static_vlan_pool
   assert:
     that:
-    - cm_remove_static_vlan_pool.changed == nm_remove_static_vlan_pool.changed == true
+    - cm_remove_static_vlan_pool is changed
+    - nm_remove_static_vlan_pool is changed
     - 'cm_remove_static_vlan_pool.current == cm_remove_static_vlan_pool.previous == nm_remove_static_vlan_pool.previous == [{"fvnsVlanInstP": {"attributes": {"allocMode": "static", "descr": "Ansible test static vlan pool", "dn": "uni/infra/vlanns-[anstest]-static", "name": "anstest", "nameAlias": "", "ownerKey": "", "ownerTag": ""}}}]'
     - nm_remove_static_vlan_pool.current == []
 
@@ -213,7 +221,8 @@
 - name: Verify remove_static_vlan_pool_again
   assert:
     that:
-    - cm_remove_static_vlan_pool_again.changed == nm_remove_static_vlan_pool_again.changed == false
+    - cm_remove_static_vlan_pool_again is not changed
+    - nm_remove_static_vlan_pool_again is not changed
     - cm_remove_static_vlan_pool_again.proposed == nm_remove_static_vlan_pool_again.proposed == {}
     - cm_remove_static_vlan_pool_again.sent == nm_remove_static_vlan_pool_again.sent == {}
     - cm_remove_static_vlan_pool_again.previous == nm_remove_static_vlan_pool_again.previous == []
@@ -240,7 +249,8 @@
 - name: Verify query_non_static_vlan_pool
   assert:
     that:
-    - cm_query_non_static_vlan_pool.changed == nm_query_non_static_vlan_pool.changed == false
+    - cm_query_non_static_vlan_pool is not changed
+    - nm_query_non_static_vlan_pool is not changed
     - cm_remove_static_vlan_pool_again.previous == nm_remove_static_vlan_pool_again.previous == []
     - cm_remove_static_vlan_pool_again.current == nm_remove_static_vlan_pool_again.current == []
 
@@ -262,7 +272,7 @@
 - name: Verify error_on_missing_required_param
   assert:
     that:
-    - error_on_missing_required_param.failed == true
+    - error_on_missing_required_param is failed
     - 'error_on_missing_required_param.msg == "state is present but all of the following are missing: pool"'
 
 - name: Error when together parameter is missing
@@ -282,5 +292,5 @@
 - name: Verify error_on_missing_together_param
   assert:
     that:
-    - error_on_missing_together_param.failed == true
+    - error_on_missing_together_param is failed
     - error_on_missing_together_param.msg == "ACI requires the 'pool_allocation_mode' when 'pool' is provided"

--- a/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
+++ b/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
@@ -54,7 +54,7 @@
 - name: Present assertions
   assert:
     that:
-      - encap_block_present_check_mode.changed == true
+      - encap_block_present_check_mode is changed
       - 'encap_block_present_check_mode.sent == {"fvnsEncapBlk": {"attributes": {"allocMode": "inherit", "descr": "Ansible Test", "from": "vlan-20", "name": "anstest", "to": "vlan-40"}}}'
 
 - name: Create vlan pool encap_block - creation works
@@ -65,7 +65,7 @@
 - name: Present assertions
   assert:
     that:
-      - encap_block_present.changed == true
+      - encap_block_present is changed
       - encap_block_present.previous == []
       - encap_block_present.sent == encap_block_present_check_mode.sent
       - encap_block_present.sent == encap_block_present.proposed
@@ -78,8 +78,8 @@
 - name: Present assertions
   assert:
     that:
-      - encap_block_present_idempotent.changed == false
-      - 'encap_block_present_idempotent.previous.0.fvnsEncapBlk.attributes.name == "anstest"'
+      - encap_block_present_idempotent is not changed
+      - encap_block_present_idempotent.previous.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: Update vlan pool range - update works
   aci_vlan_pool_encap_block:
@@ -91,7 +91,7 @@
 - name: Present assertions
   assert:
     that:
-      - encap_block_present_update.changed == true
+      - encap_block_present_update is changed
       - encap_block_present_update.previous != []
       - encap_block_present_update.sent != encap_block_present.sent
 
@@ -106,7 +106,7 @@
 - name: Present assertions
   assert:
     that:
-      - encap_block_present_2.changed == true
+      - encap_block_present_2 is changed
       - encap_block_present_2.previous == []
 
 - name: Invalid encap_block_start - error message works
@@ -119,7 +119,7 @@
 - name: Present assertions
   assert:
     that:
-      - encap_block_start_low.failed == true
+      - encap_block_start_low is failed
       - encap_block_start_low.msg == "vlan pools must have 'block_start' and 'block_end' values between 1 and 4094"
 
 - name: Invalid encap_block_start - error message works
@@ -132,7 +132,7 @@
 - name: Present assertions
   assert:
     that:
-      - encap_block_start_high.failed == true
+      - encap_block_start_high is failed
       - encap_block_start_high.msg == "vlan pools must have 'block_start' and 'block_end' values between 1 and 4094"
 
 - name: Invalid encap_block_end - error message works
@@ -145,7 +145,7 @@
 - name: Present assertions
   assert:
     that:
-      - encap_block_end_low.failed == true
+      - encap_block_end_low is failed
       - encap_block_end_low.msg == "vlan pools must have 'block_start' and 'block_end' values between 1 and 4094"
 
 - name: Invalid encap_block_end - error message works
@@ -158,7 +158,7 @@
 - name: Present assertions
   assert:
     that:
-      - encap_block_end_high.failed == true
+      - encap_block_end_high is failed
       - encap_block_end_high.msg == "vlan pools must have 'block_start' and 'block_end' values between 1 and 4094"
 
 - name: Range start higher than range end - error message works
@@ -171,7 +171,7 @@
 - name: Present assertions
   assert:
     that:
-      - encap_block_start_end.failed == true
+      - encap_block_start_end is failed
       - encap_block_start_end.msg == "The 'block_start' must be less than or equal to the 'block_end'"
 
 - name: Missing required param - error message works
@@ -183,7 +183,7 @@
 - name: Present assertions
   assert:
     that:
-      - encap_block_present_missing_param.failed == true
+      - encap_block_present_missing_param is failed
       - 'encap_block_present_missing_param.msg == "state is present but all of the following are missing: block_end, block_name, block_start"'
 
 - name: Missing required param - error message works
@@ -196,7 +196,7 @@
 - name: Present assertions
   assert:
     that:
-      - encap_block_present_allocation.failed == true
+      - encap_block_present_allocation is failed
       - encap_block_present_allocation.msg == "ACI requires the 'pool_allocation_mode' when 'pool' is provided"
 
 - name: Query specific vlan pool range
@@ -208,7 +208,7 @@
 - name: Query assertions
   assert:
     that:
-      - encap_block_query.changed == false
+      - encap_block_query is not changed
       - encap_block_query.url.endswith("infra/vlanns-[anstest]-static/from-[vlan-20]-to-[vlan-40].json")
       - encap_block_query.current | length == 1
       - encap_block_query.current.0.fvnsEncapBlk.attributes.name == "anstest"
@@ -222,9 +222,11 @@
 - name: Query assertions
   assert:
     that:
-      - encap_block_query_from_to_name.changed == false
+      - encap_block_query_from_to_name is not changed
       - encap_block_query_from_to_name.url.endswith("class/fvnsEncapBlk.json")
-      - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in encap_block_query_from_to_name.filter_string'
+      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in encap_block_query_from_to_name.filter_string'
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_from_to_name.filter_string'
+      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in encap_block_query_from_to_name.filter_string'
       - encap_block_query_from_to_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
       - encap_block_query_from_to_name.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
       - encap_block_query_from_to_name.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
@@ -238,9 +240,10 @@
 - name: Query assertions
   assert:
     that:
-      - encap_block_query_from_name.changed == false
+      - encap_block_query_from_name is not changed
       - encap_block_query_from_name.url.endswith("class/fvnsEncapBlk.json")
-      - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.name, \"anstest\"))" in encap_block_query_from_name.filter_string'
+      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in encap_block_query_from_name.filter_string'
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_from_name.filter_string'
       - encap_block_query_from_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
       - encap_block_query_from_name.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
 
@@ -253,9 +256,10 @@
 - name: Query assertions
   assert:
     that:
-      - encap_block_query_to_name.changed == false
+      - encap_block_query_to_name is not changed
       - encap_block_query_to_name.url.endswith("class/fvnsEncapBlk.json")
-      - '"query-target-filter=and(eq(fvnsEncapBlk.to, \"vlan-40\"),eq(fvnsEncapBlk.name, \"anstest\"))" in encap_block_query_to_name.filter_string'
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_to_name.filter_string'
+      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in encap_block_query_to_name.filter_string'
       - encap_block_query_to_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
       - encap_block_query_to_name.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
@@ -269,9 +273,9 @@
 - name: Query assertions
   assert:
     that:
-      - encap_block_query_name.changed == false
+      - encap_block_query_name is not changed
       - encap_block_query_name.url.endswith("class/fvnsEncapBlk.json")
-      - '"query-target-filter=eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_name.filter_string'
+      - '"eq(fvnsEncapBlk.name, \"anstest\")" in encap_block_query_name.filter_string'
       - encap_block_query_name.current.0.fvnsEncapBlk.attributes.name == "anstest"
 
 - name: Query vlan pool range - from and to are filtered
@@ -283,9 +287,10 @@
 - name: Query assertions
   assert:
     that:
-      - encap_block_query_from_to.changed == false
+      - encap_block_query_from_to is not changed
       - encap_block_query_from_to.url.endswith("class/fvnsEncapBlk.json")
-      - '"query-target-filter=and(eq(fvnsEncapBlk.from, \"vlan-20\"),eq(fvnsEncapBlk.to, \"vlan-40\"))" in encap_block_query_from_to.filter_string'
+      - '"eq(fvnsEncapBlk.from, \"vlan-20\")" in encap_block_query_from_to.filter_string'
+      - '"eq(fvnsEncapBlk.to, \"vlan-40\")" in encap_block_query_from_to.filter_string'
       - encap_block_query_from_to.current.0.fvnsEncapBlk.attributes.from == "vlan-20"
       - encap_block_query_from_to.current.0.fvnsEncapBlk.attributes.to == "vlan-40"
 
@@ -299,6 +304,7 @@
 - name: Query assertions
   assert:
     that:
+      - encap_block_query_pool is not changed
       - encap_block_query_pool.current | length == 1
       - encap_block_query_pool.current.0.fvnsVlanInstP.attributes.name == "anstest"
       - encap_block_query_pool.current.0.fvnsVlanInstP.children | length > 1
@@ -314,7 +320,7 @@
 - name: Query assertions
   assert:
     that:
-      - encap_block_query_all.changed == false
+      - encap_block_query_all is not changed
       - encap_block_query_all.current | length > 1
       - encap_block_query_all.current.0.fvnsEncapBlk is defined
       - encap_block_query_all.url.endswith("class/fvnsEncapBlk.json")
@@ -328,7 +334,7 @@
 - name: Absent assertions
   assert:
     that:
-      - delete_range.changed == true
+      - delete_range is changed
       - delete_range.proposed == {}
       - delete_range.previous.0.fvnsEncapBlk.attributes.name == "anstest"
 
@@ -342,7 +348,7 @@
 - name: Absent assertions
   assert:
     that:
-      - delete_check_mode.changed == true
+      - delete_check_mode is changed
       - delete_check_mode.previous != []
 
 - name: Delete vlan pool range - deletion works
@@ -353,7 +359,7 @@
 - name: Absent assertions
   assert:
     that:
-      - delete_encap_block_2.changed == true
+      - delete_encap_block_2 is changed
       - delete_encap_block_2.previous == delete_check_mode.previous
 
 - name: Delete vlan pool range again - idempotency works
@@ -364,11 +370,11 @@
 - name: Absent assertions
   assert:
     that:
-      - delete_idempotent.changed == false
+      - delete_idempotent is not changed
       - delete_idempotent.previous == []
 
 - name: Cleanup vlan pool
   aci_vlan_pool:
     <<: *aci_pool_present
     state: absent
-  when: pool_present.changed == true
+  when: pool_present is changed

--- a/test/integration/targets/aci_vrf/tasks/main.yml
+++ b/test/integration/targets/aci_vrf/tasks/main.yml
@@ -63,19 +63,19 @@
 - name: present asserts
   assert:
     that:
-      - vrf_present_check_mode.changed == true
+      - vrf_present_check_mode is changed
       - 'vrf_present_check_mode.sent == {"fvCtx": {"attributes": {"descr": "Ansible Test", "name": "anstest"}}}'
-      - vrf_present.changed == true
+      - vrf_present is changed
       - vrf_present.sent == vrf_present_check_mode.sent
       - vrf_present.previous == []
-      - vrf_present_idempotent.changed == false
+      - vrf_present_idempotent is not changed
       - vrf_present_idempotent.previous != []
-      - vrf_update.changed == true
+      - vrf_update is changed
       - vrf_update.previous != []
-      - vrf_update.changed != vrf_update.proposed
+      - vrf_update.sent != vrf_update.proposed
       - 'vrf_update.sent == {"fvCtx": {"attributes": {"descr": "Ansible Test Update", "pcEnfPref": "unenforced"}}}'
       - 'vrf_present_2.sent.fvCtx.attributes == {"name": "anstest2", "pcEnfDir": "egress", "descr": "Ansible Test"}'
-      - vrf_present_missing_param.failed == true
+      - vrf_present_missing_param is failed
       - 'vrf_present_missing_param.msg == "state is present but all of the following are missing: tenant"'
 
 - name: get all vrf
@@ -106,22 +106,22 @@
 - name: query asserts
   assert:
     that:
-      - query_all.changed == false
+      - query_all is not changed
       - query_all.current | length > 1
       - query_all.current.0.fvCtx is defined
       - '"class/fvCtx.json" in query_all.url'
-      - query_tenant.changed == false
+      - query_tenant is not changed
       - query_tenant.current | length == 1
       - query_tenant.current.0.fvTenant.children | length == 2
-      - 'query_tenant.current.0.fvTenant.attributes.name == "anstest"'
+      - query_tenant.current.0.fvTenant.attributes.name == "anstest"
       - '"rsp-subtree-class=fvCtx" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
-      - query_vrf_vrf.changed == false
+      - query_vrf_vrf is not changed
       - query_vrf_vrf.current != []
-      - 'query_vrf_vrf.current.0.fvCtx.attributes.name == "anstest"'
+      - query_vrf_vrf.current.0.fvCtx.attributes.name == "anstest"
       - '"query-target-filter=eq(fvCtx.name, \"anstest\")" in query_vrf_vrf.filter_string'
       - '"class/fvCtx.json" in query_vrf_vrf.url'
-      - query_vrf.changed == false
+      - query_vrf is not changed
       - query_vrf.current | length == 1
       - '"tn-anstest/ctx-anstest.json" in query_vrf.url'
 
@@ -157,18 +157,18 @@
 - name: asserts for deletion task
   assert:
     that:
-      - vrf_absent_check_mode.changed == true
+      - vrf_absent_check_mode is changed
       - vrf_absent_check_mode.previous != []
       - vrf_absent_check_mode.proposed == {}
-      - vrf_absent.changed == true
+      - vrf_absent is changed
       - vrf_absent.previous == vrf_absent_check_mode.previous
-      - vrf_absent_idempotent.changed == false
+      - vrf_absent_idempotent is not changed
       - vrf_absent_idempotent.previous == []
-      - vrf_absent_missing_param.failed == true
+      - vrf_absent_missing_param is failed
       - 'vrf_absent_missing_param.msg == "state is absent but all of the following are missing: vrf"'
 
 - name: delete tenant - cleanup before ending tests
   aci_tenant:
     <<: *aci_tenant_present
     state: absent
-  when: tenant_present.changed == true
+  when: tenant_present is changed


### PR DESCRIPTION
##### SUMMARY
This functionality was not considered when the module was written, but
there's no reason why it shouldn't be supported.

We had to rework the query string construction and object filtering.
This new functionality allows to filter on arbitrary keys and supports
None values.

This PR also fixes various issues with the existing framework, including
querying specific objects using construct_url_4 (i.e.
aci_epg_to_contract and aci_static_binding_to_epg)

This fixes #43422

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
aci_interface_policy_leaf_policy_group

##### ANSIBLE VERSION
v2.7