### PR TITLE
Support upper/lower case resource groups in azure_rm.py

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -649,7 +649,7 @@ class AzureInventory(object):
             # get VMs for requested resource groups
             for resource_group in self.resource_groups:
                 try:
-                    virtual_machines = self._compute_client.virtual_machines.list(resource_group)
+                    virtual_machines = self._compute_client.virtual_machines.list(resource_group.lower())
                 except Exception as exc:
                     sys.exit("Error: fetching virtual machines for resource group {0} - {1}".format(resource_group, str(exc)))
                 if self._args.host or self.tags:


### PR DESCRIPTION
Support upper/lower case resource groups

##### SUMMARY
Fixes #43917 which was originally reported by me in https://github.com/MicrosoftDocs/azure-docs/issues/7111 but turned out to be a issue in the parsing the resource group name.

The fix is very simple so I decide to submit the PR
 
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm.py script

##### ANSIBLE VERSION
n\a


##### ADDITIONAL INFORMATION
n\a