### PR TITLE
Update rabbitmq_binding.py

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_binding.py
+++ b/lib/ansible/modules/messaging/rabbitmq_binding.py
@@ -124,12 +124,12 @@ class RabbitMqBinding(object):
         self.arguments = self.module.params['arguments']
         self.base_url = 'http://{0}:{1}/api/bindings'.format(self.login_host,
                                                              self.login_port)
-        self.url = '{0}/{1}/e/{2}/{3}/{4}/{5}'.format(self.base_url,
-                                                      urllib_parse.quote(self.vhost),
-                                                      urllib_parse.quote(self.name),
-                                                      self.destination_type,
-                                                      self.destination,
-                                                      self.routing_key)
+        self.url = '{0}/{1}/e/{2}/{3}/{4}'.format(self.base_url,
+                                                  urllib_parse.quote(self.vhost, safe=''),
+                                                  urllib_parse.quote(self.name),
+                                                  self.destination_type,
+                                                  self.destination)
+        
         self.result = {
             'changed': False,
             'name': self.module.params['name'],
@@ -141,14 +141,19 @@ class RabbitMqBinding(object):
         self.request = requests
         self.http_check_states = {
             200: True,
+            201: True,
             404: False,
         }
         self.http_actionable_states = {
             201: True,
             204: True,
         }
-        self.api_result = self.request.get(self.url, auth=self.authentication)
-
+        
+        jsonBody = '{ "routingKey" : "' + self.routing_key + '"  }'
+        headers =  { 'content-type' : 'application/json' }
+        
+        self.api_result = self.request.post(self.url, auth=self.authentication, data = jsonBody, headers = headers)
+        
     def run(self):
         """
         :return:


### PR DESCRIPTION
Now using rabbitmq POST Api to bind queues with exchange instead of the GET one causing 404 Object not found error.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
rabbitmq_binding

##### ANSIBLE VERSION
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]


##### ADDITIONAL INFORMATION
RabbitMQ 3.6.5, Erlang 17.3 

RabbitMQ Get API _/api/bindings/vhost/e/exchange/q/queue/props_ returns _404 Object Not Found_ error when you call it.

This pull request use RabbitMq Post API _/api/bindings/vhost/e/exchange/q/queue_ with json body _{"routing_key":"my_routing_key"}_ to link a queue to an exchange. 


