### PR TITLE
cnos_conditional_command to use persistent connection instead of paramiko

### DIFF
--- a/lib/ansible/modules/network/cnos/cnos_conditional_command.py
+++ b/lib/ansible/modules/network/cnos/cnos_conditional_command.py
@@ -152,7 +152,7 @@ def main():
     output = output + str(cnos.run_cnos_commands(module, cmd))
 
     # Save it into the file
-    path = outputfile.rsplit('/',1)
+    path = outputfile.rsplit('/', 1)
     # cnos.debugOutput(path[0])
     if not os.path.exists(path[0]):
         os.makedirs(path[0])

--- a/lib/ansible/modules/network/cnos/cnos_conditional_command.py
+++ b/lib/ansible/modules/network/cnos/cnos_conditional_command.py
@@ -111,6 +111,7 @@ import array
 import json
 import time
 import re
+import os
 try:
     from ansible.module_utils.network.cnos import cnos
     HAS_LIB = True
@@ -151,6 +152,10 @@ def main():
     output = output + str(cnos.run_cnos_commands(module, cmd))
 
     # Save it into the file
+    path = outputfile.rsplit('/',1)
+    # cnos.debugOutput(path[0])
+    if not os.path.exists(path[0]):
+        os.makedirs(path[0])
     file = open(outputfile, "a")
     file.write(output)
     file.close()

--- a/lib/ansible/modules/network/cnos/cnos_conditional_command.py
+++ b/lib/ansible/modules/network/cnos/cnos_conditional_command.py
@@ -33,48 +33,54 @@ DOCUMENTATION = '''
 ---
 module: cnos_conditional_command
 author: "Anil Kumar Muraleedharan (@amuraleedhar)"
-short_description: Execute a single command based on condition on devices running Lenovo CNOS
+short_description: Execute a single command based on condition on devices
+ running Lenovo CNOS
 description:
-   - This module allows you to modify the running configuration of a switch. It provides a way to
-    execute a single CNOS command on a network device by evaluating the current running configuration
-    and executing the command only if the specific settings have not been already configured.
+   - This module allows you to modify the running configuration of a switch. It
+    provides a way to execute a single CNOS command on a network device by
+    evaluating the current running configuration and executing the command only
+    if the specific settings have not been already configured.
     The CNOS command is passed as an argument of the method.
     This module functions the same as the cnos_command module.
-    The only exception is that the following inventory variable can be specified
+    The only exception is that following inventory variable can be specified
     ["condition = <flag string>"]
-    When this inventory variable is specified as the variable of a task, the command is executed for
-    the network element that matches the flag string. Usually, commands are executed across a group
-    of network devices. When there is a requirement to skip the execution of the command on one or
-    more devices, it is recommended to use this module.
-    This module uses SSH to manage network device configuration.
-    For more information about this module from Lenovo and customizing it usage for your
-    use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_conditional_command.html)
+    When this inventory variable is specified as the variable of a task, the
+    command is executed for the network element that matches the flag string.
+    Usually, commands are executed across a group of network devices. When
+    there is a requirement to skip the execution of the command on one or
+    more devices, it is recommended to use this module. This module uses SSH to
+    manage network device configuration. For more information about this module
+    from Lenovo and customizing it usage for your use cases, please visit
+    U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_conditional_command.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options:
     clicommand:
         description:
-            - This specifies the CLI command as an attribute to this method. The command is passed using
-             double quotes. The variables can be placed directly on to the CLI commands or can be invoked
+            - This specifies the CLI command as an attribute to this method.
+             The command is passed using double quotes. The variables can be
+             placed directly on to the CLI commands or can be invoked
              from the vars directory.
         required: true
         default: Null
     condition:
         description:
-            - If you specify condition=false in the inventory file against any device, the command execution
-             is skipped for that device.
+            - If you specify condition=false in the inventory file against any
+             device, the command execution is skipped for that device.
         required: true
         default: Null
     flag:
         description:
-            - If a task needs to be executed, you have to set the flag the same as it is specified in the
-             inventory for that device.
+            - If a task needs to be executed, you have to set the flag the same
+             as it is specified in the inventory for that device.
         required: true
         default: Null
 
 '''
 EXAMPLES = '''
-Tasks : The following are examples of using the module cnos_conditional_command. These are written in the main.yml file of the tasks directory.
+Tasks : The following are examples of using the module
+ cnos_conditional_command. These are written in the main.yml file of the tasks
+ directory.
 ---
 - name: Applying CLI template on VLAG Tier1 Leaf Switch1
   cnos_conditional_command:
@@ -83,7 +89,8 @@ Tasks : The following are examples of using the module cnos_conditional_command.
       password: "{{ hostvars[inventory_hostname]['ansible_ssh_pass'] }}"
       deviceType: "{{ hostvars[inventory_hostname]['deviceType'] }}"
       enablePassword: "{{ hostvars[inventory_hostname]['enablePassword'] }}"
-      outputfile: "./results/test_conditional_command_{{ inventory_hostname }}_output.txt"
+      outputfile: "./results/test_conditional_command_
+                  {{ inventory_hostname }}_output.txt"
       condition: "{{ hostvars[inventory_hostname]['condition']}}"
       flag: leaf_switch2
       command: "spanning-tree mode enable"
@@ -98,11 +105,6 @@ msg:
 '''
 
 import sys
