### PR TITLE
Fix to make fortios_config works w/o issues when file_mode == True

### DIFF
--- a/lib/ansible/modules/network/fortios/fortios_config.py
+++ b/lib/ansible/modules/network/fortios/fortios_config.py
@@ -115,21 +115,24 @@ def main():
         module.fail_json(msg='Could not import the python library pyFG required by this module')
 
     # define device
-    f = FortiOS(module.params['host'],
-                username=module.params['username'],
-                password=module.params['password'],
-                timeout=module.params['timeout'],
-                vdom=module.params['vdom'])
-
-    # connect
-    try:
-        f.open()
-    except Exception:
-        module.fail_json(msg='Error connecting device')
+    if module.params["file_mode"]:
+        f = FortiOS("")
+    else:
+        f = FortiOS(module.params['host'],
+                    username=module.params['username'],
+                    password=module.params['password'],
+                    timeout=module.params['timeout'],
+                    vdom=module.params['vdom'])
+        # connect
+        try:
+            f.open()
+        except Exception:
+            module.fail_json(msg='Error connecting device')
 
     # get  config
     try:
-        f.load_config(path=module.params['filter'])
+        if not module.params["file_mode"]:
+            f.load_config(path=module.params['filter'])
         result['running_config'] = f.running_config.to_text()
 
     except Exception:


### PR DESCRIPTION
Fix wrong behaviors of fortios_config when file_mode == True.

- Make fortios_config not connecting to a device and just make empty
  FortiOS object for testing purpose.
- Avoid to filter empty (FortiOS) f.running_config may cause error

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The summary of changes are:

- Do not try to connect to a device when file_mode == True
- Do not try to filer empty running_config when file_mode == True

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
It may fixes #44003 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
fortios_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ssato/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
I think that file_mode is awesome to experiment this module w/o any fortigate device but it means little even if my fix was applied it because there are limitations such as (FortiOS)f.running_config is empty when file_mode == True, exist yet.

Maybe it should have another module options or something to initialize the running_config (running_config="config global\nend", for example) and save its internal configuration
(running_config) to another files different from config_file.

```
In [1]: import pyFG

In [2]: f = pyFG.FortiOS("")

In [3]: (f.running_config.to_text(), f.candidate_config.to_text())
Out[3]: (u'', u'')

In [4]: f.load_config(config_text="""config firewall
   ...: end""", in_candidate=True)

In [5]: (f.running_config.to_text(), f.candidate_config.to_text())
Out[5]: (u'', u'    config firewall\n    end\n')

In [6]:
```