### PR TITLE
Corrects module name in net_get module doc (#43816)

### DIFF
--- a/lib/ansible/modules/network/files/net_get.py
+++ b/lib/ansible/modules/network/files/net_get.py
@@ -61,7 +61,7 @@ EXAMPLES = """
     src: running_cfg_ios1.txt
 
 - name: copy file from ios to common location at /tmp
-  network_put:
+  net_get:
     src: running_cfg_sw1.txt
     dest : /tmp/ios1.txt
 """


### PR DESCRIPTION
##### SUMMARY


##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
