### PR TITLE
delegate_to: accept only string for delegation host

### DIFF
--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -36,7 +36,7 @@ from ansible.errors import AnsibleError, AnsibleParserError, AnsibleUndefinedVar
 from ansible.inventory.host import Host
 from ansible.inventory.helpers import sort_groups, get_group_vars
 from ansible.module_utils._text import to_native
-from ansible.module_utils.six import iteritems, text_type
+from ansible.module_utils.six import iteritems, text_type, string_types
 from ansible.plugins.loader import lookup_loader, vars_loader
 from ansible.plugins.cache import FactCache
 from ansible.template import Templar
@@ -530,6 +530,10 @@ class VariableManager:
             delegated_host_name = templar.template(task.delegate_to, fail_on_undefined=False)
             if delegated_host_name is None:
                 raise AnsibleError(message="Undefined delegate_to host for task:", obj=task._ds)
+            if not isinstance(delegated_host_name, string_types):
+                raise AnsibleError(message="the field 'delegate_to' has an invalid type (%s), and could not be"
+                                           " converted to a string type." % type(delegated_host_name),
+                                   obj=task._ds)
             if delegated_host_name in delegated_host_vars:
                 # no need to repeat ourselves, as the delegate_to value
                 # does not appear to be tied to the loop item variable


### PR DESCRIPTION
##### SUMMARY
delegate_to parameter in task only accepts string,
this fix will error out if other datatypes are provided instead of
string.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/vars/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```