### PR TITLE
Ensure removed_in is StrictVersion before comparing

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -1374,7 +1374,7 @@ class ModuleValidator(Validator):
 
             # See if current version => deprecated.removed_in, ie, should be docs only
             if docs and 'deprecated' in docs and docs['deprecated'] is not None:
-                removed_in = docs.get('deprecated')['removed_in']
+                removed_in = StrictVersion(str(docs.get('deprecated')['removed_in']))
                 strict_ansible_version = StrictVersion('.'.join(ansible_version.split('.')[:2]))
                 end_of_deprecation_should_be_docs_only = strict_ansible_version >= removed_in
                 # FIXME if +2 then file should be empty? - maybe add this only in the future

--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -1374,10 +1374,14 @@ class ModuleValidator(Validator):
 
             # See if current version => deprecated.removed_in, ie, should be docs only
             if docs and 'deprecated' in docs and docs['deprecated'] is not None:
-                removed_in = StrictVersion(str(docs.get('deprecated')['removed_in']))
-                strict_ansible_version = StrictVersion('.'.join(ansible_version.split('.')[:2]))
-                end_of_deprecation_should_be_docs_only = strict_ansible_version >= removed_in
-                # FIXME if +2 then file should be empty? - maybe add this only in the future
+                try:
+                    removed_in = StrictVersion(str(docs.get('deprecated')['removed_in']))
+                except ValueError:
+                    end_of_deprecation_should_be_docs_only = False
+                else:
+                    strict_ansible_version = StrictVersion('.'.join(ansible_version.split('.')[:2]))
+                    end_of_deprecation_should_be_docs_only = strict_ansible_version >= removed_in
+                    # FIXME if +2 then file should be empty? - maybe add this only in the future
 
         if self._python_module() and not self._just_docs() and not end_of_deprecation_should_be_docs_only:
             self._validate_ansible_module_call(docs)


### PR DESCRIPTION
##### SUMMARY
Ensure removed_in is StrictVersion before comparing

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/sanity/validate-modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
Prevents:

```
2018-08-07 15:16:22 Traceback (most recent call last):
2018-08-07 15:16:22   File "test/sanity/validate-modules/validate-modules", line 1593, in <module>
2018-08-07 15:16:22     main()
2018-08-07 15:16:22   File "test/sanity/validate-modules/validate-modules", line 1492, in main
2018-08-07 15:16:22     mv.validate()
2018-08-07 15:16:22   File "test/sanity/validate-modules/validate-modules", line 1379, in validate
2018-08-07 15:16:22     end_of_deprecation_should_be_docs_only = strict_ansible_version >= removed_in
2018-08-07 15:16:22   File "/usr/lib/python3.6/distutils/version.py", line 70, in __ge__
2018-08-07 15:16:22     c = self._cmp(other)
2018-08-07 15:16:22   File "/usr/lib/python3.6/distutils/version.py", line 170, in _cmp
2018-08-07 15:16:22     if self.version != other.version:
2018-08-07 15:16:22 AttributeError: 'float' object has no attribute 'version'
```