### PR TITLE
Adds new module win_mssql_login

### DIFF
--- a/lib/ansible/modules/windows/win_mssql_login.ps1
+++ b/lib/ansible/modules/windows/win_mssql_login.ps1
@@ -1,0 +1,188 @@
+#!powershell
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Daniele Lazzari  <lazzari@mailup.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+
+$ErrorActionPreference = "Stop"
+$result = @{
+    'changed' = $False;
+    'output'  = $null
+}
+
+Function Test-SQLUser {
+    Param(
+        [string]$LoginName,
+        [string]$ServerInstance,
+        [string]$ServerInstanceUser,
+        [securestring]$ServerInstancePassword
+    )
+    try {
+        if (!($ServerInstanceUser) -or !($ServerInstancePassword)) {
+            $exists = Invoke-SQLCmd -ServerInstance $ServerInstance -Query "SELECT name FROM syslogins WHERE name = '$LoginName'"
+        }
+        else {
+            $SQLCredentials = New-Object -TypeName System.Management.Automation.PSCredential ($ServerInstanceUser, $ServerInstancePassword)
+            $exists = Invoke-SQLCmd -ServerInstance $ServerInstance -Query "SELECT name FROM syslogins WHERE name = '$LoginName'" -Credential $SQLCredentials
+        }
+    }   
+    catch {
+        Fail-Json -obj $result -message $($_.exception.message)
+    }
+
+    if ($exists) {
+        return $true
+    }
+
+    return $false
+}
+
+Function Add-SQLLogin {
+
+    Param (
+        [string]$LoginName,
+        [string]$Password,
+        [string]$LoginType,
+        [string]$DefaultDatabase,
+        [string]$DefaultLanguage,
+        [bool]$CheckExpiration,
+        [bool]$CheckPolicy,
+        [string]$ServerInstance,
+        [string]$ServerInstanceUser,
+        [securestring]$ServerInstancePassword,
+        [bool]$CheckMode
+    )
+
+    $Expiration = 'CHECK_EXPIRATION=OFF'
+    $Policy = 'CHECK_POLICY=OFF'
+
+    if ($CheckExpiration) {
+        $Expiration = 'CHECK_EXPIRATION=ON'
+    }
+    if ($CheckPolicy) {
+        $Policy = 'CHECK_POLICY=ON'
+    }
+
+    if ($LoginType -eq 'sql') {
+        $QUERY = "CREATE LOGIN $LoginName WITH PASSWORD=N'$Password', DEFAULT_DATABASE=$DefaultDatabase, DEFAULT_LANGUAGE=$DefaultLanguage, $Expiration, $Policy"
+    }
+    else {
+        if ($LoginName -match "\\") {
+            $LoginName = $LoginName.Replace("\\", "\")
+        }
+        $QUERY = "CREATE LOGIN `"$LoginName`" FROM WINDOWS WITH DEFAULT_DATABASE=$DefaultDatabase, DEFAULT_LANGUAGE=$DefaultLanguage"
+    }
+    
+    $exists = Test-SQLUser -LoginName $LoginName `
+        -ServerInstance $ServerInstance `
+        -ServerInstanceUser $ServerInstanceUser `
+        -ServerInstancePassword $ServerInstancePassword
+    
+    if (!($exists)) {
+        try {
+            if (!($CheckMode)) {
+                if (!($ServerInstanceUser) -or !($ServerInstancePassword)) {
+                    Invoke-SQLCmd -ServerInstance $ServerInstance -Query $QUERY
+                }
+                else {
+                    $SQLCredentials = New-Object -TypeName System.Management.Automation.PSCredential ($ServerInstanceUser, $ServerInstancePassword)
+                    Invoke-SQLCmd -ServerInstance $ServerInstance -Query $QUERY -Credential $SQLCredentials
+                }
+            }
+            $result.output = "login $LoginName created"
+            $result.changed = $true
+        }
+        catch {
+            Fail-Json -obj $result -message $($_.exception.message)
+        }
+    }
+    else {
+        $result.output = "login $LoginName alerady exists"
+    }
+    Exit-Json $result
+}
+
+Function Remove-SQLLogin {
+    Param(
+        [Parameter(Mandatory = $true)]
+        [string]$LoginName,
+        [string]$ServerInstance,
+        [string]$ServerInstanceUser,
+        [securestring]$ServerInstancePassword,
+        [bool]$CheckMode
+    )
+    
+    $exists = Test-SQLUser -LoginName $LoginName `
+        -Password $Password `
+        -ServerInstance $ServerInstance `
+        -ServerInstanceUser $ServerInstanceUser `
+        -ServerInstancePassword $ServerInstancePassword
+    
+    if ($exists) {
+        $QUERY = "DROP LOGIN `"$LoginName`"" 
+        try {
+            if (!($CheckMode)) {
+                if (!($ServerInstanceUser) -or !($ServerInstancePassword)) {
+                    Invoke-SQLCmd -ServerInstance $ServerInstance -Query $QUERY 
+                }
+                else {
+                    $SQLCredentials = New-Object -TypeName System.Management.Automation.PSCredential ($ServerInstanceUser, $ServerInstancePassword)
+                    Invoke-SQLCmd -ServerInstance $ServerInstance -Query $QUERY -Credential $SQLCredentials
+                }
+            }
+            $result.output = "loign $LoginName removed"
+            $result.changed = $true
+        }
+        catch {
+            Fail-Json -obj $result -message $($_.exception.message)
+        }
+    }
+    else {
+        $result.output = "login $LoginName does not exist"
+    }
+    Exit-Json $result
+}
+
+$params = Parse-Args $args -supports_check_mode $true
+
+$loginName = Get-AnsibleParam -obj $params -name "login_name" -type "str" -failifempty $true
+$password = Get-AnsibleParam -obj $params -name "password" -type "str"
+$defaultDb = Get-AnsibleParam -obj $params -name "default_database" -type "str" -default "master"
+$defaultLanguage = Get-AnsibleParam -obj $params -name "default_language" -type "str" -default "us_english"
+$checkExpiration = Get-AnsibleParam -obj $params -name "check_expiration" -type "bool" -default $true
+$checkPolicy = Get-AnsibleParam -obj $params -name "check_policy" -type "bool" -default $true
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present", "absent"
+$serverInstance = Get-AnsibleParam -obj $params -name "server_instance" -type "str" -default $env:COMPUTERNAME
+$serverInstanceUser = Get-AnsibleParam -obj $params -name "server_instance_user" -type "str" -default $null
+$serverInstancePassword = Get-AnsibleParam -obj $params -name "server_instance_password" -type "str" -default $null
+$loginType = Get-AnsibleParam -obj $params -name "login_type" -type "str" -default "sql" -validateset "sql", "windows"
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
+
+
+if ($serverInstancePassword) {
+    $serverInstancePassword = ConvertTo-SecureString $serverInstancePassword -AsPlainText -Force
+}
+
+if ($state -eq "present") {
+    Add-SQLLogin -LoginName $loginName `
+        -Password $password `
+        -LoginType $loginType `
+        -DefaultDatabase $defaultDb `
+        -DefaultLanguage $defaultLanguage `
+        -CheckExpiration $checkExpiration `
+        -CheckPolicy $checkPolicy `
+        -ServerInstance $serverInstance `
+        -ServerInstanceUser $serverInstanceUser `
+        -ServerInstancePassword $serverInstancePassword `
+        -CheckMode $check_mode
+}
+
+if ($state -eq "absent")  {
+    Remove-SQLLogin -LoginName $loginName `
+        -ServerInstance $serverInstance `
+        -ServerInstanceUser $serverInstanceUser `
+        -ServerInstancePassword $serverInstancePassword `
+        -CheckMode $check_mode
+}

--- a/lib/ansible/modules/windows/win_mssql_login.py
+++ b/lib/ansible/modules/windows/win_mssql_login.py
@@ -70,12 +70,19 @@ options:
 author:
   - Daniele Lazzari
 notes:
-  - If the user that runs ansible has the appropriated permission on the db,
+  - If the user that runs ansible has the appropriate permission on the database server,
   - you don't need to set C(server_instance_user) and C(server_instance_password)
 '''
 
 EXAMPLES = r'''
 ---
+# install SqlServer module on the target server if needed 
+- name: install SqlServer powershell module
+  win_psmodule:
+    name: SqlServer
+    state: present
+    allow_clobber: yes
+
 - name: add a new login
   win_mssql_login:
     server_instance: 'MYSQLSERVER\MSSQLSERVER1'

--- a/lib/ansible/modules/windows/win_mssql_login.py
+++ b/lib/ansible/modules/windows/win_mssql_login.py
@@ -76,7 +76,7 @@ notes:
 
 EXAMPLES = r'''
 ---
-# install SqlServer module on the target server if needed 
+# install SqlServer module on the target server if needed
 - name: install SqlServer powershell module
   win_psmodule:
     name: SqlServer

--- a/lib/ansible/modules/windows/win_mssql_login.py
+++ b/lib/ansible/modules/windows/win_mssql_login.py
@@ -59,7 +59,6 @@ options:
   login_type:
     description: specifies what type of login has to be created (sql or windows)
     default: sql
-    type: string
     choices:
       - sql
       - windows

--- a/lib/ansible/modules/windows/win_mssql_login.py
+++ b/lib/ansible/modules/windows/win_mssql_login.py
@@ -1,0 +1,119 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Daniele Lazzari <lazzari@mailup.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# This is a windows documentation stub.  Actual code lives in the .ps1
+# file of the same name.
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: win_mssql_login
+version_added: '2.7'
+short_description: adds or removes a MSSQL Server login
+description:
+    - Adds or removes MSSQL Server login
+requirements:
+  - Powershell module sqlps or Powershell module SqlServer on the remote host
+options:
+  server_instance:
+    description:
+      - Name of the sql server instance where the user has to be created
+    default: computername
+  server_instance_user:
+    description:
+      - Name of a sql user with sufficient privileges to create users
+  server_instance_password:
+    description:
+      - Password for server_instance_user
+  login_name:
+    description:
+      - Login name
+    required: yes
+  password:
+    description:
+      - Password of the new login
+  default_database:
+    description:
+      - Name of the login default database
+    default: master
+  default_language:
+    description:
+      - The login default language
+    default: us_english
+  check_expiration:
+    description:
+      - Enforces password expiration
+    type: bool
+    default: 'yes'
+  check_policy:
+    description:
+      - Enforces password policy
+    type: bool
+    default: 'yes'
+  login_type:
+    description: specifies what type of login has to be created (sql or windows)
+    default: sql
+    type: string
+    choices:
+      - sql
+      - windows
+  state:
+    description:
+      - If C(present), it creates the new user
+      - If C(absent), it removes the new user
+    default: present
+author:
+  - Daniele Lazzari
+notes:
+  - If the user that runs ansible has the appropriated permission on the db,
+  - you don't need to set C(server_instance_user) and C(server_instance_password)
+'''
+
+EXAMPLES = r'''
+---
+- name: add a new login
+  win_mssql_login:
+    server_instance: 'MYSQLSERVER\MSSQLSERVER1'
+    login_name: john_doe
+    password: "{{ my_super_secret }}"
+    state: present
+
+- name: add a new login without password expiration enforcing
+  win_mssql_login:
+    server_instance: localhost
+    server_instance_user: sa
+    server_instance_password: "{{ sa }}"
+    login_name: jane_doe
+    password: "{{ my_super_secret }}"
+    check_expiration: no
+    state: present
+
+- name: add a new windows login
+  win_mssql_login:
+    server_instance: MYSQLSERVER
+    server_instance_user: sa
+    server_instance_password: "{{ sa }}"
+    login_name: 'MYSQLSERVER\jane_doe'
+    login_type: windows
+    state: present
+
+- name: remove a sql login
+  server_instance: 'myserver'
+  login_name: john_doe
+  state: absent
+'''
+
+RETURN = r'''
+---
+output:
+  description: a message describing the task result
+  returned: always
+  sample: "login john_doe created"
+  type: string
+'''

--- a/test/integration/targets/win_mssql_login/aliases
+++ b/test/integration/targets/win_mssql_login/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group2

--- a/test/integration/targets/win_mssql_login/defaults/main.yml
+++ b/test/integration/targets/win_mssql_login/defaults/main.yml
@@ -1,0 +1,2 @@
+sa: P@ssw0rd
+my_super_secret: SuperS3cret

--- a/test/integration/targets/win_mssql_login/tasks/main.yml
+++ b/test/integration/targets/win_mssql_login/tasks/main.yml
@@ -1,0 +1,78 @@
+# test code for the win_psmodule module when using winrm connection
+# (c) 2017, Daniele Lazzari <lazzari@mailup.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+- name: get facts
+  setup:
+
+- name: check sql server is installed
+  win_shell: Get-WmiObject win32_service|?{$_.name -like "MSSQL*"}
+  register: service
+
+- name: run tests
+  when: service.stdout != ''
+  block:
+
+    - name: install SqlServer powershell module
+      win_psmodule:
+        name: SqlServer
+        state: present
+        allow_clobber: yes
+      when: ansible_powershell_version >= 5
+
+    - name: install sql feature pack
+      when: ansible_powershell_version < 5
+      block: 
+
+        - name: create dir
+          win_file:
+            path: 'c:\temp'
+            state: directory
+
+        - name: download CLR types
+          win_get_url:
+            url: http://go.microsoft.com/fwlink/?LinkID=239644&clcid=0x409
+            dest: 'c:\temp\clr.msi'
+
+        - name: download smo
+          win_get_url:
+            url: http://go.microsoft.com/fwlink/?LinkID=239659&clcid=0x409
+            dest: 'c:\temp\smo.msi'
+
+        - name: download powershell tools
+          win_get_url: 
+            url: http://go.microsoft.com/fwlink/?LinkID=239656&clcid=0x409
+            dest: 'c:\temp\spt.msi'
+        
+        - name: install CLR Types
+          win_package:
+            path: 'c:\temp\clr.msi'
+            state: present
+
+        - name: install smo
+          win_package:
+            path: 'c:\temp\smo.msi'
+            state: present
+
+        - name: install pack
+          win_package:
+            path: 'c:\temp\spt.msi'
+            state: present
+
+    - name: run all tests
+      import_tasks: test.yml

--- a/test/integration/targets/win_mssql_login/tasks/test.yml
+++ b/test/integration/targets/win_mssql_login/tasks/test.yml
@@ -1,0 +1,67 @@
+---
+- name: create new sql login
+  win_mssql_login:
+    server_instance: localhost
+    server_instance_user: sa
+    server_instance_password: "{{ sa }}"
+    login_name: john_doe
+    password: "{{ my_super_secret }}"
+    state: present
+  register: res
+
+- name: test module success
+  assert:
+    that:
+      - res.changed == True
+      - res.output == "login john_doe created"
+
+- name: create new sql login
+  win_mssql_login:
+    server_instance: localhost
+    server_instance_user: sa
+    server_instance_password: "{{ sa }}"
+    login_name: john_doe
+    password: "{{ my_super_secret }}"
+    state: present
+  register: res
+
+- name: test attempt of existing user creation
+  assert:
+    that:
+      - res.changed == False
+      - res.output == "login john_doe alerady exists"
+
+- name: add a new sql user without password password policy and expiration enforcing
+  win_mssql_login:
+    server_instance: localhost
+    server_instance_user: sa
+    server_instance_password: "{{ sa }}"
+    login_name: jane_doe
+    password: "{{ my_super_secret }}"
+    check_expiration: no
+    check_policy: no
+    state: present
+  register: res
+
+- name: test module success
+  assert:
+    that:
+      - res.changed == True
+      - res.output == "login jane_doe created"
+
+- name: remove a list of sql login
+  win_mssql_login:
+    server_instance: localhost
+    server_instance_user: sa
+    server_instance_password: "{{ sa }}"
+    login_name: "{{ item }}"
+    state: absent
+  register: res
+  loop:
+    - jane_doe
+    - john_doe
+#
+- name: test module success
+  assert:
+    that:
+      - res.changed == True

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -63,6 +63,7 @@ lib/ansible/modules/windows/win_iis_website.ps1 PSAvoidUsingPositionalParameters
 lib/ansible/modules/windows/win_iis_website.ps1 PSUseBOMForUnicodeEncodedFile
 lib/ansible/modules/windows/win_iis_website.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_mapped_drive.ps1 PSAvoidUsingConvertToSecureStringWithPlainText
+lib/ansible/modules/windows/win_mssql_login.ps1 PSAvoidUsingConvertToSecureStringWithPlainText
 lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingInvokeExpression
 lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingPlainTextForPassword

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -64,6 +64,8 @@ lib/ansible/modules/windows/win_iis_website.ps1 PSUseBOMForUnicodeEncodedFile
 lib/ansible/modules/windows/win_iis_website.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_mapped_drive.ps1 PSAvoidUsingConvertToSecureStringWithPlainText
 lib/ansible/modules/windows/win_mssql_login.ps1 PSAvoidUsingConvertToSecureStringWithPlainText
+lib/ansible/modules/windows/win_mssql_login.ps1 PSAvoidUsingPlainTextForPassword
+lib/ansible/modules/windows/win_mssql_login.ps1 PSAvoidUsingUserNameAndPassWordParams
 lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingInvokeExpression
 lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingPlainTextForPassword


### PR DESCRIPTION
##### SUMMARY
New windows module that allows to add or remove MS SQL Server logins

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
win_mssql_login

##### ANSIBLE VERSION
```
2.7
```
##### ADDITIONAL INFORMATION
Idempotent creation or deletion of a MS SQL SERVER Login

<!--- Paste verbatim command output below, e.g. before and after your change -->
Ansible Task:
```
- name: create new sql login
  win_mssql_login:
    server_instance: 'myserver\instance'
    login_name: john_doe
    password: "{{ my_super_secret }}"
    state: present
```
Output: 
```
TASK [create new sql login] *********************************************************************************************************************************
changed: [ansible] => {"changed": true, "output": "login john_doe created"}
```