### PR TITLE
Describe subset and superset as "set theory tests"

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -88,8 +88,8 @@ be used.  The default is ``False``, but this setting as ``True`` uses more stric
 
 .. _math_tests:
 
-Group theory tests
-``````````````````
+Set theory tests
+````````````````
 
 .. versionadded:: 2.1
 


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
subset and superset do not belong to group theory but to set theory.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
docsite


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html
https://en.wikipedia.org/wiki/Group_theory
https://en.wikipedia.org/wiki/Set_theory
<!--- Paste verbatim command output below, e.g. before and after your change -->
