### PR TITLE
CloudFormation: Allow failed changesets to gather stack_outputs

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -382,8 +382,10 @@ def create_changeset(module, stack_params, cfn, events_limit):
                 elif newcs['Status'] == 'FAILED' and "The submitted information didn't contain changes" in newcs['StatusReason']:
                     cfn.delete_change_set(ChangeSetName=cs['Id'])
                     result = dict(changed=False,
-                                  output='Stack is already up-to-date, Change Set refused to create due to lack of changes.')
-                    module.exit_json(**result)
+                                  output='The created Change Set did not contain any changes to this stack and was deleted.')
+                    # a failed change set does not trigger any stack events so we just want to
+                    # skip any further processing of result and just return it directly
+                    return result
                 else:
                     break
                 # Lets not hog the cpu/spam the AWS API


### PR DESCRIPTION
##### SUMMARY
The `module.exit_json()` call here subverts further processing of the result dictionary, particularly here: https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/amazon/cloudformation.py#L684-L703

This results in identical invocations of this module having variable return values (accessed through `register`) based on the state of managed resources -- if the stack already exists and the changeset results in no changes, the return value does not contain resources or outputs.

Attempt at fixing #43508 although there may be a cleaner way to do this.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudformation

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = /Users/robert.stmarie/projects/ansible/ansible.cfg
  configured module search path = [u'/Users/robert.stmarie/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/robert.stmarie/.pyenv/versions/2.7/lib/python2.7/site-packages/ansible
  executable location = /Users/robert.stmarie/.pyenv/versions/2.7/bin/ansible
  python version = 2.7 (r27:82500, Jun 12 2018, 19:06:32) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
