### PR TITLE
Fix win_domain_computer replacing existing object with the same values #43653

### DIFF
--- a/lib/ansible/modules/windows/win_domain_computer.ps1
+++ b/lib/ansible/modules/windows/win_domain_computer.ps1
@@ -25,14 +25,14 @@ If (-not $sam_account_name.EndsWith("$")) {
   Fail-Json -obj $result -message "sam_account_name must end in $"
 }
 $enabled = Get-AnsibleParam -obj $params -name "enabled" -type "bool" -default $true
-$description = Get-AnsibleParam -obj $params -name "description" -default ""
+$description = Get-AnsibleParam -obj $params -name "description" -default $null
 $state = Get-AnsibleParam -obj $params -name "state" -ValidateSet "present","absent" -default "present"
 If ($state -eq "present") {
   $dns_hostname = Get-AnsibleParam -obj $params -name "dns_hostname" -failifempty $true -resultobj $result
   $ou = Get-AnsibleParam -obj $params -name "ou" -failifempty $true -resultobj $result
   $distinguished_name = "CN=$name,$ou"
 
-  $desired_state = @{
+  $desired_state = [ordered]@{
     name = $name
     sam_account_name = $sam_account_name
     dns_hostname = $dns_hostname
@@ -43,7 +43,7 @@ If ($state -eq "present") {
     state = $state
   }
 } Else {
-  $desired_state = @{
+  $desired_state = [ordered]@{
     name = $name
     state = $state
   }
@@ -58,7 +58,7 @@ Function Get-InitialState($desired_state) {
       -Properties DistinguishedName,DNSHostName,Enabled,Name,SamAccountName,Description,ObjectClass
   } Catch { $null }
   If ($computer) {
-      $initial_state = @{
+      $initial_state = [ordered]@{
         name = $computer.Name
         sam_account_name = $computer.SamAccountName
         dns_hostname = $computer.DNSHostName
@@ -70,7 +70,7 @@ Function Get-InitialState($desired_state) {
         state = "present"
       }
   } Else {
-    $initial_state = @{
+    $initial_state = [ordered]@{
       name = $desired_state.name
       state = "absent"
     }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`win_domain_computer` module failed when no change is needed and `description`parameter is empty. It tries to replace the existing Active directory Computer object with one with the same values (Internally `Set-ADComputer` fails when doing it).

* Change: Defaults description parameter to `$null`.
  Reason: When reading an empty description from AD powershell returns a null. Having a `""` as default causes an error for a change that  don't exist.
* Change: Convert `after` and `before` `diff` keys to ordered hashes.
  Reason: Unordered state descriptions make `--diff` report equal values as
  changes.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #43653 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
win_domain_computer

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = /home/dsanfab/.ansible.cfg
  configured module search path = [u'/home/dsanfab/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/dsanfab/.local/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```



