### PR TITLE
Vultr: Ensure facts works when no resource exists

### DIFF
--- a/lib/ansible/modules/cloud/vultr/vr_firewall_group_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vr_firewall_group_facts.py
@@ -103,6 +103,9 @@ class AnsibleVultrFirewallGroupFacts(Vultr):
 
 
 def parse_fw_group_list(fwgroups_list):
+    if not fwgroups_list:
+        return []
+
     return [group for id, group in fwgroups_list.items()]
 
 

--- a/lib/ansible/modules/cloud/vultr/vr_ssh_key_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vr_ssh_key_facts.py
@@ -98,6 +98,9 @@ class AnsibleVultrSSHKeyFacts(Vultr):
 
 
 def parse_keys_list(keys_list):
+    if not keys_list:
+        return []
+
     return [key for id, key in keys_list.items()]
 
 

--- a/lib/ansible/modules/cloud/vultr/vr_startup_script_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vr_startup_script_facts.py
@@ -102,6 +102,9 @@ class AnsibleVultrStartupScriptFacts(Vultr):
 
 
 def parse_startupscript_list(startupscipts_list):
+    if not startupscipts_list:
+        return []
+
     return [startupscript for id, startupscript in startupscipts_list.items()]
 
 

--- a/test/legacy/roles/vr_firewall_group_facts/tasks/main.yml
+++ b/test/legacy/roles/vr_firewall_group_facts/tasks/main.yml
@@ -1,6 +1,9 @@
 # Copyright (c) 2018, Yanis Guenane <yanis+ansible@guenane.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
+- name: test gather vultr firewall group facts - empty resources
+  vr_firewall_group_facts:
+
 - name: Create the firewall group
   vr_firewall_group:
     name: '{{ firewall_group_name }}'

--- a/test/legacy/roles/vr_ssh_key_facts/tasks/main.yml
+++ b/test/legacy/roles/vr_ssh_key_facts/tasks/main.yml
@@ -1,6 +1,9 @@
 # Copyright (c) 2018, Yanis Guenane <yanis+ansible@guenane.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
+- name: test gather vultr ssh key fact - empty resources
+  vr_ssh_key_facts:
+
 - name: Upload an ssh key
   vr_ssh_key:
     name: '{{ ssh_key_name }}'

--- a/test/legacy/roles/vr_startup_script_facts/tasks/main.yml
+++ b/test/legacy/roles/vr_startup_script_facts/tasks/main.yml
@@ -1,6 +1,9 @@
 # Copyright (c) 2018, Yanis Guenane <yanis+ansible@guenane.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
+- name: test gather vultr startup script facts - empty resources
+  vr_startup_script_facts:
+
 - name: Create the script
   vr_startup_script:
     name: '{{ startup_script_name }}'


### PR DESCRIPTION
##### SUMMARY

Vultr API is being inconsisten in what it returns. An empty list when no
resources exists, but a dict of dict when they do. The case needs to be
handled so the module do not fail. An extra test has been added.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

  - vr_ssh_key_facts
  - vr_startup_script_facts
  - vr_firewall_group_facts

##### ANSIBLE VERSION

  - devel

##### ADDITIONAL INFORMATION

  - N/A