### PR TITLE
Change default name of WEBSITE_CONTENTSHARE

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_functionapp.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_functionapp.py
@@ -271,7 +271,7 @@ class AzureRMFunctionApp(AzureRMModuleBase):
             function_app_settings.append(NameValuePair(name=key, value=self.storage_connection_string))
         function_app_settings.append(NameValuePair(name='FUNCTIONS_EXTENSION_VERSION', value='~1'))
         function_app_settings.append(NameValuePair(name='WEBSITE_NODE_DEFAULT_VERSION', value='6.5.0'))
-        function_app_settings.append(NameValuePair(name='WEBSITE_CONTENTSHARE', value=self.storage_account))
+        function_app_settings.append(NameValuePair(name='WEBSITE_CONTENTSHARE', value=self.name))
         return function_app_settings
 
     def aggregated_app_settings(self):


### PR DESCRIPTION
##### SUMMARY
Change default name of WEBSITE_CONTENTSHARE to be the same as the function name. (was tha name of the storage)

Otherwise you will run into problems when you'd attach the same storage to different functions. 

ISSUE TYPE

Bugfix Pull Request
