### PR TITLE
Add specific exceptions to except in template/__init__.py

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -86,7 +86,7 @@ def generate_ansible_template_vars(path):
     b_path = to_bytes(path)
     try:
         template_uid = pwd.getpwuid(os.stat(b_path).st_uid).pw_name
-    except:
+    except (KeyError, TypeError):
         template_uid = os.stat(b_path).st_uid
 
     temp_vars = {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR specifies exceptions that can be raised by `pwd.getpwuid`.  
A quick test shows that `getpwuid` raises `TypeError` and `KeyError`.

```
Python 3.6.6 (default, Jun 27 2018, 13:11:40) 
[GCC 8.1.1 20180531] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pwd
>>> pwd.getpwuid()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: getpwuid() takes exactly one argument (0 given)
>>> pwd.getpwuid('')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: uid should be integer, not str
>>> pwd.getpwuid(10000)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyError: 'getpwuid(): uid not found: 10000'
>>> 
```

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
template
