### PR TITLE
Give warning if user inputs not encrypted password to user module

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -227,6 +227,8 @@ from distutils.versionpredicate import VersionPredicate
 from ansible.module_utils.basic import AnsibleModule, is_executable
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import PY3
+from ansible.module_utils.common.collections import is_sequence
+
 
 #: Python one-liners to be run at the command line that will determine the
 # installed version for these special libraries.  These are libraries that
@@ -241,13 +243,13 @@ def _parse_name_str(name):
     if len(tmp) > 1:
         formula = name.replace(pkg_name, "")
         return pkg_name.strip(), formula.strip()
-    return pkg_name.strip(), None 
+    return pkg_name.strip(), None
+
 
 def _version_number_to_formula(version):
     if version[0].isdigit():
         return "==%s" % version
-    else:
-        return version
+    return version
 
 
 def _get_cmd_options(module, cmd):
@@ -531,7 +533,7 @@ def main():
 
         # check invalid combination of arguments
         if version is not None:
-            if len(name) > 1:
+            if is_sequence(name, include_strings=False) and len(name) > 1:
                 module.fail_json(msg="Version arg is not available for installing multi-packages.")
             else:
                 pkg_name, version_formula = _parse_name_str(name[0])

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -251,7 +251,7 @@ def _get_full_name(name, version=None):
         resp = name
     else:
         if version[0].isdigit():
-            resp = "%s==%s" % (name, version)
+            version = "==%s" % version
         resp = "\"%s (%s)\"" % (name, version)
     return resp
 

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -235,6 +235,13 @@ _SPECIAL_PACKAGE_CHECKERS = {'setuptools': 'import setuptools; print(setuptools.
                              'pip': 'import pkg_resources; print(pkg_resources.get_distribution("pip").version)'}
 
 
+def _version_number_to_formula(version):
+    if version[0].isdigit():
+        return "==%s" % version
+    else:
+        return version
+
+
 def _get_cmd_options(module, cmd):
     thiscmd = cmd + " --help"
     rc, stdout, stderr = module.run_command(thiscmd)
@@ -250,9 +257,7 @@ def _get_full_name(name, version=None):
     if version is None or version == "":
         resp = name
     else:
-        if version[0].isdigit():
-            version = "==%s" % version
-        resp = "\"%s (%s)\"" % (name, version)
+        resp = "\"%s %s\"" % (name, _version_number_to_formula(version))
     return resp
 
 
@@ -275,11 +280,9 @@ def _get_packages(module, pip, chdir):
 
 def _is_present(module, name, version, installed_pkgs, pkg_command):
     '''Return whether or not package is installed.'''
-    if version is not None:
-        if version[0].isdigit():
-            version = "==%s" % version
+    if version is not None and version != "":
         try:
-            vp = VersionPredicate("%s (%s)" % (name, version))
+            vp = VersionPredicate("%s (%s)" % (name, _version_number_to_formula(version)))
         except ValueError:
             module.fail_json(msg="Can parse invalid version number %s" % version)
     for pkg in installed_pkgs:

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -253,7 +253,11 @@ class Distribution:
                 separator = '==' if version_string[0].isdigit() else ' '
                 name_string = separator.join((name_string, version_string))
             self._requirement = Requirement.parse(name_string)
-            self._distribution_name = self._requirement.project_name
+            # old pkg_resource will replace 'setuptools' with 'distribute' when it already installed
+            if self._requirement.project_name == "distribute":
+                self._distribution_name = "setuptools"
+            else:
+                self._distribution_name = self._requirement.project_name
         else:
             self._plain_distribution = False
             self._distribution_name = name_string

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -245,7 +245,7 @@ class Distribution(object):
     def __init__(self, name_string, version_string=None):
         if not name_string.startswith(('svn+', 'git+', 'hg+', 'bzr+', 'file:')):
             self._plain_distribution = True
-            if version_string is not None:
+            if version_string:
                 version_string = version_string.lstrip()
                 separator = '==' if version_string[0].isdigit() else ' '
                 name_string = separator.join((name_string, version_string))
@@ -281,7 +281,7 @@ class Distribution(object):
 
 
 def _is_valid_distribution_name(name):
-    if name.startswith(('>=','<=','!=','==','>','<')):
+    if name.startswith(('>=', '<=', '!=', '==', '>', '<')):
         return False
     return True
 

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -250,7 +250,7 @@ class Distribution:
                 separator = '==' if version_string[0].isdigit() else ' '
                 name_string = separator.join((name_string, version_string))
             self._requirement = Requirement.parse(name_string)
-            self._distribution_name = self._requirement.key
+            self._distribution_name = self._requirement.project_name
         else:
             self._plain_distribution = False
             self._distribution_name = name_string
@@ -269,9 +269,11 @@ class Distribution:
     def distribution_name(self, new_name):
         self._distribution_name = new_name
 
