### PR TITLE
[backport-2.6] meraki_snmp - Added full response documentation

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_snmp.py
+++ b/lib/ansible/modules/network/meraki/meraki_snmp.py
@@ -69,19 +69,55 @@ EXAMPLES = r'''
 
 RETURN = r'''
 data:
-    description: Information about queried or updated object.
-    type: list
-    returned: info
-    sample:
-      "data": {
-          "hostname": "n110.meraki.com",
-          "peer_ips": null,
-          "port": 16100,
-          "v2c_enabled": false,
-          "v3_auth_mode": null,
-          "v3_enabled": false,
-          "v3_priv_mode": null
-      }
+    description: Information about SNMP settings.
+    type: complex
+    returned: always
+    contains:
+        hostname:
+            description: Hostname of SNMP server.
+            returned: success
+            type: string
+            sample: n1.meraki.com
+        peerIps:
+            description: Semi-colon delimited list of IPs which can poll SNMP information.
+            returned: success
+            type: string
+            sample: 192.0.1.1
+        port:
+            description: Port number of SNMP.
+            returned: success
+            type: string
+            sample: 16100
+        v2cEnabled:
+            description: Shows enabled state of SNMPv2c
+            returned: success
+            type: bool
+            sample: true
+        v3Enabled:
+            description: Shows enabled state of SNMPv3
+            returned: success
+            type: bool
+            sample: true
+        v3AuthMode:
+            description: The SNMP version 3 authentication mode either MD5 or SHA.
+            returned: success
+            type: string
+            sample: SHA
+        v3PrivMode:
+            description: The SNMP version 3 privacy mode DES or AES128.
+            returned: success
+            type: string
+            sample: AES128
+        v2CommunityString:
+            description: Automatically generated community string for SNMPv2c.
+            returned: When SNMPv2c is enabled.
+            type: string
+            sample: o/8zd-JaSb
+        v3User:
+            description: Automatically generated username for SNMPv3.
+            returned: When SNMPv3c is enabled.
+            type: string
+            sample: o/8zd-JaSb
 '''
 
 import os


### PR DESCRIPTION
##### SUMMARY
…(#42488)

* Added full response documentation.

* Changed always to success for responses

(cherry picked from commit 0c59a3bc488a77672c66601ff32461f2dce17681)


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
meraki_snmp

##### ANSIBLE VERSION
```
ansible 2.6.2.post0 (backport/2.6/42488 048f3e6154) last updated 2018/08/04 10:05:32 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]

```

