### PR TITLE
Fix actions and wait in os_server_action module

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -94,7 +94,7 @@ def _action_url(server_id):
 def _wait(timeout, cloud, server, action, module, sdk):
     """Wait for the server to reach the desired state for the given action."""
 
-    for count in sdk.utils._iterate_timeout(
+    for count in sdk.utils.iterate_timeout(
             timeout,
             "Timeout waiting for server to complete %s" % action):
         try:

--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -163,9 +163,9 @@ def main():
             if not _system_state_change(action, status):
                 module.exit_json(changed=False)
 
-                cloud.compute.post(
-                    _action_url(server.id),
-                    json={'os-start': None})
+            cloud.compute.post(
+                _action_url(server.id),
+                json={'os-start': None})
             if wait:
                 _wait(timeout, cloud, server, action, module, sdk)
                 module.exit_json(changed=True)
@@ -174,9 +174,9 @@ def main():
             if not _system_state_change(action, status):
                 module.exit_json(changed=False)
 
-                cloud.compute.post(
-                    _action_url(server.id),
-                    json={'pause': None})
+            cloud.compute.post(
+                _action_url(server.id),
+                json={'pause': None})
             if wait:
                 _wait(timeout, cloud, server, action, module, sdk)
                 module.exit_json(changed=True)
@@ -185,9 +185,9 @@ def main():
             if not _system_state_change(action, status):
                 module.exit_json(changed=False)
 
-                cloud.compute.post(
-                    _action_url(server.id),
-                    json={'unpause': None})
+            cloud.compute.post(
+                _action_url(server.id),
+                json={'unpause': None})
             if wait:
                 _wait(timeout, cloud, server, action, module, sdk)
             module.exit_json(changed=True)
@@ -210,9 +210,9 @@ def main():
             if not _system_state_change(action, status):
                 module.exit_json(changed=False)
 
-                cloud.compute.post(
-                    _action_url(server.id),
-                    json={'suspend': None})
+            cloud.compute.post(
+                _action_url(server.id),
+                json={'suspend': None})
             if wait:
                 _wait(timeout, cloud, server, action, module, sdk)
             module.exit_json(changed=True)
@@ -221,9 +221,9 @@ def main():
             if not _system_state_change(action, status):
                 module.exit_json(changed=False)
 
-                cloud.compute.post(
-                    _action_url(server.id),
-                    json={'resume': None})
+            cloud.compute.post(
+                _action_url(server.id),
+                json={'resume': None})
             if wait:
                 _wait(timeout, cloud, server, action, module, sdk)
             module.exit_json(changed=True)
@@ -235,9 +235,9 @@ def main():
                 module.fail_json(msg="Image does not exist")
 
             # rebuild doesn't set a state, just do it
-                cloud.compute.post(
-                    _action_url(server.id),
-                    json={'rebuild': None})
+            cloud.compute.post(
+                _action_url(server.id),
+                json={'rebuild': None})
             if wait:
                 _wait(timeout, cloud, server, action, module, sdk)
             module.exit_json(changed=True)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This pull request fixes the error `'module' object has no attribute '_iterate_timeout'` when executing module `os_server_action` with `wait: yes`. AFAIK the error was introduced with Ansible 2.6.x when switching from `shade` to `openstacksdk` ([this commit](https://github.com/ansible/ansible/commit/89ce826a9fb53c304238923a73667ab820711338#diff-78b6488d27c66bca465ffbe62f98ac03R97)) due to the latter requiring to call `utils.iterate_timeout()` instead of `utils._iterate_timeout()`.

Additionally, the pull request includes a fix for every `action` (excluding `stop` which works fine), caused by wrong indentations (AFAIK there is no issue for this at the moment; other OpenStack modules might be affected as well, I have not checked this as of now).

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #42408

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
os_server_action

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Dec 14 2017, 15:51:29) [GCC 6.4.0]
```

##### ADDITIONAL INFORMATION
For `_iterate_timeout` not found see: #42408 (with fix, the error message does not show up)

Regarding the `action` indentation fix, consider the following playbook:
```yaml
---
- name: "a play needs a name"
  gather_facts: no
  connection: local
  hosts: all
  tasks:
    - name: Shutdown instance
      os_server_action:
        action: stop
        auth: "{{ os_auth }}"
        server: "somehost01"
        timeout: 200
    - pause:
        seconds: 20
    - name: Start instance
      os_server_action:
        action: start
        auth: "{{ os_auth }}"
        server: "somehost01"
        timeout: 200
```

So what happens without the fix is that the `start` action does not happen, and it times out:
```
PLAY [a play needs a name] *************************************************************************************************************************************************************

TASK [Shutdown instance] ***************************************************************************************************************************************************************
changed: [somehost01]

TASK [pause] ***************************************************************************************************************************************************************************
Pausing for 20 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [somehost01]

TASK [Start instance] ******************************************************************************************************************************************************************
fatal: [somehost01]: FAILED! => {"changed": false, "extra_data": null, "msg": "Timeout waiting for server to complete start"}
 [WARNING]: Could not create retry file '/platform/stuff.retry'.         [Errno 30] Read-only file system: u'/platform/stuff.retry'


PLAY RECAP *****************************************************************************************************************************************************************************
somehost01      : ok=2    changed=1    unreachable=0    failed=1
```
OpenStack does not show start to happen:
![selection_041](https://user-images.githubusercontent.com/2979051/43514196-f234a3ea-957f-11e8-8118-39c1d4e3c653.png)



With fix:
```
PLAY [a play needs a name] *************************************************************************************************************************************************************

TASK [Shutdown instance] ***************************************************************************************************************************************************************
changed: [somehost01]

TASK [pause] ***************************************************************************************************************************************************************************
Pausing for 20 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
Press 'C' to continue the play or 'A' to abort
ok: [somehost01]

TASK [Start instance] ******************************************************************************************************************************************************************
changed: [somehost01]

PLAY RECAP *****************************************************************************************************************************************************************************
somehost01      : ok=3    changed=2    unreachable=0    failed=0
```

OpenStack shows start and stop actions:
![selection_040](https://user-images.githubusercontent.com/2979051/43513557-572ea3f6-957e-11e8-9e19-eedc690d83c4.png)
