### PR TITLE
facts: solaris: introduce distribution_major version detection for Solaris

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -26,15 +26,12 @@ from ansible.module_utils.facts.utils import get_file_content
 from ansible.module_utils.facts.collector import BaseFactCollector
 
 
-def get_uname_version(module):
-    rc, out, err = module.run_command(['uname', '-v'])
-    if rc == 0:
-        return out
-    return None
-
-
-def get_uname_release(module):
-    rc, out, err = module.run_command(['uname', '-r'])
+def get_uname(module, flags=('-v')):
+    if isinstance(flags, str):
+        flags = flags.split()
+    command = ['uname']
+    command.extend(flags)
+    rc, out, err = module.run_command(command)
     if rc == 0:
         return out
     return None
@@ -595,7 +592,7 @@ class Distribution(object):
 
         if 'Solaris' in data:
             # for solaris 10 uname_r will contain 5.10, for solaris 11 it will have 5.11
-            uname_r = get_uname_release(self.module)
+            uname_r = get_uname(self.module,flags=['-r'])
             ora_prefix = ''
             if 'Oracle Solaris' in data:
                 data = data.replace('Oracle ', '')
@@ -606,7 +603,7 @@ class Distribution(object):
             sunos_facts['distribution_major_version'] = uname_r.split('.')[1]
             return sunos_facts
 
-        uname_v = get_uname_version(self.module)
+        uname_v = get_uname(self.module,flags=['-v'])
         distribution_version = None
 
         if 'SmartOS' in data:

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -606,7 +606,7 @@ class Distribution(object):
 =======
             # FIXME: the proper way would be to exec 'uname -r' and parse it.
             # For solaris 10 it will return 5.10, for solaris 11 it will be 5.11
-            # but I can't pass ansible test unit test_distribution_version.py with it, 
+            # but I can't pass ansible test unit test_distribution_version.py with it,
             # since I've no idea how to mock `uname -r` on CI (github/shippable) run.
             # rc, uname_r, err = self.module.run_command('uname -r')
 >>>>>>> should work now...
@@ -618,6 +618,7 @@ class Distribution(object):
             sunos_facts['distribution_version'] = data.split()[1]
             sunos_facts['distribution_release'] = ora_prefix + data
 <<<<<<< HEAD
+<<<<<<< HEAD
             sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
 <<<<<<< HEAD
             # sunos_facts['distribution_major_version'] = sunos_facts['distribution_version'].split('.')[0]
@@ -625,6 +626,9 @@ class Distribution(object):
 >>>>>>> facts: solaris: introduce distribution_major version detection for Solaris
 =======
             #sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
+=======
+            # sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
+>>>>>>> fixes for W291 (trailing whitespace) and E265 (block comment)
             sunos_facts['distribution_major_version'] = sunos_facts['distribution_version'].split('.')[0]
 >>>>>>> should work now...
             return sunos_facts

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -26,15 +26,12 @@ from ansible.module_utils.facts.utils import get_file_content
 from ansible.module_utils.facts.collector import BaseFactCollector
 
 
-def get_uname_version(module):
-    rc, out, err = module.run_command(['uname', '-v'])
-    if rc == 0:
-        return out
-    return None
-
-
-def get_uname_release(module):
-    rc, out, err = module.run_command(['uname', '-r'])
+def get_uname(module, flags=('-v')):
+    if isinstance(flags, str):
+        flags = flags.split()
+    command = ['uname']
+    command.extend(flags)
+    rc, out, err = module.run_command(command)
     if rc == 0:
         return out
     return None
@@ -595,7 +592,7 @@ class Distribution(object):
 
         if 'Solaris' in data:
             # for solaris 10 uname_r will contain 5.10, for solaris 11 it will have 5.11
-            uname_r = get_uname_release(self.module)
+            uname_r = get_uname(self.module, flags=['-r'])
             ora_prefix = ''
             if 'Oracle Solaris' in data:
                 data = data.replace('Oracle ', '')
@@ -606,7 +603,7 @@ class Distribution(object):
             sunos_facts['distribution_major_version'] = uname_r.split('.')[1].rstrip();
             return sunos_facts
 
