### PR TITLE
Update documentation for gcp_compute

### DIFF
--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -60,11 +60,21 @@ projects:
 filters:
   - machineType = n1-standard-1
   - scheduling.automaticRestart = true AND machineType = n1-standard-1
-
 scopes:
   - https://www.googleapis.com/auth/compute
 service_account_file: /tmp/service_account.json
 auth_kind: serviceaccount
+keyed_groups:
+  # Create groups from GCE labels
+  - prefix: gcp
+    key: labels
+hostnames:
+  # List host by name instead of the default public ip
+  - name
+compose:
+  # Set an inventory parameter to use the Public IP address to connect to the host
+  # For Private ip use "networkInterfaces[0].networkIP"
+  ansible_host: networkInterfaces[0].accessConfigs[0].natIP
 '''
 
 from ansible.errors import AnsibleError, AnsibleParserError


### PR DESCRIPTION
##### SUMMARY
Added examples on how to use "keyed_groups", "hostnames", and "compose"

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
gcp_compute - Google Cloud Compute Engine inventory source

##### ANSIBLE VERSION
```
ansible 2.6.1
  config file = None
  configured module search path = [u'/Users/bob.lee/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```

##### ADDITIONAL INFORMATION
The compose example shows how to set the ansible_host var for a host to either the public or private ip. This is necessary when you set your hostname by name instead of ip
