### PR TITLE
Use socket.error instead of non-existent socket.Error

### DIFF
--- a/lib/ansible/module_utils/network/cnos/cnos.py
+++ b/lib/ansible/module_utils/network/cnos/cnos.py
@@ -3580,7 +3580,7 @@ def validateValueAgainstRule(ruleString, variableValue):
         try:
             socket.inet_pton(socket.AF_INET, variableValue)
             result = True
-        except socket.Error:
+        except socket.error:
             result = False
         if(result is True):
             return "ok"
@@ -3598,7 +3598,7 @@ def validateValueAgainstRule(ruleString, variableValue):
                 result = True
             else:
                 result = False
-        except socket.Error:
+        except socket.error:
             result = False
         if(result is True):
             return "ok"
@@ -3609,7 +3609,7 @@ def validateValueAgainstRule(ruleString, variableValue):
         try:
             socket.inet_pton(socket.AF_INET6, variableValue)
             result = True
-        except socket.Error:
+        except socket.error:
             result = False
         if(result is True):
             return "ok"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Use `socket.error` of non-existent `socket.Error`.

P.S. No offense, but someone should look into refactoring `lib/ansible/module_utils/network/cnos/cnos.py`. It is 3.5k lines of hard to read code that contains many pep8 violations. 

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
cnos

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ python2                                                                                 
Python 2.7.15 (default, Jun 27 2018, 13:05:28) 
[GCC 8.1.1 20180531] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import socket
>>> socket.error
<class 'socket.error'>
>>> socket.Error
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'Error'
>>>
```

```
$ python3                                                                                 
Python 3.6.6 (default, Jun 27 2018, 13:11:40) 
[GCC 8.1.1 20180531] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import socket
>>> socket.error
<class 'OSError'>
>>> socket.Error
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'socket' has no attribute 'Error'
>>>
```