-        uname_v = get_uname_version(self.module)
+        uname_v = get_uname(self.module, flags=['-v'])
         distribution_version = None
 
         if 'SmartOS' in data:

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -592,7 +592,7 @@ class Distribution(object):
 
         if 'Solaris' in data:
             # for solaris 10 uname_r will contain 5.10, for solaris 11 it will have 5.11
-            uname_r = get_uname(self.module,flags=['-r'])
+            uname_r = get_uname(self.module, flags=['-r'])
             ora_prefix = ''
             if 'Oracle Solaris' in data:
                 data = data.replace('Oracle ', '')
@@ -603,7 +603,7 @@ class Distribution(object):
             sunos_facts['distribution_major_version'] = uname_r.split('.')[1]
             return sunos_facts
 
-        uname_v = get_uname(self.module,flags=['-v'])
+        uname_v = get_uname(self.module, flags=['-v'])
         distribution_version = None
 
         if 'SmartOS' in data:

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -592,11 +592,16 @@ class Distribution(object):
         data = get_file_content('/etc/release').splitlines()[0]
 
         if 'Solaris' in data:
+<<<<<<< HEAD
             # FIXME: the proper way would be to exec 'uname -r' and parse it.
             # For solaris 10 it will return 5.10, for solaris 11 it will be 5.11
             # but I can't pass ansible test unit test_distribution_version.py with it,
             # since I've no idea how to mock `uname -r` on CI (github/shippable) run.
             uname_r = get_uname_release(self.module)
+=======
+            rc, uname_r, err = self.module.run_command('uname -r')
+            # for solaris 10 uname_r will contain 5.10, for solaris 11 it will have 5.11
+>>>>>>> facts: solaris: introduce distribution_major version detection for Solaris
             ora_prefix = ''
             if 'Oracle Solaris' in data:
                 data = data.replace('Oracle ', '')
@@ -605,7 +610,10 @@ class Distribution(object):
             sunos_facts['distribution_version'] = data.split()[1]
             sunos_facts['distribution_release'] = ora_prefix + data
             sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
+<<<<<<< HEAD
             # sunos_facts['distribution_major_version'] = sunos_facts['distribution_version'].split('.')[0]
+=======
+>>>>>>> facts: solaris: introduce distribution_major version detection for Solaris
             return sunos_facts
 
         uname_v = get_uname_version(self.module)

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -32,11 +32,13 @@ def get_uname_version(module):
         return out
     return None
 
+
 def get_uname_release(module):
     rc, out, err = module.run_command(['uname', '-r'])
     if rc == 0:
         return out
     return None
+
 
 def _file_exists(path, allow_empty=False):
     # not finding the file, exit early

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -587,8 +587,11 @@ class Distribution(object):
         data = get_file_content('/etc/release').splitlines()[0]
 
         if 'Solaris' in data:
-            rc, uname_r, err = self.module.run_command('uname -r')
-            # for solaris 10 uname_r will contain 5.10, for solaris 11 it will have 5.11
+            # FIXME: the proper way would be to exec 'uname -r' and parse it.
+            # For solaris 10 it will return 5.10, for solaris 11 it will be 5.11
+            # but I can't pass ansible test unit test_distribution_version.py with it, 
+            # since I've no idea how to mock `uname -r` on CI (github/shippable) run.
+            # rc, uname_r, err = self.module.run_command('uname -r')
             ora_prefix = ''
             if 'Oracle Solaris' in data:
                 data = data.replace('Oracle ', '')
@@ -596,7 +599,8 @@ class Distribution(object):
             sunos_facts['distribution'] = data.split()[0]
             sunos_facts['distribution_version'] = data.split()[1]
             sunos_facts['distribution_release'] = ora_prefix + data
-            sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
+            #sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
+            sunos_facts['distribution_major_version'] = sunos_facts['distribution_version'].split('.')[0]
             return sunos_facts
 
         uname_v = get_uname_version(self.module)

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -600,7 +600,7 @@ class Distribution(object):
             sunos_facts['distribution'] = data.split()[0]
             sunos_facts['distribution_version'] = data.split()[1]
             sunos_facts['distribution_release'] = ora_prefix + data
-            sunos_facts['distribution_major_version'] = uname_r.split('.')[1].rstrip();
+            sunos_facts['distribution_major_version'] = uname_r.split('.')[1].rstrip()
             return sunos_facts
 
         uname_v = get_uname(self.module, flags=['-v'])

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -603,7 +603,7 @@ class Distribution(object):
             sunos_facts['distribution'] = data.split()[0]
             sunos_facts['distribution_version'] = data.split()[1]
             sunos_facts['distribution_release'] = ora_prefix + data
