### PR TITLE
Force all args to strings for 'command' (fixes #43732)

### DIFF
--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -133,6 +133,8 @@ import os
 import shlex
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible.module_utils.common.collections import is_iterable
 
 
 def check_command(module, commandline):
@@ -214,6 +216,10 @@ def main():
         args = shlex.split(args)
 
     args = args or argv
+
+    # All args must be strings
+    if is_iterable(args, include_strings=False):
+        args = [to_native(arg, errors='surrogate_or_strict', nonstring='simplerepr') for arg in args]
 
     if chdir:
         chdir = os.path.abspath(chdir)


### PR DESCRIPTION
##### SUMMARY
Using integers in `argv` to `command` breaks, so we force all args to strings.

This fixes #43732 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`command` module

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (command_argv_strings 607f9d6b74) last updated 2018/08/06 14:46:40 (GMT -500)
```

##### ADDITIONAL INFORMATION
N/A