### PR TITLE
modules/terraform: Quote the variable values in the command line

### DIFF
--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -145,7 +145,7 @@ import os
 import json
 import tempfile
 import traceback
-from six.moves import shlex_quote
+from ansible.module_utils.six.moves import shlex_quote
 
 from ansible.module_utils.basic import AnsibleModule
 

--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -145,6 +145,7 @@ import os
 import json
 import tempfile
 import traceback
+from six.moves import shlex_quote
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -296,7 +297,7 @@ def main():
     for k, v in variables.items():
         variables_args.extend([
             '-var',
-            '{0}={1}'.format(k, v)
+            shlex_quote('{0}={1}'.format(k, v))
         ])
     if variables_file:
         variables_args.extend(['-var-file', variables_file])


### PR DESCRIPTION

##### SUMMARY
The variables values are not quoted and it can result in an interpretation by the shell during command line execution.
Example of possible failure available in #43492

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
terraform.py

##### ANSIBLE VERSION

```
ansible 2.6.0
  config file = /Users/remirey/dev/grtgaz/avignon/ansible.cfg
  configured module search path = [u'/Users/remirey/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/remirey/.virtualenvs/avignon/lib/python2.7/site-packages/ansible
  executable location = /Users/remirey/.virtualenvs/avignon/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```

##### ADDITIONAL INFORMATION

Fixes: #43492
