### PR TITLE
win_domain modules: ensure Netlogon service is still running after promotion

### DIFF
--- a/changelogs/fragments/win_domain_controller-netlogon.yaml
+++ b/changelogs/fragments/win_domain_controller-netlogon.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- win_domain - ensure the Netlogon service is up and running after promoting host to controller - https://github.com/ansible/ansible/issues/39235
+- win_domain_controller - ensure the Netlogon service is up and running after promoting host to controller - https://github.com/ansible/ansible/issues/39235

--- a/lib/ansible/modules/windows/win_domain.ps1
+++ b/lib/ansible/modules/windows/win_domain.ps1
@@ -75,6 +75,17 @@ If(-not $forest) {
         $iaf = Install-ADDSForest @install_forest_args
 
         $result.reboot_required = $iaf.RebootRequired
+
+        # The Netlogon service is set to auto start but is not started. This is
+        # required for Ansible to connect back to the host and reboot in a
+        # later task. Even if this fails Ansible can still connect but only
+        # with ansible_winrm_transport=basic so we just display a warning if
+        # this fails.
+        try {
+            Start-Service -Name Netlogon
+        } catch {
+            Add-Warning -obj $result -message "Failed to start the Netlogon service after promoting the host, Ansible may be unable to connect until the host is manually rebooting: $($_.Exception.Message)"
+        }
     }
 }
 

--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -213,7 +213,20 @@ Try {
                 }
                 $install_result = Install-ADDSDomainController -NoRebootOnCompletion -Force @install_params
 
-                Write-DebugLog "Installation completed, needs reboot..."
+                Write-DebugLog "Installation complete, trying to start the Netlogon service"
+                # The Netlogon service is set to auto start but is not started. This is
+                # required for Ansible to connect back to the host and reboot in a
+                # later task. Even if this fails Ansible can still connect but only
+                # with ansible_winrm_transport=basic so we just display a warning if
+                # this fails.
+                try {
+                    Start-Service -Name Netlogon
+                } catch {
+                    Write-DebugLog "Failed to start the Netlogon service: $($_.Exception.Message)"
+                    Add-Warning -obj $result -message "Failed to start the Netlogon service after promoting the host, Ansible may be unable to connect until the host is manually rebooting: $($_.Exception.Message)"
+                }
+
+                Write-DebugLog "Domain Controller setup completed, needs reboot..."
             }
         }
         member_server {


### PR DESCRIPTION
##### SUMMARY
When promoting a server to a domain controller, Ansible is unable to authenticate to the server unless it is manually rebooted, the `Netlogon` service is started manually, or `basic` auth is used. This change tries to start the `Netlogon` service manually before returning back to the host so subsequent calls like `win_reboot` can reboot the host.

Fixes https://github.com/ansible/ansible/issues/39235

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_domain
win_domain_controller

##### ANSIBLE VERSION
```
2.6
devel
```