### PR TITLE
Add documentation about mandatory naming convention

### DIFF
--- a/lib/ansible/plugins/inventory/scaleway.py
+++ b/lib/ansible/plugins/inventory/scaleway.py
@@ -51,6 +51,7 @@ DOCUMENTATION = '''
 EXAMPLES = '''
 # scaleway_inventory.yml file in YAML format
 # Example command line: ansible-inventory --list -i scaleway_inventory.yml
+# Warning: You need to have scaleway in your inventory name
 
 plugin: scaleway
 regions:
@@ -156,6 +157,7 @@ class InventoryModule(BaseInventoryPlugin):
     NAME = 'scaleway'
 
     def verify_file(self, path):
+        # It is mandatory to have "scaleway" in the path name of your inventory
         return "scaleway" in path
 
     def _fill_host_variables(self, host, server_info):


### PR DESCRIPTION
##### SUMMARY

Add a little documentation about naming convention of the scaleway inventory module

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

- scaleway dynamic inventory

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (inventory_documentation 929350d597) last updated 2018/08/06 14:29:05 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```


##### ADDITIONAL INFORMATION

I'm not sure if this naming convention is mandatory. I've did it mostly to have the `verify_file` method working with something that made sense. But I can modify the plugin to return True on all files.