### PR TITLE
openvswitch_db : Handle column value conversion and idempotency in no_key case

### DIFF
--- a/lib/ansible/modules/network/ovs/openvswitch_db.py
+++ b/lib/ansible/modules/network/ovs/openvswitch_db.py
@@ -120,15 +120,14 @@ def map_obj_to_commands(want, have, module):
                                   "%(col)s"
             commands.append(templatized_command % module.params)
     else:
+        if want == have:
+            # Nothing to commit
+            return commands
         if module.params['key'] is None:
             templatized_command = "%(ovs-vsctl)s -t %(timeout)s set %(table)s %(record)s " \
                                   "%(col)s=%(value)s"
             commands.append(templatized_command % module.params)
-        elif 'key' not in have.keys():
-            templatized_command = "%(ovs-vsctl)s -t %(timeout)s add %(table)s %(record)s " \
-                                  "%(col)s %(key)s=%(value)s"
-            commands.append(templatized_command % module.params)
-        elif want['value'] != have['value']:
+        else:
             templatized_command = "%(ovs-vsctl)s -t %(timeout)s set %(table)s %(record)s " \
                                   "%(col)s:%(key)s=%(value)s"
             commands.append(templatized_command % module.params)
@@ -171,7 +170,7 @@ def map_config_to_obj(module):
             obj['key'] = module.params['key']
             obj['value'] = col_value_to_dict[module.params['key']]
     else:
-            obj['value'] = col_value.strip()
+            obj['value'] = str(col_value.strip())
 
     return obj
 
@@ -199,7 +198,7 @@ def main():
         'record': {'required': True},
         'col': {'required': True},
         'key': {'required': False},
-        'value': {'required': True},
+        'value': {'required': True, 'type': 'str'},
         'timeout': {'default': 5, 'type': 'int'},
     }
 

--- a/test/integration/targets/openvswitch_db/tests/basic.yaml
+++ b/test/integration/targets/openvswitch_db/tests/basic.yaml
@@ -70,7 +70,8 @@
     table: Bridge
     record: br-test
     col: stp_enable
-    value: true
+    value: 'true'
+  become: yes
   register: result
 
 - assert:
@@ -82,7 +83,8 @@
     table: Bridge
     record: br-test
     col: stp_enable
-    value: true
+    value: 'true'
+  become: yes
   register: result
 
 - assert:
@@ -96,6 +98,7 @@
     record: br-test
     col: other_config
     value: true
+  become: yes
   register: result
 
 - assert:

--- a/test/units/modules/network/ovs/test_openvswitch_db.py
+++ b/test/units/modules/network/ovs/test_openvswitch_db.py
@@ -114,8 +114,8 @@ class TestOpenVSwitchDBModule(TestOpenVSwitchModule):
                              value='True'))
         self.execute_module(
             changed=True,
-            commands=['/usr/bin/ovs-vsctl -t 5 add Bridge test-br other_config'
-                      ' disable-in-band=True'],
+            commands=['/usr/bin/ovs-vsctl -t 5 set Bridge test-br other_config'
+                      ':disable-in-band=True'],
             test_name='test_openvswitch_db_present_adds_key')
 
     def test_openvswitch_db_present_updates_key(self):


### PR DESCRIPTION
##### SUMMARY
Fixes #43858 

1) 'value' argument if passed as boolean in playbook gets converted to standard template boolean string(True/False). Convert it to string to keep the user supplied value in playbook.
2) Idempotency was not handled in no_key case and even it was buggy in explicit 'key' case where it will not program the DB entry if column name is different but values are same. Fixed it by direct dict comparison of existing and wanted configurations.
3) Set become to True at task level so that test passes even if it not set in host vars.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
openvswitch_db

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION

ansible-test  network-integration --inventory /tmp/inventory openvswitch_db -vvv 
PLAY RECAP *******************************************************************************************************************************************ovs1                       : ok=27   changed=9    unreachable=0    failed=0 