### PR TITLE
VMware: new module: vmware_guest_custom_attribute_def_facts

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attribute_def_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attribute_def_facts.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Ansible Project
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+
+DOCUMENTATION = '''
+---
+module: vmware_guest_custom_attribute_def_facts
+short_description: Gather facts about custom attributes definitions
+description:
+    - This module can be used to gather facts about custom attributes definitions.
+version_added: 2.7
+author:
+    - Jimmy Conner
+    - Abhijeet Kasurde (@Akasurde)
+notes:
+    - Tested on vSphere 6.5
+requirements:
+    - "python >= 2.6"
+    - PyVmomi
+extends_documentation_fragment: vmware.documentation
+'''
+
+EXAMPLES = '''
+- name: List VMWare Attribute Definitions
+  vmware_guest_custom_attribute_def_facts:
+    hostname: "{{ vcenter_server }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+  delegate_to: localhost
+  register: defs
+'''
+
+RETURN = """
+custom_attribute_def_facts:
+    description: list of all current attribute definitions
+    returned: always
+    type: list
+    sample: ["sample_5", "sample_4"]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+
+class VmAttributeDefFactManager(PyVmomi):
+    def __init__(self, module):
+        super(VmAttributeDefFactManager, self).__init__(module)
+        self.custom_field_mgr = self.content.customFieldsManager.field
+
+    def gather_def_facts(self):
+        return {
+            'changed': False,
+            'failed': False,
+            'custom_attribute_def_facts': [x.name for x in self.custom_field_mgr]
+        }
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    pyv = VmAttributeDefFactManager(module)
+    results = pyv.gather_def_facts()
+    module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/vmware_guest_custom_attribute_def_facts/aliases
+++ b/test/integration/targets/vmware_guest_custom_attribute_def_facts/aliases
@@ -1,0 +1,2 @@
+cloud/vcenter
+unsupported

--- a/test/integration/targets/vmware_guest_custom_attribute_def_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_custom_attribute_def_facts/tasks/main.yml
@@ -1,0 +1,59 @@
+# Test code for the vmware_guest_custom_attribute_def_facts module.
+# Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+
+- debug: var=vcsim
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+
+- name: start vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for vcsim server to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: list custom attributes definition
+  vmware_guest_custom_attribute_def_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    validate_certs: no
+  register: list_attrib_def
+
+- debug: var=list_attrib_def
+
+- assert:
+    that:
+      - list_attrib_def.custom_attribute_def_facts is defined
+
+- name: list custom attributes definition in check mode
+  vmware_guest_custom_attribute_def_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    validate_certs: no
+  check_mode: yes
+  register: list_attrib_def
+
+- debug: var=list_attrib_def
+
+- assert:
+    that:
+      - list_attrib_def.custom_attribute_def_facts is defined


### PR DESCRIPTION
##### SUMMARY
This module adds functionality to gather facts about custom attribute definition

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest_custom_attribute_def_facts.py
test/integration/targets/vmware_guest_custom_attribute_def_facts/aliases
test/integration/targets/vmware_guest_custom_attribute_def_facts/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```