-    def is_satisfied_by(self, version_to_test):
-        if self._plain_distribution:
+    def is_satisfied_by(self, version_to_test, module):
+        if self._plain_distribution and hasattr(self._requirement, 'specifier'):
             return self._requirement.specifier.contains(version_to_test)
+        else:
+            module.warn(str(self._requirement.__dict__))
         return False
 
     def __str__(self):
@@ -342,7 +344,7 @@ def _is_present(module, req, installed_pkgs, pkg_command):
         else:
             continue
 
-        if pkg_name.lower() == req.distribution_name and req.is_satisfied_by(pkg_version):
+        if pkg_name.lower() == req.distribution_name and req.is_satisfied_by(pkg_version, module):
             return True
 
     return False

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -250,7 +250,7 @@ class Distribution:
                 separator = '==' if version_string[0].isdigit() else ' '
                 name_string = separator.join((name_string, version_string))
             self._requirement = Requirement.parse(name_string)
-            self._distribution_name = self._requirement.name.lower()
+            self._distribution_name = self._requirement.key
         else:
             self._plain_distribution = False
             self._distribution_name = name_string

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -606,7 +606,9 @@ def main():
 
             # convert raw input distribution names to distribution instances
             try:
-                distributions = [Distribution(dist) for dist in _recover_distribution_name(name)]
+                distributions = []
+                for dist in _recover_distribution_name(name):
+                    distributions.append(Distribution(dist))
             except ValueError as e:
                 # if users input some invalid distribution names, show them the parsing error
                 module.fail_json(msg="Can not parse package name '%s', error: '%s'" % (dist, str(e)))

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -522,7 +522,7 @@ class Package:
 
     def __str__(self):
         if self._plain_package:
-            return str(self._requirement)
+            return to_native(self._requirement)
         return self.package_name
 
 
@@ -623,10 +623,12 @@ def main():
 
             # convert raw input package names to Package instances
             try:
-                packages = [Package(package) for package in _recover_package_name(name)]
+                packages = []
+                for dist in _recover_package_name(name):
+                    packages.append(Package(dist))
             except ValueError as e:
                 # if users input some invalid package names, show them the parsing error
-                module.fail_json(msg="Can not parse package name '%s', error: '%s'" % (dist, str(e)))
+                module.fail_json(msg="Can not parse package name '%s', error: '%s'" % (dist, to_native(e)))
             # check invalid combination of arguments
             if version is not None:
                 if len(packages) > 1:
@@ -655,7 +657,7 @@ def main():
             cmd.append(extra_args)
 
         if name:
-            cmd.extend(str(p) for p in packages)
+            cmd.extend(to_native(p) for p in packages)
         elif requirements:
             cmd.extend(['-r', requirements])
         else:

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -374,7 +374,7 @@ def _get_packages(module, pip, chdir):
         if rc != 0:
             _fail(module, command, out, err)
 
-    return (command, out, err)
+    return command, out, err
 
 
 def _is_present(module, req, installed_pkgs, pkg_command):

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -336,9 +336,8 @@ def _recover_distribution_name(names):
         if _is_valid_distribution_name(name):
             if len(distribution_parts) > 0:
                 yield ",".join(distribution_parts)
-            distribution_parts = [name]
-        else:
-            distribution_parts.append(name)
+            distribution_parts = []
+        distribution_parts.append(name)
     yield ",".join(distribution_parts)
 
 

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -624,7 +624,7 @@ def main():
             if version is not None:
                 if len(distributions) > 1:
                     module.fail_json(
-                        msg="'version' argument is not ambiguous when installing multiple package distributions. "
+                        msg="'version' argument is ambiguous when installing multiple package distributions. "
                             "Please spefify version restrictions next to each distribution in 'name' argument."
                     )
                 if distributions[0].has_version_specifier:

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -273,21 +273,22 @@ class Distribution:
     """
 
     def __init__(self, name_string, version_string=None):
-        if not (name_string.startswith('file:') or _is_vcs_url(name_string)):
-            self._plain_distribution = True
-            if version_string:
-                version_string = version_string.lstrip()
-                separator = '==' if version_string[0].isdigit() else ' '
-                name_string = separator.join((name_string, version_string))
-            self._requirement = Requirement.parse(name_string)
-            # old pkg_resource will replace 'setuptools' with 'distribute' when it already installed
-            if self._requirement.project_name == "distribute":
-                self._distribution_name = "setuptools"
-            else:
-                self._distribution_name = self._requirement.project_name
+        self._plain_distribution = False
+        self._distribution_name = name_string
+        self._requirement = Requirement.parse(name_string)
+        if name_string.startswith('file:') or _is_vcs_url(name_string):
+            return
+
+        self._plain_distribution = True
+        if version_string:
+            version_string = version_string.lstrip()
+            separator = '==' if version_string[0].isdigit() else ' '
+            name_string = separator.join((name_string, version_string))
+        # old pkg_resource will replace 'setuptools' with 'distribute' when it already installed
+        if self._requirement.project_name == "distribute":
+            self._distribution_name = "setuptools"
         else:
-            self._plain_distribution = False
-            self._distribution_name = name_string
+            self._distribution_name = self._requirement.project_name
 
     @property
     def has_version_specifier(self):

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -364,7 +364,7 @@ def _get_packages(module, pip, chdir):
     '''Return results of pip command to get packages.'''
     # Try 'pip list' command first.
     command = '%s list --format=freeze' % pip
-    lang_env = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
+    lang_env = {'LANG': 'C', 'LC_ALL': 'C', 'LC_MESSAGES': 'C'}
     rc, out, err = module.run_command(command, cwd=chdir, environ_update=lang_env)
 
     # If there was an error (pip version too old) then use 'pip freeze'.

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -319,6 +319,9 @@ def _is_valid_distribution_name(name):
 
 def _recover_distribution_name(names):
     """Recover distribution names as list from user's raw input."""
