### PR TITLE
ACI: Add ability to enable debug for tests

### DIFF
--- a/test/integration/targets/aci_aaa_user/tasks/main.yml
+++ b/test/integration/targets/aci_aaa_user/tasks/main.yml
@@ -18,6 +18,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     aaa_user: ansible
     state: absent
 
@@ -31,6 +32,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     aaa_user: ansible
     description: Ansible test user
     email: ansible@ansible.lan
@@ -75,6 +77,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     aaa_user: ansible
     description: Ansible test user for integration tests
     email: aci-ansible@ansible.lan
@@ -113,6 +116,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     aaa_user: ansible
     state: query
   check_mode: yes

--- a/test/integration/targets/aci_aaa_user_certificate/tasks/main.yml
+++ b/test/integration/targets/aci_aaa_user_certificate/tasks/main.yml
@@ -18,6 +18,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     aaa_user: admin
     certificate_name: admin
     state: absent
@@ -32,6 +33,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     aaa_user: admin
     certificate_name: admin
     certificate: "{{ lookup('file', 'pki/admin.crt') }}"
@@ -69,6 +71,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     aaa_user: admin
     state: query
   check_mode: yes

--- a/test/integration/targets/aci_aep/tasks/main.yml
+++ b/test/integration/targets/aci_aep/tasks/main.yml
@@ -18,7 +18,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     aep: ansible_test
     state: absent
 
@@ -32,7 +32,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     aep: ansible_test
     state: present
   check_mode: yes
@@ -141,6 +141,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     state: query
   check_mode: yes
   register: cm_query_all_aeps
@@ -249,7 +250,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     state: present
   ignore_errors: yes
   register: error_on_missing_required_param

--- a/test/integration/targets/aci_aep_to_domain/tasks/main.yml
+++ b/test/integration/targets/aci_aep_to_domain/tasks/main.yml
@@ -13,7 +13,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     aep: test_aep
     domain: phys_dom
     domain_type: phys
@@ -27,6 +27,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     aep: test_aep
     description: Test AEP
     state: present
@@ -39,6 +40,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     domain: phys_dom
     domain_type: phys
     state: present
@@ -53,7 +55,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     aep: test_aep
     domain: phys_dom
     domain_type: phys
@@ -98,6 +100,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     state: query
   check_mode: yes
   register: cm_query_all_bindings

--- a/test/integration/targets/aci_contract/tasks/main.yml
+++ b/test/integration/targets/aci_contract/tasks/main.yml
@@ -17,8 +17,8 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    state: present
     tenant: anstest
+    state: present
   register: tenant_present
 
 - name: create contract - check mode works

--- a/test/integration/targets/aci_contract_subject_to_filter/tasks/main.yml
+++ b/test/integration/targets/aci_contract_subject_to_filter/tasks/main.yml
@@ -16,9 +16,9 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
-    state: present
+    output_level: '{{ aci_output_level | default("info") }}'
     tenant: anstest
+    state: present
   register: tenant_present
 
 - name: ensure filter exists for tests to kick off

--- a/test/integration/targets/aci_domain/tasks/fc.yml
+++ b/test/integration/targets/aci_domain/tasks/fc.yml
@@ -13,7 +13,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain: fc_dom
     domain_type: fc
     state: absent
@@ -28,7 +28,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain: fc_dom
     domain_type: fc
     state: present
@@ -72,7 +72,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain_type: fc
     state: query
   check_mode: yes

--- a/test/integration/targets/aci_domain/tasks/l2dom.yml
+++ b/test/integration/targets/aci_domain/tasks/l2dom.yml
@@ -13,7 +13,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain: l2_dom
     domain_type: l2dom
     state: absent
@@ -28,7 +28,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain: l2_dom
     domain_type: l2dom
     state: present
@@ -72,7 +72,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain_type: l2dom
     state: query
   check_mode: yes

--- a/test/integration/targets/aci_domain/tasks/l3dom.yml
+++ b/test/integration/targets/aci_domain/tasks/l3dom.yml
@@ -13,7 +13,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain: l3_dom
     domain_type: l3dom
     state: absent
@@ -28,7 +28,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain: l3_dom
     domain_type: l3dom
     state: present
@@ -72,7 +72,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain_type: l3dom
     state: query
   check_mode: yes

--- a/test/integration/targets/aci_domain/tasks/phys.yml
+++ b/test/integration/targets/aci_domain/tasks/phys.yml
@@ -13,7 +13,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain: phys_dom
     domain_type: phys
     state: absent
@@ -28,7 +28,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain: phys_dom
     domain_type: phys
     state: present
