### PR TITLE
Fix network config line diff ignore

### DIFF
--- a/lib/ansible/module_utils/network/common/config.py
+++ b/lib/ansible/module_utils/network/common/config.py
@@ -374,6 +374,10 @@ class NetworkConfig(object):
         # global config command
         if not parents:
             for line in lines:
+                # handle ignore lines
+                if ignore_line(line):
+                    continue
+
                 item = ConfigLine(line)
                 item.raw = line
                 if item not in self.items:
@@ -399,6 +403,10 @@ class NetworkConfig(object):
 
             # add child objects
             for line in lines:
+                # handle ignore lines
+                if ignore_line(line):
+                    continue
+
                 # check if child already exists
                 for child in ancestors[-1]._children:
                     if child.text == line:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/30562
* If config is added in form of lines add
  capability to ignore configure lines given as input
  in task
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
/module_utils/network/common/config.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
