### PR TITLE
windows: added Ansible.IO c# code to work on paths greater than 260

### DIFF
--- a/changelogs/fragments/windows_allow_file_paths_over_260.yaml
+++ b/changelogs/fragments/windows_allow_file_paths_over_260.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+- Added C# code in the namespace Ansible.IO that allows modules to work with paths that exceed 260 characters.
+- win_stat - Use Ansible.IO in Ansible.ModuleUtils.FileUtil to work with paths exceeding 260 characters.

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
@@ -507,7 +507,7 @@ namespace Ansible.IO
                     return new NotSupportedException("Illegal characters in path.");
                 case Win32Errors.ERROR_INVALID_PARAMETER:
                 default:
-                    string msg = new Win32Exception(errorCode).Message;
+                    string msg = new System.ComponentModel.Win32Exception(errorCode).Message;
                     return new IOException(
                         string.IsNullOrEmpty(path) ? msg : String.Format("{0} : '{1}'", msg, path), MakeHRFromErrorCode(errorCode));
             }
@@ -566,14 +566,14 @@ namespace Ansible.IO
                 return;
 
             Stack<string> dirsToCreate = new Stack<string>();
-            string directoryRoot = Ansible.IO.Path.GetPathRoot(fullPath);
+            string directoryRoot = Path.GetPathRoot(fullPath);
             string dir = fullPath;
             while (directoryRoot != dir)
             {
                 if (DirectoryExists(dir))
                     break;
                 dirsToCreate.Push(dir);
-                dir = Ansible.IO.Path.GetDirectoryName(dir);
+                dir = Path.GetDirectoryName(dir);
             }
 
             NativeHelpers.SecurityAttributes secAttr = new NativeHelpers.SecurityAttributes(directorySecurity);
@@ -642,7 +642,7 @@ namespace Ansible.IO
         internal static int FillAttributeInfo(string path, ref NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA data, bool returnErrorOnNotFound)
         {
             // Remove any trailing separators
-            path = Ansible.IO.Path.TrimEndingDirectorySeparator(path);
+            path = Path.TrimEndingDirectorySeparator(path);
             int errorCode = Win32Errors.ERROR_SUCCESS;
             if (!NativeMethods.GetFileAttributesExW(path, NativeHelpers.GET_FILEEX_INFO_LEVELS.GetFileExInfoStandard, out data))
             {
@@ -992,7 +992,7 @@ namespace Ansible.IO
             int errorCode;
             Exception exception = null;
 
-            IntPtr handle = NativeMethods.FindFirstFileW(Ansible.IO.Path.Combine(fullPath, "*"), out findData);
+            IntPtr handle = NativeMethods.FindFirstFileW(Path.Combine(fullPath, "*"), out findData);
             if (handle.ToInt64() == -1)
                 throw Win32Marshal.GetExceptionForLastWin32Error(fullPath);
 
@@ -1001,7 +1001,7 @@ namespace Ansible.IO
                 do
                 {
                     if ((findData.dwFileAttributes & FileAttributes.Directory) == 0)
-                        DeleteFile(Ansible.IO.Path.Combine(fullPath, findData.cFileName));
+                        DeleteFile(Path.Combine(fullPath, findData.cFileName));
                     else
                     {
                         string fileName = findData.cFileName;
@@ -1010,7 +1010,7 @@ namespace Ansible.IO
                         if (fileName == "." || fileName == "..")
                             continue;
 
-                        string filePath = Ansible.IO.Path.Combine(fullPath, fileName);
+                        string filePath = Path.Combine(fullPath, fileName);
                         bool isNamedSurrogate = IsNameSurrogateReparsePoint(ref findData);
                         try
                         {
@@ -1330,7 +1330,7 @@ namespace Ansible.IO
 
         public string Extension
         {
-            get { return Ansible.IO.Path.GetExtension(FullPath); }
+            get { return Path.GetExtension(FullPath); }
         }
 
         public virtual string Name
@@ -1347,7 +1347,7 @@ namespace Ansible.IO
                 if (_dataInitialized != 0)
                     // Unable to init data but we don't throw an excp here
                     return false;
-                return (_data.dwFileAttributes != -1) && ((this is Ansible.IO.DirectoryInfo) == ((_data.dwFileAttributes & (int)FileAttributes.Directory) == (int)FileAttributes.Directory));
+                return (_data.dwFileAttributes != -1) && ((this is DirectoryInfo) == ((_data.dwFileAttributes & (int)FileAttributes.Directory) == (int)FileAttributes.Directory));
             }
         }
 
@@ -1368,7 +1368,7 @@ namespace Ansible.IO
             }
             set
             {
-                FileSystem.SetFileTime(FullPath, (this is Ansible.IO.DirectoryInfo), value, null, null);
+                FileSystem.SetFileTime(FullPath, (this is DirectoryInfo), value, null, null);
                 _dataInitialized = -1;
             }
         }
@@ -1388,7 +1388,7 @@ namespace Ansible.IO
             }
             set
             {
-                FileSystem.SetFileTime(FullPath, (this is Ansible.IO.DirectoryInfo), null, value, null);
+                FileSystem.SetFileTime(FullPath, (this is DirectoryInfo), null, value, null);
                 _dataInitialized = -1;
             }
         }
@@ -1408,7 +1408,7 @@ namespace Ansible.IO
             }
             set
             {
-                FileSystem.SetFileTime(FullPath, (this is Ansible.IO.DirectoryInfo), null, null, value);
+                FileSystem.SetFileTime(FullPath, (this is DirectoryInfo), null, null, value);
                 _dataInitialized = -1;
             }
         }
@@ -1474,19 +1474,19 @@ namespace Ansible.IO
 
     public static class Directory
     {
-        public static void Compress(string path) { FileSystem.SetCompression(Ansible.IO.Path.CheckAndGetFullPath(path), true); }
+        public static void Compress(string path) { FileSystem.SetCompression(Path.CheckAndGetFullPath(path), true); }
         public static void Copy(string sourceDirPath, string destDirPath) { Copy(sourceDirPath, destDirPath, false); }
         public static void Copy(string sourceDirPath, string destDirPath, bool overwrite) { FileSystem.CopyFile(sourceDirPath, destDirPath, !overwrite); }
         public static DirectoryInfo CreateDirectory(string path) { return CreateDirectory(path, null); }
         public static DirectoryInfo CreateDirectory(string path, DirectorySecurity directorySecurity)
         {
-            string fullPath = Ansible.IO.Path.CheckAndGetFullPath(path);
+            string fullPath = Path.CheckAndGetFullPath(path);
             FileSystem.CreateDirectory(fullPath, directorySecurity);
             return new DirectoryInfo(path, fullPath, isNormalized: true);
         }
-        public static void Decompress(string path) { FileSystem.SetCompression(Ansible.IO.Path.CheckAndGetFullPath(path), false); }
+        public static void Decompress(string path) { FileSystem.SetCompression(Path.CheckAndGetFullPath(path), false); }
         public static void Delete(string path) { Delete(path, false); }
-        public static void Delete(string path, bool recursive) { FileSystem.RemoveDirectory(Ansible.IO.Path.GetFullPath(path), recursive); }
+        public static void Delete(string path, bool recursive) { FileSystem.RemoveDirectory(Path.GetFullPath(path), recursive); }
         public static IEnumerable<string> EnumerateDirectories(string path) { return EnumerateDirectories(path, "*", SearchOption.TopDirectoryOnly); }
         public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern) { return EnumerateDirectories(path, searchPattern, SearchOption.TopDirectoryOnly); }
         public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption) { return InternalEnumerateFolder<string>(path, searchPattern, searchOption, true, false); }
@@ -1516,21 +1516,21 @@ namespace Ansible.IO
         public static DateTime GetLastWriteTimeUtc(string path) { return File.GetLastWriteTimeUtc(path); }
         public static DirectoryInfo GetParent(string path)
         {
-            string fullPath = Ansible.IO.Path.CheckAndGetFullPath(path);
-            string s = Ansible.IO.Path.GetDirectoryName(fullPath);
+            string fullPath = Path.CheckAndGetFullPath(path);
+            string s = Path.GetDirectoryName(fullPath);
             if (s == null)
                 return null;
             return new DirectoryInfo(s);
         }
         public static void Move(string sourceDirName, string destDirName)
         {
-            string fullSource = Ansible.IO.Path.CheckAndGetFullPath(sourceDirName);
-            string fullDest = Ansible.IO.Path.CheckAndGetFullPath(destDirName);
+            string fullSource = Path.CheckAndGetFullPath(sourceDirName);
+            string fullDest = Path.CheckAndGetFullPath(destDirName);
 
             if (fullSource == fullDest)
                 throw new IOException("Source and destination path must be different.");
 
-            if (Ansible.IO.Path.GetPathRoot(fullSource) != Ansible.IO.Path.GetPathRoot(fullDest))
+            if (Path.GetPathRoot(fullSource) != Path.GetPathRoot(fullDest))
                 throw new IOException("Source and destination path must have identical roots. Move will not work across volumes.");
 
             if (!FileSystem.DirectoryExists(fullSource) && !FileSystem.FileExists(fullSource))
@@ -1541,22 +1541,22 @@ namespace Ansible.IO
         }
         public static void SetAccessControl(string path, DirectorySecurity directorySecurity) { FileSystem.SetAccessControl(path, directorySecurity); }
         public static void SetCreationTime(string path, DateTime creationTime) { SetCreationTimeUtc(path, creationTime.ToUniversalTime()); }
-        public static void SetCreationTimeUtc(string path, DateTime creationTimeUtc) { FileSystem.SetFileTime(Ansible.IO.Path.GetFullPath(path), true, creationTimeUtc, null, null); }
+        public static void SetCreationTimeUtc(string path, DateTime creationTimeUtc) { FileSystem.SetFileTime(Path.GetFullPath(path), true, creationTimeUtc, null, null); }
         public static void SetLastAccessTime(string path, DateTime lastAccessTime) { SetLastAccessTimeUtc(path, lastAccessTime.ToUniversalTime()); }
-        public static void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc) { FileSystem.SetFileTime(Ansible.IO.Path.GetFullPath(path), true, null, lastAccessTimeUtc, null); }
+        public static void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc) { FileSystem.SetFileTime(Path.GetFullPath(path), true, null, lastAccessTimeUtc, null); }
         public static void SetLastWriteTime(string path, DateTime lastWriteTime) { SetLastWriteTimeUtc(path, lastWriteTime.ToUniversalTime()); }
