### PR TITLE
Support deterministic host ordering from group ancestors

### DIFF
--- a/test/units/plugins/inventory/test_group.py
+++ b/test/units/plugins/inventory/test_group.py
@@ -76,6 +76,33 @@ class TestGroup(unittest.TestCase):
         with self.assertRaises(AnsibleError):
             C.add_child_group(A)
 
+    def test_direct_host_ordering(self):
+        """Hosts are returned in order they are added
+        """
+        group = Group('A')
+        # host names not added in alphabetical order
+        host_name_list = ['z', 'b', 'c', 'a', 'p', 'q']
+        expected_hosts = []
+        for host_name in host_name_list:
+            h = Host(host_name)
+            group.add_host(h)
+            expected_hosts.append(h)
+        assert group.get_hosts() == expected_hosts
+
+    def test_sub_group_host_ordering(self):
+        """With multiple nested groups, asserts that hosts are returned
+        in deterministic order
+        """
+        top_group = Group('A')
+        expected_hosts = []
+        for name in ['z', 'b', 'c', 'a', 'p', 'q']:
+            child = Group('group_{0}'.format(name))
+            top_group.add_child_group(child)
+            host = Host('host_{0}'.format(name))
+            child.add_host(host)
+            expected_hosts.append(host)
+        assert top_group.get_hosts() == expected_hosts
+
     def test_populates_descendant_hosts(self):
         A = Group('A')
         B = Group('B')


### PR DESCRIPTION
##### SUMMARY
fixes https://github.com/ansible/ansible/issues/44065

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/inventory/group.py

##### ANSIBLE VERSION
```
ansible --version
ansible 2.7.0.dev0
  config file = None
  configured module search path = [u'/Users/alancoding/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.7.0.dev0-py2.7.egg/ansible
  executable location = /Users/alancoding/.virtualenvs/ansible/bin/ansible
  python version = 2.7.11 (default, Oct 17 2016, 14:59:40) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```


##### ADDITIONAL INFORMATION
from steps to repro in the issue:

```
# ansible-playbook -c local -i hosts unordered.yml 

PLAY [localhost] ********************************************************************************************************************************************************************

TASK [top_group hosts] **************************************************************************************************************************************************************
ok: [localhost] => {
    "groups['top_group']": [
        "test01", 
        "host1", 
        "host2", 
        "host3", 
        "host4"
    ]
}

PLAY RECAP **************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0   

```

I feel pretty good about this solution. It adds one memory structure to the method, in addition to incurring an `in` calculation. All of these should essentially double the computation for this method, so all the important speedups from the previous PR should still remain in place. I still haven't rigorously tested this, but if I was going to test it, I would want to look into some better infrastructure for doing so.