### PR TITLE
Fix spelling of ansbile to ansible

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -123,7 +123,7 @@ VAULT_VERSION_MAX = 1.0
 # object. The dictionary values are tuples, to account for aliases
 # in variable names.
 
-COMMON_CONNECTION_VARS = frozenset(set(('ansible_connection', 'ansbile_host', 'ansible_user', 'ansible_shell_executable',
+COMMON_CONNECTION_VARS = frozenset(set(('ansible_connection', 'ansible_host', 'ansible_user', 'ansible_shell_executable',
                                         'ansible_port', 'ansible_pipelining', 'ansible_password', 'ansible_timeout',
                                         'ansible_shell_type', 'ansible_module_compression', 'ansible_private_key_file')))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fix connection var redacting (introduced in 006f08da99b) spelling of ansible_host. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
core/constants

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
