### PR TITLE
Fix assign_public_ip: no disregarded (#29691)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1055,7 +1055,7 @@ def create_instances(module, ec2, vpc, override_count=None):
                     module.fail_json(
                         msg="instance_profile_name parameter requires Boto version 2.5.0 or higher")
 
-            if assign_public_ip:
+            if assign_public_ip is not None:
                 if not boto_supports_associate_public_ip_address(ec2):
                     module.fail_json(
                         msg="assign_public_ip parameter requires Boto version 2.13.0 or higher.")


### PR DESCRIPTION
in case assign_public_ip is False, it is not handled.

##### SUMMARY
Change if statement to cases where assign_public_ip is False, by configuration of assign_public_ip: no

Fixes #29691
Handles "assign_public_ip: no"  correctly for launching an instance in a VPC subnet which the default is to assign public IP address.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2
##### ANSIBLE VERSION
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
option allows to explicitly set assign public ip to no
Fix tested on my own configuration and setup.

```
Before:
Public IP was assigned on AWS (observed via AWS console)
After:
Public IP was NOT assigned on AWS (observed via AWS console), as expected.
```
