### PR TITLE
check for chroot in systemd module

### DIFF
--- a/changelogs/fragments/systemd-warn-on-chroot.yaml
+++ b/changelogs/fragments/systemd-warn-on-chroot.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - systemd - warn when exeuting in a chroot environment rather than failing (https://github.com/ansible/ansible/pull/43904)

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -494,13 +494,12 @@ def main():
                         (rc, out, err) = module.run_command("%s %s '%s'" % (systemctl, action, unit))
                         if rc != 0:
                             module.fail_json(msg="Unable to %s service %s: %s" % (action, unit, err))
+            # check for chroot
+            elif is_chroot():
+                module.warn("Target is a chroot. This can lead to false positives or prevent the init system tools from working.")
             else:
-                # check for chroot
-                if is_chroot():
-                    module.warn("Target is a chroot. This can lead to false positives or prevent the init system tools from working." % unit)
-                else:
-                    # this should not happen?
-                    module.fail_json(msg="Service is in unknown state", status=result['status'])
+                # this should not happen?
+                module.fail_json(msg="Service is in unknown state", status=result['status'])
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -465,7 +465,7 @@ def main():
                 result['enabled'] = not enabled
 
         # set service state if requested
-        if module.params['state'] is not None:
+        if module.params['state'] is not None and result['status']:
             fail_if_missing(module, found, unit, msg="host")
 
             # default to desired state

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -494,12 +494,13 @@ def main():
                         (rc, out, err) = module.run_command("%s %s '%s'" % (systemctl, action, unit))
                         if rc != 0:
                             module.fail_json(msg="Unable to %s service %s: %s" % (action, unit, err))
-            # check for chroot
-            elif is_chroot():
-                module.warn("The service (%s) can't be managed by Ansible as it's running in a chroot" % unit)
             else:
-                # this should not happen?
-                module.fail_json(msg="Service is in unknown state", status=result['status'])
+                # check for chroot
+                if is_chroot():
+                    module.warn("Target is a chroot. This can lead to false positives or prevent the init system tools from working." % unit)
+                else:
+                    # this should not happen?
+                    module.fail_json(msg="Service is in unknown state", status=result['status'])
 
     module.exit_json(**result)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

Checks for chroot and warn when managing service state w/ systemd module.

In a chrooted environment, `result['status']` doesn't exist, so basic service/systemd tasks w/ `state: started` fail.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
systemd

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = /vagrant/ansible.cfg
  configured module search path = [u'/vagrant/library']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

In a chrooted environment, `result['status']` doesn't exist, so basic service/systemd tasks w/ `state: started` fail.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
- name: start
  service:
    name: apparmor
    state: started

```
```
# chroot /build
# systemctl status apparmor
Running in chroot, ignoring request.

```
versus
```
# systemctl status apparmor
● apparmor.service - AppArmor initialization
   Loaded: loaded (/lib/systemd/system/apparmor.service; enabled; vendor preset: enabled)
   Active: active (exited) since Thu 2018-08-09 22:42:17 UTC; 4min 2s ago
     Docs: man:apparmor(7)
           http://wiki.apparmor.net/
  Process: 331 ExecStart=/etc/init.d/apparmor start (code=exited, status=0/SUCCESS)
 Main PID: 331 (code=exited, status=0/SUCCESS)
    Tasks: 0 (limit: 4915)
   CGroup: /system.slice/apparmor.service

Aug 09 22:42:16 build-debian systemd[1]: Starting AppArmor initialization...
Aug 09 22:42:17 build-debian apparmor[331]: Starting AppArmor profiles:
Aug 09 22:42:17 build-debian apparmor[331]: Warning failed to create cache: usr.sbin.sssd
Aug 09 22:42:17 build-debian apparmor[331]: .
Aug 09 22:42:17 build-debian systemd[1]: Started AppArmor initialization.
```
