### PR TITLE
ovirt: ovirt_hosts_facts: add all_content

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_hosts_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_hosts_facts.py
@@ -41,6 +41,12 @@ options:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search host X from datacenter Y use following pattern:
            name=X and datacenter=Y"
+    all_content:
+      description:
+        - "If I(true) all the attributes of the hosts should be
+           included in the response."
+      default: False
+      version_added: "2.7"
 extends_documentation_fragment: ovirt_facts
 '''
 
@@ -78,6 +84,7 @@ from ansible.module_utils.ovirt import (
 def main():
     argument_spec = ovirt_facts_full_argument_spec(
         pattern=dict(default='', required=False),
+        all_content=dict(default=False, type='bool'),
     )
     module = AnsibleModule(argument_spec)
     check_sdk(module)
@@ -86,7 +93,10 @@ def main():
         auth = module.params.pop('auth')
         connection = create_connection(auth)
         hosts_service = connection.system_service().hosts_service()
-        hosts = hosts_service.list(search=module.params['pattern'])
+        hosts = hosts_service.list(
+            search=module.params['pattern'],
+            all_content=module.params['all_content'],
+        )
         module.exit_json(
             changed=False,
             ansible_facts=dict(


### PR DESCRIPTION
Add all_content parameter also to ovirt_hosts_facts to fetch the complete list of of details.

##### SUMMARY
Add all_content parameter also to ovirt_hosts_facts to fetch the complete list of of details.
Fixes #43524

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
ovirt_hosts_facts

##### ANSIBLE VERSION
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/stirabos/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
