### PR TITLE
[network/fortios] Fix to load config to update as candidate_config instead of running_config

### DIFF
--- a/lib/ansible/module_utils/network/fortios/fortios.py
+++ b/lib/ansible/module_utils/network/fortios/fortios.py
@@ -132,12 +132,12 @@ class AnsibleFortios(object):
             except IOError as e:
                 self.module.fail_json(msg='Error reading configuration file. %s' % to_native(e),
                                       exception=traceback.format_exc())
-            self.forti_device.load_config(config_text=running, path=path)
+            self.forti_device.load_config(config_text=running, path=path, in_candidate=True)
 
         else:
             # get  config
             try:
-                self.forti_device.load_config(path=path)
+                self.forti_device.load_config(path=path, in_candidate=True)
             except Exception as e:
                 self.forti_device.close()
                 self.module.fail_json(msg='Error reading running config. %s' % to_native(e),


### PR DESCRIPTION
From my understanding of the pyFG API doc below, it's needed to pass a keyword 
argument in_candidate=True to FortiOS.load_config(), to load configuration from a
file as 'candidate' config to update running (currrent) config later but the current code
does not look doing so. The change fixes this.

- http://pyfg.readthedocs.io/en/latest/loading_config_from_file.html

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I changed the code to load config from file into (FortiOS)forti_device.candidate_config instead of .running_config by passing in_candidate=True to FortiOS.load_config().

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
lib/ansible/module_utils/network/fortios/fortios.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ssato/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

see also: https://github.com/spotify/pyfg/blob/master/pyFG/fortios.py#L32

<!--- Paste verbatim command output below, e.g. before and after your change -->
The following log shows the difference between the effects of keyword argument in_candidate and empty_candidate passed to pyFG.FortiOS.load_config.

```
In [49]: fortios = pyFG.FortiOS("")

In [50]: fortios.load_config(config_text="""config firewall
    ...: end""")

In [51]: (fortios.running_config.to_text(), fortios.candidate_config.to_text())
Out[51]: (u'    config firewall\n    end\n', u'    config firewall\n    end\n')

In [52]: cat /tmp/running.conf
    config firewall address
        edit google_dns
          set subnet 8.8.8.8 255.255.255.255
        next
    end

In [53]: fortios.load_config(config_text=open("/tmp/running.conf").read())

In [54]: (fortios.running_config.to_text(), fortios.candidate_config.to_text())
Out[54]:
(u'    config firewall\n    end\n    config firewall address\n        edit google_dns\n          set subnet 8.8.8.8 255.255.255.255\n        next\n    end\n',
 u'    config firewall\n    end\n    config firewall address\n        edit google_dns\n          set subnet 8.8.8.8 255.255.255.255\n        next\n    end\n')

In [55]: print(fortios.compare_config())


In [56]: fortios = pyFG.FortiOS("")

In [57]: fortios.load_config(config_text="""config firewall
    ...: end""")

In [58]: (fortios.running_config.to_text(), fortios.candidate_config.to_text())
Out[58]: (u'    config firewall\n    end\n', u'    config firewall\n    end\n')

In [59]: fortios.load_config(config_text=open("/tmp/running.conf").read(), in_candidate=True)

In [60]: (fortios.running_config.to_text(), fortios.candidate_config.to_text())
Out[60]:
(u'    config firewall\n    end\n',
 u'    config firewall\n    end\n    config firewall address\n        edit google_dns\n          set subnet 8.8.8.8 255.255.255.255\n        next\n    end\n')

In [61]: print(fortios.compare_config())
    config firewall address
        edit google_dns
          set subnet 8.8.8.8 255.255.255.255
        next
    end


In [62]: fortios = pyFG.FortiOS("")

In [63]: fortios.load_config(config_text="""config firewall
    ...: end""", empty_candidate=True)

In [64]: (fortios.running_config.to_text(), fortios.candidate_config.to_text())
Out[64]: (u'    config firewall\n    end\n', u'')

In [65]: fortios.load_config(config_text=open("/tmp/running.conf").read(), in_candidate=True)

In [66]: (fortios.running_config.to_text(), fortios.candidate_config.to_text())
Out[66]:
(u'    config firewall\n    end\n',
 u'    config firewall address\n        edit google_dns\n          set subnet 8.8.8.8 255.255.255.255\n        next\n    end\n')

In [67]: print(fortios.compare_config())
    delete firewall
    config firewall address
        edit google_dns
          set subnet 8.8.8.8 255.255.255.255
        next
    end


In [68]:
```
