### PR TITLE
make password locking in user module idempotent

### DIFF
--- a/changelogs/fragments/user-password_lock-change-fix.yaml
+++ b/changelogs/fragments/user-password_lock-change-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - do not report changes every time when setting password_lock (https://github.com/ansible/ansible/issues/43670)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1220,7 +1220,6 @@ class FreeBsdUser(User):
             cmd = [
                 self.module.get_bin_path('pw', True),
                 'lock',
-                '-n',
                 self.name
             ]
             if self.uid is not None and info[2] != int(self.uid):
@@ -1231,7 +1230,6 @@ class FreeBsdUser(User):
             cmd = [
                 self.module.get_bin_path('pw', True),
                 'unlock',
-                '-n',
                 self.name
             ]
             if self.uid is not None and info[2] != int(self.uid):

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -194,7 +194,7 @@ options:
             - Lock the password (usermod -L, pw lock, usermod -C).
               BUT implementation differs on different platforms, this option does not always mean the user cannot login via other methods.
               This option does not disable the user, only lock the password. Do not change the password in the same task.
-              Currently supported on Linux, FreeBSD, DragonFlyBSD, NetBSD.
+              Currently supported on Linux, FreeBSD, DragonFlyBSD, NetBSD, OpenBSD.
         type: bool
         version_added: "2.6"
     local:
@@ -1403,6 +1403,11 @@ class OpenBSDUser(User):
             if self.login_class != user_login_class:
                 cmd.append('-L')
                 cmd.append(self.login_class)
+
+        if self.password_lock and not info[1].startswith('*'):
+            cmd.append('-Z')
+        elif self.password_lock is False and info[1].startswith('*'):
+            cmd.append('-U')
 
         if self.update_password == 'always' and self.password is not None \
                 and self.password != '*' and info[1] != self.password:

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -718,9 +718,11 @@ class User(object):
                     cmd.append('-e')
                     cmd.append(time.strftime(self.DATE_FORMAT, self.expires))
 
-        if self.password_lock:
+        # Lock if no password or unlocked, unlock if password and locked
+        if self.password_lock and (info[1] == '' or info[1][0] != '!'):
             cmd.append('-L')
-        elif self.password_lock is not None:
+        elif self.password_lock is False and (info[1] != '' and info[1][0] == '!'):
+            # usermod will refuse to unlock a user with no password, module shows 'changed' regardless
             cmd.append('-U')
 
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -628,3 +628,111 @@
   file:
     path: "{{ output_dir }}/test_id_rsa"
     state: absent
+  when: ansible_os_family == 'FreeBSD'
+
+
+## password lock
+- block:
+    - name: Set password for ansibulluser
+      user:
+        name: ansibulluser
+        password: "$6$rounds=656000$TT4O7jz2M57npccl$33LF6FcUMSW11qrESXL1HX0BS.bsiT6aenFLLiVpsQh6hDtI9pJh5iY7x8J7ePkN4fP8hmElidHXaeD51pbGS."
+
+    - name: Lock account
+      user:
+        name: ansibulluser
+        password_lock: yes
+      register: password_lock_1
+
+    - name: Lock account again
+      user:
+        name: ansibulluser
+        password_lock: yes
+      register: password_lock_2
+
+    - name: Unlock account
+      user:
+        name: ansibulluser
+        password_lock: no
+      register: password_lock_3
+
+    - name: Unlock account again
+      user:
+        name: ansibulluser
+        password_lock: no
+      register: password_lock_4
+
+    - name: Ensure task reported changes appropriately
+      assert:
+        msg: The password_lock tasks did not make changes appropriately
+        that:
+          - password_lock_1 is changed
+          - password_lock_2 is not changed
+          - password_lock_3 is changed
+          - password_lock_4 is not changed
+
+    - name: Lock account
+      user:
+        name: ansibulluser
+        password_lock: yes
+
+    - name: Verify account lock for BSD
+      block:
+        - name: BSD | Get account status
+          shell: "{{ status_command[ansible_facts['system']] }}"
+          register: account_status_locked
+
+        - name: Unlock account
+          user:
+            name: ansibulluser
+            password_lock: no
+
+        - name: BSD | Get account status
+          shell: "{{ status_command[ansible_facts['system']] }}"
+          register: account_status_unlocked
+
+        - name: FreeBSD | Ensure account is locked
+          assert:
+            that:
+              - "'LOCKED' in account_status_locked.stdout"
+              - "'LOCKED' not in account_status_unlocked.stdout"
+          when: ansible_facts['system'] == 'FreeBSD'
+
+      when: ansible_facts['system'] in ['FreeBSD', 'OpenBSD']
+
+    - name: Verify account lock for Linux
+      block:
+        - name: LINUX | Get account status
+          getent:
+            database: shadow
+            key: ansibulluser
+
+        - name: LINUX | Ensure account is locked
+          assert:
+            that:
+              - getent_shadow['ansibulluser'][0].startswith('!')
+
+        - name: Unlock account
+          user:
+            name: ansibulluser
+            password_lock: no
+
+        - name: LINUX | Get account status
+          getent:
+            database: shadow
+            key: ansibulluser
+
+        - name: LINUX | Ensure account is unlocked
+          assert:
+            that:
+              - not getent_shadow['ansibulluser'][0].startswith('!')
+
+      when: ansible_facts['system'] == 'Linux'
+
+  always:
+    - name: Unlock account
+      user:
+        name: ansibulluser
+        password_lock: no
+
+  when: ansible_facts['system'] in ['FreeBSD', 'OpenBSD', 'Linux']

--- a/test/integration/targets/user/vars/main.yml
+++ b/test/integration/targets/user/vars/main.yml
@@ -3,3 +3,7 @@ user_home_prefix:
   FreeBSD: '/home'
   SunOS: '/home'
   Darwin: '/Users'
+
+status_command:
+  OpenBSD: "grep ansibulluser /etc/master.passwd | cut -d ':' -f 2"
+  FreeBSD: 'pw user show ansibulluser'


### PR DESCRIPTION
##### SUMMARY
Fixes #43670 to add idempotency to the user password locking

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
user.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/chris/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Will add commits for other OSs later.