### PR TITLE
Replace unescaped \r before sending through socket_path

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -209,6 +209,8 @@ def main():
                 raise Exception("EOF found before vars data was complete")
             vars_data += cur_line
             cur_line = stdin.readline()
+        # restore escaped loose \r characters
+        vars_data = vars_data.replace(br'\r', b'\r')
 
         if PY3:
             pc_data = cPickle.loads(init_data, encoding='bytes')

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -936,6 +936,8 @@ class TaskExecutor:
         stdin.write(b'\n#END_INIT#\n')
 
         src = cPickle.dumps(variables, protocol=0)
+        # remaining \r fail to round-trip the socket
+        src = src.replace(b'\r', br'\r')
         stdin.write(src)
         stdin.write(b'\n#END_VARS#\n')
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
`\r` does not round-trip the local socket, escape and restore on the other side

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
ansible-connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```
