### PR TITLE
[stable-2.6] Fix 2 issues in sysvinit module (backport/2.6/42786)

### DIFF
--- a/changelogs/fragments/42786-sysvinit-fix-2-issues.yml
+++ b/changelogs/fragments/42786-sysvinit-fix-2-issues.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- "sysvinit module: handle values of optional parameters (https://github.com/ansible/ansible/pull/42786).
+  Don't disable service when `enabled` parameter isn't set.
+  Fix command when `arguments` parameter isn't set."

--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -259,7 +259,7 @@ def main():
                 elif location.get('chkconfig'):
                     (rc, out, err) = module.run_command("%s --level %s %s off" % (location['chkconfig'], ''.join(runlevels), name))
     else:
-        if enabled != runlevel_status["enabled"]:
+        if enabled is not None and enabled != runlevel_status["enabled"]:
             result['changed'] = True
             result['status']['enabled']['changed'] = True
 
@@ -300,7 +300,9 @@ def main():
 
         def runme(doit):
 
-            cmd = "%s %s %s %s" % (script, doit, name, module.params['arguments'])
+            args = module.params['arguments']
+            cmd = "%s %s %s" % (script, doit, "" if args is None else args)
+
             # how to run
             if module.params['daemonize']:
                 (rc, out, err) = daemonize(cmd)


### PR DESCRIPTION
##### SUMMARY

* Update changelog 
* cherry picked from commit f26272a:
  * Do not compare result to unset parameter in sysvinit module
  * Fix misformed command in sysvinit module
  * Small None-comparison style fix in sysvinit module

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
sysvinit

##### ANSIBLE VERSION
```
2.6.2
```

##### ADDITIONAL INFORMATION
Backport  #42786 which fixes #42620.