### PR TITLE
Promote me to a co-maintainer for get_url

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -426,7 +426,7 @@ files:
   $modules/monitoring/zabbix/zabbix_maintenance.py: abulimov
   $modules/monitoring/zabbix/zabbix_screen.py: cove harrisongu
   $modules/monitoring/zabbix/zabbix_template.py: eikef Logan2211 sookido
-  $modules/net_tools/basics/get_url.py: jpmens
+  $modules/net_tools/basics/get_url.py: jpmens ptux
   $modules/net_tools/basics/slurp.py: $team_ansible
   $modules/net_tools/basics/uri.py: $team_ansible
   $modules/net_tools/cloudflare_dns.py: mgruener andreaso


### PR DESCRIPTION
##### SUMMARY

Could you promote me from contributor to **co-maintainer** of get_url, please?

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Changing Maintainership

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->

get_url.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5 2.6 2.7 ~
```

##### ADDITIONAL INFORMATION

@jpmens 

My name is Wang.
I have been using Ansible for three years.
I have automated most of my work with Ansible.
Now, I have time and interest to be a maintainer of the get_url module.
My job is to protect, provide for, and progress web service.
So, I know how to control HTTP.
I've checked all the issues of get_url.
I noticed that you tag `waiting_on_contrabutor` positively.
I'll do my best to fix the necessary ones.

I guess you have a lot going on.
So, let me **help you and users of get_url**.
