### PR TITLE
Fix download URL for yum integration test.

### DIFF
--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -476,7 +476,7 @@
     state: absent
 
 - set_fact:
-    pkg_url: http://download.fedoraproject.org/pub/epel/7/x86_64/Packages/f/fpaste-0.3.7.4.1-1.el7.noarch.rpm
+    pkg_url: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/yum/fpaste-0.3.7.4.1-2.el7.noarch.rpm
 # setup end
 
 - name: download an rpm


### PR DESCRIPTION
##### SUMMARY

Fix download URL for yum integration test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

yum integration test

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (yum-test-fix 5d4c08cfd7) last updated 2018/08/09 12:51:24 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
