### PR TITLE
Use dbus.exceptions of non-existent dbus.Exceptions

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -627,7 +627,7 @@ class Nmcli(object):
         try:
             proxy = bus.get_object(service_name, "/org/freedesktop/NetworkManager/Settings")
             settings = dbus.Interface(proxy, "org.freedesktop.NetworkManager.Settings")
-        except dbus.Exceptions.DBusException as e:
+        except dbus.exceptions.DBusException as e:
             self.module.fail_json(msg="Unable to read Network Manager settings from DBus system bus: %s" % to_native(e),
                                   details="Please check if NetworkManager is installed and"
                                           " service network-manager is started.")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

`dbus.Exceptions` does not exist, but `dbus.exceptions` does (see additional information).  
This is probably a typo.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
net_tools

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
$ python2
Python 2.7.15 (default, Jun 27 2018, 13:05:28) 
[GCC 8.1.1 20180531] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import dbus
>>> dbus.Exceptions.DBusException
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'Exceptions'
>>> dbus.exceptions.DBusException
<class 'dbus.exceptions.DBusException'>
>>> 
```

```
$ python3
Python 3.6.6 (default, Jun 27 2018, 13:11:40) 
[GCC 8.1.1 20180531] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import dbus
>>> dbus.Exceptions.DBusException
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'dbus' has no attribute 'Exceptions'
>>> dbus.exceptions.DBusException
<class 'dbus.exceptions.DBusException'>
>>>
```