### PR TITLE
sql lookup plugin using SQLAlchemy

### DIFF
--- a/lib/ansible/plugins/lookup/sql.py
+++ b/lib/ansible/plugins/lookup/sql.py
@@ -6,7 +6,7 @@ __metaclass__ = type
 DOCUMENTATION = """
     lookup: sql
     author: Adam Howard <ahoward0920@gmail.com>
-    version_added: "1.9"
+    version_added: "2.7"
     short_description: query an SQL database using sqlalchemy
     requirements:
         - sqlalchemy (python library, http://www.sqlalchemy.org/)

--- a/lib/ansible/plugins/lookup/sql.py
+++ b/lib/ansible/plugins/lookup/sql.py
@@ -1,0 +1,68 @@
+# (c) 2018, Adam Howard <ahoward0920@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import print_function
+__metaclass__ = type
+
+DOCUMENTATION = """
+    lookup: sql
+    author: Adam Howard <ahoward@utk.edu>
+    short_description: query an SQL database using sqlalchemy
+    requirements:
+        - sqlalchemy (python library, http://www.sqlalchemy.org/)
+    description:
+        - Uses the sqlalchemy python library to run a query against an SQL database.
+        - Supports ``postgres``, ``mysql``, ``sqlite``, and any other database dialects
+          sqlalchemy supports.
+    options:
+        db_url:
+            description: RFC1738-compliant URL for the database to query
+            required: True
+        query:
+            description: the SQL query to perform
+            required: True
+"""
+
+EXAMPLES = """
+    - name: Get all widgets from a local Postgres database
+      debug: msg="{{ lookup('sql', 'postgres://user:pass@localhost/testdb' 'SELECT * FROM widgets') }}"
+    
+    - name: Get all widgets from a SQLite database using a relative path
+      debug: msg="{{ lookup('sql', 'sqlite:///testdb.sqlite' 'SELECT * FROM widgets') }}"
+
+    - name: Get all widgets from a SQLite database using an absolute path
+      debug: msg="{{ lookup('sql', 'sqlite:////path/to/testdb.sqlite' 'SELECT * FROM widgets') }}"
+"""
+
+RETURN = """
+    _list:
+        description:
+            - list of dictionaries, where each of which maps to a row in the 
+              query's results. Keys in each dictionary are the columns of the
+              query.
+"""
+
+from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.plugins.lookup import LookupBase
+
+try:
+    import sqlalchemy
+except ImportError:
+    sqlalchemy = None
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables=None, **kwargs):
+        if sqlalchemy is None:
+            raise AnsibleError("sqlalchemy is not installed")
+        
+        db_url, query = terms[0:2]
+        try:
+            engine = sqlalchemy.create_engine(db_url)
+        except sqlalchemy.exc.ArgumentError as err:
+            raise AnsibleError("db_url: '{0}' is not valid".format(db_url))
+        
+        try:
+            with engine.begin() as conn:
+                result = conn.execute(query)
+                return [dict(row) for row in result.fetchall()]
+        except sqlalchemy.exc.SQLAlchemyError as err:
+            raise AnsibleError("SQLAlchemy error occured: {0}".format(err))

--- a/lib/ansible/plugins/lookup/sql.py
+++ b/lib/ansible/plugins/lookup/sql.py
@@ -5,7 +5,8 @@ __metaclass__ = type
 
 DOCUMENTATION = """
     lookup: sql
-    author: Adam Howard <ahoward@utk.edu>
+    author: Adam Howard <ahoward0920@gmail.com>
+    version_added: "1.9"
     short_description: query an SQL database using sqlalchemy
     requirements:
         - sqlalchemy (python library, http://www.sqlalchemy.org/)

--- a/lib/ansible/plugins/lookup/sql.py
+++ b/lib/ansible/plugins/lookup/sql.py
@@ -1,6 +1,6 @@
 # (c) 2018, Adam Howard <ahoward0920@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-from __future__ import print_function
+from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -25,7 +25,7 @@ DOCUMENTATION = """
 EXAMPLES = """
     - name: Get all widgets from a local Postgres database
       debug: msg="{{ lookup('sql', 'postgres://user:pass@localhost/testdb' 'SELECT * FROM widgets') }}"
-    
+
     - name: Get all widgets from a SQLite database using a relative path
       debug: msg="{{ lookup('sql', 'sqlite:///testdb.sqlite' 'SELECT * FROM widgets') }}"
 
@@ -36,7 +36,7 @@ EXAMPLES = """
 RETURN = """
     _list:
         description:
-            - list of dictionaries, where each of which maps to a row in the 
+            - list of dictionaries, where each of which maps to a row in the
               query's results. Keys in each dictionary are the columns of the
               query.
 """
@@ -49,17 +49,18 @@ try:
 except ImportError:
     sqlalchemy = None
 
+
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
         if sqlalchemy is None:
             raise AnsibleError("sqlalchemy is not installed")
-        
+
         db_url, query = terms[0:2]
         try:
             engine = sqlalchemy.create_engine(db_url)
         except sqlalchemy.exc.ArgumentError as err:
             raise AnsibleError("db_url: '{0}' is not valid".format(db_url))
-        
+
         try:
             with engine.begin() as conn:
                 result = conn.execute(query)


### PR DESCRIPTION
##### SUMMARY
This PR adds a lookup plugin 'sql' for querying SQL databases. It uses SQLAlchemy under the hood to be compatible with as many databses as possible. 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
lib/ansible/plugins/lookup/sql.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/adam/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adam/ansible_dev/venv/lib/python2.7/site-packages/ansible-2.7.0.dev0-py2.7.egg/ansible
  executable location = /home/adam/ansible_dev/venv/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
