### PR TITLE
Fix eos_command integration test failures

### DIFF
--- a/test/integration/targets/eos_command/tests/cli/cli_command.yaml
+++ b/test/integration/targets/eos_command/tests/cli/cli_command.yaml
@@ -2,48 +2,62 @@
 - debug:
     msg: "START cli/cli_command.yaml on connection={{ ansible_connection }}"
 
-- name: get output for single command
-  cli_command:
-    command: show version
-  register: result
+- block:
+  - name: get output for single command
+    cli_command:
+      command: show version
+    register: result
 
-- assert:
-    that:
-      - "result.changed == false"
-      - "result.stdout is defined"
+  - assert:
+      that:
+        - "result.changed == false"
+        - "result.stdout is defined"
 
-- name: send invalid command
-  cli_command:
-    command: 'show foo'
-  register: result
-  ignore_errors: yes
+  - name: send invalid command
+    cli_command:
+      command: 'show foo'
+    register: result
+    ignore_errors: yes
 
-- assert:
-    that:
-      - "result.failed == true"
-      - "result.msg is defined"
+  - assert:
+      that:
+        - "result.failed == true"
+        - "result.msg is defined"
 
-- name: get output in JSON format
-  cli_command:
-    command: show version | json
-  register: result
+  - name: get output in JSON format
+    cli_command:
+      command: show version | json
+    register: result
 
-- assert:
-    that:
-      - "result.changed == false"
-      - "result.stdout is defined"
-      - "result.json is defined"
+  - assert:
+      that:
+        - "result.changed == false"
+        - "result.stdout is defined"
+        - "result.json is defined"
 
-- name: command that does require become (should fail)
-  cli_command:
-    command: show running-config
-  become: no
-  ignore_errors: yes
-  register: result
+  - name: command that does require become (should fail)
+    cli_command:
+      command: show running-config
+    become: no
+    ignore_errors: yes
+    register: result
 
-- assert:
-    that:
-      - 'result.failed == true'
-      - '"privileged mode required" in result.msg'
+  - assert:
+      that:
+        - 'result.failed == true'
+        - '"privileged mode required" in result.msg'
+  when: "ansible_connection == 'network_cli'"
+
+- block:
+  - name: test failure for local connection
+    cli_command:
+      command: show version
+    register: result
+
+  - assert:
+      that:
+        - 'result.failed == true'
+        - "'Connection type local is not valid for this module' in result.msg"
+  when: "ansible_connection == 'local'"
 
 - debug: msg="END cli/cli_command.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix eos_command integration test failures
Run cli_command module on eos only when connection type is network_cli
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
integration/targets/eos_command/tests/cli/cli_command.yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
