### PR TITLE
Removing required from documentaion of name parameter

### DIFF
--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -25,6 +25,7 @@ options:
     description:
       - name of the guest VM being managed. Note that VM must be previously
         defined with xml.
+      - This option is required unless I(command) is C(list_vms).
   state:
     description:
       - Note that there may be some lag for state requests like C(shutdown)

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -25,7 +25,6 @@ options:
     description:
       - name of the guest VM being managed. Note that VM must be previously
         defined with xml.
-    required: true
   state:
     description:
       - Note that there may be some lag for state requests like C(shutdown)


### PR DESCRIPTION
##### SUMMARY
Name parameter is not required when using virt module. In some cases like described below you do not need to specify name:

```
- name: Get list of vms
  virt:
    command: list_vms
  register: virt_vms
```

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
virt module
