### PR TITLE
PrivilegeUtil: use native methods to get pointer offset

### DIFF
--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.PrivilegeUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.PrivilegeUtil.psm1
@@ -166,7 +166,7 @@ namespace Ansible.PrivilegeUtil
 
                     NativeHelpers.TOKEN_PRIVILEGES privilegeInfo = (NativeHelpers.TOKEN_PRIVILEGES)Marshal.PtrToStructure(privilegesPtr, typeof(NativeHelpers.TOKEN_PRIVILEGES));
                     privileges = new NativeHelpers.LUID_AND_ATTRIBUTES[privilegeInfo.PrivilegeCount];
-                    PtrToStructureArray(privileges, privilegesPtr.ToInt64() + Marshal.SizeOf(privilegeInfo.PrivilegeCount));
+                    PtrToStructureArray(privileges, IntPtr.Add(privilegesPtr, Marshal.SizeOf(privilegeInfo.PrivilegeCount)));
                 }
                 finally
                 {
@@ -301,7 +301,7 @@ namespace Ansible.PrivilegeUtil
                         // Marshal the oldStatePtr to the struct
                         NativeHelpers.TOKEN_PRIVILEGES oldState = (NativeHelpers.TOKEN_PRIVILEGES)Marshal.PtrToStructure(oldStatePtr, typeof(NativeHelpers.TOKEN_PRIVILEGES));
                         oldStatePrivileges = new NativeHelpers.LUID_AND_ATTRIBUTES[oldState.PrivilegeCount];
-                        PtrToStructureArray(oldStatePrivileges, oldStatePtr.ToInt64() + Marshal.SizeOf(oldState.PrivilegeCount));
+                        PtrToStructureArray(oldStatePrivileges, IntPtr.Add(oldStatePtr, Marshal.SizeOf(oldState.PrivilegeCount)));
                     }
                     finally
                     {
@@ -334,11 +334,11 @@ namespace Ansible.PrivilegeUtil
             return name.ToString();
         }
 
-        private static void PtrToStructureArray<T>(T[] array, Int64 pointerAddress)
+        private static void PtrToStructureArray<T>(T[] array, IntPtr ptr)
         {
-            Int64 pointerOffset = pointerAddress;
-            for (int i = 0; i < array.Length; i++, pointerOffset += Marshal.SizeOf(typeof(T)))
-                array[i] = (T)Marshal.PtrToStructure(new IntPtr(pointerOffset), typeof(T));
+            IntPtr ptrOffset = ptr;
+            for (int i = 0; i < array.Length; i++, ptrOffset = IntPtr.Add(ptrOffset, Marshal.SizeOf(typeof(T))))
+                array[i] = (T)Marshal.PtrToStructure(ptrOffset, typeof(T));
         }
 
         private static int StructureToBytes<T>(T structure, byte[] array, int offset)


### PR DESCRIPTION
##### SUMMARY
Pointers are different sizes on 32/64 bit and while the code here will work because it uses Int64 by default. It isn't really correct. This changes it so it uses the native [IntPtr.Add](https://msdn.microsoft.com/en-us/library/system.intptr.add.aspx) method to do the offset calculations.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Ansible.ModuleUtils.PrivilegeUtil

##### ANSIBLE VERSION
```
devel
```