### PR TITLE
Fix cli_command junos test failure and update doc

### DIFF
--- a/lib/ansible/modules/network/cli/cli_command.py
+++ b/lib/ansible/modules/network/cli/cli_command.py
@@ -58,16 +58,16 @@ EXAMPLES = """
     prompt: This commit will replace or remove the entire running configuration
     answer: yes
 
-  - name: run config mode command and handle prompt/answer
-    cli_command:
-      command: "{{ item }}"
-      prompt:
-        - "Exit with uncommitted changes"
-      answer: yes
-    loop:
-      - configure
-      - set system syslog file test any any
-      - exit
+- name: run config mode command and handle prompt/answer
+  cli_command:
+    command: "{{ item }}"
+    prompt:
+      - "Exit with uncommitted changes"
+    answer: yes
+  loop:
+    - configure
+    - set system syslog file test any any
+    - exit
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/cli/cli_command.py
+++ b/lib/ansible/modules/network/cli/cli_command.py
@@ -57,6 +57,17 @@ EXAMPLES = """
     command: commit replace
     prompt: This commit will replace or remove the entire running configuration
     answer: yes
+
+  - name: run config mode command and handle prompt/answer
+    cli_command:
+      command: "{{ item }}"
+      prompt:
+        - "Exit with uncommitted changes"
+      answer: yes
+    loop:
+      - configure
+      - set system syslog file test any any
+      - exit
 """
 
 RETURN = """

--- a/test/integration/targets/junos_command/tests/cli/cli_commmand.yaml
+++ b/test/integration/targets/junos_command/tests/cli/cli_commmand.yaml
@@ -2,28 +2,32 @@
 - debug:
     msg: "START cli/cli_command.yaml on connection={{ ansible_connection }}"
 
-- name: get output for single command
-  cli_command:
-    commands:
-      - show version
-  register: result
+- block:
+  - name: get output for single command
+    cli_command:
+      command: show version
+    register: result
 
-- assert:
-    that:
-      - "result.changed == false"
-      - "result.stdout is defined"
+  - assert:
+      that:
+        - "result.changed == false"
+        - "result.stdout is defined"
 
-- name: get output for multiple commands
-  cli_command:
-    commands:
-      - show version
-      - show interfaces
-  register: result
+  - name: test with prompt and answer
+    cli_command:
+      command: "{{ item }}"
+      prompt:
+        - "Exit with uncommitted changes"
+      answer: yes
+    loop:
+      - configure
+      - set system syslog file test any any
+      - exit
+    register: result
 
-- assert:
-    that:
-      - "result.changed == false"
-      - "result.stdout is defined"
-      - "result.stdout | length == 2"
+  - assert:
+      that:
+        - "result.changed == false"
+  when: ansible_connection == 'network_cli'
 
 - debug: msg="END cli/cli_command.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Fix cli_command module integration test failure
   for junos
*  Update cli_command module doc for prompt and
   config command run scenario's
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
cli_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
