### PR TITLE
New module win_mssql_login_server_role: add or remove a server role to a sql login

### DIFF
--- a/lib/ansible/modules/windows/win_mssql_login_server_role.ps1
+++ b/lib/ansible/modules/windows/win_mssql_login_server_role.ps1
@@ -1,0 +1,160 @@
+#!powershell
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Daniele Lazzari  <lazzari@mailup.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+
+$ErrorActionPreference = "Stop"
+$result = @{
+    'changed' = $False;
+}
+
+Function Test-SQLServerRole {
+    Param (
+        [string]$LogiName,
+        [string]$ServerRole,
+        [string]$ServerInstance,
+        [string]$ServerInstanceUser,
+        [Security.SecureString]$ServerInstancePassword
+    )
+
+    $QUERY = "SELECT IS_SRVROLEMEMBER ( N'$ServerRole', '$LogiName' ) AS role"
+    try {
+        if (!($ServerInstanceUser) -or !($ServerInstancePassword)) {
+            $HasRole = Invoke-SqlCmd -ServerInstance $ServerInstance -Query $QUERY
+        }
+        else {
+            $SQLCredentials = New-Object -TypeName System.Management.Automation.PSCredential ($ServerInstanceUser, $ServerInstancePassword)
+            $HasRole = Invoke-SqlCmd -ServerInstance $ServerInstance -Query $QUERY -Credential $SQLCredentials
+        }
+    }
+    catch {
+        Fail-Json -obj $result -message $($_.exception.message)
+    }
+    
+    if ($HasRole.role -eq 1) {
+        return $true
+    }
+    return $false
+}
+
+Function Add-LoginServerRole {
+    Param (
+        [string]$LogiName,
+        [string]$ServerRole,
+        [string]$ServerInstance,
+        [string]$ServerInstanceUser,
+        [Security.SecureString]$ServerInstancePassword,
+        [bool]$CheckMode
+    )
+
+    $HasRole = Test-SQLServerRole -LogiName $LoginName `
+        -ServerRole $ServerRole `
+        -ServerInstance $ServerInstance `
+        -ServerInstanceUser $ServerInstanceUser `
+        -ServerInstancePassword $ServerInstancePassword
+
+    if ($HasRole) {
+        $result.role = $ServerRole
+        $result.output = "role already present"
+    }
+    else {
+        $QUERY = "sp_addsrvrolemember @loginame= N'$LoginName', @rolename=N'$ServerRole'"
+        try {
+            if (!($CheckMode)) {
+                if (!($ServerInstanceUser) -or !($ServerInstancePassword)) {
+                    Invoke-SqlCmd -ServerInstance $ServerInstance -Query $QUERY
+                }
+                else {
+                    $SQLCredentials = New-Object -TypeName System.Management.Automation.PSCredential ($ServerInstanceUser, $ServerInstancePassword)
+                    Invoke-SqlCmd -ServerInstance $ServerInstance -Query $QUERY -Credential $SQLCredentials
+                }
+            }
+        }
+        catch {
+            Fail-Json -obj $result -message $($_.exception.message)
+        }
+        $result.output = "role added"
+        $result.role = $ServerRole
+        $result.changed = $true
+    }   
+
+    Exit-Json $result
+}
+
+Function Remove-LoginServerRole {
+    Param (
+        [string]$LogiName,
+        [string]$ServerRole,
+        [string]$ServerInstance,
+        [string]$ServerInstanceUser,
+        [Security.SecureString]$ServerInstancePassword,
+        [bool]$CheckMode
+    )
+
+    $HasRole = Test-SQLServerRole -LogiName $LoginName `
+        -ServerRole $ServerRole `
+        -ServerInstance $ServerInstance `
+        -ServerInstanceUser $ServerInstanceUser `
+        -ServerInstancePassword $ServerInstancePassword
+    
+    if (!($HasRole)) {
+        $result.role = $ServerRole
+        $result.output = "no role to remove"
+    }
+    else {
+        $QUERY = "sp_dropsrvrolemember @loginame= N'$LoginName', @rolename=N'$ServerRole'"
+        try {
+            if (!($CheckMode)) {
+                if (!($ServerInstanceUser) -or !($ServerInstancePassword)) {
+                    Invoke-SqlCmd -ServerInstance $ServerInstance -Query $QUERY
+                }
+                else {
+                    $SQLCredentials = New-Object -TypeName System.Management.Automation.PSCredential ($ServerInstanceUser, $ServerInstancePassword)
+                    Invoke-SqlCmd -ServerInstance $ServerInstance -Query $QUERY -Credential $SQLCredentials
+                }
+            }
+        }
+        catch {
+            Fail-Json -obj $result -message $($_.exception.message)
+        }
+        $result.output = "role removed"
+        $result.role = $ServerRole
+        $result.changed = $true
+    }
+
+    Exit-Json $result
+}
+
+$params = Parse-Args $args -supports_check_mode $true
+
+$loginName = Get-AnsibleParam -obj $params -name "login_name" -type "str" -failifempty $true
+$serverRole = Get-AnsibleParam -obj $params -name "server_role" -type "list" -failifempty $true
+$serverInstance = Get-AnsibleParam -obj $params -name "server_instance" -type "str" -default $env:COMPUTERNAME
+$serverInstanceUser = Get-AnsibleParam -obj $params -name "server_instance_user" -type "str" -default $null
+$serverInstancePassword = Get-AnsibleParam -obj $params -name "server_instance_password" -type "str" -default $null
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present", "absent"
+
+if ($serverInstancePassword) {
+    $serverInstancePassword = ConvertTo-SecureString $serverInstancePassword -AsPlainText -Force
+}
+
+if ($state -eq "present") {
+    Add-LoginServerRole -LogiName $loginName `
+        -ServerRole $serverRole `
+        -ServerInstance $serverInstance `
+        -ServerInstanceUser $serverInstanceUser `
+        -ServerInstancePassword $serverInstancePassword `
+        -CheckMode $check_mode
+}
+else {
+    Remove-LoginServerRole -LogiName $loginName `
+        -ServerRole $serverRole `
+        -ServerInstance $serverInstance `
+        -ServerInstanceUser $serverInstanceUser `
+        -ServerInstancePassword $serverInstancePassword `
+        -CheckMode $check_mode
+}

