### PR TITLE
Extends 'which notation should I use' section in FAQ

### DIFF
--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -454,7 +454,7 @@ Ansible supports dot notation and array notation for variables. Which notation s
 The dot notation comes from Jinja and works fine for variables without special
 characters. If your variable contains dots (.), colons (:), or dashes (-), if
 a key begins and ends with two underscores, or if a key uses any of the known
-public attributes, it is safer to use the array notation. See :doc:`../user_guide/playbooks_variables`
+public attributes, it is safer to use the array notation. See :ref:`playbooks_variables`
 for a list of the known public attributes.
 
 .. code-block:: jinja

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -452,8 +452,10 @@ Ansible supports dot notation and array notation for variables. Which notation s
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 The dot notation comes from Jinja and works fine for variables without special
-characters. If your variable contains dots (.), colons (:), or dashes (-) it is
-safer to use the array notation for variables.
+characters. If your variable contains dots (.), colons (:), or dashes (-), if
+a key begins and ends with two underscores, or if a key uses any of the known
+public attributes, it is safer to use the array notation. See :doc:`../user_guide/playbooks_variables`
+for a list of the known public attributes.
 
 .. code-block:: jinja
 


### PR DESCRIPTION
- gh-11524

##### SUMMARY

Expands documentation of "Which notation should I use?" [in FAQ section](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#ansible-supports-dot-notation-and-array-notation-for-variables-which-notation-should-i-use).

See [comment](https://github.com/ansible/ansible/issues/11524#issuecomment-410778422) in #11524.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

Docs.

##### ANSIBLE VERSION

```ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/ctorgalson/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jul 23 2018, 21:27:06) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION

I'm not sure what the docs use to process RST, so I have _not_ used a named anchor in the PR to link to the specific section. I can update the PR if anyone can enlighten me on the right format for relative link to a named anchor in the docs.
