### PR TITLE
Add 'tower_settings' module for managing Ansible Tower Settings

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
@@ -18,21 +18,20 @@ DOCUMENTATION = '''
 module: tower_settings
 author: "Nikhil Jain (@jainnikhil30)"
 version_added: "2.7"
-short_description: Get, Modify Ansible Tower settings.
+short_description: Modify Ansible Tower settings.
 description:
     - Get, Modify Ansible Tower settings. See
       U(https://www.ansible.com/tower) for an overview.
 options:
     name:
       description:
-        - Name of setting to get/modify.
+        - Name of setting to get/modify
     value:
       description:
-        - Value to be modified for given setting. If this parameter is not given, module will only get the value of setting.
-extends_documentation_fragment: tower
+        - Value to be modified for given setting.
+    extends_documentation_fragment: tower
 '''
 
-RETURN = ''' # '''
 
 EXAMPLES = '''
 - name: Set the value of AWX_PROOT_BASE_PATH
@@ -51,11 +50,7 @@ EXAMPLES = '''
   tower_settings:
     name: "AUTH_LDAP_BIND_PASSWORD"
     value: "Password"
-  no_log: true
-
-- name: Get the value of AWX_PROOT_BASE_PATH
-  tower_settings:
-    name: AWX_PROOT_BASE_PATH
+  no_log: true   
 '''
 
 from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
@@ -90,11 +85,7 @@ def main():
         tower_check_mode(module)
         try:
             setting = tower_cli.get_resource('setting')
-            if value:
-                result = setting.modify(setting=name, value=value)
-                json_output['changed'] = result['changed']
-            else:
-                result = setting.get(pk=name)
+            result = setting.modify(setting=name, value=value)
 
             json_output['id'] = result['id']
             json_output['value'] = result['value']
@@ -102,6 +93,7 @@ def main():
         except (exc.ConnectionError, exc.BadRequest) as excinfo:
             module.fail_json(msg='Failed to modify the setting: {0}'.format(excinfo), changed=False)
 
+    json_output['changed'] = result['changed']
     module.exit_json(**json_output)
 
 

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
@@ -50,7 +50,7 @@ EXAMPLES = '''
   tower_settings:
     name: "AUTH_LDAP_BIND_PASSWORD"
     value: "Password"
-  no_log: true   
+  no_log: true 
 '''
 
 from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
@@ -99,3 +99,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
@@ -50,7 +50,7 @@ EXAMPLES = '''
   tower_settings:
     name: "AUTH_LDAP_BIND_PASSWORD"
     value: "Password"
-  no_log: true 
+  no_log: true
 '''
 
 from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
@@ -99,4 +99,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
@@ -32,6 +32,7 @@ options:
 extends_documentation_fragment: tower
 '''
 
