### PR TITLE
Fix introduction version for parameter "local" in module "group"

### DIFF
--- a/lib/ansible/modules/system/group.py
+++ b/lib/ansible/modules/system/group.py
@@ -44,7 +44,7 @@ options:
         type: bool
         default: 'no'
     local:
-        version_added: "2.5"
+        version_added: "2.6"
         required: false
         default: 'no'
         description:


### PR DESCRIPTION
##### SUMMARY
Documentation for parameter "local" in module "group" marks it as introduced in Ansible version 2.5, which is incorrect. The parameter has been introduced in version 2.6.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Module group.

##### ANSIBLE VERSION
N/A

##### ADDITIONAL INFORMATION
This is a minor documentation fix that will help people who use the main site for reading parameter documentation and avoid scratching their head on why the parameter is not working.