### PR TITLE
Fix docs typo modules_intro.rst (#40835)

### DIFF
--- a/docs/docsite/rst/user_guide/modules_intro.rst
+++ b/docs/docsite/rst/user_guide/modules_intro.rst
@@ -3,7 +3,7 @@
 Introduction
 ============
 
-Modules (also referred to as "task plugins" or "library plugins") are discrete unites of code that can be used from the command line or in a playbook task.
+Modules (also referred to as "task plugins" or "library plugins") are discrete units of code that can be used from the command line or in a playbook task.
 
 Let's review how we execute three different modules from the command line::
 


### PR DESCRIPTION
Fixed typo in modules_intro.rst.

+label: docsite_pr
(cherry picked from commit f785bf3a9c6f94ad738cd1fb1c77781f2ea6b5d0)

##### SUMMARY
Backports a typo fix made from github.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.6
