### PR TITLE
facts: solaris: introduce distribution_major version detection for Solaris

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -540,6 +540,7 @@ class Distribution(object):
     def get_distribution_SunOS(self):
         sunos_facts = {}
 
+        uname_v = get_uname_version(self.module)
         data = get_file_content('/etc/release').splitlines()[0]
 
         if 'Solaris' in data:
@@ -550,9 +551,9 @@ class Distribution(object):
             sunos_facts['distribution'] = data.split()[0]
             sunos_facts['distribution_version'] = data.split()[1]
             sunos_facts['distribution_release'] = ora_prefix + data
+            sunos_facts['distribution_major_version'] = uname_v.split('.')[0]
             return sunos_facts
 
-        uname_v = get_uname_version(self.module)
         distribution_version = None
 
         if 'SmartOS' in data:


### PR DESCRIPTION
facts: solaris: introduce distribution_major version detection for Solaris

Currently, there's no distribution_major in facts module on Solaris OS.
Use "uname -v" output to report major version.

````
Before the patch we get this on Solaris 11.3 :

$ ansible -o solaris11 -m setup -a filter=ansible_distribution_major_version
solaris11 | SUCCESS => {"ansible_facts": {}, "changed": false}

and after this patch, output is the following:

$ ansible -o solaris11 -m setup -a filter=ansible_distribution_major_version
solaris11 | SUCCESS => {"ansible_facts": {"ansible_distribution_major_version": "11"}, "changed": false}
````

Fixes #18197

Tested with Solaris 11.3 (x86_64 vm)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel c59db9015e) last updated 2018/08/10 02:59:02 (GMT +300)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mator/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mator/ansible/lib/ansible
  executable location = /home/mator/ansible/bin/ansible
  python version = 2.7.15 (default, Jul 28 2018, 11:29:29) [GCC 8.1.0]
```