### PR TITLE
[Ready To Review] implement part of #27617 [expend checksum format to <algorithm>:(<checksum>|<url>)]

### DIFF
--- a/changelogs/fragments/get_url.yaml
+++ b/changelogs/fragments/get_url.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+- get_url - implement [expend checksum format to <algorithm>:(<checksum>|<url>)] (https://github.com/ansible/ansible/issues/27617)
+
+bugfixes:
+- get_url - fix the bug that get_url does not change mode when checksum matches (https://github.com/ansible/ansible/issues/29614)

--- a/changelogs/fragments/get_url_bug_fix.yaml
+++ b/changelogs/fragments/get_url_bug_fix.yaml
@@ -1,2 +1,3 @@
 bugfixes:
 - get_url - fix the bug that get_url does not change mode when checksum matches (https://github.com/ansible/ansible/issues/29614)
+- get_url - implement [expend checksum format to <algorithm>:(<checksum>|<url>)] (https://github.com/ansible/ansible/issues/27617)

--- a/changelogs/fragments/get_url_bug_fix.yaml
+++ b/changelogs/fragments/get_url_bug_fix.yaml
@@ -1,3 +1,0 @@
-bugfixes:
-- get_url - fix the bug that get_url does not change mode when checksum matches (https://github.com/ansible/ansible/issues/29614)
-- get_url - implement [expend checksum format to <algorithm>:(<checksum>|<url>)] (https://github.com/ansible/ansible/issues/27617)

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -433,7 +433,10 @@ def main():
     # checksum specified, parse for algorithm and checksum
     if checksum:
         try:
-            algorithm, checksum = checksum.rsplit(':', 1)
+            algorithm, checksum = checksum.split(':', 1)
+            if checksum.startswith('http://') or checksum.startswith('https://') or checksum.startswith('ftp://'):
+                module.fail_json(msg="waiting to implement!!!")
+
             # Remove any non-alphanumeric characters, including the infamous
             # Unicode zero-width space
             checksum = re.sub(r'\W+', '', checksum).lower()

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -436,16 +436,13 @@ def main():
             algorithm, checksum = checksum.split(':', 1)
             if checksum.startswith('http://') or checksum.startswith('https://') or checksum.startswith('ftp://'):
                 checksum_url = checksum
-# implement <<<
-                # download checksum file to tmpsrc
+                # download checksum file to checksum_tmpsrc
                 checksum_tmpsrc, checksum_info = url_get(module, checksum_url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest)
                 lines = [line.rstrip('\n') for line in open(checksum_tmpsrc)]
+                os.remove(checksum_tmpsrc)
                 lines = dict(s.split(None, 1) for s in lines)
                 filename = url_filename(url)
                 [checksum] = (k for (k, v) in lines.items() if v == filename)
-
-#                module.fail_json(msg=checksums)
-# implement >>>
             # Remove any non-alphanumeric characters, including the infamous
             # Unicode zero-width space
             checksum = re.sub(r'\W+', '', checksum).lower()

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -193,7 +193,7 @@ EXAMPLES = r'''
     dest: /etc/foo.conf
     checksum: md5:66dffb5228a211e61d6d7ef4a86f5758
 
-- name: Download file with checksum url (sha256) 
+- name: Download file with checksum url (sha256)
   get_url:
     url: http://example.com/path/file.conf
     dest: /etc/foo.conf

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -85,7 +85,8 @@ options:
       - 'If a checksum is passed to this parameter, the digest of the
         destination file will be calculated after it is downloaded to ensure
         its integrity and verify that the transfer completed successfully.
-        Format: <algorithm>:<checksum>, e.g. checksum="sha256:D98291AC[...]B6DC7B97"'
+        Format: <algorithm>:<checksum|url>, e.g. checksum="sha256:D98291AC[...]B6DC7B97",
+        checksum="sha256:http://example.com/path/sha256sum.txt"'
       - If you worry about portability, only the sha1 algorithm is available
         on all platforms and python versions.
       - The third party hashlib library can be installed for access to additional algorithms.
@@ -191,6 +192,12 @@ EXAMPLES = r'''
     url: http://example.com/path/file.conf
     dest: /etc/foo.conf
     checksum: md5:66dffb5228a211e61d6d7ef4a86f5758
+
+- name: Download file with checksum url (sha256) 
+  get_url:
+    url: http://example.com/path/file.conf
+    dest: /etc/foo.conf
+    checksum: 'sha256:http://example.com/path/sha256sum.txt'
 
 - name: Download file from a file path
   get_url:

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -435,8 +435,12 @@ def main():
         try:
             algorithm, checksum = checksum.split(':', 1)
             if checksum.startswith('http://') or checksum.startswith('https://') or checksum.startswith('ftp://'):
-                module.fail_json(msg="waiting to implement!!!")
-
+                checksum_url = checksum
+# implement <<<
+                # download checksum file to tmpsrc
+                checksum_tmpsrc, checksum_info = url_get(module, checksum_url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest)
+                lines = [line.rstrip('\n') for line in open('checksum_tmpsrc')]
+# implement >>>
             # Remove any non-alphanumeric characters, including the infamous
             # Unicode zero-width space
             checksum = re.sub(r'\W+', '', checksum).lower()

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -439,7 +439,12 @@ def main():
 # implement <<<
                 # download checksum file to tmpsrc
                 checksum_tmpsrc, checksum_info = url_get(module, checksum_url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest)
-                lines = [line.rstrip('\n') for line in open('checksum_tmpsrc')]
+                lines = [line.rstrip('\n') for line in open(checksum_tmpsrc)]
+                lines = dict(s.split(None, 1) for s in lines)
+                filename = url_filename(url)
+                [checksum] = (k for (k, v) in lines.items() if v == filename)
+
+#                module.fail_json(msg=checksums)
 # implement >>>
             # Remove any non-alphanumeric characters, including the infamous
             # Unicode zero-width space

--- a/test/integration/targets/get_url/files/testserver.py
+++ b/test/integration/targets/get_url/files/testserver.py
@@ -1,0 +1,20 @@
+import sys
+
+if __name__ == '__main__':
+    if sys.version_info[0] >= 3:
+        import http.server
+        import socketserver
+        PORT = int(sys.argv[1])
+
+        class Handler(http.server.SimpleHTTPRequestHandler):
+            pass
+
+        Handler.extensions_map['.json'] = 'application/json'
+        httpd = socketserver.TCPServer(("", PORT), Handler)
+        httpd.serve_forever()
+    else:
+        import mimetypes
+        mimetypes.init()
+        mimetypes.add_type('application/json', '.json')
+        import SimpleHTTPServer
+        SimpleHTTPServer.test()

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -281,9 +281,9 @@
 
 - name: add sha1 checksum not going to be downloaded
   lineinfile:
-    dest='{{ files_dir }}/sha1sum.txt'
-    line={{ item }}
-  with_items:
+    dest: "{{ files_dir }}/sha1sum.txt"
+    line: "{{ item }}""
+  loop:
     - '3911340502960ca33aece01129234460bfeb2791  not_target1.txt'
     - '1b4b6adf30992cedb0f6edefd6478ff0a593b2e4  not_target2.txt'
 
@@ -294,9 +294,9 @@
 
 - name: add sha256 checksum not going to be downloaded
   lineinfile:
-    dest='{{ files_dir }}/sha256sum.txt'
-    line={{ item }}
-  with_items:
+    dest: "{{ files_dir }}/sha256sum.txt"
+    line: "{{ item }}""
+  loop:
     - '30949cc401e30ac494d695ab8764a9f76aae17c5d73c67f65e9b558f47eff892  not_target1.txt'
     - 'd0dbfc1945bc83bf6606b770e442035f2c4e15c886ee0c22fb3901ba19900b5b  not_target2.txt'
 

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -282,7 +282,7 @@
 - name: add sha1 checksum not going to be downloaded
   lineinfile:
     dest: "{{ files_dir }}/sha1sum.txt"
-    line: "{{ item }}""
+    line: "{{ item }}"
   loop:
     - '3911340502960ca33aece01129234460bfeb2791  not_target1.txt'
     - '1b4b6adf30992cedb0f6edefd6478ff0a593b2e4  not_target2.txt'
@@ -295,7 +295,7 @@
 - name: add sha256 checksum not going to be downloaded
   lineinfile:
     dest: "{{ files_dir }}/sha256sum.txt"
-    line: "{{ item }}""
+    line: "{{ item }}"
   loop:
     - '30949cc401e30ac494d695ab8764a9f76aae17c5d73c67f65e9b558f47eff892  not_target1.txt'
     - 'd0dbfc1945bc83bf6606b770e442035f2c4e15c886ee0c22fb3901ba19900b5b  not_target2.txt'

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -306,7 +306,7 @@
 
 - name: start SimpleHTTPServer for issues 27617
   shell: cd {{ files_dir }} && {{ ansible_python.executable }} {{ output_dir}}/testserver.py {{ http_port }}
-  async: 30
+  async: 90
   poll: 0
 
 - name: download src with sha1 checksum url

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -259,11 +259,10 @@
 
 # https://github.com/ansible/ansible/issues/27617
 
-#- name: create checksum.txt on {{ httpbin_host }}
-#  copy:
-#    dest: {{ httpbin_host }}/checksum.txt
-#    content: "7036ede810fad2b5d2e7547ec703cae8da61edbba43c23f9d7203a0239b765c4.  index.html"
-#  register: source_file_checksum_copied
+- name: create checksum.txt of index.html
+  copy:
+    dest: '{{ output_dir }}/checksum.txt'
+    content: "7036ede810fad2b5d2e7547ec703cae8da61edbba43c23f9d7203a0239b765c4.  index.html"
 
 - name: Change mode on an already downloaded file and specify checksum
   get_url:

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -264,6 +264,11 @@
     http_port: 27617
     files_dir: '{{ output_dir }}/files'
 
+- name: create files_dir
+  file:
+    dest: "{{ files_dir }}"
+    state: directory
+
 - name: create src file
   copy:
     dest: '{{ files_dir }}/27617.txt'

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -258,17 +258,32 @@
       - "stat_result.stat.mode == '0775'"
 
 # https://github.com/ansible/ansible/issues/27617
-
-- name: create checksum.txt of index.html
+- name: create src file
   copy:
-    dest: '{{ output_dir }}/checksum.txt'
-    content: "7036ede810fad2b5d2e7547ec703cae8da61edbba43c23f9d7203a0239b765c4.  index.html"
+    dest: '{{ output_dir }}/27617.txt'
+    content: "ptux"
 
-- name: Change mode on an already downloaded file and specify checksum
+- name: create sha1 checksum file of src
+  copy:
+    dest: '{{ output_dir }}/sha1sum.txt'
+    content: "a492fc1f77b49cac59b3fa65f28c37931463ebec  27617.txt"
+
+- copy:
+    src: "testserver.py"
+    dest: "{{ output_dir }}/testserver.py"
+
+- name: start SimpleHTTPServer for issues 27617
+  shell: cd {{ files_dir }} && {{ ansible_python.executable }} {{ output_dir}}/testserver.py {{ http_port }}
+  async: 120 # this test set can take ~1m to run on FreeBSD (via Shippable)
+  poll: 0
+
+- wait_for: port={{ http_port }}
+
+- name: download src with checksum
   get_url:
-    url: 'http://{{ httpbin_host }}/'
-    dest: '{{ output_dir }}/test'
-    checksum: 'sha256:http://{{ httpbin_host }}/checksum.txt'
+    url: 'http://localhost:{{ http_port }}/27617.txt'
+    dest: '{{ output_dir }}'
+    checksum: 'sha1:http://localhost:{{ http_port }}/sha1sum.txt'
   register: result
 
 - stat:

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -271,22 +271,6 @@
 - name: set role facts
   set_fact:
     http_port: 27617
-    files_dir: '{{ output_dir }}/files'
-
-- name: create a directory to serve files from
-  file:
-    dest: "{{ files_dir }}"
-    state: directory
-
-- copy:
-    src: "{{ item }}"
-    dest: "{{files_dir}}/{{ item }}"
-  with_sequence: start=0 end=4 format=pass%d.json
-
-- copy:
-    src: "{{ item }}"
-    dest: "{{files_dir}}/{{ item }}"
-  with_sequence: start=0 end=30 format=fail%d.json
 
 - copy:
     src: "testserver.py"
@@ -294,7 +278,7 @@
 
 - name: start SimpleHTTPServer for issues 27617
   shell: cd {{ files_dir }} && {{ ansible_python.executable }} {{ output_dir}}/testserver.py {{ http_port }}
-  async: 120 # this test set can take ~1m to run on FreeBSD (via Shippable)
+  async: 30
   poll: 0
 
 - wait_for: port={{ http_port }}

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -258,19 +258,21 @@
       - "stat_result.stat.mode == '0775'"
 
 # https://github.com/ansible/ansible/issues/27617
-- name: create src file
-  copy:
-    dest: '{{ output_dir }}/27617.txt'
-    content: "ptux"
-
-- name: create sha1 checksum file of src
-  copy:
-    dest: '{{ output_dir }}/sha1sum.txt'
-    content: "a492fc1f77b49cac59b3fa65f28c37931463ebec  27617.txt"
 
 - name: set role facts
   set_fact:
     http_port: 27617
+    files_dir: '{{ output_dir }}/files'
+
+- name: create src file
+  copy:
+    dest: '{{ files_dir }}/27617.txt'
+    content: "ptux"
+
+- name: create sha1 checksum file of src
+  copy:
+    dest: '{{ files_dir }}/sha1sum.txt'
+    content: "a492fc1f77b49cac59b3fa65f28c37931463ebec  27617.txt"
 
 - copy:
     src: "testserver.py"

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -285,7 +285,7 @@
 
 - name: start SimpleHTTPServer for issues 27617
   shell: cd {{ files_dir }} && {{ ansible_python.executable }} {{ output_dir}}/testserver.py {{ http_port }}
-  async: 30
+  async: 90
   poll: 0
 
 - wait_for: port={{ http_port }}

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -294,7 +294,7 @@
 
 - name: add sha256 checksum not going to be downloaded
   lineinfile:
-    dest='{{ files_dir }}/sha1sum.txt'
+    dest='{{ files_dir }}/sha256sum.txt'
     line={{ item }}
   with_items:
     - '30949cc401e30ac494d695ab8764a9f76aae17c5d73c67f65e9b558f47eff892  not_target1.txt'

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -277,7 +277,7 @@
 - name: create sha1 checksum file of src
   copy:
     dest: '{{ files_dir }}/sha1sum.txt'
-    content: "a492fc1f77b49cac59b3fa65f28c37931463ebec  27617.txt"
+    content: "a97e6837f60cec6da4491bab387296bbcd72bdba  27617.txt"
 
 - copy:
     src: "testserver.py"
@@ -285,10 +285,8 @@
 
 - name: start SimpleHTTPServer for issues 27617
   shell: cd {{ files_dir }} && {{ ansible_python.executable }} {{ output_dir}}/testserver.py {{ http_port }}
-  async: 120
+  async: 30
   poll: 0
-
-- wait_for: port={{ http_port }}
 
 - name: download src with checksum
   get_url:

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -257,6 +257,31 @@
       - result is changed
       - "stat_result.stat.mode == '0775'"
 
+# https://github.com/ansible/ansible/issues/27617
+
+#- name: create checksum.txt on {{ httpbin_host }}
+#  copy:
+#    dest: {{ httpbin_host }}/checksum.txt
+#    content: "7036ede810fad2b5d2e7547ec703cae8da61edbba43c23f9d7203a0239b765c4.  index.html"
+#  register: source_file_checksum_copied
+
+- name: Change mode on an already downloaded file and specify checksum
+  get_url:
+    url: 'http://{{ httpbin_host }}/'
+    dest: '{{ output_dir }}/test'
+    checksum: 'sha256:http://{{ httpbin_host }}/checksum.txt'
+  register: result
+
+- stat:
+    path: "{{ output_dir }}/test"
+  register: stat_result
+
+- name: Assert that the file was downloaded
+  assert:
+    that:
+      - result is changed
+      - "stat_result.stat.exists == true"
+
 #https://github.com/ansible/ansible/issues/16191
 - name: Test url split with no filename
   get_url:

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -268,6 +268,26 @@
     dest: '{{ output_dir }}/sha1sum.txt'
     content: "a492fc1f77b49cac59b3fa65f28c37931463ebec  27617.txt"
 
+- name: set role facts
+  set_fact:
+    http_port: 27617
+    files_dir: '{{ output_dir }}/files'
+
+- name: create a directory to serve files from
+  file:
+    dest: "{{ files_dir }}"
+    state: directory
+
+- copy:
+    src: "{{ item }}"
+    dest: "{{files_dir}}/{{ item }}"
+  with_sequence: start=0 end=4 format=pass%d.json
+
+- copy:
+    src: "{{ item }}"
+    dest: "{{files_dir}}/{{ item }}"
+  with_sequence: start=0 end=30 format=fail%d.json
+
 - copy:
     src: "testserver.py"
     dest: "{{ output_dir }}/testserver.py"

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -279,6 +279,27 @@
     dest: '{{ files_dir }}/sha1sum.txt'
     content: "a97e6837f60cec6da4491bab387296bbcd72bdba  27617.txt"
 
+- name: add sha1 checksum not going to be downloaded
+  lineinfile:
+    dest='{{ files_dir }}/sha1sum.txt'
+    line={{ item }}
+  with_items:
+    - '3911340502960ca33aece01129234460bfeb2791  not_target1.txt'
+    - '1b4b6adf30992cedb0f6edefd6478ff0a593b2e4  not_target2.txt'
+
+- name: create sha256 checksum file of src
+  copy:
+    dest: '{{ files_dir }}/sha256sum.txt'
+    content: "22dad1844feb094cc4fdac99a812fd6c7129e6161f627f4552d5eed2e4e07c6c  27617.txt"
+
+- name: add sha256 checksum not going to be downloaded
+  lineinfile:
+    dest='{{ files_dir }}/sha1sum.txt'
+    line={{ item }}
+  with_items:
+    - '30949cc401e30ac494d695ab8764a9f76aae17c5d73c67f65e9b558f47eff892  not_target1.txt'
+    - 'd0dbfc1945bc83bf6606b770e442035f2c4e15c886ee0c22fb3901ba19900b5b  not_target2.txt'
+
 - copy:
     src: "testserver.py"
     dest: "{{ output_dir }}/testserver.py"
@@ -288,22 +309,35 @@
   async: 30
   poll: 0
 
-- name: download src with checksum
+- name: download src with sha1 checksum url
   get_url:
     url: 'http://localhost:{{ http_port }}/27617.txt'
     dest: '{{ output_dir }}'
     checksum: 'sha1:http://localhost:{{ http_port }}/sha1sum.txt'
-  register: result
+  register: result_sha1
 
 - stat:
-    path: "{{ output_dir }}/test"
-  register: stat_result
+    path: "{{ output_dir }}/27617.txt"
+  register: stat_result_sha1
+
+- name: download src with sha256 checksum url
+  get_url:
+    url: 'http://localhost:{{ http_port }}/27617.txt'
+    dest: '{{ output_dir }}'
+    checksum: 'sha1:http://localhost:{{ http_port }}/sha256sum.txt'
+  register: result_sha256
+
+- stat:
+    path: "{{ output_dir }}/27617.txt"
+  register: stat_result_sha256
 
 - name: Assert that the file was downloaded
   assert:
     that:
-      - result is changed
-      - "stat_result.stat.exists == true"
+      - result_sha1 is changed
+      - result_sha256 is changed
+      - "stat_result_sha1.stat.exists == true"
+      - "stat_result_sha256.stat.exists == true"
 
 #https://github.com/ansible/ansible/issues/16191
 - name: Test url split with no filename

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -290,7 +290,7 @@
 - name: create sha256 checksum file of src
   copy:
     dest: '{{ files_dir }}/sha256sum.txt'
-    content: "22dad1844feb094cc4fdac99a812fd6c7129e6161f627f4552d5eed2e4e07c6c  27617.txt"
+    content: "b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006.  27617.txt"
 
 - name: add sha256 checksum not going to be downloaded
   lineinfile:
@@ -323,8 +323,8 @@
 - name: download src with sha256 checksum url
   get_url:
     url: 'http://localhost:{{ http_port }}/27617.txt'
-    dest: '{{ output_dir }}'
-    checksum: 'sha1:http://localhost:{{ http_port }}/sha256sum.txt'
+    dest: '{{ output_dir }}/27617sha256.txt'
+    checksum: 'sha256:http://localhost:{{ http_port }}/sha256sum.txt'
   register: result_sha256
 
 - stat:

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -285,7 +285,7 @@
 
 - name: start SimpleHTTPServer for issues 27617
   shell: cd {{ files_dir }} && {{ ansible_python.executable }} {{ output_dir}}/testserver.py {{ http_port }}
-  async: 90
+  async: 120
   poll: 0
 
 - wait_for: port={{ http_port }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

implement #27617 get_url should support acquiring checksum from remote source 

```
1. expend checksum format to <algorithm>:(<checksum>|<url>)
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->

- get_url

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->

- 2.5
- 2.6
- 2.7

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
<algorithm>:(<checksum>|<url>)

e.g. checksum="sha256:D98291AC[...]B6DC7B97"
e.g. checksum="sha256:http://host/path/to/checksum.txt"
```