### PR TITLE
modules/terraform: fix -no-color position in workspace command

### DIFF
--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -183,7 +183,7 @@ def init_plugins(bin_path, project_path):
 
 def get_workspace_context(bin_path, project_path):
     workspace_ctx = {"current": "default", "all": []}
-    command = [bin_path, 'workspace', '-no-color', 'list']
+    command = [bin_path, 'workspace', 'list', '-no-color']
     rc, out, err = module.run_command(command, cwd=project_path)
     if rc != 0:
         module.fail_json(msg="Failed to list Terraform workspaces:\r\n{0}".format(err))
@@ -199,7 +199,7 @@ def get_workspace_context(bin_path, project_path):
 
 
 def _workspace_cmd(bin_path, project_path, action, workspace):
-    command = [bin_path, 'workspace', '-no-color', action, workspace]
+    command = [bin_path, 'workspace', action, workspace, '-no-color']
     rc, out, err = module.run_command(command, cwd=project_path)
     if rc != 0:
         module.fail_json(msg="Failed to {0} workspace:\r\n{1}".format(action, err))


### PR DESCRIPTION
##### SUMMARY

The `-no-color` argument provided in terraform workspace command was misplaced leading in the command to return the usage message.
The issue is not detected because the return code is 0 when showin usage:

```
$ terraform workspace -no-color ne toto
Usage: terraform workspace

  Create, change and delete Terraform workspaces.
$ echo $?
0
```

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
terraform.py

##### ANSIBLE VERSION

```
ansible 2.6.0
  config file = None
  configured module search path = [u'/Users/remirey/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/remirey/.virtualenvs/avignon/lib/python2.7/site-packages/ansible
  executable location = /Users/remirey/.virtualenvs/avignon/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION

Sorry @ryansb I totally missed this in my previous PR...


