### PR TITLE
improves pam_limits documentation

### DIFF
--- a/lib/ansible/modules/system/pam_limits.py
+++ b/lib/ansible/modules/system/pam_limits.py
@@ -20,8 +20,9 @@ author:
     - "Sebastien Rohaut (@usawa)"
 short_description: Modify Linux PAM limits
 description:
-     - The C(pam_limits) module modify PAM limits, default in /etc/security/limits.conf.
-       For the full documentation, see man limits.conf(5).
+     - The C(pam_limits) module modifies PAM limits. The default file is
+       C(/etc/security/limits.conf). For the full documentation, see C(man 5
+       limits.conf).
 options:
   domain:
     description:
@@ -29,7 +30,7 @@ options:
     required: true
   limit_type:
     description:
-      - Limit type, see C(man limits) for an explanation
+      - Limit type, see C(man 5 limits.conf) for an explanation
     required: true
     choices: [ "hard", "soft", "-" ]
   limit_item:
@@ -94,7 +95,7 @@ options:
     required: false
     default: ''
 notes:
-  - If dest file doesn't exists, it is created.
+  - If C(dest) file doesn't exist, it is created.
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds some slight fixes and improvements to the documentation of the `pam_limits` module.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
pam_limits

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.6 (default, Jun 27 2018, 13:11:40) [GCC 8.1.1 20180531]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

- the man page is actually `limits.conf`, not `limits`, I checked this on CentOS 6, CentOS 7, RHEL 7 and Arch Linux
- uses code highlighting for these
