### PR TITLE
docs: remove "make viewdocs" reference

### DIFF
--- a/docs/docsite/README.md
+++ b/docs/docsite/README.md
@@ -5,7 +5,7 @@ This project hosts the source behind [docs.ansible.com](https://docs.ansible.com
 
 Contributions to the documentation are welcome. To make changes, submit a pull request that changes the reStructuredText files in the `rst/` directory only, and the core team can do a docs build and push the static files.
 
-If you wish to verify output from the markup such as link references, you may install sphinx and build the documentation by running `make viewdocs` from the `ansible/docsite` directory.
+If you wish to verify output from the markup such as link references, you may install sphinx and build the documentation by running `make webdocs` from the `ansible/docsite` directory.
 
 To include module documentation you'll need to run `make webdocs` at the top level of the repository. The generated html files are in `docsite/htmlout/`.
 


### PR DESCRIPTION

##### SUMMARY
The "viewdocs" target was removed in
0381bc170c681b6ea8a94467c62e0694e3d9029d; running "make webdocs" gets
you the output for initial testing purposes.

##### ISSUE TYPE
 - Bugfix Pull Request

