### PR TITLE
FIX ISSUE:#43878 when the vlans string have a final comma.

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -303,11 +303,12 @@ def vlan_range_to_list(vlans):
         for part in vlans.split(','):
             if part.lower() == 'none':
                 break
-            if '-' in part:
-                start, stop = (int(i) for i in part.split('-'))
-                result.extend(range(start, stop + 1))
-            else:
-                result.append(int(part))
+            if part:
+                if '-' in part:
+                    start, stop = (int(i) for i in part.split('-'))
+                    result.extend(range(start, stop + 1))
+                else:
+                    result.append(int(part))
     return sorted(result)
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Testing if part is not None in the function resolve the problem
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #43878
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
io_l2_interface
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
(venv) [clement@clemo ansible]$ ansible --version 
ansible 2.7.0.dev0 (devel_iosl2interface_vlanrangetolist af38487915) last updated 2018/08/09 12:38:08 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/clement/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/clement/Documents/PROJECTS/ansible_env_setup/ansible/lib/ansible
  executable location = /home/clement/Documents/PROJECTS/ansible_env_setup/ansible/bin/ansible
  python version = 3.6.5 (default, Mar 29 2018, 18:20:46) [GCC 8.0.1 20180317 (Red Hat 8.0.1-0.19)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
