### PR TITLE
Add now() jinja2 global func for getting the date/time

### DIFF
--- a/changelogs/fragments/jinja-now.yml
+++ b/changelogs/fragments/jinja-now.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- jinja2 - Add ``now()`` function for getting the current time

--- a/docs/docsite/rst/user_guide/playbooks_templating.rst
+++ b/docs/docsite/rst/user_guide/playbooks_templating.rst
@@ -16,6 +16,24 @@ Please note that all templating happens on the Ansible controller before the tas
    playbooks_lookups
    playbooks_python_version
 
+.. _templating_now:
+
+Get the current time
+````````````````````
+
+.. versionadded:: 2.8
+
+The ``now()`` Jinja2 function, allows you to retrieve python datetime object or a string representation for the current time.
+
+The ``now()`` function supports 2 arguments:
+
+utc
+  Specify ``True`` to get the current time in UTC. Defaults to ``False``
+
+fmt
+  Accepts a `strftime <https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior>`_ string that will be used
+  to return a formatted date time string
+
 
 .. seealso::
 

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -741,11 +741,12 @@ class Templar:
                     return data
 
             if disable_lookups:
-                t.globals['query'] = t.globals['q'] = t.globals['lookup'] = t.globals['now'] = self._fail_lookup
+                t.globals['query'] = t.globals['q'] = t.globals['lookup'] = self._fail_lookup
             else:
                 t.globals['lookup'] = self._lookup
                 t.globals['query'] = t.globals['q'] = self._query_lookup
-                t.globals['now'] = self._now_datetime
+
+            t.globals['now'] = self._now_datetime
 
             t.globals['finalize'] = self._finalize
 

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -621,6 +621,18 @@ class Templar:
     def _fail_lookup(self, name, *args, **kwargs):
         raise AnsibleError("The lookup `%s` was found, however lookups were disabled from templating" % name)
 
+    def _now_datetime(self, utc=False, fmt=None):
+        '''jinja2 global function to return current datetime, potentially formatted via strftime'''
+        if utc:
+            now = datetime.datetime.utcnow()
+        else:
+            now = datetime.datetime.now()
+
+        if fmt:
+            return now.strftime(fmt)
+
+        return now
+
     def _query_lookup(self, name, *args, **kwargs):
         ''' wrapper for lookup, force wantlist true'''
         kwargs['wantlist'] = True
@@ -729,10 +741,11 @@ class Templar:
                     return data
 
             if disable_lookups:
-                t.globals['query'] = t.globals['q'] = t.globals['lookup'] = self._fail_lookup
+                t.globals['query'] = t.globals['q'] = t.globals['lookup'] = t.globals['now'] = self._fail_lookup
             else:
                 t.globals['lookup'] = self._lookup
                 t.globals['query'] = t.globals['q'] = self._query_lookup
+                t.globals['now'] = self._now_datetime
 
             t.globals['finalize'] = self._finalize
 


### PR DESCRIPTION
##### SUMMARY
Add `now()` jinja2 global func for getting the date/time

See #22561
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/template/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
```
- hosts: localhost
  gather_facts: false
  tasks:
    - debug:
        msg: "{{ now() }}"
    - debug:
        msg: "{{ now(utc=True) }}"
    - debug:
        msg: "{{ now(fmt='%c') }}"
    - debug:
        msg: "{{ now(utc=True).isoformat() }}"
```

```
TASK [debug] *********************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "2018-08-07 15:14:20.704361"
}

TASK [debug] *********************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "2018-08-07 20:14:20.765310"
}

TASK [debug] *********************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "Tue Aug  7 15:14:20 2018"
}

TASK [debug] *********************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "2018-08-07T20:14:20.916165"
}
```