### PR TITLE
fix ec2_vpc_peer example with incorrect parameter

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
@@ -126,7 +126,7 @@ EXAMPLES = '''
     region: us-east-1
     vpc_id: vpc-12345678
     peer_vpc_id: vpc-87654321
-    peer_vpc_region: us-west-2
+    peer_region: us-west-2
     state: present
     tags:
       Name: Peering connection for us-east-1 VPC to us-west-2 VPC


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
One of the examples in the documentation is using a parameter that does not exist.  This change updates it to the correct one.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ec2_vpc_peer doc [example](https://docs.ansible.com/ansible/2.6/modules/ec2_vpc_peer_module.html#examples)

##### ANSIBLE VERSION
Tested failing example with ansible 2.6.2
Tested proposed fix with ansible 2.6.2