-            sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
+            sunos_facts['distribution_major_version'] = uname_r.split('.')[1]
             return sunos_facts
 
         uname_v = get_uname_version(self.module)

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -587,6 +587,8 @@ class Distribution(object):
         data = get_file_content('/etc/release').splitlines()[0]
 
         if 'Solaris' in data:
+            rc, uname_r, err = self.module.run_command('uname -r')
+            # for solaris 10 uname_r will contain 5.10, for solaris 11 it will have 5.11
             ora_prefix = ''
             if 'Oracle Solaris' in data:
                 data = data.replace('Oracle ', '')
@@ -594,6 +596,7 @@ class Distribution(object):
             sunos_facts['distribution'] = data.split()[0]
             sunos_facts['distribution_version'] = data.split()[1]
             sunos_facts['distribution_release'] = ora_prefix + data
+            sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
             return sunos_facts
 
         uname_v = get_uname_version(self.module)

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -593,6 +593,7 @@ class Distribution(object):
 
         if 'Solaris' in data:
 <<<<<<< HEAD
+<<<<<<< HEAD
             # FIXME: the proper way would be to exec 'uname -r' and parse it.
             # For solaris 10 it will return 5.10, for solaris 11 it will be 5.11
             # but I can't pass ansible test unit test_distribution_version.py with it,
@@ -602,6 +603,13 @@ class Distribution(object):
             rc, uname_r, err = self.module.run_command('uname -r')
             # for solaris 10 uname_r will contain 5.10, for solaris 11 it will have 5.11
 >>>>>>> facts: solaris: introduce distribution_major version detection for Solaris
+=======
+            # FIXME: the proper way would be to exec 'uname -r' and parse it.
+            # For solaris 10 it will return 5.10, for solaris 11 it will be 5.11
+            # but I can't pass ansible test unit test_distribution_version.py with it, 
+            # since I've no idea how to mock `uname -r` on CI (github/shippable) run.
+            # rc, uname_r, err = self.module.run_command('uname -r')
+>>>>>>> should work now...
             ora_prefix = ''
             if 'Oracle Solaris' in data:
                 data = data.replace('Oracle ', '')
@@ -609,11 +617,16 @@ class Distribution(object):
             sunos_facts['distribution'] = data.split()[0]
             sunos_facts['distribution_version'] = data.split()[1]
             sunos_facts['distribution_release'] = ora_prefix + data
+<<<<<<< HEAD
             sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
 <<<<<<< HEAD
             # sunos_facts['distribution_major_version'] = sunos_facts['distribution_version'].split('.')[0]
 =======
 >>>>>>> facts: solaris: introduce distribution_major version detection for Solaris
+=======
+            #sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
+            sunos_facts['distribution_major_version'] = sunos_facts['distribution_version'].split('.')[0]
+>>>>>>> should work now...
             return sunos_facts
 
         uname_v = get_uname_version(self.module)

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -32,6 +32,11 @@ def get_uname_version(module):
         return out
     return None
 
+def get_uname_release(module):
+    rc, out, err = module.run_command(['uname', '-r'])
+    if rc == 0:
+        return out
+    return None
 
 def _file_exists(path, allow_empty=False):
     # not finding the file, exit early
@@ -591,7 +596,7 @@ class Distribution(object):
             # For solaris 10 it will return 5.10, for solaris 11 it will be 5.11
             # but I can't pass ansible test unit test_distribution_version.py with it,
             # since I've no idea how to mock `uname -r` on CI (github/shippable) run.
-            # rc, uname_r, err = self.module.run_command('uname -r')
+            uname_r = get_uname_release(self.module)
             ora_prefix = ''
             if 'Oracle Solaris' in data:
                 data = data.replace('Oracle ', '')
@@ -599,8 +604,8 @@ class Distribution(object):
             sunos_facts['distribution'] = data.split()[0]
             sunos_facts['distribution_version'] = data.split()[1]
             sunos_facts['distribution_release'] = ora_prefix + data