--- a/lib/ansible/modules/windows/win_mssql_login_server_role.py
+++ b/lib/ansible/modules/windows/win_mssql_login_server_role.py
@@ -49,7 +49,7 @@ options:
 author:
   - Daniele Lazzari
 notes:
-  - If the user that runs ansible has the appropriated permission on the db,
+  - If the user that runs ansible has the appropriate permission on the database server,
   - you don't need to set C(server_instance_user) and C(server_instance_password)
 '''
 

--- a/lib/ansible/modules/windows/win_mssql_login_server_role.py
+++ b/lib/ansible/modules/windows/win_mssql_login_server_role.py
@@ -105,7 +105,7 @@ output:
   type: string
 role:
   description: name of the server role
-  returned; always
+  returned: always
   sample: "setupadmin"
   type: string
 '''

--- a/lib/ansible/modules/windows/win_mssql_login_server_role.py
+++ b/lib/ansible/modules/windows/win_mssql_login_server_role.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Daniele Lazzari <lazzari@mailup.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# This is a windows documentation stub.  Actual code lives in the .ps1
+# file of the same name.
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: win_mssql_login_server_role
+version_added: '2.7'
+short_description: adds or removes a server role to a sql login
+description:
+    - Adds or removes a server role to a sql login.
+    - Refer to https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/server-level-roles?view=sql-server-2017
+    - for more informations on how server roles work
+requirements:
+  - Powershell module sqlps or Powershell module SqlServer
+options:
+  server_instance:
+    description:
+      - Name of the sql server instance
+    default: computername
+  server_instance_user:
+    description:
+      - Name of a sql user with sufficient privileges
+  server_instance_password:
+    description:
+      - Password for server_instance_user
+  login_name:
+    description:
+      - SQL loging name
+    required: yes
+  server_role:
+    description:
+      - Name of the server role to add or remove
+    required: yes
+  state:
+    description:
+      - If C(present), adds a server role
+      - If C(absent), removes a server role
+    default: present
+author:
+  - Daniele Lazzari
+notes:
+  - If the user that runs ansible has the appropriated permission on the db,
+  - you don't need to set C(server_instance_user) and C(server_instance_password)
+'''
+
+EXAMPLES = r'''
+---
+- name: add a server role to a login
+  win_mssql_login_server_role:
+    server_instance: 'myserver\instance'
+    login_name: john_doe
+    server_role: setupadmin
+    state: present
+
+- name: remove a server role from a sql login
+  win_mssql_login_server_role:
+    server_instance: 'myserver\instance'
+    server_instance_user: sysadminUser
+    server_instance_password: "{{ sysadmin_password }}"
+    login_name: jane_doe
+    server_role: setupadmin
+    state: absent
+
+- name: add more than a server role
+  win_mssql_login_server_role:
+    server_instance: 'myserver\instance'
+    login_name: jane_doe
+    server_role: "{{ item }}"
+    loop:
+      - setupadmin
+      - securityadmin
+
+# working with win_mssql_login module
+
+- name: add a new login
+  win_mssql_login:
+    server_instance: MYSQLSERVER
+    login_name: john_doe
+    password: "{{ my_super_secret }}"
+    state: present
+
+- name: add a server role to a login
+  win_mssql_login_server_role:
+    server_instance: MYSQLSERVER
+    login_name: john_doe
+    server_role: sysadmin
+'''
+
+RETURN = r'''
+---
+output:
+  description: a message describing the task result
+  returned: always
+  sample: "role added"
+  type: string
+role:
+  description: name of the server role
+  returned; always
+  sample: "setupadmin"
+  type: string
+'''

--- a/test/integration/targets/win_mssql_login_server_role/aliases
+++ b/test/integration/targets/win_mssql_login_server_role/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group4

--- a/test/integration/targets/win_mssql_login_server_role/defaults/main.yml
+++ b/test/integration/targets/win_mssql_login_server_role/defaults/main.yml
@@ -1,0 +1,1 @@
+sa: P@sswo0rd

--- a/test/integration/targets/win_mssql_login_server_role/tasks/main.yml
+++ b/test/integration/targets/win_mssql_login_server_role/tasks/main.yml
@@ -1,0 +1,78 @@
+# test code for the win_psmodule module when using winrm connection
+# (c) 2017, Daniele Lazzari <lazzari@mailup.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+- name: get facts
+  setup:
+
+- name: check sql server is installed
+  win_shell: Get-WmiObject win32_service|?{$_.name -like "MSSQL*"}
+  register: service
+
+- name: run tests
+  when: service.stdout != ''
+  block:
+
+    - name: install SqlServer powershell module
+      win_psmodule:
+        name: SqlServer
+        state: present
+        allow_clobber: yes
+      when: ansible_powershell_version >= 5
+
+    - name: install sql feature pack
+      when: ansible_powershell_version < 5
+      block: 
+
+        - name: create dir
+          win_file:
+            path: 'c:\temp'
+            state: directory
+
+        - name: download CLR types
+          win_get_url:
+            url: http://go.microsoft.com/fwlink/?LinkID=239644&clcid=0x409
+            dest: 'c:\temp\clr.msi'
+
+        - name: download smo
+          win_get_url:
+            url: http://go.microsoft.com/fwlink/?LinkID=239659&clcid=0x409
+            dest: 'c:\temp\smo.msi'
+
+        - name: download powershell tools
+          win_get_url: 
+            url: http://go.microsoft.com/fwlink/?LinkID=239656&clcid=0x409
+            dest: 'c:\temp\spt.msi'
+        
+        - name: install CLR Types
+          win_package:
+            path: 'c:\temp\clr.msi'
+            state: present
+
+        - name: install smo
+          win_package:
+            path: 'c:\temp\smo.msi'
+            state: present
+
+        - name: install pack
+          win_package:
+            path: 'c:\temp\spt.msi'
+            state: present
+
+    - name: run all tests
+      import_tasks: test.yml

--- a/test/integration/targets/win_mssql_login_server_role/tasks/test.yml
+++ b/test/integration/targets/win_mssql_login_server_role/tasks/test.yml
@@ -1,0 +1,81 @@
+---
+- name: add server role
+  win_mssql_login_server_role:
+    server_instance: "{{ ansible_hostname }}"
+    server_instance_user: sa
+    server_instance_password: "{{ sa }}"
+    login_name: john_doe
+    server_role: "{{ item }}"
+    state: present
+  loop: 
+    - securityadmin
+    - bulkadmin
+  register: res
+
+- name: test server role
+  assert:
+    that:
+      - "res.changed == True"
+
+- name: remove securityadmin role
+  win_mssql_login_server_role:
+    server_instance: "{{ ansible_hostname }}"
+    server_instance_user: sa
+    server_instance_password: "{{ sa }}"
+    login_name: john_doe
+    server_role: securityadmin
+    state: absent
+  register: res
+
+- name: test server role
+  assert:
+    that:
+      - res.changed == True
+      - res.role == "securityadmin"
+
+- name: check module idempontece
+  win_mssql_login_server_role:
+    server_instance: "{{ ansible_hostname }}"
+    server_instance_user: sa
+    server_instance_password: "{{ sa }}"
+    login_name: john_doe
+    server_role: bulkadmin
+    state: present
+  register: res
+
+- name: check server role idempontece
+  assert:
+    that:
+      - res.changed == False
+      - res.role == "bulkadmin"
+
+- name: test check mode
+  win_mssql_login_server_role:
+    server_instance: "{{ ansible_hostname }}"
+    server_instance_user: sa
+    server_instance_password: "{{ sa }}"
+    login_name: john_doe
+    server_role: bulkadmin
+    state: absent
+  check_mode: yes
+  register: res
+
+- name: check check_mode test
+  assert:
+    that:
+      - res.changed == True
+
+- name: cleanup
+  win_mssql_login_server_role:
+    server_instance: "{{ ansible_hostname }}"
+    server_instance_user: sa
+    server_instance_password: "{{ sa }}"
+    login_name: john_doe
+    server_role: bulkadmin
+    state: absent
+  register: res
+
+- name: check cleanup
+  assert:
+    that:
+      - res.changed == True

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -63,6 +63,7 @@ lib/ansible/modules/windows/win_iis_website.ps1 PSAvoidUsingPositionalParameters
 lib/ansible/modules/windows/win_iis_website.ps1 PSUseBOMForUnicodeEncodedFile
 lib/ansible/modules/windows/win_iis_website.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_mapped_drive.ps1 PSAvoidUsingConvertToSecureStringWithPlainText
+lib/ansible/modules/windows/win_mssql_login_server_role.ps1 PSAvoidUsingConvertToSecureStringWithPlainText
 lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingInvokeExpression
 lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingPlainTextForPassword


### PR DESCRIPTION
##### SUMMARY
This module allows to add or remove a server role to a MSSSQL server login.


##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
 win_mssql_login_server_role

##### ANSIBLE VERSION
```
2.7
```

##### ADDITIONAL INFORMATION
The best way to use this module is with win_mssql_login module (added with another pull request)

Tasks:
```
- name: create new sql login
  win_mssql_login:
    server_instance: MYSQLSERVER
    login_name: john_doe
    password: "{{ my_super_secret }}"
    state: present

- name: dd server role
  win_mssql_login_server_role:
    server_instance: MYSQLSERVER
    login_name: john_doe
    server_role: sysadmin
```
Output:
```
TASK [create new sql login] **********************************************************************************************
changed: [ansible] => {"changed": true, "output": "login john_doe created"}

TASK [add server role] **********************************************************************************************
changed: [ansible] => {"changed": true, "output": "role added", "role": "sysadmin"}
```
