### PR TITLE
WIP started and stopped are now commands that the rds module understands

### DIFF
--- a/changelogs/fragments/rds_start_stop.yaml
+++ b/changelogs/fragments/rds_start_stop.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- rds module now supports starting and stopping of an rds database


### PR DESCRIPTION
##### SUMMARY

Added ability to start and stop a rds database by adding `started` and `stopped` as keywords for the `command` argument of the rds module.

The main functionality (i.e. starting and stopping) is available, however some things are still open (see TODO). I'm opening up this PR to get some more eyes on it. 

##### ISSUE TYPE

 - Feature Pull Request


##### COMPONENT NAME

rds

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (aws_rds_start_stop 07eac75db9) last updated 2018/08/07 13:49:21 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sdubrul/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sdubrul/code/github/ansible/lib/ansible
  executable location = /Users/sdubrul/code/github/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION

This module uses boto. Starting and stopping is only available in boto3 so I added some quick boilerplate for boto3 in the module.

Example of added functionality:
```
(venv) sdubrul@mac:~/code/github/ansible$ansible localhost, -m rds -a 'command=started instance_name=hdlz80cbrw9iyo'

localhost | SUCCESS => {
    "changed": false
}
(venv) sdubrul@mac:~/code/github/ansible$ansible localhost, -m rds -a 'command=stopped instance_name=hdlz80cbrw9iyo'
 
localhost | CHANGED => {
    "changed": true
}
```

##### ADDITIONAL INFORMATION TODO

- [ ] Take a closer look to https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/amazon/GUIDELINES.md and adhere as much as possible to those guidelines.
- [ ] return all information with respect to the db as in other calls (nothing is returned right now except the changed status)
- [ ] Implement the wait keyword

