### PR TITLE
Fix add member failure in ios_linkagg

### DIFF
--- a/lib/ansible/modules/network/ios/ios_linkagg.py
+++ b/lib/ansible/modules/network/ios/ios_linkagg.py
@@ -130,7 +130,7 @@ def map_obj_to_commands(updates, module):
 
         elif state == 'present':
             cmd = ['interface port-channel {0}'.format(group),
-                   'end']
+                   'exit']
             if not obj_in_have:
                 if not group:
                     module.fail_json(msg='group is a required option')


### PR DESCRIPTION
##### SUMMARY
- Fixes #42503 
- Fix not needed in devel as iOS cliconf will filter 'end' command in devel

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ios_linkagg.py

##### ANSIBLE VERSION
```
stable-2.6
```
