### PR TITLE
nxos issu should abort when issu is not possible.

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -474,8 +474,14 @@ def do_install_all(module, issu, image, kick=None):
         # needs to be upgraded.
         if impact_data['disruptive']:
             # Check mode indicated that ISSU is not possible so issue the
-            # upgrade command without the non-disruptive flag.
-            issu = 'no'
+            # upgrade command without the non-disruptive flag unless the
+            # playbook specified issu: yes/required.
+            if issu == 'yes':
+                msg = 'ISSU/ISSD requested but impact data indicates ISSU/ISSD is not possible'
+                module.fail_json(msg=msg, raw_data=impact_data['list_data'])
+            else:
+                issu = 'no'
+
         commands = build_install_cmd_set(issu, image, kick, 'install')
         opts = {'ignore_timeout': True}
         # The system may be busy from the call to check_mode so loop until
@@ -523,6 +529,9 @@ def main():
     sif = module.params['system_image_file']
     kif = module.params['kickstart_image_file']
     issu = module.params['issu']
+
+    if re.search(r'(yes|required)', issu):
+        issu = 'yes'
 
     if kif == 'null' or kif == '':
         kif = None

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -34,7 +34,7 @@ notes:
     - Tested against the following platforms and images
       - N9k 7.0(3)I4(6), 7.0(3)I5(3), 7.0(3)I6(1), 7.0(3)I7(1), 7.0(3)F2(2), 7.0(3)F3(2)
       - N3k 6.0(2)A8(6), 6.0(2)A8(8), 7.0(3)I6(1), 7.0(3)I7(1)
-      - N7k 7.3(0)D1(1), 8.0(1), 8.2(1)
+      - N7k 7.3(0)D1(1), 8.0(1), 8.1(1), 8.2(1)
     - This module requires both the ANSIBLE_PERSISTENT_CONNECT_TIMEOUT and
       ANSIBLE_PERSISTENT_COMMAND_TIMEOUT timers to be set to 600 seconds or higher.
       The module will exit if the timers are not set properly.
@@ -61,7 +61,7 @@ options:
         version_added: "2.5"
         description:
             - Upgrade using In Service Software Upgrade (ISSU).
-              (Only supported on N9k platforms)
+              (Supported on N5k, N7k, N9k platforms)
             - Selecting 'required' or 'yes' means that upgrades will only
               proceed if the switch is capable of ISSU.
             - Selecting 'desired' means that upgrades will use ISSU if possible

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
@@ -10,25 +10,30 @@
   when: connection is defined
 
 - name: "Copy {{ si }} to bootflash"
-  expect:
-    command: "scp {{image_dir}}{{ si }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }}:"
-    responses:
-      (?i)password: "{{ ansible_ssh_pass }}"
-    timeout: 1000
+  nxos_file_copy:
+    local_file: "{{image_dir}}{{ si }}"
+    file_system: "bootflash:"
   register: result
+  ignore_errors: "{{ ignore_errors_httpapi }}"
+
+- name: "Copy {{ si }} to bootflash"
+  nxos_file_copy:
+    local_file: "{{image_dir}}{{ si }}"
+    file_system: "bootflash:"
+  register: result
+  ignore_errors: "{{ ignore_errors_httpapi }}"
 
 - debug:
     msg: "{{ item.key }} {{ item.value }}"
   with_dict: "{{ result }}"
 
 - name: "Copy {{ ki }} to bootflash"
-  expect:
-    command: "scp {{image_dir}}{{ ki }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }}:"
-    responses:
-      (?i)password: "{{ ansible_ssh_pass }}"
-    timeout: 1000
-  when: ki is defined
+  nxos_file_copy:
+    local_file: "{{image_dir}}/{{ ki }}"
+    file_system: "bootflash:"
   register: result
+  when: ki is defined
+  ignore_errors: "{{ ignore_errors_httpapi }}"
 
 - debug:
     msg: "{{ item.key }} {{ item.value }}"

--- a/test/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
+++ b/test/integration/targets/nxos_install_os/tasks/upgrade/copy_kick_system_images.yaml
@@ -10,30 +10,25 @@
   when: connection is defined
 
 - name: "Copy {{ si }} to bootflash"
