### PR TITLE
support newer mongodb versions in mongodb_user

### DIFF
--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -215,7 +215,7 @@ def check_compatibility(module, client):
     """
     loose_srv_version = LooseVersion(client.server_info()['version'])
     loose_driver_version = LooseVersion(PyMongoVersion)
-    loose_versions_accepted = ['2.6', '3.0', '3.2', '3.4']
+    loose_versions_accepted = ['2.6', '3.0', '3.2', '3.4', '3.6']
 
     for version in loose_versions_accepted:
       if loose_srv_version >= LooseVersion(version) and loose_driver_version < LooseVersion(version):

--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -215,17 +215,13 @@ def check_compatibility(module, client):
     """
     loose_srv_version = LooseVersion(client.server_info()['version'])
     loose_driver_version = LooseVersion(PyMongoVersion)
+    loose_versions_accepted = ['2.6', '3.0', '3.2', '3.4']
 
-    if loose_srv_version >= LooseVersion('3.2') and loose_driver_version < LooseVersion('3.2'):
-        module.fail_json(msg=' (Note: you must use pymongo 3.2+ with MongoDB >= 3.2)')
+    for version in loose_versions_accepted:
+      if loose_srv_version >= LooseVersion(version) and loose_driver_version < LooseVersion(version):
+        module.fail_json(msg=' (Note: you must use pymongo {ver}+ with MongoDB >= {ver})'.format(ver=version))
 
-    elif loose_srv_version >= LooseVersion('3.0') and loose_driver_version <= LooseVersion('2.8'):
-        module.fail_json(msg=' (Note: you must use pymongo 2.8+ with MongoDB 3.0)')
-
-    elif loose_srv_version >= LooseVersion('2.6') and loose_driver_version <= LooseVersion('2.7'):
-        module.fail_json(msg=' (Note: you must use pymongo 2.7+ with MongoDB 2.6)')
-
-    elif LooseVersion(PyMongoVersion) <= LooseVersion('2.5'):
+    if LooseVersion(PyMongoVersion) <= LooseVersion('2.5'):
         module.fail_json(msg=' (Note: you must be on mongodb 2.4+ and pymongo 2.5+ to use the roles param)')
 
 


### PR DESCRIPTION
##### SUMMARY
Fixes #34153
Iterate through acceptable mongodb versions & make it easier to add a new one

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
mongodb_user

##### ANSIBLE VERSION
```
ansible 2.6.2
  config file = /provisioning/ansible.cfg
  configured module search path = [u'/provisioning/lib']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```
