### PR TITLE
VMware: remove unused imports

### DIFF
--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -9,7 +9,7 @@
 
 # TODO:
 #   * more jq examples
-#   * optional folder heriarchy
+#   * optional folder hierarchy
 
 """
 $ jq '._meta.hostvars[].config' data.json | head
@@ -38,9 +38,8 @@ import sys
 import uuid
 from time import time
 
-import six
 from jinja2 import Environment
-from six import integer_types, string_types
+from six import integer_types, PY3
 from six.moves import configparser
 
 try:
@@ -235,7 +234,7 @@ class VMWareInventory(object):
             'groupby_custom_field': False}
         }
 
-        if six.PY3:
+        if PY3:
             config = configparser.ConfigParser()
         else:
             config = configparser.SafeConfigParser()

--- a/lib/ansible/modules/cloud/vmware/vcenter_folder.py
+++ b/lib/ansible/modules/cloud/vmware/vcenter_folder.py
@@ -124,7 +124,7 @@ result:
 '''
 
 try:
-    from pyVmomi import vim, vmodl
+    from pyVmomi import vim
 except ImportError as e:
     pass
 

--- a/lib/ansible/modules/cloud/vmware/vcenter_license.py
+++ b/lib/ansible/modules/cloud/vmware/vcenter_license.py
@@ -77,7 +77,7 @@ licenses:
 '''
 
 try:
-    from pyVmomi import vim, vmodl
+    from pyVmomi import vim
     HAS_PYVMOMI = True
 except ImportError:
     HAS_PYVMOMI = False

--- a/lib/ansible/modules/cloud/vmware/vmware_cfg_backup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_cfg_backup.py
@@ -83,7 +83,7 @@ dest_file:
 
 import os
 try:
-    from pyVmomi import vim, vmodl
+    from pyVmomi import vim
 except ImportError:
     pass
 

--- a/lib/ansible/modules/cloud/vmware/vmware_datastore_cluster.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_datastore_cluster.py
@@ -78,11 +78,6 @@ result:
     sample: "Datastore cluster 'DSC2' created successfully."
 """
 
-try:
-    from pyVmomi import vim, vmodl
-except ImportError:
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec, wait_for_task
 from ansible.module_utils._text import to_native

--- a/lib/ansible/modules/cloud/vmware/vmware_drs_rule_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_drs_rule_facts.py
@@ -107,7 +107,7 @@ drs_rule_facts:
 '''
 
 try:
-    from pyVmomi import vim, vmodl
+    from pyVmomi import vim
 except ImportError:
     pass
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -523,9 +523,7 @@ import time
 
 HAS_PYVMOMI = False
 try:
-    import pyVmomi
     from pyVmomi import vim, vmodl
-
     HAS_PYVMOMI = True
 except ImportError:
     pass

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -87,12 +87,6 @@ instance:
     sample: None
 """
 
-try:
-    import pyVmomi
-    from pyVmomi import vim
-except ImportError:
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
 from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
@@ -152,15 +152,9 @@ instance:
     }
 """
 
-try:
-    import pyVmomi
-    from pyVmomi import vim
-except ImportError:
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec, connect_to_api, wait_for_task
+from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec, wait_for_task
 
 
 class PyVmomiHelper(PyVmomi):

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -215,7 +215,6 @@ instance:
 
 import time
 try:
-    import pyVmomi
     from pyVmomi import vim
 except ImportError:
     pass

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
@@ -110,13 +110,6 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.vmware import PyVmomi, gather_vm_facts, vmware_argument_spec
 
 
-try:
-    import pyVmomi
-    from pyVmomi import vim
-except ImportError:
-    pass
-
-
 class PyVmomiHelper(PyVmomi):
     def __init__(self, module):
         super(PyVmomiHelper, self).__init__(module)

--- a/lib/ansible/modules/cloud/vmware/vmware_host_acceptance.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_acceptance.py
@@ -103,7 +103,7 @@ facts:
 '''
 
 try:
