### PR TITLE
Display correct task title with strategy 'free' (fixes #43950)

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -167,7 +167,11 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_task_start(self, task, is_conditional):
         # Preserve task name, as all vars may not be available for templating
         # when we need it later
-        if self._play.strategy != 'free':
+        if self._play.strategy == 'free':
+            # Explicitly set to None for strategy 'free' to account for any cached
+            # task title from a previous non-free play
+            self._last_task_name = None
+        else:
             self._last_task_name = task.get_name().strip()
 
             # Display the task banner immediately if we're not doing any filtering based on task result


### PR DESCRIPTION
##### SUMMARY
In a playbook with mixed strategies, tasks in a play with `strategy: free` will always show the last task title from the previous play without `strategy: free`. This commit adds a check for `strategy: free` to discard the cached task title.

This fixes #43950 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`default` callback plugin

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (merge_stdout_callbacks_5 781268efc4) last updated 2018/08/10 13:00:31 (GMT -500)
```

##### ADDITIONAL INFORMATION
N/A