### PR TITLE
add support for opening shell on remote Windows host

### DIFF
--- a/test/runner/lib/manage_ci.py
+++ b/test/runner/lib/manage_ci.py
@@ -46,6 +46,7 @@ class ManageWindowsCI(object):
             self.ssh_args += ['-o', '%s=%s' % (ssh_option, ssh_options[ssh_option])]
 
     def setup(self):
+        """Used in delegate_remote to setup the host, no action is required for Windows."""
         pass
 
     def wait(self):

--- a/test/runner/lib/manage_ci.py
+++ b/test/runner/lib/manage_ci.py
@@ -32,6 +32,21 @@ class ManageWindowsCI(object):
         :type core_ci: AnsibleCoreCI
         """
         self.core_ci = core_ci
+        self.ssh_args = ['-i', self.core_ci.ssh_key.key]
+
+        ssh_options = dict(
+            BatchMode='yes',
+            StrictHostKeyChecking='no',
+            UserKnownHostsFile='/dev/null',
+            ServerAliveInterval=15,
+            ServerAliveCountMax=4,
+        )
+
+        for ssh_option in sorted(ssh_options):
+            self.ssh_args += ['-o', '%s=%s' % (ssh_option, ssh_options[ssh_option])]
+
+    def setup(self):
+        pass
 
     def wait(self):
         """Wait for instance to respond to ansible ping."""
@@ -58,6 +73,24 @@ class ManageWindowsCI(object):
 
         raise ApplicationError('Timeout waiting for %s/%s instance %s.' %
                                (self.core_ci.platform, self.core_ci.version, self.core_ci.instance_id))
+
+    def ssh(self, command, options=None):
+        """
+        :type command: str | list[str]
+        :type options: list[str] | None
+        """
+        if not options:
+            options = []
+
+        if isinstance(command, list):
+            command = ' '.join(pipes.quote(c) for c in command)
+
+        run_command(self.core_ci.args,
+                    ['ssh', '-tt', '-q'] + self.ssh_args +
+                    options +
+                    ['-p', '22',
+                     '%s@%s' % (self.core_ci.connection.username, self.core_ci.connection.hostname)] +
+                    [command])
 
 
 class ManageNetworkCI(object):

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -192,7 +192,7 @@ def parse_args():
                       help=argparse.SUPPRESS)
 
     add_changes(test, argparse)
-    add_environments(test, None)
+    add_environments(test)
 
     integration = argparse.ArgumentParser(add_help=False, parents=[test])
 

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -192,7 +192,7 @@ def parse_args():
                       help=argparse.SUPPRESS)
 
     add_changes(test, argparse)
-    add_environments(test)
+    add_environments(test, None)
 
     integration = argparse.ArgumentParser(add_help=False, parents=[test])
 
@@ -564,7 +564,7 @@ def add_environments(parser, tox_version=False, tox_only=False):
     environments.add_argument('--remote',
                               metavar='PLATFORM',
                               default=None,
-                              help='run from a remote instance').completer = complete_remote
+                              help='run from a remote instance').completer = complete_remote_shell if parser.prog.endswith(' shell') else complete_remote
 
     remote = parser.add_argument_group(title='remote arguments')
 
@@ -681,6 +681,24 @@ def complete_remote(prefix, parsed_args, **_):
 
     with open('test/runner/completion/remote.txt', 'r') as completion_fd:
         images = completion_fd.read().splitlines()
+
+    return [i for i in images if i.startswith(prefix)]
+
+
+def complete_remote_shell(prefix, parsed_args, **_):
+    """
+    :type prefix: unicode
+    :type parsed_args: any
+    :rtype: list[str]
+    """
+    del parsed_args
+
+    with open('test/runner/completion/remote.txt', 'r') as completion_fd:
+        images = completion_fd.read().splitlines()
+
+    # 2008 doesn't support SSH so we do not add to the list of valid images
+    with open('test/runner/completion/windows.txt', 'r') as completion_fd:
+        images.extend(["windows/%s" % i for i in completion_fd.read().splitlines() if i != '2008'])
 
     return [i for i in images if i.startswith(prefix)]
 


### PR DESCRIPTION
##### SUMMARY
Add support for running `ansible-test shell --remote windows/<version>` now that SSH is installed.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```
devel
```