### PR TITLE
Add setup roles for passlib and pexpect for use with pause and vars_prompt tests

### DIFF
--- a/test/integration/targets/pause/aliases
+++ b/test/integration/targets/pause/aliases
@@ -1,1 +1,2 @@
+setup/always/setup_pexpect
 shippable/posix/group3

--- a/test/integration/targets/pause/runme.sh
+++ b/test/integration/targets/pause/runme.sh
@@ -25,5 +25,4 @@ ansible-playbook pause-3.yml -i ../../inventory > /dev/null \
 ansible-playbook test-pause.yml -i ../../inventory "$@"
 
 # Interactively test pause
-pip install pexpect
 python test-pause.py -i ../../inventory "$@"

--- a/test/integration/targets/setup_passlib/tasks/main.yml
+++ b/test/integration/targets/setup_passlib/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: Install passlib
+  pip:
+    name: passlib
+    state: present

--- a/test/integration/targets/setup_pexpect/tasks/main.yml
+++ b/test/integration/targets/setup_pexpect/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: Install pexpect
+  pip:
+    name: pexpect
+    state: present

--- a/test/integration/targets/vars_prompt/aliases
+++ b/test/integration/targets/vars_prompt/aliases
@@ -1,1 +1,3 @@
+setup/always/setup_passlib
+setup/always/setup_pexpect
 shippable/posix/group2

--- a/test/integration/targets/vars_prompt/runme.sh
+++ b/test/integration/targets/vars_prompt/runme.sh
@@ -2,14 +2,5 @@
 
 set -eux
 
-# Install passlib on RHEL and FreeBSD
-dist=$(python -c 'import platform; print(platform.dist()[0])')
-system=$(python -c 'import platform; print(platform.system())')
-
-if [[ "$dist" == "redhat" || "$system" == "FreeBSD" ]]; then
-    pip install passlib
-fi
-
 # Interactively test vars_prompt
-pip install pexpect
 python test-vars_prompt.py -i ../../inventory "$@"

--- a/test/runner/setup/remote.sh
+++ b/test/runner/setup/remote.sh
@@ -40,6 +40,7 @@ elif [ "${platform}" = "rhel" ]; then
     done
 
     pip --version 2>/dev/null || curl --silent --show-error https://bootstrap.pypa.io/get-pip.py | python
+    pip install passlib
 fi
 
 if [ "${platform}" = "freebsd" ] || [ "${platform}" = "osx" ]; then

--- a/test/runner/setup/remote.sh
+++ b/test/runner/setup/remote.sh
@@ -40,7 +40,6 @@ elif [ "${platform}" = "rhel" ]; then
     done
 
     pip --version 2>/dev/null || curl --silent --show-error https://bootstrap.pypa.io/get-pip.py | python
-    pip install passlib
 fi
 
 if [ "${platform}" = "freebsd" ] || [ "${platform}" = "osx" ]; then


### PR DESCRIPTION
##### SUMMARY

Create `setup_passlib` and `setup_pexpect` roles for use by the `vars_prompt` and `pause` tests (and any in the future that might need them).

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
`test/runner/setup/remote.sh`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```
