### PR TITLE
Fixes #33045: get existing containers in a network via inspect_network (Rebased #33048)

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -161,6 +161,7 @@ from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseCl
 
 try:
     from docker import utils
+    from docker.errors import NotFound
     if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:
         from docker.types import IPAMPool, IPAMConfig
 except Exception as dummy:
@@ -215,14 +216,10 @@ class DockerNetworkManager(object):
             self.absent()
 
     def get_existing_network(self):
-        networks = self.client.networks(names=[self.parameters.network_name])
-        # check if a user is trying to find network by its Id
-        if not networks:
-            networks = self.client.networks(ids=[self.parameters.network_name])
-        if not networks:
+        try:
+            return self.client.inspect_network(self.parameters.network_name)
+        except NotFound:
             return None
-        else:
-            return networks[0]
 
     def has_different_config(self, net):
         '''


### PR DESCRIPTION
##### SUMMARY
Since Docker 1.28, the only way to get the existing containers in a network is to use inspect_network, this breaks idempotency of the docker_network module (#33045) when replaying a task appending a container into a network.
This PR should fix #33045, I've merely rebased #33048's PR and all credits are due to @hbruch. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- docker_network

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = None
  configured module search path = [u'/home/linouxis9/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/linouxis9/.local/lib/python2.7/site-packages/ansible
  executable location = /home/linouxis9/.local/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
See #33045 #33048