### PR TITLE
win_chocolatey: fix regression around using all as a package name

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -294,12 +294,6 @@ Function Get-ChocolateyPackageVersion {
         [Parameter(Mandatory=$true)][String]$choco_path,
         [Parameter(Mandatory=$true)][String]$name
     )
-    # returns the package version or null if it isn't installed
-    # all is a special case where we want to say it isn't installed, in choco
-    # it means runs on all the packages installed
-    if ($name -eq "all") {
-        return $null
-    }
 
     $command = Argv-ToString -arguments @($choco_path, "list", "--local-only", "--exact", "--limit-output", $name)
     $res = Run-Command -command $command
@@ -501,7 +495,16 @@ $choco_path = Install-Chocolatey -proxy_url $proxy_url -proxy_username $proxy_us
 # get the version of all specified packages
 $package_info = @{}
 foreach ($package in $name) {
-    $package_version = Get-ChocolateyPackageVersion -choco_path $choco_path -name $package
+    # all is a special package name that means all installed packages, we set
+    # a dummy version so absent, latest, and downgrade will run with all
+    if ($package -eq "all") {
+        if ($state -in @("present", "reinstalled")) {
+            Fail-Json -obj $result -message "Cannot specify the package name as 'all' when state=$state"
+        }
+        $package_version = "0.0.0"
+    } else {
+        $package_version = Get-ChocolateyPackageVersion -choco_path $choco_path -name $package
+    }
     $package_info.$package = $package_version
 }
 
@@ -535,7 +538,7 @@ if ($state -in @("downgrade", "latest", "present", "reinstalled")) {
         foreach ($package in $name) {
             $package_version = ($package_info.GetEnumerator() | Where-Object { $name -eq $_.Key -and $null -ne $_.Value }).Value
             if ($null -ne $package_version -and $package_version -ne $version) {
-                Fail-Json -obj $result -message "Chocolatey package '$package' is already installed at version '$package_version' but was expecting '$version'. Either change the expected version, set state=latest, set allow_multiple_versions=yes, or set force=yes to continue"
+                Fail-Json -obj $result -message "Chocolatey package '$package' is already installed at version '$package_version' but was expecting '$version'. Either change the expected version, set state=latest, or set force=yes to continue"
             }
         }
     }

--- a/test/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/test/integration/targets/win_chocolatey/tasks/tests.yml
@@ -1,4 +1,18 @@
 ---
+- name: raise failure when state=present and name=all
+  win_chocolatey:
+    name: all
+    state: present
+  register: fail_all_present
+  failed_when: fail_all_present.msg != "Cannot specify the package name as 'all' when state=present"
+
+- name: raise failure when state=reinstalled and name=all
+  win_chocolatey:
+    name: all
+    state: reinstalled
+  register: fail_all_reinstalled
+  failed_when: fail_all_reinstalled.msg != "Cannot specify the package name as 'all' when state=reinstalled"
+
 - name: install package (check mode)
   win_chocolatey:
     name: '{{ test_choco_package1 }}'
@@ -256,7 +270,7 @@
     state: present
     version: 0.1.0
   register: fail_multiple_versions
-  failed_when: fail_multiple_versions.msg != "Chocolatey package '" + test_choco_package1 + "' is already installed at version '0.0.1' but was expecting '0.1.0'. Either change the expected version, set state=latest, set allow_multiple_versions=yes, or set force=yes to continue"
+  failed_when: fail_multiple_versions.msg != "Chocolatey package '" + test_choco_package1 + "' is already installed at version '0.0.1' but was expecting '0.1.0'. Either change the expected version, set state=latest, or set force=yes to continue"
 
 - name: force the upgrade of an existing version
   win_chocolatey:
@@ -414,3 +428,25 @@
     that:
     - install_prerelease is changed
     - install_prerelease_actual.stdout_lines == [test_choco_package2 + "|1.0.1-beta1"]
+
+- name: downgrade package
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: downgrade
+    version: 0.0.1
+
+- name: upgrade all packages
+  win_chocolatey:
+    name: all
+    state: latest
+  register: all_latest
+
+- name: get result of upgrade all packages
+  win_command: choco.exe list --local-only --limit-output --exact {{ test_choco_package1|quote }}
+  register: all_latest_actual
+
+- name: assert upgrade all packages
+  assert:
+    that:
+    - all_latest is changed
+    - all_latest_actual.stdout_lines == [test_choco_package1 + "|0.1.0"]


### PR DESCRIPTION
##### SUMMARY
Recently win_chocolatey had a big refactor, unfortunately it broke the ability to specify `name: all` with `state: latest` to upgrade all packages. This PR brings back that ability and adds in a test to make sure it doesn't regress again in the future.

Fixes https://github.com/ansible/ansible/issues/43381

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_chocolatey

##### ANSIBLE VERSION
```
devel
```