### PR TITLE
Add Scaleway ip address management

### DIFF
--- a/lib/ansible/modules/cloud/scaleway/scaleway_ip.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_ip.py
@@ -1,0 +1,221 @@
+#!/usr/bin/python
+#
+# Scaleway ip management module
+#
+# Copyright (C) 2018 Antoine Barbare (antoinebarbare@gmail.com).
+#
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: scaleway_ip
+short_description: Scaleway ip management module
+version_added: "2.7"
+author: Antoine Barbare (@_abarbare)
+description:
+    - This module manages ips on Scaleway account
+      U(https://developer.scaleway.com)
+
+options:
+  server_id:
+    description:
+    - Scaleway Compute instance ID of the server
+    required: true
+  state:
+    description:
+     - Indicate desired state of the ip.
+    required: true
+    choices:
+      - present
+      - absent
+  oauth_token:
+    description:
+     - Scaleway OAuth token.
+    required: true
+  region:
+    description:
+     - Scaleway region to use (for example par1).
+    required: true
+    choices:
+      - ams1
+      - EMEA-NL-EVS
+      - par1
+      - EMEA-FR-PAR1
+  organization:
+    description:
+     - ScaleWay organization ID to which ip belongs.
+  timeout:
+    description:
+    - Timeout for API calls
+    default: 30
+'''
+
+EXAMPLES = '''
+  - name: Create a public IPv4 address
+    scaleway_ip:
+      server_id: '1f7751cf-5a49-4ba1-9ade-cc4cb5d7d2b0'
+      state: present
+      region: par1
+      organization: "{{ scw_org }}"
+    register: server_creation_check_task
+
+  - name: Make sure public IPv4 deleted
+    scaleway_ip:
+      server_id: '1f7751cf-5a49-4ba1-9ade-cc4cb5d7d2b0'
+      state: absent
+      region: par1
+
+'''
+
+RETURN = '''
+data:
+    description: This is only present when C(state=present)
+    returned: when C(state=present)
+    type: dict
+    sample: {
+      "ip": {
+        "organization": "eea95185-710a-4916-991a-4e1fd4b0a3688",
+        "reverse": null,
+        "id": "cc45f92b-4a0a-4857-baa6-76129f795a98",
+        "server": {
+            "id": "1f7751cf-5a49-4ba1-9ade-cc4cb5d7d2b0",
+            "name": "scw-440740"
+        },
+        "address": "51.15.232.254"
+    }
+}
+'''
+
+from ansible.module_utils.scaleway import ScalewayAPI, SCALEWAY_LOCATION
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.scaleway import ScalewayAPI
+
+
+def delete_ip_address(compute_api, ip_id):
+    response = compute_api.delete('/ips/%s' % ip_id)
+
+    if not response.ok:
+        msg = 'Error during IP address deleting: (%s) %s' % response.status_code, response.body
+        compute_api.module.fail_json(msg=msg)
+
+    return response
+
+
+def patch_ip_address(compute_api, server_id, ip_id):
+    payload = {'server': server_id}
+    response = compute_api.patch('/ips/%s' % ip_id, payload)
+
+    if not response.ok:
+        msg = 'Error attaching ip address: (%s) %s' % (
+            response.status_code, response.body)
+        compute_api.module.fail_json(msg=msg)
+
+    return response.json
+
+
+def post_ip_address(compute_api, organization):
+    payload = {'organization': organization}
+    response = compute_api.post('/ips', payload)
+
+    if not response.ok:
+        msg = 'Error during ip reservation: (%s) %s' % (
+            response.status_code, response.body)
+        compute_api.module.fail_json(msg=msg)
+
+    return response.json
+
+
+def get_server_info(compute_api, server_id):
+    compute_api.module.debug('Get server details')
+    response = compute_api.get('servers/%s' % server_id)
+
+    if not response.ok:
+        msg = 'Error during server information processing: (%s) %s' % (
+            response.status_code, response.body)
+        compute_api.module.fail_json(msg=msg)
+
+    return response.json['server']
+
+
+def core(module):
+    api_token = module.params['oauth_token']
+    region = module.params['region']
+    state = module.params['state']
+    organization = module.params['organization']
+    server_id = module.params['server_id']
+
+    compute_api = ScalewayAPI(
+        module,
+        headers={
+            'X-Auth-Token': api_token},
+        base_url=SCALEWAY_LOCATION[region]['api_endpoint'])
+
+    response = compute_api.get('ips')
+    status_code = response.status_code
+
+    if not response.ok:
+        module.fail_json(msg='Error getting ip [{0}: {1}]'.format(
+            status_code, response.json['message']))
+
+    server_info = get_server_info(compute_api, server_id)
+
+    if state in ('present',):
+        if server_info['public_ip'] and not server_info['public_ip']['dynamic']:
+            module.exit_json(changed=False)
+
+        if module.check_mode:
+            module.exit_json(changed=True)
+
+        ip = post_ip_address(compute_api, organization)
+        patch_ip_address(compute_api, server_id, ip['ip']['id'])
+        module.exit_json(changed=True, data=ip)
+
+    elif state in ('absent',):
+        if not server_info['public_ip'] or server_info['public_ip']['dynamic']:
+            module.exit_json(changed=False)
+
+        if module.check_mode:
+            module.exit_json(changed=True)
+
+        response = delete_ip_address(
+            compute_api, server_info['public_ip']['id'])
+        module.exit_json(changed=True, data=response.json)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            oauth_token=dict(
+                no_log=True,
+                # Support environment variable for Scaleway OAuth Token
+                fallback=(
+                    env_fallback, [
+                        'SCW_TOKEN', 'SCW_API_KEY', 'SCW_OAUTH_TOKEN']),
+                required=True,
+            ),
+            state=dict(choices=['present', 'absent'], required=True),
+            organization=dict(required=True),
+            server_id=dict(required=True),
+            timeout=dict(type='int', default=30),
+            region=dict(required=True, choices=SCALEWAY_LOCATION.keys()),
+        ),
+        supports_check_mode=True,
+    )
+
+    core(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/legacy/scaleway_ip_address.yml
+++ b/test/legacy/scaleway_ip_address.yml
@@ -1,0 +1,118 @@
+# SCW_API_KEY='XXX' ansible-playbook ./test/legacy/scaleway_ip_address.yml
+
+- name: Test ip address lifecyle on a Scaleway instance
+  hosts: localhost
+  gather_facts: no
+  environment:
+    SCW_API_KEY: "{{ lookup('env', 'SCW_API_KEY') }}"
+
+  tasks:
+
+  - name: Create a server
+    scaleway_compute:
+      name: foobar
+      state: present
+      image: 857de28c-39ce-4b15-9389-b68d8bb1bb51
+      organization: 43a3b6c8-916f-477b-b7ec-ff1898f5fdd9
+      region: par1
+      commercial_type: START1-S
+      wait: true
+
+    register: server_creation_task
+
+  - debug: var=server_creation_task
+
+  - set_fact:
+      server_id: "{{ server_creation_task.msg.id }}"
+
+  - debug: var=server_id
+
+  - name: Check mode static ip reservation
+    check_mode: yes
+    scaleway_ip:
+      state: present
+      region: par1
+      server_id: "{{ server_id }}"
+      organization: 43a3b6c8-916f-477b-b7ec-ff1898f5fdd9
+    register: server_ip_check_task
+
+  - debug: var=server_ip_check_task
+
+  - assert:
+      that:
+        - server_ip_check_task is success
+        - server_ip_check_task is changed    
+
+  - name: Reserve static ip address
+    scaleway_ip:
+      state: present
+      region: par1
+      server_id: "{{ server_id }}"
+      organization: 43a3b6c8-916f-477b-b7ec-ff1898f5fdd9
+    register: server_ip_check_task
+
+  - debug: var=server_ip_check_task
+
+  - assert:
+      that:
+        - server_ip_check_task is success
+        - server_ip_check_task is changed
+
+  - name: Reserve static ip address (Confirmation)
+    scaleway_ip:
+      state: present
+      region: par1
+      server_id: "{{ server_id }}"
+      organization: 43a3b6c8-916f-477b-b7ec-ff1898f5fdd9
+    register: server_ip_check_confirmation_task
+
+  - debug: var=server_ip_check_confirmation_task
+
+  - assert:
+      that:
+        - server_ip_check_confirmation_task is success
+        - server_ip_check_confirmation_task is not changed
+
+  - name: Check mode delete static ip address
+    check_mode: yes
+    scaleway_ip:
+      state: absent
+      region: par1
+      server_id: "{{ server_id }}"
+      organization: 43a3b6c8-916f-477b-b7ec-ff1898f5fdd9
+    register: server_ip_delete_task
+
+  - debug: var=server_ip_delete_task
+
+  - assert:
+      that:
+        - server_ip_delete_task is success
+        - server_ip_delete_task is changed
+
+  - name: Delete static ip address
+    scaleway_ip:
+      state: absent
+      region: par1
+      server_id: "{{ server_id }}"
+      organization: 43a3b6c8-916f-477b-b7ec-ff1898f5fdd9
+    register: server_ip_delete_task
+
+  - debug: var=server_ip_delete_task
+
+  - assert:
+      that:
+        - server_ip_delete_task is success
+        - server_ip_delete_task is changed
+
+  - name: Destroy it
+    scaleway_compute:
+      name: foobar
+      state: absent
+      region: par1
+      image: 857de28c-39ce-4b15-9389-b68d8bb1bb51
+      organization: 43a3b6c8-916f-477b-b7ec-ff1898f5fdd9
+      commercial_type: START1-S
+      wait: true
+    register: server_destroy_task
+
+  - debug: var=server_destroy_task


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This merge request adds a Scaleway module to manage IPv4 address on a Scaleway instance. It is especially useful to use a non-dynamic IP address to be able to move this IP to another server.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
scaleway_ip

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /Users/abarbare/.ansible.cfg
  configured module search path = [u'/Users/abarbare/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.6.0/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/Cellar/ansible/2.6.0/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```
