### PR TITLE
change raising errors example to raise error

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -26,7 +26,7 @@ In general, errors encountered during execution should be returned by raising An
     try:
         cause_an_exception()
     except Exception as e:
-        AnsibleError('Something happened, this was original exception: %s' % to_native(e))
+        raise AnsibleError('Something happened, this was original exception: %s' % to_native(e))
 
 Check the different AnsibleError objects and see which one applies the best to your situation.
 


### PR DESCRIPTION
Example instantiates an AnsibleError which derives from Exception but doesn't actually raise it like intended. This is misleading as it's not clear without examining the code for AnsibleError to know that it's not some function which would raise the exception automatically.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
