### PR TITLE
Update cliconf get_config api

### DIFF
--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -136,7 +136,7 @@ class Cli:
         except KeyError:
             conn = self._get_connection()
             try:
-                out = conn.get_config(filter=flags)
+                out = conn.get_config(flags=flags)
             except ConnectionError as exc:
                 self._module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
 

--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -111,7 +111,7 @@ def get_config(module, flags=None):
     except KeyError:
         connection = get_connection(module)
         try:
-            out = connection.get_config(filter=flags)
+            out = connection.get_config(flags=flags)
         except ConnectionError as exc:
             module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
         cfg = to_text(out, errors='surrogate_then_replace').strip()

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -140,7 +140,7 @@ class Cli:
         except KeyError:
             connection = self._get_connection()
             try:
-                out = connection.get_config(filter=flags)
+                out = connection.get_config(flags=flags)
             except ConnectionError as exc:
                 self._module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
 

--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -165,7 +165,7 @@ class CliconfBase(AnsiblePlugin):
         self.response_logging = False
 
     @abstractmethod
-    def get_config(self, source='running', filter=None, format=None):
+    def get_config(self, source='running', flag=None, format=None):
         """Retrieves the specified configuration from the device
 
         This method will retrieve the configuration specified by source and
@@ -175,7 +175,7 @@ class CliconfBase(AnsiblePlugin):
         :param source: The configuration source to return from the device.
             This argument accepts either `running` or `startup` as valid values.
 
-        :param filter: For devices that support configuration filtering, this
+        :param flag: For devices that support configuration filtering, this
             keyword argument is used to filter the returned configuration.
             The use of this keyword argument is device dependent adn will be
             silently ignored on devices that do not support it.

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -75,7 +75,7 @@ class Cliconf(CliconfBase):
         return resp
 
     @enable_mode
-    def get_config(self, source='running', format='text', filter=None):
+    def get_config(self, source='running', format='text', flag=None):
         options_values = self.get_option_values()
         if format not in options_values['format']:
             raise ValueError("'format' value %s is invalid. Valid values are %s" % (format, ','.join(options_values['format'])))
@@ -88,7 +88,7 @@ class Cliconf(CliconfBase):
         if format and format is not 'text':
             cmd += '| %s ' % format
 
-        cmd += ' '.join(to_list(filter))
+        cmd += ' '.join(to_list(flag))
         cmd = cmd.strip()
         return self.send_command(cmd)
 

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -37,21 +37,21 @@ from ansible.plugins.cliconf import CliconfBase, enable_mode
 class Cliconf(CliconfBase):
 
     @enable_mode
-    def get_config(self, source='running', filter=None, format=None):
+    def get_config(self, source='running', flag=None, format=None):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
 
         if format:
             raise ValueError("'format' value %s is not supported for get_config" % format)
 
-        if not filter:
-            filter = []
+        if not flag:
+            flag = []
         if source == 'running':
             cmd = 'show running-config '
         else:
             cmd = 'show startup-config '
 
-        cmd += ' '.join(to_list(filter))
+        cmd += ' '.join(to_list(flag))
         cmd = cmd.strip()
 
         return self.send_command(cmd)

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -131,7 +131,7 @@ class Cliconf(CliconfBase):
         diff['config_diff'] = dumps(configdiffobjs, 'commands') if configdiffobjs else ''
         return diff
 
-    def get_config(self, source='running', format='text', filter=None):
+    def get_config(self, source='running', format='text', flag=None):
         options_values = self.get_option_values()
         if format not in options_values['format']:
             raise ValueError("'format' value %s is invalid. Valid values are %s" % (format, ','.join(options_values['format'])))
@@ -144,8 +144,8 @@ class Cliconf(CliconfBase):
         if format and format is not 'text':
             cmd += '| %s ' % format
 
-        if filter:
-            cmd += ' '.join(to_list(filter))
+        if flag:
+            cmd += ' '.join(to_list(flag))
         cmd = cmd.strip()
 
         return self.send_command(cmd)

--- a/lib/ansible/plugins/cliconf/vyos.py
+++ b/lib/ansible/plugins/cliconf/vyos.py
@@ -54,7 +54,7 @@ class Cliconf(CliconfBase):
 
         return device_info
 
-    def get_config(self, filter=None, format=None):
+    def get_config(self, flag=None, format=None):
         if format:
             option_values = self.get_option_values()
             if format not in option_values['format']:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Change `filter` parameter to `flag` to be in sync
   with original naming convention
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
module_utils/network/eos/eos.py
module_utils/network/ios/ios.py
module_utils/network/nxos/nxos.py
plugins/cliconf/eos.py
plugins/cliconf/ios.py
plugins/cliconf/nxos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
