### PR TITLE
win-async: fix race condition in async run

### DIFF
--- a/test/integration/targets/win_async_wrapper/library/async_test.ps1
+++ b/test/integration/targets/win_async_wrapper/library/async_test.ps1
@@ -1,21 +1,8 @@
 #!powershell
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-# WANT_JSON
-# POWERSHELL_COMMON
+# Copyright: (c) 2018, Ansible Project
+
+#Requires -Module Ansible.ModuleUtils.Legacy
 
 $parsed_args = Parse-Args $args
 

--- a/test/integration/targets/win_async_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_async_wrapper/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: async fire and forget
   async_test:
-    sleep_delay_sec: 8
+    sleep_delay_sec: 10
   async: 20
   poll: 0
   register: asyncresult
@@ -23,7 +23,7 @@
 - name: async poll immediate success
   async_test:
     sleep_delay_sec: 0
-  async: 20
+  async: 10
   poll: 1
   register: asyncresult
 
@@ -61,7 +61,7 @@
 - name: async poll retry
   async_test:
     sleep_delay_sec: 5
-  async: 20
+  async: 10
   poll: 1
   register: asyncresult
 
@@ -97,8 +97,8 @@
 
 - name: async poll timeout
   async_test:
-    sleep_delay_sec: 25
-  async: 20
+    sleep_delay_sec: 5
+  async: 3
   poll: 1
   register: asyncresult
   ignore_errors: true
@@ -152,7 +152,7 @@
 
 - name: echo some non ascii characters
   win_command: cmd.exe /c echo über den Fußgängerübergang gehen
-  async: 20
+  async: 10
   poll: 1
   register: nonascii_output
 


### PR DESCRIPTION
##### SUMMARY
Fixes a race condition where the async results file may not exist in when the child process tries to read from it. This change also adds a trap to log out any errors that occur to a file making it easier to debug issues like this in the future.

Fixes https://github.com/ansible/ansible/issues/42838

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_async

##### ANSIBLE VERSION
```
devel
```

##### ADDITIONAL INFORMATION
No need for backport as this issue was only in the devel branch and has not been part of a release yet.