### PR TITLE
Corrects the problem of having the special "+" character in the URL

### DIFF
--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -166,7 +166,7 @@ class RoleRequirement(RoleDefinition):
                     role["src"] = "git+" + role["src"]
 
                 if '+' in role["src"]:
-                    (scm, src) = role["src"].split('+')
+                    (scm, src) = role["src"].split('+', 1)
                     role["scm"] = scm
                     role["src"] = src
 


### PR DESCRIPTION
An example of a problem:

##### SUMMARY
I'm using Deploy Tokens for install ansible requirements.yml.
Because the dynamically created username has a special character, at startup:
```
$ ansible-galaxy install -r requirements.yml
found role {'scm': 'https://gitlab', 'src': 'deploy-token-2:<TOKEN>@gitlab.mydomain/ansible-roles/role1.git', 'version': 'v1.0.0', 'name': 'role1'} in yaml file
 [WARNING]: - role1 was NOT installed successfully: - scm https://gitlab is not currently supported
```
I get an error, because ansible tries to parse the URL by specifier.
Here is the content of the requirements.yml:
```
- src: "https://gitlab+deploy-token-2:<TOKEN>@gitlab.mydomain/ansible-roles/role1.git"
  version: v1.0.0
  name: role1
```
I tried to isolate the URL in the requirements.yml file.
But for some reason ansible ignores the screens of special characters.
```
"https://gitlab+deploy-token-2:<TOKEN>@gitlab.mydomain/ansible-roles/role1.git"
'https://gitlab+deploy-token-2:<TOKEN>@gitlab.mydomain/ansible-roles/role1.git'
https://"gitlab+deploy-token-2:<TOKEN>"@gitlab.mydomain/ansible-roles/role1.git
https://'gitlab+deploy-token-2:<TOKEN>'@gitlab.mydomain/ansible-roles/role1.git
```
(I tried a lot more variation, but it does not work.)  

#### Playback example:
Bug example:
```
>>> 'git+https://gitlab+deploy-token-2:<TOKEN>@gitlab.mydomain/role1.git'.split('+')
['git', 'https://gitlab', 'deploy-token-2:<TOKEN>@gitlab.mydomain/role1.git']
```
Fixed example:
```
>>> 'git+https://gitlab+deploy-token-2:<TOKEN>@gitlab.mydomain/role1.git'.split('+', 1)
['git', 'https://gitlab+deploy-token-2:<TOKEN>@gitlab.mydomain/role1.git']
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible/playbook/role/requirement.py

##### ANSIBLE VERSION
```
ansible 2.6.2
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
