### PR TITLE
gather facts improvements

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -589,7 +589,7 @@ DEFAULT_GATHERING:
   choices: ['smart', 'explicit', 'implicit']
 DEFAULT_GATHER_SUBSET:
   name: Gather facts subset
-  default: 'all'
+  default: ['all']
   description:
       - Set the `gather_subset` option for the M(setup) task in the implicit fact gathering.
         See the module documentation for specifics.

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -59,7 +59,7 @@ class Play(Base, Taggable, Become):
     # Facts
     _fact_path = FieldAttribute(isa='string', default=None)
     _gather_facts = FieldAttribute(isa='bool', default=None, always_post_validate=True)
-    _gather_subset = FieldAttribute(isa='list', default=None, always_post_validate=True)
+    _gather_subset = FieldAttribute(isa='list', default=None, listof=string_types, always_post_validate=True)
     _gather_timeout = FieldAttribute(isa='int', default=None, always_post_validate=True)
 
     # Variable Attributes

--- a/test/integration/targets/gathering_facts/test_run_once.yml
+++ b/test/integration/targets/gathering_facts/test_run_once.yml
@@ -2,6 +2,10 @@
 - hosts: facthost1
   gather_facts: no
   tasks:
+    - name: check that smart gathering is enabled
+      fail:
+        msg: 'smart gathering must be enabled'
+      when: 'lookup("env", "ANSIBLE_GATHERING") != "smart"'
     - name: install test local facts
       copy:
         src: uuid.fact

--- a/test/integration/targets/gathering_facts/test_run_once.yml
+++ b/test/integration/targets/gathering_facts/test_run_once.yml
@@ -17,14 +17,14 @@
   run_once: yes
   tasks:
     - block:
-      - name: 'Check the same host is used'
-        assert:
-          that: 'hostvars.facthost1.ansible_fqdn == hostvars.facthost2.ansible_fqdn'
-          msg: 'This test requires 2 inventory hosts referring to the same host.'
-      - name: "Check that run_once doesn't prevent fact gathering (#39453)"
-        assert:
-          that: 'hostvars.facthost1.ansible_local.uuid != hostvars.facthost2.ansible_local.uuid'
-          msg: "{{ 'Same value for ansible_local.uuid on both hosts: ' ~ hostvars.facthost1.ansible_local.uuid }}"
+        - name: 'Check the same host is used'
+          assert:
+            that: 'hostvars.facthost1.ansible_fqdn == hostvars.facthost2.ansible_fqdn'
+            msg: 'This test requires 2 inventory hosts referring to the same host.'
+        - name: "Check that run_once doesn't prevent fact gathering (#39453)"
+          assert:
+            that: 'hostvars.facthost1.ansible_local.uuid != hostvars.facthost2.ansible_local.uuid'
+            msg: "{{ 'Same value for ansible_local.uuid on both hosts: ' ~ hostvars.facthost1.ansible_local.uuid }}"
       always:
         - name: remove test local facts
           file:


### PR DESCRIPTION
##### SUMMARY
`gather_facts` improvements:
* `DEFAULT_GATHER_SUBSET` default value: use a list instead of a string
* `gather_subset` is a list of strings: add `listof` parameter
  `AttributeError: 'int' object has no attribute 'startswith'` is replaced by `ERROR! the field 'gather_subset' should be a list of (<class 'str'>,), but the item '42' is a <class 'int'>`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
gather_facts

##### ANSIBLE VERSION
```
2.7
```