### PR TITLE
Feature: Support 1&1 Firewall policy updates made to the 1&1 Cloud Server API (cloud/oneandone/oneandone_firewall_policy)

### DIFF
--- a/lib/ansible/module_utils/oneandone.py
+++ b/lib/ansible/module_utils/oneandone.py
@@ -204,6 +204,41 @@ def get_public_ip(oneandone_conn, public_ip, full_object=False):
             return _public_ip['id']
 
 
+def populate_firewall_rules(oneandone, rules):
+    """
+    Returns a list of firewall policy rule objects
+    """
+    firewall_rules = []
+    pf = None
+    pt = None
+    port = None
+    action = None
+    description = None
+
+    for rule in rules:
+        if 'port_from' in rule:
+            pf = rule['port_from']
+        if 'port_to' in rule:
+            pt = rule['port_to']
+        if 'port' in rule:
+            port = rule['port']
+        if 'action' in rule:
+            action = rule['action']
+        if 'description' in rule:
+            description = rule['description']
+        firewall_rule = oneandone.client.FirewallPolicyRule(
+            protocol=rule['protocol'],
+            port_from=pf,
+            port_to=pt,
+            port=port,
+            action=action,
+            description=description,
+            source=rule['source'])
+        firewall_rules.append(firewall_rule)
+
+    return firewall_rules
+
+
 def wait_for_resource_creation_completion(oneandone_conn,
                                           resource_type,
                                           resource_id,


### PR DESCRIPTION
##### SUMMARY
Updates were made to accommodate the firewall policy updates made to the 1&1 Cloud Server API in the [1.10 release](https://cloudpanel-api.1and1.com/documentation/v1/en/api/change_log.html).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
oneandone_firewall_policy cloud module
oneandone module_util

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (oneandone_firewall_updates 5caab0c531) last updated 2018/08/01 16:48:51 (GMT +200)
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
Below is the output from one of the test playbooks utilizing the new feature:
```
PLAY [localhost] **************************************************************

TASK [Gathering Facts] ****************************************************
ok: [localhost]

TASK [Create a firewall policy] ********************************************
changed: [localhost]

PLAY RECAP *****************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0   

```
