### PR TITLE
[trivial doc fix] Fixed wrong storage platform on module docs for EMC VNX

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/emc.py
+++ b/lib/ansible/utils/module_docs_fragments/emc.py
@@ -39,5 +39,5 @@ requirements:
   - Ansible 2.7.
   - storops (0.5.10 or greater). Install using 'pip install storops'.
 notes:
-  - The modules prefixed with emc_vnx are built to support the ONTAP storage platform.
+  - The modules prefixed with emc_vnx are built to support the EMC VNX storage platform.
     """


### PR DESCRIPTION
##### SUMMARY
The module fragment for emc vnx modules is reporting wrong storage platform (ONTAP instead of EMC VNX)

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
emc module fragment

##### ANSIBLE VERSION
Ansible devel branch

##### ADDITIONAL INFORMATION

