### PR TITLE
Fill subscription id in url param of rest modules automatically

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_resource.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resource.py
@@ -27,6 +27,7 @@ options:
   url:
     description:
       - Azure RM Resource URL.
+      - Use * instead of subscription id and it will be replaced with default subscription.
   api_version:
     description:
       - Specific API version to be used.
@@ -239,6 +240,10 @@ class AzureRMResource(AzureRMModuleBase):
 
             if orphan is not None:
                 self.url += '/' + orphan
+        else:
+            # this is for user convenience, * can be replaced with subscription id so no need to do the lookup
+            self.url = self.url.replace('/subscriptions/*/', '/subscriptions/' + self.subscription_id + '/')
+
         query_parameters = {}
         query_parameters['api-version'] = self.api_version
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_resource_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resource_facts.py
@@ -27,6 +27,7 @@ options:
   url:
     description:
       - Azure RM Resource URL.
+      - Use * instead of subscription id and it will be replaced with default subscription.
   api_version:
     description:
       - Specific API version to be used.
@@ -181,6 +182,9 @@ class AzureRMResourceFacts(AzureRMModuleBase):
 
             if orphan is not None:
                 self.url += '/' + orphan
+        else:
+            # this is for user convenience, * can be replaced with subscription id so no need to do the lookup
+            self.url = self.url.replace('/subscriptions/*/', '/subscriptions/' + self.subscription_id + '/')
 
         self.results['url'] = self.url
 

--- a/test/integration/targets/azure_rm_resource/tasks/main.yml
+++ b/test/integration/targets/azure_rm_resource/tasks/main.yml
@@ -67,7 +67,7 @@
 - debug:
     var: output
 
-    - name: Try to get information using URL
+- name: Try to get information using URL
   azure_rm_resource_facts:
     api_version: '2018-02-01'
     url: /subscriptions/*/resourceGroups/{{ resource_group }}/providers/Microsoft.Network/networkSecurityGroups/{{ nsgname }}

--- a/test/integration/targets/azure_rm_resource/tasks/main.yml
+++ b/test/integration/targets/azure_rm_resource/tasks/main.yml
@@ -67,6 +67,10 @@
 - debug:
     var: output
 
+- name: Assert that there's response
+  assert:
+    that: output.response[0]['id'] is not None
+
 - name: Try to get information using URL
   azure_rm_resource_facts:
     api_version: '2018-02-01'
@@ -76,7 +80,11 @@
 - debug:
     var: output
 
-- name: Create storage account for Registry
+- name: Assert that there's response
+  assert:
+    that: output.response[0]['id'] is not None
+
+    - name: Create storage account for Registry
   azure_rm_storageaccount:
     resource_group: "{{ resource_group }}"
     name: "{{ storageaccountname }}"

--- a/test/integration/targets/azure_rm_resource/tasks/main.yml
+++ b/test/integration/targets/azure_rm_resource/tasks/main.yml
@@ -64,6 +64,12 @@
     resource_name: "{{ nsgname }}"
   register: output
 
+- name: Try to get information using URL
+  azure_rm_resource_facts:
+    api_version: '2018-02-01'
+    url: /subscriptions/*/resourceGroups/{{ resource_group }}/providers/Microsoft.Network/networkSecurityGroups/{{ nsgname }}
+  register: output
+
 - name: Create storage account for Registry
   azure_rm_storageaccount:
     resource_group: "{{ resource_group }}"

--- a/test/integration/targets/azure_rm_resource/tasks/main.yml
+++ b/test/integration/targets/azure_rm_resource/tasks/main.yml
@@ -84,7 +84,7 @@
   assert:
     that: output.response[0]['id'] is not None
 
-    - name: Create storage account for Registry
+- name: Create storage account for Registry
   azure_rm_storageaccount:
     resource_group: "{{ resource_group }}"
     name: "{{ storageaccountname }}"

--- a/test/integration/targets/azure_rm_resource/tasks/main.yml
+++ b/test/integration/targets/azure_rm_resource/tasks/main.yml
@@ -64,12 +64,9 @@
     resource_name: "{{ nsgname }}"
   register: output
 
-- debug:
-    var: output
-
 - name: Assert that there's response
   assert:
-    that: output.response[0]['id'] is not None
+    that: '"id" in output.response[0]'
 
 - name: Try to get information using URL
   azure_rm_resource_facts:
@@ -77,12 +74,9 @@
     url: /subscriptions/*/resourceGroups/{{ resource_group }}/providers/Microsoft.Network/networkSecurityGroups/{{ nsgname }}
   register: output
 
-- debug:
-    var: output
-
 - name: Assert that there's response
   assert:
-    that: output.response[0]['id'] is not None
+    that: '"id" in output.response[0]'
 
 - name: Create storage account for Registry
   azure_rm_storageaccount:

--- a/test/integration/targets/azure_rm_resource/tasks/main.yml
+++ b/test/integration/targets/azure_rm_resource/tasks/main.yml
@@ -64,11 +64,17 @@
     resource_name: "{{ nsgname }}"
   register: output
 
-- name: Try to get information using URL
+- debug:
+    var: output
+
+    - name: Try to get information using URL
   azure_rm_resource_facts:
     api_version: '2018-02-01'
     url: /subscriptions/*/resourceGroups/{{ resource_group }}/providers/Microsoft.Network/networkSecurityGroups/{{ nsgname }}
   register: output
+
+- debug:
+    var: output
 
 - name: Create storage account for Registry
   azure_rm_storageaccount:


### PR DESCRIPTION
##### SUMMARY
This is small improvement in handling REST API url parameter.
User will be able to use * instead of subscription id, so current subscription id will be filled automatically.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
azure_rm_resource
azure_rm_resource_facts

##### ANSIBLE VERSION
2.6

##### ADDITIONAL INFORMATION