-        public static void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc) { FileSystem.SetFileTime(Ansible.IO.Path.GetFullPath(path), true, null, null, lastWriteTimeUtc); }
+        public static void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc) { FileSystem.SetFileTime(Path.GetFullPath(path), true, null, null, lastWriteTimeUtc); }
 
         internal static IEnumerable<T> InternalEnumerateFolder<T>(string path, string searchPattern, SearchOption searchOption, bool returnFolders, bool returnFiles)
         {
-            Ansible.IO.File.GetAttributes(path);  // verifies the root path exists or throws exception if not
+            File.GetAttributes(path);  // verifies the root path exists or throws exception if not
             Queue<string> dirs = new Queue<string>();
             dirs.Enqueue(path);
 
             while (dirs.Count > 0)
             {
                 string currentPath = dirs.Dequeue();
-                string searchPath = Ansible.IO.Path.Combine(currentPath, Ansible.IO.Path.TrimEndingDirectorySeparator(searchPattern));
+                string searchPath = Path.Combine(currentPath, Path.TrimEndingDirectorySeparator(searchPattern));
 
                 NativeHelpers.WIN32_FIND_DATA findData = new NativeHelpers.WIN32_FIND_DATA();
                 IntPtr findHandle = NativeMethods.FindFirstFileW(searchPath, out findData);
@@ -1566,7 +1566,7 @@ namespace Ansible.IO
                 do
                 {
                     string fileName = findData.cFileName;
-                    string filePath = Ansible.IO.Path.Combine(currentPath, fileName);
+                    string filePath = Path.Combine(currentPath, fileName);
                     FileAttributes attr = findData.dwFileAttributes;
 
                     if (attr.HasFlag(FileAttributes.Directory))
@@ -1600,7 +1600,7 @@ namespace Ansible.IO
 
     public sealed class DirectoryInfo : FileSystemInfo
     {
-        public DirectoryInfo(string path) { Init(originalPath: path, fullPath: Ansible.IO.Path.GetFullPath(path), isNormalized: true); }
+        public DirectoryInfo(string path) { Init(originalPath: path, fullPath: Path.GetFullPath(path), isNormalized: true); }
         internal DirectoryInfo(string originalPath, string fullPath = null, string fileName = null, bool isNormalized = false) { Init(originalPath, fullPath, fileName, isNormalized); }
 
         private void Init(string originalPath, string fullPath = null, string fileName = null, bool isNormalized = false)
@@ -1610,9 +1610,9 @@ namespace Ansible.IO
             OriginalPath = originalPath;
 
             fullPath = fullPath ?? originalPath;
-            fullPath = isNormalized ? fullPath : Ansible.IO.Path.GetFullPath(fullPath);
-            if (fileName == null && (Ansible.IO.Path.GetPathRoot(fullPath) != fullPath))
-                _name = Ansible.IO.Path.GetFileName(Ansible.IO.Path.TrimEndingDirectorySeparator(fullPath));
+            fullPath = isNormalized ? fullPath : Path.GetFullPath(fullPath);
+            if (fileName == null && (Path.GetPathRoot(fullPath) != fullPath))
+                _name = Path.GetFileName(Path.TrimEndingDirectorySeparator(fullPath));
             else if (fileName == null)
                 _name = fullPath;
             else
@@ -1624,7 +1624,7 @@ namespace Ansible.IO
         {
             get
             {
-                string parentName = Ansible.IO.Path.GetDirectoryName(Ansible.IO.Path.TrimEndingDirectorySeparator(FullPath));
+                string parentName = Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(FullPath));
                 return parentName != null
                     ? new DirectoryInfo(parentName, isNormalized: true)
                     : null;
@@ -1634,7 +1634,7 @@ namespace Ansible.IO
         {
             get
             {
-                return new DirectoryInfo(Ansible.IO.Path.GetPathRoot(FullPath));
+                return new DirectoryInfo(Path.GetPathRoot(FullPath));
             }
         }
 
@@ -1645,12 +1645,12 @@ namespace Ansible.IO
         {
             if (path == null)
                 throw new ArgumentNullException("path");
-            if (Ansible.IO.Path.IsEffectivelyEmpty(path))
+            if (Path.IsEffectivelyEmpty(path))
                 throw new ArgumentException("Path cannot be the empty string or all whitespace.", "path");
-            if (Ansible.IO.Path.IsPathRooted(path))
+            if (Path.IsPathRooted(path))
                 throw new ArgumentException("Second path fragment must not be a drive or UNC name.", "path");
 
-            string newPath = Ansible.IO.Path.GetFullPath(Ansible.IO.Path.Combine(FullPath, path));
+            string newPath = Path.GetFullPath(Path.Combine(FullPath, path));
             DirectoryInfo subDir = new DirectoryInfo(newPath);
             subDir.Create(directorySecurity);
             return subDir;
@@ -1684,7 +1684,7 @@ namespace Ansible.IO
             if (destDirName.Length == 0)
                 throw new ArgumentException("Empty file name is not legal.", "destDirName");
 
-            string destination = Ansible.IO.Path.GetFullPath(destDirName);
+            string destination = Path.GetFullPath(destDirName);
             if (!Exists && !FileSystem.FileExists(FullPath))
                 throw new DirectoryNotFoundException(String.Format("Could not find a part of the path '{0}'.", FullPath));
             if (FileSystem.DirectoryExists(destination))
@@ -1732,12 +1732,12 @@ namespace Ansible.IO
                 throw;
             }
         }
-        public static void Compress(string path) { FileSystem.SetCompression(Ansible.IO.Path.CheckAndGetFullPath(path), true); }
+        public static void Compress(string path) { FileSystem.SetCompression(Path.CheckAndGetFullPath(path), true); }
         public static void Copy(string sourceFileName, string destFileName) { Copy(sourceFileName, destFileName, false); }
         public static void Copy(string sourceFileName, string destFileName, bool overwrite)
         {
-            string fullSource = Ansible.IO.Path.CheckAndGetFullPath(sourceFileName);
-            string fullDest = Ansible.IO.Path.CheckAndGetFullPath(destFileName);
+            string fullSource = Path.CheckAndGetFullPath(sourceFileName);
+            string fullDest = Path.CheckAndGetFullPath(destFileName);
             FileSystem.CopyFile(fullSource, fullDest, overwrite);
         }
         public static FileStream Create(string path) { return Open(path, FileMode.Create, FileAccess.ReadWrite); }
@@ -1749,30 +1749,30 @@ namespace Ansible.IO
                 return new FileStream(handle, FileAccess.ReadWrite, DefaultBuffer, options.HasFlag(FileOptions.Asynchronous));
         }
         public static StreamWriter CreateText(string path) { return new StreamWriter(Open(path, FileMode.Create, FileAccess.ReadWrite)); }
-        public static void Decompress(string path) { FileSystem.SetCompression(Ansible.IO.Path.CheckAndGetFullPath(path), false); }
-        public static void Decrypt(string path) { FileSystem.Decrypt(Ansible.IO.Path.CheckAndGetFullPath(path)); }
+        public static void Decompress(string path) { FileSystem.SetCompression(Path.CheckAndGetFullPath(path), false); }
+        public static void Decrypt(string path) { FileSystem.Decrypt(Path.CheckAndGetFullPath(path)); }
         public static void Delete(string path)
         {
             if (path == null)
                 throw new ArgumentNullException("path");
-            FileSystem.DeleteFile(Ansible.IO.Path.GetFullPath(path));
+            FileSystem.DeleteFile(Path.GetFullPath(path));
         }
-        public static void Encrypt(string path) { FileSystem.Encrypt(Ansible.IO.Path.CheckAndGetFullPath(path)); }
+        public static void Encrypt(string path) { FileSystem.Encrypt(Path.CheckAndGetFullPath(path)); }
         public static bool Exists(string path) { return new FileInfo(path).Exists; }
         public static FileSecurity GetAccessControl(string path) { return GetAccessControl(path, AccessControlSections.Access | AccessControlSections.Group | AccessControlSections.Owner); }
         public static FileSecurity GetAccessControl(string path, AccessControlSections includeSections) { return FileSystem.GetAccessControl<FileSecurity>(path, includeSections); }
-        public static FileAttributes GetAttributes(string path) { return FileSystem.GetAttributes(Ansible.IO.Path.GetFullPath(path)); }
-        public static DateTime GetCreationTime(string path) { return FileSystem.GetCreationTime(Ansible.IO.Path.GetFullPath(path)).LocalDateTime; }
-        public static DateTime GetCreationTimeUtc(string path) { return FileSystem.GetCreationTime(Ansible.IO.Path.GetFullPath(path)).UtcDateTime; }
-        public static DateTime GetLastAccessTime(string path) { return FileSystem.GetLastAccessTime(Ansible.IO.Path.GetFullPath(path)).LocalDateTime; }
-        public static DateTime GetLastAccessTimeUtc(string path) { return FileSystem.GetLastAccessTime(Ansible.IO.Path.GetFullPath(path)).UtcDateTime; }
-        public static DateTime GetLastWriteTime(string path) { return FileSystem.GetLastWriteTime(Ansible.IO.Path.GetFullPath(path)).LocalDateTime; }
-        public static DateTime GetLastWriteTimeUtc(string path) { return FileSystem.GetLastWriteTime(Ansible.IO.Path.GetFullPath(path)).UtcDateTime; }
-        public static List<StreamInformation> GetStreamInfo(string path) { return FileSystem.GetStreamInfo(Ansible.IO.Path.CheckAndGetFullPath(path)); }
+        public static FileAttributes GetAttributes(string path) { return FileSystem.GetAttributes(Path.GetFullPath(path)); }
+        public static DateTime GetCreationTime(string path) { return FileSystem.GetCreationTime(Path.GetFullPath(path)).LocalDateTime; }
+        public static DateTime GetCreationTimeUtc(string path) { return FileSystem.GetCreationTime(Path.GetFullPath(path)).UtcDateTime; }
+        public static DateTime GetLastAccessTime(string path) { return FileSystem.GetLastAccessTime(Path.GetFullPath(path)).LocalDateTime; }
+        public static DateTime GetLastAccessTimeUtc(string path) { return FileSystem.GetLastAccessTime(Path.GetFullPath(path)).UtcDateTime; }
+        public static DateTime GetLastWriteTime(string path) { return FileSystem.GetLastWriteTime(Path.GetFullPath(path)).LocalDateTime; }
+        public static DateTime GetLastWriteTimeUtc(string path) { return FileSystem.GetLastWriteTime(Path.GetFullPath(path)).UtcDateTime; }
+        public static List<StreamInformation> GetStreamInfo(string path) { return FileSystem.GetStreamInfo(Path.CheckAndGetFullPath(path)); }
         public static void Move(string sourceFileName, string destFileName)
         {
-            string fullSourceFileName = Ansible.IO.Path.CheckAndGetFullPath(sourceFileName);
-            string fullDestFileName = Ansible.IO.Path.CheckAndGetFullPath(destFileName);
+            string fullSourceFileName = Path.CheckAndGetFullPath(sourceFileName);
+            string fullDestFileName = Path.CheckAndGetFullPath(destFileName);
 
             if (!FileSystem.FileExists(fullSourceFileName))
                 throw new FileNotFoundException(String.Format("Could not find file '{0}'.", fullSourceFileName), fullSourceFileName);
@@ -1844,25 +1844,25 @@ namespace Ansible.IO
         public static void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName) { Replace(sourceFileName, destinationFileName, destinationBackupFileName, false); }
         public static void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
         {
-            string fullSource = Ansible.IO.Path.CheckAndGetFullPath(sourceFileName);
-            string fullDest = Ansible.IO.Path.CheckAndGetFullPath(destinationFileName);
+            string fullSource = Path.CheckAndGetFullPath(sourceFileName);
+            string fullDest = Path.CheckAndGetFullPath(destinationFileName);
             FileSystem.ReplaceFile(fullSource, fullDest,
-                destinationBackupFileName != null ? Ansible.IO.Path.GetFullPath(destinationBackupFileName) : null,
+                destinationBackupFileName != null ? Path.GetFullPath(destinationBackupFileName) : null,
                 ignoreMetadataErrors);
         }
         public static void SetAccessControl(string path, FileSecurity fileSecurity) { FileSystem.SetAccessControl(path, fileSecurity); }
         public static void SetAttributes(string path, FileAttributes fileAttributes)
         {
-            string fullPath = Ansible.IO.Path.GetFullPath(path);
+            string fullPath = Path.GetFullPath(path);
             FileAttributes existingAttributes = File.GetAttributes(fullPath);
             FileSystem.SetAttributes(fullPath, fileAttributes, existingAttributes);
         }
         public static void SetCreationTime(string path, DateTime creationTime) { SetCreationTimeUtc(path, creationTime.ToUniversalTime()); }
-        public static void SetCreationTimeUtc(string path, DateTime creationTimeUtc) { FileSystem.SetFileTime(Ansible.IO.Path.GetFullPath(path), false, creationTimeUtc, null, null); }
+        public static void SetCreationTimeUtc(string path, DateTime creationTimeUtc) { FileSystem.SetFileTime(Path.GetFullPath(path), false, creationTimeUtc, null, null); }
         public static void SetLastAccessTime(string path, DateTime lastAccessTime) { SetLastAccessTimeUtc(path, lastAccessTime.ToUniversalTime()); }
-        public static void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc) { FileSystem.SetFileTime(Ansible.IO.Path.GetFullPath(path), false, null, lastAccessTimeUtc, null); }
+        public static void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc) { FileSystem.SetFileTime(Path.GetFullPath(path), false, null, lastAccessTimeUtc, null); }
         public static void SetLastWriteTime(string path, DateTime lastWriteTime) { SetLastWriteTimeUtc(path, lastWriteTime.ToUniversalTime()); }
-        public static void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc) { FileSystem.SetFileTime(Ansible.IO.Path.GetFullPath(path), false, null, null, lastWriteTimeUtc); }
+        public static void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc) { FileSystem.SetFileTime(Path.GetFullPath(path), false, null, null, lastWriteTimeUtc); }
         public static void WriteAllBytes(string path, byte[] bytes)
         {
             using (FileStream fs = Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
@@ -1904,8 +1904,8 @@ namespace Ansible.IO
                 throw new ArgumentNullException("fileName");
             OriginalPath = originalPath;
             fullpath = fullpath ?? originalPath;
-            FullPath = isNormalized ? fullpath ?? originalPath : Ansible.IO.Path.GetFullPath(fullpath);
-            _name = fileName ?? Ansible.IO.Path.GetFileName(originalPath);
+            FullPath = isNormalized ? fullpath ?? originalPath : Path.GetFullPath(fullpath);
+            _name = fileName ?? Path.GetFileName(originalPath);
         }
 
         public DirectoryInfo Directory
@@ -1914,7 +1914,7 @@ namespace Ansible.IO
         }
         public string DirectoryName
         {
-            get { return Ansible.IO.Path.GetDirectoryName(FullPath); }
+            get { return Path.GetDirectoryName(FullPath); }
         }
         public bool IsReadOnly
         {
@@ -1951,7 +1951,7 @@ namespace Ansible.IO
         public FileInfo CopyTo(string destFileName) { return CopyTo(destFileName, false); }
         public FileInfo CopyTo(string destFileName, bool overwrite)
         {
-            string destinationPath = Ansible.IO.Path.CheckAndGetFullPath(destFileName);
+            string destinationPath = Path.CheckAndGetFullPath(destFileName);
             FileSystem.CopyFile(FullPath, destinationPath, overwrite);
             return new FileInfo(destinationPath, isNormalized: true);
         }
@@ -1965,7 +1965,7 @@ namespace Ansible.IO
         public List<StreamInformation> GetStreamInfo() { return FileSystem.GetStreamInfo(FullPath); }
         public void MoveTo(string destFileName)
         {
-            string fullDestFileName = Ansible.IO.Path.CheckAndGetFullPath(destFileName);
+            string fullDestFileName = Path.CheckAndGetFullPath(destFileName);
 
             if (!Directory.Exists)
                 throw new DirectoryNotFoundException(String.Format("Could not find a part of the path '{0}'.", FullName));
@@ -1975,7 +1975,7 @@ namespace Ansible.IO
 
             FullPath = fullDestFileName;
             OriginalPath = destFileName;
-            _name = Ansible.IO.Path.GetFileName(fullDestFileName);
+            _name = Path.GetFileName(fullDestFileName);
             Invalidate();
         }
         public FileStream Open(FileMode mode) { return Open(mode, FileAccess.Read, FileShare.None); }
@@ -1989,8 +1989,8 @@ namespace Ansible.IO
         {
             if (destinationFileName == null)
                 throw new ArgumentNullException("destinationFileName");
-            FileSystem.ReplaceFile(FullPath, Ansible.IO.Path.GetFullPath(destinationFileName),
-                destinationBackupFileName != null ? Ansible.IO.Path.GetFullPath(destinationBackupFileName) : null,
+            FileSystem.ReplaceFile(FullPath, Path.GetFullPath(destinationFileName),
+                destinationBackupFileName != null ? Path.GetFullPath(destinationBackupFileName) : null,
                 ignoreMetadataErrors);
             return new FileInfo(destinationFileName);
         }
@@ -2171,19 +2171,19 @@ namespace Ansible.IO
 
     public static class SparseFile
     {
-        public static void AddSparseAttribute(string path) { FileSystem.SetSparseFlag(Ansible.IO.Path.CheckAndGetFullPath(path), true); }
+        public static void AddSparseAttribute(string path) { FileSystem.SetSparseFlag(Path.CheckAndGetFullPath(path), true); }
         public static List<SparseAllocations> GetAllAllocations(string path)
         {
-            Ansible.IO.FileInfo fileInfo = new Ansible.IO.FileInfo(path);
+            FileInfo fileInfo = new FileInfo(path);
             return FileSystem.QuerySparseAllocatedRanges(fileInfo.FullName, 0, fileInfo.Length);
         }
-        public static List<SparseAllocations> GetAllocations(string path, Int64 offset, Int64 length) { return FileSystem.QuerySparseAllocatedRanges(Ansible.IO.Path.CheckAndGetFullPath(path), offset, length); }
-        public static long GetDiskSize(string path) { return new Ansible.IO.FileInfo(path).DiskLength; }
-        public static long GetFileSize(string path) { return new Ansible.IO.FileInfo(path).Length; }
+        public static List<SparseAllocations> GetAllocations(string path, Int64 offset, Int64 length) { return FileSystem.QuerySparseAllocatedRanges(Path.CheckAndGetFullPath(path), offset, length); }
+        public static long GetDiskSize(string path) { return new FileInfo(path).DiskLength; }
+        public static long GetFileSize(string path) { return new FileInfo(path).Length; }
 
-        public static bool IsSparseFile(string path) { return File.GetAttributes(Ansible.IO.Path.CheckAndGetFullPath(path)).HasFlag(FileAttributes.SparseFile); }
-        public static void RemoveSparseAttribute(string path) { FileSystem.SetSparseFlag(Ansible.IO.Path.CheckAndGetFullPath(path), false); }
-        public static void ZeroData(string path, Int64 offset, Int64 length) { FileSystem.SetSparseZeroData(Ansible.IO.Path.CheckAndGetFullPath(path), offset, length); }
+        public static bool IsSparseFile(string path) { return File.GetAttributes(Path.CheckAndGetFullPath(path)).HasFlag(FileAttributes.SparseFile); }
+        public static void RemoveSparseAttribute(string path) { FileSystem.SetSparseFlag(Path.CheckAndGetFullPath(path), false); }
+        public static void ZeroData(string path, Int64 offset, Int64 length) { FileSystem.SetSparseZeroData(Path.CheckAndGetFullPath(path), offset, length); }
     }
 }
 '@
@@ -2210,23 +2210,15 @@ Function Import-FileUtil {
 
         'C:\temp' == '\\?\C:\temp'
         '\\server\share\path' == '\\?\UNC\server\share\path'
-
-    This module util is reliant on Ansible.ModuleUtils.PrivilegeUtil. Do not
-    call the Import-PrivilegeUtil function as this relies on that namespace
-    not being used upon loading.
     #>
-
-    # check if Ansible.IO is already loaded before trying again, this check is
-    # required because it could already be loaded from calling Import-LinkUtil
-    $namespace_loaded = [System.AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { "Ansible.IO" -in $_.ExportedTypes.Namespace }
-    if ($namespace_loaded) {
-        return
-    }
-
     # build the C# code to compile
     $namespaces = $ansible_privilege_util_namespaces + $ansible_file_util_namespaces | Select-Object -Unique
     $namespace_import = ($namespaces | ForEach-Object { "using $_;" }) -join "`r`n"
-    $platform_util = "$namespace_import`r`n`r`n$ansible_privilege_util_code`r`n`r`n$ansible_file_util_code"
+
+    $file_util = $ansible_file_util_code.Split([String[]]@("`r`n", "`r", "`n"), [System.StringSplitOptions]::None)
+    $file_util_code = "$($file_util[0])`r`n`r`n$($file_util[1])`r`n`r`n$ansible_privilege_util_code`r`n`r`n$($file_util[2..$file_util.Length] -join "`r`n")"
+
+    $platform_util = "$namespace_import`r`n`r`n$file_util_code"
 
     # FUTURE: find a better way to get the _ansible_remote_tmp variable
     $original_tmp = $env:TMP

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
@@ -1,51 +1,1917 @@
 # Copyright (c) 2017 Ansible Project
 # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
-<#
-Test-Path/Get-Item cannot find/return info on files that are locked like
-C:\pagefile.sys. These 2 functions are designed to work with these files and
-provide similar functionality with the normal cmdlets with as minimal overhead
-as possible. They work by using Get-ChildItem with a filter and return the
-result from that.
-#>
+#Requires -Module Ansible.ModuleUtils.PrivilegeUtil
+
+$ansible_file_util_namespaces = @(
+    "Microsoft.Win32.SafeHandles",
+    "System",
+    "System.Collections.Generic",
+    "System.ComponentModel",
+    "System.IO",
+    "System.Linq",
+    "System.Runtime.InteropServices",
+    "System.Security.AccessControl",
+    "System.Text"
+)
+
+# Most of the C# code has been slightly modified from the .NET Framework repo
+# https://github.com/dotnet/corefx but includes support for long file paths
+# The original code is licensed to the .NET Foundation under the MIT license.
+$ansible_file_util_code = @'
+namespace Ansible.IO
+{
+    internal static class Win32Errors
+    {
+        public const Int32 ERROR_SUCCESS = 0x00000000;
+        public const Int32 ERROR_FILE_NOT_FOUND = 0x00000002;
+        public const Int32 ERROR_PATH_NOT_FOUND = 0x00000003;
+        public const Int32 ERROR_ACCESS_DENIED = 0x00000005;
+        public const Int32 ERROR_NO_MORE_FILES = 0x00000012;
+        public const Int32 ERROR_NOT_READY = 0x00000015;
+        public const Int32 ERROR_SHARING_VIOLATION = 0x00000020;
+        public const Int32 ERROR_FILE_EXISTS = 0x00000050;
+        public const Int32 ERROR_INVALID_PARAMETER = 0x00000057;
+        public const Int32 ERROR_INVALID_NAME = 0x0000007B;
+        public const Int32 ERROR_DIR_NOT_EMPTY = 0x00000091;
+        public const Int32 ERROR_ALREADY_EXISTS = 0x000000B7;
+        public const Int32 ERROR_FILENAME_EXCED_RANGE = 0x000000CE;
+        public const Int32 ERROR_OPERATION_ABORTED = 0x000003E3;
+    }
+
+    internal class NativeHelpers
+    {
+        internal enum GET_FILEEX_INFO_LEVELS
+        {
+            GetFileExInfoStandard,
+            GetFileExMaxInfoLevel
+        }
+
+        internal enum SE_OBJECT_TYPE
+        {
+            SE_FILE_OBJECT = 1,
+        }
+
+        [Flags]
+        internal enum FlagsAndAttributes : uint
+        {
+            NONE = 0x00000000,
+            FILE_ATTRIBUTE_READONLY = 0x00000001,
+            FILE_ATTRIBUTE_HIDDEN = 0x00000002,
+            FILE_ATTRIBUTE_SYSTEM = 0x00000004,
+            FILE_ATTRIBUTE_ARCHIVE = 0x00000020,
+            FILE_ATTRIBUTE_NORMAL = 0x00000080,
+            FILE_ATTRIBUTE_TEMPORARY = 0x00000100,
+            FILE_ATTRIBUTE_OFFLINE = 0x00001000,
+            FILE_ATTRIBUTE_ENCRYPTED = 0x00004000,
+            FILE_FLAG_OPEN_NO_RECALL = 0x00100000,
+            FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000,
+            FILE_FLAG_SESSION_AWARE = 0x00800000,
+            FILE_FLAG_BACKUP_SEMANTICS = 0x02000000,
+            FILE_FLAG_DELETE_ON_CLOSE = 0x04000000,
+            FILE_FLAG_SEQUENTIAL_SCAN = 0x08000000,
+            FILE_FLAG_RANDOM_ACCESS = 0x10000000,
+            FILE_FLAG_NO_BUFFERING = 0x20000000,
+            FILE_FLAG_OVERLAPPED = 0x40000000,
+            FILE_FLAG_WRITE_THROUGH = 0x80000000,
+        }
+
+        [Flags]
+        internal enum ReplaceFlags : uint
+        {
+            REPLACEFILE_WRITE_THROUGH = 0x00000001,
+            REPLACEFILE_IGNORE_MERGE_ERRORS = 0x00000002,
+            REAPLCEFILE_IGNORE_ACL_ERRORS = 0x00000004,
+        }
+
+        [Flags]
+        internal enum SECURITY_DESCRIPTOR_CONTROL : uint
+        {
+            SE_NONE = 0x0000,
+            SE_OWNER_DEFAULTED = 0x0001,
+            SE_GROUP_DEFAULTED = 0x0002,
+            SE_DACL_PRESENT = 0x0004,
+            SE_DACL_DEFAULTED = 0x0008,
+            SE_SACL_DEFAULTED = 0x0008,
+            SE_SACL_PRESENT = 0x0010,
+            SE_DACL_AUTO_INHERIT_REQ = 0x0100,
+            SE_SACL_AUTO_INHERIT_REQ = 0x0200,
+            SE_DACL_AUTO_INHERITED = 0x0400,
+            SE_SACL_AUTO_INHERITED = 0x0800,
+            SE_DACL_PROTECTED = 0x1000,
+            SE_SACL_PROTECTED = 0x2000,
+            SE_RM_CONTROL_VALID = 0x4000,
+            SE_SELF_RELATIVE = 0x8000,
+        }
+
+        [Flags]
+        internal enum SECURITY_INFORMATION : uint
+        {
+            NONE = 0x00000000,
+            OWNER_SECURITY_INFORMATION = 0x00000001,
+            GROUP_SECURITY_INFORMATION = 0x00000002,
+            DACL_SECURITY_INFORMATION = 0x00000004,
+            SACL_SECURITY_INFORMATION = 0x00000008,
+            UNPROTECTED_SACL_SECURITY_INFORMATION = 0x10000000,
+            UNPROTECTED_DACL_SECURITY_INFORMATION = 0x20000000,
+            PROTECTED_SACL_SECURITY_INFORMATION = 0x40000000,
+            PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct FILETIME
+        {
+            internal UInt32 dwLowDateTime;
+            internal UInt32 dwHighDateTime;
+
+            public static implicit operator long(FILETIME v) { return ((long)v.dwHighDateTime << 32) + v.dwLowDateTime; }
+            public static explicit operator DateTime(FILETIME v) { return DateTime.FromFileTimeUtc(v); }
+            public static explicit operator DateTimeOffset(FILETIME v) { return DateTimeOffset.FromFileTime(v); }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct WIN32_FILE_ATTRIBUTE_DATA
+        {
+            public Int32 dwFileAttributes;
+            public FILETIME ftCreationTime;
+            public FILETIME ftLastAccessTime;
+            public FILETIME ftLastWriteTime;
+            public UInt32 nFileSizeHigh;
+            public UInt32 nFileSizeLow;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        internal struct WIN32_FIND_DATA
+        {
+            public FileAttributes dwFileAttributes;
+            public FILETIME ftCreationTime;
+            public FILETIME ftLastAccessTime;
+            public FILETIME ftLastWriteTime;
+            public UInt32 nFileSizeHigh;
+            public UInt32 nFileSizeLow;
+            public UInt32 dwReserved0;
+            public UInt32 dwReserved1;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)] public string cFileName;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 14)] public string cAlternateFileName;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal class SecurityAttributes : IDisposable
+        {
+            public UInt32 nLength = 0;
+            public IntPtr lpSecurityDescriptor = IntPtr.Zero;
+            public bool bInheritHandle = false;
+
+            public SecurityAttributes(ObjectSecurity securityDescriptor)
+            {
+                if (securityDescriptor != null)
+                {
+                    byte[] secDesc = securityDescriptor.GetSecurityDescriptorBinaryForm();
+                    nLength = (UInt32)secDesc.Length;
+                    lpSecurityDescriptor = Marshal.AllocHGlobal(secDesc.Length);
+                    Marshal.Copy(secDesc, 0, lpSecurityDescriptor, secDesc.Length);
+                }
+            }
+
+            public void Dispose()
+            {
+                if (lpSecurityDescriptor != IntPtr.Zero)
+                    Marshal.FreeHGlobal(lpSecurityDescriptor);
+                GC.SuppressFinalize(this);
+            }
+            ~SecurityAttributes() { Dispose(); }
+        }
+    }
+
+    // This is also used in Ansible.ModuleUtils.LinkUtil.psm1
+    internal class PrivilegeEnabler : IDisposable
+    {
+        private SafeWaitHandle process;
+        private Dictionary<string, bool?> previousState;
+
+        internal PrivilegeEnabler(string[] privileges)
+        {
+            if (privileges.Length > 0)
+            {
+                process = Ansible.PrivilegeUtil.Privileges.GetCurrentProcess();
+                Dictionary<string, bool?> newState = new Dictionary<string, bool?>();
+                for (int i = 0; i < privileges.Length; i++)
+                    newState.Add(privileges[i], true);
+                previousState = Ansible.PrivilegeUtil.Privileges.SetTokenPrivileges(process, newState);
+            }
+        }
+
+        public void Dispose()
+        {
+            // disables any privileges that were enabled by this class
+            if (previousState != null)
+                Ansible.PrivilegeUtil.Privileges.SetTokenPrivileges(process, previousState);
+            GC.SuppressFinalize(this);
+        }
+        ~PrivilegeEnabler() { Dispose(); }
+    }
+
+    internal class NativeMethods
+    {
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool CopyFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpExistingFileName,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpNewFileName,
+            [MarshalAs(UnmanagedType.Bool)] bool bFailIfExists);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool CreateDirectoryW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpPathName,
+            NativeHelpers.SecurityAttributes lpSecurityAttributes);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern SafeFileHandle CreateFileW(
+             [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+             [MarshalAs(UnmanagedType.U4)] FileSystemRights dwDesiredAccess,
+             [MarshalAs(UnmanagedType.U4)] FileShare dwShareMode,
+             NativeHelpers.SecurityAttributes lpSecurityAttributes,
+             [MarshalAs(UnmanagedType.U4)] FileMode dwCreationDisposition,
+             NativeHelpers.FlagsAndAttributes dwFlagsAndAttributes,
+             IntPtr hTemplateFile);
+
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool DecryptFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            UInt32 dwReserved);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool DeleteFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName);
+
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool EncryptFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool FindClose(
+            IntPtr hFindFile);
+
+        [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern IntPtr FindFirstFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            out NativeHelpers.WIN32_FIND_DATA lpFindFileData);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool FindNextFileW(
+            IntPtr hFindFile,
+            out NativeHelpers.WIN32_FIND_DATA lpFindFileData);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool GetFileAttributesExW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            NativeHelpers.GET_FILEEX_INFO_LEVELS fInfoLevelId,
+            out NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA lpFileInformation);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern UInt32 GetFullPathNameW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            UInt32 nBufferLength,
+            StringBuilder lpBuffer,
+            out IntPtr lpFilePart);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+        internal static extern UInt32 GetNamedSecurityInfoW(
+            [MarshalAs(UnmanagedType.LPWStr)] string pObjectName,
+            NativeHelpers.SE_OBJECT_TYPE ObjectType,
+            NativeHelpers.SECURITY_INFORMATION SecurityInfo,
+            out IntPtr ppsidOwner,
+            out IntPtr ppsidGroup,
+            out IntPtr ppDacl,
+            out IntPtr ppSacl,
+            out IntPtr ppSecurityDescriptor);
+
+        [DllImport("advapi32.dll")]
+        internal static extern UInt32 GetSecurityDescriptorLength(
+            IntPtr pSecurityDescriptor);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool GetSecurityDescriptorControl(
+            IntPtr pSecurityDescriptor,
+            out NativeHelpers.SECURITY_DESCRIPTOR_CONTROL pControl,
+            out UInt32 lpdwRevision);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool GetSecurityDescriptorDacl(
+            IntPtr pSecurityDescriptor,
+            [MarshalAs(UnmanagedType.Bool)] out bool lpbDaclPresent,
+            out IntPtr pDacl,
+            [MarshalAs(UnmanagedType.Bool)] out bool lpbDaclDefaulted);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool GetSecurityDescriptorGroup(
+            IntPtr pSecurityDescriptor,
+            out IntPtr pGroup,
+            [MarshalAs(UnmanagedType.Bool)] out bool lpbGroupDefaulted);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool GetSecurityDescriptorOwner(
+            IntPtr pSecurityDescriptor,
+            out IntPtr pOwner,
+            [MarshalAs(UnmanagedType.Bool)] out bool lpbOwnerDefaulted);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool GetSecurityDescriptorSacl(
+            IntPtr pSecurityDescriptor,
+            [MarshalAs(UnmanagedType.Bool)] out bool lpbSaclPresent,
+            out IntPtr pSacl,
+            [MarshalAs(UnmanagedType.Bool)] out bool lpbSaclDefaulted);
+
+        [DllImport("kernel32.dll")]
+        internal static extern IntPtr LocalFree(
+            IntPtr hMem);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool MoveFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpExistingFileName,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpNewFileName);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool ReplaceFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpReplacedFileName,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpReplacementFileName,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpBackupFileName,
+            NativeHelpers.ReplaceFlags dwReplaceFlags,
+            IntPtr lpExclude,
+            IntPtr lpReserved);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool SetFileAttributesW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            FileAttributes dwFileAttributes);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool SetFileTime(
+            SafeFileHandle hFile,
+            ref long lpCreationTime,
+            ref long lpLastAccessTime,
+            ref long lpLastWriteTime);
+
+        [DllImport("advapi32.dll")]
+        internal static extern UInt32 SetNamedSecurityInfoW(
+            [MarshalAs(UnmanagedType.LPWStr)] string pObjectName,
+            NativeHelpers.SE_OBJECT_TYPE objectType,
+            NativeHelpers.SECURITY_INFORMATION securityInfo,
+            IntPtr pSidOwner,
+            IntPtr pSidGroup,
+            IntPtr pDacl,
+            IntPtr pSacl);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool RemoveDirectoryW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpPathName);
+    }
+
+    internal static class Win32Marshal
+    {
+        internal static Exception GetExceptionForLastWin32Error(string path = "") { return GetExceptionForWin32Error(Marshal.GetLastWin32Error(), path); }
+
+        internal static Exception GetExceptionForWin32Error(int errorCode, string path = "")
+        {
+            switch (errorCode)
+            {
+                case Win32Errors.ERROR_FILE_NOT_FOUND:
+                    return new FileNotFoundException(
+                        string.IsNullOrEmpty(path) ? "Unable to find the specified file." : String.Format("Could not find file '{0}'", path), path);
+                case Win32Errors.ERROR_PATH_NOT_FOUND:
+                    return new DirectoryNotFoundException(
+                        string.IsNullOrEmpty(path) ? "Could not find a part of the path." : String.Format("Could not find a part of the path '{0}'.", path));
+                case Win32Errors.ERROR_ACCESS_DENIED:
+                    return new UnauthorizedAccessException(
+                        string.IsNullOrEmpty(path) ? "Access to the path is denied." : String.Format("Access to the path '{0}' is denied.", path));
+                case Win32Errors.ERROR_ALREADY_EXISTS:
+                    if (string.IsNullOrEmpty(path))
+                        goto default;
+                    return new IOException(
+                        String.Format("Cannot create '{0}' because a file or directory with the same name already exists.", path), MakeHRFromErrorCode(errorCode));
+                case Win32Errors.ERROR_SHARING_VIOLATION:
+                    return new IOException(string.IsNullOrEmpty(path) ?
+                        "The process cannot access the file because it is being used by another process." :
+                        String.Format("The process cannot access the file '{0}' because it is being used by another process.", path),
+                        MakeHRFromErrorCode(errorCode));
+                case Win32Errors.ERROR_FILE_EXISTS:
+                    if (string.IsNullOrEmpty(path))
+                        goto default;
+                    return new IOException(
+                        String.Format("The file '{0}' already exists.", path), MakeHRFromErrorCode(errorCode));
+                case Win32Errors.ERROR_OPERATION_ABORTED:
+                    return new OperationCanceledException();
+                case Win32Errors.ERROR_INVALID_NAME:
+                    return new NotSupportedException("Illegal characters in path.");
+                case Win32Errors.ERROR_INVALID_PARAMETER:
+                default:
+                    string msg = new Win32Exception(errorCode).Message;
+                    return new IOException(
+                        string.IsNullOrEmpty(path) ? msg : String.Format("{0} : '{1}'", msg, path), MakeHRFromErrorCode(errorCode));
+            }
+        }
+
+        internal static int MakeHRFromErrorCode(int errorCode)
+        {
+            // Don't convert it if it is already an HRESULT
+            if ((0xFFFF0000 & errorCode) != 0)
+                return errorCode;
+            return unchecked(((int)0x80070000) | errorCode);
+        }
+    }
+
+    internal static partial class FileSystem
+    {
+        public static void CopyFile(string sourceFullPath, string destFullPath, bool overwrite)
+        {
+            if (!NativeMethods.CopyFileW(sourceFullPath, destFullPath, !overwrite))
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                string fileName = destFullPath;
+                if (errorCode != Win32Errors.ERROR_FILE_EXISTS)
+                {
+                    // For some error codes we don't know if the problem was
+                    // source or dest, try reading source to rule it out
+                    SafeFileHandle handle = NativeMethods.CreateFileW(sourceFullPath,
+                        FileSystemRights.Read, FileShare.Read, null, FileMode.Open,
+                        (NativeHelpers.FlagsAndAttributes)0, IntPtr.Zero);
+                    if (handle.IsInvalid)
+                        fileName = sourceFullPath;
+                    else
+                        handle.Dispose();
+
+                    if (errorCode == Win32Errors.ERROR_ACCESS_DENIED)
+                    {
+                        if (DirectoryExists(destFullPath))
+                            throw new IOException(String.Format("The target file '{0}' is a directory, not a file.", destFullPath, Win32Errors.ERROR_ACCESS_DENIED));
+                    }
+
+                }
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode, fileName);
+            }
+        }
+
+        public static void ReplaceFile(string sourceFullPath, string destFullPath, string destBackupFullPath, bool ignoreMetadataErrors)
+        {
+            NativeHelpers.ReplaceFlags flags = ignoreMetadataErrors ? NativeHelpers.ReplaceFlags.REPLACEFILE_IGNORE_MERGE_ERRORS : 0;
+            if (!NativeMethods.ReplaceFileW(destFullPath, sourceFullPath, destBackupFullPath, flags, IntPtr.Zero, IntPtr.Zero))
+                throw Win32Marshal.GetExceptionForLastWin32Error();
+        }
+
+        public static void CreateDirectory(string fullPath, DirectorySecurity directorySecurity)
+        {
+            if (DirectoryExists(fullPath))
+                return;
+
+            Stack<string> dirsToCreate = new Stack<string>();
+            string directoryRoot = Ansible.IO.Path.GetPathRoot(fullPath);
+            string dir = fullPath;
+            while (directoryRoot != dir)
+            {
+                if (DirectoryExists(dir))
+                    break;
+                dirsToCreate.Push(dir);
+                dir = Ansible.IO.Path.GetDirectoryName(dir);
+            }
+
+            NativeHelpers.SecurityAttributes secAttr = new NativeHelpers.SecurityAttributes(directorySecurity);
+            try
+            {
+                while (dirsToCreate.Count > 0)
+                {
+                    dir = dirsToCreate.Pop();
+                    if (!NativeMethods.CreateDirectoryW(dir, secAttr))
+                    {
+                        int errorCode = Marshal.GetLastWin32Error();
+                        if (errorCode != Win32Errors.ERROR_ALREADY_EXISTS)
+                            throw Win32Marshal.GetExceptionForWin32Error(errorCode, dir);
+                    }
+                }
+            }
+            finally
+            {
+                secAttr.Dispose();
+            }
+        }
+
+        public static void DeleteFile(string fullPath)
+        {
+            if (!NativeMethods.DeleteFileW(fullPath))
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                if (errorCode != Win32Errors.ERROR_FILE_NOT_FOUND)
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
+            }
+        }
+
+        public static bool DirectoryExists(string fullPath)
+        {
+            NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA data = new NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA();
+            int lastError = FillAttributeInfo(fullPath, ref data, returnErrorOnNotFound: true);
+            return (lastError == 0) && (data.dwFileAttributes != -1) && ((data.dwFileAttributes & (int)FileAttributes.Directory) != 0);
+        }
+
+        internal static int FillAttributeInfo(string path, ref NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA data, bool returnErrorOnNotFound)
+        {
+            // Remove any trailing separators
+            path = Ansible.IO.Path.TrimEndingDirectorySeparator(path);
+            int errorCode = Win32Errors.ERROR_SUCCESS;
+            if (!NativeMethods.GetFileAttributesExW(path, NativeHelpers.GET_FILEEX_INFO_LEVELS.GetFileExInfoStandard, out data))
+            {
+                errorCode = Marshal.GetLastWin32Error();
+                // special system files like pagefile.sys returns
+                // ERROR_SHARING_VIOLATION but FindFirstFileW works so we try
+                // that here
+                if (errorCode == Win32Errors.ERROR_SHARING_VIOLATION)
+                {
+                    NativeHelpers.WIN32_FIND_DATA findData;
+                    IntPtr findHandle = NativeMethods.FindFirstFileW(path, out findData);
+                    if (findHandle.ToInt64() == -1)
+                        errorCode = Marshal.GetLastWin32Error();
+                    else
+                    {
+                        errorCode = Win32Errors.ERROR_SUCCESS;
+                        data.dwFileAttributes = (int)findData.dwFileAttributes;
+                        data.ftCreationTime = findData.ftCreationTime;
+                        data.ftLastAccessTime = findData.ftLastAccessTime;
+                        data.ftLastWriteTime = findData.ftLastWriteTime;
+                        data.nFileSizeHigh = findData.nFileSizeHigh;
+                        data.nFileSizeLow = findData.nFileSizeLow;
+                    }
+                }
+            }
+
+            if (errorCode != Win32Errors.ERROR_SUCCESS && !returnErrorOnNotFound)
+            {
+                switch (errorCode)
+                {
+                    case Win32Errors.ERROR_FILE_NOT_FOUND:
+                    case Win32Errors.ERROR_PATH_NOT_FOUND:
+                    case Win32Errors.ERROR_NOT_READY:
+                        // Return default value for backwards compatibility
+                        data.dwFileAttributes = -1;
+                        return Win32Errors.ERROR_SUCCESS;
+                }
+            }
+
+            return errorCode;
+        }
+
+        public static bool FileExists(string fullPath)
+        {
+            NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA data = new NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA();
+            int errorCode = FillAttributeInfo(fullPath, ref data, returnErrorOnNotFound: true);
+            return (errorCode == 0) && (data.dwFileAttributes != -1) && ((data.dwFileAttributes & (int)FileAttributes.Directory) == 0);
+        }
+
+        public static FileAttributes GetAttributes(string fullPath) { return (FileAttributes)GetFileAttributeData(fullPath).dwFileAttributes; }
+
+        public static DateTimeOffset GetCreationTime(string fullPath) { return (DateTimeOffset)GetFileAttributeData(fullPath).ftCreationTime; }
+
+        private static NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA GetFileAttributeData(string path)
+        {
+            NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA data = new NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA();
+            int errorCode = FillAttributeInfo(path, ref data, returnErrorOnNotFound: true);
+            if (errorCode != Win32Errors.ERROR_SUCCESS)
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode, path);
+            return data;
+        }
+
+        public static DateTimeOffset GetLastAccessTime(string fullPath) { return (DateTimeOffset)GetFileAttributeData(fullPath).ftLastAccessTime; }
+        public static DateTimeOffset GetLastWriteTime(string fullPath) { return (DateTimeOffset)GetFileAttributeData(fullPath).ftLastAccessTime; }
+
+        public static void MoveDirectory(string sourceFullPath, string destFullPath)
+        {
+            if (!NativeMethods.MoveFileW(sourceFullPath, destFullPath))
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                if (errorCode == Win32Errors.ERROR_FILE_NOT_FOUND)
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, sourceFullPath);
+                // This check was originally put in for Win9x (unfortunately without special casing it to be for Win9x only). We can't change the NT codepath now for backcomp reasons.
+                if (errorCode == Win32Errors.ERROR_ACCESS_DENIED)
+                    throw new IOException(String.Format("Access to the path '{0}' is denied.", sourceFullPath), Win32Marshal.MakeHRFromErrorCode(errorCode));
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+            }
+        }
+
+        public static void MoveFile(string sourceFullPath, string destFullPath)
+        {
+            if (!NativeMethods.MoveFileW(sourceFullPath, destFullPath))
+                throw Win32Marshal.GetExceptionForLastWin32Error();
+        }
+
+        internal static SafeFileHandle OpenHandle(string path, FileMode mode, FileAccess access, FileShare share, FileOptions options, FileSecurity fileSecurity)
+        {
+            FileSystemRights accessRights;
+            if (access == FileAccess.Read)
+                accessRights = FileSystemRights.Read;
+            else if (access == FileAccess.Write)
+                accessRights = FileSystemRights.WriteData;
+            else
+                accessRights = FileSystemRights.ReadData | FileSystemRights.WriteData;
+            NativeHelpers.FlagsAndAttributes attr = (NativeHelpers.FlagsAndAttributes)options;
+
+            List<string> privileges = new List<string>();
+            if (fileSecurity != null)
+            {
+                byte[] securityInfoBytes = fileSecurity.GetSecurityDescriptorBinaryForm();
+                IntPtr securityInfo = Marshal.AllocHGlobal(securityInfoBytes.Length);
+                Marshal.Copy(securityInfoBytes, 0, securityInfo, securityInfoBytes.Length);
+                try
+                {
+                    IntPtr pSacl = IntPtr.Zero;
+                    bool saclPresent, saclDefaulted;
+                    if (!NativeMethods.GetSecurityDescriptorSacl(securityInfo, out saclPresent, out pSacl, out saclDefaulted))
+                        throw new Win32Exception(Marshal.GetLastWin32Error(), "GetSecurityDescriptorSacl() failed");
+
+                    if (saclPresent)
+                    {
+                        accessRights |= (FileSystemRights)0x01000000;  // ACCESS_SYSTEM_SECURITY - Bit 24
+                        privileges.Add("SeSecurityPrivilege");
+                    }
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(securityInfo);
+                }
+            }
+
+            NativeHelpers.SecurityAttributes secAttr = new NativeHelpers.SecurityAttributes(fileSecurity);
+            SafeFileHandle fileHandle;
+            using (new PrivilegeEnabler(privileges.ToArray()))
+            {
+                fileHandle = NativeMethods.CreateFileW(path, accessRights, share, secAttr, mode, attr, IntPtr.Zero);
+                secAttr.Dispose();
+                if (fileHandle.IsInvalid)
+                    throw Win32Marshal.GetExceptionForLastWin32Error(path);
+            }
+
+            return fileHandle;
+        }
+
+        public static void RemoveDirectory(string fullPath, bool recursive)
+        {
+            if (!recursive)
+            {
+                RemoveDirectoryInternal(fullPath, topLevel: true);
+                return;
+            }
+
+            NativeHelpers.WIN32_FIND_DATA findData = new NativeHelpers.WIN32_FIND_DATA();
+            GetFindData(fullPath, ref findData);
+            if (IsNameSurrogateReparsePoint(ref findData))
+                // Don't recurse
+                RemoveDirectoryInternal(fullPath, topLevel: true);
+            else
+                RemoveDirectoryRecursive(fullPath, ref findData, topLevel: true);
+        }
+
+        public static T GetAccessControl<T>(string fullpath, AccessControlSections includeSections) where T : ObjectSecurity, new()
+        {
+            NativeHelpers.SECURITY_INFORMATION secInfo = NativeHelpers.SECURITY_INFORMATION.NONE;
+            List<string> privileges = new List<string>();
+            if ((includeSections.HasFlag(AccessControlSections.Access)))
+                secInfo |= NativeHelpers.SECURITY_INFORMATION.DACL_SECURITY_INFORMATION;
+            if ((includeSections.HasFlag(AccessControlSections.Audit)))
+            {
+                secInfo |= NativeHelpers.SECURITY_INFORMATION.SACL_SECURITY_INFORMATION;
+                privileges.Add("SeSecurityPrivilege");
+            }
+            if ((includeSections.HasFlag(AccessControlSections.Group)))
+                secInfo |= NativeHelpers.SECURITY_INFORMATION.GROUP_SECURITY_INFORMATION;
+            if ((includeSections.HasFlag(AccessControlSections.Owner)))
+                secInfo |= NativeHelpers.SECURITY_INFORMATION.OWNER_SECURITY_INFORMATION;
+
+            var acl = new T();
+            using (new PrivilegeEnabler(privileges.ToArray()))
+            {
+                IntPtr pSidOwner, pSidGroup, pDacl, pSacl, pSecurityDescriptor = IntPtr.Zero;
+                UInt32 res = NativeMethods.GetNamedSecurityInfoW(fullpath, NativeHelpers.SE_OBJECT_TYPE.SE_FILE_OBJECT, secInfo,
+                    out pSidOwner, out pSidGroup, out pDacl, out pSacl, out pSecurityDescriptor);
+                if (res != Win32Errors.ERROR_SUCCESS)
+                    throw Win32Marshal.GetExceptionForWin32Error((int)res, fullpath);
+
+                try
+                {
+                    UInt32 length = NativeMethods.GetSecurityDescriptorLength(pSecurityDescriptor);
+                    byte[] securityDescriptor = new byte[length];
+                    Marshal.Copy(pSecurityDescriptor, securityDescriptor, 0, (int)length);
+                    acl.SetSecurityDescriptorBinaryForm(securityDescriptor);
+                }
+                finally
+                {
+                    NativeMethods.LocalFree(pSecurityDescriptor);
+                }
+            }
+
+            return acl;
+        }
+
+        private static void GetFindData(string fullPath, ref NativeHelpers.WIN32_FIND_DATA findData)
+        {
+            IntPtr handle = NativeMethods.FindFirstFileW(fullPath, out findData);
+            if (handle.ToInt64() == -1)
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                // File not found doesn't make much sense coming from a directory delete.
+                if (errorCode == Win32Errors.ERROR_FILE_NOT_FOUND)
+                    errorCode = Win32Errors.ERROR_PATH_NOT_FOUND;
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
+            }
+            NativeMethods.FindClose(handle);
+        }
+
+        private static bool IsNameSurrogateReparsePoint(ref NativeHelpers.WIN32_FIND_DATA data)
+        {
+            // Reparse points that are not name surrogates should be treated like any other directory
+            return data.dwFileAttributes.HasFlag(FileAttributes.ReparsePoint) && (data.dwReserved0 & 0x20000000) != 0;
+        }
+
+        private static void RemoveDirectoryRecursive(string fullPath, ref NativeHelpers.WIN32_FIND_DATA findData, bool topLevel)
+        {
+            int errorCode;
+            Exception exception = null;
+
+            IntPtr handle = NativeMethods.FindFirstFileW(Ansible.IO.Path.Combine(fullPath, "*"), out findData);
+            if (handle.ToInt64() == -1)
+                throw Win32Marshal.GetExceptionForLastWin32Error(fullPath);
+
+            try
+            {
+                do
+                {
+                    if ((findData.dwFileAttributes & FileAttributes.Directory) == 0)
+                        DeleteFile(Ansible.IO.Path.Combine(fullPath, findData.cFileName));
+                    else
+                    {
+                        string fileName = findData.cFileName;
+
+                        // skip . and ..
+                        if (fileName == "." || fileName == "..")
+                            continue;
+
+                        string filePath = Ansible.IO.Path.Combine(fullPath, fileName);
+                        bool isNamedSurrogate = IsNameSurrogateReparsePoint(ref findData);
+                        try
+                        {
+                            if (isNamedSurrogate == true)
+                                RemoveDirectoryInternal(filePath, false, false);
+                            else
+                                RemoveDirectoryRecursive(filePath, ref findData, false);
+                        }
+                        catch (Exception e)
+                        {
+                            if (exception == null)
+                                exception = e;
+                        }
+                    }
+                } while (NativeMethods.FindNextFileW(handle, out findData));
+
+                if (exception != null)
+                    throw exception;
+
+                errorCode = Marshal.GetLastWin32Error();
+                if (errorCode != Win32Errors.ERROR_SUCCESS && errorCode != Win32Errors.ERROR_NO_MORE_FILES)
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
+            }
+            finally
+            {
+                NativeMethods.FindClose(handle);
+            }
+            RemoveDirectoryInternal(fullPath, topLevel: topLevel, allowDirectoryNotEmpty: true);
+        }
+
+        private static void RemoveDirectoryInternal(string fullPath, bool topLevel, bool allowDirectoryNotEmpty = false)
+        {
+            if (!NativeMethods.RemoveDirectoryW(fullPath))
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                switch (errorCode)
+                {
+                    case Win32Errors.ERROR_FILE_NOT_FOUND:
+                        errorCode = Win32Errors.ERROR_PATH_NOT_FOUND;
+                        goto case Win32Errors.ERROR_PATH_NOT_FOUND;
+                    case Win32Errors.ERROR_PATH_NOT_FOUND:
+                        // we only throw for the top level directory not found, not for any contents.
+                        if (!topLevel)
+                            return;
+                        break;
+                    case Win32Errors.ERROR_DIR_NOT_EMPTY:
+                        if (allowDirectoryNotEmpty)
+                            return;
+                        break;
+                    case Win32Errors.ERROR_ACCESS_DENIED:
+                        // This conversion was originally put in for Win9x. Keeping for compatibility.
+                        throw new IOException(String.Format("Access to the path '{0}' is denied.", fullPath));
+                }
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
+            }
+        }
+
+        public static void SetAccessControl(string fullPath, ObjectSecurity objectSecurity)
+        {
+            byte[] securityInfoBytes = objectSecurity.GetSecurityDescriptorBinaryForm();
+            IntPtr securityInfo = Marshal.AllocHGlobal(securityInfoBytes.Length);
+            try
+            {
+                Marshal.Copy(securityInfoBytes, 0, securityInfo, securityInfoBytes.Length);
+                NativeHelpers.SECURITY_INFORMATION securityInformation = NativeHelpers.SECURITY_INFORMATION.NONE;
+                List<string> privileges = new List<string>();
+
+                NativeHelpers.SECURITY_DESCRIPTOR_CONTROL control;
+                UInt32 lpdwRevision;
+                if (!NativeMethods.GetSecurityDescriptorControl(securityInfo, out control, out lpdwRevision))
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), "GetSecurityDescriptorControl() failed");
+
+                IntPtr pOwner = IntPtr.Zero;
+                bool ownerDefaulted;
+                if (!NativeMethods.GetSecurityDescriptorOwner(securityInfo, out pOwner, out ownerDefaulted))
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), "GetSecurityDescriptorOwner() failed");
+                if (pOwner != IntPtr.Zero)
+                {
+                    securityInformation |= NativeHelpers.SECURITY_INFORMATION.OWNER_SECURITY_INFORMATION;
+                    // Try and set some higher privileges, do not fail if this does not succeed as it may not be needed
+                    SafeWaitHandle process = Ansible.PrivilegeUtil.Privileges.GetCurrentProcess();
+                    Dictionary<string, Ansible.PrivilegeUtil.PrivilegeAttributes> currPrivileges = Ansible.PrivilegeUtil.Privileges.GetAllPrivilegeInfo(process);
+                    if (currPrivileges.ContainsKey("SeTakeOwnershipPrivilege"))
+                        privileges.Add("SeTakeOwnershipPrivilege");
+                    if (currPrivileges.ContainsKey("SeRestorePrivilege"))
+                        privileges.Add("SeRestorePrivilege");
+
+                    // On Server 2008 (and R2), you need to set the owner before the DACL/SACL/Group
+                    // in case we are taking ownership from another user so we do it first here
+                    using (new PrivilegeEnabler(privileges.ToArray()))
+                    {
+                        UInt32 res = NativeMethods.SetNamedSecurityInfoW(fullPath, NativeHelpers.SE_OBJECT_TYPE.SE_FILE_OBJECT, securityInformation, pOwner, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+                        if (res != Win32Errors.ERROR_SUCCESS)
+                            throw Win32Marshal.GetExceptionForWin32Error((int)res, fullPath);
+                    }
+                }
+
+                IntPtr pDacl = IntPtr.Zero;
+                bool daclPresent, daclDefaulted;
+                if (!NativeMethods.GetSecurityDescriptorDacl(securityInfo, out daclPresent, out pDacl, out daclDefaulted))
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), "GetSecurityDescriptorDacl() failed");
+                if (daclPresent)
+                {
+                    securityInformation |= NativeHelpers.SECURITY_INFORMATION.DACL_SECURITY_INFORMATION;
+                    securityInformation |= (control & NativeHelpers.SECURITY_DESCRIPTOR_CONTROL.SE_DACL_PROTECTED) != 0
+                        ? NativeHelpers.SECURITY_INFORMATION.PROTECTED_DACL_SECURITY_INFORMATION
+                        : NativeHelpers.SECURITY_INFORMATION.UNPROTECTED_DACL_SECURITY_INFORMATION;
+                }
+
+                IntPtr pGroup = IntPtr.Zero;
+                bool groupDefaulted;
+                if (!NativeMethods.GetSecurityDescriptorGroup(securityInfo, out pGroup, out groupDefaulted))
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), "GetSecurityDescriptorGroup() failed");
+                if (pGroup != IntPtr.Zero)
+                    securityInformation |= NativeHelpers.SECURITY_INFORMATION.GROUP_SECURITY_INFORMATION;
+
+                IntPtr pSacl = IntPtr.Zero;
+                bool saclPresent, saclDefaulted;
+                if (!NativeMethods.GetSecurityDescriptorSacl(securityInfo, out saclPresent, out pSacl, out saclDefaulted))
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), "GetSecurityDescriptorSacl() failed");
+                if (saclPresent)
+                {
+                    securityInformation |= NativeHelpers.SECURITY_INFORMATION.SACL_SECURITY_INFORMATION;
+                    securityInformation |= (control & NativeHelpers.SECURITY_DESCRIPTOR_CONTROL.SE_SACL_PROTECTED) != 0
+                        ? NativeHelpers.SECURITY_INFORMATION.PROTECTED_SACL_SECURITY_INFORMATION
+                        : NativeHelpers.SECURITY_INFORMATION.UNPROTECTED_SACL_SECURITY_INFORMATION;
+                    privileges.Add("SeSecurityPrivilege");
+                }
+
+                using (new PrivilegeEnabler(privileges.ToArray()))
+                {
+                    UInt32 res = NativeMethods.SetNamedSecurityInfoW(fullPath, NativeHelpers.SE_OBJECT_TYPE.SE_FILE_OBJECT, securityInformation, pOwner, pGroup, pDacl, pSacl);
+                    if (res != Win32Errors.ERROR_SUCCESS)
+                        throw Win32Marshal.GetExceptionForWin32Error((int)res, fullPath);
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(securityInfo);
+            }
+        }
+
+        public static void SetAttributes(string fullPath, FileAttributes attributes)
+        {
+            if (!NativeMethods.SetFileAttributesW(fullPath, attributes))
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                if (errorCode == Win32Errors.ERROR_INVALID_PARAMETER)
+                    throw new ArgumentException("Invalid File or Directory attributes value.", "attributes");
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
+            }
+        }
+
+        public static void SetFileTime(string fullPath, bool asDirectory, DateTime? creationTime, DateTime? lastAccessTime, DateTime? lastWriteTime)
+        {
+            using (SafeFileHandle handle = NativeMethods.CreateFileW(fullPath, FileSystemRights.WriteAttributes, FileShare.ReadWrite | FileShare.Delete,
+                null, FileMode.Open, NativeHelpers.FlagsAndAttributes.FILE_FLAG_BACKUP_SEMANTICS, IntPtr.Zero))
+            {
+                if (handle.IsInvalid)
+                    throw Win32Marshal.GetExceptionForLastWin32Error(fullPath);
+                long creation = creationTime.HasValue ? creationTime.Value.ToFileTimeUtc() : 0;
+                long access = lastAccessTime.HasValue ? lastAccessTime.Value.ToFileTimeUtc() : 0;
+                long write = lastWriteTime.HasValue ? lastWriteTime.Value.ToFileTimeUtc() : 0;
+
+                if (!NativeMethods.SetFileTime(handle, ref creation, ref access, ref write))
+                    throw Win32Marshal.GetExceptionForLastWin32Error(fullPath);
+            }
+        }
+    }
+
+    public abstract class FileSystemInfo : MarshalByRefObject
+    {
+        // -1 is not initialized, else the res of getting the file attribute data
+        private int _dataInitialized = -1;
+        private NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA _data;
+
+        protected string FullPath;
+        protected string OriginalPath;
+
+        internal string _name;
+
+        protected FileSystemInfo() { }
+
+        public virtual string FullName
+        {
+            get { return FullPath; }
+        }
+
+        public string Extension
+        {
+            get { return Ansible.IO.Path.GetExtension(FullPath); }
+        }
+
+        public virtual string Name
+        {
+            get { return _name; }
+        }
+
+        public virtual bool Exists
+        {
+            get
+            {
+                if (_dataInitialized == -1)
+                    Refresh();
+                if (_dataInitialized != 0)
+                    // Unable to init data but we don't throw an excp here
+                    return false;
+                return (_data.dwFileAttributes != -1) && ((this is Ansible.IO.DirectoryInfo) == ((_data.dwFileAttributes & (int)FileAttributes.Directory) == (int)FileAttributes.Directory));
+            }
+        }
+
+        public abstract void Delete();
+
+        public DateTime CreationTime
+        {
+            get { return CreationTimeUtc.ToLocalTime(); }
+            set { CreationTimeUtc = value.ToUniversalTime(); }
+        }
+
+        public DateTime CreationTimeUtc
+        {
+            get
+            {
+                EnsureDataInitialized();
+                return (DateTime)_data.ftCreationTime;
+            }
+            set
+            {
+                FileSystem.SetFileTime(FullPath, (this is Ansible.IO.DirectoryInfo), value, null, null);
+                _dataInitialized = -1;
+            }
+        }
+
+        public DateTime LastAccessTime
+        {
+            get { return LastAccessTimeUtc.ToLocalTime(); }
+            set { LastAccessTimeUtc = value.ToUniversalTime(); }
+        }
+
+        public DateTime LastAccessTimeUtc
+        {
+            get
+            {
+                EnsureDataInitialized();
+                return (DateTime)_data.ftLastAccessTime;
+            }
+            set
+            {
+                FileSystem.SetFileTime(FullPath, (this is Ansible.IO.DirectoryInfo), null, value, null);
+                _dataInitialized = -1;
+            }
+        }
+
+        public DateTime LastWriteTime
+        {
+            get { return LastWriteTimeUtc.ToLocalTime(); }
+            set { LastWriteTimeUtc = value.ToUniversalTime(); }
+        }
+
+        public DateTime LastWriteTimeUtc
+        {
+            get
+            {
+                EnsureDataInitialized();
+                return (DateTime)_data.ftLastWriteTime;
+            }
+            set
+            {
+                FileSystem.SetFileTime(FullPath, (this is Ansible.IO.DirectoryInfo), null, null, value);
+                _dataInitialized = -1;
+            }
+        }
+
+        internal long LengthCore
+        {
+            get
+            {
+                EnsureDataInitialized();
+                return ((long)_data.nFileSizeHigh) << 32 | _data.nFileSizeLow & 0xFFFFFFFFL;
+            }
+        }
+
+        public override string ToString() { return OriginalPath ?? string.Empty; }
+        internal void Invalidate() { _dataInitialized = -1; }
+
+        public FileAttributes Attributes
+        {
+            get
+            {
+                EnsureDataInitialized();
+                return (FileAttributes)_data.dwFileAttributes;
+            }
+            set
+            {
+                FileSystem.SetAttributes(FullPath, value);
+                _dataInitialized = -1;
+            }
+        }
+
+        private void EnsureDataInitialized()
+        {
+            if (_dataInitialized == -1)
+            {
+                _data = new NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA();
+                Refresh();
+            }
+
+            if (_dataInitialized != 0)  // Refresh was unable to init data
+                throw Win32Marshal.GetExceptionForWin32Error(_dataInitialized, FullPath);
+        }
+
+        public void Refresh() { _dataInitialized = FileSystem.FillAttributeInfo(FullPath, ref _data, returnErrorOnNotFound: false); }
+    }
+
+    public static class Directory
+    {
+        public static void Copy(string sourceDirPath, string destDirPath) { Copy(sourceDirPath, destDirPath, false); }
+        public static void Copy(string sourceDirPath, string destDirPath, bool overwrite) { FileSystem.CopyFile(sourceDirPath, destDirPath, !overwrite); }
+        public static DirectoryInfo CreateDirectory(string path) { return CreateDirectory(path, null); }
+        public static DirectoryInfo CreateDirectory(string path, DirectorySecurity directorySecurity)
+        {
+            string fullPath = Ansible.IO.Path.CheckAndGetFullPath(path);
+            FileSystem.CreateDirectory(fullPath, directorySecurity);
+            return new DirectoryInfo(path, fullPath, isNormalized: true);
+        }
+        public static void Delete(string path) { Delete(path, false); }
+        public static void Delete(string path, bool recursive) { FileSystem.RemoveDirectory(Ansible.IO.Path.GetFullPath(path), recursive); }
+        public static IEnumerable<string> EnumerateDirectories(string path) { return EnumerateDirectories(path, "*", SearchOption.TopDirectoryOnly); }
+        public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern) { return EnumerateDirectories(path, searchPattern, SearchOption.TopDirectoryOnly); }
+        public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption) { return InternalEnumerateFolder<string>(path, searchPattern, searchOption, true, false); }
+        public static IEnumerable<string> EnumerateFiles(string path) { return EnumerateFiles(path, "*", SearchOption.TopDirectoryOnly); }
+        public static IEnumerable<string> EnumerateFiles(string path, string searchPattern) { return EnumerateFiles(path, searchPattern, SearchOption.TopDirectoryOnly); }
+        public static IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption) { return InternalEnumerateFolder<string>(path, searchPattern, searchOption, false, true); }
+        public static IEnumerable<string> EnumerateFileSystemEntries(string path) { return EnumerateFileSystemEntries(path, "*", SearchOption.TopDirectoryOnly); }
+        public static IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern) { return EnumerateFileSystemEntries(path, searchPattern, SearchOption.TopDirectoryOnly); }
+        public static IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, SearchOption searchOption) { return InternalEnumerateFolder<string>(path, searchPattern, searchOption, true, true); }
+        public static bool Exists(string path) { return new DirectoryInfo(path).Exists; }
+        public static DirectorySecurity GetAccessControl(string path) { return GetAccessControl(path, AccessControlSections.Access | AccessControlSections.Group | AccessControlSections.Owner); }
+        public static DirectorySecurity GetAccessControl(string path, AccessControlSections includeSections) { return FileSystem.GetAccessControl<DirectorySecurity>(path, includeSections); }
+        public static DateTime GetCreationTime(string path) { return File.GetCreationTime(path); }
+        public static DateTime GetCreationTimeUtc(string path) { return File.GetCreationTimeUtc(path); }
+        public static string[] GetDirectories(string path) { return EnumerateDirectories(path).ToArray(); }
+        public static string[] GetDirectories(string path, string searchPattern) { return EnumerateDirectories(path, searchPattern).ToArray(); }
+        public static string[] GetDirectories(string path, string searchPattern, SearchOption searchOption) { return EnumerateDirectories(path, searchPattern, searchOption).ToArray(); }
+        public static string[] GetFiles(string path) { return EnumerateFiles(path).ToArray(); }
+        public static string[] GetFiles(string path, string searchPattern) { return EnumerateFiles(path, searchPattern).ToArray(); }
+        public static string[] GetFiles(string path, string searchPattern, SearchOption searchOption) { return EnumerateFiles(path, searchPattern, searchOption).ToArray(); }
+        public static string[] GetFileSystemInfos(string path) { return EnumerateFileSystemEntries(path).ToArray(); }
+        public static string[] GetFileSystemInfos(string path, string searchPattern) { return EnumerateFileSystemEntries(path, searchPattern).ToArray(); }
+        public static string[] GetFileSystemInfos(string path, string searchPattern, SearchOption searchOption) { return EnumerateFileSystemEntries(path, searchPattern, searchOption).ToArray(); }
+        public static DateTime GetLastAccessTime(string path) { return File.GetLastAccessTime(path); }
+        public static DateTime GetLastAccessTimeUtc(string path) { return File.GetLastAccessTimeUtc(path); }
+        public static DateTime GetLastWriteTime(string path) { return File.GetLastWriteTime(path); }
+        public static DateTime GetLastWriteTimeUtc(string path) { return File.GetLastWriteTimeUtc(path); }
+        public static DirectoryInfo GetParent(string path)
+        {
+            string fullPath = Ansible.IO.Path.CheckAndGetFullPath(path);
+            string s = Ansible.IO.Path.GetDirectoryName(fullPath);
+            if (s == null)
+                return null;
+            return new DirectoryInfo(s);
+        }
+        public static void Move(string sourceDirName, string destDirName)
+        {
+            string fullSource = Ansible.IO.Path.CheckAndGetFullPath(sourceDirName);
+            string fullDest = Ansible.IO.Path.CheckAndGetFullPath(destDirName);
+
+            if (fullSource == fullDest)
+                throw new IOException("Source and destination path must be different.");
+
+            if (Ansible.IO.Path.GetPathRoot(fullSource) != Ansible.IO.Path.GetPathRoot(fullDest))
+                throw new IOException("Source and destination path must have identical roots. Move will not work across volumes.");
+
+            if (!FileSystem.DirectoryExists(fullSource) && !FileSystem.FileExists(fullSource))
+                throw new DirectoryNotFoundException(String.Format("Could not find a part of the path '{0}'.", fullSource));
+            if (FileSystem.DirectoryExists(fullDest))
+                throw new IOException(String.Format("Cannot create '{0}' because a file or directory with the same name already exists.", fullDest));
+            FileSystem.MoveDirectory(fullSource, fullDest);
+        }
+        public static void SetAccessControl(string path, DirectorySecurity directorySecurity) { FileSystem.SetAccessControl(path, directorySecurity); }
+        public static void SetCreationTime(string path, DateTime creationTime) { SetCreationTimeUtc(path, creationTime.ToUniversalTime()); }
+        public static void SetCreationTimeUtc(string path, DateTime creationTimeUtc) { FileSystem.SetFileTime(Ansible.IO.Path.GetFullPath(path), true, creationTimeUtc, null, null); }
+        public static void SetLastAccessTime(string path, DateTime lastAccessTime) { SetLastAccessTimeUtc(path, lastAccessTime.ToUniversalTime()); }
+        public static void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc) { FileSystem.SetFileTime(Ansible.IO.Path.GetFullPath(path), true, null, lastAccessTimeUtc, null); }
+        public static void SetLastWriteTime(string path, DateTime lastWriteTime) { SetLastWriteTimeUtc(path, lastWriteTime.ToUniversalTime()); }
+        public static void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc) { FileSystem.SetFileTime(Ansible.IO.Path.GetFullPath(path), true, null, null, lastWriteTimeUtc); }
+
+        internal static IEnumerable<T> InternalEnumerateFolder<T>(string path, string searchPattern, SearchOption searchOption, bool returnFolders, bool returnFiles)
+        {
+            Ansible.IO.File.GetAttributes(path);  // verifies the root path exists or throws exception if not
+            Queue<string> dirs = new Queue<string>();
+            dirs.Enqueue(path);
+
+            while (dirs.Count > 0)
+            {
+                string currentPath = dirs.Dequeue();
+                string searchPath = Ansible.IO.Path.Combine(currentPath, Ansible.IO.Path.TrimEndingDirectorySeparator(searchPattern));
+
+                NativeHelpers.WIN32_FIND_DATA findData = new NativeHelpers.WIN32_FIND_DATA();
+                IntPtr findHandle = NativeMethods.FindFirstFileW(searchPath, out findData);
+                if (findHandle.ToInt64() == -1)
+                    continue;  // failed to get find handle, just continue through the queue we have
+
+                do
+                {
+                    string fileName = findData.cFileName;
+                    string filePath = Ansible.IO.Path.Combine(currentPath, fileName);
+                    FileAttributes attr = findData.dwFileAttributes;
+
+                    if (attr.HasFlag(FileAttributes.Directory))
+                    {
+                        // Skip current directory and parent directory names
+                        if (fileName == "." || fileName == "..")
+                            continue;
+                        else if (searchOption.HasFlag(SearchOption.AllDirectories))
+                            dirs.Enqueue(filePath);
+
+                        if (returnFolders)
+                            if (typeof(T) == typeof(string))
+                                yield return (T)(object)filePath;
+                            else
+                                yield return (T)(object)new DirectoryInfo(filePath);
+                    }
+                    else if (returnFiles)
+                        if (typeof(T) == typeof(string))
+                            yield return (T)(object)filePath;
+                        else
+                            yield return (T)(object)new FileInfo(filePath);
+                } while (NativeMethods.FindNextFileW(findHandle, out findData));
+
+                int lastErr = Marshal.GetLastWin32Error();
+                NativeMethods.FindClose(findHandle);
+                if (lastErr != Win32Errors.ERROR_NO_MORE_FILES)
+                    throw Win32Marshal.GetExceptionForLastWin32Error();
+            }
+        }
+    }
+
+    public sealed class DirectoryInfo : FileSystemInfo
+    {
+        public DirectoryInfo(string path) { Init(originalPath: path, fullPath: Ansible.IO.Path.GetFullPath(path), isNormalized: true); }
+        internal DirectoryInfo(string originalPath, string fullPath = null, string fileName = null, bool isNormalized = false) { Init(originalPath, fullPath, fileName, isNormalized); }
+
+        private void Init(string originalPath, string fullPath = null, string fileName = null, bool isNormalized = false)
+        {
+            if (originalPath == null)
+                throw new ArgumentNullException("path");
+            OriginalPath = originalPath;
+
+            fullPath = fullPath ?? originalPath;
+            fullPath = isNormalized ? fullPath : Ansible.IO.Path.GetFullPath(fullPath);
+            if (fileName == null && (Ansible.IO.Path.GetPathRoot(fullPath) != fullPath))
+                _name = Ansible.IO.Path.GetFileName(Ansible.IO.Path.TrimEndingDirectorySeparator(fullPath));
+            else if (fileName == null)
+                _name = fullPath;
+            else
+                _name = fileName;
+            FullPath = fullPath;
+        }
+
+        public DirectoryInfo Parent
+        {
+            get
+            {
+                string parentName = Ansible.IO.Path.GetDirectoryName(Ansible.IO.Path.TrimEndingDirectorySeparator(FullPath));
+                return parentName != null
+                    ? new DirectoryInfo(parentName, isNormalized: true)
+                    : null;
+            }
+        }
+        public DirectoryInfo Root
+        {
+            get
+            {
+                return new DirectoryInfo(Ansible.IO.Path.GetPathRoot(FullPath));
+            }
+        }
+
+        public void Create() { Create(null); }
+        public void Create(DirectorySecurity directorySecurity) { FileSystem.CreateDirectory(FullPath, directorySecurity); }
+        public DirectoryInfo CreateSubdirectory(string path) { return CreateSubdirectory(path, null); }
+        public DirectoryInfo CreateSubdirectory(string path, DirectorySecurity directorySecurity)
+        {
+            if (path == null)
+                throw new ArgumentNullException("path");
+            if (Ansible.IO.Path.IsEffectivelyEmpty(path))
+                throw new ArgumentException("Path cannot be the empty string or all whitespace.", "path");
+            if (Ansible.IO.Path.IsPathRooted(path))
+                throw new ArgumentException("Second path fragment must not be a drive or UNC name.", "path");
+
+            string newPath = Ansible.IO.Path.GetFullPath(Ansible.IO.Path.Combine(FullPath, path));
+            DirectoryInfo subDir = new DirectoryInfo(newPath);
+            subDir.Create(directorySecurity);
+            return subDir;
+        }
+        public override void Delete() { Delete(false); }
+        public void Delete(bool recursive) { FileSystem.RemoveDirectory(FullPath, recursive); }
+        public IEnumerable<DirectoryInfo> EnumerateDirectories() { return EnumerateDirectories("*", SearchOption.TopDirectoryOnly); }
+        public IEnumerable<DirectoryInfo> EnumerateDirectories(string searchPattern) { return EnumerateDirectories(searchPattern, SearchOption.TopDirectoryOnly); }
+        public IEnumerable<DirectoryInfo> EnumerateDirectories(string searchPattern, SearchOption searchOption) { return Directory.InternalEnumerateFolder<DirectoryInfo>(FullPath, searchPattern, searchOption, true, false); }
+        public IEnumerable<FileInfo> EnumerateFiles() { return EnumerateFiles("*", SearchOption.TopDirectoryOnly); }
+        public IEnumerable<FileInfo> EnumerateFiles(string searchPattern) { return EnumerateFiles(searchPattern, SearchOption.TopDirectoryOnly); }
+        public IEnumerable<FileInfo> EnumerateFiles(string searchPattern, SearchOption searchOption) { return Directory.InternalEnumerateFolder<FileInfo>(FullPath, searchPattern, searchOption, false, true); }
+        public IEnumerable<FileSystemInfo> EnumerateFileSystemInfos() { return EnumerateFileSystemInfos("*", SearchOption.TopDirectoryOnly); }
+        public IEnumerable<FileSystemInfo> EnumerateFileSystemInfos(string searchPattern) { return EnumerateFileSystemInfos(searchPattern, SearchOption.TopDirectoryOnly); }
+        public IEnumerable<FileSystemInfo> EnumerateFileSystemInfos(string searchPattern, SearchOption searchOption) { return Directory.InternalEnumerateFolder<FileSystemInfo>(FullPath, searchPattern, searchOption, true, true); }
+        public DirectorySecurity GetAccessControl() { return GetAccessControl(AccessControlSections.Access | AccessControlSections.Group | AccessControlSections.Owner); }
+        public DirectorySecurity GetAccessControl(AccessControlSections includeSections) { return FileSystem.GetAccessControl<DirectorySecurity>(FullPath, includeSections); }
+        public DirectoryInfo[] GetDirectories() { return EnumerateDirectories().ToArray(); }
+        public DirectoryInfo[] GetDirectories(string searchPattern) { return EnumerateDirectories(searchPattern).ToArray(); }
+        public DirectoryInfo[] GetDirectories(string searchPattern, SearchOption searchOption) { return EnumerateDirectories(searchPattern, searchOption).ToArray(); }
+        public FileInfo[] GetFiles() { return EnumerateFiles().ToArray(); }
+        public FileInfo[] GetFiles(string searchPattern) { return EnumerateFiles(searchPattern).ToArray(); }
+        public FileInfo[] GetFiles(string searchPattern, SearchOption searchOption) { return EnumerateFiles(searchPattern, searchOption).ToArray(); }
+        public FileSystemInfo[] GetFileSystemInfos() { return EnumerateFileSystemInfos().ToArray(); }
+        public FileSystemInfo[] GetFileSystemInfos(string searchPattern) { return EnumerateFileSystemInfos(searchPattern).ToArray(); }
+        public FileSystemInfo[] GetFileSystemInfos(string searchPattern, SearchOption searchOption) { return EnumerateFileSystemInfos(searchPattern, searchOption).ToArray(); }
+        public void MoveTo(string destDirName)
+        {
+            if (destDirName == null)
+                throw new ArgumentNullException("destDirName");
+            if (destDirName.Length == 0)
+                throw new ArgumentException("Empty file name is not legal.", "destDirName");
+
+            string destination = Ansible.IO.Path.GetFullPath(destDirName);
+            if (!Exists && !FileSystem.FileExists(FullPath))
+                throw new DirectoryNotFoundException(String.Format("Could not find a part of the path '{0}'.", FullPath));
+            if (FileSystem.DirectoryExists(destination))
+                throw new IOException(String.Format("Cannot create '{0}' because a file or directory with the same name already exists.", destination));
+
+            FileSystem.MoveDirectory(FullPath, destination);
+            Init(destDirName, destination, _name, true);
+            Invalidate();
+        }
+        public void SetAccessControl(DirectorySecurity directorySecurity) { FileSystem.SetAccessControl(FullPath, directorySecurity); }
+    }
+
+    public static class File
+    {
+        private static Encoding DefaultEncoding = new UTF8Encoding(false);
+        private static int DefaultBuffer = 4096;
+
+        public static void AppendAllLines(string path, IEnumerable<string> contents) { AppendAllLines(path, contents, DefaultEncoding); }
+        public static void AppendAllLines(string path, IEnumerable<string> contents, Encoding encoding)
+        {
+            using (StreamWriter writer = AppendText(path, encoding))
+            {
+                foreach (string content in contents)
+                    writer.Write(content);
+            }
+        }
+        public static void AppendAllText(string path, string contents) { AppendAllText(path, contents, DefaultEncoding); }
+        public static void AppendAllText(string path, string contents, Encoding encoding)
+        {
+            using (StreamWriter writer = AppendText(path, encoding))
+                writer.Write(contents);
+        }
+        public static StreamWriter AppendText(string path) { return AppendText(path, DefaultEncoding); }
+        public static StreamWriter AppendText(string path, Encoding encoding)
+        {
+            FileStream fs = Open(path, FileMode.OpenOrCreate, FileAccess.Write);
+            try
+            {
+                fs.Seek(0, SeekOrigin.End);
+                return new StreamWriter(fs, encoding);
+            }
+            catch
+            {
+                fs.Close();
+                throw;
+            }
+        }
+        public static void Copy(string sourceFileName, string destFileName) { Copy(sourceFileName, destFileName, false); }
+        public static void Copy(string sourceFileName, string destFileName, bool overwrite)
+        {
+            string fullSource = Ansible.IO.Path.CheckAndGetFullPath(sourceFileName);
+            string fullDest = Ansible.IO.Path.CheckAndGetFullPath(destFileName);
+            FileSystem.CopyFile(fullSource, fullDest, overwrite);
+        }
+        public static FileStream Create(string path) { return Open(path, FileMode.Create, FileAccess.ReadWrite); }
+        public static FileStream Create(string path, int bufferSize) { return Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, bufferSize, FileOptions.None); }
+        public static FileStream Create(string path, int bufferSize, FileOptions options) { return Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, bufferSize, options); }
+        public static FileStream Create(string path, int bufferSize, FileOptions options, FileSecurity fileSecurity)
+        {
+            using (SafeFileHandle handle = FileSystem.OpenHandle(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, options, fileSecurity))
+                return new FileStream(handle, FileAccess.ReadWrite, DefaultBuffer, options.HasFlag(FileOptions.Asynchronous));
+        }
+        public static StreamWriter CreateText(string path) { return new StreamWriter(Open(path, FileMode.Create, FileAccess.ReadWrite)); }
+        public static void Decrypt(string path)
+        {
+            if (!NativeMethods.DecryptFileW(path, 0))
+                throw new Win32Exception(Marshal.GetLastWin32Error(), String.Format("DecryptFileW({0}) failed", path));
+        }
+        public static void Delete(string path)
+        {
+            if (path == null)
+                throw new ArgumentNullException("path");
+            FileSystem.DeleteFile(Ansible.IO.Path.GetFullPath(path));
+        }
+        public static void Encrypt(string path)
+        {
+            if (!NativeMethods.EncryptFileW(path))
+                throw new Win32Exception(Marshal.GetLastWin32Error(), String.Format("EncryptFileW({0}) failed", path));
+        }
+        public static bool Exists(string path) { return new FileInfo(path).Exists; }
+        public static FileSecurity GetAccessControl(string path) { return GetAccessControl(path, AccessControlSections.Access | AccessControlSections.Group | AccessControlSections.Owner); }
+        public static FileSecurity GetAccessControl(string path, AccessControlSections includeSections) { return FileSystem.GetAccessControl<FileSecurity>(path, includeSections); }
+        public static FileAttributes GetAttributes(string path) { return FileSystem.GetAttributes(Ansible.IO.Path.GetFullPath(path)); }
+        public static DateTime GetCreationTime(string path) { return FileSystem.GetCreationTime(Ansible.IO.Path.GetFullPath(path)).LocalDateTime; }
+        public static DateTime GetCreationTimeUtc(string path) { return FileSystem.GetCreationTime(Ansible.IO.Path.GetFullPath(path)).UtcDateTime; }
+        public static DateTime GetLastAccessTime(string path) { return FileSystem.GetLastAccessTime(Ansible.IO.Path.GetFullPath(path)).LocalDateTime; }
+        public static DateTime GetLastAccessTimeUtc(string path) { return FileSystem.GetLastAccessTime(Ansible.IO.Path.GetFullPath(path)).UtcDateTime; }
+        public static DateTime GetLastWriteTime(string path) { return FileSystem.GetLastWriteTime(Ansible.IO.Path.GetFullPath(path)).LocalDateTime; }
+        public static DateTime GetLastWriteTimeUtc(string path) { return FileSystem.GetLastWriteTime(Ansible.IO.Path.GetFullPath(path)).UtcDateTime; }
+        public static void Move(string sourceFileName, string destFileName)
+        {
+            string fullSourceFileName = Ansible.IO.Path.CheckAndGetFullPath(sourceFileName);
+            string fullDestFileName = Ansible.IO.Path.CheckAndGetFullPath(destFileName);
+
+            if (!FileSystem.FileExists(fullSourceFileName))
+                throw new FileNotFoundException(String.Format("Could not find file '{0}'.", fullSourceFileName), fullSourceFileName);
+            FileSystem.MoveFile(fullSourceFileName, fullDestFileName);
+        }
+        public static FileStream Open(string path, FileMode mode) { return Open(path, mode, mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite, FileShare.None); }
+        public static FileStream Open(string path, FileMode mode, FileAccess access) { return Open(path, mode, access, FileShare.None); }
+        public static FileStream Open(string path, FileMode mode, FileAccess access, FileShare share) { return Open(path, mode, access, share, DefaultBuffer, FileOptions.None); }
+        public static FileStream Open(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
+        {
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            FileMode fileMode;
+            if (mode == FileMode.Append)
+                fileMode = FileMode.Open;
+            else
+                fileMode = mode;
+
+            SafeFileHandle handle = FileSystem.OpenHandle(path, fileMode, access, share, options, null);
+            FileStream fs = null;
+            try
+            {
+                fs = new FileStream(handle, access, bufferSize, options.HasFlag(FileOptions.Asynchronous));
+                if (mode == FileMode.Append)
+                    fs.Seek(0, SeekOrigin.End);
+                return fs;
+            }
+            catch
+            {
+                handle.Dispose();
+                if (fs != null)
+                    fs.Close();
+                throw;
+            }
+        }
+        public static FileStream OpenRead(string path) { return Open(path, FileMode.Open, FileAccess.Read); }
+        public static StreamReader OpenText(string path) { return OpenText(path, DefaultEncoding); }
+        public static StreamReader OpenText(string path, Encoding encoding) { return new StreamReader(OpenRead(path), encoding); }
+        public static FileStream OpenWrite(string path) { return Open(path, FileMode.OpenOrCreate, FileAccess.Write); }
+        public static byte[] ReadAllBytes(string path)
+        {
+            byte[] buffer = null;
+            using (FileStream fs = OpenRead(path))
+            {
+                buffer = new byte[fs.Length];
+                fs.Read(buffer, 0, (int)fs.Length);
+            }
+            return buffer;
+        }
+        public static string[] ReadAllLines(string path) { return ReadLines(path, DefaultEncoding).ToArray(); }
+        public static string[] ReadAllLines(string path, Encoding encoding) { return ReadLines(path, encoding).ToArray(); }
+        public static string ReadAllText(string path) { return ReadAllText(path, DefaultEncoding); }
+        public static string ReadAllText(string path, Encoding encoding)
+        {
+            using (StreamReader reader = OpenText(path, encoding))
+                return reader.ReadToEnd();
+        }
+        public static IEnumerable<string> ReadLines(string path) { return ReadLines(path, DefaultEncoding); }
+        public static IEnumerable<string> ReadLines(string path, Encoding encoding)
+        {
+            using (StreamReader reader = OpenText(path, encoding))
+            {
+                string line = null;
+                while ((line = reader.ReadLine()) != null)
+                    yield return line;
+            }
+        }
+        public static void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName) { Replace(sourceFileName, destinationFileName, destinationBackupFileName, false); }
+        public static void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
+        {
+            string fullSource = Ansible.IO.Path.CheckAndGetFullPath(sourceFileName);
+            string fullDest = Ansible.IO.Path.CheckAndGetFullPath(destinationFileName);
+            FileSystem.ReplaceFile(fullSource, fullDest,
+                destinationBackupFileName != null ? Ansible.IO.Path.GetFullPath(destinationBackupFileName) : null,
+                ignoreMetadataErrors);
+        }
+        public static void SetAccessControl(string path, FileSecurity fileSecurity) { FileSystem.SetAccessControl(path, fileSecurity); }
+        public static void SetAttributes(string path, FileAttributes fileAttributes) { FileSystem.SetAttributes(Ansible.IO.Path.GetFullPath(path), fileAttributes); }
+        public static void SetCreationTime(string path, DateTime creationTime) { SetCreationTimeUtc(path, creationTime.ToUniversalTime()); }
+        public static void SetCreationTimeUtc(string path, DateTime creationTimeUtc) { FileSystem.SetFileTime(Ansible.IO.Path.GetFullPath(path), false, creationTimeUtc, null, null); }
+        public static void SetLastAccessTime(string path, DateTime lastAccessTime) { SetLastAccessTimeUtc(path, lastAccessTime.ToUniversalTime()); }
+        public static void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc) { FileSystem.SetFileTime(Ansible.IO.Path.GetFullPath(path), false, null, lastAccessTimeUtc, null); }
+        public static void SetLastWriteTime(string path, DateTime lastWriteTime) { SetLastWriteTimeUtc(path, lastWriteTime.ToUniversalTime()); }
+        public static void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc) { FileSystem.SetFileTime(Ansible.IO.Path.GetFullPath(path), false, null, null, lastWriteTimeUtc); }
+        public static void WriteAllBytes(string path, byte[] bytes)
+        {
+            using (FileStream fs = Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
+                fs.Write(bytes, 0, bytes.Length);
+        }
+        public static void WriteAllLines(string path, IEnumerable<string> contents) { WriteAllLines(path, contents, DefaultEncoding); }
+        public static void WriteAllLines(string path, IEnumerable<string> contents, Encoding encoding)
+        {
+            using (StreamWriter writer = WriteText(path, encoding))
+                foreach (string line in contents)
+                    writer.WriteLine(line);
+        }
+        public static void WriteAllLines(string path, string[] contents) { WriteAllLines(path, contents, DefaultEncoding); }
+        public static void WriteAllLines(string path, string[] contents, Encoding encoding)
+        {
+            using (StreamWriter writer = WriteText(path, encoding))
+                foreach (string line in contents)
+                    writer.WriteLine(line);
+        }
+        public static void WriteAllText(string path, string contents) { WriteAllText(path, contents, DefaultEncoding); }
+        public static void WriteAllText(string path, string contents, Encoding encoding)
+        {
+            using (StreamWriter writer = WriteText(path, encoding))
+                writer.Write(contents);
+        }
+        public static StreamWriter WriteText(string path) { return WriteText(path, DefaultEncoding); }
+        public static StreamWriter WriteText(string path, Encoding encoding) { return new StreamWriter(Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None), encoding); }
+    }
+
+    public sealed class FileInfo : FileSystemInfo
+    {
+        private FileInfo() { }
+
+        public FileInfo(string fileName) : this(fileName, isNormalized: false) { }
+
+        internal FileInfo(string originalPath, string fullpath = null, string fileName = null, bool isNormalized = false)
+        {
+            if (originalPath == null)
+                throw new ArgumentNullException("fileName");
+            OriginalPath = originalPath;
+            fullpath = fullpath ?? originalPath;
+            FullPath = isNormalized ? fullpath ?? originalPath : Ansible.IO.Path.GetFullPath(fullpath);
+            _name = fileName ?? Ansible.IO.Path.GetFileName(originalPath);
+        }
+
+        public DirectoryInfo Directory
+        {
+            get { return (DirectoryName == null) ? null : new DirectoryInfo(DirectoryName); }
+        }
+        public string DirectoryName
+        {
+            get { return Ansible.IO.Path.GetDirectoryName(FullPath); }
+        }
+        public bool IsReadOnly
+        {
+            get { return (Attributes.HasFlag(FileAttributes.ReadOnly)); }
+            set
+            {
+                if (value)
+                    Attributes |= FileAttributes.ReadOnly;
+                else
+                    Attributes &= ~FileAttributes.ReadOnly;
+            }
+
+        }
+        public long Length
+        {
+            get
+            {
+                if (Attributes.HasFlag(FileAttributes.Directory))
+                    throw new FileNotFoundException(String.Format("Could not find file '{0}'.", FullPath), FullPath);
+                return LengthCore;
+            }
+        }
+
+        public StreamWriter AppendText() { return File.AppendText(FullPath); }
+        public FileInfo CopyTo(string destFileName) { return CopyTo(destFileName, false); }
+        public FileInfo CopyTo(string destFileName, bool overwrite)
+        {
+            string destinationPath = Ansible.IO.Path.CheckAndGetFullPath(destFileName);
+            FileSystem.CopyFile(FullPath, destinationPath, overwrite);
+            return new FileInfo(destinationPath, isNormalized: true);
+        }
+        public FileStream Create() { return File.Create(FullPath); }
+        public StreamWriter CreateText() { return File.CreateText(FullPath); }
+        public void Decrypt() { File.Decrypt(FullPath); }
+        public override void Delete() { File.Delete(FullPath); }
+        public void Encrypt() { File.Encrypt(FullPath); }
+        public FileSecurity GetAccessControl() { return GetAccessControl(AccessControlSections.Access | AccessControlSections.Group | AccessControlSections.Owner); }
+        public FileSecurity GetAccessControl(AccessControlSections includeSelections) { return FileSystem.GetAccessControl<FileSecurity>(FullPath, includeSelections); }
+        public void MoveTo(string destFileName)
+        {
+            string fullDestFileName = Ansible.IO.Path.CheckAndGetFullPath(destFileName);
+
+            if (!Directory.Exists)
+                throw new DirectoryNotFoundException(String.Format("Could not find a part of the path '{0}'.", FullName));
+            if (!Exists)
+                throw new FileNotFoundException(String.Format("Could not find file '{0}'.", FullName), FullName);
+            FileSystem.MoveFile(FullName, fullDestFileName);
+
+            FullPath = fullDestFileName;
+            OriginalPath = destFileName;
+            _name = Ansible.IO.Path.GetFileName(fullDestFileName);
+            Invalidate();
+        }
+        public FileStream Open(FileMode mode) { return Open(mode, FileAccess.Read, FileShare.None); }
+        public FileStream Open(FileMode mode, FileAccess access) { return Open(mode, access, FileShare.None); }
+        public FileStream Open(FileMode mode, FileAccess access, FileShare share) { return File.Open(FullPath, mode, access, share); }
+        public FileStream OpenRead() { return File.OpenRead(FullPath); }
+        public StreamReader OpenText() { return File.OpenText(FullPath); }
+        public FileStream OpenWrite() { return File.OpenWrite(FullPath); }
+        public FileInfo Replace(string destinationFileName, string destinationBackupFileName) { return Replace(destinationFileName, destinationBackupFileName, false); }
+        public FileInfo Replace(string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
+        {
+            if (destinationFileName == null)
+                throw new ArgumentNullException("destinationFileName");
+            FileSystem.ReplaceFile(FullPath, Ansible.IO.Path.GetFullPath(destinationFileName),
+                destinationBackupFileName != null ? Ansible.IO.Path.GetFullPath(destinationBackupFileName) : null,
+                ignoreMetadataErrors);
+            return new FileInfo(destinationFileName);
+        }
+        public void SetAccessControl(FileSecurity fileSecurity) { FileSystem.SetAccessControl(FullPath, fileSecurity); }
+    }
+
+    public static class Path
+    {
+        internal const char DirectorySeparatorChar = '\\';
+        internal const char AltDirectorySeparatorChar = '/';
+
+        public static string ChangeExtension(string path, string extension) { return System.IO.Path.ChangeExtension(path, extension); }
+        public static string Combine(params string[] paths) { return System.IO.Path.Combine(paths); }
+        public static string GetDirectoryName(string path)
+        {
+            if (path == null || IsEffectivelyEmpty(path))
+                return null;
+
+            int end = GetDirectoryNameOffset(path);
+            return end >= 0 ? NormalizeDirectorySeparators(path.Substring(0, end)) : null;
+        }
+        public static string GetExtension(string path) { return System.IO.Path.GetExtension(path); }
+        public static string GetFileName(string path) { return System.IO.Path.GetFileName(path); }
+        public static string GetFileNameWithoutExtension(string path) { return System.IO.Path.GetFileNameWithoutExtension(path); }
+        public static string GetFullPath(string path)
+        {
+            if (path == null)
+                throw new ArgumentNullException("The path is not of a legal form.");
+            else if (IsEffectivelyEmpty(path))
+                throw new ArgumentException("The path is not of a legal form.");
+
+            if (path.IndexOf('\0') != -1)
+                throw new ArgumentException("The path is not of a legal form.", "path");
+
+            // if starting with \\?\ don't parse and return as is, it should not be relative
+            if (path.StartsWith(@"\\?\"))
+                return path;
+
+            UInt32 bufferLength = 0;
+            StringBuilder lpBuffer = new StringBuilder();
+            IntPtr lpFilePart = IntPtr.Zero;
+            UInt32 returnLength = NativeMethods.GetFullPathNameW(path, bufferLength, lpBuffer, out lpFilePart);
+
+            lpBuffer.EnsureCapacity((int)returnLength);
+            returnLength = NativeMethods.GetFullPathNameW(path, returnLength, lpBuffer, out lpFilePart);
+            if (returnLength == 0)
+                throw new Win32Exception(Marshal.GetLastWin32Error(), String.Format("GetFullPathName({0}, {1}) failed when getting full path", path, returnLength));
+
+            return lpBuffer.ToString();
+        }
+        public static char[] GetInvalidFileNameChars() { return System.IO.Path.GetInvalidFileNameChars(); }
+        public static char[] GetInvalidPathChars() { return System.IO.Path.GetInvalidPathChars(); }
+        public static string GetPathRoot(string path)
+        {
+            // Strip the extended length path prefix if present
+            string pathPrefix = "";
+            if (path.StartsWith(@"\\?\UNC\", true, System.Globalization.CultureInfo.InvariantCulture))
+            {
+                path = @"\\" + path.Substring(8);
+                pathPrefix = @"\\?\UNC\";
+            }
+            else if (path.StartsWith(@"\\?\"))
+            {
+                path = path.Substring(4);
+                pathPrefix = @"\\?\";
+            }
+
+            // Make sure we don't exceed 256 chars and get the root from there
+            // the extra path info isn't needed 
+            if (path.Length > 256)
+                path = path.Substring(0, 256);
+            string pathRoot = System.IO.Path.GetPathRoot(path);
+
+            // Make sure the \\server is changed back to \\?\UNC\server
+            if (pathPrefix == @"\\?\UNC\")
+                return pathPrefix + pathRoot.Substring(2);
+            else
+                return pathPrefix + pathRoot;
+        }
+        public static string GetRandomFileName() { return System.IO.Path.GetRandomFileName(); }
+        public static string GetTempFileName() { return System.IO.Path.GetTempFileName(); }
+        public static string GetTempPath() { return System.IO.Path.GetTempPath(); }
+        public static bool HasExtension(string path) { return System.IO.Path.HasExtension(path); }
+        public static bool IsPathRooted(string path) { return System.IO.Path.IsPathRooted(path); }
+
+        internal static string CheckAndGetFullPath(string path)
+        {
+            if (path == null)
+                throw new ArgumentNullException("path");
+            if (path.Length == 0)
+                throw new ArgumentException("Path cannot be the empty string or all whitespace.", "path");
+            return GetFullPath(path);
+        }
+        internal static int GetDirectoryNameOffset(string path)
+        {
+            int rootLength = GetPathRoot(path).Length;
+            int end = path.Length;
+            if (end <= rootLength)
+                return -1;
+
+            while (end > rootLength && !IsDirectorySeparator(path[--end])) ;
+
+            // Trim off any remaining separators (to deal with C:\foo\\bar)
+            while (end > rootLength && IsDirectorySeparator(path[end - 1]))
+                end--;
+
+            return end;
+        }
+        internal static bool IsDirectorySeparator(char c) { return c == DirectorySeparatorChar || c == AltDirectorySeparatorChar; }
+        internal static bool IsEffectivelyEmpty(string path)
+        {
+            if (path.Length == 0)
+                return true;
+
+            foreach (char c in path)
+                if (c != ' ')
+                    return false;
+            return true;
+        }
+        internal static string NormalizeDirectorySeparators(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return path;
+            if (path.StartsWith(@"\\?\"))
+                return path;
+
+            char current;
+
+            // Make a pass to see if we need to normalize so we can potentially skip allocating
+            bool normalized = true;
+
+            for (int i = 0; i < path.Length; i++)
+            {
+                current = path[i];
+                if (IsDirectorySeparator(current)
+                    && (current != DirectorySeparatorChar
+                        // Check for sequential separators past the first position (we need to keep initial two for UNC/extended)
+                        || (i > 0 && i + 1 < path.Length && IsDirectorySeparator(path[i + 1]))))
+                {
+                    normalized = false;
+                    break;
+                }
+            }
+
+            if (normalized)
+                return path;
+
+            StringBuilder builder = new StringBuilder(path.Length);
+            int start = 0;
+            if (IsDirectorySeparator(path[start]))
+            {
+                start++;
+                builder.Append(DirectorySeparatorChar);
+            }
+
+            for (int i = start; i < path.Length; i++)
+            {
+                current = path[i];
+
+                // If we have a separator
+                if (IsDirectorySeparator(current))
+                {
+                    // If the next is a separator, skip adding this
+                    if (i + 1 < path.Length && IsDirectorySeparator(path[i + 1]))
+                        continue;
+
+                    // Ensure it is the primary separator
+                    current = DirectorySeparatorChar;
+                }
+                builder.Append(current);
+            }
+            return builder.ToString();
+        }
+        internal static string TrimEndingDirectorySeparator(string path)
+        {
+            return (path.Length > 0 && IsDirectorySeparator(path[path.Length - 1])) && !(GetPathRoot(path) == path)
+                ? path.Substring(0, path.Length - 1)
+                : path;
+        }
+    }
+}
+'@
+
+Function Import-FileUtil {
+    <#
+    .SYNOPSIS
+    Compiles the C# code that loads the Ansible.IO namespace. This namespace
+    contains classes that replicate the main System.IO classes but adds the
+    ability to use paths that exceed MAX_PATH. More specifically this loads
+    the following classes
+
+        Ansible.IO.Directory
+        Ansible.IO.DirectoryInfo
+        Ansible.IO.File
+        Ansible.IO.FileInfo
+        Ansible.IO.Path
+
+    By default they won't automatically work with paths that exceed 260 chars
+    but by prefixing an existing path with \\?\ it will work, e.g.
+
+        'C:\temp' == '\\?\C:\temp'
+        '\\server\share\path' == '\\?\UNC\server\share\path'
+
+    This module util is reliant on Ansible.ModuleUtils.PrivilegeUtil. Do not
+    call the Import-PrivilegeUtil function as this relies on that namespace
+    not being used upon loading.
+    #>
+
+    # check if Ansible.IO is already loaded before trying again, this check is
+    # required because it could already be loaded from calling Import-LinkUtil
+    $namespace_loaded = [System.AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { "Ansible.IO" -in $_.ExportedTypes.Namespace }
+    if ($namespace_loaded) {
+        return
+    }
+
+    # build the C# code to compile
+    $namespaces = $ansible_privilege_util_namespaces + $ansible_file_util_namespaces | Select-Object -Unique
+    $namespace_import = ($namespaces | ForEach-Object { "using $_;" }) -join "`r`n"
+    $platform_util = "$namespace_import`r`n`r`n$ansible_privilege_util_code`r`n`r`n$ansible_file_util_code"
+
+    # FUTURE: find a better way to get the _ansible_remote_tmp variable
+    $original_tmp = $env:TMP
+
+    $remote_tmp = $original_tmp
+    $module_params = Get-Variable -Name complex_args -ErrorAction SilentlyContinue
+    if ($module_params) {
+        if ($module_params.Value.ContainsKey("_ansible_remote_tmp") ) {
+            $remote_tmp = $module_params.Value["_ansible_remote_tmp"]
+            $remote_tmp = [System.Environment]::ExpandEnvironmentVariables($remote_tmp)
+        }
+    }
+
+    $env:TMP = $remote_tmp
+    Add-Type -TypeDefinition $platform_util
+    $env:TMP = $original_tmp
+}
 
 Function Test-AnsiblePath {
+    <#
+    .SYNOPSIS
+    Due to an underlying issue in the .NET framework, the Test-Path cmdlet is
+    unable to work with special locked files like C:\pagefile.sys and files
+    exceeding MAX_PATH. This cmdlet is designed to work with these files.
+    #>
     [CmdletBinding()]
     Param(
-        [Parameter(Mandatory=$true)][string]$Path
+        [Parameter(Mandatory=$true)][string]$Path,
+        [Parameter()][ValidateSet("Any", "Container", "Leaf")][string]$PathType = "Any"
     )
-    # Replacement for Test-Path
-    try {
-        $file_attributes = [System.IO.File]::GetAttributes($Path)
-    } catch [System.IO.FileNotFoundException], [System.IO.DirectoryNotFoundException] {
-        return $false
-    } catch [NotSupportedException] {
+
+    $ps_providers = (Get-PSDrive).Name | Where-Object { $_ -notmatch "^[A-Za-z]$" -and $Path.Startswith("$($_):", $true, [System.Globalization.CultureInfo]::InvariantCulture) }
+    if ($null -ne $ps_providers) {
         # When testing a path like Cert:\LocalMachine\My, System.IO.File will
         # not work, we just revert back to using Test-Path for this
-        return Test-Path -Path $Path
+        return Test-Path -Path $Path -PathType $PathType
     }
+
+    # Use the Ansible.IO.File functions to get the info on the file
+    Import-FileUtil
+    try {
+        $file_attributes = [Ansible.IO.File]::GetAttributes($Path)
+    } catch [System.IO.FileNotFoundException], [System.IO.DirectoryNotFoundException] {
+        return $false
+    } catch [System.NotSupportedException] {
+        # potentially contains illegal characters, try with Test-Path as a fallback
+        return Test-Path -Path $Path -PathType $PathType
+    }
+    # also throw IOException, and UnauthorizedAccessException but Test-Path does the same
 
     if ([Int32]$file_attributes -eq -1) {
         return $false
-    } else {
+    } elseif ($PathType -eq "Any") {
         return $true
+    } elseif ($PathType -eq "Container" -and $file_attributes.HasFlag([System.IO.FileAttributes]::Directory)) {
+        return $true
+    } elseif ($PathType -eq "Leaf" -and (-not $file_attributes.HasFlag([System.IO.FileAttributes]::Directory))) {
+        return $true
+    } else {
+        return $false
     }
 }
 
 Function Get-AnsibleItem {
+    <#
+    .SYNOPSIS
+    Due to an underlying issue in the .NET framework, the Get-Item cmdlet is
+    unable to work with special locked files like C:\pagefile.sys. This cmdlet
+    is designed to work with these files.
+    #>
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory=$true)][string]$Path
     )
+    Import-FileUtil
+
     # Replacement for Get-Item
-    $file_attributes = [System.IO.File]::GetAttributes($Path)
+    try {
+        $file_attributes = [Ansible.IO.File]::GetAttributes($Path)
+    } catch [System.IO.FileNotFoundException], [System.IO.DirectoryNotFoundException] {
+        throw New-Object -TypeName System.Management.Automation.ItemNotFoundException -ArgumentList "Cannot find path '$Path' because it does not exist."
+    }
+    
     if ([Int32]$file_attributes -eq -1) {
         throw New-Object -TypeName System.Management.Automation.ItemNotFoundException -ArgumentList "Cannot find path '$Path' because it does not exist."
     } elseif ($file_attributes.HasFlag([System.IO.FileAttributes]::Directory)) {
-        return New-Object -TypeName System.IO.DirectoryInfo -ArgumentList $Path
+        return New-Object -TypeName Ansible.IO.DirectoryInfo -ArgumentList $Path
     } else {
-        return New-Object -TypeName System.IO.FileInfo -ArgumentList $Path
+        return New-Object -TypeName Ansible.IO.FileInfo -ArgumentList $Path
     }
 }
 
-Export-ModuleMember -Function Test-AnsiblePath, Get-AnsibleItem
+Function Get-AnsibleFileHash {
+    <#
+    .SYNOPSIS
+    Get the hash of a file, also supports getting the hash of a file that
+    exceeds MAX_PATH.
+    #>#
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)][string]$Path,
+        [Parameter()][string]$Algorithm = "sha1"
+    )
+    Import-FileUtil
+
+    # Replacement for Get-FileHash
+    $crypto_service_provider = "$($algorithm)CryptoServiceProvider"
+    $sp = New-Object -TypeName System.Security.Cryptography.$crypto_service_provider
+    $compute_method = $sp | Get-Member -Type Method | Where-Object { $_.Name -eq "ComputeHash" }
+    if ($null -eq $compute_method) {
+        throw New-Object -TypeName System.ArgumentException -ArgumentList "Unsupported hash algorithm supplied '$algorithm'"
+    }
+
+    $fs = [Ansible.IO.File]::Open($path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::None)
+    try {
+        $hash = $sp.ComputeHash($fs)
+        $hash_string = [System.BitConverter]::ToString($hash).Replace("-", "").ToLower()
+    } finally {
+        $fs.Close()
+    }
+    return $hash_string
+}
+
+Export-ModuleMember -Function Import-FileUtil, Test-AnsiblePath, Get-AnsibleItem, Get-AnsibleFileHash `
+    -Variable ansible_file_util_namespaces, ansible_file_util_code

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
@@ -923,6 +923,13 @@ namespace Ansible.IO
         {
             NativeHelpers.SECURITY_INFORMATION secInfo = NativeHelpers.SECURITY_INFORMATION.NONE;
             List<string> privileges = new List<string>();
+
+            // Add the SeBackupPrivilege if it is on the process token
+            SafeWaitHandle process = Ansible.PrivilegeUtil.Privileges.GetCurrentProcess();
+            Dictionary<string, Ansible.PrivilegeUtil.PrivilegeAttributes> currPrivileges = Ansible.PrivilegeUtil.Privileges.GetAllPrivilegeInfo(process);
+            if (currPrivileges.ContainsKey("SeBackupPrivilege"))
+                privileges.Add("SeBackupPrivilege");
+
             if ((includeSections.HasFlag(AccessControlSections.Access)))
                 secInfo |= NativeHelpers.SECURITY_INFORMATION.DACL_SECURITY_INFORMATION;
             if ((includeSections.HasFlag(AccessControlSections.Audit)))

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
@@ -209,8 +209,10 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj = @{}, $fail
         if ($type -eq "path") {
             # Expand environment variables on path-type
             $value = Expand-Environment($value)
-            # Test if a valid path is provided
-            if (-not (Test-Path -IsValid $value)) {
+            # Test-Path -IsValid failed when the long path prefix is there, we don't want
+            # to check this ourselves and just rely on Windows to validate the path when
+            # using it
+            if ((-not ($value.StartsWith("\\?\"))) -and (-not (Test-Path -Path $value -IsValid))) {
                 $path_invalid = $true
                 # could still be a valid-shaped path with a nonexistent drive letter
                 if ($value -match "^\w:") {

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.LinkUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.LinkUtil.psm1
@@ -1,18 +1,20 @@
- # Copyright (c) 2017 Ansible Project
- # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+# Copyright (c) 2017 Ansible Project
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
 #Requires -Module Ansible.ModuleUtils.PrivilegeUtil
+#Requires -Module Ansible.ModuleUtils.FileUtil
 
-Function Load-LinkUtils() {
-    $link_util = @'
-using Microsoft.Win32.SafeHandles;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Runtime.InteropServices;
-using System.Text;
+$ansible_link_util_namespaces = @(
+    "Microsoft.Win32.SafeHandles",
+    "System",
+    "System.Collections.Generic",
+    "System.IO",
+    "System.Runtime.InteropServices",
+    "System.Text"
+)
 
-namespace Ansible
+$ansible_link_util_code = @'
+namespace Ansible.LinkUtil
 {
     public enum LinkType
     {
@@ -21,71 +23,63 @@ namespace Ansible
         HardLink
     }
 
-    public class LinkUtilWin32Exception : System.ComponentModel.Win32Exception
+    public class Win32Exception : System.ComponentModel.Win32Exception
     {
         private string _msg;
 
-        public LinkUtilWin32Exception(string message) : this(Marshal.GetLastWin32Error(), message) { }
+        public Win32Exception(string message) : this(Marshal.GetLastWin32Error(), message) { }
 
-        public LinkUtilWin32Exception(int errorCode, string message) : base(errorCode)
+        public Win32Exception(int errorCode, string message) : base(errorCode)
         {
             _msg = String.Format("{0} ({1}, Win32ErrorCode {2})", message, base.Message, errorCode);
         }
 
         public override string Message { get { return _msg; } }
-        public static explicit operator LinkUtilWin32Exception(string message) { return new LinkUtilWin32Exception(message); }
+        public static explicit operator Win32Exception(string message) { return new Win32Exception(message); }
     }
 
     public class LinkInfo
     {
         public LinkType Type { get; internal set; }
+
+        // Part of REPARSE_DATA_BUFFER, this is just a label of the target
         public string PrintName { get; internal set; }
+
+        // Part of REPARSE_DATA_BUFFER, this is the actual target using the NT Kernel path (differs from the Win32 path)
         public string SubstituteName { get; internal set; }
+
+        // Converts the SubstituteName value to the Win32 path, this is the absolute path
         public string AbsolutePath { get; internal set; }
+
+        // Converts the SubstituteName value to the Win32 path, this is not resolved to the absolute path and can be related to the path of the link itself
         public string TargetPath { get; internal set; }
+
+        // If LinkType is HardLinnk, this is an array of paths that are linked together
         public string[] HardTargets { get; internal set; }
     }
 
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-    public struct REPARSE_DATA_BUFFER
+    internal class NativeHelpers
     {
-        public UInt32 ReparseTag;
-        public UInt16 ReparseDataLength;
-        public UInt16 Reserved;
-        public UInt16 SubstituteNameOffset;
-        public UInt16 SubstituteNameLength;
-        public UInt16 PrintNameOffset;
-        public UInt16 PrintNameLength;
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        internal struct REPARSE_DATA_BUFFER
+        {
+            public UInt32 ReparseTag;
+            public UInt16 ReparseDataLength;
+            public UInt16 Reserved;
+            public UInt16 SubstituteNameOffset;
+            public UInt16 SubstituteNameLength;
+            public UInt16 PrintNameOffset;
+            public UInt16 PrintNameLength;
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = LinkUtil.MAXIMUM_REPARSE_DATA_BUFFER_SIZE)]
-        public char[] PathBuffer;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = Links.MAXIMUM_REPARSE_DATA_BUFFER_SIZE)]
+            public byte[] PathBuffer;
+        }
     }
 
-    public class LinkUtil
+    internal class NativeMethods
     {
-        public const int MAXIMUM_REPARSE_DATA_BUFFER_SIZE = 1024 * 16;
-
-        private const UInt32 FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
-        private const UInt32 FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000;
-
-        private const UInt32 FSCTL_GET_REPARSE_POINT = 0x000900A8;
-        private const UInt32 FSCTL_SET_REPARSE_POINT = 0x000900A4;
-        private const UInt32 FILE_DEVICE_FILE_SYSTEM = 0x00090000;
-
-        private const UInt32 IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003;
-        private const UInt32 IO_REPARSE_TAG_SYMLINK = 0xA000000C;
-
-        private const UInt32 SYMLINK_FLAG_RELATIVE = 0x00000001;
-
-        private const Int64 INVALID_HANDLE_VALUE = -1;
-
-        private const UInt32 SIZE_OF_WCHAR = 2;
-
-        private const UInt32 SYMBOLIC_LINK_FLAG_FILE = 0x00000000;
-        private const UInt32 SYMBOLIC_LINK_FLAG_DIRECTORY = 0x00000001;
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
-        private static extern SafeFileHandle CreateFile(
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern SafeFileHandle CreateFileW(
             string lpFileName,
             [MarshalAs(UnmanagedType.U4)] FileAccess dwDesiredAccess,
             [MarshalAs(UnmanagedType.U4)] FileShare dwShareMode,
@@ -94,76 +88,98 @@ namespace Ansible
             UInt32 dwFlagsAndAttributes,
             IntPtr hTemplateFile);
 
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool CreateHardLinkW(
+            string lpFileName,
+            string lpExistingFileName,
+            IntPtr lpSecurityAttributes);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        internal static extern bool CreateSymbolicLinkW(
+            string lpSymlinkFileName,
+            string lpTargetFileName,
+            UInt32 dwFlags);
+
         // Used by GetReparsePointInfo()
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool DeviceIoControl(
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool DeviceIoControl(
             SafeFileHandle hDevice,
             UInt32 dwIoControlCode,
             IntPtr lpInBuffer,
             UInt32 nInBufferSize,
-            out REPARSE_DATA_BUFFER lpOutBuffer,
+            out NativeHelpers.REPARSE_DATA_BUFFER lpOutBuffer,
             UInt32 nOutBufferSize,
             out UInt32 lpBytesReturned,
             IntPtr lpOverlapped);
 
         // Used by CreateJunctionPoint()
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool DeviceIoControl(
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool DeviceIoControl(
             SafeFileHandle hDevice,
             UInt32 dwIoControlCode,
-            REPARSE_DATA_BUFFER lpInBuffer,
+            ref NativeHelpers.REPARSE_DATA_BUFFER lpInBuffer,
             UInt32 nInBufferSize,
             IntPtr lpOutBuffer,
             UInt32 nOutBufferSize,
             out UInt32 lpBytesReturned,
             IntPtr lpOverlapped);
 
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool GetVolumePathName(
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern UInt32 GetFullPathNameW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            UInt32 nBufferLength,
+            StringBuilder lpBuffer,
+            out IntPtr lpFilePart);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool GetVolumePathNameW(
             string lpszFileName,
             StringBuilder lpszVolumePathName,
             ref UInt32 cchBufferLength);
 
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern IntPtr FindFirstFileNameW(
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool FindClose(
+            IntPtr hFindFile);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern IntPtr FindFirstFileNameW(
             string lpFileName,
             UInt32 dwFlags,
             ref UInt32 StringLength,
             StringBuilder LinkName);
 
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool FindNextFileNameW(
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool FindNextFileNameW(
             IntPtr hFindStream,
             ref UInt32 StringLength,
             StringBuilder LinkName);
+    }
 
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern bool FindClose(
-            IntPtr hFindFile);
+    public class Links
+    {
+        public const int MAXIMUM_REPARSE_DATA_BUFFER_SIZE = 16384 - 16;  // 16 KiB - 16 bytes for the REPARSE_DATA_BUFFER headers
 
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool RemoveDirectory(
-            string lpPathName);
+        private const UInt32 FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
+        private const UInt32 FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000;
 
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool DeleteFile(
-            string lpFileName);
+        private const UInt32 FSCTL_GET_REPARSE_POINT = 0x000900A8;
+        private const UInt32 FSCTL_SET_REPARSE_POINT = 0x000900A4;
 
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool CreateSymbolicLink(
-            string lpSymlinkFileName,
-            string lpTargetFileName,
-            UInt32 dwFlags);
+        private const UInt32 IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003;
+        private const UInt32 IO_REPARSE_TAG_SYMLINK = 0xA000000C;
 
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool CreateHardLink(
-            string lpFileName,
-            string lpExistingFileName,
-            IntPtr lpSecurityAttributes);
+        private const UInt32 SYMLINK_FLAG_RELATIVE = 0x00000001;
+
+        private const Int64 INVALID_HANDLE_VALUE = -1;
+
+        private const UInt32 SYMBOLIC_LINK_FLAG_FILE = 0x00000000;
+        private const UInt32 SYMBOLIC_LINK_FLAG_DIRECTORY = 0x00000001;
+        private const UInt32 SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE = 0x00000002;
 
         public static LinkInfo GetLinkInfo(string linkPath)
         {
-            FileAttributes attr = File.GetAttributes(linkPath);
+            FileAttributes attr = Ansible.IO.File.GetAttributes(linkPath);
             if (attr.HasFlag(FileAttributes.ReparsePoint))
                 return GetReparsePointInfo(linkPath);
 
@@ -175,19 +191,15 @@ namespace Ansible
 
         public static void DeleteLink(string linkPath)
         {
-            bool success;
-            FileAttributes attr = File.GetAttributes(linkPath);
+            FileAttributes attr = Ansible.IO.File.GetAttributes(linkPath);
             if (attr.HasFlag(FileAttributes.Directory))
             {
-                success = RemoveDirectory(linkPath);
+                Ansible.IO.Directory.Delete(linkPath);
             }
             else
             {
-                success = DeleteFile(linkPath);
+                Ansible.IO.File.Delete(linkPath);
             }
-
-            if (!success)
-                throw new LinkUtilWin32Exception(String.Format("Failed to delete link at {0}", linkPath));
         }
 
         public static void CreateLink(string linkPath, String linkTarget, LinkType linkType)
@@ -195,58 +207,65 @@ namespace Ansible
             switch (linkType)
             {
                 case LinkType.SymbolicLink:
-                    UInt32 linkFlags;
-                    FileAttributes attr = File.GetAttributes(linkTarget);
-                    if (attr.HasFlag(FileAttributes.Directory))
-                        linkFlags = SYMBOLIC_LINK_FLAG_DIRECTORY;
-                    else
-                        linkFlags = SYMBOLIC_LINK_FLAG_FILE;
-
-                    if (!CreateSymbolicLink(linkPath, linkTarget, linkFlags))
-                        throw new LinkUtilWin32Exception(String.Format("CreateSymbolicLink({0}, {1}, {2}) failed", linkPath, linkTarget, linkFlags));
+                    CreateSymbolicLink(linkPath, linkTarget);
                     break;
                 case LinkType.JunctionPoint:
                     CreateJunctionPoint(linkPath, linkTarget);
                     break;
                 case LinkType.HardLink:
-                    if (!CreateHardLink(linkPath, linkTarget, IntPtr.Zero))
-                        throw new LinkUtilWin32Exception(String.Format("CreateHardLink({0}, {1}) failed", linkPath, linkTarget));
+                    if (!NativeMethods.CreateHardLinkW(linkPath, linkTarget, IntPtr.Zero))
+                        throw new Win32Exception(String.Format("CreateHardLinkW({0}, {1}) failed", linkPath, linkTarget));
                     break;
             }
         }
 
         private static LinkInfo GetHardLinkInfo(string linkPath)
         {
-            UInt32 maxPath = 260;
+            // GetVolumePathNameW indicates to get the max buffer size by getting the size of
+            // GetFullPathName which Ansible.IO.Path.GetFullPath() does
+            string fullPath = Ansible.IO.Path.GetFullPath(linkPath);
+            StringBuilder volumePathName = new StringBuilder(fullPath.Length);
+            UInt32 bufferLength = (UInt32)fullPath.Length;
+            if (!NativeMethods.GetVolumePathNameW(linkPath, volumePathName, ref bufferLength))
+                throw new Win32Exception(String.Format("GetVolumePathNameW({0}) failed", linkPath));
+            string volume = volumePathName.ToString();
+
+            UInt32 stringLength = 0;
+            StringBuilder linkName = new StringBuilder();
+            NativeMethods.FindFirstFileNameW(linkPath, 0, ref stringLength, linkName);
+            linkName.EnsureCapacity((int)stringLength);
+
             List<string> result = new List<string>();
+            IntPtr findHandle = NativeMethods.FindFirstFileNameW(linkPath, 0, ref stringLength, linkName);
+            if (findHandle.ToInt64() == INVALID_HANDLE_VALUE)
+                throw new Win32Exception(String.Format("FindFirstFileNameW({0} failed", linkPath));
 
-            StringBuilder sb = new StringBuilder((int)maxPath);
-            UInt32 stringLength = maxPath;
-            if (!GetVolumePathName(linkPath, sb, ref stringLength))
-                throw new LinkUtilWin32Exception("GetVolumePathName() failed");
-            string volume = sb.ToString();
-
-            stringLength = maxPath;
-            IntPtr findHandle = FindFirstFileNameW(linkPath, 0, ref stringLength, sb);
-            if (findHandle.ToInt64() != INVALID_HANDLE_VALUE)
+            try
             {
-                try
+                while (true)
                 {
-                    do
+                    string hardLinkPath = linkName.ToString();
+                    hardLinkPath = hardLinkPath.StartsWith(@"\") ? hardLinkPath.Substring(1, hardLinkPath.Length - 1) : hardLinkPath;
+                    result.Add(Ansible.IO.Path.Combine(volume, hardLinkPath));
+
+                    // get the buffer size for the next file
+                    linkName = new StringBuilder();
+                    stringLength = 0;
+                    NativeMethods.FindNextFileNameW(findHandle, ref stringLength, linkName);
+                    linkName.Capacity = (int)stringLength;
+
+                    if (!NativeMethods.FindNextFileNameW(findHandle, ref stringLength, linkName))
                     {
-                        string hardLinkPath = sb.ToString();
-                        if (hardLinkPath.StartsWith("\\"))
-                            hardLinkPath = hardLinkPath.Substring(1, hardLinkPath.Length - 1);
-
-                        result.Add(Path.Combine(volume, hardLinkPath));
-                        stringLength = maxPath;
-
-                    } while (FindNextFileNameW(findHandle, ref stringLength, sb));
+                        int errorCode = Marshal.GetLastWin32Error();
+                        if (errorCode == 38)  // ERROR_HANDLE_EOF
+                            break;
+                        throw new Win32Exception(errorCode, "FindNextFIleNameW() failed");
+                    }
                 }
-                finally
-                {
-                    FindClose(findHandle);
-                }                
+            }
+            finally
+            {
+                NativeMethods.FindClose(findHandle);
             }
 
             if (result.Count > 1)
@@ -261,136 +280,219 @@ namespace Ansible
 
         private static LinkInfo GetReparsePointInfo(string linkPath)
         {
-            SafeFileHandle fileHandle = CreateFile(
-                linkPath,
-                FileAccess.Read,
-                FileShare.None,
-                IntPtr.Zero,
-                FileMode.Open,
-                FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
-                IntPtr.Zero);
+            // enable the SeBackupPrivilege if possible so that CreateFileW can get a read handle
+            // even if it does not have Read rights
+            List<string> privileges = new List<string>();
+            SafeWaitHandle process = Ansible.PrivilegeUtil.Privileges.GetCurrentProcess();
+            if (Ansible.PrivilegeUtil.Privileges.GetAllPrivilegeInfo(process).ContainsKey("SeBackupPrivilege"))
+                privileges.Add("SeBackupPrivilege");
 
-            if (fileHandle.IsInvalid)
-                throw new LinkUtilWin32Exception(String.Format("CreateFile({0}) failed", linkPath));            
+            NativeHelpers.REPARSE_DATA_BUFFER buffer = new NativeHelpers.REPARSE_DATA_BUFFER();
+            using (new Ansible.IO.PrivilegeEnabler(privileges.ToArray()))
+            {
+                using (SafeFileHandle handle = NativeMethods.CreateFileW(
+                    linkPath, FileAccess.Read, FileShare.None, IntPtr.Zero, FileMode.Open,
+                    FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, IntPtr.Zero))
+                {
+                    if (handle.IsInvalid)
+                        throw new Win32Exception(String.Format("CreateFile({0}) failed", linkPath));
 
-            REPARSE_DATA_BUFFER buffer = new REPARSE_DATA_BUFFER();
-            UInt32 bytesReturned;
-            try
-            {
-                if (!DeviceIoControl(
-                    fileHandle,
-                    FSCTL_GET_REPARSE_POINT,
-                    IntPtr.Zero,
-                    0,
-                    out buffer,
-                    MAXIMUM_REPARSE_DATA_BUFFER_SIZE,
-                    out bytesReturned,
-                    IntPtr.Zero))
-                    throw new LinkUtilWin32Exception(String.Format("DeviceIoControl() failed for file at {0}", linkPath));
-            }
-            finally
-            {
-                fileHandle.Dispose();
+                    UInt32 bytesReturned;
+                    if (!NativeMethods.DeviceIoControl(handle, FSCTL_GET_REPARSE_POINT, IntPtr.Zero, 0, out buffer,
+                        MAXIMUM_REPARSE_DATA_BUFFER_SIZE, out bytesReturned, IntPtr.Zero))
+                        throw new Win32Exception(String.Format("DeviceIoControl() failed for file at {0}", linkPath));
+                }
             }
 
             bool isRelative = false;
-            int pathOffset = 0;
             LinkType linkType;
+            int offset = 0;
             if (buffer.ReparseTag == IO_REPARSE_TAG_SYMLINK)
             {
-                UInt32 bufferFlags = Convert.ToUInt32(buffer.PathBuffer[0]) + Convert.ToUInt32(buffer.PathBuffer[1]);
+                linkType = LinkType.SymbolicLink;
+                UInt32 bufferFlags = BitConverter.ToUInt32(buffer.PathBuffer, 0);
                 if (bufferFlags == SYMLINK_FLAG_RELATIVE)
                     isRelative = true;
-                pathOffset = 2;
-                linkType = LinkType.SymbolicLink;
+                offset = 4;
             }
             else if (buffer.ReparseTag == IO_REPARSE_TAG_MOUNT_POINT)
-            {
                 linkType = LinkType.JunctionPoint;
-            }
+            else
+                throw new Exception(String.Format("Unsupported Reparse Tag: 0x{0}", buffer.ReparseTag.ToString("X8")));
+
+            string printName = Encoding.Unicode.GetString(buffer.PathBuffer, buffer.PrintNameOffset + offset, buffer.PrintNameLength);
+            string substituteName = Encoding.Unicode.GetString(buffer.PathBuffer, buffer.SubstituteNameOffset + offset, buffer.SubstituteNameLength);
+            string targetPath = substituteName;
+            string absolutePath;
+
+            if (isRelative)
+                absolutePath = ResolveRelativePath(targetPath, Ansible.IO.Path.GetDirectoryName(linkPath));
             else
             {
-                string errorMessage = String.Format("Invalid Reparse Tag: {0}", buffer.ReparseTag.ToString());
-                throw new Exception(errorMessage);
+                // Remove the NT object namespace \??\, \DosDevices\ and get a normal Win32 path
+                if (targetPath.StartsWith(@"\??\UNC") && (linkPath.StartsWith(@"\\?\") || printName.Length > 250))
+                    targetPath = @"\\?\" + targetPath.Substring(4, targetPath.Length - 4);
+                else if (targetPath.StartsWith(@"\??\UNC"))
+                    targetPath = @"\" + targetPath.Substring(7, targetPath.Length - 7);
+                else if (targetPath.StartsWith(@"\??\") && (linkPath.StartsWith(@"\\?\") || printName.Length > 250))
+                    targetPath = @"\\?\" + targetPath.Substring(4, targetPath.Length - 4);
+                else if (targetPath.StartsWith(@"\??\"))
+                    targetPath = targetPath.Substring(4, targetPath.Length - 4);
+                else if (targetPath.StartsWith(@"\DosDevices\") && (linkPath.StartsWith(@"\\?\") || printName.Length > 250))
+                    targetPath = @"\\?\" + targetPath.Substring(12, targetPath.Length - 12);
+                else if (targetPath.StartsWith(@"\DosDevices\"))
+                    targetPath = targetPath.Substring(12, targetPath.Length - 12);
+                absolutePath = targetPath;
             }
-
-            string printName = new string(buffer.PathBuffer, (int)(buffer.PrintNameOffset / SIZE_OF_WCHAR) + pathOffset, (int)(buffer.PrintNameLength / SIZE_OF_WCHAR));
-            string substituteName = new string(buffer.PathBuffer, (int)(buffer.SubstituteNameOffset / SIZE_OF_WCHAR) + pathOffset, (int)(buffer.SubstituteNameLength / SIZE_OF_WCHAR));
-
-            // TODO: should we check for \?\UNC\server for convert it to the NT style \\server path
-            // Remove the leading Windows object directory \?\ from the path if present
-            string targetPath = substituteName;
-            if (targetPath.StartsWith("\\??\\"))
-                targetPath = targetPath.Substring(4, targetPath.Length - 4);
-
-            string absolutePath = targetPath;
-            if (isRelative)
-                absolutePath = Path.GetFullPath(Path.Combine(new FileInfo(linkPath).Directory.FullName, targetPath));
 
             return new LinkInfo
             {
                 Type = linkType,
-                PrintName = printName,
-                SubstituteName = substituteName,
-                AbsolutePath = absolutePath,
-                TargetPath = targetPath
+                PrintName = printName,  // raw PrintName from buffer
+                SubstituteName = substituteName,  // raw SubstitueName from buffer (contains NT obj namespace)
+                AbsolutePath = absolutePath,  // The absolute path of TargetPath
+                TargetPath = targetPath  // SubstituteName but without the obj namespace
             };
+        }
+
+        private static void CreateSymbolicLink(string linkPath, string linkTarget)
+        {
+            string absoluteTarget = linkTarget;
+            if (!Ansible.IO.Path.IsPathRooted(linkTarget))
+            {
+                string parentDir = Ansible.IO.Path.GetDirectoryName(linkPath);
+                absoluteTarget = Ansible.IO.Path.GetFullPath(Ansible.IO.Path.Combine(parentDir, linkTarget));
+            }
+
+            UInt32 linkFlags = 0;
+            try
+            {
+                FileAttributes attr = Ansible.IO.File.GetAttributes(absoluteTarget);
+                if (attr.HasFlag(FileAttributes.Directory))
+                    linkFlags = SYMBOLIC_LINK_FLAG_DIRECTORY;
+                else
+                    linkFlags = SYMBOLIC_LINK_FLAG_FILE;
+            }
+            catch (Exception e)
+            {
+                if (e is FileNotFoundException || e is DirectoryNotFoundException)
+                    // Cannot determine link type based on the target as it does not exist, use dir if no extension is present otherwise file
+                    linkFlags = Ansible.IO.Path.GetExtension(absoluteTarget) == "" ? SYMBOLIC_LINK_FLAG_DIRECTORY : SYMBOLIC_LINK_FLAG_FILE;
+            }
+
+            // Try and run with the new flag that allows non elevated processes to create symlinks
+            // will return ERROR_INVALID_PARAMETER if on an unsupported host
+            // added in Windows 10 build 14972
+            linkFlags |= SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
+
+            if (!NativeMethods.CreateSymbolicLinkW(linkPath, linkTarget, linkFlags))
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                if (errorCode == 0x00000057)  // ERROR_INVALID_PARAMETER - try again without flag
+                    if (!NativeMethods.CreateSymbolicLinkW(linkPath, linkTarget, linkFlags &= ~SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE))
+                        errorCode = Marshal.GetLastWin32Error();
+                    else
+                        errorCode = 0;
+
+                if (errorCode != 0)
+                    throw new Win32Exception(String.Format("CreateSymbolicLinkW({0}, {1}, {2}) failed", linkPath, linkTarget, linkFlags));
+            }
         }
 
         private static void CreateJunctionPoint(string linkPath, string linkTarget)
         {
+            string substituteName;
+            if (linkTarget.StartsWith(@"\\?\"))
+                substituteName = @"\??\" + Ansible.IO.Path.GetFullPath(linkTarget).Substring(4);
+            else
+                substituteName = @"\??\" + Ansible.IO.Path.GetFullPath(linkTarget);
+            string printName = linkTarget;
+
+            UInt16 substituteNameLength = (UInt16)Encoding.Unicode.GetByteCount(substituteName);
+            UInt16 printNameLength = (UInt16)Encoding.Unicode.GetByteCount(printName);
+            byte[] pathBuffer = Encoding.Unicode.GetBytes(substituteName + "\0" + printName + "\0");
+
+            NativeHelpers.REPARSE_DATA_BUFFER buffer = new NativeHelpers.REPARSE_DATA_BUFFER();
+            buffer.ReparseTag = IO_REPARSE_TAG_MOUNT_POINT;
+            buffer.SubstituteNameOffset = 0;
+            buffer.SubstituteNameLength = substituteNameLength;
+            buffer.PrintNameOffset = (UInt16)(substituteNameLength + sizeof(char));  // offset include the null unicode terminator
+            buffer.PrintNameLength = printNameLength;
+            buffer.PathBuffer = new byte[MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
+            Array.Copy(pathBuffer, buffer.PathBuffer, pathBuffer.Length);
+            buffer.ReparseDataLength = (UInt16)(pathBuffer.Length + (4 * sizeof(UInt16)));  // sizeof fields past Reserved in REPARSE_DATA_BUFFER
+            UInt32 reparseHeaderSize = sizeof(UInt32) + (2 * sizeof(UInt16));  // sizof ReparseTag + ReparseDataLength + Reserved
+
             // We need to create the link as a dir beforehand
-            Directory.CreateDirectory(linkPath);
-            SafeFileHandle fileHandle = CreateFile(
-                linkPath,
-                FileAccess.Write,
-                FileShare.Read | FileShare.Write | FileShare.None,
-                IntPtr.Zero,
-                FileMode.Open,
-                FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
-                IntPtr.Zero);
+            Ansible.IO.Directory.CreateDirectory(linkPath);
 
-            if (fileHandle.IsInvalid)
-                throw new LinkUtilWin32Exception(String.Format("CreateFile({0}) failed", linkPath));
-
-            try
+            // Open a handle to the new dir and write the reparse buffer data
+            using (SafeFileHandle handle = NativeMethods.CreateFileW(linkPath, FileAccess.Write,
+                FileShare.Read | FileShare.Write | FileShare.None, IntPtr.Zero, FileMode.Open,
+                FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, IntPtr.Zero))
             {
-                string substituteName = "\\??\\" + Path.GetFullPath(linkTarget);
-                string printName = linkTarget;
-
-                REPARSE_DATA_BUFFER buffer = new REPARSE_DATA_BUFFER();
-                buffer.SubstituteNameOffset = 0;
-                buffer.SubstituteNameLength = (UInt16)(substituteName.Length * SIZE_OF_WCHAR);
-                buffer.PrintNameOffset = (UInt16)(buffer.SubstituteNameLength + 2);
-                buffer.PrintNameLength = (UInt16)(printName.Length * SIZE_OF_WCHAR);
-
-                buffer.ReparseTag = IO_REPARSE_TAG_MOUNT_POINT;
-                buffer.ReparseDataLength = (UInt16)(buffer.SubstituteNameLength + buffer.PrintNameLength + 12);
-                buffer.PathBuffer = new char[MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
-
-                byte[] unicodeBytes = Encoding.Unicode.GetBytes(substituteName + "\0" + printName);
-                char[] pathBuffer = Encoding.Unicode.GetChars(unicodeBytes);
-                Array.Copy(pathBuffer, buffer.PathBuffer, pathBuffer.Length);
+                if (handle.IsInvalid)
+                    throw new Win32Exception(String.Format("CreateFile({0}) failed", linkPath));
 
                 UInt32 bytesReturned;
-                if (!DeviceIoControl(
-                    fileHandle,
-                    FSCTL_SET_REPARSE_POINT,
-                    buffer,
-                    (UInt32)(buffer.ReparseDataLength + 8),
-                    IntPtr.Zero, 0,
-                    out bytesReturned,
-                    IntPtr.Zero))
-                    throw new LinkUtilWin32Exception(String.Format("DeviceIoControl() failed to create junction point at {0} to {1}", linkPath, linkTarget));
+                if (!NativeMethods.DeviceIoControl(handle, FSCTL_SET_REPARSE_POINT, ref buffer,
+                    reparseHeaderSize + buffer.ReparseDataLength, IntPtr.Zero, 0, out bytesReturned, IntPtr.Zero))
+                    throw new Win32Exception(String.Format("DeviceIoControl() failed to create junction point at {0} to {1}", linkPath, linkTarget));
             }
-            finally
-            {
-                fileHandle.Dispose();
-            }
+        }
+
+        private static string ResolveRelativePath(string path, string location)
+        {
+            // Cannot use Path.GetFullPath as it will return path if it starts with \\?\
+            path = Ansible.IO.Path.Combine(location, path);
+
+            UInt32 bufferLength = 0;
+            StringBuilder lpBuffer = new StringBuilder();
+            IntPtr lpFilePart = IntPtr.Zero;
+            UInt32 returnLength = NativeMethods.GetFullPathNameW(path, bufferLength, lpBuffer, out lpFilePart);
+
+            lpBuffer.EnsureCapacity((int)returnLength);
+            returnLength = NativeMethods.GetFullPathNameW(path, returnLength, lpBuffer, out lpFilePart);
+            if (returnLength == 0)
+                throw new Win32Exception(Marshal.GetLastWin32Error(), String.Format("GetFullPathName({0}, {1}) failed when getting full path", path, returnLength));
+
+            return lpBuffer.ToString();
         }
     }
 }
 '@
+
+Function Load-LinkUtils {
+    <#
+    .SYNOPSIS
+    This is deprecated as Load is not a proper ps nouns and the verb should not
+    be a plural. We will try and add a deprecation warning and call the proper
+    cmdlet.
+    #>
+    if ((Get-Command -Name Add-DeprecationWarning -ErrorAction SilentlyContinue) -and (Get-Variable -Name result -ErrorAction SilentlyContinue)) {
+        Add-DeprecationWarning -obj $result -message "Load-LinkUtils is deprecated in favour of Import-LinkUtil, this cmdlet will be removed in a future version" -version 2.11
+    }
+    Import-LinkUtil
+}
+
+Function Import-LinkUtil {
+    <#
+    .SYNOPSIS
+    Compiles the C# code that can be used to manage links on Windows platforms.
+    Once this function is called, the following cmdlets can be called
+
+        Get-Link
+        Remove-Link
+        New-Link
+
+    This module util is reliant on Ansible.ModuleUtils.PrivilegeUtil and
+    Ansible.ModuleUtils.FileUtil. Do not call the Import-* functions as this
+    relies on those namspaces not being used upon loading.
+    #>
+    # build the C# code to compile
+    $namespaces = $ansible_privilege_util_namespaces + $ansible_file_util_namespaces + $ansible_link_util_namespaces | Select-Object -Unique
+    $namespace_import = ($namespaces | ForEach-Object { "using $_;" }) -join "`r`n"
+    $platform_util = "$namespace_import`r`n`r`n$ansible_privilege_util_code`r`n`r`n$ansible_file_util_code`r`n`r`n$ansible_link_util_code"
 
     # FUTURE: find a better way to get the _ansible_remote_tmp variable
     $original_tmp = $env:TMP
@@ -405,51 +507,59 @@ namespace Ansible
     }
 
     $env:TMP = $remote_tmp
-    Add-Type -TypeDefinition $link_util
+    Add-Type -TypeDefinition $platform_util
     $env:TMP = $original_tmp
-
-    Import-PrivilegeUtil
-    # enable the SeBackupPrivilege if it is disabled
-    $state = Get-AnsiblePrivilege -Name SeBackupPrivilege
-    if ($state -eq $false) {
-        Set-AnsiblePrivilege -Name SeBackupPrivilege -Value $true
-    }
 }
 
 Function Get-Link($link_path) {
-    $link_info = [Ansible.LinkUtil]::GetLinkInfo($link_path)
+    <#
+    .SYNOPSIS
+    Returns a Ansible.LinkUtil.LinkInfo object that contains information
+    about the file/dir specified by $link_path. This contains info such as
+    the target of the link.
+    #>
+    $link_info = [Ansible.LinkUtil.Links]::GetLinkInfo($link_path)
     return $link_info
 }
 
 Function Remove-Link($link_path) {
-    [Ansible.LinkUtil]::DeleteLink($link_path)
+    <#
+    .SYNOPSIS
+    Removes the file/dir specified by $link_path. This works with broken links
+    unlike Remote-Item.
+    #>
+    [Ansible.LinkUtil.Links]::DeleteLink($link_path)
 }
 
-Function New-Link($link_path, $link_target, $link_type) {
-    if (-not (Test-Path -Path $link_target)) {
-        throw "link_target '$link_target' does not exist, cannot create link"
-    }
-    
+Function New-Link($link_path, $link_target, $link_type) {   
+    <#
+    .SYNOPSIS
+    Creates a symbolic link, junction point, or hard link at the path specified
+    by $link_path. The valid types at 'link', 'junction', or 'hard'.
+    #>
     switch($link_type) {
         "link" {
-            $type = [Ansible.LinkType]::SymbolicLink
+            $type = [Ansible.LinkUtil.LinkType]::SymbolicLink
         }
         "junction" {
-            if (Test-Path -Path $link_target -PathType Leaf) {
+            if ([Ansible.IO.File]::Exists($link_target)) {
                 throw "cannot set the target for a junction point to a file"
             }
-            $type = [Ansible.LinkType]::JunctionPoint
+            $type = [Ansible.LinkUtil.LinkType]::JunctionPoint
         }
         "hard" {
-            if (Test-Path -Path $link_target -PathType Container) {
+            if ([Ansible.IO.Directory]::Exists($link_target)) {
                 throw "cannot set the target for a hard link to a directory"
+            } elseif (-not ([Ansible.IO.File]::Exists($link_target))) {
+                throw "link_target '$link_target' does not exist, cannot create hard link"
             }
-            $type = [Ansible.LinkType]::HardLink
+            $type = [Ansible.LinkUtil.LinkType]::HardLink
         }
         default { throw "invalid link_type option $($link_type): expecting link, junction, hard" }
     }
-    [Ansible.LinkUtil]::CreateLink($link_path, $link_target, $type)
+    [Ansible.LinkUtil.Links]::CreateLink($link_path, $link_target, $type)
 }
 
 # this line must stay at the bottom to ensure all defined module parts are exported
-Export-ModuleMember -Alias * -Function * -Cmdlet *
+Export-ModuleMember -Function Import-LinkUtil, Load-LinkUtils, Get-Link, Remove-Link, New-Link `
+    -Variable ansible_link_util_code, ansible_link_util_namespaces

--- a/lib/ansible/modules/windows/win_command.ps1
+++ b/lib/ansible/modules/windows/win_command.ps1
@@ -27,6 +27,8 @@ $result = @{
     cmd = $raw_command_line
 }
 
+Import-FileUtil
+
 if ($creates -and $(Test-AnsiblePath -Path $creates)) {
     Exit-Json @{msg="skipped, since $creates exists";cmd=$raw_command_line;changed=$false;skipped=$true;rc=0}
 }

--- a/lib/ansible/modules/windows/win_shell.ps1
+++ b/lib/ansible/modules/windows/win_shell.ps1
@@ -55,6 +55,8 @@ $result = @{
     cmd = $raw_command_line
 }
 
+Import-FileUtil
+
 if ($creates -and $(Test-AnsiblePath -Path $creates)) {
     Exit-Json @{msg="skipped, since $creates exists";cmd=$raw_command_line;changed=$false;skipped=$true;rc=0}
 }

--- a/lib/ansible/modules/windows/win_stat.ps1
+++ b/lib/ansible/modules/windows/win_stat.ps1
@@ -27,6 +27,8 @@ $result = @{
     }
 }
 
+Import-LinkUtil
+
 # get_md5 will be an undocumented option in 2.9 to be removed at a later
 # date if possible (3.0+)
 if (Get-Member -inputobject $params -name "get_md5") {
@@ -97,14 +99,14 @@ If ($info -ne $null) {
 
         if ($get_md5) {
             try {
-                $stat.md5 = Get-FileChecksum -path $path -algorithm "md5"
+                $stat.md5 = Get-AnsibleFileHash -Path $path -Algorithm "md5"
             } catch {
                 Fail-Json -obj $result -message "failed to get MD5 hash of file, remove get_md5 to ignore this error: $($_.Exception.Message)"
             }
         }
         if ($get_checksum) {
             try {
-                $stat.checksum = Get-FileChecksum -path $path -algorithm $checksum_algorithm
+                $stat.checksum = Get-AnsibleFileHash -Path $path -Algorithm $checksum_algorithm
             } catch {
                 Fail-Json -obj $result -message "failed to get hash of file, set get_checksum to False to ignore this error: $($_.Exception.Message)"
             }
@@ -112,7 +114,6 @@ If ($info -ne $null) {
     }
 
     # Get symbolic link, junction point, hard link info
-    Load-LinkUtils
     try {
         $link_info = Get-Link -link_path $info.FullName
     } catch {

--- a/lib/ansible/modules/windows/win_stat.py
+++ b/lib/ansible/modules/windows/win_stat.py
@@ -24,6 +24,8 @@ options:
         description:
             - The full path of the file/object to get the facts of; both forward and
               back slashes are accepted.
+            - To get information on a path that exceeds 260 characters, prepend with
+              C(\\?\C:\...) for local paths or C(\\?\UNC\server\share\..) for UNC paths.
         required: yes
         type: path
     get_md5:
@@ -96,6 +98,14 @@ EXAMPLES = r'''
 
 - debug:
     var: sha256_checksum.stat.checksum
+
+- name: get info on a local file that exceeds 260 characters
+  win_stat:
+    path: \\?\C:\Users\user\AppData\{{ some_really_long_path }}\dir\test.txt
+
+- name: get info on a network file that exceeds 260 characters
+  win_stat:
+    path: \\?\UNC\server\share\Documents\Users\user\{{ some_really_long_path }}\dir\test.txt
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/windows/win_wait_for.ps1
+++ b/lib/ansible/modules/windows/win_wait_for.ps1
@@ -25,6 +25,8 @@ $result = @{
     changed = $false
 }
 
+Import-FileUtil
+
 # validate the input with the various options
 if ($port -ne $null -and $path -ne $null) {
     Fail-Json $result "port and path parameter can not both be passed to win_wait_for"

--- a/test/integration/targets/win_module_utils/library/file_util_test.ps1
+++ b/test/integration/targets/win_module_utils/library/file_util_test.ps1
@@ -31,10 +31,15 @@ Function Get-PagefilePath() {
     return $pagefile
 }
 
+Import-FileUtil
+
 $pagefile = Get-PagefilePath
 if ($pagefile) {
     # Test-AnsiblePath Hidden system file
     $actual = Test-AnsiblePath -Path $pagefile
+    Assert-Equals -actual $actual -expected $true
+
+    $actual = Test-AnsiblePath -Path "\\?\$pagefile"
     Assert-Equals -actual $actual -expected $true
 
     # Get-AnsibleItem file
@@ -60,19 +65,29 @@ Assert-Equals -actual $actual -expected $false
 $actual = Test-AnsiblePath -Path C:\Windows
 Assert-Equals -actual $actual -expected $true
 
+# Test-AnsiblePath Normal directory with Container type
+$actual = Test-AnsiblePath -Path C:\Windows -PathType Container
+Assert-Equals -actual $actual -expected $true
+
+# Test-AnsiblePath Normal directory with Leaf type
+$actual = Test-AnsiblePath -Path C:\Windows -PathType Leaf
+Assert-Equals -actual $actual -expected $false
+
 # Test-AnsiblePath Normal file
 $actual = Test-AnsiblePath -Path C:\Windows\System32\kernel32.dll
 Assert-Equals -actual $actual -expected $true
 
-# Test-AnsiblePath fails with wildcard
-$failed = $false
-try {
-    Test-AnsiblePath -Path C:\Windows\*.exe
-} catch {
-    $failed = $true
-    Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"GetAttributes`" with `"1`" argument(s): `"Illegal characters in path.`""
-}
-Assert-Equals -actual $failed -expected $true
+# Test-AnsiblePath Normal file with Container type
+$actual = Test-AnsiblePath -Path C:\Windows\System32\kernel32.dll -PathType Container
+Assert-Equals -actual $actual -expected $false
+
+# Test-AnsiblePath Normal file with Leaf type
+$actual = Test-AnsiblePath -Path C:\Windows\System32\kernel32.dll -PathType Leaf
+Assert-Equals -actual $actual -expected $true
+
+# Test-AnsiblePath works with wildcard (this works in Test-Path so we should replicate it here)
+$actual = Test-AnsiblePath -Path C:\Windows\*.exe
+Assert-Equals -actual $actual -expected $true
 
 # Test-AnsiblePath on non file PS Provider object
 $actual = Test-AnsiblePath -Path Cert:\LocalMachine\My
@@ -95,6 +110,49 @@ $actual = Get-AnsibleItem -Path C:\Windows
 Assert-Equals -actual $actual.FullName -expected C:\Windows
 Assert-Equals -actual $actual.Attributes.HasFlag([System.IO.FileAttributes]::Directory) -expected $true
 Assert-Equals -actual $actual.Exists -expected $true
+
+# Get-AnsibleItem doesn't exists
+$failed = $false
+try {
+    $actual = Get-AnsibleItem -Path C:\fakefile
+} catch {
+    $failed = $true
+    Assert-Equals -actual $_.Exception.Message -expected "Cannot find path 'C:\fakefile' because it does not exist."
+}
+Assert-Equals -actual $failed -expected $true
+
+# call Get-AnsibleFileHash with invalid algorithm
+$failed = $false
+try {
+    Get-AnsibleFileHash -Path C:\fakefile -Algorithm sha449
+} catch {
+    $failed = $true
+    Assert-Equals -actual ($_.Exception.Message.StartsWith("Cannot find type [System.Security.Cryptography.sha449CryptoServiceProvider]")) -expected $true
+}
+Assert-Equals -actual $failed -expected $true
+
+# call Get-AnsibleFileHash with various algorithms
+$tmp_file = [System.IO.Path]::GetTempFileName()
+try {
+    [System.IO.File]::WriteAllText($tmp_file, "Hello World", [System.Text.Encoding]::ASCII)
+
+    $actual = Get-AnsibleFileHash -Path $tmp_file -Algorithm md5
+    Assert-Equals -actual $actual -expected "b10a8db164e0754105b7a99be72e3fe5"
+
+    $actual = Get-AnsibleFileHash -Path $tmp_file -Algorithm sha1
+    Assert-Equals -actual $actual -expected "0a4d55a8d778e5022fab701977c5d840bbc486d0"
+
+    $actual = Get-AnsibleFileHash -Path $tmp_file -Algorithm sha256
+    Assert-Equals -actual $actual -expected "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e"
+
+    $actual = Get-AnsibleFileHash -Path $tmp_file -Algorithm sha384
+    Assert-Equals -actual $actual -expected "99514329186b2f6ae4a1329e7ee6c610a729636335174ac6b740f9028396fcc803d0e93863a7c3d90f86beee782f4f3f"
+
+    $actual = Get-AnsibleFileHash -Path $tmp_file -Algorithm sha512
+    Assert-Equals -actual $actual -expected "2c74fd17edafd80e8447b0d46741ee243b7eb74dd2149a0ab1b9246fb30382f27e853d8585719e0e67cbda0daa8f51671064615d645ae27acb15bfb1447f459b"
+} finally {
+    Remove-Item -Path $tmp_file -Force > $null
+}
 
 $result.data = "success"
 Exit-Json -obj $result

--- a/test/integration/targets/win_module_utils/library/file_util_test_ansible_io.ps1
+++ b/test/integration/targets/win_module_utils/library/file_util_test_ansible_io.ps1
@@ -1,0 +1,1668 @@
+#!powershell
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+#Requires -Module Ansible.ModuleUtils.FileUtil
+
+$ErrorActionPreference = "Stop"
+
+$params = Parse-Args $args
+$path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true
+$encrypt_tests = Get-AnsibleParam -obj $params -name "encrypt_tests" -type "bool" -default $false
+
+$result = @{
+    changed = $false
+}
+
+Import-FileUtil
+
+Function Assert-Equals($actual, $expected) {
+    if ($actual -ne $expected) {
+        $call_stack = (Get-PSCallStack)[1]
+        $error_msg = "AssertionError:`r`nActual: `"$actual`" != Expected: `"$expected`"`r`nLine: $($call_stack.ScriptLineNumber), Method: $($call_stack.Position.Text)"
+        Fail-Json -obj $result -message $error_msg
+    }
+}
+
+Function Assert-ArrayEquals($actual, $expected) {
+    $equals = $true
+    if ($actual.Count -ne $expected.Count) {
+        $equals = $false
+    } else {
+        for ($i = 0; $i -lt $actual.Count; $i++) {
+            if ($actual[$i] -ne $expected[$i]) {
+                $equals = $false
+                break
+            }
+        }
+    }
+    
+    if (-not $equals) {
+        $call_stack = (Get-PSCallStack)[1]
+        $error_msg = "AssertionError:`r`nActual: `"$actual`" != Expected: `"$expected`"`r`nLine: $($call_stack.ScriptLineNumber), Method: $($call_stack.Position.Text)"
+        Fail-Json -obj $result -message $error_msg
+    }
+}
+
+Function Clear-TestDirectory($path) {
+    $search_path = $path
+    if (-not $search_path.StartsWith("\\?\")) {
+        $search_path = "\\?\$search_path"
+    }
+
+    if (Test-AnsiblePath -Path $search_path) {
+        # previous tests may have ended in a bad state and some folders are not
+        # accessible to the current user. This defensively set's the owner back to
+        # the current user so we can delete the folders
+        $current_sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+        $dirs = [Ansible.IO.Directory]::GetDirectories($search_path, "*", [System.IO.SearchOption]::AllDirectories)
+        foreach ($dir in $dirs) {
+            # SetAccessControl should be setting SeReplace, and SeTakeOwnershipPrivilege for us
+            $acl = New-Object -TypeName System.Security.AccessControl.DirectorySecurity
+            $acl.SetOwner($current_sid)
+            $ace = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList @(
+                $current_sid,
+                [System.Security.AccessControl.FileSystemRights]::Delete,
+                [System.Security.AccessControl.AccessControlType]::Allow
+            )
+            $acl.AddAccessRule($ace)
+            [Ansible.IO.Directory]::SetAccessControl($dir, $acl)
+        }
+
+        [Ansible.IO.Directory]::Delete($search_path, $true)
+    }
+
+    [Ansible.IO.Directory]::CreateDirectory($search_path) > $null
+}
+
+Function Test-FileClass($root_path) {
+    $file_path = "$root_path\file.txt"
+
+    ### FileInfo Tests ###
+    # Test Class Attributes when file does not exist
+    $file = New-Object -TypeName Ansible.IO.FileInfo -ArgumentList $file_path
+    Assert-Equals -actual ([Int32]$file.Attributes) -expected -1
+    Assert-Equals -actual $file.CreationTimeUtc.ToFileTimeUtc() -expected 0
+    Assert-Equals -actual $file.Directory.FullName -expected $root_path
+    Assert-Equals -actual $file.DirectoryName -expected $root_path
+    Assert-Equals -actual $file.Exists -expected $false
+    Assert-Equals -actual $file.Extension -expected ".txt"
+    Assert-Equals -actual $file.FullName -expected $file_path
+    Assert-Equals -actual $file.IsReadOnly -expected $true
+    Assert-Equals -actual $file.LastAccessTimeUtc.ToFileTimeUtc() -expected 0
+    Assert-Equals -actual $file.LastWriteTimeUtc.ToFileTimeUtc() -expected 0
+    Assert-Equals -actual $file.Length -expected $null
+    Assert-Equals -actual $file.Name -expected "file.txt"
+    
+    # Test Class Attributes when file exists
+    $current_time = (Get-Date).ToFileTimeUtc()
+    $fs = $file.Create()
+    $fs.Close()
+    $file.Refresh()
+    Assert-Equals -actual $file.Attributes -expected ([System.IO.FileAttributes]::Archive)
+    Assert-Equals -actual ($file.CreationTimeUtc.ToFileTimeUtc() -ge $current_time) -expected $true
+    Assert-Equals -actual $file.Directory.FullName -expected $root_path
+    Assert-Equals -actual $file.DirectoryName -expected $root_path
+    Assert-Equals -actual $file.Exists -expected $true
+    Assert-Equals -actual $file.Extension -expected ".txt"
+    Assert-Equals -actual $file.FullName -expected $file_path
+    Assert-Equals -actual $file.IsReadOnly -expected $false
+    Assert-Equals -actual ($file.LastAccessTimeUtc.ToFileTimeUtc() -ge $current_time) -expected $true
+    Assert-Equals -actual ($file.LastWriteTimeUtc.ToFileTimeUtc() -ge $current_time) -expected $true
+    Assert-Equals -actual $file.Length -expected 0
+    Assert-Equals -actual $file.Name -expected "file.txt"
+
+    # Set Properties
+    $file.Attributes = $file.Attributes -bor [System.IO.FileAttributes]::Hidden
+    Assert-Equals -actual $file.Attributes -expected ([System.IO.FileAttributes]::Archive -bor [System.IO.FileAttributes]::Hidden)
+
+    $file.IsReadOnly = $true
+    Assert-Equals -actual $file.Attributes.HasFlag([System.IO.FileAttributes]::ReadOnly) -expected $true
+
+    $file.IsReadOnly = $false
+    Assert-Equals -actual $file.Attributes.HasFlag([System.IO.FileAttributes]::ReadOnly) -expected $false
+    
+    $new_date = (Get-Date -Date "1993-06-11 06:51:32Z")
+    $file.CreationTimeUtc = $new_date
+    Assert-Equals -actual $file.CreationTimeUtc -expected $new_date
+
+    $file.LastAccessTimeUtc = $new_date
+    Assert-Equals -actual $file.LastAccessTimeUtc -expected $new_date
+
+    $file.LastWriteTimeUtc = $new_date
+    Assert-Equals -actual $file.LastWriteTimeUtc -expected $new_date
+
+    # Test Functions
+    # CreateText() fails if the file is already open
+    $failed = $false
+    try {
+        $sw = $file.CreateText()
+        $sw.Close()
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"CreateText`" with `"0`" argument(s): `"Access to the path '$root_path\file.txt' is denied.`""
+    }
+    Assert-Equals -actual $failed -expected $true
+
+    $file.Delete()
+    $file.Refresh()
+    Assert-Equals -actual $file.Exists -expected $false
+    
+    $sw = $file.CreateText()
+    try {
+        $sw.WriteLine("line1")
+        $sw.WriteLine("line2")
+    } finally {
+        $sw.Close()
+    }
+    $file.Refresh()
+
+    $sr = $file.OpenText()
+    try {
+        $file_contents = $sr.ReadToEnd()
+    } finally {
+        $sr.Close()
+    }
+    Assert-Equals -actual $file_contents -expected "line1`r`nline2`r`n"
+
+    $copied_file = $file.CopyTo("$root_path\copy.txt")
+    Assert-Equals -actual $file.Exists -expected $true
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\copy.txt")) -expected $true
+    $file_hash = Get-AnsibleFileHash -Path $file.FullName
+    $copied_file_hash = Get-AnsibleFileHash -Path $copied_file.FullName
+    Assert-Equals -actual $file_hash -expected $copied_file_hash
+
+    $failed = $false
+    try {
+        $file.CopyTo("$root_path\copy.txt")
+    } catch {
+        Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"CopyTo`" with `"1`" argument(s): `"The file '$root_path\copy.txt' already exists.`""
+        $failed = $true
+    }
+    Assert-Equals -actual $failed -expected $true
+
+    $sw = $file.AppendText()
+    try {
+        $sw.WriteLine("line3")
+    } finally {
+        $sw.Close()
+    }
+    $copied_file = $file.CopyTo("$root_path\copy.txt", $true)
+    Assert-Equals -actual $file.Exists -expected $true
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\copy.txt")) -expected $true
+    $file_hash = Get-AnsibleFileHash -Path $file.FullName
+    $copied_file_hash = Get-AnsibleFileHash -Path $copied_file.FullName
+    Assert-Equals -actual $file_hash -expected $copied_file_hash
+
+    # also test out the line3 was appended correctly
+    $sr = $file.OpenText()
+    try {
+        $file_contents = $sr.ReadToEnd()
+    } finally {
+        $sr.Close()
+    }
+    Assert-Equals -actual $file_contents -expected "line1`r`nline2`r`nline3`r`n"
+
+    # these tests will only work over WinRM when become or CredSSP is used
+    if ($encrypt_tests) {
+        $file.Encrypt()
+        $file.Refresh()
+        Assert-Equals $file.Attributes.HasFlag([System.IO.FileAttributes]::Encrypted) -expected $true
+
+        $file.Decrypt()
+        $file.Refresh()
+        Assert-Equals $file.Attributes.HasFlag([System.IO.FileAttributes]::Encrypted) -expected $false
+    }
+
+    $original_hash = Get-AnsibleFileHash -Path $copied_file.FullName
+    $copied_file.MoveTo("$root_path\moved.txt")
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\copy.txt")) -expected $false
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\moved.txt")) -expected $true
+    $moved_hash = Get-AnsibleFileHash -path "$root_path\moved.txt"
+    Assert-Equals -actual $moved_hash -expected $original_hash
+
+    $target_file = New-Object -TypeName Ansible.IO.FileInfo -ArgumentList "$root_path\target.txt"
+    $backup_file = New-Object -TypeName Ansible.IO.FileInfo -ArgumentList "$root_path\backup.txt"
+    $sw = $target_file.CreateText()
+    try {
+        $sw.WriteLine("original target")
+    } finally {
+        $sw.Close()
+    }
+    $original_target_hash = Get-AnsibleFileHash -Path $target_file.FullName
+    $original_source_hash = Get-AnsibleFileHash -Path $file.FullName
+    $replaced_file = $file.Replace($target_file.FullName, $backup_file.FullName)
+    $file.Refresh()
+    $target_file.Refresh()
+    $backup_file.Refresh()
+    $new_target_hash = Get-AnsibleFileHash -Path $replaced_file.FullName
+    $backup_hash = Get-AnsibleFileHash -Path $backup_file.FullName
+    Assert-Equals -actual $file.Exists -expected $false
+    Assert-Equals -actual $replaced_file.FullName -expected $target_file.FullName
+    Assert-Equals -actual $replaced_file.Exists -expected $true
+    Assert-Equals -actual $backup_file.Exists -expected $true
+    Assert-Equals -actual $new_target_hash -expected $original_source_hash
+    Assert-Equals -actual $backup_hash -expected $original_target_hash
+    $file = $replaced_file
+
+    $fs = $file.OpenRead()
+    $failed = $false
+    try {
+        $fs.WriteByte([byte]0x21)
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"WriteByte`" with `"1`" argument(s): `"Stream does not support writing.`""
+    } finally {
+        $fs.Close()
+    }
+    Assert-Equals -actual $failed -expected $true
+
+    $fs = $file.OpenRead()
+    try {
+        $file_bytes = New-Object -TypeName Byte[] -ArgumentList $fs.Length
+        $bytes_read = $fs.Read($file_bytes, 0, $fs.Length)
+    } finally {
+        $fs.Close()
+    }
+    $file_contents = ([System.Text.Encoding]::UTF8).GetString($file_bytes)
+    Assert-Equals -actual $file_contents -expected "line1`r`nline2`r`nline3`r`n"
+
+    $fs = $file.OpenWrite()
+    try {
+        $fs.WriteByte([byte]0x21)
+    } finally {
+        $fs.Close()
+    }
+    $fs = $file.OpenRead()
+    try {
+        $file_bytes = New-Object -TypeName Byte[] -ArgumentList $fs.Length
+        $bytes_read = $fs.Read($file_bytes, 0, $fs.Length)
+    } finally {
+        $fs.Close()
+    }
+    $file_contents = ([System.Text.Encoding]::UTF8).GetString($file_bytes)
+    Assert-Equals -actual $file_contents -expected "!ine1`r`nline2`r`nline3`r`n"
+
+    $fs = $file.Open([System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::ReadWrite)
+    try {
+        $fs.WriteByte([byte]0x21)
+        $fs.Flush()
+    } finally {
+        $fs.Close()
+    }
+    $fs = $file.Open([System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
+    try {
+        $file_bytes = New-Object -TypeName Byte[] -ArgumentList $fs.Length
+        $bytes_read = $fs.Read($file_bytes, 0, $fs.Length)
+    } finally {
+        $fs.Close()
+    }
+    $file_contents = ([System.Text.Encoding]::UTF8).GetString($file_bytes)
+    Assert-Equals -actual $file_contents -expected "!"
+
+    # open a file with append (CreateFileW doesn't work with append so make sure the stuff around it is fine)
+    $fs = $file.Open([System.IO.FileMode]::Append, [System.IO.FileAccess]::Write)
+    try {
+        $fs.WriteByte([byte]0x21)
+        $fs.Flush()
+    } finally {
+        $fs.Close()
+    }
+    $fs = $file.Open([System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
+    try {
+        $file_bytes = New-Object -TypeName Byte[] -ArgumentList $fs.Length
+        $bytes_read = $fs.Read($file_bytes, 0, $fs.Length)
+    } finally {
+        $fs.Close()
+    }
+    $file_contents = ([System.Text.Encoding]::UTF8).GetString($file_bytes)
+    Assert-Equals -actual $file_contents -expected "!!"
+
+    $current_sid = ([System.Security.Principal.WindowsIdentity]::GetCurrent()).User
+    $everyone_sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-1-0"
+    
+    $acl = New-Object -TypeName System.Security.AccessControl.FileSecurity
+    $acl.SetGroup($everyone_sid)
+    $acl.SetOwner($current_sid)
+    $acl.SetAccessRule((New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList $everyone_sid, "FullControl", "Allow"))
+    $file.SetAccessControl($acl)
+
+    $file.Refresh()
+    $acl = $file.GetAccessControl()
+    $access_rules = $acl.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier])
+    $explicit_access_rules = $access_rules | Where-Object { $_.IsInherited -eq $false }
+    $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+    $group = $acl.GetGroup([System.Security.Principal.SecurityIdentifier])
+    Assert-Equals -actual $owner -expected $current_sid
+    Assert-Equals -actual $group -expected $everyone_sid
+    Assert-Equals -actual $explicit_access_rules.Count -expected 1
+    Assert-Equals -actual $explicit_access_rules[0].IdentityReference -expected $everyone_sid
+    
+    $limited_acl = $file.GetAccessControl([System.Security.AccessControl.AccessControlSections]::Owner)
+    $owner = $limited_acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+    $group = $limited_acl.GetGroup([System.Security.Principal.SecurityIdentifier])
+    Assert-Equals -actual $owner -expected $current_sid
+    Assert-Equals -actual $group -expected $null
+
+    ### File Tests ###
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($root_path)) -expected $false
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($file_path)) -expected $false
+
+    $fs = [Ansible.IO.File]::Create($file_path)
+    $fs.Close()
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($file_path)) -expected $true
+
+    [Ansible.IO.File]::Delete($file_path)
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($file_path)) -expected $false
+
+    $fs = [Ansible.IO.File]::Create($file_path, 4096, [System.IO.FileOptions]::None, $acl)
+    $fs.Close()
+    $acl = [Ansible.IO.File]::GetAccessControl($file_path)
+    $access_rules = $acl.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier])
+    $explicit_access_rules = $access_rules | Where-Object { $_.IsInherited -eq $false }
+    $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+    $group = $acl.GetGroup([System.Security.Principal.SecurityIdentifier])
+    Assert-Equals -actual $owner -expected $current_sid
+    Assert-Equals -actual $group -expected $everyone_sid
+    Assert-Equals -actual $explicit_access_rules.Count -expected 1
+    Assert-Equals -actual $explicit_access_rules[0].IdentityReference -expected $everyone_sid
+
+    # need to be an admin to set this
+    if ([bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544")) {
+        $admin_sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-5-32-544"
+        $acl.SetOwner($admin_sid)
+        [Ansible.IO.File]::SetAccessControl($file_path, $acl)
+
+        $limited_acl = [Ansible.IO.File]::GetAccessControl($file_path, [System.Security.AccessControl.AccessControlSections]::Owner)
+        $owner = $limited_acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+        $group = $limited_acl.GetGroup([System.Security.Principal.SecurityIdentifier])
+        Assert-Equals -actual $owner -expected $admin_sid
+        Assert-Equals -actual $group -expected $null
+    }
+
+    [Ansible.IO.File]::SetCreationTimeUtc($file_path, $new_date)
+    $creation_time = [Ansible.IO.File]::GetCreationTimeUtc($file_path)
+    Assert-Equals -actual $creation_time -expected $new_date
+
+    [Ansible.IO.File]::SetLastAccessTimeUtc($file_path, $new_date)
+    $lastaccess_time = [Ansible.IO.File]::GetLastAccessTimeUtc($file_path)
+    Assert-Equals -actual $lastaccess_time -expected $new_date
+
+    [Ansible.IO.File]::SetLastWriteTimeUtc($file_path, $new_date)
+    $lastwrite_time = [Ansible.IO.File]::GetLastWriteTimeUtc($file_path)
+    Assert-Equals -actual $lastwrite_time -expected $new_date
+
+    $attributes = [Ansible.IO.File]::GetAttributes($file_path)
+    Assert-Equals -actual $attributes -expected ([System.IO.FileAttributes]::Archive)
+
+    [Ansible.IO.File]::SetAttributes($file_path, ($attributes -bor [System.IO.FileAttributes]::Hidden))
+    $attributes = [Ansible.IO.File]::GetAttributes($file_path)
+    Assert-Equals -actual $attributes -expected ([System.IO.FileAttributes]::Archive -bor [System.IO.FileAttributes]::Hidden)
+
+    if ($encrypt_tests) {
+        [Ansible.IO.File]::Encrypt($file_path)
+        $attributes = [Ansible.IO.File]::GetAttributes($file_path)
+        Assert-Equals -actual $attributes.HasFlag([System.IO.FileAttributes]::Encrypted) -expected $true
+
+        [Ansible.IO.File]::Decrypt($file_path)
+        $attributes = [Ansible.IO.File]::GetAttributes($file_path)
+        Assert-Equals -actual $attributes.HasFlag([System.IO.FileAttributes]::Encrypted) -expected $false
+    }
+
+    [Ansible.IO.File]::AppendAllText($file_path, "line1`r`nline2`r`n")
+    $file_contents = [Ansible.IO.File]::ReadAllText($file_path)
+    Assert-Equals -actual $file_contents -expected "line1`r`nline2`r`n"
+
+    [Ansible.IO.File]::AppendAllText($file_path, "line3`r`nline4`r`n")
+    $file_contents = [Ansible.IO.File]::ReadAllText($file_path)
+    Assert-Equals -actual $file_contents -expected "line1`r`nline2`r`nline3`r`nline4`r`n"
+
+    [Ansible.IO.File]::Copy($file_path, "$root_path\copy-file.txt")
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($file_path)) -expected $true
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\copy-file.txt")) -expected $true
+    $source_hash = Get-AnsibleFileHash -Path $file_path
+    $target_hash = Get-AnsibleFileHash -Path "$root_path\copy-file.txt"
+    Assert-Equals -actual $target_hash -expected $source_hash
+
+    [Ansible.IO.File]::Move($file_path, "$root_path\move-file.txt")
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($file_path)) -expected $false
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\move-file.txt")) -expected $true
+    $target_hash = Get-AnsibleFileHash -Path "$root_path\move-file.txt"
+    Assert-Equals -actual $target_hash -expected $source_hash
+
+    $failed = $false
+    try {
+        [Ansible.IO.File]::Move("$root_path\copy-file.txt", "$root_path\move-file.txt")
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"Move`" with `"2`" argument(s): `"Cannot create a file when that file already exists`""
+    }
+    Assert-Equals -actual $failed -expected $true
+
+    $fs = [Ansible.IO.File]::Create($file_path)
+    $fs.Close()
+    [Ansible.IO.File]::AppendAllText($file_path, "source text")
+    [Ansible.IO.File]::Delete("$root_path\target.txt")
+    $fs = [Ansible.IO.File]::Create("$root_path\target.txt")
+    $fs.Close()
+    [Ansible.IO.File]::AppendAllText("$root_path\target.txt", "target text")
+
+    $source_hash = Get-AnsibleFileHash -Path $file_path
+    $target_hash = Get-AnsibleFileHash -Path "$root_path\target.txt"
+    [Ansible.IO.File]::Replace($file_path, "$root_path\target.txt", "$root_path\backup.txt")
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($file_path)) -expected $false
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\target.txt")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\backup.txt")) -expected $true
+    $new_target_hash = Get-AnsibleFileHash -Path "$root_path\target.txt"
+    $backup_hash = Get-AnsibleFileHash -Path "$root_path\backup.txt"
+    Assert-Equals -actual $new_target_hash -expected $source_hash
+    Assert-Equals -actual $backup_hash -expected $target_hash
+
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\target.txt")
+    $file_contents = ([System.Text.Encoding]::UTF8).GetString($file_bytes)
+    Assert-Equals -actual $file_contents -expected "source text"
+
+    $utf8_bytes = ([System.Text.Encoding]::UTF8).GetBytes("Hello World!")
+    $utf16_bytes = ([System.Text.Encoding]::Unicode).GetBytes("Hello World!")
+    $fs = [Ansible.IO.File]::OpenWrite("$root_path\utf8.txt")
+    try {
+        $fs.Write($utf8_bytes, 0, $utf8_bytes.Length)
+    } finally {
+        $fs.Close()
+    }
+    $fs = [Ansible.IO.File]::OpenWrite("$root_path\utf16.txt")
+    try {
+        $fs.Write($utf16_bytes, 0, $utf16_bytes.Length)
+    } finally {
+        $fs.Close()
+    }
+
+    [Ansible.IO.File]::AppendAllText("$root_path\utf8.txt", "`r`nanother line")
+    $expected_text = "Hello World!`r`nanother line"
+    $expected_bytes = ([System.Text.Encoding]::UTF8).GetBytes($expected_text)
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf8.txt")
+    $file_text = [Ansible.IO.File]::ReadAllText("$root_path\utf8.txt")
+    $file_lines = [Ansible.IO.File]::ReadAllLines("$root_path\utf8.txt")
+    $file_lines_enumerable = [Ansible.IO.File]::ReadLines("$root_path\utf8.txt")
+    Assert-ArrayEquals -actual $file_bytes -expected $expected_bytes
+    Assert-Equals -actual $file_text -expected $expected_text
+    Assert-Equals -actual $file_lines.Count -expected 2
+    Assert-Equals -actual $file_lines[0] -expected "Hello World!"
+    Assert-Equals -actual $file_lines[1] -expected "another line"
+    $is_first = $true
+    foreach ($line in $file_lines_enumerable) {
+        if ($is_first) {
+            Assert-Equals -actual $line -expected "Hello World!"
+        } else {
+            Assert-Equals -actual $line -expected "another line"
+        }
+        $is_first = $false
+    }
+
+
+    [Ansible.IO.File]::AppendAllText("$root_path\utf16.txt", "`r`nanother line", [System.Text.Encoding]::Unicode)
+    $expected_text = "Hello World!`r`nanother line"
+    $expected_bytes = ([System.Text.Encoding]::Unicode).GetBytes($expected_text)
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf16.txt")
+    $file_text = [Ansible.IO.File]::ReadAllText("$root_path\utf16.txt", [System.Text.Encoding]::Unicode)
+    $file_lines = [Ansible.IO.File]::ReadAllLines("$root_path\utf16.txt", [System.Text.Encoding]::Unicode)
+    $file_lines_enumerable = [Ansible.IO.File]::ReadLines("$root_path\utf16.txt", [System.Text.Encoding]::Unicode)
+    Assert-ArrayEquals -actual $file_bytes -expected $expected_bytes
+    Assert-Equals -actual $file_text -expected $expected_text
+    Assert-Equals -actual $file_lines.Count -expected 2
+    Assert-Equals -actual $file_lines[0] -expected "Hello World!"
+    Assert-Equals -actual $file_lines[1] -expected "another line"
+    $is_first = $true
+    foreach ($line in $file_lines_enumerable) {
+        if ($is_first) {
+            Assert-Equals -actual $line -expected "Hello World!"
+        } else {
+            Assert-Equals -actual $line -expected "another line"
+        }
+        $is_first = $false
+    }
+
+    [Ansible.IO.File]::WriteAllLines("$root_path\utf8.txt", [string[]]@("line 1", "line 2"))
+    $expected_bytes = [System.Text.Encoding]::UTF8.GetBytes("line 1`r`nline 2`r`n")
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf8.txt")
+    Assert-ArrayEquals -actual $file_bytes -expected $expected_bytes
+
+    [Ansible.IO.File]::WriteAllLines("$root_path\utf16.txt", [string[]]@("line 1", "line 2"), [System.Text.Encoding]::Unicode)
+    $expected_bytes = [byte[]](([System.Text.Encoding]::Unicode).GetPreamble() + ([System.Text.Encoding]::Unicode).GetBytes("line 1`r`nline 2`r`n"))
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf16.txt")
+    Assert-ArrayEquals -actual $file_bytes -expected $expected_bytes
+
+    [Ansible.IO.File]::WriteAllText("$root_path\utf8.txt", "another line 1`r`nanother line 2`r`n")
+    $expected_bytes = [System.Text.Encoding]::UTF8.GetBytes("another line 1`r`nanother line 2`r`n")
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf8.txt")
+    Assert-ArrayEquals -actual $file_bytes -expected $expected_bytes
+
+    [Ansible.IO.File]::WriteAllText("$root_path\utf16.txt", "another line 1`r`nanother line 2`r`n", [System.Text.Encoding]::Unicode)
+    $expected_bytes = [byte[]](([System.Text.Encoding]::Unicode).GetPreamble() + ([System.Text.Encoding]::Unicode).GetBytes("another line 1`r`nanother line 2`r`n"))
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf16.txt")
+    Assert-ArrayEquals -actual $file_bytes -expected $expected_bytes
+
+    [Ansible.IO.File]::WriteAllBytes("$root_path\utf8.txt", [byte[]]@(0x21, 0x21))
+    $file_contents = [Ansible.IO.File]::ReadAllText("$root_path\utf8.txt")
+    Assert-Equals -actual $file_contents -expected "!!"
+
+    $sw = [Ansible.IO.File]::AppendText("$root_path\utf8.txt")
+    try {
+        $sw.WriteLine("!!")
+    } finally {
+        $sw.Close()
+    }
+    $file_contents = [Ansible.IO.File]::ReadAllText("$root_path\utf8.txt")
+    Assert-Equals -actual $file_contents -expected "!!!!`r`n"
+
+    $sw = [Ansible.IO.File]::CreateText("$root_path\utf8.txt")
+    try {
+        $sw.WriteLine("!!")
+    } finally {
+        $sw.Close()
+    }
+    $file_contents = [Ansible.IO.File]::ReadAllText("$root_path\utf8.txt")
+    Assert-Equals -actual $file_contents -expected "!!`r`n"
+
+    $sr = [Ansible.IO.File]::OpenText("$root_path\utf8.txt")
+    try {
+        $file_contents = $sr.ReadToEnd()
+    } finally {
+        $sr.Close()
+    }
+    Assert-Equals -actual $file_contents -expected "!!`r`n"
+
+    $fs = [Ansible.IO.File]::OpenRead("$root_path\utf8.txt")
+    try {
+        Assert-Equals -actual $fs.CanRead -expected $true
+        Assert-Equals -actual $fs.CanWrite -expected $false
+        $file_bytes = New-Object -TypeName Byte[] -ArgumentList $fs.Length
+        $bytes_read = $fs.Read($file_bytes, 0, $fs.Length)
+    } finally {
+        $fs.Close()
+    }
+    Assert-ArrayEquals -actual $file_bytes -expected ([byte[]]@(33, 33, 13, 10))
+
+    $fs = [Ansible.IO.File]::OpenWrite("$root_path\utf8.txt")
+    try {
+        Assert-Equals -actual $fs.CanRead -expected $false
+        Assert-Equals -actual $fs.CanWrite -expected $true
+        $fs.WriteByte([byte]32)
+    } finally {
+        $fs.Close()
+    }
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf8.txt")
+    Assert-ArrayEquals -actual $file_bytes -expected ([byte[]]@(32, 33, 13, 10))
+
+    $fs = [Ansible.IO.File]::Open("$root_path\utf8.txt", [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::ReadWrite)
+    try {
+        Assert-Equals -actual $fs.CanRead -expected $false
+        Assert-Equals -actual $fs.CanWrite -expected $true
+        $fs.WriteByte([byte]33)
+        $fs.Flush()
+    } finally {
+        $fs.Close()
+    }
+    $fs = [Ansible.IO.File]::Open("$root_path\utf8.txt", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
+    try {
+        Assert-Equals -actual $fs.CanRead -expected $true
+        Assert-Equals -actual $fs.CanWrite -expected $false
+        $file_bytes = New-Object -TypeName Byte[] -ArgumentList $fs.Length
+        $bytes_read = $fs.Read($file_bytes, 0, $fs.Length)
+    } finally {
+        $fs.Close()
+    }
+    Assert-ArrayEquals -actual $file_bytes -expected ([byte[]]@(33))
+
+    # open a file with append (CreateFileW doesn't work with append so make sure the stuff around it is fine)
+    $fs = [Ansible.IO.File]::Open("$root_path\utf8.txt", [System.IO.FileMode]::Append, [System.IO.FileAccess]::ReadWrite)
+    try {
+        Assert-Equals -actual $fs.CanRead -expected $true
+        Assert-Equals -actual $fs.CanWrite -expected $true
+        $fs.WriteByte([byte]32)
+        $fs.Flush()
+    } finally {
+        $fs.Close()
+    }
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf8.txt")
+    Assert-ArrayEquals -actual $file_bytes -expected ([byte[]]@(33, 32))
+}
+
+Function Test-DirectoryClass($root_path) {
+    $directory_path = "$root_path\dir"
+
+    ### DirectoryInfo Tests ###
+    $dir = New-Object -TypeName Ansible.IO.DirectoryInfo -ArgumentList $directory_path
+
+    # Test class attributes when it doesn't exist
+    Assert-Equals -actual $dir.Exists -expected $false
+    Assert-Equals -actual $dir.Name -expected "dir"
+    Assert-Equals -actual $dir.Parent.ToString() -expected $root_path
+    if ($root_path.StartsWith("\\?\UNC\127.0.0.1")) {
+        Assert-Equals -actual $dir.Root.ToString() -expected "\\?\UNC\127.0.0.1\c$"
+    } elseif ($root_path.StartsWith("\\?\")) {
+        Assert-Equals -actual $dir.Root.ToString() -expected "\\?\C:\"
+    } elseif ($root_path.StartsWith("\\127.0.0.1")) {
+        Assert-Equals -actual $dir.Root.ToString() -expected "\\127.0.0.1\c$"
+    } else {
+        Assert-Equals -actual $dir.Root.ToString() -expected "C:\"
+    }
+    Assert-Equals -actual ([Int32]$dir.Attributes) -expected -1
+    Assert-Equals -actual $dir.CreationTimeUtc.ToFileTimeUtc() -expected 0
+    Assert-Equals -actual $dir.Extension -expected ""
+    Assert-Equals -actual $dir.FullName -expected $directory_path
+    Assert-Equals -actual $dir.LastAccessTimeUtc.ToFileTimeUtc() -expected 0
+    Assert-Equals -actual $dir.LastWriteTimeUtc.ToFileTimeUtc() -expected 0
+
+    # create directory
+    $current_time = (Get-Date).ToFileTimeUtc()
+    $dir.Create()
+    $dir.Refresh() # resets the properties of the class
+
+    # Test class attributes when it does exist
+    Assert-Equals -actual $dir.Exists -expected $true
+    Assert-Equals -actual $dir.Name -expected "dir"
+    Assert-Equals -actual $dir.Parent.ToString() -expected $root_path 
+    if ($root_path.StartsWith("\\?\UNC\127.0.0.1")) {
+        Assert-Equals -actual $dir.Root.ToString() -expected "\\?\UNC\127.0.0.1\c$"
+    } elseif ($root_path.StartsWith("\\?\")) {
+        Assert-Equals -actual $dir.Root.ToString() -expected "\\?\C:\"
+    } elseif ($root_path.StartsWith("\\127.0.0.1")) {
+        Assert-Equals -actual $dir.Root.ToString() -expected "\\127.0.0.1\c$"
+    } else {
+        Assert-Equals -actual $dir.Root.ToString() -expected "C:\"
+    }
+    Assert-Equals -actual $dir.Attributes -expected ([System.IO.FileAttributes]::Directory)
+    Assert-Equals -actual ($dir.CreationTimeUtc.ToFileTimeUtc() -ge $current_time) -expected $true
+    Assert-Equals -actual $dir.Extension -expected ""
+    Assert-Equals -actual $dir.FullName -expected $directory_path
+    Assert-Equals -actual ($dir.LastAccessTimeUtc.ToFileTimeUtc() -ge $current_time) -expected $true
+    Assert-Equals -actual ($dir.LastWriteTimeUtc.ToFileTimeUtc() -ge $current_time) -expected $true
+
+    # set properties
+    $dir.Attributes = $dir.Attributes -bor [System.IO.FileAttributes]::Archive -bor [System.IO.FileAttributes]::Hidden
+    Assert-Equals -actual $dir.Attributes -expected ([System.IO.FileAttributes]::Directory -bor [System.IO.FileAttributes]::Archive -bor [System.IO.FileAttributes]::Hidden)
+
+    $new_date = (Get-Date -Date "1993-06-11 06:51:32Z")
+    $dir.CreationTimeUtc = $new_date
+    Assert-Equals -actual $dir.CreationTimeUtc.ToFileTimeUtc() -expected $new_date.ToFileTimeUtc()
+    $dir.LastAccessTimeUtc = $new_date
+    Assert-Equals -actual $dir.LastAccessTimeUtc.ToFileTimeUtc() -expected $new_date.ToFileTimeUtc()
+    $dir.LastWriteTimeUtc = $new_date
+    Assert-Equals -actual $dir.LastWriteTimeUtc.ToFileTimeUtc() -expected $new_date.ToFileTimeUtc()
+
+    # test DirectoryInfo methods
+    # create tests
+    $subdir = $dir.CreateSubDirectory("subdir")
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\subdir")) -expected $true
+
+    # enumerate tests
+    $subdir1 = $dir.CreateSubDirectory("subdir-1")
+    $subdir2 = $dir.CreateSubDirectory("subdir-2")
+    $subdir1.CreateSubDirectory("subdir3") > $null
+    $file = [Ansible.IO.File]::CreateText("$directory_path\file.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\anotherfile.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\subdir-1\file-1.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\subdir-2\file-2.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\subdir-1\subdir3\file-3.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+
+    $dir_dirs = $dir.EnumerateDirectories()
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
+        Assert-Equals -actual ($dir_name.Name -in (
+            "subdir",
+            "subdir-1",
+            "subdir-2")) -expected $true
+    }
+    $dir_dirs = $dir.EnumerateDirectories("subdir-?")
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
+        Assert-Equals -actual ($dir_name.Name -in (
+            "subdir-1",
+            "subdir-2")) -expected $true
+    }
+    $dir_dirs = $dir.EnumerateDirectories("*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
+        Assert-Equals -actual ($dir_name.Name -in (
+            "subdir",
+            "subdir-1",
+            "subdir-2",
+            "subdir3")) -expected $true
+    }
+
+    $dir_dirs = $dir.GetDirectories()
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
+        Assert-Equals -actual ($dir_name.Name -in (
+            "subdir",
+            "subdir-1",
+            "subdir-2")) -expected $true
+    }
+    $dir_dirs = $dir.GetDirectories("subdir-?")
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
+        Assert-Equals -actual ($dir_name.Name -in (
+            "subdir-1",
+            "subdir-2")) -expected $true
+    }
+    $dir_dirs = $dir.GetDirectories("*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
+        Assert-Equals -actual ($dir_name.Name -in (
+            "subdir",
+            "subdir-1",
+            "subdir-2",
+            "subdir3")) -expected $true
+    }
+
+    $dir_files = $dir.EnumerateFiles()
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
+        Assert-Equals -actual ($dir_file.Name -in (
+            "file.txt",
+            "anotherfile.txt")) -expected $true
+    }
+    $dir_files = $dir.EnumerateFiles("anotherfile*")
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
+        Assert-Equals -actual ($dir_file.Name -in ("anotherfile.txt")) -expected $true
+    }
+    $dir_files = $dir.EnumerateFiles("*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
+        Assert-Equals -actual ($dir_file.Name -in (
+            "file.txt",
+            "anotherfile.txt",
+            "file-1.txt",
+            "file-2.txt",
+            "file-3.txt")) -expected $true
+    }
+
+    $dir_files = $dir.GetFiles()
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
+        Assert-Equals -actual ($dir_file.Name -in (
+            "file.txt",
+            "anotherfile.txt")) -expected $true
+    }
+    $dir_files = $dir.GetFiles("anotherfile*")
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
+        Assert-Equals -actual ($dir_file.Name -in ("anotherfile.txt")) -expected $true
+    }
+    $dir_files = $dir.GetFiles("*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
+        Assert-Equals -actual ($dir_file.Name -in (
+            "file.txt",
+            "anotherfile.txt",
+            "file-1.txt",
+            "file-2.txt",
+            "file-3.txt")) -expected $true
+    }
+
+    $dir_entries = $dir.EnumerateFileSystemInfos()
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in (
+            "file.txt",
+            "anotherfile.txt",
+            "subdir",
+            "subdir-1",
+            "subdir-2")) -expected $true
+    }
+    $dir_entries = $dir.EnumerateFileSystemInfos("anotherfile*")
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in ("anotherfile.txt")) -expected $true
+    }
+    $dir_entries = $dir.EnumerateFileSystemInfos("*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in (
+            "file.txt",
+            "anotherfile.txt",
+            "file-1.txt",
+            "file-2.txt",
+            "file-3.txt",
+            "subdir",
+            "subdir-1",
+            "subdir-2",
+            "subdir3")) -expected $true
+    }
+
+    $dir_entries = $dir.GetFileSystemInfos()
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in (
+            "file.txt",
+            "anotherfile.txt",
+            "subdir",
+            "subdir-1",
+            "subdir-2")) -expected $true
+    }
+    $dir_entries = $dir.GetFileSystemInfos("anotherfile*")
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in ("anotherfile.txt")) -expected $true
+    }
+    $dir_entries = $dir.GetFileSystemInfos("*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in (
+            "file.txt",
+            "anotherfile.txt",
+            "file-1.txt",
+            "file-2.txt",
+            "file-3.txt",
+            "subdir",
+            "subdir-1",
+            "subdir-2",
+            "subdir3")) -expected $true
+    }
+    
+    # move tests
+    $subdir2.MoveTo("$directory_path\subdir-move")
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\subdir-move")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$directory_path\subdir-move\file-2.txt")) -expected $true
+
+    # delete tests
+    $failed = $false
+    try {
+        # fail to delete a directory that has contents
+        $subdir1.Delete()
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"Delete`" with `"0`" argument(s): `"The directory is not empty : '$($subdir1.FullName)'`""
+    }
+    Assert-Equals -actual $failed -expected $true
+    $subdir1.Delete($true)
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\subdir-1")) -expected $false
+    $subdir = $dir.CreateSubDirectory("subdir")
+    $subdir.Delete()
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\subdir")) -expected $false
+
+    # ACL tests
+    $current_sid = ([System.Security.Principal.WindowsIdentity]::GetCurrent()).User
+    $everyone_sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-1-0"
+
+    $dir_sec = New-Object -TypeName System.Security.AccessControl.DirectorySecurity
+    $read_rule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList $everyone_sid, "FullControl", "Allow"
+    $dir_sec.SetAccessRule($read_rule)
+    $dir_sec.SetOwner($current_sid)
+    $dir_sec.SetGroup($everyone_sid)
+    $acl_dir = $dir.CreateSubDirectory("acl-dir", $dir_sec)
+
+    $actual_acl = $acl_dir.GetAccessControl()
+    $access_rules = $actual_acl.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier])
+
+    $acl_owner = $actual_acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+    $acl_group = $actual_acl.GetGroup([System.Security.Principal.SecurityIdentifier])
+    Assert-Equals -actual $acl_owner -expected $current_sid
+    Assert-Equals -actual $acl_group -expected $everyone_sid
+
+    # only admins can set audit rules, we test for failure if not running as admin
+    $audit_rule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule -ArgumentList $everyone_sid, "Read", "Success"
+    $dir_sec = $acl_dir.GetAccessControl()
+    $dir_sec.SetAuditRule($audit_rule)
+    if ([bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544")) {
+        $acl_dir.SetAccessControl($dir_sec)
+        $actual_acl = $acl_dir.GetAccessControl([System.Security.AccessControl.AccessControlSections]::All)
+        $audit_rules = $actual_acl.GetAuditRules($true, $true, [System.Security.Principal.SecurityIdentifier])
+        Assert-Equals -actual $audit_rules.Count -expected 1
+        Assert-Equals -actual $audit_rules[0].FileSystemRights.ToString() -expected "Read"
+        Assert-Equals -actual $audit_rules[0].AuditFlags.ToString() -expected "Success"
+        Assert-Equals -actual $audit_rules[0].IsInherited -expected $false
+        Assert-Equals -actual $audit_rules[0].IdentityReference -expected $everyone_sid
+    } else {
+        $failed = $false
+        try {
+            $acl_dir.SetAccessControl($dir_sec)
+        } catch {
+            $failed = $true
+            Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"SetAccessControl`" with `"1`" argument(s): `"AdjustTokenPrivileges() failed (Not all privileges or groups referenced are assigned to the caller, Win32ErrorCode 1300)`""
+        }
+        Assert-Equals -actual $failed -expected $true
+    }
+
+    # clear for the Ansible.IO.Directory tests
+    [Ansible.IO.Directory]::Delete($directory_path, $true)
+
+    ### Directory Tests ###
+    $dir = [Ansible.IO.Directory]::CreateDirectory($directory_path)
+    Assert-Equals -actual ($dir -is [Ansible.IO.DirectoryInfo]) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists($directory_path)) -expected $true
+
+    # ACL Tests
+    $acl = New-Object -TypeName System.Security.AccessControl.DirectorySecurity
+    $read_rule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList $everyone_sid, "FullControl", "Allow"
+    $acl.SetAccessRule($read_rule)
+    $acl.SetOwner($current_sid)
+    $acl.SetGroup($everyone_sid)
+    $acl_dir = [Ansible.IO.Directory]::CreateDirectory("$directory_path\acl-dir", $acl)
+    Assert-Equals -actual ($acl_dir -is [Ansible.IO.DirectoryInfo]) -expected $true
+
+    $acl = [Ansible.IO.Directory]::GetAccessControl("$directory_path\acl-dir")
+    $access_rules = $acl.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier])
+    $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+    $group = $acl.GetGroup([System.Security.Principal.SecurityIdentifier])
+    Assert-Equals -actual $access_rules.Count -expected 1
+    Assert-Equals -actual $access_rules[0].IdentityReference -expected $everyone_sid
+    Assert-Equals -actual $access_rules[0].IsInherited -expected $false
+    Assert-Equals -actual $owner -expected $current_sid
+    Assert-Equals -actual $group -expected $everyone_sid
+
+    # only admins can set this
+    if ([bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544")) {
+        $acl = [Ansible.IO.Directory]::GetAccessControl("$directory_path\acl-dir")
+        $admin_sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-5-32-544"
+        $acl.SetOwner($admin_sid)
+        [Ansible.IO.Directory]::SetAccessControl("$directory_path\acl-dir", $acl)
+
+        $acl_owner = [Ansible.IO.Directory]::GetAccessControl("$directory_path\acl-dir", [System.Security.AccessControl.AccessControlSections]::Owner)
+        $owner = $acl_owner.GetOwner([System.Security.Principal.SecurityIdentifier])
+        $group = $acl_owner.GetGroup([System.Security.Principal.SecurityIdentifier])
+        Assert-Equals -actual $owner -expected $admin_sid
+        Assert-Equals -actual $group -expected $null
+    }
+
+    [Ansible.IO.Directory]::CreateDirectory("$directory_path\subdir-1") > $null
+    [Ansible.IO.Directory]::CreateDirectory("$directory_path\subdir-1\subdir-3") > $null
+    [Ansible.IO.Directory]::CreateDirectory("$directory_path\subdir-2") > $null
+    $file = [Ansible.IO.File]::CreateText("$directory_path\file.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\anotherfile.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\subdir-1\file-1.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\subdir-1\subdir-3\file-3.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\subdir-2\file-2.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+
+    $dir_dirs = [Ansible.IO.Directory]::EnumerateDirectories($directory_path)
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_name -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir")) -expected $true
+    }
+    $dir_dirs = [Ansible.IO.Directory]::EnumerateDirectories($directory_path, "acl-*")
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_name -in ("$directory_path\acl-dir")) -expected $true
+    }
+    $dir_dirs = [Ansible.IO.Directory]::EnumerateDirectories($directory_path, "*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_name -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-1\subdir-3",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir")) -expected $true
+    }
+
+    $dir_dirs = [Ansible.IO.Directory]::GetDirectories($directory_path)
+    Assert-Equals -actual ($dir_dirs.Count) -expected 3
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_name -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir")) -expected $true
+    }
+    $dir_dirs = [Ansible.IO.Directory]::GetDirectories($directory_path, "acl-*")
+    Assert-Equals -actual ($dir_dirs.Count) -expected 1
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_name -in ("$directory_path\acl-dir")) -expected $true
+    }
+    $dir_dirs = [Ansible.IO.Directory]::GetDirectories($directory_path, "*", [System.IO.SearchOption]::AllDirectories)
+    Assert-Equals -actual ($dir_dirs.Count) -expected 4
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_name -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-1\subdir-3",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir")) -expected $true
+    }
+
+    $dir_files = [Ansible.IO.Directory]::EnumerateFiles($directory_path)
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_file -in (
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_files = [Ansible.IO.Directory]::EnumerateFiles($directory_path, "another*")
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_file -in ("$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_files = [Ansible.IO.Directory]::EnumerateFiles($directory_path, "*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_file -in (
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt",
+            "$directory_path\subdir-1\file-1.txt",
+            "$directory_path\subdir-1\subdir-3\file-3.txt",
+            "$directory_path\subdir-2\file-2.txt")) -expected $true
+    }
+
+    $dir_files = [Ansible.IO.Directory]::GetFiles($directory_path)
+    Assert-Equals -actual ($dir_files.Count) -expected 2
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_file -in (
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_files = [Ansible.IO.Directory]::GetFiles($directory_path, "another*")
+    Assert-Equals -actual ($dir_files.Count) -expected 1
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_file -in ("$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_files = [Ansible.IO.Directory]::GetFiles($directory_path, "*", [System.IO.SearchOption]::AllDirectories)
+    Assert-Equals -actual ($dir_files.Count) -expected 5
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_file -in (
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt",
+            "$directory_path\subdir-1\file-1.txt",
+            "$directory_path\subdir-1\subdir-3\file-3.txt",
+            "$directory_path\subdir-2\file-2.txt")) -expected $true
+    }
+
+    $dir_entries = [Ansible.IO.Directory]::EnumerateFileSystemEntries($directory_path)
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual $dir_entry.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_entry -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir",
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_entries = [Ansible.IO.Directory]::EnumerateFileSystemEntries($directory_path, "another*")
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual $dir_entry.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_entry -in ("$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_entries = [Ansible.IO.Directory]::EnumerateFileSystemEntries($directory_path, "*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual $dir_entry.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_entry -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-1\subdir-3",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir",
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt",
+            "$directory_path\subdir-1\file-1.txt",
+            "$directory_path\subdir-1\subdir-3\file-3.txt",
+            "$directory_path\subdir-2\file-2.txt")) -expected $true
+    }
+    
+    $dir_entries = [Ansible.IO.Directory]::GetFileSystemInfos($directory_path)
+    Assert-Equals -actual ($dir_entries.Count) -expected 5
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual $dir_entry.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_entry -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir",
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_entries = [Ansible.IO.Directory]::GetFileSystemInfos($directory_path, "another*")
+    Assert-Equals -actual ($dir_entries.Count) -expected 1
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual $dir_entry.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_entry -in ("$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_entries = [Ansible.IO.Directory]::GetFileSystemInfos($directory_path, "*", [System.IO.SearchOption]::AllDirectories)
+    Assert-Equals -actual ($dir_entries.Count) -expected 9
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual $dir_entry.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_entry -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-1\subdir-3",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir",
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt",
+            "$directory_path\subdir-1\file-1.txt",
+            "$directory_path\subdir-1\subdir-3\file-3.txt",
+            "$directory_path\subdir-2\file-2.txt")) -expected $true
+    }
+
+    [Ansible.IO.Directory]::Move("$directory_path\subdir-1", "$directory_path\moved-dir")
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\subdir-1")) -expected $false
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\moved-dir")) -expected $true
+    
+    $parent_dir = [Ansible.IO.Directory]::GetParent("$directory_path\moved-dir")
+    Assert-Equals -actual $parent_dir.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
+    Assert-Equals -actual $parent_dir.Fullname -expected $directory_path
+
+    [Ansible.IO.Directory]::Delete("$directory_path\acl-dir")
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\acl-dir")) -expected $false
+    $failed = $false
+    try {
+        [Ansible.IO.Directory]::Delete("$directory_path\moved-dir")
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"Delete`" with `"1`" argument(s): `"The directory is not empty : '$directory_path\moved-dir'`""
+    }
+    Assert-Equals -actual $failed -expected $true
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\moved-dir")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\moved-dir\subdir-3")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$directory_path\moved-dir\file-1.txt")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$directory_path\moved-dir\subdir-3\file-3.txt")) -expected $true
+
+    [Ansible.IO.Directory]::Delete("$directory_path\moved-dir", $true)
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\moved-dir")) -expected $false
+
+    $current_time = (Get-Date).ToFileTimeUtc()
+    [Ansible.IO.Directory]::CreateDirectory("$directory_path\date") > $null
+
+    $creation_time = [Ansible.IO.Directory]::GetCreationTimeUtc("$directory_path\date")
+    Assert-Equals -actual $creation_time.GetType().FullName -expected "System.DateTime"
+    Assert-Equals -actual ($creation_time.ToFileTimeUtc() -ge $current_time) -expected $true
+
+    $lastaccess_time = [Ansible.IO.Directory]::GetLastAccessTimeUtc("$directory_path\date")
+    Assert-Equals -actual $lastaccess_time.GetType().FullName -expected "System.DateTime"
+    Assert-Equals -actual ($lastaccess_time.ToFileTimeUtc() -ge $current_time) -expected $true
+
+    $lastwrite_time = [Ansible.IO.Directory]::GetLastWriteTimeUtc("$directory_path\date")
+    Assert-Equals -actual $lastwrite_time.GetType().FullName -expected "System.DateTime"
+    Assert-Equals -actual ($lastwrite_time.ToFileTimeUtc() -ge $current_time) -expected $true
+
+    [Ansible.IO.Directory]::SetCreationTimeUtc("$directory_path\date", $new_date)
+    $creation_time = [Ansible.IO.Directory]::GetCreationTimeUtc("$directory_path\date")
+    Assert-Equals -actual $creation_time -expected $new_date
+
+    [Ansible.IO.Directory]::SetLastAccessTimeUtc("$directory_path\date", $new_date)
+    $lastaccess_time = [Ansible.IO.Directory]::GetLastAccessTimeUtc("$directory_path\date")
+    Assert-Equals -actual $lastaccess_time -expected $new_date
+
+    [Ansible.IO.Directory]::SetLastWriteTimeUtc("$directory_path\date", $new_date)
+    $lastwrite_time = [Ansible.IO.Directory]::GetLastWriteTimeUtc("$directory_path\date")
+    Assert-Equals -actual $lastwrite_time -expected $new_date
+}
+
+Function Test-IOPath($root_path) {
+    $long_path = "{0}\{0}\{0}\{0}\{0}\{0}\{0}\dir" -f ("a" * 250)
+    ### A lot of these expectations were derived by running System.IO.Path on 2016 which is more lenient with most long paths ###
+
+    # ChangeExtension
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("C:\path\dir", "")) -expected "C:\path\dir."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("C:\path\dir", "txt")) -expected "C:\path\dir.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("C:/path/dir", "")) -expected "C:/path/dir."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("C:/path/dir", "txt")) -expected "C:/path/dir.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\C:\path\dir", "")) -expected "\\?\C:\path\dir."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\C:\path\dir", "txt")) -expected "\\?\C:\path\dir.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\C:\path\$long_path\dir", "")) -expected "\\?\C:\path\$long_path\dir."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\C:\path\$long_path\dir", "txt")) -expected "\\?\C:\path\$long_path\dir.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\127.0.0.1\c$\path\dir", "")) -expected "\\127.0.0.1\c$\path\dir."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\127.0.0.1\c$\path\dir", "txt")) -expected "\\127.0.0.1\c$\path\dir.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir", "")) -expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir", "txt")) -expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir.txt"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("C:\path\dir\file.txt", "")) -expected "C:\path\dir\file."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("C:\path\dir\file.txt", "txt2")) -expected "C:\path\dir\file.txt2"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("C:/path/dir/file.txt", "")) -expected "C:/path/dir/file."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("C:/path/dir/file.txt", "txt2")) -expected "C:/path/dir/file.txt2"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\C:\path\dir\file.txt", "")) -expected "\\?\C:\path\dir\file."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\C:\path\dir\file.txt", "txt2")) -expected "\\?\C:\path\dir\file.txt2"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\C:\path\$long_path\dir\file.txt", "")) -expected "\\?\C:\path\$long_path\dir\file."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\C:\path\$long_path\dir\file.txt", "txt2")) -expected "\\?\C:\path\$long_path\dir\file.txt2"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\127.0.0.1\c$\path\dir\file.txt", "")) -expected "\\127.0.0.1\c$\path\dir\file."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\127.0.0.1\c$\path\dir\file.txt", "txt2")) -expected "\\127.0.0.1\c$\path\dir\file.txt2"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt", "")) -expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt", "txt2")) -expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt2"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("C:\path\dir\file.", "")) -expected "C:\path\dir\file."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("C:\path\dir\file.", "txt")) -expected "C:\path\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("C:/path/dir/file.", "")) -expected "C:/path/dir/file."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("C:/path/dir/file.", "txt")) -expected "C:/path/dir/file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\C:\path\dir\file.", "")) -expected "\\?\C:\path\dir\file."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\C:\path\dir\file.", "txt")) -expected "\\?\C:\path\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\C:\path\$long_path\dir\file.", "")) -expected "\\?\C:\path\$long_path\dir\file."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\C:\path\$long_path\dir\file.", "txt")) -expected "\\?\C:\path\$long_path\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\127.0.0.1\c$\path\dir\file.", "")) -expected "\\127.0.0.1\c$\path\dir\file."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\127.0.0.1\c$\path\dir\file.", "txt")) -expected "\\127.0.0.1\c$\path\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.", "")) -expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file."
+    Assert-Equals -actual ([Ansible.IO.Path]::ChangeExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.", "txt")) -expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt"
+
+    # Combine
+    Assert-Equals -actual ([Ansible.IO.Path]::Combine("C:\path\dir", "dir", "file.txt")) -expected "C:\path\dir\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::Combine("C:/path/dir", "dir", "file.txt")) -expected "C:/path/dir\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::Combine("\\?\C:\path\dir", "dir", "file.txt")) -expected "\\?\C:\path\dir\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::Combine("\\?\C:\path\$long_path\dir", "dir", "file.txt")) -expected "\\?\C:\path\$long_path\dir\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::Combine("\\127.0.0.1\c$\path\dir", "dir", "file.txt")) -expected "\\127.0.0.1\c$\path\dir\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::Combine("\\?\UNC\127.0.0.1\c$\path\$long_path\dir", "dir", "file.txt")) -expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir\dir\file.txt"
+
+    # GetDirectoryName - this is manually done so lots of scrutiny needed here
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("C:\path\dir")) -expected "C:\path"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("C:/path/dir")) -expected "C:\path"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\C:\path\dir")) -expected "\\?\C:\path"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\C:\path\$long_path\dir")) -expected "\\?\C:\path\$long_path"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\127.0.0.1\c$\path\dir")) -expected "\\127.0.0.1\c$\path"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC\127.0.0.1\c$\path\$long_path\dir")) -expected "\\?\UNC\127.0.0.1\c$\path\$long_path"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("C:\path\dir\file.txt")) -expected "C:\path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("C:/path/dir/file.txt")) -expected "C:\path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\C:\path\dir\file.txt")) -expected "\\?\C:\path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\C:\path\$long_path\dir\file.txt")) -expected "\\?\C:\path\$long_path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\127.0.0.1\c$\path\dir\file.txt")) -expected "\\127.0.0.1\c$\path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt")) -expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("C:\path\dir\file.")) -expected "C:\path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("C:/path/dir/file.")) -expected "C:\path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\C:\path\dir\file.")) -expected "\\?\C:\path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\C:\path\$long_path\dir\file.")) -expected "\\?\C:\path\$long_path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\127.0.0.1\c$\path\dir\file.")) -expected "\\127.0.0.1\c$\path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.")) -expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName($null)) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("C")) -expected ""
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("C:")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("C:\")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("C:/")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("C:\a")) -expected "C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("C:\a\")) -expected "C:\a"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("C:\a\b")) -expected "C:\a"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("C:/a")) -expected "C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\C:")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\C:\")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\C:/")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\C:\a")) -expected "\\?\C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\C:/a")) -expected "\\?\C:/"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\C:/a/")) -expected "\\?\C:/a"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\C:/a/b")) -expected "\\?\C:/a"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\server")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\server\")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\server\share")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\server\share\")) -expected "\\server\share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\server\share\path")) -expected "\\server\share"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("//")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("//server")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("//server/")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("//server/share")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("//server/share/")) -expected "\\server\share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("//server/share/path")) -expected "\\server\share"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC\")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server\")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server\share")) -expected $null
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server\share\")) -expected "\\?\UNC\server\share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server\share\path")) -expected "\\?\UNC\server\share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server/share\path")) -expected "\\?\UNC\server/share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server/share\path\")) -expected "\\?\UNC\server/share\path"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC\server/share\path/")) -expected "\\?\UNC\server/share\path"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?/UNC/server/share/")) -expected "\\?\UNC\server\share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?/UNC/server/share/path")) -expected "\\?\UNC\server\share"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC/")) -expected "\\?\UNC"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC/server")) -expected "\\?\UNC"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC/server/")) -expected "\\?\UNC/server"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC/server/share")) -expected "\\?\UNC/server"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC/server/share/")) -expected "\\?\UNC/server/share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetDirectoryName("\\?\UNC/server/share/path")) -expected "\\?\UNC/server/share"
+
+    # GetExtension
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("C:\path\dir")) -expected ""
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("C:/path/dir")) -expected ""
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("\\?\C:\path\dir")) -expected ""
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("\\?\C:\path\$long_path\dir")) -expected ""
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("\\127.0.0.1\c$\path\dir")) -expected ""
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir")) -expected ""
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("C:\path\dir\file.txt")) -expected ".txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("C:/path/dir/file.txt")) -expected ".txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("\\?\C:\path\dir\file.txt")) -expected ".txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("\\?\C:\path\$long_path\dir\file.txt")) -expected ".txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("\\127.0.0.1\c$\path\dir\file.txt")) -expected ".txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt")) -expected ".txt"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("C:\path\dir\file.")) -expected ""
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("C:/path/dir/file.")) -expected ""
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("\\?\C:\path\dir\file.")) -expected ""
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("\\?\C:\path\$long_path\dir\file.")) -expected ""
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("\\127.0.0.1\c$\path\dir\file.")) -expected ""
+    Assert-Equals -actual ([Ansible.IO.Path]::GetExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.")) -expected ""
+
+    # GetFileName
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("C:\path\dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("C:/path/dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("\\?\C:\path\dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("\\?\C:\path\$long_path\dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("\\127.0.0.1\c$\path\dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("\\?\UNC\127.0.0.1\c$\path\$long_path\dir")) -expected "dir"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("C:\path\dir\file.txt")) -expected "file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("C:/path/dir/file.txt")) -expected "file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("\\?\C:\path\dir\file.txt")) -expected "file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("\\?\C:\path\$long_path\dir\file.txt")) -expected "file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("\\127.0.0.1\c$\path\dir\file.txt")) -expected "file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt")) -expected "file.txt"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("C:\path\dir\file.")) -expected "file."
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("C:/path/dir/file.")) -expected "file."
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("\\?\C:\path\dir\file.")) -expected "file."
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("\\?\C:\path\$long_path\dir\file.")) -expected "file."
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("\\127.0.0.1\c$\path\dir\file.")) -expected "file."
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileName("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.")) -expected "file."
+
+    # GetFileNameWithoutExtension
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("C:\path\dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("C:/path/dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\C:\path\dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\C:\path\$long_path\dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\127.0.0.1\c$\path\dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir")) -expected "dir"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("C:\path\dir\file.txt")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("C:/path/dir/file.txt")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\C:\path\dir\file.txt")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\C:\path\$long_path\dir\file.txt")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\127.0.0.1\c$\path\dir\file.txt")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt")) -expected "file"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("C:\path\dir\file.")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("C:/path/dir/file.")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\C:\path\dir\file.")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\C:\path\$long_path\dir\file.")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\127.0.0.1\c$\path\dir\file.")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.")) -expected "file"
+
+    # GetFullPath - custom impl, heavy scrutiny
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("C:\path\dir")) -expected "C:\path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("C:/path/dir")) -expected "C:\path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C:\path\dir")) -expected "\\?\C:\path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C:\path/dir")) -expected "\\?\C:\path/dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C:\path\$long_path\dir")) -expected "\\?\C:\path\$long_path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\127.0.0.1\c$\path\dir")) -expected "\\127.0.0.1\c$\path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC\127.0.0.1\c$\path\$long_path\dir")) -expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC\127.0.0.1\c$\path/$long_path\dir")) -expected "\\?\UNC\127.0.0.1\c$\path/$long_path\dir"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("C:\path\dir\file.txt")) -expected "C:\path\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("C:/path/dir/file.txt")) -expected "C:\path\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C:\path\dir\file.txt")) -expected "\\?\C:\path\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C:\path\$long_path\dir\file.txt")) -expected "\\?\C:\path\$long_path\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\127.0.0.1\c$\path\dir\file.txt")) -expected "\\127.0.0.1\c$\path\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\127.0.0.1\c$\path\dir/file.txt")) -expected "\\127.0.0.1\c$\path\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt")) -expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC\127.0.0.1\c$\path\$long_path\dir/file.txt")) -expected "\\?\UNC\127.0.0.1\c$\path\$long_path\dir/file.txt"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("C:\path\dir\file.")) -expected "C:\path\dir\file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("C:/path/dir/file.")) -expected "C:\path\dir\file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C:\path\dir\file.")) -expected "\\?\C:\path\dir\file."
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C:\path\$long_path\dir\file.")) -expected "\\?\C:\path\$long_path\dir\file."
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\127.0.0.1\c$\path\dir\file.")) -expected "\\127.0.0.1\c$\path\dir\file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC\127.0.0.1\c$\path\dir\file.")) -expected "\\?\UNC\127.0.0.1\c$\path\dir\file."
+
+    $failed = $false
+    try {
+        [Ansible.IO.Path]::GetFullPath($null)
+    } catch [System.ArgumentException] {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "The path is not of a legal form."
+    }
+    Assert-Equals -actual $failed -expected $true
+    $failed = $false
+    try {
+        [Ansible.IO.Path]::GetFullPath("")
+    } catch [System.ArgumentException] {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "The path is not of a legal form."
+    }
+    Assert-Equals -actual $failed -expected $true
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("C:\")) -expected "C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("C:/")) -expected "C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("C:\a")) -expected "C:\a"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("C:\a\")) -expected "C:\a\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("C:\a\b")) -expected "C:\a\b"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("C:/a")) -expected "C:\a"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?")) -expected "\\?\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\")) -expected "\\?\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C")) -expected "\\?\C"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C:")) -expected "\\?\C:"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C:\")) -expected "\\?\C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C:/")) -expected "\\?\C:/"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C:\a")) -expected "\\?\C:\a"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C:/a")) -expected "\\?\C:/a"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C:/a/")) -expected "\\?\C:/a/"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\C:/a/b")) -expected "\\?\C:/a/b"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\server\share")) -expected "\\server\share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\server\share\")) -expected "\\server\share\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\server\share\path")) -expected "\\server\share\path"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("//server/share")) -expected "\\server\share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("//server/share/")) -expected "\\server\share\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("//server/share/path")) -expected "\\server\share\path"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC")) -expected "\\?\UNC"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC\")) -expected "\\?\UNC\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC\server")) -expected "\\?\UNC\server"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC\server\")) -expected "\\?\UNC\server\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC\server\share")) -expected "\\?\UNC\server\share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC\server\share\")) -expected "\\?\UNC\server\share\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC\server\share\path")) -expected "\\?\UNC\server\share\path"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC\server/share\path")) -expected "\\?\UNC\server/share\path"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC\server/share\path\")) -expected "\\?\UNC\server/share\path\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC\server/share\path/")) -expected "\\?\UNC\server/share\path/"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?/UNC")) -expected "\\?\UNC"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?/UNC/")) -expected "\\?\UNC\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?/UNC/server")) -expected "\\?\UNC\server"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?/UNC/server/")) -expected "\\?\UNC\server\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?/UNC/server/share")) -expected "\\?\UNC\server\share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?/UNC/server/share/")) -expected "\\?\UNC\server\share\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?/UNC/server/share/path")) -expected "\\?\UNC\server\share\path"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC")) -expected "\\?\UNC"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC/")) -expected "\\?\UNC/"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC/server")) -expected "\\?\UNC/server"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC/server/")) -expected "\\?\UNC/server/"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC/server/share")) -expected "\\?\UNC/server/share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC/server/share/")) -expected "\\?\UNC/server/share/"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFullPath("\\?\UNC/server/share/path")) -expected "\\?\UNC/server/share/path"
+
+    # GetPathRoot() - custom impl
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("C:\path\dir")) -expected "C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("C:/path/dir")) -expected "C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\C:\path\dir")) -expected "\\?\C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\C:\path\$long_path\dir")) -expected "\\?\C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\127.0.0.1\c$\path\dir")) -expected "\\127.0.0.1\c$"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\UNC\127.0.0.1\c$\path\$long_path\dir")) -expected "\\?\UNC\127.0.0.1\c$"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("C:\path\dir\file.txt")) -expected "C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("C:/path/dir/file.txt")) -expected "C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\C:\path\dir\file.txt")) -expected "\\?\C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\C:\path\$long_path\dir\file.txt")) -expected "\\?\C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\127.0.0.1\c$\path\dir\file.txt")) -expected "\\127.0.0.1\c$"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt")) -expected "\\?\UNC\127.0.0.1\c$"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("C:\path\dir\file.")) -expected "C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("C:/path/dir/file.")) -expected "C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\C:\path\dir\file.")) -expected "\\?\C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\C:\path\$long_path\dir\file.")) -expected "\\?\C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\127.0.0.1\c$\path\dir\file.")) -expected "\\127.0.0.1\c$"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.")) -expected "\\?\UNC\127.0.0.1\c$"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("test")) -expected ""
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot(".\test")) -expected ""
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("C:")) -expected "C:"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\C:")) -expected "\\?\C:"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("C:\")) -expected "C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\C:\")) -expected "\\?\C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("C:\path")) -expected "C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\C:\path")) -expected "\\?\C:\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\")) -expected "\\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\UNC\")) -expected "\\?\UNC\"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\server")) -expected "\\server"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\UNC\server")) -expected "\\?\UNC\server"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\server\share")) -expected "\\server\share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\UNC\server\share")) -expected "\\?\UNC\server\share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\server\share\path")) -expected "\\server\share"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetPathRoot("\\?\UNC\server\share\path")) -expected "\\?\UNC\server\share"
+
+    # HasExtension()
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("C:\path\dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("C:/path/dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\C:\path\dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\C:\path\$long_path\dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\127.0.0.1\c$\path\dir")) -expected "dir"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir")) -expected "dir"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("C:\path\dir\file.txt")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("C:/path/dir/file.txt")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\C:\path\dir\file.txt")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\C:\path\$long_path\dir\file.txt")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\127.0.0.1\c$\path\dir\file.txt")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt")) -expected "file"
+
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("C:\path\dir\file.")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("C:/path/dir/file.")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\C:\path\dir\file.")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\C:\path\$long_path\dir\file.")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\127.0.0.1\c$\path\dir\file.")) -expected "file"
+    Assert-Equals -actual ([Ansible.IO.Path]::GetFileNameWithoutExtension("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.")) -expected "file"
+
+    # IsPathRooted()
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("C:\path\dir")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("C:/path/dir")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\C:\path\dir")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\C:\path\$long_path\dir")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\127.0.0.1\c$\path\dir")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\UNC\127.0.0.1\c$\path\$long_path\dir")) -expected $true
+
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("C:\path\dir\file.txt")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("C:/path/dir/file.txt")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\C:\path\dir\file.txt")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\C:\path\$long_path\dir\file.txt")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\127.0.0.1\c$\path\dir\file.txt")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.txt")) -expected $true
+
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("C:\path\dir\file.")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("C:/path/dir/file.")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\C:\path\dir\file.")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\C:\path\$long_path\dir\file.")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\127.0.0.1\c$\path\dir\file.")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\UNC\127.0.0.1\c$\path\$long_path\dir\file.")) -expected $true
+
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("test")) -expected $false
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted(".\test")) -expected $false
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("C:")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\C:")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("C:\")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\C:\")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("C:\path")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\C:\path")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\UNC\")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\server")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\UNC\server")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\server\share")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\UNC\server\share")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\server\share\path")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Path]::IsPathRooted("\\?\UNC\server\share\path")) -expected $true
+}
+
+# call each test five times
+# 1 - Normal Path
+# 2 - Normal Path with the \\?\ prefix
+# 3 - Path exceeding 260 chars with the \\?\ prefix
+# 4 - Normal UNC Path
+# 5 - Extended UNC Path with the \\?\UNC\ prefix
+
+Clear-TestDirectory -path $path
+Test-FileClass -root_path $path
+Test-DirectoryClass -root_path $path
+
+Clear-TestDirectory -path $path
+Test-FileClass -root_path "\\?\$path"
+Test-DirectoryClass -root_path "\\?\$path"
+
+Clear-TestDirectory -path $path
+$long_path = "\\?\$path\long-path-test\{0}\{0}\{0}\{0}\{0}\{0}\{0}" -f ("a" * 250)
+[Ansible.IO.Directory]::CreateDirectory($long_path) > $null
+Test-FileClass -root_path $long_path
+Test-DirectoryClass -root_path $long_path
+
+Clear-TestDirectory -path $path
+Test-FileClass -root_path "\\127.0.0.1\c$\$($path.Substring(3))"
+Test-DirectoryClass -root_path "\\127.0.0.1\c$\$($path.Substring(3))"
+
+Clear-TestDirectory -path $path
+$long_unc_path = "\\?\UNC\127.0.0.1\c$\$($path.Substring(3))\long-path-test\{0}\{0}\{0}\{0}\{0}\{0}\{0}" -f ("a" * 250)
+[Ansible.IO.Directory]::CreateDirectory($long_unc_path) > $null
+Test-FileClass -root_path $long_unc_path
+Test-DirectoryClass -root_path $long_unc_path
+
+# Ansible.IO.Path tests
+Test-IOPath -root_path $path
+
+[Ansible.IO.Directory]::Delete("\\?\" + $path, $true)
+$result.data = "success"
+Exit-Json -obj $result

--- a/test/integration/targets/win_module_utils/library/file_util_test_ansible_io.ps1
+++ b/test/integration/targets/win_module_utils/library/file_util_test_ansible_io.ps1
@@ -437,6 +437,13 @@ Function Test-FileClass($root_path) {
     [Ansible.IO.File]::Delete($file_path)
     Assert-Equals -actual ([Ansible.IO.File]::Exists($file_path)) -expected $false
 
+    # make sure we can delete a file with the ReadOnly attribute set
+    $fs = [Ansible.IO.File]::Create($file_path)
+    $fs.Close()
+    [Ansible.IO.File]::SetAttributes($file_path, [System.IO.FileAttributes]::ReadOnly)
+    [Ansible.IO.File]::Delete($file_path)
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($file_path)) -expected $false
+
     $fs = [Ansible.IO.File]::Create($file_path, 4096, [System.IO.FileOptions]::None, $acl)
     $fs.Close()
     $acl = [Ansible.IO.File]::GetAccessControl($file_path)
@@ -1069,6 +1076,13 @@ Function Test-DirectoryClass($root_path) {
     $dir = [Ansible.IO.Directory]::CreateDirectory($directory_path)
     Assert-Equals -actual ($dir -is [Ansible.IO.DirectoryInfo]) -expected $true
     Assert-Equals -actual ([Ansible.IO.Directory]::Exists($directory_path)) -expected $true
+
+    # delete directory with the ReadOnly attribute set
+    $dir.Attributes = [System.IO.FileAttributes]"Directory, ReadOnly"
+    [Ansible.IO.Directory]::Delete($directory_path)
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists($directory_path)) -expected $false
+
+    $dir = [Ansible.IO.Directory]::CreateDirectory($directory_path)
 
     # ACL Tests
     $acl = New-Object -TypeName System.Security.AccessControl.DirectorySecurity

--- a/test/integration/targets/win_module_utils/library/file_util_test_ansible_io.ps1
+++ b/test/integration/targets/win_module_utils/library/file_util_test_ansible_io.ps1
@@ -143,6 +143,25 @@ Function Test-FileClass($root_path) {
     }
     Assert-Equals -actual $failed -expected $true
 
+    # compress/decompress
+    $file.Compress()
+    $file.Refresh()
+    $actual = $file.Attributes
+    Assert-Equals -actual $actual.HasFlag([System.IO.FileAttributes]::Compressed) -expected $true
+
+    $file.Decompress()
+    $file.Refresh()
+    $actual = $file.Attributes
+    Assert-Equals -actual $actual.HasFlag([System.IO.FileAttributes]::Compressed) -expected $false
+
+    [Ansible.IO.File]::Compress($file.FullName)
+    $actual = [Ansible.IO.File]::GetAttributes($file.FullName)
+    Assert-Equals -actual $actual.HasFlag([System.IO.FileAttributes]::Compressed) -expected $true
+
+    [Ansible.IO.File]::Decompress($file.FullName)
+    $actual = [Ansible.IO.File]::GetAttributes($file.FullName)
+    Assert-Equals -actual $actual.HasFlag([System.IO.FileAttributes]::Compressed) -expected $false
+
     $file.Delete()
     $file.Refresh()
     Assert-Equals -actual $file.Exists -expected $false
@@ -694,6 +713,25 @@ Function Test-DirectoryClass($root_path) {
     # create tests
     $subdir = $dir.CreateSubDirectory("subdir")
     Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\subdir")) -expected $true
+
+    # compress/decompress
+    $dir.Compress()
+    $dir.Refresh()
+    $actual = $dir.Attributes
+    Assert-Equals -actual $actual.HasFlag([System.IO.FileAttributes]::Compressed) -expected $true
+
+    $dir.Decompress()
+    $dir.Refresh()
+    $actual = $dir.Attributes
+    Assert-Equals -actual $actual.HasFlag([System.IO.FileAttributes]::Compressed) -expected $false
+
+    [Ansible.IO.Directory]::Compress($dir.FullName)
+    $actual = [Ansible.IO.File]::GetAttributes($dir.FullName)
+    Assert-Equals -actual $actual.HasFlag([System.IO.FileAttributes]::Compressed) -expected $true
+
+    [Ansible.IO.Directory]::Decompress($dir.FullName)
+    $actual = [Ansible.IO.File]::GetAttributes($dir.FullName)
+    Assert-Equals -actual $actual.HasFlag([System.IO.FileAttributes]::Compressed) -expected $false
 
     # enumerate tests
     $subdir1 = $dir.CreateSubDirectory("subdir-1")

--- a/test/integration/targets/win_module_utils/library/symbolic_link_test.ps1
+++ b/test/integration/targets/win_module_utils/library/symbolic_link_test.ps1
@@ -2,166 +2,397 @@
 
 #Requires -Module Ansible.ModuleUtils.Legacy
 #Requires -Module Ansible.ModuleUtils.LinkUtil
-#Requires -Module Ansible.ModuleUtils.CommandUtil
 
 $ErrorActionPreference = 'Stop'
 
-$params = Parse-Args $args;
+$params = Parse-Args $args
 $path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true
 
-$folder_target = "$path\folder"
-$file_target = "$path\file"
-$symlink_file_path = "$path\file-symlink"
-$symlink_folder_path = "$path\folder-symlink"
-$hardlink_path = "$path\hardlink"
-$hardlink_path_2 = "$path\hardlink2"
-$junction_point_path = "$path\junction"
-
-if (Test-Path -Path $path) {
-    Remove-Item -Path $path -Force -Recurse | Out-Null
-}
-New-Item -Path $path -ItemType Directory | Out-Null
-New-Item -Path $folder_target -ItemType Directory | Out-Null
-New-Item -Path $file_target -ItemType File | Out-Null
-Set-Content -Path $file_target -Value "a"
-
-Function Assert-Equals($actual, $expected) {
-    if ($actual -ne $expected) {
-        Fail-Json @{} "actual != expected`nActual: $actual`nExpected: $expected"
-    }
-}
-
-Function Assert-True($expression, $message) {
-    if ($expression -ne $true) {
-        Fail-Json @{} $message
-    }
+$result = @{
+    changed = $false
 }
 
 # need to manually set this
-Load-LinkUtils
+Import-LinkUtil
 
-# path is not a link
-$no_link_result = Get-Link -link_path $path
-Assert-True -expression ($no_link_result -eq $null) -message "did not return null result for a non link"
-
-# fail to create hard link pointed to a directory
-try {
-    New-Link -link_path "$path\folder-hard" -link_target $folder_target -link_type "hard"
-    Assert-True -expression $false -message "creation of hard link should have failed if target was a directory"
-} catch {
-    Assert-Equals -actual $_.Exception.Message -expected "cannot set the target for a hard link to a directory"
+Function Assert-Equals($actual, $expected) {
+    if ($actual -ne $expected) {
+        $call_stack = (Get-PSCallStack)[1]
+        $error_msg = "AssertionError:`r`nActual: `"$actual`" != Expected: `"$expected`"`r`nLine: $($call_stack.ScriptLineNumber), Method: $($call_stack.Position.Text)"
+        Fail-Json -obj $result -message $error_msg
+    }
 }
 
-# fail to create a junction point pointed to a file
-try {
-    New-Link -link_path "$path\junction-fail" -link_target $file_target -link_type "junction"
-    Assert-True -expression $false -message "creation of junction point should have failed if target was a file"
-} catch {
-    Assert-Equals -actual $_.Exception.Message -expected "cannot set the target for a junction point to a file"
+Function Remove-TestDirectory($path) {
+    if (Test-AnsiblePath -Path $path) {
+        # previous tests may have ended in a bad state and some folders are not
+        # accessible to the current user. This defensively set's the owner back to
+        # the current user so we can delete the folders
+        $current_sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+        $search_path = $path
+        if (-not $search_path.StartsWith("\\?\")) {
+            $search_path = "\\?\$search_path"
+        }
+        $dirs = [Ansible.IO.Directory]::GetDirectories($search_path, "*", [System.IO.SearchOption]::AllDirectories)
+        foreach ($dir in $dirs) {
+            # SetAccessControl should be setting SeReplace, and SeTakeOwnershipPrivilege for us
+            $acl = New-Object -TypeName System.Security.AccessControl.DirectorySecurity
+            $acl.SetOwner($current_sid)
+            $ace = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList @(
+                $current_sid,
+                [System.Security.AccessControl.FileSystemRights]::Delete,
+                [System.Security.AccessControl.AccessControlType]::Allow
+            )
+            $acl.AddAccessRule($ace)
+            [Ansible.IO.Directory]::SetAccessControl($dir, $acl)
+        }
+
+        [Ansible.IO.Directory]::Delete($search_path, $true)
+    }
 }
 
-# fail to create a symbolic link with non-existent target
-try {
-    New-Link -link_path "$path\symlink-fail" -link_target "$path\fake-folder" -link_type "link"
-    Assert-True -expression $false -message "creation of symbolic link should have failed if target did not exist"
-} catch {
-    Assert-Equals -actual $_.Exception.Message -expected "link_target '$path\fake-folder' does not exist, cannot create link"
+Function Test-LinkUtil($path) {
+    $folder_target = "$path\folder"
+    $file_target = "$path\file"
+    $symlink_file_path = "$path\file-symlink"
+    $symlink_folder_path = "$path\folder-symlink"
+    $symlink_missing_path = "$path\symlink-folder-missing"
+    $hardlink_path = "$path\hardlink"
+    $hardlink_path_2 = "$path\hardlink2"
+    $junction_point_path = "$path\junction"
+
+    Remove-TestDirectory -path $path
+    [Ansible.IO.Directory]::CreateDirectory($path) > $null
+    [Ansible.IO.Directory]::CreateDirectory($folder_target) > $null
+    $sw = [Ansible.IO.File]::CreateText($file_target)
+    try {
+        $sw.Write("a")
+    } finally {
+        $sw.Close()
+    }
+
+    # path is not a link
+    $no_link_result = Get-Link -link_path $path
+    Assert-Equals -actual ($null -eq $no_link_result) -expected $true
+
+    # fail to create hard link pointed to a directory
+    $failed = $false
+    try {
+        New-Link -link_path "$path\folder-hard" -link_target $folder_target -link_type "hard"
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "cannot set the target for a hard link to a directory"
+    }
+    Assert-Equals -actual $failed -expected $true
+
+    # hard link target does not exist
+    $failed = $false
+    try {
+        New-Link -link_path "$path\hard-missing" -link_target "$path\fake" -link_type "hard"
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "link_target '$path\fake' does not exist, cannot create hard link"
+    }
+    Assert-Equals -actual $failed -expected $true
+
+    # fail to create a junction point pointed to a file
+    $failed = $false
+    try {
+        New-Link -link_path "$path\junction-fail" -link_target $file_target -link_type "junction"
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "cannot set the target for a junction point to a file"
+    }
+    Assert-Equals -actual $failed -expected $true
+
+    # create relative symlink
+    New-Link -link_path "$path\symlink-rel" -link_target "folder" -link_type "link"
+    $rel_link_result = Get-Link -link_path "$path\symlink-rel"
+    Assert-Equals -actual $rel_link_result.Type -expected "SymbolicLink"
+    Assert-Equals -actual $rel_link_result.SubstituteName -expected "folder"
+    Assert-Equals -actual $rel_link_result.PrintName -expected "folder"
+    Assert-Equals -actual $rel_link_result.TargetPath -expected "folder"
+    Assert-Equals -actual $rel_link_result.AbsolutePath -expected $folder_target
+    Assert-Equals -actual $rel_link_result.HardTargets -expected $null
+
+    # create a symbolic file test
+    New-Link -link_path $symlink_file_path -link_target $file_target -link_type "link"
+    $file_link_result = Get-Link -link_path $symlink_file_path
+    Assert-Equals -actual $file_link_result.Type -expected "SymbolicLink"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $file_link_result.SubstituteName -expected "\??\$($file_target.Substring(4))"
+    } else {
+        Assert-Equals -actual $file_link_result.SubstituteName -expected "\??\$($file_target)"
+    }
+    Assert-Equals -actual $file_link_result.PrintName -expected $file_target
+    Assert-Equals -actual $file_link_result.TargetPath -expected $file_target
+    Assert-Equals -actual $file_link_result.AbsolutePath -expected $file_target
+    Assert-Equals -actual $file_link_result.HardTargets -expected $null
+
+    # create a symbolic link folder test
+    New-Link -link_path $symlink_folder_path -link_target $folder_target -link_type "link"
+    $folder_link_result = Get-Link -link_path $symlink_folder_path
+    Assert-Equals -actual $folder_link_result.Type -expected "SymbolicLink"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $folder_link_result.SubstituteName -expected "\??\$($folder_target.Substring(4))"
+    } else {
+        Assert-Equals -actual $folder_link_result.SubstituteName -expected "\??\$($folder_target)"
+    }
+    Assert-Equals -actual $folder_link_result.PrintName -expected $folder_target
+    Assert-Equals -actual $folder_link_result.TargetPath -expected $folder_target
+    Assert-Equals -actual $folder_link_result.AbsolutePath -expected $folder_target
+    Assert-Equals -actual $folder_link_result.HardTargets -expected $null
+
+    # create a symbolic link with missing target and no file extension (auto dir)
+    New-Link -link_path $symlink_missing_path -link_target "$path\symlink-target" -link_type "link"
+    $folder_link_result = Get-Link -link_path $symlink_missing_path
+    Assert-Equals -actual $folder_link_result.Type -expected "SymbolicLink"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $folder_link_result.SubstituteName -expected "\??\$($path.Substring(4))\symlink-target"
+    } else {
+        Assert-Equals -actual $folder_link_result.SubstituteName -expected "\??\$($path)\symlink-target"
+    }
+    Assert-Equals -actual $folder_link_result.PrintName -expected "$path\symlink-target"
+    Assert-Equals -actual $folder_link_result.TargetPath -expected "$path\symlink-target"
+    Assert-Equals -actual $folder_link_result.AbsolutePath -expected "$path\symlink-target"
+    Assert-Equals -actual $folder_link_result.HardTargets -expected $null
+
+    # create a symbolic link with missing target and file extension (auto file)
+    New-Link -link_path "$path\symlink-file-missing" -link_target "$path\symlink-target.txt" -link_type "link"
+    $folder_link_result = Get-Link -link_path "$path\symlink-file-missing"
+    Assert-Equals -actual $folder_link_result.Type -expected "SymbolicLink"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $folder_link_result.SubstituteName -expected "\??\$($path.Substring(4))\symlink-target.txt"
+    } else {
+        Assert-Equals -actual $folder_link_result.SubstituteName -expected "\??\$($path)\symlink-target.txt"
+    }
+    Assert-Equals -actual $folder_link_result.PrintName -expected "$path\symlink-target.txt"
+    Assert-Equals -actual $folder_link_result.TargetPath -expected "$path\symlink-target.txt"
+    Assert-Equals -actual $folder_link_result.AbsolutePath -expected "$path\symlink-target.txt"
+    Assert-Equals -actual $folder_link_result.HardTargets -expected $null
+
+    # create a junction point test
+    New-Link -link_path $junction_point_path -link_target $folder_target -link_type "junction"
+    $junction_point_result = Get-Link -link_path $junction_point_path
+    Assert-Equals -actual $junction_point_result.Type -expected "JunctionPoint"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $junction_point_result.SubstituteName -expected "\??\$($folder_target.Substring(4))"
+    } else {
+        Assert-Equals -actual $junction_point_result.SubstituteName -expected "\??\$($folder_target)"
+    }
+    Assert-Equals -actual $junction_point_result.PrintName -expected $folder_target
+    Assert-Equals -actual $junction_point_result.TargetPath -expected $folder_target
+    Assert-Equals -actual $junction_point_result.AbsolutePath -expected $folder_target
+    Assert-Equals -actual $junction_point_result.HardTargets -expected $null
+
+    # create a junction point with missing target test
+    New-Link -link_path "$path\junction-missing" -link_target "$path\fail" -link_type "junction"
+    $junction_point_result = Get-Link -link_path "$path\junction-missing"
+    Assert-Equals -actual $junction_point_result.Type -expected "JunctionPoint"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $junction_point_result.SubstituteName -expected "\??\$($path.Substring(4))\fail"
+    } else {
+        Assert-Equals -actual $junction_point_result.SubstituteName -expected "\??\$($path)\fail"
+    }
+    Assert-Equals -actual $junction_point_result.PrintName -expected "$path\fail"
+    Assert-Equals -actual $junction_point_result.TargetPath -expected "$path\fail"
+    Assert-Equals -actual $junction_point_result.AbsolutePath -expected "$path\fail"
+    Assert-Equals -actual $junction_point_result.HardTargets -expected $null
+
+    # create a hard link test
+    New-Link -link_path $hardlink_path -link_target $file_target -link_type "hard"
+    $hardlink_result = Get-Link -link_path $hardlink_path
+    Assert-Equals -actual $hardlink_result.Type -expected "HardLink"
+    Assert-Equals -actual $hardlink_result.SubstituteName -expected $null
+    Assert-Equals -actual $hardlink_result.PrintName -expected $null
+    Assert-Equals -actual $hardlink_result.TargetPath -expected $null
+    Assert-Equals -actual $hardlink_result.AbsolutePath -expected $null
+    if ($hardlink_result.HardTargets[0] -ne $hardlink_path -and $hardlink_result.HardTargets[1] -ne $hardlink_path) {
+        # file $hardlink_path is not a target of the hard link
+        Assert-Equals -actual $true -expected $false
+    }
+    if ($hardlink_result.HardTargets[0] -ne $file_target -and $hardlink_result.HardTargets[1] -ne $file_target) {
+        # file $file_target is not a target of the hard link
+        Assert-Equals -actual $true -expected $false
+    }
+    $hardlink_contents = [Ansible.IO.File]::ReadAllText($hardlink_path)
+    $file_contents = [Ansible.IO.File]::ReadAllText($file_target)
+    Assert-Equals -actual $hardlink_contents -expected $file_contents
+
+    # create a new hard link and verify targets go to 3
+    New-Link -link_path $hardlink_path_2 -link_target $file_target -link_type "hard"
+    $hardlink_result_2 = Get-Link -link_path $hardlink_path
+    Assert-Equals -actual ($hardlink_result_2.HardTargets.Count -eq 3) -expected $true
+
+    # check if broken symbolic link still works
+    Remove-Item -Path $folder_target -Force > $null
+    $broken_link_result = Get-Link -link_path $symlink_folder_path
+    Assert-Equals -actual $broken_link_result.Type -expected "SymbolicLink"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $broken_link_result.SubstituteName -expected "\??\$($folder_target.Substring(4))"
+    } else {
+        Assert-Equals -actual $broken_link_result.SubstituteName -expected "\??\$($folder_target)"
+    }
+    Assert-Equals -actual $broken_link_result.PrintName -expected $folder_target
+    Assert-Equals -actual $broken_link_result.TargetPath -expected $folder_target
+    Assert-Equals -actual $broken_link_result.AbsolutePath -expected $folder_target
+    Assert-Equals -actual $broken_link_result.HardTargets -expected $null
+
+    # check if broken junction point still works
+    $broken_junction_result = Get-Link -link_path $junction_point_path
+    Assert-Equals -actual $broken_junction_result.Type -expected "JunctionPoint"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $broken_junction_result.SubstituteName -expected "\??\$($folder_target.Substring(4))"
+    } else {
+        Assert-Equals -actual $broken_junction_result.SubstituteName -expected "\??\$($folder_target)"
+    }
+    Assert-Equals -actual $broken_junction_result.PrintName -expected $folder_target
+    Assert-Equals -actual $broken_junction_result.TargetPath -expected $folder_target
+    Assert-Equals -actual $broken_junction_result.AbsolutePath -expected $folder_target
+    Assert-Equals -actual $broken_junction_result.HardTargets -expected $null
+
+    # remove all rights to a symlink that verifies SeBackupPrivilege is set when getting link info
+    $system_sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-5-18"
+    $ace = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList @($system_sid,
+        [System.Security.AccessControl.FileSystemRights]::FullControl,
+        [System.Security.AccessControl.AccessControlType]::Allow)
+    $acl = [Ansible.IO.Directory]::GetAccessControl($symlink_missing_path, [System.Security.AccessControl.AccessControlSections]"Access, Owner, Group")
+    $acl.SetAccessRule($ace)
+    $acl.SetAccessRuleProtection($true, $false)  # disable inheritance
+    $acl.SetGroup($system_sid)
+    $acl.SetOwner($system_sid)
+    [Ansible.IO.Directory]::SetAccessControl($symlink_missing_path, $acl)
+    $folder_link_result = Get-Link -link_path $symlink_missing_path
+    Assert-Equals -actual $folder_link_result.Type -expected "SymbolicLink"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $folder_link_result.SubstituteName -expected "\??\$($path.Substring(4))\symlink-target"
+    } else {
+        Assert-Equals -actual $folder_link_result.SubstituteName -expected "\??\$($path)\symlink-target"
+    }
+    Assert-Equals -actual $folder_link_result.PrintName -expected "$path\symlink-target"
+    Assert-Equals -actual $folder_link_result.TargetPath -expected "$path\symlink-target"
+    Assert-Equals -actual $folder_link_result.AbsolutePath -expected "$path\symlink-target"
+    Assert-Equals -actual $folder_link_result.HardTargets -expected $null
+
+    # delete file symbolic link
+    Remove-Link -link_path $symlink_file_path
+    Assert-Equals -actual (-not (Test-Path -Path $symlink_file_path)) -expected $true
+
+    # delete folder symbolic link
+    Remove-Link -link_path $symlink_folder_path
+    Assert-Equals -actual (-not (Test-Path -Path $symlink_folder_path)) -expected $true
+
+    # delete junction point
+    Remove-Link -link_path $junction_point_path
+    Assert-Equals -actual (-not (Test-Path -Path $junction_point_path)) -expected $true
+
+    # delete hard link
+    Remove-Link -link_path $hardlink_path
+    Assert-Equals -actual (-not (Test-Path -Path $hardlink_path)) -expected $true
 }
 
-# create recursive symlink
-Run-Command -command "cmd.exe /c mklink /D symlink-rel folder" -working_directory $path | Out-Null
-$rel_link_result = Get-Link -link_path "$path\symlink-rel"
-Assert-Equals -actual $rel_link_result.Type -expected "SymbolicLink"
-Assert-Equals -actual $rel_link_result.SubstituteName -expected "folder"
-Assert-Equals -actual $rel_link_result.PrintName -expected "folder"
-Assert-Equals -actual $rel_link_result.TargetPath -expected "folder"
-Assert-Equals -actual $rel_link_result.AbsolutePath -expected $folder_target
-Assert-Equals -actual $rel_link_result.HardTargets -expected $null
+Function Test-LinkUtilUNC($path) {
+    Remove-TestDirectory -path $path
+    $local_path = "$path\local"
+    [Ansible.IO.Directory]::CreateDirectory($local_path) > $null
+    $local_dir = "$local_path\directory"
+    $local_file = "$local_dir\file.txt"
+    [Ansible.IO.Directory]::CreateDirectory($local_dir) > $null
+    [Ansible.IO.File]::WriteAllText($local_file, "local")
 
-# create a symbolic file test
-New-Link -link_path $symlink_file_path -link_target $file_target -link_type "link"
-$file_link_result = Get-Link -link_path $symlink_file_path
-Assert-Equals -actual $file_link_result.Type -expected "SymbolicLink"
-Assert-Equals -actual $file_link_result.SubstituteName -expected "\??\$file_target"
-Assert-Equals -actual $file_link_result.PrintName -expected $file_target
-Assert-Equals -actual $file_link_result.TargetPath -expected $file_target
-Assert-Equals -actual $file_link_result.AbsolutePath -expected $file_target
-Assert-Equals -actual $file_link_result.HardTargets -expected $null
+    if ($path.StartsWith("\\?\")) {
+        $unc_path = "\\?\UNC\127.0.0.1\c$\$($path.Substring(7))\unc"
+    } else {
+        $unc_path = "\\127.0.0.1\c$\$($path.Substring(3))\unc"
+    }
+    [Ansible.IO.Directory]::CreateDirectory($unc_path) > $null
+    $unc_dir = "$unc_path\directory"
+    $unc_file = "$unc_dir\file.txt"
+    [Ansible.IO.Directory]::CreateDirectory($unc_dir) > $null
+    [Ansible.IO.File]::WriteAllText($unc_file, "unc")
 
-# create a symbolic link folder test
-New-Link -link_path $symlink_folder_path -link_target $folder_target -link_type "link"
-$folder_link_result = Get-Link -link_path $symlink_folder_path
-Assert-Equals -actual $folder_link_result.Type -expected "SymbolicLink"
-Assert-Equals -actual $folder_link_result.SubstituteName -expected "\??\$folder_target"
-Assert-Equals -actual $folder_link_result.PrintName -expected $folder_target
-Assert-Equals -actual $folder_link_result.TargetPath -expected $folder_target
-Assert-Equals -actual $folder_link_result.AbsolutePath -expected $folder_target
-Assert-Equals -actual $folder_link_result.HardTargets -expected $null
+    $local_to_unc_dir_path = "$local_path\to-unc-dir"
+    $local_to_unc_file_path = "$local_path\to-unc-file"
+    $unc_to_local_dir_path = "$unc_path\to-unc-dir"
+    $unc_to_local_file_path = "$unc_path\to-local-dir"
 
-# create a junction point test
-New-Link -link_path $junction_point_path -link_target $folder_target -link_type "junction"
-$junction_point_result = Get-Link -link_path $junction_point_path
-Assert-Equals -actual $junction_point_result.Type -expected "JunctionPoint"
-Assert-Equals -actual $junction_point_result.SubstituteName -expected "\??\$folder_target"
-Assert-Equals -actual $junction_point_result.PrintName -expected $folder_target
-Assert-Equals -actual $junction_point_result.TargetPath -expected $folder_target
-Assert-Equals -actual $junction_point_result.AbsolutePath -expected $folder_target
-Assert-Equals -actual $junction_point_result.HardTargets -expected $null
+    # test create a symlink dir from local => unc
+    New-Link -link_path $local_to_unc_dir_path -link_target $unc_dir -link_type "link"
+    $local_to_unc_dir = Get-Link -link_path $local_to_unc_dir_path
+    $local_to_unc_dir_text = [Ansible.IO.File]::ReadAllText("$local_to_unc_dir_path\file.txt")
+    Assert-Equals -actual $local_to_unc_dir.Type -expected "SymbolicLink"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $local_to_unc_dir.SubstituteName -expected "\??\$($unc_dir.Substring(4))"
+    } else {
+        Assert-Equals -actual $local_to_unc_dir.SubstituteName -expected "\??\UNC$($unc_dir.Substring(1))"
+    }
+    Assert-Equals -actual $local_to_unc_dir.PrintName -expected $unc_dir
+    Assert-Equals -actual $local_to_unc_dir.TargetPath -expected $unc_dir
+    Assert-Equals -actual $local_to_unc_dir.AbsolutePath -expected $unc_dir
+    Assert-Equals -actual $local_to_unc_dir.HardTargets -expected $null
+    Assert-Equals -actual $local_to_unc_dir_text -expected "unc"
 
-# create a hard link test
-New-Link -link_path $hardlink_path -link_target $file_target -link_type "hard"
-$hardlink_result = Get-Link -link_path $hardlink_path
-Assert-Equals -actual $hardlink_result.Type -expected "HardLink"
-Assert-Equals -actual $hardlink_result.SubstituteName -expected $null
-Assert-Equals -actual $hardlink_result.PrintName -expected $null
-Assert-Equals -actual $hardlink_result.TargetPath -expected $null
-Assert-Equals -actual $hardlink_result.AbsolutePath -expected $null
-if ($hardlink_result.HardTargets[0] -ne $hardlink_path -and $hardlink_result.HardTargets[1] -ne $hardlink_path) {
-    Assert-True -expression $false -message "file $hardlink_path is not a target of the hard link"
+    # test create a symlink file from local => unc
+    New-Link -link_path $local_to_unc_file_path -link_target $unc_file -link_type "link"
+    $local_to_unc_file = Get-Link -link_path $local_to_unc_file_path
+    $local_to_unc_file_text = [Ansible.IO.File]::ReadAllText($local_to_unc_file_path)
+    Assert-Equals -actual $local_to_unc_file.Type -expected "SymbolicLink"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $local_to_unc_file.SubstituteName -expected "\??\$($unc_file.Substring(4))"
+    } else {
+        Assert-Equals -actual $local_to_unc_file.SubstituteName -expected "\??\UNC$($unc_file.Substring(1))"
+    }
+    Assert-Equals -actual $local_to_unc_file.PrintName -expected $unc_file
+    Assert-Equals -actual $local_to_unc_file.TargetPath -expected $unc_file
+    Assert-Equals -actual $local_to_unc_file.AbsolutePath -expected $unc_file
+    Assert-Equals -actual $local_to_unc_file.HardTargets -expected $null
+    Assert-Equals -actual $local_to_unc_file_text -expected "unc"
+
+    # test create a symlink dir from unc => local
+    New-Link -link_path $unc_to_local_dir_path -link_target $local_dir -link_type "link"
+    $unc_to_local_dir = Get-Link -link_path $unc_to_local_dir_path
+    $unc_to_local_dir_text = [Ansible.IO.File]::ReadAllText("$unc_to_local_dir_path\file.txt")
+    Assert-Equals -actual $unc_to_local_dir.Type -expected "SymbolicLink"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $unc_to_local_dir.SubstituteName -expected "\??\$($local_dir.Substring(4))"
+    } else {
+        Assert-Equals -actual $unc_to_local_dir.SubstituteName -expected "\??\$local_dir"
+    }
+    Assert-Equals -actual $unc_to_local_dir.PrintName -expected $local_dir
+    Assert-Equals -actual $unc_to_local_dir.TargetPath -expected $local_dir
+    Assert-Equals -actual $unc_to_local_dir.AbsolutePath -expected $local_dir
+    Assert-Equals -actual $unc_to_local_dir.HardTargets -expected $null
+    Assert-Equals -actual $unc_to_local_dir_text -expected "local"
+
+    # test create a symlink file from unc => local
+    New-Link -link_path $unc_to_local_file_path -link_target $local_file -link_type "link"
+    $unc_to_local_file = Get-Link -link_path $unc_to_local_file_path
+    $unc_to_local_file_text = [Ansible.IO.File]::ReadAllText($unc_to_local_file_path)
+    Assert-Equals -actual $unc_to_local_file.Type -expected "SymbolicLink"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $unc_to_local_file.SubstituteName -expected "\??\$($local_file.Substring(4))"
+    } else {
+        Assert-Equals -actual $unc_to_local_file.SubstituteName -expected "\??\$local_file"
+    }
+    Assert-Equals -actual $unc_to_local_file.PrintName -expected $local_file
+    Assert-Equals -actual $unc_to_local_file.TargetPath -expected $local_file
+    Assert-Equals -actual $unc_to_local_file.AbsolutePath -expected $local_file
+    Assert-Equals -actual $unc_to_local_file.HardTargets -expected $null
+    Assert-Equals -actual $unc_to_local_file_text -expected "local"
 }
-if ($hardlink_result.HardTargets[0] -ne $file_target -and $hardlink_result.HardTargets[1] -ne $file_target) {
-    Assert-True -expression $false -message "file $file_target is not a target of the hard link"
-}
-Assert-equals -actual (Get-Content -Path $hardlink_path -Raw) -expected (Get-Content -Path $file_target -Raw)
 
-# create a new hard link and verify targets go to 3
-New-Link -link_path $hardlink_path_2 -link_target $file_target -link_type "hard"
-$hardlink_result_2 = Get-Link -link_path $hardlink_path
-Assert-True -expression ($hardlink_result_2.HardTargets.Count -eq 3) -message "did not return 3 targets for the hard link, actual $($hardlink_result_2.Targets.Count)"
+# tests a really long path ~ 2000 chars
+$path = "$path\link-util-test"
+$long_path = "\\?\$path\{0}\{0}\{0}\{0}\{0}\{0}\{0}" -f ("a" * 250)
 
-# check if broken symbolic link still works
-Remove-Item -Path $folder_target -Force | Out-Null
-$broken_link_result = Get-Link -link_path $symlink_folder_path
-Assert-Equals -actual $broken_link_result.Type -expected "SymbolicLink"
-Assert-Equals -actual $broken_link_result.SubstituteName -expected "\??\$folder_target"
-Assert-Equals -actual $broken_link_result.PrintName -expected $folder_target
-Assert-Equals -actual $broken_link_result.TargetPath -expected $folder_target
-Assert-Equals -actual $broken_link_result.AbsolutePath -expected $folder_target
-Assert-Equals -actual $broken_link_result.HardTargets -expected $null
+Test-LinkUtil -path $path
+Test-LinkUtil -path $long_path
 
-# check if broken junction point still works
-$broken_junction_result = Get-Link -link_path $junction_point_path
-Assert-Equals -actual $broken_junction_result.Type -expected "JunctionPoint"
-Assert-Equals -actual $broken_junction_result.SubstituteName -expected "\??\$folder_target"
-Assert-Equals -actual $broken_junction_result.PrintName -expected $folder_target
-Assert-Equals -actual $broken_junction_result.TargetPath -expected $folder_target
-Assert-Equals -actual $broken_junction_result.AbsolutePath -expected $folder_target
-Assert-Equals -actual $broken_junction_result.HardTargets -expected $null
+# only symbolic links work across volumes/UNC so these tests need to stay separate to the above
+Test-LinkUtilUNC -path $path
+Test-LinkUtilUNC -path $long_path
 
-# delete file symbolic link
-Remove-Link -link_path $symlink_file_path
-Assert-True -expression (-not (Test-Path -Path $symlink_file_path)) -message "failed to delete file symbolic link"
+Remove-TestDirectory -path "\\?\$path"
 
-# delete folder symbolic link
-Remove-Link -link_path $symlink_folder_path
-Assert-True -expression (-not (Test-Path -Path $symlink_folder_path)) -message "failed to delete folder symbolic link"
-
-# delete junction point
-Remove-Link -link_path $junction_point_path
-Assert-True -expression (-not (Test-Path -Path $junction_point_path)) -message "failed to delete junction point"
-
-# delete hard link
-Remove-Link -link_path $hardlink_path
-Assert-True -expression (-not (Test-Path -Path $hardlink_path)) -message "failed to delete hard link"
-
-Exit-Json @{ data = "success" }
+$result.data = "success"
+Exit-Json -obj $result

--- a/test/integration/targets/win_module_utils/library/symbolic_link_test.ps1
+++ b/test/integration/targets/win_module_utils/library/symbolic_link_test.ps1
@@ -105,7 +105,7 @@ Function Test-LinkUtil($path) {
     }
     Assert-Equals -actual $failed -expected $true
 
-    # create relative symlink
+    # create relative symlink dir
     New-Link -link_path "$path\symlink-rel" -link_target "folder" -link_type "link"
     $rel_link_result = Get-Link -link_path "$path\symlink-rel"
     Assert-Equals -actual $rel_link_result.Type -expected "SymbolicLink"
@@ -113,6 +113,16 @@ Function Test-LinkUtil($path) {
     Assert-Equals -actual $rel_link_result.PrintName -expected "folder"
     Assert-Equals -actual $rel_link_result.TargetPath -expected "folder"
     Assert-Equals -actual $rel_link_result.AbsolutePath -expected $folder_target
+    Assert-Equals -actual $rel_link_result.HardTargets -expected $null
+
+    # create relative symlink file
+    New-Link -link_path "$path\folder\symlink-rel-file" -link_target "..\file" -link_type "link"
+    $rel_link_result = Get-Link -link_path "$path\folder\symlink-rel-file"
+    Assert-Equals -actual $rel_link_result.Type -expected "SymbolicLink"
+    Assert-Equals -actual $rel_link_result.SubstituteName -expected "..\file"
+    Assert-Equals -actual $rel_link_result.PrintName -expected "..\file"
+    Assert-Equals -actual $rel_link_result.TargetPath -expected "..\file"
+    Assert-Equals -actual $rel_link_result.AbsolutePath -expected $file_target
     Assert-Equals -actual $rel_link_result.HardTargets -expected $null
 
     # create a symbolic file test
@@ -225,7 +235,7 @@ Function Test-LinkUtil($path) {
     Assert-Equals -actual ($hardlink_result_2.HardTargets.Count -eq 3) -expected $true
 
     # check if broken symbolic link still works
-    Remove-Item -Path $folder_target -Force > $null
+    [Ansible.IO.Directory]::Delete($folder_target, $true)
     $broken_link_result = Get-Link -link_path $symlink_folder_path
     Assert-Equals -actual $broken_link_result.Type -expected "SymbolicLink"
     if ($path.StartsWith("\\?\")) {

--- a/test/integration/targets/win_module_utils/tasks/main.yml
+++ b/test/integration/targets/win_module_utils/tasks/main.yml
@@ -1,145 +1,112 @@
-- name: call old WANTS_JSON module
-  legacy_only_old_way:
-  register: old_way
+---
+- name: set facts for test
+  set_fact:
+    become_test_standard_username: ansible_become_stan
+    become_test_admin_username: ansible_become_admin
+    sid_test_username: S-1-0-0
+    test_util_path: C:\ansible testing
+    gen_pw: password123! + {{ lookup('password', '/dev/null chars=ascii_letters,digits length=8') }}
 
-- assert:
-    that:
-    - old_way.data == 'success'
+- name: create normal user
+  win_user:
+    name: '{{ become_test_standard_username }}'
+    password: '{{ gen_pw }}'
+    update_password: always
+    groups: Users
+  register: standard_user
 
-- name: call module with only legacy requires
-  legacy_only_new_way:
-  register: new_way
+- name: create admin user
+  win_user:
+    name: '{{ become_test_admin_username }}'
+    password: '{{ gen_pw }}'
+    update_password: always
+    groups: Administrators
+  register: admin_user
 
-- assert:
-    that:
-    - new_way.data == 'success'
-
-- name: call old WANTS_JSON module with windows line endings
-  legacy_only_old_way_win_line_ending:
-  register: old_way_win
-
-- assert:
-    that:
-    - old_way_win.data == 'success'
-
-- name: call module with only legacy requires and windows line endings
-  legacy_only_new_way_win_line_ending:
-  register: new_way_win
-
-- assert:
-    that:
-    - new_way_win.data == 'success'
-
-- name: call module with local module_utils
-  uses_local_utils:
-  register: local_utils
-
-- assert:
-    that:
-    - local_utils.data == "ValueFromCustomFunction"
-
-- name: call module that imports bogus Ansible-named module_utils
-  uses_bogus_utils:
-  ignore_errors: true
-  register: bogus_utils
-
-- assert:
-    that:
-    - bogus_utils is failed
-    - bogus_utils.msg is search("Could not find")
-
-- name: call module that imports module_utils with further imports
-  recursive_requires:
-  register: recursive_requires
-
-- assert:
-    that:
-    - 'recursive_requires.value == "Get-Test3: 2: Get-Test2, 1: Get-Test1, 3: Get-NewTest3"'
-
-- name: call module with camel conversion tests
-  camel_conversion_test:
-  register: camel_conversion
-
-- assert:
-    that:
-    - camel_conversion.data == 'success'
-
-- block:
-  - name: create test user with well know SID as the name
-    win_user:
-      name: S-1-0-0
-      password: AbcDef123!@#
-      state: present
-
-  - name: call module with SID tests
-    sid_utils_test:
-      sid_account: S-1-0-0
-    register: sid_test
-
-  always:
-  - name: remove test SID user
-    win_user:
-      name: S-1-0-0
-      state: absent
-
-- assert:
-    that:
-    - sid_test.data == 'success'
+- name: create test sid user
+  win_user:
+    name: '{{ sid_test_username }}'
+    password: '{{ gen_pw }}'
+    state: present
 
 - name: create temp testing folder
   win_file:
-    path: C:\ansible testing
+    path: '{{ test_util_path }}'
     state: directory
 
-- name: download binary the outputs argv to stdout
+- name: download binary that outputs argv to stdout
   win_get_url:
     url: https://s3.amazonaws.com/ansible-ci-files/test/integration/roles/test_win_module_utils/PrintArgv.exe
-    dest: C:\ansible testing\PrintArgv.exe
+    dest: '{{ test_util_path }}\PrintArgv.exe'
 
-- name: call module with CommandUtil tests
-  command_util_test:
-    exe: C:\ansible testing\PrintArgv.exe
-  register: command_util
+- block:
+  - name: ensure current user is not the become user
+    win_whoami:
+    register: whoami_out
+    failed_when: whoami_out.account.sid in [ standard_user.sid, admin_user.sid ]
 
-- assert:
-    that:
-    - command_util.data == 'success'
+  - name: get become user profile dir so we can clean it up later
+    vars:
+      ansible_become_user: '{{ become_test_standard_username }}'
+      ansible_become_password: '{{ gen_pw }}'
+      ansible_become_method: runas
+      ansible_become: yes
+    win_shell: $env:USERPROFILE
+    register: standard_profile_dir_out
 
-- name: call module with ArgvParser tests
-  argv_parser_test:
-    exe: C:\ansible testing\PrintArgv.exe
-  register: argv_test
+  - name: ensure standard profile dir contains test username
+    assert:
+      that:
+      - become_test_standard_username in standard_profile_dir_out.stdout_lines[0]
 
-- assert:
-    that:
-    - argv_test.data == 'success'
+  - name: get become admin user profile dir so we can clean it up later
+    vars:
+      ansible_become_user: '{{ become_test_admin_username }}'
+      ansible_become_password: '{{ gen_pw }}'
+      ansible_become_method: runas
+      ansible_become: yes
+    win_shell: $env:USERPROFILE
+    register: admin_profile_dir_out
 
-- name: call module with symbolic link tests
-  symbolic_link_test:
-    path: C:\ansible testing
-  register: symbolic_link
+  - name: ensure admin profile dir contains test username
+    assert:
+      that:
+      - become_test_admin_username in admin_profile_dir_out.stdout_lines[0]
 
-- assert:
-    that:
-    - symbolic_link.data == 'success'
+  - name: run tests
+    include_tasks: tests.yml
 
-- name: remove testing folder
-  win_file:
-    path: C:\ansible testing
-    state: absent
+  always:
+  - name: ensure standard become user is deleted
+    win_user:
+      name: '{{ become_test_standard_username }}'
+      state: absent
 
-- name: call module with FileUtil tests
-  file_util_test:
-  register: file_util_test
+  - name: ensure admin become user is deleted
+    win_user:
+      name: '{{ become_test_admin_username }}'
+      state: absent
 
-- assert:
-    that:
-    - file_util_test.data == 'success'
+  - name: remove test SID user
+    win_user:
+      name: '{{ sid_test_username }}'
+      state: absent
 
-- name: call module with PrivilegeUtil tests
-  privilege_util_test:
-  register: privilege_util_test
+  # FUTURE use win_file once MAX_PATH support is added
+  - name: remove testing directory
+    win_shell: rmdir /S /Q "{{ test_util_path }}"
+    args:
+      executable: cmd.exe
+      removes: '{{ test_util_path }}'
 
-- assert:
-    that:
-    - privilege_util_test.data == 'success'
+  - name: ensure standard become user profile is delete
+    win_shell: rmdir /S /Q {{ standard_profile_dir_out.stdout_lines[0] }}
+    args:
+      executable: cmd.exe
+    when: become_test_standard_username in standard_profile_dir_out.stdout_lines[0]
+
+  - name: ensure admin become user profile is deleted
+    win_shell: rmdir /S /Q {{ admin_profile_dir_out.stdout_lines[0] }}
+    args:
+      executable: cmd.exe
+    when: become_test_admin_username in admin_profile_dir_out.stdout_lines[0]

--- a/test/integration/targets/win_module_utils/tasks/tests.yml
+++ b/test/integration/targets/win_module_utils/tasks/tests.yml
@@ -1,0 +1,158 @@
+---
+- name: call old WANTS_JSON module
+  legacy_only_old_way:
+  register: old_way
+
+- assert:
+    that:
+    - old_way.data == 'success'
+
+- name: call module with only legacy requires
+  legacy_only_new_way:
+  register: new_way
+
+- assert:
+    that:
+    - new_way.data == 'success'
+
+- name: call old WANTS_JSON module with windows line endings
+  legacy_only_old_way_win_line_ending:
+  register: old_way_win
+
+- assert:
+    that:
+    - old_way_win.data == 'success'
+
+- name: call module with only legacy requires and windows line endings
+  legacy_only_new_way_win_line_ending:
+  register: new_way_win
+
+- assert:
+    that:
+    - new_way_win.data == 'success'
+
+- name: call module with local module_utils
+  uses_local_utils:
+  register: local_utils
+
+- assert:
+    that:
+    - local_utils.data == "ValueFromCustomFunction"
+
+- name: call module that imports bogus Ansible-named module_utils
+  uses_bogus_utils:
+  ignore_errors: true
+  register: bogus_utils
+
+- assert:
+    that:
+    - bogus_utils is failed
+    - bogus_utils.msg is search("Could not find")
+
+- name: call module that imports module_utils with further imports
+  recursive_requires:
+  register: recursive_requires
+
+- assert:
+    that:
+    - 'recursive_requires.value == "Get-Test3: 2: Get-Test2, 1: Get-Test1, 3: Get-NewTest3"'
+
+- name: call module with camel conversion tests
+  camel_conversion_test:
+  register: camel_conversion
+
+- assert:
+    that:
+    - camel_conversion.data == 'success'
+
+- name: call module with SID tests
+  sid_utils_test:
+    sid_account: '{{ sid_test_username }}'
+  register: sid_test
+
+- assert:
+    that:
+    - sid_test.data == 'success'
+
+- name: call module with CommandUtil tests
+  command_util_test:
+    exe: '{{ test_util_path }}\PrintArgv.exe'
+  register: command_util
+
+- assert:
+    that:
+    - command_util.data == 'success'
+
+- name: call module with ArgvParser tests
+  argv_parser_test:
+    exe: '{{ test_util_path }}\PrintArgv.exe'
+  register: argv_test
+
+- assert:
+    that:
+    - argv_test.data == 'success'
+
+- name: call module with LinkUtil tests
+  symbolic_link_test:
+    path: '{{ test_util_path }}'
+  register: symbolic_link
+
+- assert:
+    that:
+    - symbolic_link.data == 'success'
+
+- name: call module with FileUtil tests
+  file_util_test:
+  register: file_util_test
+
+- assert:
+    that:
+    - file_util_test.data == 'success'
+
+- name: call module with FileUtil tests for Ansible.IO c# code
+  file_util_test_ansible_io:
+    path: '{{ test_util_path }}'
+    encrypt_tests: no
+  register: file_util_test
+
+- assert:
+    that:
+    - file_util_test.data == 'success'
+
+- name: call module with FileUtil tests for Ansible.IO c# code as standard become user
+  file_util_test_ansible_io:
+    path: '{{ test_util_path }}'
+    encrypt_tests: yes
+  vars:
+    ansible_become_user: '{{ become_test_standard_username }}'
+    ansible_become_password: '{{ gen_pw }}'
+    ansible_become_method: runas
+    ansible_become: yes
+  register: file_util_test
+
+- assert:
+    that:
+    - file_util_test.data == 'success'
+
+- name: call module with FileUtil tests for Ansible.IO c# code as admin become user
+  file_util_test_ansible_io:
+    path: '{{ test_util_path }}'
+    encrypt_tests: yes
+  vars:
+    ansible_become_user: '{{ become_test_admin_username }}'
+    ansible_become_password: '{{ gen_pw }}'
+    ansible_become_method: runas
+    ansible_become: yes
+  register: file_util_test
+
+- assert:
+    that:
+    - file_util_test.data == 'success'
+
+- name: call module with PrivilegeUtil tests
+  privilege_util_test:
+  register: privilege_util_test
+
+- assert:
+    that:
+    - privilege_util_test.data == 'success'

--- a/test/integration/targets/win_module_utils_legacy/tasks/main.yml
+++ b/test/integration/targets/win_module_utils_legacy/tasks/main.yml
@@ -21,6 +21,13 @@
   - path: '{{ bogus_driveletter.stdout_lines[0] }}:\goodpath'
   - path: '{{ bogus_driveletter.stdout_lines[0] }}:\badpath*%@:\blar'
     should_fail: true
+  # path validation should not occur with \\?\, pretty much the only invalid char is \x00 but Win32 handles everything differently
+  # we rely on CreateFileW to handle the validation for us
+  - path: \\?\C:\long_path
+  - path: \\?\C:\path\{{ "a" * 255 }}\{{ "a" * 255 }}\dir
+  - path: \\?\{{ bogus_driveletter.stdout_lines[0] }}:\badpath*%@:\blar
+  - path: \\?\UNC\server\share\file
+  - path: \\?\UNC\server\share\file\badpath*%@:\blar
 
 - name: test list parameters
   testlist:

--- a/test/integration/targets/win_stat/defaults/main.yml
+++ b/test/integration/targets/win_stat/defaults/main.yml
@@ -1,2 +1,5 @@
 win_stat_dir: '{{win_output_dir}}\win_stat'
+win_stat_dir_forward: "{{win_stat_dir|regex_replace('\\\\', '/')}}"
+win_stat_dir_double: "{{win_stat_dir|regex_replace('\\\\', '\\\\\\\\')}}"
+win_stat_dir_long: \\?\{{win_stat_dir}}
 win_stat_user: test-stat

--- a/test/integration/targets/win_stat/filter_plugins/update_path.py
+++ b/test/integration/targets/win_stat/filter_plugins/update_path.py
@@ -1,0 +1,11 @@
+class FilterModule(object):
+    def filters(self):
+        return {
+            'update_stat': self.update_stat
+        }
+
+    def update_stat(self, dict_value, repl_dict):
+        new_dict = dict_value.copy()
+        for key, value in repl_dict.items():
+            new_dict['stat'][key] = value
+        return new_dict

--- a/test/integration/targets/win_stat/library/test_symlink_file.ps1
+++ b/test/integration/targets/win_stat/library/test_symlink_file.ps1
@@ -13,15 +13,15 @@ $result = @{
     changed = $false
 }
 
+Import-LinkUtil
+
 if ($state -eq "absent") {
-    if (Test-Path -Path $src) {
-        Load-LinkUtils
+    if (Test-AnsiblePath -Path $src) {
         Remove-Link -link_path $src
         $result.changed = $true
     }
 } else {
-    if (-not (Test-Path -Path $src)) {
-        Load-LinkUtils
+    if (-not (Test-AnsiblePath -Path $src)) {
         New-Link -link_path $src -link_target $target -link_type "link"
         $result.changed = $true
     }

--- a/test/integration/targets/win_stat/tasks/tests.yml
+++ b/test/integration/targets/win_stat/tasks/tests.yml
@@ -4,6 +4,26 @@
     path: '{{win_stat_dir}}\nested\file.ps1'
   register: stat_file
 
+- name: test win_stat module on file with forward slashes in path
+  win_stat:
+    path: '{{win_stat_dir_forward}}/nested/file.ps1'
+  register: stat_file_forward
+
+- name: test win_stat module on file with double back slashes in path
+  win_stat:
+    path: '{{win_stat_dir_double}}\\nested\\file.ps1'
+  register: stat_file_double
+
+- name: test win_stat module on file with long path prefix in path
+  win_stat:
+    path: '{{win_stat_dir_long}}\nested\file.ps1'
+  register: stat_file_long
+
+- name: set override assertion keys for long path
+  set_fact:
+    long_override:
+      path: '{{stat_file.stat.path}}'
+
 - name: check actual for file
   assert:
     that:
@@ -29,6 +49,10 @@
     - stat_file.stat.owner == 'BUILTIN\Administrators'
     - stat_file.stat.path == win_stat_dir + '\\nested\\file.ps1'
     - stat_file.stat.size == 3
+    - stat_file == stat_file_forward
+    - stat_file == stat_file_double
+    - stat_file_long.stat.path == '\\\\?\\' + stat_file.stat.path
+    - stat_file == stat_file_long|update_stat(long_override)
 
 # get_md5 will be undocumented in 2.9, remove this test then
 - name: test win_stat module on file with md5
@@ -142,6 +166,27 @@
     path: '{{win_stat_dir}}\nested\hard-link.ps1'
   register: stat_hard_link
 
+- name: test win_stat on hard link file with forward slashes in path
+  win_stat:
+    path: '{{win_stat_dir_forward}}/nested/hard-link.ps1'
+  register: stat_hard_link_forward
+
+- name: test win_stat on hard link file with double back slashes in path
+  win_stat:
+    path: '{{win_stat_dir_double}}\\nested\\hard-link.ps1'
+  register: stat_hard_link_double
+
+- name: test win_stat on hard link file with long path prefix in path
+  win_stat:
+    path: '{{win_stat_dir_long}}\nested\hard-link.ps1'
+  register: stat_hard_link_long
+
+- name: set override assertion keys for long path
+  set_fact:
+    long_override:
+      path: '{{stat_hard_link.stat.path}}'
+      hlnk_targets: '{{stat_hard_link.stat.hlnk_targets}}'
+
 - name: check actual for hard link file
   assert:
     that:
@@ -166,11 +211,36 @@
     - stat_hard_link.stat.owner == 'BUILTIN\Administrators'
     - stat_hard_link.stat.path == win_stat_dir + '\\nested\\hard-link.ps1'
     - stat_hard_link.stat.size == 3
+    - stat_hard_link == stat_hard_link_forward
+    - stat_hard_link == stat_hard_link_double
+    - stat_hard_link_long.stat.path == '\\\\?\\' + stat_hard_link.stat.path
+    - stat_hard_link_long.stat.hlnk_targets == [ '\\\\?\\' + stat_hard_link.stat.hlnk_targets[0] ]
+    - stat_hard_link == stat_hard_link_long|update_stat(long_override)
 
 - name: test win_stat on directory
   win_stat:
     path: '{{win_stat_dir}}\nested'
   register: stat_directory
+
+- name: test win_stat module on directory with forward slashes in path
+  win_stat:
+    path: '{{win_stat_dir_forward}}/nested'
+  register: stat_directory_forward
+
+- name: test win_stat module on directory with double back slashes in path
+  win_stat:
+    path: '{{win_stat_dir_double}}\\nested'
+  register: stat_directory_double
+
+- name: test win_stat module on directory with long path prefix in path
+  win_stat:
+    path: '{{win_stat_dir_long}}\nested'
+  register: stat_directory_long
+
+- name: set override assertion keys for long path
+  set_fact:
+    long_override:
+      path: '{{stat_directory.stat.path}}'
 
 - name: check actual for directory
   assert:
@@ -197,6 +267,10 @@
     - stat_directory.stat.owner == 'BUILTIN\Administrators'
     - stat_directory.stat.path == win_stat_dir + '\\nested'
     - stat_directory.stat.size == 24
+    - stat_directory == stat_directory_forward
+    - stat_directory == stat_directory_double
+    - stat_directory_long.stat.path == '\\\\?\\' + stat_directory.stat.path
+    - stat_directory == stat_directory_long|update_stat(long_override)
 
 - name: test win_stat on empty directory
   win_stat:
@@ -328,6 +402,28 @@
     path: '{{win_stat_dir}}\link'
   register: stat_symlink
 
+- name: test win_stat module on directory symlink with forward slashes in path
+  win_stat:
+    path: '{{win_stat_dir_forward}}/link'
+  register: stat_symlink_forward
+
+- name: test win_stat module on directory symlink with double back slashes in path
+  win_stat:
+    path: '{{win_stat_dir_double}}\\link'
+  register: stat_symlink_double
+
+- name: test win_stat module on directory symlink with long path prefix in path
+  win_stat:
+    path: '{{win_stat_dir_long}}\link'
+  register: stat_symlink_long
+
+- name: set override assertion keys for long path
+  set_fact:
+    long_override:
+      path: '{{stat_symlink.stat.path}}'
+      lnk_source: '{{stat_symlink.stat.lnk_source}}'
+      lnk_target: '{{stat_symlink.stat.lnk_target}}'
+
 - name: assert directory symlink actual
   assert:
     that:
@@ -353,11 +449,39 @@
     - stat_symlink.stat.path == win_stat_dir + '\\link'
     - stat_symlink.stat.checksum is not defined
     - stat_symlink.stat.md5 is not defined
+    - stat_symlink == stat_symlink_forward
+    - stat_symlink == stat_symlink_double
+    - stat_symlink_long.stat.path == '\\\\?\\' + stat_symlink.stat.path
+    - stat_symlink_long.stat.lnk_source == '\\\\?\\' + win_stat_dir + '\\link-dest'
+    - stat_symlink_long.stat.lnk_target == '\\\\?\\' + win_stat_dir + '\\link-dest'
+    - stat_symlink == stat_symlink_long|update_stat(long_override)
 
 - name: test win_stat on file symlink
   win_stat:
     path: '{{win_stat_dir}}\file-link.txt'
   register: stat_file_symlink
+
+- name: test win_stat module on file symlink with forward slashes in path
+  win_stat:
+    path: '{{win_stat_dir_forward}}/file-link.txt'
+  register: stat_file_symlink_forward
+
+- name: test win_stat module ony file symlink with double back slashes in path
+  win_stat:
+    path: '{{win_stat_dir_double}}\\file-link.txt'
+  register: stat_file_symlink_double
+
+- name: test win_stat module on file symlink with long path prefix in path
+  win_stat:
+    path: '{{win_stat_dir_long}}\file-link.txt'
+  register: stat_file_symlink_long
+
+- name: set override assertion keys for long path
+  set_fact:
+    long_override:
+      path: '{{stat_file_symlink.stat.path}}'
+      lnk_source: '{{stat_file_symlink.stat.lnk_source}}'
+      lnk_target: '{{stat_file_symlink.stat.lnk_target}}'
 
 - name: assert file symlink actual
   assert:
@@ -385,11 +509,38 @@
     - stat_file_symlink.stat.nlink == 1
     - stat_file_symlink.stat.owner == 'BUILTIN\\Administrators'
     - stat_file_symlink.stat.path == win_stat_dir + '\\file-link.txt'
+    - stat_file_symlink == stat_file_symlink_forward
+    - stat_file_symlink == stat_file_symlink_double
+    - stat_file_symlink_long.stat.path == '\\\\?\\' + stat_file_symlink.stat.path
+    - stat_file_symlink_long.stat.lnk_source == '\\\\?\\' + win_stat_dir + '\\nested\\file.ps1'
+    - stat_file_symlink_long.stat.lnk_target == '\\\\?\\' + win_stat_dir + '\\nested\\file.ps1'
+    - stat_file_symlink == stat_file_symlink_long|update_stat(long_override)
 
 - name: test win_stat on relative symlink
   win_stat:
     path: '{{win_stat_dir}}\nested\nested\link-rel'
   register: stat_rel_symlink
+
+- name: test win_stat on relative symlink with forward slashes in path
+  win_stat:
+    path: '{{win_stat_dir_forward}}/nested/nested/link-rel'
+  register: stat_rel_symlink_forward
+
+- name: test win_stat on relative symlink with double back slashes in path
+  win_stat:
+    path: '{{win_stat_dir_double}}\\nested\\nested\\link-rel'
+  register: stat_rel_symlink_double
+
+- name: test win_stat on relative symlink with long path prefix in path
+  win_stat:
+    path: '{{win_stat_dir_long}}\nested\nested\link-rel'
+  register: stat_rel_symlink_long
+
+- name: set override assertion keys for long path
+  set_fact:
+    long_override:
+      path: '{{stat_rel_symlink.stat.path}}'
+      lnk_source: '{{stat_rel_symlink.stat.lnk_source}}'
 
 - name: assert directory relative symlink actual
   assert:
@@ -416,11 +567,38 @@
     - stat_rel_symlink.stat.path == win_stat_dir + '\\nested\\nested\\link-rel'
     - stat_rel_symlink.stat.checksum is not defined
     - stat_rel_symlink.stat.md5 is not defined
+    - stat_rel_symlink == stat_rel_symlink_forward
+    - stat_rel_symlink == stat_rel_symlink_double
+    - stat_rel_symlink_long.stat.path == '\\\\?\\' + stat_rel_symlink.stat.path
+    - stat_rel_symlink_long.stat.lnk_source == '\\\\?\\' + win_stat_dir + '\\link-dest'
+    - stat_rel_symlink == stat_rel_symlink_long|update_stat(long_override)
 
 - name: test win_stat on junction
   win_stat:
     path: '{{win_stat_dir}}\junction-link'
   register: stat_junction_point
+
+- name: test win_stat on junction with forward slashes in path
+  win_stat:
+    path: '{{win_stat_dir_forward}}/junction-link'
+  register: stat_junction_point_forward
+
+- name: test win_stat on junction with double back slashes in path
+  win_stat:
+    path: '{{win_stat_dir_double}}\\junction-link'
+  register: stat_junction_point_double
+
+- name: test win_stat on junction with long path prefix in path
+  win_stat:
+    path: '{{win_stat_dir_long}}\junction-link'
+  register: stat_junction_point_long
+
+- name: set override assertion keys for long path
+  set_fact:
+    long_override:
+      path: '{{stat_junction_point.stat.path}}'
+      lnk_source: '{{stat_junction_point.stat.lnk_source}}'
+      lnk_target: '{{stat_junction_point.stat.lnk_target}}'
 
 - name: assert junction actual
   assert:
@@ -446,6 +624,12 @@
     - stat_junction_point.stat.owner == 'BUILTIN\\Administrators'
     - stat_junction_point.stat.path == win_stat_dir + '\\junction-link'
     - stat_junction_point.stat.size == 0
+    - stat_junction_point == stat_junction_point_forward
+    - stat_junction_point == stat_junction_point_double
+    - stat_junction_point_long.stat.path == '\\\\?\\' + stat_junction_point.stat.path
+    - stat_junction_point_long.stat.lnk_source == '\\\\?\\' + win_stat_dir + '\\junction-dest'
+    - stat_junction_point_long.stat.lnk_target == '\\\\?\\' + win_stat_dir + '\\junction-dest'
+    - stat_junction_point == stat_junction_point_long|update_stat(long_override)
 
 - name: test win_stat module non-existent path
   win_stat:

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -4,7 +4,6 @@ examples/scripts/upgrade_to_ps3.ps1 PSAvoidUsingWriteHost
 examples/scripts/upgrade_to_ps3.ps1 PSUseApprovedVerbs
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.ArgvParser.psm1 PSUseApprovedVerbs
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CommandUtil.psm1 PSUseApprovedVerbs
-lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1 PSProvideCommentHelp
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1 PSUseOutputTypeCorrectly
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1 PSAvoidUsingWMICmdlet
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1 PSUseApprovedVerbs


### PR DESCRIPTION
##### SUMMARY
This PR adds the namespace `Ansible.IO` to the `Ansible.ModuleUtils.FileUtil` that allows modules to interact with paths that exceeds MAX_PATH (~260 chars). This namespace is designed to replicate the functionality of `System.IO.Directory/DirectoryInfo/File/FileInfo/Path` but also to add support for the following;

* Interact with paths that exceed MAX_PATH when using the `\\?\` prefix
* Automatic privilege enablement when setting ACLs that require the relevant privileges
* Added `Compress()` and `Decompress()` methods to enable the toggling of the Compress attribute
* Added the ability to manipulate sparse files and clear ranges within a sparse file
* More functions to enumerate alternative streams and read/write to these streams

Further changes to this PR are to LinkUtil which changes;

* Support for links greater than MAX_PATH
* Support for creating symlinks/junction points against a missing target
* Support for creating relative symlinks
* Support for creating symlinks on newer Windows versions without having admin privileges
* Only enable the `SeBackupPrivilege` when required instead of doing it globally

First part to achieve https://github.com/ansible/ansible/issues/43060.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
lib/ansible/module_utils/powershell/Ansible.ModuleUtils.LinkUtil.psm1
win_stat
win_command
win_shell
win_wait_for

##### ANSIBLE VERSION
```
devel
```

##### ADDITIONAL INFORMATION
There is a lot of code in the Ansible.ModuleUtils.FileUtil.psm1 is slightly modified from https://github.com/dotnet/corefx which is licensed under the MIT license. When doing some testing against devel, the `win_stat` tests only took an extra 1-3 seconds so the extra code does not seem to slow anything down dramatically.