-            # sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
-            sunos_facts['distribution_major_version'] = sunos_facts['distribution_version'].split('.')[0]
+            sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
+            # sunos_facts['distribution_major_version'] = sunos_facts['distribution_version'].split('.')[0]
             return sunos_facts
 
         uname_v = get_uname_version(self.module)

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -600,7 +600,7 @@ class Distribution(object):
             sunos_facts['distribution'] = data.split()[0]
             sunos_facts['distribution_version'] = data.split()[1]
             sunos_facts['distribution_release'] = ora_prefix + data
-            sunos_facts['distribution_major_version'] = uname_r.split('.')[1]
+            sunos_facts['distribution_major_version'] = uname_r.split('.')[1].rstrip();
             return sunos_facts
 
         uname_v = get_uname(self.module, flags=['-v'])

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -592,28 +592,8 @@ class Distribution(object):
         data = get_file_content('/etc/release').splitlines()[0]
 
         if 'Solaris' in data:
-<<<<<<< HEAD
-<<<<<<< HEAD
-            # FIXME: the proper way would be to exec 'uname -r' and parse it.
-            # For solaris 10 it will return 5.10, for solaris 11 it will be 5.11
-            # but I can't pass ansible test unit test_distribution_version.py with it,
-            # since I've no idea how to mock `uname -r` on CI (github/shippable) run.
-            uname_r = get_uname_release(self.module)
-=======
-            rc, uname_r, err = self.module.run_command('uname -r')
             # for solaris 10 uname_r will contain 5.10, for solaris 11 it will have 5.11
->>>>>>> facts: solaris: introduce distribution_major version detection for Solaris
-=======
-            # FIXME: the proper way would be to exec 'uname -r' and parse it.
-            # For solaris 10 it will return 5.10, for solaris 11 it will be 5.11
-            # but I can't pass ansible test unit test_distribution_version.py with it,
-            # since I've no idea how to mock `uname -r` on CI (github/shippable) run.
-<<<<<<< HEAD
-            # rc, uname_r, err = self.module.run_command('uname -r')
->>>>>>> should work now...
-=======
             uname_r = get_uname_release(self.module)
->>>>>>> mock uname_release for solaris 10 and solaris 11
             ora_prefix = ''
             if 'Oracle Solaris' in data:
                 data = data.replace('Oracle ', '')
@@ -621,25 +601,7 @@ class Distribution(object):
             sunos_facts['distribution'] = data.split()[0]
             sunos_facts['distribution_version'] = data.split()[1]
             sunos_facts['distribution_release'] = ora_prefix + data
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
             sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
-<<<<<<< HEAD
-            # sunos_facts['distribution_major_version'] = sunos_facts['distribution_version'].split('.')[0]
-=======
->>>>>>> facts: solaris: introduce distribution_major version detection for Solaris
-=======
-            #sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
-=======
-            # sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
->>>>>>> fixes for W291 (trailing whitespace) and E265 (block comment)
-            sunos_facts['distribution_major_version'] = sunos_facts['distribution_version'].split('.')[0]
->>>>>>> should work now...
-=======
-            sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
-            # sunos_facts['distribution_major_version'] = sunos_facts['distribution_version'].split('.')[0]
->>>>>>> mock uname_release for solaris 10 and solaris 11
             return sunos_facts
 
         uname_v = get_uname_version(self.module)

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -26,12 +26,15 @@ from ansible.module_utils.facts.utils import get_file_content
 from ansible.module_utils.facts.collector import BaseFactCollector
 
 
-def get_uname(module, flags=('-v')):
-    if isinstance(flags, str):
-        flags = flags.split()
-    command = ['uname']
-    command.extend(flags)
-    rc, out, err = module.run_command(command)
+def get_uname_version(module):
+    rc, out, err = module.run_command(['uname', '-v'])
+    if rc == 0:
+        return out
+    return None
+
+
+def get_uname_release(module):
+    rc, out, err = module.run_command(['uname', '-r'])
     if rc == 0:
         return out
     return None
@@ -592,7 +595,7 @@ class Distribution(object):
 
         if 'Solaris' in data:
             # for solaris 10 uname_r will contain 5.10, for solaris 11 it will have 5.11
-            uname_r = get_uname(self.module, flags=['-r'])
+            uname_r = get_uname_release(self.module)
             ora_prefix = ''
             if 'Oracle Solaris' in data:
                 data = data.replace('Oracle ', '')