+RETURN = ''' # '''
 
 EXAMPLES = '''
 - name: Set the value of AWX_PROOT_BASE_PATH

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
@@ -29,7 +29,7 @@ options:
     value:
       description:
         - Value to be modified for given setting.
-    extends_documentation_fragment: tower
+extends_documentation_fragment: tower
 '''
 
 

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
@@ -67,13 +67,13 @@ except ImportError:
 
 def main():
     argument_spec = dict(
-        name=dict(),
-        value=dict(),
+        name=dict(Required=True),
+        value=dict(Required=True),
     )
 
     module = TowerModule(
         argument_spec=argument_spec,
-        supports_check_mode=True
+        supports_check_mode=False
     )
 
     json_output = {}

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_settings.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+# (c) 2018, Nikhil Jain <nikjain@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: tower_settings
+author: "Nikhil Jain (@jainnikhil30)"
+version_added: "2.7"
+short_description: Get, Modify Ansible Tower settings.
+description:
+    - Get, Modify Ansible Tower settings. See
+      U(https://www.ansible.com/tower) for an overview.
+options:
+    name:
+      description:
+        - Name of setting to get/modify.
+    value:
+      description:
+        - Value to be modified for given setting. If this parameter is not given, module will only get the value of setting.
+extends_documentation_fragment: tower
+'''
+
+
+EXAMPLES = '''
+- name: Set the value of AWX_PROOT_BASE_PATH
+  tower_settings:
+    name: AWX_PROOT_BASE_PATH
+    value: "/tmp"
+  register: testing_settings
+
+- name: Set the value of AWX_PROOT_SHOW_PATHS
+  tower_settings:
+    name: "AWX_PROOT_SHOW_PATHS"
+    value: "'/var/lib/awx/projects/', '/tmp'"
+  register: testing_settings
+
+- name: Set the LDAP Auth Bind Password
+  tower_settings:
+    name: "AUTH_LDAP_BIND_PASSWORD"
+    value: "Password"
+  no_log: true
+
+- name: Get the value of AWX_PROOT_BASE_PATH
+  tower_settings:
+    name: AWX_PROOT_BASE_PATH
+'''
+
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
+
+try:
+    import tower_cli
+    import tower_cli.utils.exceptions as exc
+
+    from tower_cli.conf import settings
+except ImportError:
+    pass
+
+
+def main():
+    argument_spec = dict(
+        name=dict(),
+        value=dict(),
+    )
+
+    module = TowerModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    json_output = {}
+
+    name = module.params.get('name')
+    value = module.params.get('value')
+
+    tower_auth = tower_auth_config(module)
+    with settings.runtime_values(**tower_auth):
+        tower_check_mode(module)
+        try:
+            setting = tower_cli.get_resource('setting')
+            if value:
+                result = setting.modify(setting=name, value=value)
+                json_output['changed'] = result['changed']
+            else:
+                result = setting.get(pk=name)
+
+            json_output['id'] = result['id']
+            json_output['value'] = result['value']
+
+        except (exc.ConnectionError, exc.BadRequest) as excinfo:
+            module.fail_json(msg='Failed to modify the setting: {0}'.format(excinfo), changed=False)
+
+    module.exit_json(**json_output)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/tower_settings/aliases
+++ b/test/integration/targets/tower_settings/aliases
@@ -1,0 +1,2 @@
+cloud/tower
+shippable/tower/group1

--- a/test/integration/targets/tower_settings/tasks/main.yml
+++ b/test/integration/targets/tower_settings/tasks/main.yml
@@ -1,13 +1,3 @@
-- name: get the value of AWX_PROOT_BASE_PATH for resetting it again after the test
-  tower_settings:
-    name: "AWX_PROOT_BASE_PATH"
-  register: base_path
-
-- name: get the value of AWX_PROOT_SHOW_PATHS for resetting it again after the test
-  tower_settings:
-    name: "AWX_PROOT_SHOW_PATHS"
-  register: show_path
-
 - name: Set the value of AWX_PROOT_SHOW_PATHS
   tower_settings:
     name: "AWX_PROOT_SHOW_PATHS"
@@ -24,21 +14,6 @@
     value: "/tmp"
   register: result
 
-- name: Get the value of AWX_PROOT_BASE_PATH
-  tower_settings:
-    name: AWX_PROOT_BASE_PATH
-  register: result
-
 - assert:
     that:
       - "result.value == '/tmp'"
-
-- name: reset the value of AWX_PROOT_BASE_PATH to previous value
-  tower_settings:
-    name: "AWX_PROOT_BASE_PATH"
-    value: "{{ base_path.value }}"
-
-- name: reset the value of AWX_PROOT_SHOW_PATHS to previous value
-  tower_settings:
-    name: "AWX_PROOT_SHOW_PATHS"
-    value: "{{ show_path.value }}"

--- a/test/integration/targets/tower_settings/tasks/main.yml
+++ b/test/integration/targets/tower_settings/tasks/main.yml
@@ -1,3 +1,13 @@
+- name: get the value of AWX_PROOT_BASE_PATH for resetting it again after the test
+  tower_settings:
+    name: "AWX_PROOT_BASE_PATH"
+  register: base_path
+
+- name: get the value of AWX_PROOT_SHOW_PATHS for resetting it again after the test
+  tower_settings:
+    name: "AWX_PROOT_SHOW_PATHS"
+  register: show_path
+
 - name: Set the value of AWX_PROOT_SHOW_PATHS
   tower_settings:
     name: "AWX_PROOT_SHOW_PATHS"
@@ -22,3 +32,13 @@
 - assert:
     that:
       - "result.value == '/tmp'"
+
+- name: reset the value of AWX_PROOT_BASE_PATH to previous value
+  tower_settings:
+    name: "AWX_PROOT_BASE_PATH"
+    value: "{{ base_path.value }}"
+
+- name: reset the value of AWX_PROOT_SHOW_PATHS to previous value
+  tower_settings:
+    name: "AWX_PROOT_SHOW_PATHS"
+    value: "{{ show_path.value }}"

--- a/test/integration/targets/tower_settings/tasks/main.yml
+++ b/test/integration/targets/tower_settings/tasks/main.yml
@@ -1,0 +1,24 @@
+- name: Set the value of AWX_PROOT_SHOW_PATHS
+  tower_settings:
+    name: "AWX_PROOT_SHOW_PATHS"
+    value: "'/var/lib/awx/projects/', '/tmp'"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Set the value of AWX_PROOT_BASE_PATH
+  tower_settings:
+    name: AWX_PROOT_BASE_PATH
+    value: "/tmp"
+  register: result
+
+- name: Get the value of AWX_PROOT_BASE_PATH
+  tower_settings:
+    name: AWX_PROOT_BASE_PATH
+  register: result
+
+- assert:
+    that:
+      - "result.value == '/tmp'"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

This is to add a tower_settings module which provides the ability to get, modify
tower settings, which are at /api/v2/settings/all.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
tower_settings
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```

