### PR TITLE
ignore empty lines in rabbitmqctl output

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_parameter.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_parameter.py
@@ -78,7 +78,7 @@ class RabbitMqParameter(object):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
             cmd = [self._rabbitmqctl, '-q', '-n', self.node]
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
-            return out.splitlines()
+            return [line for line in out.splitlines() if line != '']
         return list()
 
     def get(self):

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_parameter.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_parameter.py
@@ -78,7 +78,7 @@ class RabbitMqParameter(object):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
             cmd = [self._rabbitmqctl, '-q', '-n', self.node]
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
-            return [line for line in out.splitlines() if line != '']
+            return out.strip().splitlines()
         return list()
 
     def get(self):


### PR DESCRIPTION
##### SUMMARY
this fixes a bug with rabbitmq 3.7.5
rabbitmqctl can return empty lines, breaking the rabbitmq_parameter module
especially in a new vhost, the command rabbitmqctl list_parameters -q -p <vhost> will return an empty line

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_parameters

##### ANSIBLE VERSION
```
ansible 2.5.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/fdeschamps/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]
```