-    from pyVmomi import vim, vmodl
+    from pyVmomi import vim
 except ImportError:
     pass
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
@@ -108,7 +108,7 @@ from ansible.module_utils.basic import AnsibleModule, bytes_to_human
 from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec, find_obj
 
 try:
-    from pyVmomi import vim, vmodl
+    from pyVmomi import vim
 except ImportError:
     pass
 

--- a/lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
@@ -110,7 +110,7 @@ rule_set_state:
 '''
 
 try:
-    from pyVmomi import vim, vmodl
+    from pyVmomi import vim
 except ImportError:
     pass
 

--- a/lib/ansible/modules/cloud/vmware/vmware_host_lockdown.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_lockdown.py
@@ -122,7 +122,7 @@ results:
 '''
 
 try:
-    from pyvmomi import vim, vmodl
+    from pyvmomi import vim
 except ImportError:
     pass
 

--- a/lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
@@ -94,7 +94,7 @@ RETURN = r'''#
 '''
 
 try:
-    from pyVmomi import vim, vmodl
+    from pyVmomi import vim
 except ImportError:
     pass
 

--- a/lib/ansible/modules/cloud/vmware/vmware_host_powerstate.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_powerstate.py
@@ -111,11 +111,6 @@ result:
     }
 '''
 
-try:
-    from pyVmomi import vim, vmodl
-except ImportError:
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec, wait_for_task, TaskError
 from ansible.module_utils._text import to_native

--- a/lib/ansible/modules/cloud/vmware/vmware_local_user_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_local_user_facts.py
@@ -66,11 +66,6 @@ local_user_facts:
     ]
 '''
 
-try:
-    from pyVmomi import vim, vmodl
-except ImportError:
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec
 

--- a/lib/ansible/modules/cloud/vmware/vmware_resource_pool_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_resource_pool_facts.py
@@ -78,7 +78,7 @@ resource_pool_facts:
 '''
 
 try:
-    from pyVmomi import vim, vmodl
+    from pyVmomi import vim
 except ImportError:
     pass
 

--- a/lib/ansible/modules/cloud/vmware/vmware_target_canonical_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_target_canonical_facts.py
@@ -109,11 +109,6 @@ scsi_tgt_facts:
     }
 """
 
-try:
-    from pyVmomi import vim, vmodl
-except ImportError:
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec
 

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
@@ -87,7 +87,7 @@ virtual_machines:
 '''
 
 try:
-    from pyVmomi import vim, vmodl
+    from pyVmomi import vim
 except ImportError:
     pass
 


### PR DESCRIPTION
##### SUMMARY
Idea taken from https://github.com/ansible/ansible/pull/43402

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/vmware_inventory.py
lib/ansible/modules/cloud/vmware/vcenter_folder.py
lib/ansible/modules/cloud/vmware/vcenter_license.py
lib/ansible/modules/cloud/vmware/vmware_cfg_backup.py
lib/ansible/modules/cloud/vmware/vmware_datastore_cluster.py
lib/ansible/modules/cloud/vmware/vmware_drs_rule_facts.py
lib/ansible/modules/cloud/vmware/vmware_guest.py
lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
lib/ansible/modules/cloud/vmware/vmware_guest_move.py
lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
lib/ansible/modules/cloud/vmware/vmware_host_acceptance.py
lib/ansible/modules/cloud/vmware/vmware_host_facts.py
lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
lib/ansible/modules/cloud/vmware/vmware_host_lockdown.py
lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
lib/ansible/modules/cloud/vmware/vmware_host_powerstate.py
lib/ansible/modules/cloud/vmware/vmware_local_user_facts.py
lib/ansible/modules/cloud/vmware/vmware_resource_pool_facts.py
lib/ansible/modules/cloud/vmware/vmware_target_canonical_facts.py
lib/ansible/modules/cloud/vmware/vmware_vm_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```