### PR TITLE
Ansible continue execution even if attribute is invalid (#44061)

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -234,7 +234,7 @@ class Task(Base, Conditional, Taggable, Become):
                 elif C.INVALID_TASK_ATTRIBUTE_FAILED or k in self._valid_attrs:
                     new_ds[k] = v
                 else:
-                    display.warning("Ignoring invalid attribute: %s" % k)
+                    raise AnsibleError("Unknown attribute %s" % k)
 
         return super(Task, self).preprocess_data(new_ds)
 


### PR DESCRIPTION
    * Changed warning to error;

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Ansible continue execution even if attribute is invalid; This can be pretty threatfull. For example if attribute "deletgate_to" will be ignored ansible will execute task on all configured hosts;

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
ansible/lib/ansible/playbook/task.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.6.2-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```


