### PR TITLE
Gather operating system name and use it set ansible_connection: winrm…

### DIFF
--- a/contrib/inventory/cloudforms.py
+++ b/contrib/inventory/cloudforms.py
@@ -277,7 +277,8 @@ class CloudFormsInventory(object):
 
         while not last_page:
             offset = page * limit
-            ret = self._get_json("%s/api/vms?offset=%s&limit=%s&expand=resources,tags,hosts,&attributes=ipaddresses,operating_system.product_name" % (self.cloudforms_url, offset, limit))
+            ret = self._get_json("%s/api/vms?offset=%s&limit=%s&expand=resources,tags,hosts,&attributes=ipaddresses,operating_system.product_name" 
+                   % (self.cloudforms_url, offset, limit))
             results += ret['resources']
             if ret['subcount'] < limit:
                 last_page = True

--- a/contrib/inventory/cloudforms.py
+++ b/contrib/inventory/cloudforms.py
@@ -277,8 +277,8 @@ class CloudFormsInventory(object):
 
         while not last_page:
             offset = page * limit
-            ret = self._get_json("%s/api/vms?offset=%s&limit=%s&expand=resources,tags,hosts,&attributes=ipaddresses,operating_system.product_name" 
-                   % (self.cloudforms_url, offset, limit))
+            ret = self._get_json("%s/api/vms?offset=%s&limit=%s&expand=resources,tags,hosts,&attributes=ipaddresses,operating_system.product_name"
+                                 % (self.cloudforms_url, offset, limit))
             results += ret['resources']
             if ret['subcount'] < limit:
                 last_page = True

--- a/contrib/inventory/cloudforms.py
+++ b/contrib/inventory/cloudforms.py
@@ -77,7 +77,7 @@ class CloudFormsInventory(object):
 
                 if 'ansible_connection' in self.hosts[hostname]:
                     self.inventory['_meta']['hostvars'][hostname]['ansible_connection'] = self.hosts[hostname]['ansible_connection']
-                    
+
             data_to_print += self.json_format_dict(self.inventory, self.args.pretty)
 
         print(data_to_print)


### PR DESCRIPTION
… if Windows flavor

##### SUMMARY
Gather information about host operating system so that ansible_connection is set to winrm when OS is Microsoft Windows variant.


##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
contrib/inventory/cloudforms.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul  3 2018, 16:01:59) [GCC 4.8.5 20150623 (SuSE 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
