### PR TITLE
Fix openstack inventory plugin for API changes

### DIFF
--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -17,6 +17,9 @@ DOCUMENTATION = '''
     short_description: OpenStack inventory source
     requirements:
         - openstacksdk
+    extends_documentation_fragment:
+        - inventory_cache
+        - constructed
     description:
         - Get inventory hosts from OpenStack clouds
         - Uses openstack.(yml|yaml) YAML configuration file to configure the inventory plugin
@@ -152,10 +155,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if 'clouds' in self._config_data:
             self._config_data = {}
 
+        if cache:
+            cache = self.get_option('cache')
         source_data = None
-        if cache and cache_key in self._cache:
+        if cache:
             try:
-                source_data = self._cache[cache_key]
+                source_data = self.cache.get(cache_key)
             except KeyError:
                 pass
 
@@ -191,7 +196,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             source_data = cloud_inventory.list_hosts(
                 expand=expand_hostvars, fail_on_cloud_config=fail_on_errors)
 
-            self._cache[cache_key] = source_data
+            self.cache.set(cache_key, source_data)
 
         self._populate_from_source(source_data)
 


### PR DESCRIPTION
##### SUMMARY
The inventory plugin api grew a self.cache that wasn't there when we
first wrote it. There's also a need to pull in the documentation
fragments so that we have the cache parameters.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/openstack.py

##### ANSIBLE VERSION
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible']
  ansible python module location = /usr/local/lib/python3.6/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, Apr  1 2018, 05:46:30) [GCC 7.3.0]

```