### PR TITLE
fixes broken link

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_gce.rst
+++ b/docs/docsite/rst/scenario_guides/guide_gce.rst
@@ -240,4 +240,4 @@ rest.
 Note that use of the "add_host" module above creates a temporary, in-memory group.  This means that a play in the same playbook can then manage machines
 in the 'new_instances' group, if so desired.  Any sort of arbitrary configuration is possible at this point.
 
-For more information about Google Cloud, please visit the `Google Cloud website <https://cloud.google.com>`
+For more information about Google Cloud, please visit the `Google Cloud website <https://cloud.google.com>`_.


### PR DESCRIPTION
##### SUMMARY
The final link in the Google Cloud scenario guide was missing the trailing underscore, so it was showing as text rather than a link.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.7
