### PR TITLE
underscore not dash for links

### DIFF
--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -41,7 +41,7 @@ Release status
 Ansible Release   Latest Version               Status
 ===============   ==========================   =================================================
 devel             2.7 (unreleased, trunk)      In development
-`2.6`-            2.6.1 (2018-07-05)           Supported (security **and** general bug fixes)
+`2.6`_            2.6.1 (2018-07-05)           Supported (security **and** general bug fixes)
 `2.5`_            2.5.6 (2018-07-05)           Supported (security **and** critical bug fixes)
 `2.4`_            2.4.6 (2018-07-05)           Supported (security fixes)
 `2.3`_            2.3.3 (2017-12-20)           Unsupported (end of life)


### PR DESCRIPTION
##### SUMMARY
Fixes bad link from release and maintenance docs page to 2.6 changelog.

This fix was included in backport PRs #43572 and #43567 for the docs for 2.5 and 2.6.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.7
