### PR TITLE
Support unix socket with urls/uri

### DIFF
--- a/changelogs/fragments/uri-unix-socket.yml
+++ b/changelogs/fragments/uri-unix-socket.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- uri/urls - Support unix domain sockets (https://github.com/ansible/ansible/pull/43560)

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -428,7 +428,7 @@ class UnixHTTPSConnection(httplib.HTTPSConnection):
             super(UnixHTTPSConnection, self).connect()
 
     def __call__(self, *args, **kwargs):
-        super(UnixHTTPSConnection, self).__init__(*args, **kwargs)
+        httplib.HTTPSConnection.__init__(self, *args, **kwargs)
         return self
 
 

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -425,7 +425,7 @@ class UnixHTTPConnection(httplib.HTTPConnection):
         try:
             self.sock.connect(self._unix_socket)
         except OSError as e:
-            raise OSError('Invalid Socket File (%s): %s' % (unix_socket, e))
+            raise OSError('Invalid Socket File (%s): %s' % (self._unix_socket, e))
         if self.timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
             self.sock.settimeout(self.timeout)
 

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1015,6 +1015,8 @@ class Request:
         :kwarg cookies: (optional) CookieJar object to send with the
             request
         :kwarg use_gssapi: (optional) Use GSSAPI handler of requests.
+        :kwarg unix_socket: (optional) String of file system path to unix socket file to use when establishing
+        connection to the provided url
         :returns: HTTPResponse
         """
 
@@ -1312,6 +1314,8 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     :kwarg last_mod_time: Default: None
     :kwarg int timeout:   Default: 10
     :kwarg boolean use_gssapi:   Default: False
+    :kwarg unix_socket: (optional) String of file system path to unix socket file to use when establishing
+    connection to the provided url
 
     :returns: A tuple of (**response**, **info**). Use ``response.read()`` to read the data.
         The **info** contains the 'status' and other meta data. When a HttpError (status > 400)

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -71,7 +71,7 @@ except ImportError:
 urllib_request.HTTPRedirectHandler.http_error_308 = urllib_request.HTTPRedirectHandler.http_error_307
 
 try:
-    from ansible.module_utils.six.moves.urllib.parse import urlparse, urlunparse, urlsplit
+    from ansible.module_utils.six.moves.urllib.parse import urlparse, urlunparse
     HAS_URLPARSE = True
 except Exception:
     HAS_URLPARSE = False

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -991,7 +991,11 @@ class Request:
         cookies = self._fallback(cookies, self.cookies)
         unix_socket = self._fallback(unix_socket, self.unix_socket)
 
-        handlers = [UnixHTTPHandler(unix_socket)]
+        handlers = []
+
+        if unix_socket:
+            handlers.append(UnixHTTPHandler(unix_socket))
+
         ssl_handler = maybe_add_ssl_handler(url, validate_certs)
         if ssl_handler:
             handlers.append(ssl_handler)

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -170,7 +170,7 @@ options:
       - If C(no), it will not use a proxy, even if one is defined in an environment variable on the target hosts.
     type: bool
     default: yes
-    unix_socket:
+  unix_socket:
     description:
     - Path to Unix domain socket to use for connection
     version_added: '2.8'

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -460,7 +460,7 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout):
             _, redir_info = fetch_url(module, url, data=body,
                                       headers=headers,
                                       method=method,
-                                      timeout=socket_timeout)
+                                      timeout=socket_timeout, unix_socket=module.params['unix_socket'])
             # if we are redirected, update the url with the location header,
             # and update dest with the new url filename
             if redir_info['status'] in (301, 302, 303, 307):
@@ -475,7 +475,8 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout):
         module.params['follow_redirects'] = follow_redirects
 
     resp, info = fetch_url(module, url, data=data, headers=headers,
-                           method=method, timeout=socket_timeout, **kwargs)
+                           method=method, timeout=socket_timeout, unix_socket=module.params['unix_socket'],
+                           **kwargs)
 
     try:
         content = resp.read()
@@ -515,6 +516,7 @@ def main():
         status_code=dict(type='list', default=[200]),
         timeout=dict(type='int', default=30),
         headers=dict(type='dict', default={}),
+        unix_socket=dict(),
     )
 
     module = AnsibleModule(
@@ -535,6 +537,7 @@ def main():
     removes = module.params['removes']
     status_code = [int(x) for x in list(module.params['status_code'])]
     socket_timeout = module.params['timeout']
+    unix_socket = module.params['unix_socket']
 
     dict_headers = module.params['headers']
 

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -170,6 +170,10 @@ options:
       - If C(no), it will not use a proxy, even if one is defined in an environment variable on the target hosts.
     type: bool
     default: yes
+    unix_socket:
+    description:
+    - Path to Unix domain socket to use for connection
+    version_added: '2.8'
 notes:
   - The dependency on httplib2 was removed in Ansible 2.1.
   - The module returns all the HTTP headers in lower-case.
@@ -516,7 +520,7 @@ def main():
         status_code=dict(type='list', default=[200]),
         timeout=dict(type='int', default=30),
         headers=dict(type='dict', default={}),
-        unix_socket=dict(),
+        unix_socket=dict(type='path'),
     )
 
     module = AnsibleModule(

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -537,7 +537,6 @@ def main():
     removes = module.params['removes']
     status_code = [int(x) for x in list(module.params['status_code'])]
     socket_timeout = module.params['timeout']
-    unix_socket = module.params['unix_socket']
 
     dict_headers = module.params['headers']
 

--- a/test/units/module_utils/urls/test_Request.py
+++ b/test/units/module_utils/urls/test_Request.py
@@ -137,7 +137,7 @@ def test_Request_open_unix_socket(urlopen_mock, install_opener_mock):
 
     found_handlers = []
     for handler in handlers:
-        if isinstance(handler, UnixHTTPHandler:
+        if isinstance(handler, UnixHTTPHandler):
             found_handlers.append(handler)
 
     assert len(found_handlers) == 1

--- a/test/units/module_utils/urls/test_Request.py
+++ b/test/units/module_utils/urls/test_Request.py
@@ -417,4 +417,5 @@ def test_open_url(urlopen_mock, install_opener_mock, mocker):
                                      force=False, last_mod_time=None, timeout=10, validate_certs=True,
                                      url_username=None, url_password=None, http_agent=None,
                                      force_basic_auth=False, follow_redirects='urllib2',
-                                     client_cert=None, client_key=None, cookies=None, use_gssapi=False)
+                                     client_cert=None, client_key=None, cookies=None, use_gssapi=False,
+                                     unix_socket=None)

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -67,7 +67,7 @@ def test_fetch_url(open_url_mock, fake_ansible_module):
     open_url_mock.assert_called_once_with('http://ansible.com/', client_cert=None, client_key=None, cookies=kwargs['cookies'], data=None,
                                           follow_redirects='urllib2', force=False, force_basic_auth='', headers=None,
                                           http_agent='ansible-httpget', last_mod_time=None, method=None, timeout=10, url_password='', url_username='',
-                                          use_proxy=True, validate_certs=True, use_gssapi=False)
+                                          use_proxy=True, validate_certs=True, use_gssapi=False, unix_socket=None)
 
 
 def test_fetch_url_params(open_url_mock, fake_ansible_module):
@@ -89,7 +89,7 @@ def test_fetch_url_params(open_url_mock, fake_ansible_module):
     open_url_mock.assert_called_once_with('http://ansible.com/', client_cert='client.pem', client_key='client.key', cookies=kwargs['cookies'], data=None,
                                           follow_redirects='all', force=False, force_basic_auth=True, headers=None,
                                           http_agent='ansible-test', last_mod_time=None, method=None, timeout=10, url_password='passwd', url_username='user',
-                                          use_proxy=True, validate_certs=False, use_gssapi=False)
+                                          use_proxy=True, validate_certs=False, use_gssapi=False, unix_socket=None)
 
 
 def test_fetch_url_cookies(mocker, fake_ansible_module):

--- a/test/units/module_utils/urls/test_urls.py
+++ b/test/units/module_utils/urls/test_urls.py
@@ -91,9 +91,9 @@ def test_ParseResultDottedDict():
     assert dotted_parts.as_list() == list(parts)
 
 
-def test_disable_httpconnection_connect():
+def test_unix_socket_patch_httpconnection_connect(mocker):
+    unix_conn = mocker.patch.object(urls.UnixHTTPConnection, 'connect')
     conn = urls.httplib.HTTPConnection('ansible.com')
-    assert conn.sock is None
-    with urls.disable_httpconnection_connect():
+    with urls.unix_socket_patch_httpconnection_connect():
         conn.connect()
-    assert conn.sock is None
+    assert unix_conn.call_count == 1

--- a/test/units/module_utils/urls/test_urls.py
+++ b/test/units/module_utils/urls/test_urls.py
@@ -89,3 +89,11 @@ def test_ParseResultDottedDict():
     assert parts[0] == dotted_parts.scheme
 
     assert dotted_parts.as_list() == list(parts)
+
+
+def test_disable_httpconnection_connect():
+    conn = urls.httplib.HTTPConnection('ansible.com')
+    assert conn.sock is None
+    with urls.disable_httpconnection_connect():
+        conn.connect()
+    assert conn.sock is None


### PR DESCRIPTION
##### SUMMARY

Support unix socket with urls/uri. See #42341

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/urls.py
lib/ansible/modules/net_tools/basic/uri.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
```
$ ansible localhost -m uri -a 'url=http://localhost/ unix_socket=/Users/matt/projects/flask/get.sock'
localhost | SUCCESS => {
    "changed": false,
    "connection": "close",
    "content_length": "2",
    "content_type": "text/html; charset=utf-8",
    "cookies": {},
    "cookies_string": "",
    "date": "Wed, 01 Aug 2018 18:11:07 GMT",
    "msg": "OK (2 bytes)",
    "redirected": false,
    "server": "gunicorn/19.9.0",
    "status": 200,
    "url": "http://localhost/"
}
```