@@ -72,7 +72,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain_type: phys
     state: query
   check_mode: yes

--- a/test/integration/targets/aci_domain/tasks/vmm-vmware.yml
+++ b/test/integration/targets/aci_domain/tasks/vmm-vmware.yml
@@ -13,7 +13,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain: vmm_dom
     domain_type: vmm
     vm_provider: vmware
@@ -29,7 +29,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain: vmm_dom
     domain_type: vmm
     vm_provider: vmware
@@ -75,7 +75,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain_type: vmm
     vm_provider: vmware
     state: query

--- a/test/integration/targets/aci_domain_to_vlan_pool/tasks/main.yml
+++ b/test/integration/targets/aci_domain_to_vlan_pool/tasks/main.yml
@@ -13,7 +13,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain: phys_dom
     domain_type: phys
     pool: test_pool
@@ -28,6 +28,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     domain: phys_dom
     domain_type: phys
     state: absent
@@ -40,6 +41,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     pool: test_pool
     pool_allocation_mode: dynamic
     description: Test VLAN pool
@@ -55,7 +57,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain: phys_dom
     domain_type: phys
     pool: test_pool
@@ -101,7 +103,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     domain_type: phys
     pool_allocation_mode: dynamic
     state: query

--- a/test/integration/targets/aci_encap_pool/tasks/vsan.yml
+++ b/test/integration/targets/aci_encap_pool/tasks/vsan.yml
@@ -7,7 +7,8 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    state: absent
+    output_level: '{{ aci_output_level | default("info") }}'
     pool: anstest
     pool_type: vsan
     pool_allocation_mode: static
+    state: absent

--- a/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
+++ b/test/integration/targets/aci_encap_pool_range/tasks/vlan.yml
@@ -6,6 +6,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     state: absent
     pool: anstest
     pool_type: vlan

--- a/test/integration/targets/aci_encap_pool_range/tasks/vsan.yml
+++ b/test/integration/targets/aci_encap_pool_range/tasks/vsan.yml
@@ -6,11 +6,12 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    state: present
+    output_level: '{{ aci_output_level | default("info") }}'
     pool: anstest
     pool_type: vsan
     allocation_mode: static
     description: Ansible Test
+    state: present
 
 - name: cleanup vsan pool
   aci_encap_pool:

--- a/test/integration/targets/aci_encap_pool_range/tasks/vxlan.yml
+++ b/test/integration/targets/aci_encap_pool_range/tasks/vxlan.yml
@@ -6,10 +6,11 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    state: present
+    output_level: '{{ aci_output_level | default("info") }}'
     pool: anstest
     pool_type: vxlan
     description: Ansible Test
+    state: present
 
 - name: cleanup vxlan pool
   aci_encap_pool:

--- a/test/integration/targets/aci_epg_to_contract/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_contract/tasks/main.yml
@@ -17,8 +17,8 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    state: present
     tenant: anstest
+    state: present
   register: tenant_present
 
 - name: ensure contracts exist for tests to kick off

--- a/test/integration/targets/aci_epg_to_domain/tasks/main.yml
+++ b/test/integration/targets/aci_epg_to_domain/tasks/main.yml
@@ -17,8 +17,8 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    state: present
     tenant: anstest
+    state: present
   register: tenant_present
 
 - name: ensure ap exists for tests to kick off
@@ -41,6 +41,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     method: post
     path: api/mo/uni/phys-anstest.json
     content: {"physDomP": {"attributes": {}}}

--- a/test/integration/targets/aci_fabric_node/tasks/main.yml
+++ b/test/integration/targets/aci_fabric_node/tasks/main.yml
@@ -18,7 +18,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     serial: ansible_test
     node_id: 105
     state: absent
@@ -123,6 +123,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     state: query
   check_mode: yes
   register: cm_query_all_fabric_nodes

--- a/test/integration/targets/aci_filter/tasks/main.yml
+++ b/test/integration/targets/aci_filter/tasks/main.yml
@@ -17,6 +17,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     tenant: ansible_test
     state: present
 
@@ -28,6 +29,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     tenant: ansible_test
     filter: filter_test
     state: absent
@@ -41,6 +43,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     tenant: ansible_test
     filter: filter_test
     state: present
@@ -128,6 +131,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     state: query
   check_mode: yes
   register: cm_query_all_filters

--- a/test/integration/targets/aci_filter_entry/tasks/main.yml
+++ b/test/integration/targets/aci_filter_entry/tasks/main.yml
@@ -16,8 +16,9 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    state: absent
+    output_level: '{{ aci_output_level | default("info") }}'
     tenant: anstest