@@ -603,7 +606,7 @@ class Distribution(object):
             sunos_facts['distribution_major_version'] = uname_r.split('.')[1].rstrip();
             return sunos_facts
 
-        uname_v = get_uname(self.module, flags=['-v'])
+        uname_v = get_uname_version(self.module)
         distribution_version = None
 
         if 'SmartOS' in data:

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -608,8 +608,12 @@ class Distribution(object):
             # For solaris 10 it will return 5.10, for solaris 11 it will be 5.11
             # but I can't pass ansible test unit test_distribution_version.py with it,
             # since I've no idea how to mock `uname -r` on CI (github/shippable) run.
+<<<<<<< HEAD
             # rc, uname_r, err = self.module.run_command('uname -r')
 >>>>>>> should work now...
+=======
+            uname_r = get_uname_release(self.module)
+>>>>>>> mock uname_release for solaris 10 and solaris 11
             ora_prefix = ''
             if 'Oracle Solaris' in data:
                 data = data.replace('Oracle ', '')
@@ -617,6 +621,7 @@ class Distribution(object):
             sunos_facts['distribution'] = data.split()[0]
             sunos_facts['distribution_version'] = data.split()[1]
             sunos_facts['distribution_release'] = ora_prefix + data
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
             sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
@@ -631,6 +636,10 @@ class Distribution(object):
 >>>>>>> fixes for W291 (trailing whitespace) and E265 (block comment)
             sunos_facts['distribution_major_version'] = sunos_facts['distribution_version'].split('.')[0]
 >>>>>>> should work now...
+=======
+            sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
+            # sunos_facts['distribution_major_version'] = sunos_facts['distribution_version'].split('.')[0]
+>>>>>>> mock uname_release for solaris 10 and solaris 11
             return sunos_facts
 
         uname_v = get_uname_version(self.module)

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -589,7 +589,7 @@ class Distribution(object):
         if 'Solaris' in data:
             # FIXME: the proper way would be to exec 'uname -r' and parse it.
             # For solaris 10 it will return 5.10, for solaris 11 it will be 5.11
-            # but I can't pass ansible test unit test_distribution_version.py with it, 
+            # but I can't pass ansible test unit test_distribution_version.py with it,
             # since I've no idea how to mock `uname -r` on CI (github/shippable) run.
             # rc, uname_r, err = self.module.run_command('uname -r')
             ora_prefix = ''
@@ -599,7 +599,7 @@ class Distribution(object):
             sunos_facts['distribution'] = data.split()[0]
             sunos_facts['distribution_version'] = data.split()[1]
             sunos_facts['distribution_release'] = ora_prefix + data
-            #sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
+            # sunos_facts['distribution_major_version'] = int(uname_r.split('.')[1])
             sunos_facts['distribution_major_version'] = sunos_facts['distribution_version'].split('.')[0]
             return sunos_facts
 

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -845,10 +845,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
         "name": "Solaris 10",
         "uname_v": "Generic_141445-09",
 <<<<<<< HEAD
+<<<<<<< HEAD
         "uname_v": "5.10",
 =======
         "uname_r": "5.10",
 >>>>>>> Try to fix test unit
