### PR TITLE
Update eos clcionf plugin

### DIFF
--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -275,7 +275,7 @@ class Cliconf(CliconfBase):
             'supports_multiline_delimiter': False,
             'supports_diff_match': True,
             'supports_diff_ignore_lines': True,
-            'supports_generate_diff': True,
+            'supports_generate_diff': False if self.supports_sessions else True,
             'supports_replace': True if self.supports_sessions else False
         }
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* If the remote host supports session
  capability set the `supports_generate_diff`
  flag to false which identifies if config diff should
  be generated within module or not
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
plugins/cliconf/eos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
