### PR TITLE
Add module parameter to control Puppet agent noop switch

### DIFF
--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -38,7 +38,7 @@ options:
       - Undefined, use default or puppet.conf value if defined.
       - true, Run puppet agent with --noop switch set.
       - false, Run puppet agent with --no-noop switch set.
-    version_added: "2.7"
+    version_added: "2.8"
   facts:
     description:
       - A dict of values to pass in as persistent external facter facts.

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -36,7 +36,7 @@ options:
     description:
       - Override puppet.conf noop mode.
       - Undefined, use default or puppet.conf value if defined.
-      - true, Run puppet agent with --noop switch set.
+      - true, Run Puppet agent with C(--noop) switch set.
       - false, Run puppet agent with --no-noop switch set.
     version_added: "2.8"
   facts:

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -37,7 +37,7 @@ options:
       - Override puppet.conf noop mode.
       - Undefined, use default or puppet.conf value if defined.
       - true, Run Puppet agent with C(--noop) switch set.
-      - false, Run puppet agent with --no-noop switch set.
+      - false, Run Puppet agent with C(--no-noop) switch set.
     version_added: "2.8"
   facts:
     description:

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -32,6 +32,13 @@ options:
   manifest:
     description:
       - Path to the manifest file to run puppet apply on.
+  noop:
+    description:
+      - Override puppet.conf noop mode.
+      - Undefined, use default or puppet.conf value if defined.
+      - true, Run puppet agent with --noop switch set.
+      - false, Run puppet agent with --no-noop switch set.
+    version_added: "2.7"
   facts:
     description:
       - A dict of values to pass in as persistent external facter facts.
@@ -104,6 +111,10 @@ EXAMPLES = '''
   puppet:
     tags: update,nginx
 
+- name: Run puppet agent in noop mode
+  puppet:
+    noop: true
+
 - name: Run a manifest with debug, log to both syslog and stdout, specify module path
   puppet:
     modulepath: /etc/puppet/modules:/opt/stack/puppet-modules:/usr/share/openstack-puppet/modules
@@ -148,6 +159,7 @@ def main():
             puppetmaster=dict(type='str'),
             modulepath=dict(type='str'),
             manifest=dict(type='str'),
+            noop=dict(required=False, type='bool'),
             logdest=dict(type='str', default='stdout', choices=['stdout',
                                                                 'syslog',
                                                                 'all']),
@@ -230,8 +242,11 @@ def main():
             cmd += " --certname='%s'" % p['certname']
         if module.check_mode:
             cmd += " --noop"
-        else:
-            cmd += " --no-noop"
+        elif 'noop' in p:
+            if p['noop']:
+                cmd += " --noop"
+            else:
+                cmd += " --no-noop"
     else:
         cmd = "%s apply --detailed-exitcodes " % base_cmd
         if p['logdest'] == 'syslog':
@@ -248,8 +263,11 @@ def main():
             cmd += " --tags '%s'" % ','.join(p['tags'])
         if module.check_mode:
             cmd += "--noop "
-        else:
-            cmd += "--no-noop "
+        elif 'noop' in p:
+            if p['noop']:
+                cmd += " --noop"
+            else:
+                cmd += " --no-noop"
         if p['execute']:
             cmd += " --execute '%s'" % p['execute']
         else:


### PR DESCRIPTION
@emonty 

Current module overrides puppet.conf noop setting by forcing '--no-noop' switch which may not be expected or desired.

 Adds parameter to allow user to control noop mode, or honour local puppet agent configuration.

`noop: None` - Use agent configuration

`noop: true` - Add --noop switch to cmd
`noop: false` - Add --no-noop switch to cmd

*Note:* Ansible check mode always runs with --noop switch

Fixes: #43686
