### PR TITLE
cs instance root_disk size update resizes the root volume

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_instance.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance.py
@@ -151,7 +151,7 @@ options:
     description:
       - Enables a volume shrinkage when the new size is smaller than the old one.
     type: bool
-    false: no
+    default: no
   tags:
     description:
       - List of tags. Tags are a list of dictionaries having keys C(key) and C(value).

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance.py
@@ -152,6 +152,7 @@ options:
       - Enables a volume shrinkage when the new size is smaller than the old one.
     type: bool
     default: no
+    version_added: '2.7'
   tags:
     description:
       - List of tags. Tags are a list of dictionaries having keys C(key) and C(value).
@@ -1018,6 +1019,7 @@ def main():
         tags=dict(type='list', aliases=['tag']),
         details=dict(type='dict'),
         poll_async=dict(type='bool', default=True),
+        shrinkok=dict(type='bool', default=False),
     ))
 
     required_together = cs_required_together()

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance.py
@@ -147,7 +147,7 @@ options:
       - Force stop/start the instance if required to apply changes, otherwise a running instance will not be changed.
     type: bool
     default: no
-  shrinkok:
+  allow_root_disk_shrink:
     description:
       - Enables a volume shrinkage when the new size is smaller than the old one.
     type: bool
@@ -764,7 +764,7 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
             args_volume_update['id'] = volume['id']
             args_volume_update['size'] = root_disk_size
 
-            shrinkok = self.module.params.get('shrinkok')
+            shrinkok = self.module.params.get('allow_root_disk_shrink')
             if shrinkok:
                 args_volume_update['shrinkok'] = shrinkok
 
@@ -1019,7 +1019,7 @@ def main():
         tags=dict(type='list', aliases=['tag']),
         details=dict(type='dict'),
         poll_async=dict(type='bool', default=True),
-        shrinkok=dict(type='bool', default=False),
+        allow_root_disk_shrink=dict(type='bool', default=False),
     ))
 
     required_together = cs_required_together()

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance.py
@@ -147,6 +147,11 @@ options:
       - Force stop/start the instance if required to apply changes, otherwise a running instance will not be changed.
     type: bool
     default: no
+  shrinkok:
+    description:
+      - Enables a volume shrinkage when the new size is smaller than the old one.
+    type: bool
+    false: no
   tags:
     description:
       - List of tags. Tags are a list of dictionaries having keys C(key) and C(value).
@@ -743,11 +748,33 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
 
         security_groups_changed = self.security_groups_has_changed()
 
+        # Volume data
+
+        args_volume_update = {}
+        root_disk_size = self.module.params.get('root_disk_size')
+        root_disk_size_changed = False
+
+        if root_disk_size is not None:
+            res = self.query_api('listVolumes', type='ROOT', virtualmachineid=instance['id'])
+            [volume] = res['volume']
+
+            size = volume['size'] >> 30
+
+            args_volume_update['id'] = volume['id']
+            args_volume_update['size'] = root_disk_size
+
+            shrinkok = self.module.params.get('shrinkok')
+            if shrinkok:
+                args_volume_update['shrinkok'] = shrinkok
+
+            root_disk_size_changed = root_disk_size != size
+
         changed = [
             service_offering_changed,
             instance_changed,
             security_groups_changed,
             ssh_key_changed,
+            root_disk_size_changed,
         ]
 
         if any(changed):
@@ -786,6 +813,11 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
                         instance = self.query_api('resetSSHKeyForVirtualMachine', **args_ssh_key)
                         instance = self.poll_job(instance, 'virtualmachine')
                         self.instance = instance
+
+                    # Root disk size
+                    if root_disk_size_changed:
+                        async_result = self.query_api('resizeVolume', **args_volume_update)
+                        self.poll_job(async_result, 'volume')
 
                     # Start VM again if it was running before
                     if instance_state == 'running' and start_vm:


### PR DESCRIPTION
##### SUMMARY

CloudStack's [resizeVolume](http://cloudstack.apache.org/api/apidocs-4.10/apis/resizeVolume.html) on the `ROOT` volume of a VM based on the `root_disk_size`.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

cloud / cloudstack / cs_instance

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (cs-instance-root-disk-size c9a9a5d39a) last updated 2018/08/08 11:47:28 (GMT +200)
  config file = None
  configured module search path = ['/home/yoan/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/yoan/soft/ansible/lib/ansible
  executable location = /home/yoan/soft/ansible/venv36/bin/ansible
  python version = 3.6.6 (default, Aug  6 2018, 17:27:47) [GCC 8.2.0]
```


##### ADDITIONAL INFORMATION

Assuming, you created an instance with a `root_disk_size` or based on a template supporting it. Changing its value will triggers a `resizeVolume` call applying the changes. `shrinkok` is an extra option.

```yml
      cs_instance:
        template: Linux Debian 9 64-bit
        name: test
        state: present
        root_disk_size: 14
        shrinkok: true
        force: true
```
