### PR TITLE
Meraki/doc response vlan

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_vlan.py
+++ b/lib/ansible/modules/network/meraki/meraki_vlan.py
@@ -145,9 +145,45 @@ response:
       type: string
       sample: upstream_dns
     fixedIpAssignments:
-      description: List of fixed IP address assignments between IP addresses and MAC addresses.
+      description: List of MAC addresses which have IP addresses assigned.
       returned: success
-      type: list
+      type: complex
+      contains:
+        macaddress:
+          description: MAC address which has IP address assigned to it.
+          returned: success
+          type: complex
+            contains:
+              ip:
+                description: IP address which is assigned to the MAC address.
+                returned: success
+                type: string
+                sample: 192.0.1.4
+              name:
+                description: Descriptive name for binding.
+                returned: success
+                type: string
+                sample: fixed_ip
+    reservedIpRanges:
+      description: List of IP address ranges which are reserved for static assignment.
+      returned: success
+      type: complex
+      contains:
+        comment:
+          description: Description for IP address reservation.
+          returned: success
+          type: string
+          sample: reserved_range
+        end:
+          description: Last IP address in reservation range.
+          returned: success
+          type: string
+          sample: 192.0.1.10
+        start:
+          description: First IP address in reservation range.
+          returned: success
+          type: string
+          sample: 192.0.1.5
     id:
       description: VLAN ID number.
       returned: success

--- a/lib/ansible/modules/network/meraki/meraki_vlan.py
+++ b/lib/ansible/modules/network/meraki/meraki_vlan.py
@@ -128,21 +128,50 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
+
 response:
-    description: Data returned from Meraki dashboard about VLAN.
-    type: dict
-    returned: success
-    example:
-        {
-            "applianceIp": "192.0.1.1",
-            "dnsNameservers": "upstream_dns",
-            "fixedIpAssignments": {},
-            "id": 2,
-            "name": "TestVLAN",
-            "networkId": "N_12345",
-            "reservedIpRanges": [],
-            "subnet": "192.0.1.0/24"
-        }
+  description: Information about the organization which was created or modified
+  returned: success
+  type: complex
+  contains:
+    applianceIp:
+      description: IP address of Meraki appliance in the VLAN
+      returned: success
+      type: string
+      sample: 192.0.1.1
+    dnsnamservers:
+      description: IP address or Meraki defined DNS servers which VLAN should use by default
+      returned: success
+      type: string
+      sample: upstream_dns
+    fixedIpAssignments:
+      description: List of fixed IP address assignments between IP addresses and MAC addresses.
+      returned: success
+      type: list
+    id:
+      description: VLAN ID number.
+      returned: success
+      type: int
+      sample: 2
+    name:
+      description: Descriptive name of VLAN
+      returned: success
+      type: string
+      sample: TestVLAN
+    networkId:
+      description: ID number of Meraki network which VLAN is associated to.
+      returned: success
+      type: string
+      sample: N_12345
+    reservedIpRanges:
+      description: List of IP address ranges which are avoided when assigning IP addresses via DHCP.
+      returned: success
+      type: list
+    subnet:
+      description: CIDR notation IP subnet of VLAN.
+      returned: success
+      type: string
+      sample: 192.0.1.0/24
 '''
 
 import os

--- a/lib/ansible/modules/network/meraki/meraki_vlan.py
+++ b/lib/ansible/modules/network/meraki/meraki_vlan.py
@@ -199,10 +199,6 @@ response:
       returned: success
       type: string
       sample: N_12345
-    reservedIpRanges:
-      description: List of IP address ranges which are avoided when assigning IP addresses via DHCP.
-      returned: success
-      type: list
     subnet:
       description: CIDR notation IP subnet of VLAN.
       returned: success

--- a/lib/ansible/modules/network/meraki/meraki_vlan.py
+++ b/lib/ansible/modules/network/meraki/meraki_vlan.py
@@ -150,20 +150,20 @@ response:
       type: complex
       contains:
         macaddress:
-          description: MAC address which has IP address assigned to it.
+          description: MAC address which has IP address assigned to it. Key value is the actual MAC address.
           returned: success
           type: complex
-            contains:
-              ip:
-                description: IP address which is assigned to the MAC address.
-                returned: success
-                type: string
-                sample: 192.0.1.4
-              name:
-                description: Descriptive name for binding.
-                returned: success
-                type: string
-                sample: fixed_ip
+          contains:
+            ip:
+              description: IP address which is assigned to the MAC address.
+              returned: success
+              type: string
+              sample: 192.0.1.4
+            name:
+              description: Descriptive name for binding.
+              returned: success
+              type: string
+              sample: fixed_ip
     reservedIpRanges:
       description: List of IP address ranges which are reserved for static assignment.
       returned: success


### PR DESCRIPTION
##### SUMMARY
- Add documentation for response information for meraki_vlan module

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
meraki_vlan

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (meraki/doc-response-vlan 43235c7877) last updated 2018/08/04 22:19:49 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
```
        "data": [
            {
                "applianceIp": "192.168.128.1",
                "dnsNameservers": "upstream_dns",
                "fixedIpAssignments": {},
                "id": 1,
                "name": "Default",
                "networkId": "N_624874448297671833",
                "reservedIpRanges": [],
                "subnet": "192.168.128.0/24"
            },
            {
                "applianceIp": "192.168.250.2",
                "dnsNameservers": "opendns",
                "fixedIpAssignments": {
                    "13:37:de:ad:be:ef": {
                        "ip": "192.168.250.10",
                        "name": "fixed_ip"
                    }
                },
                "id": 2,
                "name": "TestVLAN",
                "networkId": "N_624874448297671833",
                "reservedIpRanges": [
                    {
                        "comment": "reserved_range",
                        "end": "192.168.250.20",
                        "start": "192.168.250.10"
                    }
                ],
                "subnet": "192.168.250.0/24"
            }
```
