### PR TITLE
Issue #40425 fix: create 1&1 server (cloud/oneandone/oneandone_server)

### DIFF
--- a/lib/ansible/modules/cloud/oneandone/oneandone_server.py
+++ b/lib/ansible/modules/cloud/oneandone/oneandone_server.py
@@ -401,12 +401,16 @@ def create_server(module, oneandone_conn):
             module.fail_json(
                 msg='load balancer %s not found.' % load_balancer)
 
+    hostnames = []
+    descriptions = []
     if auto_increment:
         hostnames = _auto_increment_hostname(count, hostname)
-        descriptions = _auto_increment_description(count, description)
+        if description:
+            descriptions = _auto_increment_description(count, description)
     else:
         hostnames = [hostname] * count
-        descriptions = [description] * count
+        if description:
+            descriptions = [description] * count
 
     hdd_objs = []
     if hdds:
@@ -418,11 +422,16 @@ def create_server(module, oneandone_conn):
 
     servers = []
     for index, name in enumerate(hostnames):
+        desc = None
+
+        if descriptions:
+            desc = descriptions[index]
+
         server = _create_server(
             module=module,
             oneandone_conn=oneandone_conn,
             hostname=name,
-            description=descriptions[index],
+            description=desc,
             fixed_instance_size_id=fixed_instance_size_id,
             vcore=vcore,
             cores_per_processor=cores_per_processor,


### PR DESCRIPTION
##### SUMMARY
Fixes #40425.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
oneandone_server cloud module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (oneandone_issue40425_fix 35d95eb377) last updated 2018/08/01 15:32:36 (GMT +200)
python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
Below is the output from one of the test playbooks utilizing the oneandone_server module
```
PLAY [localhost] ***********************************************************************

TASK [Gathering Facts] *************************************************************
ok: [localhost]

TASK [Server should be created] *************************************************
changed: [localhost]

PLAY RECAP *************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0   

```
