### PR TITLE
Fix openstack inventory plugin

### DIFF
--- a/contrib/inventory/openstack_inventory.py
+++ b/contrib/inventory/openstack_inventory.py
@@ -192,8 +192,12 @@ def is_cache_stale(cache_file, cache_expiration_time, refresh=False):
 
 def get_cache_settings(cloud=None):
     config_files = cloud_config.CONFIG_FILES + CONFIG_FILES
-    config = cloud_config.OpenStackConfig(
-        config_files=config_files).get_one(cloud=cloud)
+    if cloud:
+        config = cloud_config.OpenStackConfig(
+            config_files=config_files).get_one(cloud=cloud)
+    else:
+        config = cloud_config.OpenStackConfig(
+            config_files=config_files).get_all()[0]
     # For inventory-wide caching
     cache_expiration_time = config.get_cache_expiration_time()
     cache_path = config.get_cache_path()

--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -15,6 +15,9 @@ DOCUMENTATION = '''
       - Marco Vito Moscaritolo <marco@agavee.com>
       - Jesse Keating <jesse.keating@rackspace.com>
     short_description: OpenStack inventory source
+    extends_documentation_fragment:
+        - inventory_cache
+        - constructed
     description:
         - Get inventory hosts from OpenStack clouds
         - Uses openstack.(yml|yaml) YAML configuration file to configure the inventory plugin
@@ -146,10 +149,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if 'clouds' in self._config_data:
             self._config_data = {}
 
+        if cache:
+            cache = self.get_option('cache')
         source_data = None
-        if cache and cache_key in self._cache:
+        if cache:
             try:
-                source_data = self._cache[cache_key]
+                source_data = self.cache.get(cache_key)
             except KeyError:
                 pass
 
@@ -185,7 +190,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             source_data = cloud_inventory.list_hosts(
                 expand=expand_hostvars, fail_on_cloud_config=fail_on_errors)
 
-            self._cache[cache_key] = source_data
+            self.cache.set(cache_key, source_data)
 
         self._populate_from_source(source_data)
 


### PR DESCRIPTION
##### SUMMARY
The inventory plugin api grew a self.cache that wasn't there when we
first wrote it. There's also a need to pull in the documentation
fragments so that we have the cache parameters.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/openstack.py

##### ANSIBLE VERSION
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible']
  ansible python module location = /usr/local/lib/python3.6/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, Apr  1 2018, 05:46:30) [GCC 7.3.0]

```