### PR TITLE
[WIP] Decouple display from config initialization

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -138,7 +138,7 @@ if __name__ == '__main__':
         display.error("User interrupted execution")
         exit_code = 99
     except Exception as e:
-        if C.DEFAULT_DEBUG:
+        if hasattr(C, 'DEFAULT_DEBUG') and C.DEFAULT_DEBUG:
             # Show raw stacktraces in debug mode, It also allow pdb to
             # enter post mortem mode.
             raise
@@ -158,6 +158,7 @@ if __name__ == '__main__':
         exit_code = 250
     finally:
         # Remove ansible tmpdir
-        shutil.rmtree(C.DEFAULT_LOCAL_TMP, True)
+        if hasattr(C, 'DEFAULT_LOCAL_TMP'):
+            shutil.rmtree(C.DEFAULT_LOCAL_TMP, True)
 
     sys.exit(exit_code)


### PR DESCRIPTION
This is an attempt to give ansible the ability to print out errors with
the config code.  It does succeed in decoupling display from config.
Unfortunately, the structure of config and cli currently means that you
have to load a bunch of other pieces of code which need config before
you get to process the code which could print out the config errors.
Since those fail without config, those cause the whole thing to break
down.

It could be worthwhile to continue in this vein, reorganizing the code
so that we can do all of our static loading (option parsing and config
loading) up front before moving on to the rest of the code which needs
to utilize config but before that happens I hope to move display() to
using a logging framework.  If that happens, we won't need this anyway.

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
utils/display.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.6 2.5
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
