### PR TITLE
Add some requirements to the plugin docstrings.

### DIFF
--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -8,6 +8,9 @@ DOCUMENTATION = '''
     name: aws_ec2
     plugin_type: inventory
     short_description: ec2 inventory source
+    requirements:
+        - boto3
+        - botocore
     extends_documentation_fragment:
         - inventory_cache
         - constructed

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -10,6 +10,8 @@ DOCUMENTATION = '''
     plugin_type: inventory
     short_description: foreman inventory source
     version_added: "2.6"
+    requirements:
+        - requests >= 1.1
     description:
         - Get inventory hosts from the foreman service.
         - "Uses a configuration file as an inventory source, it must end in foreman.yml or foreman.yaml and has a ``plugin: foreman`` entry."

--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -15,6 +15,8 @@ DOCUMENTATION = '''
       - Marco Vito Moscaritolo <marco@agavee.com>
       - Jesse Keating <jesse.keating@rackspace.com>
     short_description: OpenStack inventory source
+    requirements:
+        - openstacksdk
     description:
         - Get inventory hosts from OpenStack clouds
         - Uses openstack.(yml|yaml) YAML configuration file to configure the inventory plugin


### PR DESCRIPTION
##### SUMMARY

Inventory plugins generally have requirements. Not all of the current ones listed them in their documentation.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/openstack.py
plugins/inventory/aws_ec2.py
plugins/inventory/foreman.py

##### ANSIBLE VERSION
```
f968fcd288dc5b320b68b0dbf627acc79d5bd5ad from git
```
##### ADDITIONAL INFORMATION
