### PR TITLE
'system=yes' was ignored in a 'group' step

### DIFF
--- a/lib/ansible/modules/system/group.py
+++ b/lib/ansible/modules/system/group.py
@@ -117,7 +117,7 @@ class Group(object):
             if key == 'gid' and kwargs[key] is not None:
                 cmd.append('-g')
                 cmd.append(kwargs[key])
-            elif key == 'system' and kwargs[key] is True:
+            elif key == 'system' and kwargs[key]:
                 cmd.append('-r')
         cmd.append(self.name)
         return self.execute_command(cmd)
@@ -208,7 +208,7 @@ class AIX(Group):
         for key in kwargs:
             if key == 'gid' and kwargs[key] is not None:
                 cmd.append('id=' + kwargs[key])
-            elif key == 'system' and kwargs[key] is True:
+            elif key == 'system' and kwargs[key]:
                 cmd.append('-a')
         cmd.append(self.name)
         return self.execute_command(cmd)
@@ -301,7 +301,7 @@ class DarwinGroup(Group):
         cmd += ['-o', 'create']
         if self.gid is not None:
             cmd += ['-i', self.gid]
-        elif 'system' in kwargs and kwargs['system'] is True:
+        elif 'system' in kwargs and kwargs['system']:
             gid = self.get_lowest_available_system_gid()
             if gid is not False:
                 self.gid = str(gid)


### PR DESCRIPTION
I have neither tested this exact fix on all platforms nor audited other modules for a similar bug. Release 2.6.2 is broken, though, and a fix like this makes it work.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
group

##### ANSIBLE VERSION
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/drewp/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
Traceback (most recent call last):
  File "/usr/bin/ansible", line 161, in <module>
    shutil.rmtree(C.DEFAULT_LOCAL_TMP, True)
AttributeError: 'module' object has no attribute 'DEFAULT_LOCAL_TMP'

```


##### ADDITIONAL INFORMATION

```
This step

- group: name=docker system=yes

made this -vv output:

task path: ansible/roles/bigasterisk_users/tasks/main.yml:13
ok: [dot] => {"changed": false, "gid": 3019, "name": "docker", "state": "present", "system": false}

The 'false' there is wrong. 
```

This was apparently fixed before in https://github.com/ansible/ansible/issues/2836 and 1) it got reverted to 'is True' again; and 2) "== True" is also probably the wrong test.