### PR TITLE
network - IOS cliconf plugin typo in edit_banner

### DIFF
--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -231,13 +231,13 @@ class Cliconf(CliconfBase):
         if commit:
             for key, value in iteritems(banners_obj):
                 key += ' %s' % multiline_delimiter
-                self.send_commad('config terminal', sendonly=True)
+                self.send_command('config terminal', sendonly=True)
                 for cmd in [key, value, multiline_delimiter]:
                     obj = {'command': cmd, 'sendonly': True}
                     results.append(self.send_command(**obj))
                     requests.append(cmd)
 
-                self.send_commad('end', sendonly=True)
+                self.send_command('end', sendonly=True)
                 time.sleep(0.1)
                 results.append(self.send_command('\n'))
                 requests.append('\n')


### PR DESCRIPTION
Looks like `send_commad` was mistakenly added in https://github.com/ansible/ansible/pull/43203. Should be `send_command`

##### SUMMARY
Fixes typo in IOS edit_banner() method.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

plugins/cliconf/ios.py

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (voss_command e630dd9e39) last updated 2018/08/02 15:55:25 (GMT -700)
  config file = /home/extreme/.ansible.cfg
  configured module search path = [u'/home/extreme/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/extreme/ansible.voss/lib/ansible
  executable location = /home/extreme/ansible.voss/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION