### PR TITLE
Fix typo in cliconf get_config

### DIFF
--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -165,7 +165,7 @@ class CliconfBase(AnsiblePlugin):
         self.response_logging = False
 
     @abstractmethod
-    def get_config(self, source='running', flag=None, format=None):
+    def get_config(self, source='running', flags=None, format=None):
         """Retrieves the specified configuration from the device
 
         This method will retrieve the configuration specified by source and

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -75,7 +75,7 @@ class Cliconf(CliconfBase):
         return resp
 
     @enable_mode
-    def get_config(self, source='running', format='text', flag=None):
+    def get_config(self, source='running', format='text', flags=None):
         options_values = self.get_option_values()
         if format not in options_values['format']:
             raise ValueError("'format' value %s is invalid. Valid values are %s" % (format, ','.join(options_values['format'])))
@@ -88,7 +88,7 @@ class Cliconf(CliconfBase):
         if format and format is not 'text':
             cmd += '| %s ' % format
 
-        cmd += ' '.join(to_list(flag))
+        cmd += ' '.join(to_list(flags))
         cmd = cmd.strip()
         return self.send_command(cmd)
 

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -37,21 +37,21 @@ from ansible.plugins.cliconf import CliconfBase, enable_mode
 class Cliconf(CliconfBase):
 
     @enable_mode
-    def get_config(self, source='running', flag=None, format=None):
+    def get_config(self, source='running', flags=None, format=None):
         if source not in ('running', 'startup'):
             return self.invalid_params("fetching configuration from %s is not supported" % source)
 
         if format:
             raise ValueError("'format' value %s is not supported for get_config" % format)
 
-        if not flag:
-            flag = []
+        if not flags:
+            flags = []
         if source == 'running':
             cmd = 'show running-config '
         else:
             cmd = 'show startup-config '
 
-        cmd += ' '.join(to_list(flag))
+        cmd += ' '.join(to_list(flags))
         cmd = cmd.strip()
 
         return self.send_command(cmd)

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -131,7 +131,7 @@ class Cliconf(CliconfBase):
         diff['config_diff'] = dumps(configdiffobjs, 'commands') if configdiffobjs else ''
         return diff
 
-    def get_config(self, source='running', format='text', flag=None):
+    def get_config(self, source='running', format='text', flags=None):
         options_values = self.get_option_values()
         if format not in options_values['format']:
             raise ValueError("'format' value %s is invalid. Valid values are %s" % (format, ','.join(options_values['format'])))
@@ -144,8 +144,8 @@ class Cliconf(CliconfBase):
         if format and format is not 'text':
             cmd += '| %s ' % format
 
-        if flag:
-            cmd += ' '.join(to_list(flag))
+        if flags:
+            cmd += ' '.join(to_list(flags))
         cmd = cmd.strip()
 
         return self.send_command(cmd)

--- a/lib/ansible/plugins/cliconf/vyos.py
+++ b/lib/ansible/plugins/cliconf/vyos.py
@@ -54,7 +54,7 @@ class Cliconf(CliconfBase):
 
         return device_info
 
-    def get_config(self, flag=None, format=None):
+    def get_config(self, flags=None, format=None):
         if format:
             option_values = self.get_option_values()
             if format not in option_values['format']:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix typo in cliconf get_config. Change parameter `flag to `flags`
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
plugins/cliconf/eos.py
plugins/cliconf/ios.py
plugins/cliconf/nxos.py
plugins/cliconf/vyos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
