### PR TITLE
Avoid fetching unnecessary data before executing jenkins_script

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_script.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_script.py
@@ -157,7 +157,7 @@ def main():
 
     headers = {}
     crumb = get_crumb(module)
-    if crumb != None:
+    if crumb is not None:
         headers = {crumb['crumbRequestField']: crumb['crumb']}
 
     resp, info = fetch_url(module,

--- a/lib/ansible/modules/web_infrastructure/jenkins_script.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_script.py
@@ -113,7 +113,8 @@ from ansible.module_utils._text import to_native
 def get_crumb(module):
     resp, info = fetch_url(module,
                            module.params['url'] + '/crumbIssuer/api/json',
-                           method='GET')
+                           method='GET',
+                           timeout=module.params['timeout'])
     if info["status"] == 404:
         return None
 


### PR DESCRIPTION
##### SUMMARY

Invoking `jenkins_script` module can fail with timeout error sooner than the configured module timeout expires. The confusion originates from the module actually doing 3 http requests from which only the last one respects the module timeout (the rest gets the default of 10s):

- Detect jenkins is using CSRF crumb issuer (`/api/json`)
- If it does, get the crumb (`/crumbIssuer/api/json`)
- Execute the script itself (`/scriptText`)

The way the first call is used is severely suboptimal as it fetches an amount of data proportional to the size of the individual deployment (build records might even get read from disk) just to get a `true`/`false` value that resides in Jenkins memory. In practice, I have seen this particular request to fail for handful out of the 100+ hosts in playbook practically every time.

Instead of fixing the wasteful detection, the whole approach is changed to eliminate the first request altogether. The second request is issued every time treating `404` as a signal the instance does not distribute crumbs. Both requests now respect the the timeout field. Additionally, the failure messages now specify which http request has failed.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

`lib/ansible/modules/web_infrastructure/jenkins_script.py`

##### ANSIBLE VERSION

```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/ogondza/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.6 (default, Jun 27 2018, 13:11:40) [GCC 8.1.1 20180531]
```

##### ADDITIONAL INFORMATION

The fix was retested against the grid where issue was consistently reproduced before, and the problem is not appearing. It was also tested against both Jenkins with and without crumb issuer configured.