### PR TITLE
add a function to modify existing lxc containers in proxmox

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -139,6 +139,7 @@ options:
       - if set to C(no) configuration will not be updated and container will not be restarted.
     type: bool
     default: 'no'
+    version_added: "2.7"
   pubkey:
     description:
       - Public key to add to /root/.ssh/authorized_keys. This was added on Proxmox 4.2, it is ignored for earlier versions

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -385,8 +385,8 @@ def modify_instance(module, proxmox, vm, vmid, timeout, cpus, memory, swap, **kw
             del kwargs['pubkey']
     else:
         kwargs['cpus'] = cpus
-        kwargs['memory'] = memory
-        kwargs['swap'] = swap
+    kwargs['memory'] = memory
+    kwargs['swap'] = swap
     vmconfig = get_vm_conf(proxmox, vm, vmid)
     if vmconfig_changed(vmconfig, **kwargs):
         vmstatus = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()['status']


### PR DESCRIPTION
add option restart and documentation
fix pep8

##### SUMMARY
Proxmox API allows to update most configuration parameters for existing containers but this functionality is currently missing in proxmox ansible module. This PR enables updating configuration for existing containers with ansible. 

##### COMPONENT NAME
Proxmox module

##### ADDITIONAL INFORMATION
"restart" module option added to allow restarting the container when configuration change is required. If "restart" is set to "no" then configuration will not be updated.
If set to "yes" (and "force" is set to "no") then:
* existing container configuration will be pulled from proxmox host and compared to ansible container configuration. 
  * if it doesn't match, then container will be stopped, configuration updated through proxmox API and container started.
  * if it matches nothing will be done

This is my first PR to ansible, any help or advise appreciated!