### PR TITLE
Give warning if user inputs not encrypted password to user module

### DIFF
--- a/changelogs/fragments/password_sanity_check.yml
+++ b/changelogs/fragments/password_sanity_check.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - user module - add a sanity check for user password and a more helpful warning message (https://github.com/ansible/ansible/pull/43615)

--- a/changelogs/fragments/password_sanity_check.yml
+++ b/changelogs/fragments/password_sanity_check.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - user module - add a sanity check for user password and a more helpful warning message (https://github.com/ansible/ansible/pull/43615)
+  - user module - add a sanity check for the user's password and a more helpful warning message (https://github.com/ansible/ansible/pull/43615)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -448,7 +448,7 @@ class User(object):
                 if len(fields) >= 3:
                     # contains character outside crypt constrain
                     if bool(_HASH_RE.search(fields[-1])):
-                      maybe_invalid = True
+                        maybe_invalid = True
                     # md5
                     if fields[1] == '1' and len(fields[-1]) != 22:
                         maybe_invalid = True
@@ -462,7 +462,7 @@ class User(object):
                     maybe_invalid = True
             if maybe_invalid:
                 self.module.warn("The iunput password seems not been hashed, "
-                            "please note that 'password' argument requires an encrypted value or the password will not work properly.")
+                                 "please note that 'password' argument requires an encrypted value or the password will not work properly.")
 
     def execute_command(self, cmd, use_unsafe_shell=False, data=None, obey_checkmode=True):
         if self.module.check_mode and obey_checkmode:

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -461,7 +461,7 @@ class User(object):
                 else:
                     maybe_invalid = True
             if maybe_invalid:
-                self.module.warn("The iunput password seems not been hashed, "
+                self.module.warn("The input password seems not been hashed, "
                                  "please note that 'password' argument requires an encrypted value or the password will not work properly.")
 
     def execute_command(self, cmd, use_unsafe_shell=False, data=None, obey_checkmode=True):

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -438,7 +438,7 @@ class User(object):
         if self.module.params['password'] and self.platform != 'Darwin':
             maybe_invalid = False
             # : for delimiter, * for disable user, ! for lock user
-            # these character are invalid in password
+            # these characters are invalid in the password
             if any(char in self.module.params['password'] for char in ':*!'):
                 maybe_invalid = True
             if '$' not in self.module.params['password']:
@@ -446,7 +446,7 @@ class User(object):
             else:
                 fields = self.module.params['password'].split("$")
                 if len(fields) >= 3:
-                    # contains character outside crypt constrain
+                    # contains character outside the crypto constraint
                     if bool(_HASH_RE.search(fields[-1])):
                         maybe_invalid = True
                     # md5
@@ -461,8 +461,8 @@ class User(object):
                 else:
                     maybe_invalid = True
             if maybe_invalid:
-                self.module.warn("The input password seems not been hashed, "
-                                 "please note that 'password' argument requires an encrypted value or the password will not work properly.")
+                self.module.warn("The input password appears not to have been hashed. "
+                                 "The 'password' argument must be encrypted for this module to work properly.")
 
     def execute_command(self, cmd, use_unsafe_shell=False, data=None, obey_checkmode=True):
         if self.module.check_mode and obey_checkmode:

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -342,6 +342,7 @@ uid:
 import errno
 import grp
 import os
+import re
 import platform
 import pwd
 import shutil
@@ -356,6 +357,9 @@ try:
     HAVE_SPWD = True
 except ImportError:
     HAVE_SPWD = False
+
+
+_HASH_RE = re.compile(r'[^a-zA-Z0-9./=]')
 
 
 class User(object):
@@ -428,6 +432,37 @@ class User(object):
             self.ssh_file = module.params['ssh_key_file']
         else:
             self.ssh_file = os.path.join('.ssh', 'id_%s' % self.ssh_type)
+
+    def check_password_encrypted(self):
+        # darwin need cleartext password, so no check
+        if self.module.params['password'] and self.platform != 'Darwin':
+            maybe_invalid = False
+            # : for delimiter, * for disable user, ! for lock user
+            # these character are invalid in password
+            if any(char in self.module.params['password'] for char in ':*!'):
+                maybe_invalid = True
+            if '$' not in self.module.params['password']:
+                maybe_invalid = True
+            else:
+                fields = self.module.params['password'].split("$")
+                if len(fields) >= 3:
+                    # contains character outside crypt constrain
+                    if bool(_HASH_RE.search(fields[-1])):
+                      maybe_invalid = True
+                    # md5
+                    if fields[1] == '1' and len(fields[-1]) != 22:
+                        maybe_invalid = True
+                    # sha256
+                    if fields[1] == '5' and len(fields[-1]) != 43:
+                        maybe_invalid = True
+                    # sha512
+                    if fields[1] == '6' and len(fields[-1]) != 86:
+                        maybe_invalid = True
+                else:
+                    maybe_invalid = True
+            if maybe_invalid:
+                self.module.warn("The iunput password seems not been hashed, "
+                            "please note that 'password' argument requires an encrypted value or the password will not work properly.")
 
     def execute_command(self, cmd, use_unsafe_shell=False, data=None, obey_checkmode=True):
         if self.module.check_mode and obey_checkmode:
@@ -2392,6 +2427,7 @@ def main():
     )
 
     user = User(module)
+    user.check_password_encrypted()
 
     module.debug('User instantiated - platform %s' % user.platform)
     if user.distribution:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -98,7 +98,7 @@
         update_password: always
       register: test_user_encrypt2
 
-    - name:
+    - name: there should be a warning complains about the character set of password
       assert:
         that: "'warnings' in test_user_encrypt2"
   when: ansible_system != 'Darwin'

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -64,6 +64,46 @@
       - user_test0_1 is not changed
       - '"ansibulluser" in user_names.stdout_lines'
 
+# test user add with password
+- name: add an encrypted password for user
+  user:
+    name: ansibulluser
+    password: "{{lookup('password', '/dev/null encrypt=sha512_crypt')}}"
+    state: present
+    update_password: always
+  register: test_user_encrypt0
+
+- name: there should not be warnings
+  assert:
+    that: "'warnings' not in test_user_encrypt0"
+
+- block:
+    - name: add an plaintext password for user
+      user:
+        name: ansibulluser
+        password: "plaintextpassword"
+        state: present
+        update_password: always
+      register: test_user_encrypt1
+
+    - name: there should be a warning complains that the password is plaintext
+      assert:
+        that: "'warnings' in test_user_encrypt1"
+
+    - name: add an invalid hashed password
+      user:
+        name: ansibulluser
+        password: "$6$rounds=656000$tgK3gYTyRLUmhyv2$lAFrYUQwn7E6VsjPOwQwoSx30lmpiU9r/E0Al7tzKrR9mkodcMEZGe9OXD0H/clOn6qdsUnaL4zefy5fG+++++"
+        state: present
+        update_password: always
+      register: test_user_encrypt2
+
+    - name:
+      assert:
+        that: "'warnings' in test_user_encrypt2"
+  when: ansible_system != 'Darwin'
+
+
 # https://github.com/ansible/ansible/issues/42484
 # Skipping macOS for now since there is a bug when changing home directory
 - block:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -68,7 +68,7 @@
 - name: add an encrypted password for user
   user:
     name: ansibulluser
-    password: "{{lookup('password', '/dev/null encrypt=sha512_crypt')}}"
+    password: "$6$rounds=656000$TT4O7jz2M57npccl$33LF6FcUMSW11qrESXL1HX0BS.bsiT6aenFLLiVpsQh6hDtI9pJh5iY7x8J7ePkN4fP8hmElidHXaeD51pbGS."
     state: present
     update_password: always
   register: test_user_encrypt0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`user` module doesn't check the input password and return very little information if users input unencrypted password (which is wrong), it's hard for users to figure out what's wrong. This PR check the format of the input password and give a warning if the password is not encrypted.
Fix #28772
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
/lib/ansible/modules/system/user.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (issue_28772 f5fa73be30) last updated 2018/08/02 13:59:35 (GMT -400)
  config file = None
  configured module search path = [u'/home/zhikangzhang/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/zhikangzhang/Desktop/ansible/lib/ansible
  executable location = /home/zhikangzhang/Desktop/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