-try:
-    import paramiko
-    HAS_PARAMIKO = True
-except ImportError:
-    HAS_PARAMIKO = False
 import time
 import socket
 import array
@@ -129,52 +131,24 @@ def main():
             deviceType=dict(required=True),
             username=dict(required=True),
             password=dict(required=True, no_log=True),
-            enablePassword=dict(required=False, no_log=True), ), supports_check_mode=False)
+            enablePassword=dict(required=False,
+                                no_log=True), ), supports_check_mode=False)
 
-    username = module.params['username']
-    password = module.params['password']
-    enablePassword = module.params['enablePassword']
     condition = module.params['condition']
     flag = module.params['flag']
     cliCommand = module.params['clicommand']
     outputfile = module.params['outputfile']
-    deviceType = module.params['deviceType']
-    hostIP = module.params['host']
-    output = ""
-    if not HAS_PARAMIKO:
-        module.fail_json(msg='paramiko is required for this module')
-
-    if (condition != flag):
-        module.exit_json(changed=True, msg="Command Skipped for this value")
-        return " "
-    # Create instance of SSHClient object
-    remote_conn_pre = paramiko.SSHClient()
-
-    # Automatically add untrusted hosts (make sure okay for security policy in your environment)
-    remote_conn_pre.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
-    # initiate SSH connection with the switch
-    remote_conn_pre.connect(hostIP, username=username, password=password)
-    time.sleep(2)
-
-    # Use invoke_shell to establish an 'interactive session'
-    remote_conn = remote_conn_pre.invoke_shell()
-    time.sleep(2)
-
-    # Enable and enter configure terminal then send command
-    #
-    # Enable and enter configure terminal then send command
-    output = output + cnos.waitForDeviceResponse("\n", ">", 2, remote_conn)
-    output = output + cnos.enterEnableModeForDevice(enablePassword, 3, remote_conn)
-
-    # Make terminal length = 0
-    output = output + cnos.waitForDeviceResponse("terminal length 0\n", "#", 2, remote_conn)
-
-    # Go to config mode
-    output = output + cnos.waitForDeviceResponse("configure device\n", "(config)#", 2, remote_conn)
-
+    output = ''
+    if (condition is None or condition != flag):
+        module.exit_json(changed=True, msg="Command Skipped for this switch")
+        return ''
     # Send the CLi command
-    output = output + cnos.waitForDeviceResponse(cliCommand + "\n", "(config)#", 2, remote_conn)
+    cmd = [{'command': cliCommand, 'prompt': None, 'answer': None}]
+    output = output + str(cnos.run_cnos_commands(module, cmd))
+    # Write to memory
+    save_cmd = [{'command': 'save', 'prompt': None, 'answer': None}]
+    cmd.extend(save_cmd)
+    output = output + str(cnos.run_cnos_commands(module, cmd))
 
     # Save it into the file
     file = open(outputfile, "a")
@@ -184,7 +158,8 @@ def main():
     # Logic to check when changes occur or not
     errorMsg = cnos.checkOutputForError(output)
     if(errorMsg is None):
-        module.exit_json(changed=True, msg="CLI Command executed and results saved in file ")
+        module.exit_json(changed=True,
+                         msg="CLI Command executed and results saved in file ")
     else:
         module.fail_json(msg=errorMsg)
 


### PR DESCRIPTION
SUMMARY
CNOS Modules were originally using Paramiko. Here this is an attempt to change from paramiko to persistence connection of Ansible.

ISSUE TYPE
Bugfix Pull Request

COMPONENT NAME
lib/ansible/modules/network/cnos/cnos_conditional_command.py

ANSIBLE VERSION
ansible 2.7.0.dev0 (devel f9cbdcd) last updated 2018/07/03 14:55:43 (GMT +550)
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /home/ansible/sheru/ansible/lib/ansible
executable location = /home/ansible/sheru/ansible/bin/ansible
python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]

ADDITIONAL INFORMATION
This is tested on CNOS Mars switch version 10.8.0.42