### PR TITLE
ansible-test: Create public key creating Windows targets

### DIFF
--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -115,13 +115,11 @@ class AnsibleCoreCI(object):
                 region = 'us-east-1'
 
             self.endpoints = AWS_ENDPOINTS[region],
+            self.ssh_key = SshKey(args)
 
             if self.platform == 'windows':
-                # Windows supports SSH for all hosts except 2008 (non R2)
-                self.ssh_key = None if self.version == '2008' else SshKey(args)
                 self.port = 5986
             else:
-                self.ssh_key = SshKey(args)
                 self.port = 22
         elif self.provider == 'parallels':
             self.endpoints = self._get_parallels_endpoints()

--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -117,7 +117,8 @@ class AnsibleCoreCI(object):
             self.endpoints = AWS_ENDPOINTS[region],
 
             if self.platform == 'windows':
-                self.ssh_key = None
+                # Windows supports SSH for all hosts except 2008 (non R2)
+                self.ssh_key = None if self.version == '2008' else SshKey(args)
                 self.port = 5986
             else:
                 self.ssh_key = SshKey(args)


### PR DESCRIPTION
##### SUMMARY
Create a local SSH key pair for Windows targets (except for 2008) and send to Ansible core-ci. 2008 does not support Win32-OpenSSH so it is excluded from this.

Requires changes on core-ci to start working.

##### ISSUE TYPE
 - Test Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```
devel
```