### PR TITLE
ACME: updating maintainers for ansibot

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -694,6 +694,7 @@ files:
   $modules/web_infrastructure/_letsencrypt.py: mgruener resmo felixfontein
   $modules/web_infrastructure/acme_account.py: mgruener resmo felixfontein
   $modules/web_infrastructure/acme_certificate.py: mgruener resmo felixfontein
+  $modules/web_infrastructure/acme_certificate_revoke.py: mgruener resmo felixfontein
   $modules/web_infrastructure/ansible_tower/: $team_tower
   $modules/web_infrastructure/apache2_mod_proxy.py: oboukili
   $modules/web_infrastructure/deploy_helper.py: ramondelafuente
@@ -1225,6 +1226,8 @@ files:
     labels:
     - networking
     - nxos
+  test/integration/targets/setup_acme:
+    maintainers: mgruener resmo felixfontein
   test/integration/targets/setup_zabbix:
     maintainers: eikef D3DeFi
   test/integration/targets/ucs:


### PR DESCRIPTION
##### SUMMARY
Adds maintainers for module `acme_certificate_revoke` and for integration test setup `setup_acme`. CC @resmo. We noticed in #42170 that they are missing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
acme_certificate_revoke
setup_acme

##### ANSIBLE VERSION
```
2.7.0
```
