### PR TITLE
new networking module: exos_config

### DIFF
--- a/lib/ansible/modules/network/exos/exos_command.py
+++ b/lib/ansible/modules/network/exos/exos_command.py
@@ -37,7 +37,7 @@ description:
     module to wait for a specific condition before returning or timing out if
     the condition is not met.
   - This module does not support running configuration commands.
-    We expect to release an exos_config module soon to configure EXOS devices.
+    Please use M(exos_config) to configure EXOS devices.
 notes:
   - If a command sent to the device requires answering a prompt, it is possible
     to pass a dict containing I(command), I(answer) and I(prompt). See examples.

--- a/lib/ansible/modules/network/exos/exos_config.py
+++ b/lib/ansible/modules/network/exos/exos_config.py
@@ -1,0 +1,422 @@
+#!/usr/bin/python
+#
+# (c) 2018 Extreme Networks Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: exos_config
+version_added: "2.7"
+author: "Lance Richardson (@hlrichardson)"
+short_description: Manage Extreme Networks EXOS configuration sections
+description:
+  - Extreme EXOS configurations use a simple flat text file syntax.
+    This module provides an implementation for working with EXOS
+    configuration lines in a deterministic way.
+notes:
+  - Tested against EXOS version 22.6.0b19
+options:
+  lines:
+    description:
+      - The ordered set of commands that should be configured in the
+        section.  The commands must be the exact same commands as found
+        in the device running-config.  Be sure to note the configuration
+        command syntax as some commands are automatically modified by the
+        device config parser.
+    default: null
+    aliases: ['commands']
+  src:
+    description:
+      - Specifies the source path to the file that contains the configuration
+        or configuration template to load.  The path to the source file can
+        either be the full path on the Ansible control host or a relative
+        path from the playbook or role root directory.  This argument is mutually
+        exclusive with I(lines).
+    default: null
+  before:
+    description:
+      - The ordered set of commands to push on to the command stack if
+        a change needs to be made.  This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
+        any changes without affecting how the set of commands are matched
+        against the system.
+    default: null
+  after:
+    description:
+      - The ordered set of commands to append to the end of the command
+        stack if a change needs to be made.  Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
+        executed after the command set.
+    default: null
+  match:
+    description:
+      - Instructs the module on the way to perform the matching of
+        the set of commands against the current device config.  If
+        match is set to I(line), commands are matched line by line.  If
+        match is set to I(strict), command lines are matched with respect
+        to position.  If match is set to I(exact), command lines
+        must be an equal match.  Finally, if match is set to I(none), the
+        module will not attempt to compare the source configuration with
+        the running configuration on the remote device.
+    default: line
+    choices: ['line', 'strict', 'exact', 'none']
+  replace:
+    description:
+      - Instructs the module on the way to perform the configuration
+        on the device.  If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode.  If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
+        line is not correct.
+    default: line
+    choices: ['line', 'block']
+  backup:
+    description:
+      - This argument will cause the module to create a full backup of
+        the current C(running-config) from the remote device before any
+        changes are made.  The backup file is written to the C(backup)
+        folder in the playbook root directory.  If the directory does not
+        exist, it is created.
+    default: no
+    type: bool
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source.  There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(running_config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison.
+    default: null
+    aliases: ['config']
+  defaults:
+    description:
+      - This argument specifies whether or not to collect all defaults
+        when getting the remote device running config.  When enabled,
+        the module will get the current config by issuing the command
+        C(show running-config all).
+    type: bool
+    default: 'no'
+  save_when:
+    description:
+      - When changes are made to the device running-configuration, the
+        changes are not copied to non-volatile storage by default.  Using
+        this argument will change that behavior.  If the argument is set to
+        I(always), then the running-config will always be copied to the
+        startup-config and the I(modified) flag will always be set to
+        True.  If the argument is set to I(modified), then the running-config
+        will only be copied to the startup-config if it has changed since
+        the last save to startup-config.  If the argument is set to
+        I(never), the running-config will never be copied to the
+        startup-config.  If the argument is set to I(changed), then the running-config
+        will only be copied to the startup-config if the task has made a change.
+    default: never
+    choices: ['always', 'never', 'modified', 'changed']
+  diff_against:
+    description:
+      - When using the C(ansible-playbook --diff) command line argument
+        the module can generate diffs against different sources.
+      - When this option is configure as I(startup), the module will return
+        the diff of the running-config against the startup-config.
+      - When this option is configured as I(intended), the module will
+        return the diff of the running-config against the configuration
+        provided in the C(intended_config) argument.
+      - When this option is configured as I(running), the module will
+        return the before and after diff of the running-config with respect
+        to any changes made to the device configuration.
+    choices: ['running', 'startup', 'intended']
+  diff_ignore_lines:
+    description:
+      - Use this argument to specify one or more lines that should be
+        ignored during the diff.  This is used for lines in the configuration
+        that are automatically updated by the system.  This argument takes
+        a list of regular expressions or exact line matches.
+  intended_config:
+    description:
+      - The C(intended_config) provides the master configuration that
+        the node should conform to and is used to check the final
+        running-config against.   This argument will not modify any settings
+        on the remote device and is strictly used to check the compliance
+        of the current device's configuration against.  When specifying this
+        argument, the task should also modify the C(diff_against) value and
+        set it to I(intended).
+"""
+
+EXAMPLES = """
+- name: configure SNMP system name
+  exos_config:
+    lines: configure snmp sysName "{{ inventory_hostname }}"
+
+- name: configure interface settings
+  exos_config:
+    lines:
+      - configure ports 2 description-string "Master Uplink"
+    backup: yes
+
+- name: check the running-config against master config
+  exos_config:
+    diff_against: intended
+    intended_config: "{{ lookup('file', 'master.cfg') }}"
+
+- name: check the startup-config against the running-config
+  exos_config:
+    diff_against: startup
+    diff_ignore_lines:
+      - ntp clock .*
+
+- name: save running to startup when modified
+  exos_config:
+    save_when: modified
+"""
+
+RETURN = """
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['switch-attributes hostname foo', 'router ospf', 'area 0']
+commands:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['create vlan "foo"', 'configure snmp sysName "x620-red"']
+backup_path:
+  description: The full path to the backup file
+  returned: when backup is yes
+  type: string
+  sample: /playbooks/ansible/backup/x870_config.2018-08-08@15:00:21
+
+"""
+import re
+import time
+
+from ansible.module_utils.network.exos.exos import run_commands, get_config, load_config
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.common.parsing import Conditional
+from ansible.module_utils.network.common.config import NetworkConfig, dumps
+from ansible.module_utils.six import iteritems
+from ansible.module_utils._text import to_text
+
+__metaclass__ = type
+
+
+def get_running_config(module, current_config=None):
+    contents = module.params['running_config']
+    if not contents:
+        if current_config:
+            contents = current_config.config_text
+        else:
+            contents = get_config(module)
+    return NetworkConfig(indent=1, contents=contents)
+
+
+def get_startup_config_text(module):
+    reply = run_commands(module, ['show switch | include "Config Selected"'])
+    match = re.search(r': +(\S+)\.cfg', to_text(reply, errors='surrogate_or_strict').strip())
+    if match:
+        cfgname = match.group(1).strip()
+        reply = run_commands(module, ['debug cfgmgr show configuration file ' + cfgname])
+        data = reply[0]
+    else:
+        data = ''
+    return data
+
+
+def get_startup_config(module):
+    data = get_startup_config_text(module)
+    return NetworkConfig(indent=1, contents=data)
+
+
+def get_candidate(module):
+    candidate = NetworkConfig(indent=1)
+
+    if module.params['src']:
+        candidate.load(module.params['src'])
+
+    elif module.params['lines']:
+        candidate.add(module.params['lines'])
+
+    return candidate
+
+
+def save_config(module, result):
+    result['changed'] = True
+    if not module.check_mode:
+        command = {"command": "save configuration",
+                   "prompt": "Do you want to save configuration", "answer": "y"}
+        run_commands(module, command)
+    else:
+        module.warn('Skipping command `save configuration` '
+                    'due to check_mode.  Configuration not copied to '
+                    'non-volatile storage')
+
+
+def main():
+    """ main entry point for module execution
+    """
+    argument_spec = dict(
+        src=dict(type='path'),
+
+        lines=dict(aliases=['commands'], type='list'),
+
+        before=dict(type='list'),
+        after=dict(type='list'),
+
+        match=dict(default='line', choices=['line', 'strict', 'exact', 'none']),
+        replace=dict(default='line', choices=['line', 'block']),
+
+        running_config=dict(aliases=['config']),
+        intended_config=dict(),
+
+        defaults=dict(type='bool', default=False),
+        backup=dict(type='bool', default=False),
+
+        save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never'),
+
+        diff_against=dict(choices=['startup', 'intended', 'running']),
+        diff_ignore_lines=dict(type='list'),
+    )
+
+    mutually_exclusive = [('lines', 'src')]
+
+    required_if = [('match', 'strict', ['lines']),
+                   ('match', 'exact', ['lines']),
+                   ('replace', 'block', ['lines']),
+                   ('diff_against', 'intended', ['intended_config'])]
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           mutually_exclusive=mutually_exclusive,
+                           required_if=required_if,
+                           supports_check_mode=True)
+
+    result = {'changed': False}
+
+    warnings = list()
+    result['warnings'] = warnings
+
+    config = None
+
+    if module.params['backup'] or (module._diff and module.params['diff_against'] == 'running'):
+        contents = get_config(module)
+        config = NetworkConfig(indent=1, contents=contents)
+        if module.params['backup']:
+            result['__backup__'] = contents
+
+    if any((module.params['lines'], module.params['src'])):
+        match = module.params['match']
+        replace = module.params['replace']
+
+        candidate = get_candidate(module)
+
+        if match != 'none':
+            config = get_running_config(module, config)
+            configobjs = candidate.difference(config, match=match, replace=replace)
+        else:
+            configobjs = candidate.items
+
+        if configobjs:
+            commands = dumps(configobjs, 'commands').split('\n')
+
+            if module.params['before']:
+                commands[:0] = module.params['before']
+
+            if module.params['after']:
+                commands.extend(module.params['after'])
+
+            result['commands'] = commands
+            result['updates'] = commands
+
+            # send the configuration commands to the device and merge
+            # them with the current running config
+            if not module.check_mode:
+                if commands:
+                    load_config(module, commands)
+
+            result['changed'] = True
+
+    running_config = None
+    startup_config = None
+
+    diff_ignore_lines = module.params['diff_ignore_lines']
+
+    if module.params['save_when'] == 'always':
+        save_config(module, result)
+    elif module.params['save_when'] == 'modified':
+        running = get_running_config(module).config_text
+        startup = get_startup_config(module).config_text
+
+        running_config = NetworkConfig(indent=1, contents=running, ignore_lines=diff_ignore_lines)
+        startup_config = NetworkConfig(indent=1, contents=startup, ignore_lines=diff_ignore_lines)
+
+        if running_config.sha1 != startup_config.sha1:
+            save_config(module, result)
+    elif module.params['save_when'] == 'changed' and result['changed']:
+        save_config(module, result)
+
+    if module._diff:
+        if not running_config:
+            contents = get_running_config(module).config_text
+        else:
+            contents = running_config.config_text
+
+        # recreate the object in order to process diff_ignore_lines
+        running_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)
+
+        if module.params['diff_against'] == 'running':
+            if module.check_mode:
+                module.warn("unable to perform diff against running-config due to check mode")
+                contents = None
+            else:
+                contents = config.config_text
+
+        elif module.params['diff_against'] == 'startup':
+            if not startup_config:
+                contents = get_startup_config(module).config_text
+            else:
+                contents = startup_config.config_text
+
+        elif module.params['diff_against'] == 'intended':
+            contents = module.params['intended_config']
+
+        if contents is not None:
+            base_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)
+
+            if running_config.sha1 != base_config.sha1:
+                if module.params['diff_against'] == 'intended':
+                    before = running_config
+                    after = base_config
+                elif module.params['diff_against'] in ('startup', 'running'):
+                    before = base_config
+                    after = running_config
+
+                result.update({
+                    'changed': True,
+                    'diff': {'before': str(before), 'after': str(after)}
+                })
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/plugins/action/exos_config.py
+++ b/lib/ansible/plugins/action/exos_config.py
@@ -1,0 +1,114 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import re
+import time
+import glob
+
+from ansible.plugins.action.normal import ActionModule as _ActionModule
+from ansible.module_utils._text import to_text
+from ansible.module_utils.six.moves.urllib.parse import urlsplit
+from ansible.utils.vars import merge_hash
+
+
+PRIVATE_KEYS_RE = re.compile('__.+__')
+
+
+class ActionModule(_ActionModule):
+
+    def run(self, tmp=None, task_vars=None):
+
+        if self._task.args.get('src'):
+            try:
+                self._handle_template()
+            except ValueError as exc:
+                return dict(failed=True, msg=str(exc))
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        if self._task.args.get('backup') and result.get('__backup__'):
+            # User requested backup and no error occurred in module.
+            # NOTE: If there is a parameter error, _backup key may not be in results.
+            filepath = self._write_backup(task_vars['inventory_hostname'],
+                                          result['__backup__'])
+
+            result['backup_path'] = filepath
+
+        # strip out any keys that have two leading and two trailing
+        # underscore characters
+        for key in list(result.keys()):
+            if PRIVATE_KEYS_RE.match(key):
+                del result[key]
+
+        return result
+
+    def _get_working_path(self):
+        cwd = self._loader.get_basedir()
+        if self._task._role is not None:
+            cwd = self._task._role._role_path
+        return cwd
+
+    def _write_backup(self, host, contents):
+        backup_path = self._get_working_path() + '/backup'
+        if not os.path.exists(backup_path):
+            os.mkdir(backup_path)
+        for fn in glob.glob('%s/%s*' % (backup_path, host)):
+            os.remove(fn)
+        tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
+        filename = '%s/%s_config.%s' % (backup_path, host, tstamp)
+        open(filename, 'w').write(contents)
+        return filename
+
+    def _handle_template(self):
+        src = self._task.args.get('src')
+        working_path = self._get_working_path()
+
+        if os.path.isabs(src) or urlsplit('src').scheme:
+            source = src
+        else:
+            source = self._loader.path_dwim_relative(working_path, 'templates', src)
+            if not source:
+                source = self._loader.path_dwim_relative(working_path, src)
+
+        if not os.path.exists(source):
+            raise ValueError('path specified in src not found')
+
+        try:
+            with open(source, 'r') as f:
+                template_data = to_text(f.read())
+        except IOError:
+            return dict(failed=True, msg='unable to load src file')
+
+        # Create a template search path in the following order:
+        # [working_path, self_role_path, dependent_role_paths, dirname(source)]
+        searchpath = [working_path]
+        if self._task._role is not None:
+            searchpath.append(self._task._role._role_path)
+            if hasattr(self._task, "_block:"):
+                dep_chain = self._task._block.get_dep_chain()
+                if dep_chain is not None:
+                    for role in dep_chain:
+                        searchpath.append(role._role_path)
+        searchpath.append(os.path.dirname(source))
+        self._templar.environment.loader.searchpath = searchpath
+        self._task.args['src'] = self._templar.template(template_data)

--- a/lib/ansible/plugins/cliconf/exos.py
+++ b/lib/ansible/plugins/cliconf/exos.py
@@ -90,9 +90,34 @@ class Cliconf(CliconfBase):
     def get(self, command, prompt=None, answer=None, sendonly=False):
         return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
 
+    def get_device_operations(self):
+        return {
+            'supports_diff_replace': True,
+            'supports_commit': False,
+            'supports_rollback': False,
+            'supports_defaults': True,
+            'supports_onbox_diff': False,
+            'supports_commit_comment': False,
+            'supports_multiline_delimiter': False,
+            'supports_diff_match': True,
+            'supports_diff_ignore_lines': True,
+            'supports_generate_diff': True,
+            'supports_replace': True
+        }
+
+    def get_option_values(self):
+        return {
+            'format': ['text'],
+            'diff_match': ['line', 'strict', 'exact', 'none'],
+            'diff_replace': ['line', 'block'],
+            'output': ['text']
+        }
+
     def get_capabilities(self):
         result = {}
         result['rpc'] = self.get_base_rpc()
         result['network_api'] = 'cliconf'
         result['device_info'] = self.get_device_info()
+        result['device_operations'] = self.get_device_operations()
+        result.update(self.get_option_values())
         return json.dumps(result)

--- a/lib/ansible/plugins/terminal/exos.py
+++ b/lib/ansible/plugins/terminal/exos.py
@@ -43,7 +43,8 @@ class TerminalModule(TerminalBase):
         re.compile(br"Bad mask", re.I),
         re.compile(br"% ?(\S+) ?overlaps with ?(\S+)", re.I),
         re.compile(br"[%\S] ?Error: ?[\s]+", re.I),
-        re.compile(br"[%\S] ?Informational: ?[\s]+", re.I)
+        re.compile(br"[%\S] ?Informational: ?[\s]+", re.I),
+        re.compile(br"%% Invalid .* at '\^' marker.", re.I),
     ]
 
     def on_open_shell(self):

--- a/test/units/modules/network/exos/fixtures/exos_config_config.cfg
+++ b/test/units/modules/network/exos/fixtures/exos_config_config.cfg
@@ -1,0 +1,31 @@
+#
+# Module devmgr configuration.
+#
+configure snmp sysName "x870"
+configure snmp sysContact "support@extremenetworks.com, +1 888 257 3000"
+configure sys-recovery-level switch reset
+
+#
+# Module vpex configuration.
+#
+
+#
+# Module vlan configuration.
+#
+configure vlan default delete ports all
+configure vr VR-Default delete ports 1-128
+configure vr VR-Default add ports 1-128
+configure vlan default delete ports 1-2
+create vlan "ansible_test"
+configure vlan ansible_test tag 1111
+create vlan "vlan1"
+create vlan "vlan2"
+create vlan "vlan3"
+configure ports 1 description-string "Firewall"
+configure ports 2 description-string "Master Uplink"
+configure ports 3 description-string "Database Server"
+configure vlan ansible_test add ports 1 tagged  
+configure vlan Default add ports 3-128 untagged  
+configure vlan vlan1 ipaddress 10.0.1.1 255.255.255.0
+configure vlan vlan2 ipaddress 192.168.1.1 255.255.0.0
+configure vlan3 ipaddress fe80::202:b3ff:fe1e:8329/64

--- a/test/units/modules/network/exos/fixtures/exos_config_modified.cfg
+++ b/test/units/modules/network/exos/fixtures/exos_config_modified.cfg
@@ -1,0 +1,31 @@
+#
+# Module devmgr configuration.
+#
+configure snmp sysName "marble"
+configure snmp sysContact "support@extremenetworks.com, +1 888 257 3000"
+configure sys-recovery-level switch reset
+
+#
+# Module vpex configuration.
+#
+
+#
+# Module vlan configuration.
+#
+configure vlan default delete ports all
+configure vr VR-Default delete ports 1-128
+configure vr VR-Default add ports 1-128
+configure vlan default delete ports 1-2
+create vlan "ansible_test"
+configure vlan ansible_test tag 1111
+create vlan "vlan1"
+create vlan "vlan2"
+create vlan "vlan3"
+configure ports 1 description-string "Firewall"
+configure ports 2 description-string "Master Uplink"
+configure ports 3 description-string "Database Server"
+configure vlan ansible_test add ports 1 tagged  
+configure vlan Default add ports 3-128 untagged  
+configure vlan vlan1 ipaddress 10.0.1.1 255.255.255.0
+configure vlan vlan2 ipaddress 192.168.1.1 255.255.0.0
+configure vlan3 ipaddress fe80::202:b3ff:fe1e:8329/64

--- a/test/units/modules/network/exos/fixtures/exos_config_src.cfg
+++ b/test/units/modules/network/exos/fixtures/exos_config_src.cfg
@@ -1,0 +1,2 @@
+configure snmp sysName "marble"
+configure ports 1 description-string "IDS"

--- a/test/units/modules/network/exos/test_exos_config.py
+++ b/test/units/modules/network/exos/test_exos_config.py
@@ -1,0 +1,246 @@
+#
+# (c) 2018 Extreme Networks Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.compat.tests.mock import patch
+from ansible.modules.network.exos import exos_config
+from units.modules.utils import set_module_args
+from .exos_module import TestExosModule, load_fixture
+
+
+class TestExosConfigModule(TestExosModule):
+
+    module = exos_config
+
+    def setUp(self):
+        super(TestExosConfigModule, self).setUp()
+
+        self.mock_get_config = patch('ansible.modules.network.exos.exos_config.get_config')
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch('ansible.modules.network.exos.exos_config.load_config')
+        self.load_config = self.mock_load_config.start()
+
+        self.mock_run_commands = patch('ansible.modules.network.exos.exos_config.run_commands')
+        self.run_commands = self.mock_run_commands.start()
+
+    def tearDown(self):
+        super(TestExosConfigModule, self).tearDown()
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+        self.mock_run_commands.stop()
+
+    def load_fixtures(self, commands=None):
+        config_file = 'exos_config_config.cfg'
+        self.get_config.return_value = load_fixture(config_file)
+        self.load_config.return_value = None
+
+    def test_exos_config_unchanged(self):
+        src = load_fixture('exos_config_config.cfg')
+        set_module_args(dict(src=src))
+        self.execute_module()
+
+    def test_exos_config_src(self):
+        src = load_fixture('exos_config_src.cfg')
+        set_module_args(dict(src=src))
+        commands = ['configure ports 1 description-string "IDS"',
+                    'configure snmp sysName "marble"']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_exos_config_backup(self):
+        set_module_args(dict(backup=True))
+        result = self.execute_module()
+        self.assertIn('__backup__', result)
+
+    def test_exos_config_save_always(self):
+        self.run_commands.return_value = 'configure snmp sysName "marble"'
+        set_module_args(dict(save_when='always'))
+        self.execute_module(changed=True)
+        self.assertEqual(self.run_commands.call_count, 1)
+        self.assertEqual(self.get_config.call_count, 0)
+        self.assertEqual(self.load_config.call_count, 0)
+        args = self.run_commands.call_args[0][1]
+        self.assertIn('save configuration', args['command'])
+
+    def test_exos_config_save_changed_true(self):
+        src = load_fixture('exos_config_src.cfg')
+        set_module_args(dict(src=src, save_when='changed'))
+        commands = ['configure ports 1 description-string "IDS"',
+                    'configure snmp sysName "marble"']
+        self.execute_module(changed=True, commands=commands)
+        self.assertEqual(self.run_commands.call_count, 1)
+        self.assertEqual(self.get_config.call_count, 1)
+        self.assertEqual(self.load_config.call_count, 1)
+        args = self.run_commands.call_args[0][1]
+        self.assertIn('save configuration', args['command'])
+
+    def test_exos_config_save_changed_true_check_mode(self):
+        src = load_fixture('exos_config_src.cfg')
+        set_module_args(dict(src=src, save_when='changed', _ansible_check_mode=True))
+        commands = ['configure ports 1 description-string "IDS"',
+                    'configure snmp sysName "marble"']
+        self.execute_module(changed=True, commands=commands)
+        self.assertEqual(self.run_commands.call_count, 0)
+        self.assertEqual(self.get_config.call_count, 1)
+        self.assertEqual(self.load_config.call_count, 0)
+
+    def test_exos_config_save_changed_false(self):
+        set_module_args(dict(save_when='changed'))
+        self.execute_module(changed=False)
+        self.assertEqual(self.run_commands.call_count, 0)
+        self.assertEqual(self.get_config.call_count, 0)
+        self.assertEqual(self.load_config.call_count, 0)
+
+    def test_exos_config_save_modified_false(self):
+        mock_get_startup_config_text = patch('ansible.modules.network.exos.exos_config.get_startup_config_text')
+        get_startup_config_text = mock_get_startup_config_text.start()
+        get_startup_config_text.return_value = load_fixture('exos_config_config.cfg')
+
+        set_module_args(dict(save_when='modified'))
+        self.execute_module(changed=False)
+        self.assertEqual(self.run_commands.call_count, 0)
+        self.assertEqual(self.get_config.call_count, 1)
+        self.assertEqual(get_startup_config_text.call_count, 1)
+        self.assertEqual(self.load_config.call_count, 0)
+
+        mock_get_startup_config_text.stop()
+
+    def test_exos_config_save_modified_true(self):
+        mock_get_startup_config_text = patch('ansible.modules.network.exos.exos_config.get_startup_config_text')
+        get_startup_config_text = mock_get_startup_config_text.start()
+        get_startup_config_text.return_value = load_fixture('exos_config_modified.cfg')
+
+        set_module_args(dict(save_when='modified'))
+        self.execute_module(changed=True)
+        self.assertEqual(self.run_commands.call_count, 1)
+        self.assertTrue(self.get_config.call_count > 0)
+        self.assertEqual(get_startup_config_text.call_count, 1)
+        self.assertEqual(self.load_config.call_count, 0)
+
+        mock_get_startup_config_text.stop()
+
+    def test_exos_config_lines(self):
+        set_module_args(dict(lines=['configure snmp sysName "marble"']))
+        commands = ['configure snmp sysName "marble"']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_exos_config_before(self):
+        set_module_args(dict(lines=['configure snmp sysName "marble"'], before=['test1', 'test2']))
+        commands = ['test1', 'test2', 'configure snmp sysName "marble"']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_exos_config_after(self):
+        set_module_args(dict(lines=['hostname foo'], after=['test1', 'test2']))
+        commands = ['hostname foo', 'test1', 'test2']
+        set_module_args(dict(lines=['configure snmp sysName "marble"'], after=['test1', 'test2']))
+        commands = ['configure snmp sysName "marble"', 'test1', 'test2']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_exos_config_before_after_no_change(self):
+        set_module_args(dict(lines=['configure snmp sysName "x870"'],
+                             before=['test1', 'test2'],
+                             after=['test3', 'test4']))
+        self.execute_module()
+
+    def test_exos_config_config(self):
+        config = 'hostname localhost'
+        set_module_args(dict(lines=['configure snmp sysName "x870"'], config=config))
+        commands = ['configure snmp sysName "x870"']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_exos_config_match_none(self):
+        lines = ['configure snmp sysName "x870"']
+        set_module_args(dict(lines=lines, match='none'))
+        self.execute_module(changed=True, commands=lines)
+
+    def test_exos_config_src_and_lines_fails(self):
+        args = dict(src='foo', lines='foo')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_exos_config_match_exact_requires_lines(self):
+        args = dict(match='exact')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_exos_config_match_strict_requires_lines(self):
+        args = dict(match='strict')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_exos_config_replace_block_requires_lines(self):
+        args = dict(replace='block')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_exos_config_replace_config_requires_src(self):
+        args = dict(replace='config')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_exos_diff_running_unchanged(self):
+        args = dict(diff_against='running', _ansible_diff=True)
+        set_module_args(args)
+        self.execute_module(changed=False)
+
+    def test_exos_diff_running_unchanged_check(self):
+        args = dict(diff_against='running',
+                    _ansible_diff=True,
+                    _ansible_check_mode=True)
+        set_module_args(args)
+        self.execute_module(changed=False)
+
+    def test_exos_diff_startup_unchanged(self):
+        mock_get_startup_config_text = patch('ansible.modules.network.exos.exos_config.get_startup_config_text')
+        get_startup_config_text = mock_get_startup_config_text.start()
+        get_startup_config_text.return_value = load_fixture('exos_config_config.cfg')
+
+        args = dict(diff_against='startup', _ansible_diff=True)
+        set_module_args(args)
+        self.execute_module(changed=False)
+        self.assertEqual(get_startup_config_text.call_count, 1)
+
+        mock_get_startup_config_text.stop()
+
+    def test_exos_diff_startup_changed(self):
+        mock_get_startup_config_text = patch('ansible.modules.network.exos.exos_config.get_startup_config_text')
+        get_startup_config_text = mock_get_startup_config_text.start()
+        get_startup_config_text.return_value = load_fixture('exos_config_modified.cfg')
+
+        args = dict(diff_against='startup', _ansible_diff=True)
+        set_module_args(args)
+        self.execute_module(changed=True)
+        self.assertEqual(get_startup_config_text.call_count, 1)
+
+        mock_get_startup_config_text.stop()
+
+    def test_exos_diff_intended_unchanged(self):
+        args = dict(diff_against='intended',
+                    intended_config=load_fixture('exos_config_config.cfg'),
+                    _ansible_diff=True)
+        set_module_args(args)
+        self.execute_module(changed=False)
+
+    def test_exos_diff_intended_modified(self):
+        args = dict(diff_against='intended',
+                    intended_config=load_fixture('exos_config_modified.cfg'),
+                    _ansible_diff=True)
+        set_module_args(args)
+        self.execute_module(changed=True)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- support config operations for EXOS-based platforms
- add regex to detect command failure responses
- add exos action plugin for "backup" operation
- add unit tests for exos_command (currently 88% coverage of
  exos_config.py)
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
exos_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
  config file = /home/lrichardson/.ansible.cfg
  configured module search path = [u'/home/lrichardson/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/lrichardson/git/ansible/lib/ansible
  executable location = /home/lrichardson/git/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Example Playbook:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
---
- hosts: x870
  
  tasks:
    - name: backup config
      exos_config:
          backup: yes
      register: backup_result
    - name: var_result
      debug:
          var: backup_result.backup_path
    - name: create vlan
      exos_config:
          lines:
              - create vlan "ansible_test"
              - configure vlan ansible_test tag 1111
              - configure vlan ansible_test add ports 1 tagged
          save_when: changed
    - name: configure sysname
      exos_config:
          lines:
              - configure snmp sysName "{{ inventory_hostname }}"
          save_when: changed
    - name: port configuration
      exos_config:
          lines:
              - configure ports 2 description-string "Master Uplink"
          save_when: changed
    - name: check the saved config against the running config
      exos_config:
          diff_against: startup

```
Output:
```
PLAY [x870] *********************************************************************************************

TASK [Gathering Facts] **********************************************************************************
ok: [x870]

TASK [backup config] ************************************************************************************
ok: [x870]

TASK [var_result] ***************************************************************************************
ok: [x870] => {
    "backup_result.backup_path": "/home/lrichardson/playbooks/backup/x870_config.2018-08-09@17:38:19"
}

TASK [create vlan] **************************************************************************************
changed: [x870]

TASK [configure sysname] ********************************************************************************
ok: [x870]

TASK [port configuration] *******************************************************************************
ok: [x870]

TASK [check the saved config against the running config] ************************************************
ok: [x870]

PLAY RECAP **********************************************************************************************
x870                       : ok=7    changed=1    unreachable=0    failed=0   


```
