### PR TITLE
Fixed auth_source default value problem (#42923)

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -23,8 +23,7 @@ except ImportError:
 AZURE_COMMON_ARGS = dict(
     auth_source=dict(
         type='str',
-        choices=['auto', 'cli', 'env', 'credential_file', 'msi'],
-        default='auto'
+        choices=['auto', 'cli', 'env', 'credential_file', 'msi']
     ),
     profile=dict(type='str'),
     subscription_id=dict(type='str', no_log=True),

--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -70,6 +70,7 @@ options:
     auth_source:
         description:
             - Controls the source of the credentials to use for authentication.
+            - If not specified, ANSIBLE_AZURE_AUTH_SOURCE environment variable will be used and default to C(auto) if variable is not defined.
             - C(auto) will follow the default precedence of module parameters -> environment variables -> default profile in credential file
               C(~/.azure/credentials).
             - When set to C(cli), the credentials will be sources from the default Azure CLI profile.
@@ -84,7 +85,6 @@ options:
         - credential_file
         - env
         - msi
-        default: auto
         version_added: 2.5
     api_profile:
         description:


### PR DESCRIPTION
* set default value of auth_source to None, as previous default value fix broken scenario of
ANSIBLE_AZURE_AUTH_SOURCE environment variable.

(cherry picked from commit 750774d768a631c16d49ee328170f1a6bda9b660)

##### SUMMARY
Setting default value of auth_source to None, as previous default value fix broken scenario of
ANSIBLE_AZURE_AUTH_SOURCE environment variable.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

##### ANSIBLE VERSION


##### ADDITIONAL INFORMATION
