### PR TITLE
WIP: Deterministic encryption for ansible-vault (Implementing #35480)

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -1241,14 +1241,18 @@ class VaultAES256:
         # assert b_plaintext
 
         b_secret = secret.bytes
-        b_plaintextAndSecret = b_plaintext + b_secret
+        b_plaintextAndSecret = b_secret + b_plaintext
 
         if HAS_CRYPTOGRAPHY:
             digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
             digest.update(b_plaintextAndSecret)
+            b_hash = digest.finalize()
+            digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
+            digest.update(b_hash)
             b_salt = digest.finalize()
         elif HAS_PYCRYPTO:
-            b_salt = SHA256_pycrypto.new(b_plaintextAndSecret).digest()
+            b_hash = SHA256_pycrypto.new(b_plaintextAndSecret).digest()
+            b_salt = SHA256_pycrypto.new(b_hash).digest()
         else:
             b_salt = os.urandom(32)
         return b_salt


### PR DESCRIPTION
##### SUMMARY
The salt that is used for generating the keys and the iv's is now derived from the plaintext and the secret.
Therefore the same key and plaintext generates always the same ciphertext.

Also a minore refactoring is done to simplify implementing of future encryption algorithms.
The encryption whitelist and write_whitelist is now generated dynamically.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Vault

##### ADDITIONAL INFORMATION
Before the salt was derived by calling `os.urandom(32)` which provides 256 random bits.
Now it is derived by:
sha256(b_plaintext + b_secret)
and if either b_plaintext or b_secret is None (what should never happen, except code reuses) the salt is still calculated randomly, as it could simplify brute forcing the plaintext or the passphrase, as an attacker could simply do:
```
for e in dictionary:
  if sha256(e) == sha256(b_plaintext):
    print(e)
    break
```
and if parallel execution of this loop is considered (rewritten for parallel execution), it gets even worse, if you choose weak input. To prevent this, the plaintext and the secret are concatenated, as the secret is said to be secure (and if it is not, we really have other problems) and the plaintext is unknown to the attacker. So the only way an attacker has to brut force is is by trying to decrypt.

Fixes #35480