### PR TITLE
 Create a template for security related bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/security_bug_report.md
@@ -1,0 +1,6 @@
+---
+name: 🔥 Security bug report
+about: How to report security vulnerabilities
+---
+
+For all security related bugs, email security@ansible.com instead of using this issue tracker and you will receive a prompt response.

--- a/.github/ISSUE_TEMPLATE/security_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/security_bug_report.md
@@ -4,3 +4,5 @@ about: How to report security vulnerabilities
 ---
 
 For all security related bugs, email security@ansible.com instead of using this issue tracker and you will receive a prompt response.
+
+For more information, see https://docs.ansible.com/ansible/latest/community/reporting_bugs_and_features.html


### PR DESCRIPTION
##### SUMMARY
This pull request adds a template that serves as a redirect for people who might not know where to open security related issues.  It guides them to email security@ansible.com instead of opening an issue here.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
N/A

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
N/A


##### ADDITIONAL INFORMATION
N/A