### PR TITLE
Fix netconf plugin set_option

### DIFF
--- a/lib/ansible/plugins/netconf/__init__.py
+++ b/lib/ansible/plugins/netconf/__init__.py
@@ -19,12 +19,12 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 from functools import wraps
 
 from ansible.errors import AnsibleError
-from ansible.module_utils.six import with_metaclass
-from ansible.module_utils._text import to_bytes
+from ansible.plugins import AnsiblePlugin
+
 
 try:
     from ncclient.operations import RPCError
@@ -47,7 +47,7 @@ def ensure_connected(func):
     return wrapped
 
 
-class NetconfBase(with_metaclass(ABCMeta, object)):
+class NetconfBase(AnsiblePlugin):
     """
     A base class for implementing Netconf connections
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* To enable set config option with `Netconf` plugin
  inherit `NetconfBase` class from `AnsiblePlugin` parent class
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
plugins/netconf/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