-  nxos_file_copy:
-    local_file: "{{image_dir}}{{ si }}"
-    file_system: "bootflash:"
+  expect:
+    command: "scp {{image_dir}}{{ si }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }}:"
+    responses:
+      (?i)password: "{{ ansible_ssh_pass }}"
+    timeout: 1000
   register: result
-  ignore_errors: "{{ ignore_errors_httpapi }}"
-
-- name: "Copy {{ si }} to bootflash"
-  nxos_file_copy:
-    local_file: "{{image_dir}}{{ si }}"
-    file_system: "bootflash:"
-  register: result
-  ignore_errors: "{{ ignore_errors_httpapi }}"
 
 - debug:
     msg: "{{ item.key }} {{ item.value }}"
   with_dict: "{{ result }}"
 
 - name: "Copy {{ ki }} to bootflash"
-  nxos_file_copy:
-    local_file: "{{image_dir}}/{{ ki }}"
-    file_system: "bootflash:"
-  register: result
+  expect:
+    command: "scp {{image_dir}}{{ ki }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }}:"
+    responses:
+      (?i)password: "{{ ansible_ssh_pass }}"
+    timeout: 1000
   when: ki is defined
-  ignore_errors: "{{ ignore_errors_httpapi }}"
+  register: result
 
 - debug:
     msg: "{{ item.key }} {{ item.value }}"


### PR DESCRIPTION
##### SUMMARY

