### PR TITLE
Catch exceptions when importing plugins, and display an appropriate warning

### DIFF
--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -486,7 +486,10 @@ class PluginLoader:
                 continue
 
             if path not in self._module_cache:
-                module = self._load_module_source(name, path)
+                try:
+                    module = self._load_module_source(name, path)
+                except Exception as e:
+                    display.warning("Skipping plugin (%s) as it seems to be invalid: %s" % (path, to_text(e)))
                 self._module_cache[path] = module
                 found_in_cache = False
 


### PR DESCRIPTION
##### SUMMARY
Catch exceptions when importing plugins, and display an appropriate warning. Fixes #43237
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/loader.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
2.6
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```