+    state: absent
 
 - name: ensure tenant exists for tests to kick off
   aci_tenant: &aci_tenant_present
@@ -28,8 +29,8 @@
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: debug
-    state: present
     tenant: anstest
+    state: present
   register: tenant_present
 
 - name: ensure filter exists for tests to kick off

--- a/test/integration/targets/aci_firmware_source/tasks/main.yml
+++ b/test/integration/targets/aci_firmware_source/tasks/main.yml
@@ -13,7 +13,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     source: aci-msft-pkg-3.1.1i.zip
     state: absent
 
@@ -27,7 +27,7 @@
 #    validate_certs: '{{ aci_validate_certs | default(false) }}'
 #    use_ssl: '{{ aci_use_ssl | default(true) }}'
 #    use_proxy: '{{ aci_use_proxy | default(true) }}'
-#    output_level: info
+#    output_level: '{{ aci_output_level | default("info") }}'
 #    source: aci-msft-pkg-3.1.1i.zip
 #    url: foobar.cisco.com/download/cisco/aci/aci-msft-pkg-3.1.1i.zip
 #    url_protocol: http
@@ -74,6 +74,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     state: query
   check_mode: yes
   register: cm_query_all_sources
@@ -177,7 +178,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     state: present
   ignore_errors: yes
   register: error_on_missing_required_param

--- a/test/integration/targets/aci_interface_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_interface_policy_leaf_profile/tasks/main.yml
@@ -18,6 +18,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     leaf_interface_profile: ansible_test
     state: absent
 
@@ -31,6 +32,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     leaf_interface_profile: ansible_test
     state: present
   check_mode: yes
@@ -115,6 +117,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     state: query
   check_mode: yes
   register: cm_query_all_leaf_interface_profiles

--- a/test/integration/targets/aci_interface_policy_ospf/tasks/main.yml
+++ b/test/integration/targets/aci_interface_policy_ospf/tasks/main.yml
@@ -31,6 +31,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     tenant: anstest
     ospf: ansible_ospf
     state: absent
@@ -45,6 +46,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     tenant: anstest
     ospf: ansible_ospf
     state: present
@@ -130,6 +132,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     tenant: anstest
     state: query
   check_mode: yes

--- a/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_interface_selector_to_switch_policy_leaf_profile/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     leaf_profile: swleafprftest
     state: absent
 
@@ -27,6 +28,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     leaf_interface_profile: leafintprftest
     state: absent
 
@@ -51,7 +53,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     leaf_interface_profile: leafintprftest
     state: present
   register: leaf_profile_present

--- a/test/integration/targets/aci_rest/tasks/json_inline.yml
+++ b/test/integration/targets/aci_rest/tasks/json_inline.yml
@@ -13,6 +13,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].json
     method: delete
 
@@ -25,6 +26,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni.json
     method: post
     content:
@@ -58,6 +60,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni.json
     method: post
     content:
@@ -103,6 +106,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].json
     method: get
   delegate_to: localhost
@@ -122,6 +126,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].json
     method: get
   delegate_to: localhost

--- a/test/integration/targets/aci_rest/tasks/json_string.yml
+++ b/test/integration/targets/aci_rest/tasks/json_string.yml
@@ -13,6 +13,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].json
     method: delete
 
@@ -25,6 +26,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni.json
     method: post
     content: |
@@ -56,6 +58,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni.json
     method: post
     content: |
@@ -98,6 +101,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].json
     method: get
   register: nm_query_all_tenants
@@ -116,6 +120,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].json
     method: get
   register: nm_query_tenant

--- a/test/integration/targets/aci_rest/tasks/xml_string.yml
+++ b/test/integration/targets/aci_rest/tasks/xml_string.yml
@@ -13,6 +13,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].xml
     method: delete
 
@@ -25,6 +26,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni.xml
     method: post
     content: |
@@ -50,6 +52,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni.xml
     method: post
     content: |
@@ -85,6 +88,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].xml
     method: get
   register: nm_query_all_tenants
@@ -103,6 +107,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].xml
     method: get
   register: nm_query_tenant

--- a/test/integration/targets/aci_rest/tasks/yaml_inline.yml
+++ b/test/integration/targets/aci_rest/tasks/yaml_inline.yml
@@ -13,6 +13,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].json
     method: delete
 
@@ -25,6 +26,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni.json
     method: post
     content:
@@ -52,6 +54,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni.json
     method: post
     content:
@@ -90,6 +93,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].json
     method: get
   register: nm_query_all_tenants
@@ -108,6 +112,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].json
     method: get
   register: nm_query_tenant

