### PR TITLE
[Junos] Add l3-interface option for vlan

### DIFF
--- a/lib/ansible/modules/network/junos/junos_vlan.py
+++ b/lib/ansible/modules/network/junos/junos_vlan.py
@@ -32,7 +32,8 @@ options:
     required: true
   l3_interface:
     description:
-      -  Name of logical layer 3 interface
+      -  Name of logical layer 3 interface.
+    version_added: "2.7"
   description:
     description:
       - Text description of VLANs.

--- a/lib/ansible/modules/network/junos/junos_vlan.py
+++ b/lib/ansible/modules/network/junos/junos_vlan.py
@@ -30,6 +30,9 @@ options:
     description:
       - ID of the VLAN. Range 1-4094.
     required: true
+  l3_interface:
+    description:
+      -  Name of logical layer 3 interface
   description:
     description:
       - Text description of VLANs.
@@ -65,6 +68,13 @@ EXAMPLES = """
   junos_vlan:
     vlan_name: test
     vlan_id: 20
+    name: test-vlan
+
+- name: Link to logical layer 3 interface
+  junos_vlan:
+    vlan_name: test
+    vlan_id: 20
+    l3-interface: vlan.20
     name: test-vlan
 
 - name: remove VLAN configuration
@@ -145,6 +155,7 @@ def main():
         vlan_id=dict(type='int'),
         description=dict(),
         interfaces=dict(),
+        l3_interface=dict(),
         state=dict(default='present', choices=['present', 'absent']),
         active=dict(default=True, type='bool')
     )
@@ -182,6 +193,7 @@ def main():
     param_to_xpath_map.update([
         ('name', {'xpath': 'name', 'is_key': True}),
         ('vlan_id', 'vlan-id'),
+        ('l3_interface', 'l3-interface'),
         ('description', 'description')
     ])
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add `l3-interface` option for vlan on junos module.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
junos_vlan

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = /project/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jul 31 2018, 23:03:52) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Currently, if you need to set RVI, you can use [junos_config](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/network/junos/junos_config.py#L153).

Instead of using `junos_config`, I think that `junos_l3_interface` and `junos_vlan` are also able to do this setting.

You can see document of l3-interface of vlan.
https://www.juniper.net/documentation/en_US/junos/topics/task/configuration/bridging-routed-vlan-interfaces-ex-series-cli.html

And I have tested it on Juniper  EX3300.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
