### PR TITLE
Enable HTTP Authentication for url lookup

### DIFF
--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -30,12 +30,12 @@ options:
     description: Username to use for HTTP authentication.
     type: string
     default: None
-    version_added: "2.7"
+    version_added: "2.8"
   url_password:
     description: Password to use for HTTP authentication.
     type: string
     default: None
-    version_added: "2.7"
+    version_added: "2.8"
 """
 
 EXAMPLES = """

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -78,10 +78,10 @@ class LookupModule(LookupBase):
         for term in terms:
             display.vvvv("url lookup connecting to %s" % term)
             try:
-                response = open_url(term, validate_certs=self.get_option('validate_certs'), 
-                                          use_proxy=self.get_option('use_proxy'), 
-                                          url_username=self.get_option('url_username'), 
-                                          url_password=self.get_option('url_password'))
+                response = open_url(term, validate_certs=self.get_option('validate_certs'),
+                                    use_proxy=self.get_option('use_proxy'),
+                                    url_username=self.get_option('url_username'),
+                                    url_password=self.get_option('url_password'))
             except HTTPError as e:
                 raise AnsibleError("Received HTTP error for %s : %s" % (term, to_native(e)))
             except URLError as e:

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -29,11 +29,11 @@ options:
   url_username:
     description: Username to use for HTTP authentication.
     type: string
-    default: ""
+    default: None
   url_password:
     description: Password to use for HTTP authentication.
     type: string
-    default: ""
+    default: None
 """
 
 EXAMPLES = """

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -30,10 +30,12 @@ options:
     description: Username to use for HTTP authentication.
     type: string
     default: None
+    version_added: "2.7"
   url_password:
     description: Password to use for HTTP authentication.
     type: string
     default: None
+    version_added: "2.7"
 """
 
 EXAMPLES = """

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -78,7 +78,10 @@ class LookupModule(LookupBase):
         for term in terms:
             display.vvvv("url lookup connecting to %s" % term)
             try:
-                response = open_url(term, validate_certs=self.get_option('validate_certs'), use_proxy=self.get_option('use_proxy'), url_username=self.get_option('url_username'), url_password=self.get_option('url_password'))
+                response = open_url(term, validate_certs=self.get_option('validate_certs'), 
+                                          use_proxy=self.get_option('use_proxy'), 
+                                          url_username=self.get_option('url_username'), 
+                                          url_password=self.get_option('url_password'))
             except HTTPError as e:
                 raise AnsibleError("Received HTTP error for %s : %s" % (term, to_native(e)))
             except URLError as e:

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -45,8 +45,7 @@ EXAMPLES = """
   debug: msg="{{ lookup('url', 'https://ip-ranges.amazonaws.com/ip-ranges.json', split_lines=False) }}"
 
 - name: url lookup using authentication
-  debug: msg="{{item}}"
-  loop: "{{ lookup('url', 'https://some.private.site.com/file.txt', url_username='bob', url_password='hunter2') }}"
+  debug: msg="{{ lookup('url', 'https://some.private.site.com/file.txt', url_username='bob', url_password='hunter2') }}"
 """
 
 RETURN = """

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -26,6 +26,14 @@ options:
     description: Flag to control if the lookup will observe HTTP proxy environment variables when present.
     type: boolean
     default: True
+  url_username:
+    description: Username to use for HTTP authentication.
+    type: string
+    default: ""
+  url_password:
+    description: Password to use for HTTP authentication.
+    type: string
+    default: ""
 """
 
 EXAMPLES = """
@@ -35,6 +43,10 @@ EXAMPLES = """
 
 - name: display ip ranges
   debug: msg="{{ lookup('url', 'https://ip-ranges.amazonaws.com/ip-ranges.json', split_lines=False) }}"
+
+- name: url lookup using authentication
+  debug: msg="{{item}}"
+  loop: "{{ lookup('url', 'https://some.private.site.com/file.txt', url_username='bob', url_password='hunter2') }}"
 """
 
 RETURN = """
@@ -65,7 +77,7 @@ class LookupModule(LookupBase):
         for term in terms:
             display.vvvv("url lookup connecting to %s" % term)
             try:
-                response = open_url(term, validate_certs=self.get_option('validate_certs'), use_proxy=self.get_option('use_proxy'))
+                response = open_url(term, validate_certs=self.get_option('validate_certs'), use_proxy=self.get_option('use_proxy'), url_username=self.get_option('url_username'), url_password=self.get_option('url_password'))
             except HTTPError as e:
                 raise AnsibleError("Received HTTP error for %s : %s" % (term, to_native(e)))
             except URLError as e:


### PR DESCRIPTION
##### SUMMARY
Enabling HTTP Authentication for url lookup. This allows the lookup plugin to retrieve resources that require HTTP Authentication

Fixes #42549

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/lookup/url.py

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel c2d95428ac) last updated 2018/07/10 23:26:26 (GMT +000)
  config file = None
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Rebase of PR #42603

<!--- Paste verbatim command output below, e.g. before and after your change -->
