### PR TITLE
modules/terraform: use -no-color option in workspace commands

### DIFF
--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -183,7 +183,7 @@ def init_plugins(bin_path, project_path):
 
 def get_workspace_context(bin_path, project_path):
     workspace_ctx = {"current": "default", "all": []}
-    command = [bin_path, 'workspace', 'list']
+    command = [bin_path, 'workspace', '-no-color', 'list']
     rc, out, err = module.run_command(command, cwd=project_path)
     if rc != 0:
         module.fail_json(msg="Failed to list Terraform workspaces:\r\n{0}".format(err))
@@ -199,7 +199,7 @@ def get_workspace_context(bin_path, project_path):
 
 
 def _workspace_cmd(bin_path, project_path, action, workspace):
-    command = [bin_path, 'workspace', action, workspace]
+    command = [bin_path, 'workspace', '-no-color', action, workspace]
     rc, out, err = module.run_command(command, cwd=project_path)
     if rc != 0:
         module.fail_json(msg="Failed to {0} workspace:\r\n{1}".format(action, err))


### PR DESCRIPTION
##### SUMMARY

The use of workspace sometimes fails with an error message that looks related to color interpretation issue.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
terraform

##### ANSIBLE VERSION

```
ansible 2.6.0
  config file = None
  configured module search path = [u'/Users/remirey/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/remirey/.virtualenvs/avignon/lib/python2.7/site-packages/ansible
  executable location = /Users/remirey/.virtualenvs/avignon/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION

Here is the error raised by ansible:
```
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "binary_path": null, 
            "delete_workspace": false, 
            "force_init": true, 
            "lock": true, 
            "lock_timeout": null, 
            "plan_file": null, 
            "project_path": "files/containers/", 
            "state": "present", 
            "state_file": null, 
            "targets": [], 
            "variables": {
                "prefix": "av-1419"
            }, 
            "variables_file": null, 
            "workspace": "av-1419"
        }
    }, 
    "msg": "Failed to create workspace:\r\n\u001b[31mstate data in S3 does not have the expected content.\n\nThis may be caused by unusually long delays in S3 processing a previous state\nupdate.  Please wait for a minute or two and try again. If this problem\npersists, and neither S3 nor DynamoDB are experiencing an outage, you may need\nto manually verify the remote state and update the Digest value stored in the\nDynamoDB table to the following value: \n\u001b[0m\u001b[0m\n"
```

the `\u001b[0m\u001b[0m` string is clearly an ansi color output