### PR TITLE
Do not substitute ssh_executable until we need to

### DIFF
--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -70,7 +70,22 @@ class TestConnectionBaseClass(unittest.TestCase):
         pc = PlayContext()
         new_stdin = StringIO()
         conn = connection_loader.get('ssh', pc, new_stdin)
-        conn._build_command('ssh')
+        cmd = conn._build_command('ssh', ['sshcommand'])
+        self.assertEqual(cmd[0], b'ssh')
+        self.assertIn(b'sshcommand', cmd)
+
+    def test_plugins_connection_ssh__build_command_custom_exec(self):
+        pc = PlayContext()
+        pc.ssh_executable = 'mysshwrapper'
+        pc.ssh_extra_args = '--customarg value'
+        new_stdin = StringIO()
+        conn = connection_loader.get('ssh', pc, new_stdin)
+        cmd = conn._build_command('ssh', ['sshcommand', 'arg1', 'arg2'])
+        self.assertEqual(cmd[0], b'mysshwrapper')
+        self.assertIn(b'--customarg', cmd)
+        self.assertIn(b'sshcommand', cmd)
+        self.assertIn(b'arg1', cmd)
+        self.assertIn(b'arg2', cmd)
 
     def test_plugins_connection_ssh_exec_command(self):
         pc = PlayContext()


### PR DESCRIPTION
Do not substitute ssh_executable until we need to

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This is a re-application of the changes from https://github.com/ansible/ansible/pull/20950, since there appears to be a regression.

We need to use ssh_executable instead of hardcoding ssh in the command
we run but we need to use "ssh" when we lookup the value of the
{command}_extra_args variable.  Do this by leaving binary as "ssh" and
only expanding when we place it into b_command.

Fixes #43502

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
ssh

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mike/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
[1
```
