### PR TITLE
fixes data loss when reading kernel cmdline (#22766)

### DIFF
--- a/lib/ansible/module_utils/facts/system/cmdline.py
+++ b/lib/ansible/module_utils/facts/system/cmdline.py
@@ -38,7 +38,14 @@ class CmdLineFactCollector(BaseFactCollector):
                 if len(item) == 1:
                     cmdline_dict[item[0]] = True
                 else:
-                    cmdline_dict[item[0]] = item[1]
+                    # space separated list if multiple key matches
+                    # allows user to call split() on this fact
+                    # in all cases with consistent behavior
+                    if item[0] in cmdline_dict:
+                        cmdline_dict[item[0]] += " " + item[1]
+                    else:
+                        cmdline_dict[item[0]] = item[1]
+
         except ValueError:
             pass
 

--- a/test/units/module_utils/facts/test_collectors.py
+++ b/test/units/module_utils/facts/test_collectors.py
@@ -137,7 +137,7 @@ class TestCmdLineFacts(BaseFactsTest):
                     'LANG': 'en_US.UTF-8',
                     'quiet': True,
                     'rd.luks.uuid': 'luks-c80b7537-358b-4a07-b88c-c59ef187479b',
-                    'rd.lvm.lv': 'fedora/swap',
+                    'rd.lvm.lv': 'fedora/root fedora/swap',
                     'rhgb': True,
                     'ro': True,
                     'root': '/dev/mapper/fedora-root'}
@@ -150,16 +150,14 @@ class TestCmdLineFacts(BaseFactsTest):
     def test_parse_proc_cmdline_dup_console(self):
         example = r'BOOT_IMAGE=/boot/vmlinuz-4.4.0-72-generic root=UUID=e12e46d9-06c9-4a64-a7b3-60e24b062d90 ro console=tty1 console=ttyS0'
 
-        # FIXME: Two 'console' keywords? Using a dict for the fact value here loses info. Currently the 'last' one wins
         expected = {'BOOT_IMAGE': '/boot/vmlinuz-4.4.0-72-generic',
                     'root': 'UUID=e12e46d9-06c9-4a64-a7b3-60e24b062d90',
                     'ro': True,
-                    'console': 'ttyS0'}
+                    'console': 'tty1 ttyS0'}
 
         fact_collector = self.collector_class()
         facts_dict = fact_collector._parse_proc_cmdline(example)
 
-        # TODO: fails because we lose a 'console'
         self.assertDictEqual(facts_dict, expected)
 
 


### PR DESCRIPTION
##### SUMMARY
Added check for dict key collisions when parsing /proc/cmdline.

Current behavior causes any additional matching keys to overwrite the previous one.

I went with keeping the string type for this fact in all cases because there are a lot of possible kernel options and it's hard to know which ones can exist multiple times. Ascertaining and maintaining a list of them and changing them all to a list type seems burdensome.

I didn't want to change str->list on the fly if there are multiple keys since that puts the burden of type checking the fact on the user. 

I'm open to other approaches, especially if there is an established way to handle it.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/facts

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (fixes_#22766_data_loss_on_cmdline_facts e82ae4885b) last updated 2018/08/09 11:18:17 (GMT -400)
  config file = /root/code/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/code/hacking/ansible/lib/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION

Before:
```
[root@hostname ansible]# ansible -c local -m setup -a 'filter=ansible_cmdline*' localhost
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_cmdline": {
            "BOOT_IMAGE": "/vmlinuz-3.10.0-693.11.1.el7.x86_64",
            "LANG": "en_US.UTF-8",
            "quiet": true,
            "rd.lvm.lv": "centos/root",
            "rhgb": true,
            "ro": true,
            "root": "/dev/mapper/centos-root",
            "vconsole.font": "latarcyrheb-sun16",
            "vconsole.keymap": "us"
        }
    },
    "changed": false
}
```
After:
```
[root@hostname ansible]# ansible -c local -m setup -a 'filter=ansible_cmdline*' localhost
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_cmdline": {
            "BOOT_IMAGE": "/vmlinuz-3.10.0-693.11.1.el7.x86_64",
            "LANG": "en_US.UTF-8",
            "quiet": true,
            "rd.lvm.lv": "centos/swap centos/root",
            "rhgb": true,
            "ro": true,
            "root": "/dev/mapper/centos-root",
            "vconsole.font": "latarcyrheb-sun16",
            "vconsole.keymap": "us"
        }
    },
    "changed": false
}
```
