### PR TITLE
Fix telnet action plugin type error

### DIFF
--- a/lib/ansible/plugins/action/telnet.py
+++ b/lib/ansible/plugins/action/telnet.py
@@ -69,7 +69,6 @@ class ActionModule(ActionBase):
                     tn.read_until(to_bytes(login_prompt))
                     tn.write(to_bytes(user + "\n"))
 
-
                     if password:
                         tn.read_until(to_bytes(password_prompt))
                         tn.write(to_bytes(password + "\n"))

--- a/lib/ansible/plugins/action/telnet.py
+++ b/lib/ansible/plugins/action/telnet.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 import telnetlib
 from time import sleep
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_bytes
 from ansible.module_utils.six import text_type
 from ansible.plugins.action import ActionBase
 
@@ -64,26 +64,27 @@ class ActionModule(ActionBase):
                 output = []
                 try:
                     if send_newline:
-                        tn.write('\n')
+                        tn.write(b'\n')
 
-                    tn.read_until(login_prompt)
-                    tn.write('%s\n' % to_native(user))
+                    tn.read_until(to_bytes(login_prompt))
+                    tn.write(to_bytes(user + "\n"))
+
 
                     if password:
-                        tn.read_until(password_prompt)
-                        tn.write('%s\n' % to_native(password))
+                        tn.read_until(to_bytes(password_prompt))
+                        tn.write(to_bytes(password + "\n"))
 
-                    tn.expect(prompts)
+                    tn.expect(list(map(to_bytes, prompts)))
 
                     for cmd in commands:
                         display.vvvvv('>>> %s' % cmd)
-                        tn.write('%s\n' % to_native(cmd))
-                        index, match, out = tn.expect(prompts)
+                        tn.write(to_bytes(cmd + "\n"))
+                        index, match, out = tn.expect(list(map(to_bytes, prompts)))
                         display.vvvvv('<<< %s' % cmd)
                         output.append(out)
                         sleep(pause)
 
-                    tn.write("exit\n")
+                    tn.write(b"exit\n")
 
                 except EOFError as e:
                     result['failed'] = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #36199
The telnet module gave the following error:
`TypeError: a bytes-like object is required, not 'AnsibleUnicode'`
This commit fixes this error by changing the types of the str type arguments to telnetlib to bytes types.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
telnet action plugin
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = None
  configured module search path = ['/home/nicolas/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible-2.7.0.dev0-py3.6.egg/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.6 (default, Jun 27 2018, 13:11:40) [GCC 8.1.1 20180531]
```