### PR TITLE
iosxr_system always syntax error

### DIFF
--- a/test/integration/targets/iosxr_system/tests/netconf/set_hostname.yaml
+++ b/test/integration/targets/iosxr_system/tests/netconf/set_hostname.yaml
@@ -31,7 +31,7 @@
   - assert:
       that:
         - "result.changed == false"
-- always:
+  always:
   - name: teardown
     iosxr_config:
       lines: "hostname {{ inventory_hostname }}"


### PR DESCRIPTION
##### SUMMARY
Correct indentation

##### ISSUE TYPE
 - Bugfix Pull Request