This PR addresses the following:
* Resolves https://github.com/ansible/ansible/issues/42959
* Adds/verifies support for n5k and n7k

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_install_os

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (fix_nxos_install_os b8454b12c9) last updated 2018/08/07 16:43:37 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```

##### VALIDATION INFORMATION

ISSU workflow tested/verified on:

* N5k(Nexus 5672UP) Upgrade:
  * From: 7.3(0)N1(1) --> To: 7.3(3)N1(1)
* N7k(Nexus7000 C7010): Upgrade:
  * From: 8.0(1) --> To: 8.1(1)
* N9k(Nexus9000 C9504): Upgrade:
  * From: 7.0(3)I5.3 --> To: 7.0(3)I7.1


##### ADDITIONAL INFORMATION
During validation of this module against N5k and N7k platforms a defect was discovered.  When the issu options is set to `issu: yes` or `issu: required` then the module should abort if ISSU is not possible/supported on the platform/image combination.

In such and event the following output and failure message will be generated.

```
TASK [nxos_install_os : Install OS image n6000-uk9.7.3.0.N1.1.bin] ******************************************************************************************************************
task path: /Users/ansible/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_install_os/tasks/upgrade/install_with_kick.yaml:2
<n5k.example.com> attempting to start connection
<n5k.example.com> using connection plugin network_cli
<n5k.example.com> found existing local domain socket, using it!
<n5k.example.com> updating play_context for connection
<n5k.example.com> 
<n5k.example.com> local domain socket path is /Users/ansible/.ansible/pc/e15eecd87f
<n5k.example.com> ESTABLISH LOCAL CONNECTION FOR USER: ansible
<n5k.example.com> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/ansible/.ansible/tmp/ansible-local-29690wpiaE2/ansible-tmp-1533646910.37-262418498763391 `" && echo ansible-tmp-1533646910.37-262418498763391="` echo /Users/ansible/.ansible/tmp/ansible-local-29690wpiaE2/ansible-tmp-1533646910.37-262418498763391 `" ) && sleep 0'
Using module file /Users/ansible/Projects/nxos_ansible/fix_ansible/lib/ansible/modules/network/nxos/nxos_install_os.py
<n5k.example.com> PUT /Users/ansible/.ansible/tmp/ansible-local-29690wpiaE2/tmp2LhCSK TO /Users/ansible/.ansible/tmp/ansible-local-29690wpiaE2/ansible-tmp-1533646910.37-262418498763391/nxos_install_os.py
<n5k.example.com> EXEC /bin/sh -c 'chmod u+x /Users/ansible/.ansible/tmp/ansible-local-29690wpiaE2/ansible-tmp-1533646910.37-262418498763391/ /Users/ansible/.ansible/tmp/ansible-local-29690wpiaE2/ansible-tmp-1533646910.37-262418498763391/nxos_install_os.py && sleep 0'
<n5k.example.com> EXEC /bin/sh -c '/Users/ansible/Virtualenvs/py2-ansible/bin/python /Users/ansible/.ansible/tmp/ansible-local-29690wpiaE2/ansible-tmp-1533646910.37-262418498763391/nxos_install_os.py && sleep 0'
<n5k.example.com> EXEC /bin/sh -c 'rm -f -r /Users/ansible/.ansible/tmp/ansible-local-29690wpiaE2/ansible-tmp-1533646910.37-262418498763391/ > /dev/null 2>&1 && sleep 0'
fatal: [n5k.example.com]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "auth_pass": null, 
            "authorize": null, 
            "host": null, 
            "issu": "required", 
            "kickstart_image_file": "n6000-uk9-kickstart.7.3.0.N1.1.bin", 
            "password": null, 
            "port": null, 
            "provider": null, 
            "ssh_keyfile": null, 
            "system_image_file": "n6000-uk9.7.3.0.N1.1.bin", 
            "timeout": null, 
            "transport": null, 
            "use_ssl": null, 
            "username": null, 
            "validate_certs": null
        }
    }, 
    "msg": "ISSU/ISSD requested but impact data indicates ISSU/ISSD is not possible", 
    "raw_data": [
        "Verifying image bootflash:/n6000-uk9-kickstart.7.3.0.N1.1.bin for boot variable \"kickstart\".", 
        "[#                   ]   0%####################] 100% -- SUCCESS", 
        "", 
        "Verifying image bootflash:/n6000-uk9.7.3.0.N1.1.bin for boot variable \"system\".", 
        "[#                   ]   0%####################] 100% -- SUCCESS", 
        "", 
        "Verifying image type.", 
        "[#                   ]   0%#####               ]  20%#######             ]  30%#########           ]  40%###########         ]  50%###########         ]  50%################### ]  90%####################] 100%####################] 100% -- SUCCESS", 
        "", 
        "Extracting \"system\" version from image bootflash:/n6000-uk9.7.3.0.N1.1.bin.", 
        "[#                   ]   0%####################] 100% -- SUCCESS", 
        "", 
        "Extracting \"kickstart\" version from image bootflash:/n6000-uk9-kickstart.7.3.0.N1.1.bin.", 
        "[#                   ]   0%####################] 100% -- SUCCESS", 
        "", 
        "Extracting \"bios\" version from image bootflash:/n6000-uk9.7.3.0.N1.1.bin.", 
        "[#                   ]   0%####################] 100% -- SUCCESS", 
        "", 
        "Performing module support checks.", 
        "[####################] 100% -- SUCCESS", 
        "", 
        "", 
        "", 
        "Compatibility check is done:", 
        "Module  bootable          Impact  Install-type  Reason", 
        "------  --------  --------------  ------------  ------", 
        "     0       yes      disruptive         reset  ISSD is not supported and switch will reset with ascii configuration", 
        "     1       yes      disruptive         reset  ISSD is not supported and switch will reset with ascii configuration", 
        "     2       yes      disruptive         reset  ISSD is not supported and switch will reset with ascii configuration", 
        "", 
        "", 
        "", 
        "Images will be upgraded according to following table:", 
        "Module             Image         Running-Version             New-Version  Upg-Required", 
        "------  ----------------  ----------------------  ----------------------  ------------", 
        "     0            system             7.3(3)N1(1)             7.3(0)N1(1)           yes", 
        "     0         kickstart             7.3(3)N1(1)             7.3(0)N1(1)           yes", 
        "     0              bios      v0.2.0(05/27/2016)      v0.1.6(12/03/2015)            no", 
        "     0         power-seq    SF-uC:37, SF-FPGA:35    SF-uC:37, SF-FPGA:35            no", 
        "     0            iofpga               v0.0.0.39               v0.0.0.39            no", 
        "     1            iofpga               v0.0.0.18               v0.0.0.18            no", 
        "     2            iofpga               v0.0.0.18               v0.0.0.18            no", 
        "", 
        "Warning : ISSD is not supported and switch will reset with ASCII configuration.", 
        "All incompatible configuration will be lost in the target release.", 
        "Please also refer the downgrade procedure documentation of the release for more details."
    ]
}
	to retry, use: --limit @/Users/ansible/Projects/nxos_ansible/fix_ansible/test/integration/nxos.retry

PLAY RECAP **************************************************************************************************************************************************************************
n5k.example.com          : ok=39   changed=1    unreachable=0    failed=1   

```