### PR TITLE
Add hard_limit support to Pure Storage FlashBlade filesystem module

### DIFF
--- a/lib/ansible/modules/storage/purestorage/purefb_fs.py
+++ b/lib/ansible/modules/storage/purestorage/purefb_fs.py
@@ -78,6 +78,15 @@ options:
     required: false
     type: bool
     default: false
+  hard_limit:
+    description:
+      - Define whether the capacity for a filesystem is a hard limit.
+      - CAUTION This will cause the filesystem to go Read-Only if the
+        capacity has already exceeded the logical size of the filesystem.
+    required: false
+    type: bool
+    default: false
+    version_added: 2.8
 extends_documentation_fragment:
     - purestorage.fb
 '''
@@ -122,6 +131,7 @@ EXAMPLES = '''
     nfs_rules: '*(ro)'
     snapshot: true
     fastremove: true
+    hard_limit: true
     smb: true
     state: present
     fb_url: 10.10.10.2
@@ -138,6 +148,9 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule, human_to_bytes
 from ansible.module_utils.pure import get_blade, purefb_argument_spec
+
+
+HARD_LIMIT_API_VERSION = '1.4'
 
 
 def get_fs(module, blade):
@@ -161,14 +174,26 @@ def create_fs(module, blade):
 
     if not module.check_mode:
         try:
-            fs_obj = FileSystem(name=module.params['name'],
-                                provisioned=size,
-                                fast_remove_directory_enabled=module.params['fastremove'],
-                                snapshot_directory_enabled=module.params['snapshot'],
-                                nfs=NfsRule(enabled=module.params['nfs'], rules=module.params['nfs_rules']),
-                                smb=ProtocolRule(enabled=module.params['smb']),
-                                http=ProtocolRule(enabled=module.params['http'])
-                                )
+            api_version = blade.api_version.list_versions().versions
+            if HARD_LIMIT_API_VERSION in api_version:
+                fs_obj = FileSystem(name=module.params['name'],
+                                    provisioned=size,
+                                    fast_remove_directory_enabled=module.params['fastremove'],
+                                    hard_limit_enabled=module.params['hard_limit'],
+                                    snapshot_directory_enabled=module.params['snapshot'],
+                                    nfs=NfsRule(enabled=module.params['nfs'], rules=module.params['nfs_rules']),
+                                    smb=ProtocolRule(enabled=module.params['smb']),
+                                    http=ProtocolRule(enabled=module.params['http'])
+                                    )
+            else:
+                fs_obj = FileSystem(name=module.params['name'],
+                                    provisioned=size,
+                                    fast_remove_directory_enabled=module.params['fastremove'],
+                                    snapshot_directory_enabled=module.params['snapshot'],
+                                    nfs=NfsRule(enabled=module.params['nfs'], rules=module.params['nfs_rules']),
+                                    smb=ProtocolRule(enabled=module.params['smb']),
+                                    http=ProtocolRule(enabled=module.params['http'])
+                                    )
             blade.file_systems.create_file_systems(fs_obj)
             changed = True
         except:
@@ -223,6 +248,11 @@ def modify_fs(module, blade):
         if not module.params['fastremove'] and fs.fast_remove_directory_enabled:
             attr['fast_remove_directory_enabled'] = module.params['fastremove']
             changed = True
+        api_version = blade.api_version.list_versions().versions
+        if HARD_LIMIT_API_VERSION in api_version:
+            if not module.params['hard_limit'] and fs.hard_limit_enabled:
+                attr['hard_limit_enabled'] = module.params['hard_limit']
+                changed = True
         if changed:
             n_attr = FileSystem(**attr)
             try:
@@ -277,6 +307,7 @@ def main():
             http=dict(default='false', type='bool'),
             snapshot=dict(default='false', type='bool'),
             fastremove=dict(default='false', type='bool'),
+            hard_limit=dict(default='false', type='bool'),
             state=dict(default='present', choices=['present', 'absent']),
             size=dict()
         )


### PR DESCRIPTION
##### SUMMARY
Add hard_limit support to filesystem module for Pure Storage FlashBlade.
Default setting for hard_limit is false.
Enforcing hard_limit will make a filesystem a Read-Only when the real capacity of the filesystem reaches the logical capacity of the filesystem.
WARNING: Modifying an existing filesystem to enforce this parameter when the real capacity has already exceeded the logical capacity will force the filesystem to go Read-Only immediately.  

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
storage/purestorage/purefb_fs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.7.0.dev0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```


##### ADDITIONAL INFORMATION
This parameter can only be applied to a filesystem when the FlashBlade on which the filesystem has been created is running REST v1.4 or higher. (Purity//FB 2.2.3+)
