### PR TITLE
Fix path handling in hacking/env-setup.

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -1,6 +1,22 @@
 # usage: source hacking/env-setup [-q]
 #    modifies environment for running Ansible from checkout
 
+# prepend a value to a potentially empty path variable
+# usage: prepend_path variable_name value
+prepend_path()
+{
+    variable_name="$1"
+    value="$2"
+
+    old_value=$( eval "echo \$$variable_name" )
+
+    if [ "x$old_value" != "x" ]; then
+        value="$value:"
+    fi
+
+    export "$variable_name=$value$old_value"
+}
+
 # Default values for shell variables we use
 PYTHONPATH=${PYTHONPATH-""}
 PATH=${PATH-""}
@@ -34,9 +50,9 @@ PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib"
 PREFIX_PATH="$ANSIBLE_HOME/bin:$ANSIBLE_HOME/test/runner"
 PREFIX_MANPATH="$ANSIBLE_HOME/docs/man"
 
-expr "$PYTHONPATH" : "${PREFIX_PYTHONPATH}.*" > /dev/null || export PYTHONPATH="$PREFIX_PYTHONPATH:$PYTHONPATH"
-expr "$PATH" : "${PREFIX_PATH}.*" > /dev/null || export PATH="$PREFIX_PATH:$PATH"
-expr "$MANPATH" : "${PREFIX_MANPATH}.*" > /dev/null || export MANPATH="$PREFIX_MANPATH:$MANPATH"
+expr "$PYTHONPATH" : "${PREFIX_PYTHONPATH}.*" > /dev/null || prepend_path PYTHONPATH "$PREFIX_PYTHONPATH"
+expr "$PATH" : "${PREFIX_PATH}.*" > /dev/null || prepend_path PATH "$PREFIX_PATH"
+expr "$MANPATH" : "${PREFIX_MANPATH}.*" > /dev/null || prepend_path MANPATH "$PREFIX_MANPATH"
 
 #
 # Generate egg_info so that pkg_resources works


### PR DESCRIPTION
##### SUMMARY

Fix path handling in hacking/env-setup.

(cherry picked from commit 0392dbeba19d742741f95903de6e048f65510a50)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

hacking/env-setup

##### ANSIBLE VERSION

```
ansible 2.4.6.0 (fix-env-setup-2.4 d1f938a9c7) last updated 2018/08/13 10:36:25 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
