### PR TITLE
Deprecate dest with uri module. get_url should be used instead

### DIFF
--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -30,6 +30,8 @@ options:
     description:
       - A path of where to download the file to (if desired). If I(dest) is a
         directory, the basename of the file on the remote server will be used.
+        This argument is deprecated and will be removed in version 2.11. Please
+        use the M(get_url) module instead.
   user:
     description:
       - A username for the module to use for Digest, Basic or WSSE authentication.

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -495,6 +495,10 @@ def main():
 
     dict_headers = module.params['headers']
 
+    if dest:
+        module.deprecate('Supplying "dest" with the "uri" module is deprecated. Please use "get_url" instead',
+                         version=2.11)
+
     if body_format == 'json':
         # Encode the body unless its a string, then assume it is pre-formatted JSON
         if not isinstance(body, string_types):


### PR DESCRIPTION
##### SUMMARY
Deprecate dest with uri module. get_url should be used instead

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/net_tools/basic/uri.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```