### PR TITLE
Fix replace module bug : when specify after and before option same time

### DIFF
--- a/lib/ansible/modules/files/replace.py
+++ b/lib/ansible/modules/files/replace.py
@@ -224,7 +224,7 @@ def main():
 
     pattern = u''
     if params['after'] and params['before']:
-        pattern = u'%s(?P<subsection>.*?)%s' % (params['before'], params['after'])
+        pattern = u'%s(?P<subsection>.*?)%s' % (params['after'], params['before'])
     elif params['after']:
         pattern = u'%s(?P<subsection>.*)' % params['after']
     elif params['before']:


### PR DESCRIPTION
##### SUMMARY

In replace module, when specify options both `after` and `before` , it does not work well.

I think `after` line comes before `before` line.
But `replace.py` seems pass argument to regex pattern by reversed  order. 

###### replace module document

```yaml
# Replace between the expressions (requires >=2.4)
- replace:
    path: /etc/hosts
    regexp: '(\s+)old\.host\.name(\s+.*)?$'
    replace: '\1new.host.name\2'
    after: 'Start after line.*'
    before: 'Start before line.*'
    backup: yes
```

[replace - Replace all instances of a particular string in a file using a back-referenced regular expression. — Ansible Documentation](https://docs.ansible.com/ansible/2.6/modules/replace_module.html#examples)

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
replace (module)

##### ANSIBLE VERSION

```
ansible 2.6.1
  config file = /Users/yuma/.ansible.cfg
  configured module search path = [u'/Users/yuma/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.6.1/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jun 19 2018, 20:16:43) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]

```

##### ADDITIONAL INFORMATION

###### example text

`source.txt`

```
Alice
REPLACE AFTER THIS LINE
Alice
Alice
REPLACE BEFORE THIS LINE
Alice
```

###### Example playbook

```yaml
- hosts:
    - localhost

  tasks:
    - name: copy
      copy:
        src: source.txt
        dest: replace_between.txt

    - name: Replace "Alice" Between
      replace:
        path: replace_between.txt
        regexp: '^Alice$'
        replace: David
        after: 'REPLACE AFTER THIS LINE'
        before: 'REPLACE BEFORE THIS LINE'
```

###### playbook result

Nothing done.

```
$ ansible-playbook replace_between.yml && cat replace_between.txt
 [WARNING]: Unable to parse /etc/ansible/hosts as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] **************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************
ok: [localhost]

TASK [copy] *******************************************************************************************************************************
ok: [localhost]

TASK [Replace "Alice" Between] ************************************************************************************************************
ok: [localhost]

PLAY RECAP ********************************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0

Alice
REPLACE AFTER THIS LINE
Alice
Alice
REPLACE BEFORE THIS LINE
Alice
```

I think expected result ( replaced file body ) is bellow.

```
Alice
REPLACE AFTER THIS LINE
David
David
REPLACE BEFORE THIS LINE
Alice
```

Because when specified only after or before option, Correct replacing happens.

*e.g*

```
Alice
REPLACE AFTER THIS LINE
David
David
REPLACE BEFORE THIS LINE
David
```

```
David
REPLACE AFTER THIS LINE
David
David
REPLACE BEFORE THIS LINE
Alice
```


###### Ref

I tested this behaviour and created [Gist](https://gist.github.com/YumaInaura/e1004e77cb253d58d8e707c1fa26200c).

 Probably anybody can check results easy with git clone this gist.

