### PR TITLE
Last two fields in fstab are optional (fixes #43855)

### DIFF
--- a/changelogs/fragments/mount-optional-fields.yaml
+++ b/changelogs/fragments/mount-optional-fields.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - mount - make last two fields optional (https://github.com/ansible/ansible/issues/43855)

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -187,10 +187,14 @@ def set_mount(module, args):
 
             continue
 
+        fields = line.split()
+
         # Check if we got a valid line for splitting
+        # (on Linux the 5th and the 6th field is optional)
         if (
-                get_platform() == 'SunOS' and len(line.split()) != 7 or
-                get_platform() != 'SunOS' and len(line.split()) != 6):
+                get_platform() == 'SunOS' and len(fields) != 7 or
+                get_platform() == 'Linux' and len(fields) not in [4, 5, 6] or
+                get_platform() not in ['SunOS', 'Linux'] and len(fields) != 6):
             to_write.append(line)
 
             continue
@@ -206,16 +210,17 @@ def set_mount(module, args):
                 ld['passno'],
                 ld['boot'],
                 ld['opts']
-            ) = line.split()
+            ) = fields
         else:
-            (
-                ld['src'],
-                ld['name'],
-                ld['fstype'],
-                ld['opts'],
-                ld['dump'],
-                ld['passno']
-            ) = line.split()
+            fields_labels = ['src', 'name', 'fstype', 'opts', 'dump', 'passno']
+
+            # The last two fields are optional on Linux so we fill in default values
+            ld['dump'] = 0
+            ld['passno'] = 0
+
+            # Fill in the rest of the available fields
+            for i, field in enumerate(fields):
+                ld[fields_labels[i]] = field
 
         # Check if we found the correct line
         if (

--- a/test/integration/targets/mount/tasks/main.yml
+++ b/test/integration/targets/mount/tasks/main.yml
@@ -119,8 +119,6 @@
   shell: mount | grep mount_dest | grep -E -w '(ro|read-only)' | wc -l
   register: remount_options
 
-- debug: var=remount_options
-
 - name: Make sure the filesystem now has the new opts
   assert:
     that:
@@ -247,4 +245,34 @@
     that:
       - "swap2_removed['changed']"
       - "not swap2_removed_again['changed']"
+  when: ansible_system in ('Linux')
+
+- name: Create fstab record with missing last two fields
+  copy:
+    dest: /etc/fstab
+    content: |
+      //nas/photo /home/jik/pictures cifs defaults,credentials=/etc/security/nas.creds,uid=jik,gid=users,forceuid,forcegid,noserverino,_netdev
+  when: ansible_system in ('Linux')
+
+- name: Try to change the fstab record with the missing last two fields
+  mount:
+    src: //nas/photo
+    path: /home/jik/pictures
+    fstype: cifs
+    opts: defaults,credentials=/etc/security/nas.creds,uid=jik,gid=users,forceuid,forcegid,noserverino,_netdev,x-systemd.mount-timeout=0
+    state: present
+  register: optional_fields_update
+  when: ansible_system in ('Linux')
+
+- name: Get the content of the fstab file
+  shell: cat /etc/fstab
+  register: optional_fields_content
+  when: ansible_system in ('Linux')
+
+- name: Check if the line containing the missing last two fields was changed
+  assert:
+    that:
+      - "optional_fields_update['changed']"
+      - "' 0 0' in optional_fields_content.stdout"
+      - "1 == optional_fields_content.stdout_lines | length"
   when: ansible_system in ('Linux')


### PR DESCRIPTION
##### SUMMARY
According to the Linux documentation for [`fstab`](http://man7.org/linux/man-pages/man5/fstab.5.html), the last two fields are optional. Current `mount` module is expecting to always have 6 fields which makes leads to adding an extra record.

This PR is fixing this behaviour by allowing to have 4, 5 or 6 fields on Linux. This fixes the issue #43855.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
`mount`

##### ANSIBLE VERSION
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.0 (default, Jul 15 2018, 10:44:58) [GCC 8.1.1 20180531]
```

##### ADDITIONAL INFORMATION
None