+    # rebuild input name to a flat list so we can tolerate any combination of input
+    names = [one_part for one_line in names for one_part in one_line.split(",")]
+    # reconstruct the names
     name_parts = []
     distribution_names = []
     for name in names:

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -255,7 +255,7 @@ _SPECIAL_PACKAGE_CHECKERS = {'setuptools': 'import setuptools; print(setuptools.
 _VCS_RE = re.compile(r'(svn|git|hg|bzr)\+')
 
 op_dict = {">=": operator.ge, "<=": operator.le, ">": operator.gt,
-           "<": operator.lt, "==": operator.eq, "!=": operator.ne}
+           "<": operator.lt, "==": operator.eq, "!=": operator.ne, "~=": operator.ge}
 
 
 def _is_vcs_url(name):
@@ -615,7 +615,6 @@ def main():
         # Automatically apply -e option to extra_args when source is a VCS url. VCS
         # includes those beginning with svn+, git+, hg+ or bzr+
         has_vcs = False
-
         if name:
             for pkg in name:
                 if bool(pkg and _is_vcs_url(pkg)):
@@ -659,10 +658,9 @@ def main():
 
         if name:
             for p in packages:
-                cmd.append('%s' % p)
+                cmd.append(str(p))
         elif requirements:
-            cmd.append('-r')
-            cmd.append('%s' % requirements)
+            cmd.extend(['-r', requirements])
         else:
             module.exit_json(
                 changed=False,

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -23,12 +23,10 @@ options:
   name:
     description:
       - The name of a Python library to install or the url of the remote package.
-      - As of 2.2 you can supply a list of names.
-      - As of 2.7, you can supply a list of names with version specifiers.
+      - This can be a list (since 2.2) and contain version specifiers (since 2.7).
   version:
     description:
       - The version number to install of the Python library specified in the I(name) parameter.
-      - As of 2.7, you can supply version specifiers.
   requirements:
     description:
       - The path to a pip requirements file, which should be local to the remote system.
@@ -124,23 +122,17 @@ EXAMPLES = '''
 
 # Install (Bottle) python package on version 0.11.
 - pip:
-    name: bottle
-    version: 0.11
+    name: bottle==0.11
 
-# Install (bottle) python package with version specifiers (only in 2.7)
+# Install (bottle) python package with version specifiers
 - pip:
-    name: bottle
-    version: '>0.10,<0.20,!=0.11'
+    name: bottle>0.10,<0.20,!=0.11
 
-# Install multi python packages with version specifiers (only in 2.7)
+# Install multi python packages with version specifiers
 - pip:
     name:
-      - 'django>1.11.0,<1.12.0'
-      - 'bottle>0.10,<0.20,!=0.11'
-
-# 2.7 also support multi packages in one name string
-- pip:
-    name: 'djang>1.11.0,<1.12.0,bottle>0.10,<0.20,!=0.11'
+      - django>1.11.0,<1.12.0
+      - bottle>0.10,<0.20,!=0.11
 
 # Install (MyApp) using one of the remote protocols (bzr+,hg+,git+,svn+). You do not have to supply '-e' option in extra_args.
 - pip:
@@ -625,13 +617,14 @@ def main():
                 if len(distributions) > 1:
                     module.fail_json(
                         msg="'version' argument is ambiguous when installing multiple package distributions. "
-                            "Please spefify version restrictions next to each distribution in 'name' argument."
+                            "Please specify version restrictions next to each distribution in 'name' argument."
                     )
                 if distributions[0].has_version_specifier:
                     module.fail_json(
-                        msg="'version' argument conflicts with version specifier provided along with a package name. "
-                            "Please keep a version specifier, but remove the 'version' argument."
+                        msg="The 'version' argument conflicts with any version specifier provided along with a package name. "
+                            "Please keep the version specifier, but remove the 'version' argument."
                     )
+                # if the version specifier is provided by version, append that into the distribution
                 distributions[0] = Distribution(distributions[0].distribution_name, version)
 
         if module.params['editable']:

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -265,11 +265,11 @@ op_dict = {">=": operator.ge, "<=": operator.le, ">": operator.gt,
 
 
 class Distribution:
-
     """Python distribution package metadata wrapper.
 
-    A wrapper class for Requirement, provide usefual API to parse package name and version specifier,
-    do fallback if the installed setuptools version doesn't support some features.
+    A wrapper class for Requirement, which provides API to parse package name
+    and version specifier, providing fallback if the installed setuptools version
+    doesn't support required features.
     """
 
     def __init__(self, name_string, version_string=None):

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -609,7 +609,7 @@ def main():
                 distributions = [Distribution(dist) for dist in _recover_distribution_name(name)]
             except ValueError as e:
                 # if users input some invalid distribution names, show them the parsing error
-                module.fail_json(msg=str(e))
+                module.fail_json(msg="Can not parse package name '%s', error: '%s'" % (dist, str(e)))
             # check invalid combination of arguments
             if version is not None:
                 if len(distributions) > 1:

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -301,17 +301,17 @@ class Distribution:
         return self._distribution_name
 
     def is_satisfied_by(self, version_to_test):
-        if self._plain_distribution:
-            if hasattr(self._requirement, 'specifier'):
-                return self._requirement.specifier.contains(version_to_test)
-            else:
-                # old setuptools has no specifier, do fallback
-                version_to_test = LooseVersion(version_to_test)
-                for (op, ver) in self._requirement.specs:
-                    if not op_dict[op](version_to_test, LooseVersion(ver)):
-                        return False
-                return True
-        return False
+        if not self._plain_distribution:
+            return False
+        try:
+            return self._requirement.specifier.contains(version_to_test)
+        except AttributeError:
+            # old setuptools has no specifier, do fallback
+            version_to_test = LooseVersion(version_to_test)
+            for op, ver in self._requirement.specs:
+                if not op_dict[op](version_to_test, LooseVersion(ver)):
+                    return False
+            return True
 
     def __str__(self):
         if self._plain_distribution:

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -266,7 +266,7 @@ class Distribution:
 
     def __init__(self, name_string, version_string=None):
         self._plain_distribution = False
-        self._distribution_name = name_string
+        self.distribution_name = name_string
         if name_string.startswith('file:') or _is_vcs_url(name_string):
             return
 
@@ -278,19 +278,15 @@ class Distribution:
         self._requirement = Requirement.parse(name_string)
         # old pkg_resource will replace 'setuptools' with 'distribute' when it already installed
         if self._requirement.project_name == "distribute":
-            self._distribution_name = "setuptools"
+            self.distribution_name = "setuptools"
         else:
-            self._distribution_name = self._requirement.project_name
+            self.distribution_name = self._requirement.project_name
 
     @property
     def has_version_specifier(self):
         if self._plain_distribution:
             return bool(self._requirement.specs)
         return False
-
-    @property
-    def distribution_name(self):
-        return self._distribution_name
 
     def is_satisfied_by(self, version_to_test):
         if not self._plain_distribution:
@@ -308,7 +304,7 @@ class Distribution:
     def __str__(self):
         if self._plain_distribution:
             return str(self._requirement)
-        return self._distribution_name
+        return self.distribution_name
 
 
 def _is_vcs_url(name):

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -646,11 +646,11 @@ def main():
         if extra_args:
             cmd += ' %s' % extra_args
 
+        cmd += ' '
         if name:
-            for distribution in distributions:
-                cmd += ' "%s"' % distribution
+            cmd += ' '.join('"%s"' % d for d in distributions)
         elif requirements:
-            cmd += ' -r %s' % requirements
+            cmd += '-r "%s"' % requirements
         else:
             module.exit_json(
                 changed=False,

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -528,10 +528,10 @@ class Package:
 
 def main():
     state_map = dict(
-        present='install',
-        absent='uninstall -y',
-        latest='install -U',
-        forcereinstall='install -U --force-reinstall',
+        present=['install'],
+        absent=['uninstall', '-y'],
+        latest=['install', '-U'],
+        forcereinstall=['install', '-U', '--force-reinstall'],
     )
 
     module = AnsibleModule(
@@ -600,7 +600,7 @@ def main():
 
         pip = _get_pip(module, env, module.params['executable'])
 
-        cmd = '%s %s' % (pip, state_map[state])
+        cmd = [pip] + state_map[state]
 
         # If there's a virtualenv we want things we install to be able to use other
         # installations that exist as binaries within this virtualenv. Example: we
@@ -655,13 +655,14 @@ def main():
                 extra_args = ' '.join(args_list)
 
         if extra_args:
-            cmd += ' %s' % extra_args
+            cmd.append(extra_args)
 
-        cmd += ' '
         if name:
-            cmd += ' '.join('"%s"' % d for d in packages)
+            for p in packages:
+                cmd.append('%s' % p)
         elif requirements:
-            cmd += '-r "%s"' % requirements
+            cmd.append('-r')
+            cmd.append('%s' % requirements)
         else:
             module.exit_json(
                 changed=False,

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -275,7 +275,6 @@ class Distribution:
     def __init__(self, name_string, version_string=None):
         self._plain_distribution = False
         self._distribution_name = name_string
-        self._requirement = Requirement.parse(name_string)
         if name_string.startswith('file:') or _is_vcs_url(name_string):
             return
 
@@ -284,6 +283,7 @@ class Distribution:
             version_string = version_string.lstrip()
             separator = '==' if version_string[0].isdigit() else ' '
             name_string = separator.join((name_string, version_string))
+        self._requirement = Requirement.parse(name_string)
         # old pkg_resource will replace 'setuptools' with 'distribute' when it already installed
         if self._requirement.project_name == "distribute":
             self._distribution_name = "setuptools"

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -623,10 +623,15 @@ def main():
             # check invalid combination of arguments
             if version is not None:
                 if len(distributions) > 1:
-                    module.fail_json(msg="'version' is not available for installing multi-packages.")
+                    module.fail_json(
+                        msg="'version' argument is not ambiguous when installing multiple package distributions. "
+                            "Please spefify version restrictions next to each distribution in 'name' argument."
+                    )
                 if distributions[0].has_version_specifier:
-                    module.fail_json(msg="'version' argument conflicts with version specifier provided along with a package name."
-                                     "Please keep a version specifier, but remove the 'version' argument.")
+                    module.fail_json(
+                        msg="'version' argument conflicts with version specifier provided along with a package name. "
+                            "Please keep a version specifier, but remove the 'version' argument."
+                    )
                 distributions[0] = Distribution(distributions[0].distribution_name, version)
 
         if module.params['editable']:

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -308,10 +308,10 @@ class Distribution:
         except AttributeError:
             # old setuptools has no specifier, do fallback
             version_to_test = LooseVersion(version_to_test)
-            for op, ver in self._requirement.specs:
-                if not op_dict[op](version_to_test, LooseVersion(ver)):
-                    return False
-            return True
+            return all(
+                op_dict[op](version_to_test, LooseVersion(ver))
+                for op, ver in self._requirement.specs
+            )
 
     def __str__(self):
         if self._plain_distribution:

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -342,6 +342,7 @@ uid:
 import errno
 import grp
 import os
+import re
 import platform
 import pwd
 import shutil
@@ -356,6 +357,9 @@ try:
     HAVE_SPWD = True
 except ImportError:
     HAVE_SPWD = False
+
+
+_HASH_RE = re.compile(r'[^a-zA-Z0-9./=]')
 
 
 class User(object):
@@ -428,6 +432,37 @@ class User(object):
             self.ssh_file = module.params['ssh_key_file']
         else:
             self.ssh_file = os.path.join('.ssh', 'id_%s' % self.ssh_type)
+
+    def check_password_encrypted(self):
+        # darwin need cleartext password, so no check
+        if self.module.params['password'] and self.platform != 'Darwin':
+            maybe_invalid = False
+            # : for delimiter, * for disable user, ! for lock user
+            # these character are invalid in password
+            if any(char in self.module.params['password'] for char in ':*!'):
+                maybe_invalid = True
+            if '$' not in self.module.params['password']:
+                maybe_invalid = True
+            else:
+                fields = self.module.params['password'].split("$")
+                if len(fields) >= 3:
+                    # contains character outside crypt constrain
+                    if bool(_HASH_RE.search(fields[-1])):
+                      maybe_invalid = True
+                    # md5
+                    if fields[1] == '1' and len(fields[-1]) != 22:
+                        maybe_invalid = True
+                    # sha256
+                    if fields[1] == '5' and len(fields[-1]) != 43:
+                        maybe_invalid = True
+                    # sha512
+                    if fields[1] == '6' and len(fields[-1]) != 86:
+                        maybe_invalid = True
+                else:
+                    maybe_invalid = True
+            if maybe_invalid:
+                self.module.warn("The iunput password seems not been hashed, "
+                            "please note that 'password' argument requires an encrypted value or the password will not work properly.")
 
     def execute_command(self, cmd, use_unsafe_shell=False, data=None, obey_checkmode=True):
         if self.module.check_mode and obey_checkmode:
@@ -2391,6 +2426,7 @@ def main():
     )
 
     user = User(module)
+    user.check_password_encrypted()
 
     module.debug('User instantiated - platform %s' % user.platform)
     if user.distribution:

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -273,3 +273,56 @@
   assert:
     that:
       - pip_install_empty_version_string is successful
+
+# test version specifiers
+- name: make sure no test_package installed now
+  pip:
+    name: "{{ pip_test_package }}"
+    state: absent
+
+- name : install package with version specifiers
+  pip:
+    name: "{{ pip_test_package }}"
+    version: "<100.0.0,!=1.0.0,>0.0.0"
+  register: version
+
+- name: assert package installed correctly
+  assert:
+    that: "version.changed"
+
+- name: reinstall package
+  pip:
+    name: "{{ pip_test_package }}"
+    version: "<100.0.0,!=1.0.0,>0.0.0"
+  register: version2
+
+- name: assert no changes ocurred
+  assert:
+    that: "version2.changed == False"
+
+- name: test the check_mod
+  pip:
+    name: "{{ pip_test_package }}"
+    version: "<100.0.0,!=1.0.0,>0.0.0"
+  check_mode: yes
+  register: version3
+
+- name: assert no changes since satisfied the requirment
+  assert:
+    that: "version3.changed == False"
+
+- name: test the check_mod with unsatisfied version
+  pip:
+    name: "{{ pip_test_package }}"
+    version: ">100.0.0"
+  check_mode: yes
+  register: version4
+
+- name: assert changed
+  assert:
+    that: "version4.changed == True"
+
+- name: uninstall test package
+  pip:
+    name: "{{ pip_test_package }}"
+    state: absent

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -307,7 +307,7 @@
   check_mode: yes
   register: version3
 
-- name: assert no changes since satisfied the requirment
+- name: assert no changes
   assert:
     that: "version3.changed == False"
 
@@ -322,7 +322,73 @@
   assert:
     that: "version4.changed == True"
 
-- name: uninstall test package
+- name: uninstall test packages
   pip:
-    name: "{{ pip_test_package }}"
+    name: "{{ pip_test_packages }}"
+    state: absent
+
+- name: test invalid combination of arguments
+  pip:
+    name: "{{ pip_test_pkg_ver }}"
+    version: "1.11.1"
+  ignore_errors: yes
+  register: version5
+
+- name: assert the invalid combination should fail
+  assert:
+    that: "version5 is failed"
+
+- name: another invalid combination of arguments
+  pip:
+    name: "{{ pip_test_package }}>=0.0.0,<=99.0.0,!=12.0.0"
+    version: "<100.0.0"
+  ignore_errors: yes
+  register: version6
+
+- name: assert invalid combination should fail
+  assert:
+    that: "version6 is failed"
+
+- name: try to install invalid package
+  pip:
+    name: "{{ pip_test_pkg_ver_unsatisfied }}"
+  ignore_errors: yes
+  register: version7
+
+- name: assert install should fail
+  assert:
+    that: "version7 is failed"
+
+- name: test install multi-packages with version specifiers
+  pip:
+    name: "{{ pip_test_pkg_ver }}"
+  register: version8
+
+- name: assert packages installed correctly
+  assert:
+    that: "version8.changed"
+
+- name: test install multi-packages with check_mode
+  pip:
+    name: "{{ pip_test_pkg_ver }}"
+  check_mode: yes
+  register: version9
+
+- name: assert no change
+  assert:
+    that: "version9.changed == False"
+
+- name: test install unsatisfied multi-packages with check_mode
+  pip:
+    name: "{{ pip_test_pkg_ver_unsatisfied }}"
+  check_mode: yes
+  register: version10
+
+- name: assert changes needed
+  assert:
+    that: "version10.changed"
+
+- name: clean up
+  pip:
+    name: "{{ pip_test_pkg_ver }}"
     state: absent

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -280,7 +280,7 @@
     name: "{{ pip_test_package }}"
     state: absent
 
-- name : install package with version specifiers
+- name: install package with version specifiers
   pip:
     name: "{{ pip_test_package }}"
     version: "<100.0.0,!=1.0.0,>0.0.0"

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -277,13 +277,13 @@
 # test version specifiers
 - name: make sure no test_package installed now
   pip:
-    name: "{{ pip_test_package }}"
+    name: "{{ pip_test_packages }}"
     state: absent
 
 - name: install package with version specifiers
   pip:
     name: "{{ pip_test_package }}"
-    version: "<100.0.0,!=1.0.0,>0.0.0"
+    version: "<100,!=1.0,>0.0.0"
   register: version
 
 - name: assert package installed correctly
@@ -293,7 +293,7 @@
 - name: reinstall package
   pip:
     name: "{{ pip_test_package }}"
-    version: "<100.0.0,!=1.0.0,>0.0.0"
+    version: "<100,!=1.0,>0.0.0"
   register: version2
 
 - name: assert no changes ocurred
@@ -303,7 +303,7 @@
 - name: test the check_mod
   pip:
     name: "{{ pip_test_package }}"
-    version: "<100.0.0,!=1.0.0,>0.0.0"
+    version: "<100,!=1.0,>0.0.0"
   check_mode: yes
   register: version3
 
@@ -322,7 +322,7 @@
   assert:
     that: "version4.changed == True"
 
-- name: uninstall test packages
+- name: uninstall test packages for next test
   pip:
     name: "{{ pip_test_packages }}"
     state: absent
@@ -340,7 +340,7 @@
 
 - name: another invalid combination of arguments
   pip:
-    name: "{{ pip_test_package }}>=0.0.0,<=99.0.0,!=12.0.0"
+    name: "{{ pip_test_pkg_ver[0] }}"
     version: "<100.0.0"
   ignore_errors: yes
   register: version6
@@ -388,7 +388,31 @@
   assert:
     that: "version10.changed"
 
+- name: uninstall packages for next test
+  pip:
+    name: "{{ pip_test_packages }}"
+    state: absent
+
+- name: test install multi package provided by one single string
+  pip:
+    name: "{{pip_test_pkg_ver[0]}},{{pip_test_pkg_ver[1]}}"
+  register: version11
+
+- name: assert the install ran correctly
+  assert:
+    that: "version11.changed == True"
+
+- name: test install multi package provided by one single string with check_mode
+  pip:
+    name: "{{pip_test_pkg_ver[0]}},{{pip_test_pkg_ver[1]}}"
+  check_mode: yes
+  register: version12
+
+- name: assert no changes needed
+  assert:
+    that: "version12.changed == False"
+
 - name: clean up
   pip:
-    name: "{{ pip_test_pkg_ver }}"
+    name: "{{ pip_test_packages }}"
     state: absent

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -412,6 +412,12 @@
   assert:
     that: "not version12.changed"
 
+- name: test module can parse the combination of multi-packages one line and git url
+  pip:
+    name:
+      - git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601
+      - "{{pip_test_pkg_ver[0]}},{{pip_test_pkg_ver[1]}}"
+
 - name: clean up
   pip:
     name: "{{ pip_test_packages }}"

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -298,7 +298,7 @@
 
 - name: assert no changes ocurred
   assert:
-    that: "version2.changed == False"
+    that: "not version2.changed"
 
 - name: test the check_mod
   pip:
@@ -320,7 +320,7 @@
 
 - name: assert changed
   assert:
-    that: "version4.changed == True"
+    that: "version4.changed"
 
 - name: uninstall test packages for next test
   pip:
@@ -376,7 +376,7 @@
 
 - name: assert no change
   assert:
-    that: "version9.changed == False"
+    that: "not version9.changed"
 
 - name: test install unsatisfied multi-packages with check_mode
   pip:
@@ -400,7 +400,7 @@
 
 - name: assert the install ran correctly
   assert:
-    that: "version11.changed == True"
+    that: "version11.changed"
 
 - name: test install multi package provided by one single string with check_mode
   pip:
@@ -410,7 +410,7 @@
 
 - name: assert no changes needed
   assert:
-    that: "version12.changed == False"
+    that: "not version12.changed"
 
 - name: clean up
   pip:

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -309,7 +309,7 @@
 
 - name: assert no changes
   assert:
-    that: "version3.changed == False"
+    that: "not version3.changed"
 
 - name: test the check_mod with unsatisfied version
   pip:

--- a/test/integration/targets/pip/vars/main.yml
+++ b/test/integration/targets/pip/vars/main.yml
@@ -2,6 +2,12 @@ pip_test_package: sampleproject
 pip_test_packages:
   - sampleproject
   - decorator
+pip_test_pkg_ver:
+  - sampleproject<=10.0.0,!=9.0.0,>=0.0.0
+  - decorator<10.0.0,!=9.0.0,>=0.0.0
+pip_test_pkg_ver_unsatisfied:
+  - sampleproject>=99.0.0
+  - decorator>99.0.0
 pip_test_modules:
   - sample
   - decorator

--- a/test/integration/targets/pip/vars/main.yml
+++ b/test/integration/targets/pip/vars/main.yml
@@ -3,11 +3,11 @@ pip_test_packages:
   - sampleproject
   - decorator
 pip_test_pkg_ver:
-  - sampleproject<=10.0.0,!=9.0.0,>=0.0.0
-  - decorator<10.0.0,!=9.0.0,>=0.0.0
+  - sampleproject<=100,!=9.0.0,>=0.0.1
+  - decorator<100,!=9,>=0.0.1
 pip_test_pkg_ver_unsatisfied:
-  - sampleproject>=99.0.0
-  - decorator>99.0.0
+  - sampleproject>=999.0.0
+  - decorator>999.0
 pip_test_modules:
   - sample
   - decorator

--- a/test/integration/targets/pip/vars/main.yml
+++ b/test/integration/targets/pip/vars/main.yml
@@ -3,11 +3,11 @@ pip_test_packages:
   - sampleproject
   - decorator
 pip_test_pkg_ver:
-  - sampleproject<=100,!=9.0.0,>=0.0.1
-  - decorator<100,!=9,>=0.0.1
+  - sampleproject<=100, !=9.0.0,>=0.0.1 
+  - decorator<100 ,!=9,>=0.0.1
 pip_test_pkg_ver_unsatisfied:
-  - sampleproject>=999.0.0
-  - decorator>999.0
+  - sampleproject>= 999.0.0
+  - decorator >999.0
 pip_test_modules:
   - sample
   - decorator

--- a/test/units/modules/packaging/language/test_pip.py
+++ b/test/units/modules/packaging/language/test_pip.py
@@ -23,13 +23,13 @@ def test_failure_when_pip_absent(mocker, capfd):
     assert results['failed']
     assert 'pip needs to be installed' in results['msg']
 
-@pytest.mark.parametrize('test_input,expected',[
-    pytest.param(['django>1.11.1', '<1.11.2', 'ipaddress', 'simpleproject<2.0.0', '>1.1.0'],
-     ['django>1.11.1,<1.11.2', 'ipaddress', 'simpleproject<2.0.0,>1.1.0']),
-    pytest.param(['django>1.11.1,<1.11.2,ipaddress', 'simpleproject<2.0.0,>1.1.0'],
-     ['django>1.11.1,<1.11.2', 'ipaddress', 'simpleproject<2.0.0,>1.1.0']),
-    pytest.param(['django>1.11.1', '<1.11.2', 'git+https://github.com/some_repo', 'simpleproject<2.0.0', '>1.1.0'],
-     ['django>1.11.1,<1.11.2', 'git+https://github.com/some_repo', 'simpleproject<2.0.0,>1.1.0'])
-    ])
-def test_recover_distribution_name(test_input, expected):
-    assert pip._recover_distribution_name(test_input) == expected
+
+@pytest.mark.parametrize('patch_ansible_module, test_input, expected', [
+    [None, ['django>1.11.1', '<1.11.2', 'ipaddress', 'simpleproject<2.0.0', '>1.1.0'],
+        ['django>1.11.1,<1.11.2', 'ipaddress', 'simpleproject<2.0.0,>1.1.0']],
+    [None, ['django>1.11.1,<1.11.2,ipaddress', 'simpleproject<2.0.0,>1.1.0'],
+        ['django>1.11.1,<1.11.2', 'ipaddress', 'simpleproject<2.0.0,>1.1.0']],
+    [None, ['django>1.11.1', '<1.11.2', 'ipaddress,simpleproject<2.0.0,>1.1.0'],
+        ['django>1.11.1,<1.11.2', 'ipaddress', 'simpleproject<2.0.0,>1.1.0']]])
+def test_recover_package_name(test_input, expected):
+    assert pip._recover_package_name(test_input) == expected

--- a/test/units/modules/packaging/language/test_pip.py
+++ b/test/units/modules/packaging/language/test_pip.py
@@ -22,3 +22,14 @@ def test_failure_when_pip_absent(mocker, capfd):
     results = json.loads(out)
     assert results['failed']
     assert 'pip needs to be installed' in results['msg']
+
+@pytest.mark.parametrize('test_input,expected',[
+    pytest.param(['django>1.11.1', '<1.11.2', 'ipaddress', 'simpleproject<2.0.0', '>1.1.0'],
+     ['django>1.11.1,<1.11.2', 'ipaddress', 'simpleproject<2.0.0,>1.1.0']),
+    pytest.param(['django>1.11.1,<1.11.2,ipaddress', 'simpleproject<2.0.0,>1.1.0'],
+     ['django>1.11.1,<1.11.2', 'ipaddress', 'simpleproject<2.0.0,>1.1.0']),
+    pytest.param(['django>1.11.1', '<1.11.2', 'git+https://github.com/some_repo', 'simpleproject<2.0.0', '>1.1.0'],
+     ['django>1.11.1,<1.11.2', 'git+https://github.com/some_repo', 'simpleproject<2.0.0,>1.1.0'])
+    ])
+def test_recover_distribution_name(test_input, expected):
+    assert pip._recover_distribution_name(test_input) == expected


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`user` module doesn't check the input password and return very little information if users input unencrypted password (which is wrong), it's hard for users to figure out what's wrong. This PR check the format of the input password and give a warning if the password is not encrypted.
Fix #28772
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
/lib/ansible/modules/system/user.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (issue_28772 f5fa73be30) last updated 2018/08/02 13:59:35 (GMT -400)
  config file = None
  configured module search path = [u'/home/zhikangzhang/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/zhikangzhang/Desktop/ansible/lib/ansible
  executable location = /home/zhikangzhang/Desktop/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```