### PR TITLE
Fix link description typo in tools documentation

### DIFF
--- a/docs/docsite/rst/community/other_tools_and_programs.rst
+++ b/docs/docsite/rst/community/other_tools_and_programs.rst
@@ -28,7 +28,7 @@ Emacs
 A free, open-source text editor and IDE that supports auto-indentation, syntax highlighting and built in terminal shell(among other things).
 
 * `yaml-mode <https://github.com/yoshiki/yaml-mode>`_ - YAML highlighting and syntax checking.
-* `inja2-mode <https://github.com/paradoxxxzero/jinja2-mode>`_ - Jinja2 highlighting and syntax checking.
+* `jinja2-mode <https://github.com/paradoxxxzero/jinja2-mode>`_ - Jinja2 highlighting and syntax checking.
 * `magit-mode <https://github.com/magit/magit>`_ -  Git porcelain within Emacs.
 
 


### PR DESCRIPTION
##### SUMMARY
s/inja2-mode/jinja2-mode/

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
tools documentation

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel bd4d68c785) last updated 2018/08/08 16:25:59 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/labs/ansible/devel/lib/ansible
  executable location = /home/andreas/labs/ansible/devel/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```