### PR TITLE
Vultr: Introducing vultr_network_facts module

### DIFF
--- a/lib/ansible/modules/cloud/vultr/vultr_network_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_network_facts.py
@@ -1,0 +1,135 @@
+#!/usr/bin/python
+#
+# (c) 2018, Yanis Guenane <yanis+ansible@guenane.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: vultr_network_facts
+short_description: Gather facts about the Vultr networks available.
+description:
+  - Gather facts about networks available in Vultr.
+version_added: "2.7"
+author: "Yanis Guenane (@Spredzy)"
+extends_documentation_fragment: vultr
+'''
+
+EXAMPLES = r'''
+- name: Gather Vultr networks facts
+  local_action:
+    module: vultr_network_facts
+
+- name: Print the gathered facts
+  debug:
+    var: ansible_facts.vultr_network_facts
+'''
+
+RETURN = r'''
+---
+vultr_api:
+  description: Response from Vultr API with a few additions/modification
+  returned: success
+  type: complex
+  contains:
+    api_account:
+      description: Account used in the ini file to select the key
+      returned: success
+      type: string
+      sample: default
+    api_timeout:
+      description: Timeout used for the API requests
+      returned: success
+      type: int
+      sample: 60
+    api_retries:
+      description: Amount of max retries for the API requests
+      returned: success
+      type: int
+      sample: 5
+    api_endpoint:
+      description: Endpoint used for the API requests
+      returned: success
+      type: string
+      sample: "https://api.vultr.com"
+vultr_network_facts:
+  description: Response from Vultr API
+  returned: success
+  type: complex
+  contains:
+    "vultr_network_facts": [
+      {
+        "date_created": "2018-08-02 11:18:49",
+        "id": "net5b62e8991adfg",
+        "name": "mynet",
+        "region": "Amsterdam",
+        "v4_subnet": "192.168.42.0",
+        "v4_subnet_mask": 24
+      }
+    ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vultr import (
+    Vultr,
+    vultr_argument_spec,
+)
+
+
+class AnsibleVultrNetworkFacts(Vultr):
+
+    def __init__(self, module):
+        super(AnsibleVultrNetworkFacts, self).__init__(module, "vultr_network_facts")
+
+        self.returns = {
+            'DCID': dict(key='region', transform=self._get_region_name),
+            'NETWORKID': dict(key='id'),
+            'date_created': dict(),
+            'description': dict(key='name'),
+            'v4_subnet': dict(),
+            'v4_subnet_mask': dict(convert_to='int'),
+        }
+
+    def _get_region_name(self, region):
+        return self.query_resource_by_key(
+            key='DCID',
+            value=region,
+            resource='regions',
+            use_cache=True
+        )['name']
+
+    def get_networks(self):
+        return self.api_query(path="/v1/network/list")
+
+
+def parse_network_list(network_list):
+    if isinstance(network_list, list):
+        return []
+
+    return [network for id, network in network_list.items()]
+
+
+def main():
+    argument_spec = vultr_argument_spec()
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    network_facts = AnsibleVultrNetworkFacts(module)
+    result = network_facts.get_result(parse_network_list(network_facts.get_networks()))
+    ansible_facts = {
+        'vultr_network_facts': result['vultr_network_facts']
+    }
+    module.exit_json(ansible_facts=ansible_facts, **result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/legacy/roles/vultr_network_facts/defaults/main.yml
+++ b/test/legacy/roles/vultr_network_facts/defaults/main.yml
@@ -1,0 +1,3 @@
+vultr_network_name: mytestnetwork
+vultr_network_cidr: 192.168.42.0/24
+vultr_network_region: New Jersey

--- a/test/legacy/roles/vultr_network_facts/tasks/main.yml
+++ b/test/legacy/roles/vultr_network_facts/tasks/main.yml
@@ -1,0 +1,33 @@
+# Copyright (c) 2018, Yanis Guenane <yanis+ansible@guenane.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: test gather vultr network facts - empty resources
+  vultr_network_facts:
+
+- name: Create the network
+  vultr_network:
+    name: '{{ vultr_network_name }}'
+    cidr: '{{ vultr_network_cidr }}'
+    region: '{{ vultr_network_region }}'
+
+- name: test gather vultr network facts in check mode
+  vultr_network_facts:
+  check_mode: yes
+
+- name: verify test gather vultr network facts in check mode
+  assert:
+    that:
+    - ansible_facts.vultr_network_facts|selectattr('name','equalto','{{ vultr_network_name }}') | list | count == 1
+
+- name: test gather vultr network facts
+  vultr_network_facts:
+
+- name: verify test gather vultr network facts
+  assert:
+    that:
+    - ansible_facts.vultr_network_facts|selectattr('name','equalto','{{ vultr_network_name }}') | list | count == 1
+
+- name: Delete the script
+  vultr_network:
+    name: '{{ vultr_network_name }}'
+    state: absent

--- a/test/legacy/vultr.yml
+++ b/test/legacy/vultr.yml
@@ -15,6 +15,7 @@
     - { role: vultr_firewall_group_facts, tags: test_vultr_firewall_group_facts }
     - { role: vultr_firewall_rule, tags: test_vultr_firewall_rule }
     - { role: vultr_network, tags: test_vultr_network }
+    - { role: vultr_network_facts, tags: test_vultr_network_facts }
     - { role: vultr_os_facts, tags: test_vultr_os_facts }
     - { role: vultr_plan_facts, tags: test_vultr_plan_facts }
     - { role: vultr_region_facts, tags: test_vultr_region_facts }


### PR DESCRIPTION
##### SUMMARY

This commit introduces a new module called vultr_network_facts.

This module aims to return the list of networks available in Vultr.

Sample available here:

```
"vultr_network_facts": [
  {
    "date_created": "2018-08-02 11:18:49",
    "id": "net5b62e8991adfg",
    "name": "mynet",
    "region": "Amsterdam",
    "v4_subnet": "192.168.42.0",
    "v4_subnet_mask": 24
  }
]
```

##### ISSUE TYPE

 - New Module Pull Request

##### COMPONENT NAME

  - vr_network_facts

##### ANSIBLE VERSION

  - devel

##### ADDITIONAL INFORMATION

  - N/A