--- a/test/integration/targets/aci_rest/tasks/yaml_string.yml
+++ b/test/integration/targets/aci_rest/tasks/yaml_string.yml
@@ -13,6 +13,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].json
     method: delete
 
@@ -25,6 +26,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni.json
     method: post
     content: |
@@ -52,6 +54,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni.json
     method: post
     content: |
@@ -90,6 +93,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].json
     method: get
   register: nm_query_all_tenants
@@ -108,6 +112,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     path: /api/mo/uni/tn-[ansible_test].json
     method: get
   register: nm_query_tenant

--- a/test/integration/targets/aci_switch_leaf_policy_profile/tasks/main.yml
+++ b/test/integration/targets/aci_switch_leaf_policy_profile/tasks/main.yml
@@ -18,6 +18,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     leaf_profile: ansible_test
     state: absent
 
@@ -31,6 +32,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     leaf_profile: ansible_test
     state: present
   check_mode: yes
@@ -115,6 +117,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     state: query
   check_mode: yes
   register: cm_query_all_switch_leaf_profiles

--- a/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
+++ b/test/integration/targets/aci_switch_leaf_selector/tasks/main.yml
@@ -16,6 +16,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     leaf_profile: sw_name_test
     state: absent
 

--- a/test/integration/targets/aci_switch_policy_vpc_protection_group/tasks/main.yml
+++ b/test/integration/targets/aci_switch_policy_vpc_protection_group/tasks/main.yml
@@ -17,6 +17,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     protection_group: ansible_test
     state: absent
 
@@ -30,6 +31,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     protection_group: ansible_test
     protection_group_id: 6
     switch_1_id: 3811
@@ -120,6 +122,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     state: query
   check_mode: yes
   register: cm_query_all_vpc_prot_grps

--- a/test/integration/targets/aci_taboo_contract/tasks/main.yml
+++ b/test/integration/targets/aci_taboo_contract/tasks/main.yml
@@ -13,7 +13,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     tenant: ansible_test
     taboo_contract: taboo_contract_test
     state: absent
@@ -26,7 +26,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     tenant: ansible_test
     state: present
 
@@ -40,7 +40,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     tenant: ansible_test
     taboo_contract: taboo_contract_test
     state: present
@@ -151,6 +151,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     state: query
   check_mode: yes
   register: cm_query_all_taboo_contracts
@@ -263,7 +264,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     state: present
   ignore_errors: yes
   register: error_on_missing_required_param

--- a/test/integration/targets/aci_tenant/tasks/main.yml
+++ b/test/integration/targets/aci_tenant/tasks/main.yml
@@ -18,6 +18,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     tenant: ansible_test
     state: absent
 
@@ -31,6 +32,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     tenant: ansible_test
     state: present
   check_mode: yes
@@ -115,6 +117,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     state: query
   check_mode: yes
   register: cm_query_all_tenants

--- a/test/integration/targets/aci_vlan_pool/tasks/dynamic.yml
+++ b/test/integration/targets/aci_vlan_pool/tasks/dynamic.yml
@@ -12,7 +12,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     pool: anstest
     pool_allocation_mode: dynamic
     state: absent
@@ -27,7 +27,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     pool: anstest
     pool_allocation_mode: dynamic
     state: present
@@ -140,6 +140,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     state: query
   check_mode: yes
   register: cm_query_all_dynamic_vlan_pools
@@ -253,7 +254,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     state: present
   ignore_errors: yes
   register: error_on_missing_required_param
@@ -272,7 +273,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     pool: anstest
     state: present
   ignore_errors: yes

--- a/test/integration/targets/aci_vlan_pool/tasks/static.yml
+++ b/test/integration/targets/aci_vlan_pool/tasks/static.yml
@@ -12,7 +12,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     pool: anstest
     pool_allocation_mode: static
     state: absent
@@ -27,7 +27,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     pool: anstest
     pool_allocation_mode: static
     state: present
@@ -140,6 +140,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     state: query
   check_mode: yes
   register: cm_query_all_static_vlan_pools
@@ -253,7 +254,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     state: present
   ignore_errors: yes
   register: error_on_missing_required_param
@@ -272,7 +273,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: info
+    output_level: '{{ aci_output_level | default("info") }}'
     pool: anstest
     state: present
   ignore_errors: yes

--- a/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
+++ b/test/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
@@ -17,6 +17,7 @@
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
     use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
     state: absent
     pool: anstest
     allocation_mode: static


### PR DESCRIPTION
##### SUMMARY
This facilitates comparing tests before and after commits by enabling debug output.

This relates to #43441 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ACI tests

##### ANSIBLE VERSION
v2.7