+=======
+>>>>>>> should work now...
         "result": {
             "distribution_release": "Solaris 10 10/09 s10x_u8wos_08a X86",
             "distribution": "Solaris",
@@ -871,7 +874,6 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     {
         "name": "Solaris 11",
         "uname_v": "11.0",
-        "uname_r": "5.11",
         "result": {
             "distribution_release": "Oracle Solaris 11 11/11 X86",
             "distribution": "Solaris",
@@ -892,7 +894,6 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     },
     {
         "name": "Solaris 11.3",
-        "uname_r": "5.11",
         "platform.dist": [
             "",
             "",
@@ -915,7 +916,6 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     },
     {
         "name": "Solaris 10",
-        "uname_r": "5.10",
         "platform.dist": [
             "",
             "",

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -844,22 +844,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     {
         "name": "Solaris 10",
         "uname_v": "Generic_141445-09",
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        "uname_v": "5.10",
-=======
         "uname_r": "5.10",
->>>>>>> Try to fix test unit
-=======
->>>>>>> should work now...
-=======
-        "uname_v": "5.10",
->>>>>>> mock uname_release for solaris 10 and solaris 11
-=======
-        "uname_r": "5.10",
->>>>>>> typo uname_v -> uname_r
         "result": {
             "distribution_release": "Solaris 10 10/09 s10x_u8wos_08a X86",
             "distribution": "Solaris",

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -844,6 +844,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     {
         "name": "Solaris 10",
         "uname_v": "Generic_141445-09",
+        "uname_r": "5.10",
         "result": {
             "distribution_release": "Solaris 10 10/09 s10x_u8wos_08a X86",
             "distribution": "Solaris",
@@ -866,6 +867,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     {
         "name": "Solaris 11",
         "uname_v": "11.0",
+        "uname_r": "5.11",
         "result": {
             "distribution_release": "Oracle Solaris 11 11/11 X86",
             "distribution": "Solaris",
@@ -886,6 +888,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     },
     {
         "name": "Solaris 11.3",
+        "uname_r": "5.11",
         "platform.dist": [
             "",
             "",
@@ -908,6 +911,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     },
     {
         "name": "Solaris 10",
+        "uname_r": "5.10",
         "platform.dist": [
             "",
             "",

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -846,12 +846,16 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
         "uname_v": "Generic_141445-09",
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
         "uname_v": "5.10",
 =======
         "uname_r": "5.10",
 >>>>>>> Try to fix test unit
 =======
 >>>>>>> should work now...
+=======
+        "uname_v": "5.10",
+>>>>>>> mock uname_release for solaris 10 and solaris 11
         "result": {
             "distribution_release": "Solaris 10 10/09 s10x_u8wos_08a X86",
             "distribution": "Solaris",
@@ -874,6 +878,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     {
         "name": "Solaris 11",
         "uname_v": "11.0",
+        "uname_r": "5.11",
         "result": {
             "distribution_release": "Oracle Solaris 11 11/11 X86",
             "distribution": "Solaris",
@@ -894,6 +899,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     },
     {
         "name": "Solaris 11.3",
+        "uname_r": "5.11",
         "platform.dist": [
             "",
             "",
@@ -916,6 +922,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     },
     {
         "name": "Solaris 10",
+        "uname_r": "5.10",
         "platform.dist": [
             "",
             "",

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -844,7 +844,11 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     {
         "name": "Solaris 10",
         "uname_v": "Generic_141445-09",
+<<<<<<< HEAD
         "uname_v": "5.10",
+=======
+        "uname_r": "5.10",
+>>>>>>> Try to fix test unit
         "result": {
             "distribution_release": "Solaris 10 10/09 s10x_u8wos_08a X86",
             "distribution": "Solaris",

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -847,6 +847,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
         "uname_v": "5.10",
 =======
         "uname_r": "5.10",
@@ -856,6 +857,9 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
 =======
         "uname_v": "5.10",
 >>>>>>> mock uname_release for solaris 10 and solaris 11
+=======
+        "uname_r": "5.10",
+>>>>>>> typo uname_v -> uname_r
         "result": {
             "distribution_release": "Solaris 10 10/09 s10x_u8wos_08a X86",
             "distribution": "Solaris",

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -910,6 +910,29 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
         }
     },
     {
+        "name": "Solaris 11.4",
+        "uname_r": "5.11",
+        "platform.dist": [
+            "",
+            "",
+            ""
+        ],
+        "input": {
+            "/etc/release": (
+                "                            Oracle Solaris 11.4 SPARC\n    Copyright (c) 1983, 2018, Oracle and/or its affiliates."
+                "  All rights reserved.\n                           Assembled 14 September 2018\n"
+            )
+        },
+        "platform.system": "SunOS",
+        "result": {
+            "distribution_release": "Oracle Solaris 11.4 SPARC",
+            "distribution": "Solaris",
+            "os_family": "Solaris",
+            "distribution_major_version": "11",
+            "distribution_version": "11.4"
+        }
+    },
+    {
         "name": "Solaris 10",
         "uname_r": "5.10",
         "platform.dist": [

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -1186,8 +1186,8 @@ def test_distribution_version(am, mocker, testcase):
         return False
 
     mocker.patch('ansible.module_utils.facts.system.distribution.get_file_content', mock_get_file_content)
-    mocker.patch('ansible.module_utils.facts.system.distribution.get_uname_version', mock_get_uname_version)
-    mocker.patch('ansible.module_utils.facts.system.distribution.get_uname_release', mock_get_uname_release)
+    mocker.patch('ansible.module_utils.facts.system.distribution.get_uname_version', mock_get_uname(flags='-v'))
+    mocker.patch('ansible.module_utils.facts.system.distribution.get_uname_release', mock_get_uname(flags='-r'))
     mocker.patch('ansible.module_utils.facts.system.distribution._file_exists', mock_file_exists)
     mocker.patch('ansible.module_utils.distro.name', mock_distro_name)
     mocker.patch('ansible.module_utils.distro.id', mock_distro_name)

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -1186,8 +1186,8 @@ def test_distribution_version(am, mocker, testcase):
         return False
 
     mocker.patch('ansible.module_utils.facts.system.distribution.get_file_content', mock_get_file_content)
-    mocker.patch('ansible.module_utils.facts.system.distribution.get_uname_version', mock_get_uname(flags='-v'))
-    mocker.patch('ansible.module_utils.facts.system.distribution.get_uname_release', mock_get_uname(flags='-r'))
+    mocker.patch('ansible.module_utils.facts.system.distribution.get_uname_version', mock_get_uname_version)
+    mocker.patch('ansible.module_utils.facts.system.distribution.get_uname_release', mock_get_uname_release)
     mocker.patch('ansible.module_utils.facts.system.distribution._file_exists', mock_file_exists)
     mocker.patch('ansible.module_utils.distro.name', mock_distro_name)
     mocker.patch('ansible.module_utils.distro.id', mock_distro_name)

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -844,6 +844,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     {
         "name": "Solaris 10",
         "uname_v": "Generic_141445-09",
+        "uname_v": "5.10",
         "result": {
             "distribution_release": "Solaris 10 10/09 s10x_u8wos_08a X86",
             "distribution": "Solaris",
@@ -866,6 +867,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     {
         "name": "Solaris 11",
         "uname_v": "11.0",
+        "uname_r": "5.11",
         "result": {
             "distribution_release": "Oracle Solaris 11 11/11 X86",
             "distribution": "Solaris",
@@ -886,6 +888,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     },
     {
         "name": "Solaris 11.3",
+        "uname_r": "5.11",
         "platform.dist": [
             "",
             "",
@@ -908,6 +911,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     },
     {
         "name": "Solaris 10",
+        "uname_r": "5.10",
         "platform.dist": [
             "",
             "",
@@ -1116,6 +1120,9 @@ def test_distribution_version(am, mocker, testcase):
     def mock_get_uname_version(am):
         return testcase.get('uname_v', None)
 
+    def mock_get_uname_release(am):
+        return testcase.get('uname_r', None)
+
     def mock_file_exists(fname, allow_empty=False):
         if fname not in testcase['input']:
             return False
@@ -1157,6 +1164,7 @@ def test_distribution_version(am, mocker, testcase):
 
     mocker.patch('ansible.module_utils.facts.system.distribution.get_file_content', mock_get_file_content)
     mocker.patch('ansible.module_utils.facts.system.distribution.get_uname_version', mock_get_uname_version)
+    mocker.patch('ansible.module_utils.facts.system.distribution.get_uname_release', mock_get_uname_release)
     mocker.patch('ansible.module_utils.facts.system.distribution._file_exists', mock_file_exists)
     mocker.patch('ansible.module_utils.distro.name', mock_distro_name)
     mocker.patch('ansible.module_utils.distro.id', mock_distro_name)

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -844,7 +844,6 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     {
         "name": "Solaris 10",
         "uname_v": "Generic_141445-09",
-        "uname_r": "5.10",
         "result": {
             "distribution_release": "Solaris 10 10/09 s10x_u8wos_08a X86",
             "distribution": "Solaris",
@@ -867,7 +866,6 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     {
         "name": "Solaris 11",
         "uname_v": "11.0",
-        "uname_r": "5.11",
         "result": {
             "distribution_release": "Oracle Solaris 11 11/11 X86",
             "distribution": "Solaris",
@@ -888,7 +886,6 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     },
     {
         "name": "Solaris 11.3",
-        "uname_r": "5.11",
         "platform.dist": [
             "",
             "",
@@ -911,7 +908,6 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     },
     {
         "name": "Solaris 10",
-        "uname_r": "5.10",
         "platform.dist": [
             "",
             "",

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -848,6 +848,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "distribution_release": "Solaris 10 10/09 s10x_u8wos_08a X86",
             "distribution": "Solaris",
             "os_family": "Solaris",
+            "distribution_major_version": "10",
             "distribution_version": "10"
         },
         "platform.dist": [
@@ -869,6 +870,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "distribution_release": "Oracle Solaris 11 11/11 X86",
             "distribution": "Solaris",
             "os_family": "Solaris",
+            "distribution_major_version": "11",
             "distribution_version": "11"
         },
         "platform.dist": [
@@ -891,8 +893,8 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
         ],
         "input": {
             "/etc/release": (
-                "                             Oracle Solaris 11.3 X86\n  Copyright (c) 1983, 2015, Oracle and/or its affiliates.  "
-                "All rights reserved.\n                            Assembled 06 October 2015\n"
+                "                             Oracle Solaris 11.3 X86\n  Copyright (c) 1983, 2018, Oracle and/or its affiliates.  "
+                "All rights reserved.\n                              Assembled 09 May 2018\n"
             )
         },
         "platform.system": "SunOS",
@@ -900,6 +902,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "distribution_release": "Oracle Solaris 11.3 X86",
             "distribution": "Solaris",
             "os_family": "Solaris",
+            "distribution_major_version": "11",
             "distribution_version": "11.3"
         }
     },
@@ -919,6 +922,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "distribution_release": "Oracle Solaris 10 1/13 s10x_u11wos_24a X86",
             "distribution": "Solaris",
             "os_family": "Solaris",
+            "distribution_major_version": "10",
             "distribution_version": "10"
         }
     },

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -1140,11 +1140,13 @@ def test_distribution_version(am, mocker, testcase):
             data = data.strip()
         return data
 
-    def mock_get_uname_version(am):
-        return testcase.get('uname_v', None)
-
-    def mock_get_uname_release(am):
-        return testcase.get('uname_r', None)
+    def mock_get_uname(am, flags):
+        if '-v' in flags:
+            return testcase.get('uname_v', None)
+        elif '-r' in flags:
+            return testcase.get('uname_r', None)
+        else:
+            return None
 
     def mock_file_exists(fname, allow_empty=False):
         if fname not in testcase['input']:
@@ -1186,8 +1188,7 @@ def test_distribution_version(am, mocker, testcase):
         return False
 
     mocker.patch('ansible.module_utils.facts.system.distribution.get_file_content', mock_get_file_content)
-    mocker.patch('ansible.module_utils.facts.system.distribution.get_uname_version', mock_get_uname_version)
-    mocker.patch('ansible.module_utils.facts.system.distribution.get_uname_release', mock_get_uname_release)
+    mocker.patch('ansible.module_utils.facts.system.distribution.get_uname', mock_get_uname)
     mocker.patch('ansible.module_utils.facts.system.distribution._file_exists', mock_file_exists)
     mocker.patch('ansible.module_utils.distro.name', mock_distro_name)
     mocker.patch('ansible.module_utils.distro.id', mock_distro_name)


### PR DESCRIPTION
facts: solaris: introduce distribution_major version detection for Solaris

Currently, there's no distribution_major in facts module on Solaris OS.
Use "uname -r" output to report major version.

Before the patch we get this on Solaris 11.3 :
```
$ ansible -o solaris11 -m setup -a filter=ansible_distribution_major_version
solaris11 | SUCCESS => {"ansible_facts": {}, "changed": false}
```
and after this patch, output is the following:
```
$ ansible -o solaris11 -m setup -a filter=ansible_distribution_major_version
solaris11 | SUCCESS => {"ansible_facts": {"ansible_distribution_major_version": "11"}, "changed": false}
```
Tested with Solaris 11.3 and Solaris 10 (both are x86_64 VMs)

Includes patch for test/units.

Fixes #18197

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
`lib/ansible/module_utils/facts/system/distribution.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel e583484d59) last updated 2018/08/10 22:46:38 (GMT +300)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mator/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mator/ansible/lib/ansible
  executable location = /home/mator/ansible/bin/ansible
  python version = 2.7.15 (default, Jul 28 2018, 11:29:29) [GCC 8.1.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
