### PR TITLE
WIP: first version of cloud auth plugins/parameter profiles

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3_bucket_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3_bucket_facts.py
@@ -8,6 +8,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
+                    'cloud_auth': {'version': 1, 'type': 'amazon'},
                     'supported_by': 'community'}
 
 DOCUMENTATION = '''

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -363,6 +363,18 @@ class PlayContext(Base):
                 if exe_var in variables:
                     setattr(new_info, 'executable', variables.get(exe_var))
 
+        if variables.get('param_profile') and all(v not in variables for v in C.COMMON_CONNECTION_VARS) and all(v not in variables for v in C.MAGIC_VARIABLE_MAPPING.get('remote_addr')):
+            if task.delegate_to is None:
+                display.debug("Parameter profile is used, and no Ansible host target has been set for %s. Overriding to use local connection." % variables.get('inventory_hostname'))
+                setattr(new_info, 'remote_addr', 'localhost')
+                setattr(new_info, 'connection', 'local')
+            elif delegated_vars.get('param_profile'):
+                display.debug("Parameter profile is used on the delegated host, and no Ansible host target has been set for %s. Overriding to use local connection." % variables.get('inventory_hostname'))
+                # TODO: we are delegated, so use the delegated host's variables
+                pass
+            elif not delegated_vars.get('param_profile'):
+                display.debug("Parameter profile is not used on the delegated host %s, ignoring parameter profile plugin" % variables.get('inventory_hostname'))
+
         attrs_considered = []
         for (attr, variable_names) in iteritems(C.MAGIC_VARIABLE_MAPPING):
             for variable_name in variable_names:

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -749,6 +749,19 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
         self._update_module_args(module_name, module_args, task_vars)
 
+        module_path = self._shared_loader_obj.module_loader.find_plugin(module_name, '.py')
+        with open(module_path, 'rb') as f:
+            from ansible.parsing.metadata import extract_metadata
+            module_meta = extract_metadata(module_data=f.read())[0] #TODO fail gracefully when no metadata is parsed
+            #TODO this part should be in configure_module, but we don't have it there because we need to finalize args first
+        if module_meta.get('cloud_auth') and task_vars.get('param_profile') and module_meta.get('cloud_auth').get('type') == task_vars.get('param_profile'):
+            from ansible.plugins.param_profiles import load as load_param_profile
+            final_params = load_param_profile(module_meta['cloud_auth']).parameterize(task_vars, self._task.args)
+            import sys
+            if 'ansible_python_interpreter' not in task_vars:
+                task_vars['ansible_python_interpreter'] = sys.executable
+            module_args = final_params
+
         # FUTURE: refactor this along with module build process to better encapsulate "smart wrapper" functionality
         (module_style, shebang, module_data, module_path) = self._configure_module(module_name=module_name, module_args=module_args, task_vars=task_vars)
         display.vvv("Using module file %s" % module_path)

--- a/lib/ansible/plugins/param_profiles/__init__.py
+++ b/lib/ansible/plugins/param_profiles/__init__.py
@@ -1,0 +1,10 @@
+# (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+def load(plugin_name):
+    import ansible.plugins.param_profiles.aws as aws
+    return aws

--- a/lib/ansible/plugins/param_profiles/aws.py
+++ b/lib/ansible/plugins/param_profiles/aws.py
@@ -1,0 +1,14 @@
+# (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+def parameterize(squashed_vars, task_params):
+    params = dict((k, v) for k, v in task_params.items())
+    if 'aws_profile' in squashed_vars and 'profile' not in task_params:
+        params['profile'] = squashed_vars['aws_profile']
+    if 'aws_region' in squashed_vars and 'region' not in task_params:
+        params['region'] = squashed_vars['aws_region']
+    return params


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This is a beta-extreme-unstable PR for parameter profiles/auth plugins, and currently only works for hosts that are *not* delegates. 

The name is something I'm still moving back and forth on: these aren't strictly cloud-focused, or only for auth. I think "Parameter Profiles" or similar is a nice option but I'm not set on it. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
cloud connection plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# inventory
aws_prod param_profile=amazon aws_profile=myProdAccount aws_region=us-east-1
aws_dev param_profile=amazon aws_profile=myDevAccount aws_region=us-east-2

# old version of checking S3 info
hosts: [aws_prod, aws_dev]
tasks:
- aws_s3_bucket_facts: profile={{ aws_profile }} region={{ aws_s3_region }}

# new way, using parameter profiles
hosts: [aws_prod, aws_dev]
tasks:
- aws_s3_bucket_facts:
```

These will also be mixable via delegate_to, but right now delegate handling is not working because the injection of the parameters in `ActionBase` doesn't seem to be delegate-aware. 