### PR TITLE
To resolve nios_network issue where vendor-encapsulated-options can not have a use_option flag 

### DIFF
--- a/lib/ansible/modules/net_tools/nios/nios_network.py
+++ b/lib/ansible/modules/net_tools/nios/nios_network.py
@@ -178,6 +178,19 @@ def check_ip_addr_type(ip):
         return NIOS_IPV6_NETWORK
 
 
+def check_vendor_specific_dhcp_option(module, ib_spec):
+    '''This function will check if the argument dhcp option belongs to vendor-specific and if yes then will remove
+     use_options flag which is not supported with vendor-specific dhcp options.
+    '''
+    for key, value in iteritems(ib_spec):
+        if isinstance(module.params[key], list):
+            temp_dict = module.params[key][0]
+            if 'num' in temp_dict:
+                if temp_dict['num'] in {43, 124, 125}:
+                    del module.params[key][0]['use_option']
+    return ib_spec
+
+
 def main():
     ''' Main entry point for module execution
     '''
@@ -218,6 +231,9 @@ def main():
     network_type = check_ip_addr_type(obj_filter['network'])
 
     wapi = WapiModule(module)
+    # to check for vendor specific dhcp option
+    ib_spec = check_vendor_specific_dhcp_option(module, ib_spec)
+
     result = wapi.run(network_type, ib_spec)
 
     module.exit_json(**result)

--- a/lib/ansible/modules/net_tools/nios/nios_network.py
+++ b/lib/ansible/modules/net_tools/nios/nios_network.py
@@ -186,7 +186,7 @@ def check_vendor_specific_dhcp_option(module, ib_spec):
         if isinstance(module.params[key], list):
             temp_dict = module.params[key][0]
             if 'num' in temp_dict:
-                if temp_dict['num'] in {43, 124, 125}:
+                if temp_dict['num'] in (43, 124, 125):
                     del module.params[key][0]['use_option']
     return ib_spec
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
To resolve the bug #43657 where `nios_network` module was trying to set `use_option` flag for vendor-specific DHCP options which are `43, 124 and 125`. Now, if the user tries to set DHCP options from any one of the vendor-specific options, `user_options` flag will be removed from argument which is by default set to `True` in the arguments.  
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
nios
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
