### PR TITLE
restore task arg splatting

### DIFF
--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -471,7 +471,10 @@ When is it unsafe to bulk-set task arguments from a variable?
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 
-Ansible allows all of a task's arguments to be bulk-set from a dictionary-typed variable, but issues a warning that the practice is unsafe. For example::
+You can set all of a task's arguments from a dictionary-typed variable. This
+technique can be useful in some dynamic execution scenarios. However, it
+introduces a security risk. We do not recommend it, so Ansible issues a
+warning when you do something like this::
 
     #...
     vars:
@@ -482,12 +485,13 @@ Ansible allows all of a task's arguments to be bulk-set from a dictionary-typed 
     tasks:
     - user: '{{ usermod_args }}'
 
-This technique can be useful in some dynamic execution scenarios. However, it is important to define the argument
-dictionary variable at a relatively high level of precedence, specifically, anything greater than *host facts* in the
-order of precedence found in the :ref:`ansible_variable_precedence` section of the *Variables* chapter. This prevents
-fact gathering on a compromised target system from overwriting the task argument dictionary with potentially
-malicious values. The risk of setting the variable at a lower precedence may also be mitigated by disabling the
-:ref:`inject_facts_as_vars` configuration setting, which prevents fact values from colliding with variables (and also disables the original warning).
+This particular example is safe. However, constructing tasks like this is
+risky because the parameters and values passed to ``usermod_args`` could
+be overwritten by malicious values in the ``host facts`` on a compromised
+target machine. To mitigate this risk:
+
+* set bulk variables at a level of precedence greater than ``host facts`` in the order of precedence found in :ref:`ansible_variable_precedence` (the example above is safe because play vars take precedence over facts)
+* disable the :ref:`inject_facts_as_vars` configuration setting to prevent fact values from colliding with variables (this will also disable the original warning)
 
 
 .. _commercial_support:

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -446,7 +446,7 @@ In OpenBSD, a similar option is available in the base system called encrypt(1):
 
     encrypt
 
-.. _commercial_support:
+.. _dot_or_array_notation:
 
 Ansible supports dot notation and array notation for variables. Which notation should I use?
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -463,6 +463,34 @@ safer to use the array notation for variables.
     It is {{ temperature['Celsius']['-3'] }} outside.
 
 Also array notation allows for dynamic variable composition, see dynamic_variables_.
+
+
+.. _argsplat_unsafe:
+
+When is it unsafe to bulk-set task arguments from a variable?
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Ansible allows all of a task's arguments to be bulk-set from a dictionary-typed variable, but issues a warning that the practice is unsafe. For example::
+
+    #...
+    vars:
+      usermod_args:
+        name: testuser
+        state: present
+        update_password: always
+    tasks:
+    - user: '{{ usermod_args }}'
+
+This technique can be useful in some dynamic execution scenarios. However, it is important to define the argument
+dictionary variable at a relatively high level of precedence, specifically, anything greater than *host facts* in the
+order of precedence found in the :ref:`ansible_variable_precedence` section of the *Variables* chapter. This prevents
+fact gathering on a compromised target system from overwriting the task argument dictionary with potentially
+malicious values. The risk of setting the variable at a lower precedence may also be mitigated by disabling the
+:ref:`inject_facts_as_vars` configuration setting, which prevents fact values from colliding with variables.
+
+
+.. _commercial_support:
 
 Can I get training on Ansible?
 ++++++++++++++++++++++++++++++

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -487,7 +487,7 @@ dictionary variable at a relatively high level of precedence, specifically, anyt
 order of precedence found in the :ref:`ansible_variable_precedence` section of the *Variables* chapter. This prevents
 fact gathering on a compromised target system from overwriting the task argument dictionary with potentially
 malicious values. The risk of setting the variable at a lower precedence may also be mitigated by disabling the
-:ref:`inject_facts_as_vars` configuration setting, which prevents fact values from colliding with variables.
+:ref:`inject_facts_as_vars` configuration setting, which prevents fact values from colliding with variables (and also disables the original warning).
 
 
 .. _commercial_support:

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -518,7 +518,11 @@ class TaskExecutor:
         if '_variable_params' in self._task.args:
             variable_params = self._task.args.pop('_variable_params')
             if isinstance(variable_params, dict):
-                raise AnsibleError("Using a variable for a task's 'args' is not allowed as it is unsafe, facts can come from untrusted sources.")
+                if C.INJECT_FACTS_AS_VARS:
+                    display.warning("Using a variable for a task's 'args' is unsafe in some situations "
+                                    "(see https://docs.ansible.com/ansible/devel/reference_appendices/faq.html#argsplat-unsafe)")
+                variable_params.update(self._task.args)
+                self._task.args = variable_params
 
         # get the connection and the handler for this execution
         if (not self._connection or


### PR DESCRIPTION
##### SUMMARY
* reverts #41804
* supersedes #41295
* fixes #42192
* after lots of discussion amongst the core team, we decided to preserve this feature, clarify the runtime warnings/docs, and prioritize a path toward fixing the underlying behavior that causes this feature to be insecure (un-namespaced facts).

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
task_executor.py

##### ANSIBLE VERSION
2.7

##### ADDITIONAL INFORMATION
