### PR TITLE
Azure RM Common - use built in module logging

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -9,6 +9,7 @@ import types
 import copy
 import inspect
 import traceback
+import json
 
 from os.path import expanduser
 

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -984,7 +984,6 @@ class AzureRMModuleBase(object):
 
     @property
     def storage_models(self):
-        self.log('Getting storage models...')
         return StorageManagementClient.models("2017-10-01")
 
     @property

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -36,7 +36,6 @@ AZURE_COMMON_ARGS = dict(
     cert_validation_mode=dict(type='str', choices=['validate', 'ignore']),
     api_profile=dict(type='str', default='latest'),
     adfs_authority_url=dict(type='str', default=None)
-    # debug=dict(type='bool', default=False),
 )
 
 AZURE_CREDENTIAL_ENV_MAPPING = dict(
@@ -278,7 +277,6 @@ class AzureRMModuleBase(object):
         self.check_mode = self.module.check_mode
         self.api_profile = self.module.params.get('api_profile')
         self.facts_module = facts_module
-        # self.debug = self.module.params.get('debug')
 
         # authenticate
         self.credentials = self._get_credentials(self.module.params)
@@ -431,14 +429,10 @@ class AzureRMModuleBase(object):
         self.module.deprecate(msg, version)
 
     def log(self, msg, pretty_print=False):
-        pass
-        # Use only during module development
-        # if self.debug:
-        #     log_file = open('azure_rm.log', 'a')
-        #     if pretty_print:
-        #         log_file.write(json.dumps(msg, indent=4, sort_keys=True))
-        #     else:
-        #         log_file.write(msg + u'\n')
+        if pretty_print:
+            self.module.debug(json.dumps(msg, indent=4, sort_keys=True))
+        else:
+            self.module.debug(msg)
 
     def validate_tags(self, tags):
         '''


### PR DESCRIPTION
##### SUMMARY
Instead of logging azure module debug to a custom file (only if you remove the commented out code). The basic module already has this functionality even using the same debug flag on the module. So we're much better using that!

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Azure RM Common

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = None
  configured module search path = ['/Users/georgewilson/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.7.0 (default, Jul 23 2018, 20:22:55) [Clang 9.1.0 (clang-902.0.39.2)]
```


##### ADDITIONAL INFORMATION
I'm not sure that the pretty print option is very useful - but made the decision to leave that for a future PR rather than try doing too much in this one