### PR TITLE
docker_container: ambiguous parameter "stop_timeout" 

### DIFF
--- a/changelogs/fragments/43874-docker_container-stop_timeout.yaml
+++ b/changelogs/fragments/43874-docker_container-stop_timeout.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-- "docker_container - ``stop_timeout`` is now also used to set the ``StopTimeout`` property of the docker container on creation time."
+- "docker_container - ``stop_timeout`` is now also used to set the ``StopTimeout`` property of the docker container when creating the container."

--- a/changelogs/fragments/43874-docker_container-stop_timeout.yaml
+++ b/changelogs/fragments/43874-docker_container-stop_timeout.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_container - ``stop_timeout`` is now also used to set the ``StopTimeout`` property of the docker container on creation time."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -391,10 +391,14 @@ options:
   stop_timeout:
     description:
       - Number of seconds to wait for the container to stop before sending SIGKILL.
-        When C(state) is I(present), set container's C(StopTimeout) configuration (in seconds). This only applies on container creation time.
-        C(StopTimeout) won't be updated on existing containers.
-        When C(state) is I(stopped), set timeout (in seconds) to stop a container.
-        This ignores default or custom C(StopTimeout) configuration of the container.
+        When C(state) is not I(absent) and the container is (re-)created, set container's
+        C(StopTimeout) configuration (in seconds). C(StopTimeout) won't be updated on
+        existing containers.
+      - When the container is stopped, will be used as a timeout for stopping the
+        container. In case the container has a custom C(StopTimeout) configuration,
+        the behavior depends on the version of docker. New versions of docker will
+        always use the container's configured C(StopTimeout) value if it has been
+        configured.
   trust_image_content:
     description:
       - If C(yes), skip image verification.

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1506,7 +1506,7 @@ class Container(DockerBaseClass):
 
         if self.parameters.client.HAS_STOP_TIMEOUT_OPT:
             # stop_timeout is only supported in docker>=2.1
-            config_mapping['stop_timeout'] = host_config.get('StopTimeout')
+            config_mapping['stop_timeout'] = config.get('StopTimeout')
 
         if HAS_DOCKER_PY_3:
             # volume_driver moved to create_host_config in > 3

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -931,13 +931,15 @@ class TaskParameters(DockerBaseClass):
             mac_address='mac_address',
             labels='labels',
             stop_signal='stop_signal',
-            stop_timeout='stop_timeout',
             working_dir='working_dir',
         )
 
         if not HAS_DOCKER_PY_3:
             create_params['cpu_shares'] = 'cpu_shares'
             create_params['volume_driver'] = 'volume_driver'
+
+        if self.client.HAS_STOP_TIMEOUT_OPT:
+            create_params['stop_timeout'] = 'stop_timeout'
 
         result = dict(
             host_config=self._host_config(),
@@ -2293,10 +2295,29 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
             self.fail("docker or docker-py version is %s. Minimum version required is 2.3 to set cpuset_mems option. "
                       "If you use the 'docker-py' module, you have to switch to the docker 'Python' package." % (docker_version,))
 
+        stop_timeout_supported = LooseVersion(docker_api_version) >= LooseVersion('1.25')
+        stop_timeout_needed_for_update = self.module.params.get("stop_timeout") is not None and self.module.params.get('state') != 'absent'
+        if stop_timeout_supported:
+            stop_timeout_supported = LooseVersion(docker_version) >= LooseVersion('2.1')
+            if stop_timeout_needed_for_update and not stop_timeout_supported:
+                # We warn (instead of fail) since in older versions, stop_timeout was not used
+                # to update the container's configuration, but only when stopping a container.
+                self.module.warn("docker or docker-py version is %s. Minimum version required is 2.1 to update "
+                                 "the container's stop_timeout configuration. "
+                                 "If you use the 'docker-py' module, you have to switch to the docker 'Python' package." % (docker_version,))
+        else:
+            if stop_timeout_needed_for_update and not stop_timeout_supported:
+                # We warn (instead of fail) since in older versions, stop_timeout was not used
+                # to update the container's configuration, but only when stopping a container.
+                self.module.warn("docker API version is %s. Minimum version required is 1.25 to set or "
+                                 "update the container's stop_timeout configuration." % (docker_api_version,))
+
         self.HAS_INIT_OPT = init_supported
         self.HAS_UTS_MODE_OPT = uts_mode_supported
         self.HAS_BLKIO_WEIGHT_OPT = blkio_weight_supported
         self.HAS_CPUSET_MEMS_OPT = cpuset_mems_supported
+        self.HAS_STOP_TIMEOUT_OPT = stop_timeout_supported
+
         self.HAS_AUTO_REMOVE_OPT = HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3
         if self.module.params.get('auto_remove') and not self.HAS_AUTO_REMOVE_OPT:
             self.fail("'auto_remove' is not compatible with the 'docker-py' Python package. It requires the newer 'docker' Python package.")

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -391,6 +391,10 @@ options:
   stop_timeout:
     description:
       - Number of seconds to wait for the container to stop before sending SIGKILL.
+        When C(state) is I(present), set container's C(StopTimeout) configuration (in seconds). This only applies on container creation time.
+        C(StopTimeout) won't be updated on existing containers.
+        When C(state) is I(stopped), set timeout (in seconds) to stop a container.
+        This ignores default or custom C(StopTimeout) configuration of the container.
   trust_image_content:
     description:
       - If C(yes), skip image verification.
@@ -923,6 +927,7 @@ class TaskParameters(DockerBaseClass):
             mac_address='mac_address',
             labels='labels',
             stop_signal='stop_signal',
+            stop_timeout='stop_timeout',
             working_dir='working_dir',
         )
 

--- a/test/integration/targets/docker_container/tasks/tests/comparisons.yml
+++ b/test/integration/targets/docker_container/tasks/tests/comparisons.yml
@@ -381,6 +381,7 @@
     name: "{{ cname }}"
     state: started
     hostname: example.com
+    stop_timeout: 1
     labels:
       ansible.test.1: hello
       ansible.test.2: world
@@ -394,6 +395,7 @@
     name: "{{ cname }}"
     state: started
     hostname: example.org
+    stop_timeout: 2
     labels:
       ansible.test.1: hello
       ansible.test.4: ignore

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -2626,7 +2626,45 @@
 ## stop_timeout ####################################################
 ####################################################################
 
-# TODO: - stop_timeout
+- name: stop_timeout
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    stop_timeout: 2
+    state: started
+  register: stop_timeout_1
+
+- name: stop_timeout (idempotency)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    stop_timeout: 2
+    state: started
+  register: stop_timeout_2
+
+- name: stop_timeout (no change)
+  # stop_timeout changes are ignored by default
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    stop_timeout: 1
+    state: started
+  register: stop_timeout_3
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    stop_timeout: 1
+
+- assert:
+    that:
+    - stop_timeout_1 is changed
+    - stop_timeout_2 is not changed
+    - stop_timeout_3 is not changed
 
 ####################################################################
 ## sysctls #########################################################


### PR DESCRIPTION
##### SUMMARY
Fixes #43814
Honour stop_timeout when creating docker containers and updates documentation accordingly.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.4
  config file = /Users/remo.wenger/.ansible.cfg
  configured module search path = [u'/Users/remo.wenger/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.5.4/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 13:05:56) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```