### PR TITLE
document rescue vars (#43101)

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/user_guide/playbooks_blocks.rst
@@ -95,6 +95,17 @@ Another example is how to run handlers after an error occurred :
        debug:
          msg: 'This handler runs even on error'
 
+
+.. versionadded:: 2.1
+
+Ansible also provides a couple of variables for tasks in the ``rescue`` portion of a block:
+
+ansible_failed_task
+    The task that returned 'failed' and triggered the rescue. For example, to get the name use ``ansible_failed_task.name``.
+
+ansible_failed_result
+    The captured return result of the failed task that triggered the rescue. This would equate to having used this var in the ``register`` keyword.
+
 .. seealso::
 
    :doc:`playbooks`


### PR DESCRIPTION
(cherry picked from commit c809500c7940d54c7cd320d86508d87e4100d779)

##### SUMMARY
Backports documentation for `ansible_failed_task` and `ansible_failed_result`.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.6
