### PR TITLE
ACME: using new acme-test-container

### DIFF
--- a/test/integration/targets/acme_account/tasks/impl.yml
+++ b/test/integration/targets/acme_account/tasks/impl.yml
@@ -56,6 +56,30 @@
     - mailto:example@example.com
   register: account_modified_idempotent
 
+- name: Clear contact email addresses
+  acme_account:
+    select_crypto_backend: "{{ select_crypto_backend }}"
+    account_key_src: "{{ output_dir }}/accountkey.pem"
+    acme_version: 2
+    acme_directory: https://{{ acme_host }}:14000/dir
+    validate_certs: no
+    state: present
+    # allow_creation: no
+    contact: []
+  register: account_modified_2
+
+- name: Clear contact email addresses (idempotent)
+  acme_account:
+    select_crypto_backend: "{{ select_crypto_backend }}"
+    account_key_src: "{{ output_dir }}/accountkey.pem"
+    acme_version: 2
+    acme_directory: https://{{ acme_host }}:14000/dir
+    validate_certs: no
+    state: present
+    # allow_creation: no
+    contact: []
+  register: account_modified_2_idempotent
+
 - name: Generate new account key
   command: openssl ecparam -name secp384r1 -genkey -out {{ output_dir }}/accountkey2.pem
 

--- a/test/integration/targets/acme_account/tests/validate.yml
+++ b/test/integration/targets/acme_account/tests/validate.yml
@@ -22,6 +22,18 @@
       - account_modified_idempotent is not changed
       - account_modified_idempotent.account_uri is not none
 
+- name: Validate that email address was cleared
+  assert:
+    that:
+      - account_modified_2 is changed
+      - account_modified_2.account_uri is not none
+
+- name: Validate that email address was not cleared a second time (idempotency)
+  assert:
+    that:
+      - account_modified_2_idempotent is not changed
+      - account_modified_2_idempotent.account_uri is not none
+
 # Note that pebble has no change key endpoint implemented yet!
 # When it has (and the container was updated), uncomment the
 # following validations, and delete the ones below the

--- a/test/integration/targets/acme_certificate/tasks/impl.yml
+++ b/test/integration/targets/acme_certificate/tasks/impl.yml
@@ -196,27 +196,27 @@
 ## DISSECT CERTIFICATES #######################################################################
 # Make sure certificates are valid. Root certificate for Pebble equals the chain certificate.
 - name: Verifying cert 1
-  command: openssl verify -CAfile "{{ output_dir }}/cert-1-chain.pem" "{{ output_dir }}/cert-1.pem"
+  command: openssl verify -CAfile "{{ output_dir }}/cert-1-root.pem" -untrusted "{{ output_dir }}/cert-1-chain.pem" "{{ output_dir }}/cert-1.pem"
   ignore_errors: yes
   register: cert_1_valid
 - name: Verifying cert 2
-  command: openssl verify -CAfile "{{ output_dir }}/cert-2-chain.pem" "{{ output_dir }}/cert-2.pem"
+  command: openssl verify -CAfile "{{ output_dir }}/cert-2-root.pem" -untrusted "{{ output_dir }}/cert-2-chain.pem" "{{ output_dir }}/cert-2.pem"
   ignore_errors: yes
   register: cert_2_valid
 - name: Verifying cert 3
-  command: openssl verify -CAfile "{{ output_dir }}/cert-3-chain.pem" "{{ output_dir }}/cert-3.pem"
+  command: openssl verify -CAfile "{{ output_dir }}/cert-3-root.pem" -untrusted "{{ output_dir }}/cert-3-chain.pem" "{{ output_dir }}/cert-3.pem"
   ignore_errors: yes
   register: cert_3_valid
 - name: Verifying cert 4
-  command: openssl verify -CAfile "{{ output_dir }}/cert-4-chain.pem" "{{ output_dir }}/cert-4.pem"
+  command: openssl verify -CAfile "{{ output_dir }}/cert-4-root.pem" -untrusted "{{ output_dir }}/cert-4-chain.pem" "{{ output_dir }}/cert-4.pem"
   ignore_errors: yes
   register: cert_4_valid
 - name: Verifying cert 5
-  command: openssl verify -CAfile "{{ output_dir }}/cert-5-chain.pem" "{{ output_dir }}/cert-5.pem"
+  command: openssl verify -CAfile "{{ output_dir }}/cert-5-root.pem" -untrusted "{{ output_dir }}/cert-5-chain.pem" "{{ output_dir }}/cert-5.pem"
   ignore_errors: yes
   register: cert_5_valid
 - name: Verifying cert 6
-  command: openssl verify -CAfile "{{ output_dir }}/cert-6-chain.pem" "{{ output_dir }}/cert-6.pem"
+  command: openssl verify -CAfile "{{ output_dir }}/cert-6-root.pem" -untrusted "{{ output_dir }}/cert-6-chain.pem" "{{ output_dir }}/cert-6.pem"
   ignore_errors: yes
   register: cert_6_valid
 # Dump certificate info

--- a/test/integration/targets/setup_acme/tasks/obtain-cert.yml
+++ b/test/integration/targets/setup_acme/tasks/obtain-cert.yml
@@ -87,7 +87,7 @@
   when: "challenge_data is changed and challenge == 'dns-01'"
 - name: ({{ certgen_title }}) Create TLS ALPN challenges
   uri:
-    url: "http://{{ acme_host }}:5000/tls-alpn/{{ item.value['tls-alpn-01'].resource }}"
+    url: "http://{{ acme_host }}:5000/tls-alpn/{{ item.value['tls-alpn-01'].resource }}/der-value-b64"
     method: PUT
     body_format: raw
     body: "{{ item.value['tls-alpn-01'].resource_value }}"
@@ -154,4 +154,8 @@
     method: DELETE
   with_dict: "{{ challenge_data.challenge_data }}"
   when: "challenge_data is changed and challenge == 'tls-alpn-01'"
+- name: ({{ certgen_title }}) Get root certificate
+  get_url:
+    url: "http://{{ acme_host }}:5000/root-certificate-for-ca"
+    dest: "{{ output_dir }}/{{ certificate_name }}-root.pem"
 ###############################################################################################

--- a/test/runner/lib/cloud/acme.py
+++ b/test/runner/lib/cloud/acme.py
@@ -50,7 +50,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:1.1.0'
+            self.image = 'quay.io/ansible/acme-test-container:1.2.0'
         self.container_name = ''
 
     def _wait_for_service(self, protocol, acme_host, port, local_part, name):


### PR DESCRIPTION
##### SUMMARY
Upgrading to newest ACME test container (ansible/acme-test-container#5). This integrates some changes in Pebble and the controller, most notably:
 1. The trust chain is now correct (letsencrypt/pebble#148), and there's a mechanism to obtain the root (letsencrypt/pebble#153) which is needed to verify the complete trusted chain;
 2. The controller allows to set up TLS-ALPN-01 via the base64-encoded DER value (as before), or by providing a challenge certificate and private key (required for tests for #43756);
 3. Pebble allows to clear the contact list (letsencrypt/pebble#149).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
acme_account
acme_certificate

##### ANSIBLE VERSION
```
2.7.0
```
