### PR TITLE
smart fact gathering: gather facts when play level requested facts aren't available

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -589,7 +589,7 @@ DEFAULT_GATHERING:
   choices: ['smart', 'explicit', 'implicit']
 DEFAULT_GATHER_SUBSET:
   name: Gather facts subset
-  default: 'all'
+  default: ['all']
   description:
       - Set the `gather_subset` option for the M(setup) task in the implicit fact gathering.
         See the module documentation for specifics.

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -59,7 +59,7 @@ class Play(Base, Taggable, Become):
     # Facts
     _fact_path = FieldAttribute(isa='string', default=None)
     _gather_facts = FieldAttribute(isa='bool', default=None, always_post_validate=True)
-    _gather_subset = FieldAttribute(isa='list', default=None, always_post_validate=True)
+    _gather_subset = FieldAttribute(isa='list', default=None, listof=string_types, always_post_validate=True)
     _gather_timeout = FieldAttribute(isa='int', default=None, always_post_validate=True)
 
     # Variable Attributes

--- a/test/integration/targets/gathering_facts/runme.sh
+++ b/test/integration/targets/gathering_facts/runme.sh
@@ -7,3 +7,12 @@ ansible-playbook test_gathering_facts.yml -i ../../inventory -v "$@"
 #ANSIBLE_CACHE_PLUGIN=base ansible-playbook test_gathering_facts.yml -i ../../inventory -v "$@"
 
 ANSIBLE_GATHERING=smart ansible-playbook test_run_once.yml -i ../../inventory -v "$@"
+
+ANSIBLE_GATHERING=smart ansible-playbook test_smart_gathering.yml -i ../../inventory -v "$@"
+
+# because facthost* are all the same host (localhost), tests are executed host by host,
+# otherwise cleaning task of a play (/etc/ansible/facts.d/uuid.fact removal) will
+# interfere with the next play
+for host in facthost1 facthost2 facthost3 facthost4 facthost5 facthost6; do
+    ANSIBLE_GATHERING=smart ansible-playbook test_smart_gathering_gather_subset.yml -i ../../inventory -l ${host} -v "$@"
+done

--- a/test/integration/targets/gathering_facts/test_run_once.yml
+++ b/test/integration/targets/gathering_facts/test_run_once.yml
@@ -2,6 +2,10 @@
 - hosts: facthost1
   gather_facts: no
   tasks:
+    - name: check that smart gathering is enabled
+      fail:
+        msg: 'smart gathering must be enabled'
+      when: 'lookup("env", "ANSIBLE_GATHERING") != "smart"'
     - name: install test local facts
       copy:
         src: uuid.fact

--- a/test/integration/targets/gathering_facts/test_run_once.yml
+++ b/test/integration/targets/gathering_facts/test_run_once.yml
@@ -17,14 +17,14 @@
   run_once: yes
   tasks:
     - block:
-      - name: 'Check the same host is used'
-        assert:
-          that: 'hostvars.facthost1.ansible_fqdn == hostvars.facthost2.ansible_fqdn'
-          msg: 'This test requires 2 inventory hosts referring to the same host.'
-      - name: "Check that run_once doesn't prevent fact gathering (#39453)"
-        assert:
-          that: 'hostvars.facthost1.ansible_local.uuid != hostvars.facthost2.ansible_local.uuid'
-          msg: "{{ 'Same value for ansible_local.uuid on both hosts: ' ~ hostvars.facthost1.ansible_local.uuid }}"
+        - name: 'Check the same host is used'
+          assert:
+            that: 'hostvars.facthost1.ansible_fqdn == hostvars.facthost2.ansible_fqdn'
+            msg: 'This test requires 2 inventory hosts referring to the same host.'
+        - name: "Check that run_once doesn't prevent fact gathering (#39453)"
+          assert:
+            that: 'hostvars.facthost1.ansible_local.uuid != hostvars.facthost2.ansible_local.uuid'
+            msg: "{{ 'Same value for ansible_local.uuid on both hosts: ' ~ hostvars.facthost1.ansible_local.uuid }}"
       always:
         - name: remove test local facts
           file:

--- a/test/integration/targets/gathering_facts/test_smart_gathering.yml
+++ b/test/integration/targets/gathering_facts/test_smart_gathering.yml
@@ -1,0 +1,54 @@
+- hosts: facthost1
+  gather_facts: no
+  tasks:
+    - name: check that smart gathering is enabled
+      fail:
+        msg: 'smart gathering must be enabled'
+      when: 'lookup("env", "ANSIBLE_GATHERING") != "smart"'
+
+    - name: install test local facts
+      copy:
+        src: uuid.fact
+        dest: /etc/ansible/facts.d/
+        mode: 0755
+
+    - block:
+        - name: "explicit call to setup (gather_subset: '!min' and 'local')"
+          setup:
+            gather_subset:
+              - '!min'
+              - 'local'
+
+        - name: save uuid custom fact
+          set_fact:
+            uuid_first_play: '{{ ansible_local.uuid }}'
+
+        - name: 'check that os_family fact is not defined (due to gather_subset value)'
+          fail:
+            msg: os_family fact is defined, it should not
+          when: ansible_os_family is defined
+
+      rescue:
+        - name: remove test local facts
+          file:
+            path: /etc/ansible/facts.d/uuid.fact
+            state: absent
+
+- hosts: facthost1
+  tasks:
+    - block:
+        - name: check that os_family fact is defined
+          fail:
+            msg: "os_family fact isn't defined"
+          when: ansible_os_family is not defined
+
+        - name: check that setup has been called
+          fail:
+            msg: uuids should not be equal
+          when: uuid_first_play == ansible_local.uuid
+
+      always:
+        - name: remove test local facts
+          file:
+            path: /etc/ansible/facts.d/uuid.fact
+            state: absent

--- a/test/integration/targets/gathering_facts/test_smart_gathering_gather_subset.yml
+++ b/test/integration/targets/gathering_facts/test_smart_gathering_gather_subset.yml
@@ -1,0 +1,264 @@
+- name: 'Add custom fact, call setup using a gather_subset param, save custom
+        fact value'
+  hosts: '~facthost[1-5]'
+  gather_facts: no
+  tasks:
+    - name: check that smart gathering is enabled
+      run_once: true
+      fail:
+        msg: smart gathering must be enabled
+      when: 'lookup("env", "ANSIBLE_GATHERING") != "smart"'
+
+    - name: install test local facts
+      copy:
+        src: uuid.fact
+        dest: /etc/ansible/facts.d/
+        mode: 0755
+
+    - block:
+        - name: "explicit call to setup (gather_subset: '!min' and 'local')"
+          setup:
+            gather_subset:
+              - '!min'
+              - 'local'
+
+        - name: save uuid custom fact
+          set_fact:
+            uuid_first_play: '{{ ansible_local.uuid }}'
+
+        - name: 'check that os_family fact is not defined (due to gather_subset task value)'
+          fail:
+          when: ansible_os_family is defined
+
+      rescue:
+        - name: remove test local facts
+          file:
+            path: /etc/ansible/facts.d/uuid.fact
+            state: absent
+
+# gather_subset at setup task: ['!min', 'local']
+# gather_subset at play: '!min,local'
+# => setup is called once
+- name: "use 'gather_subset' keyword at play level, value is a string"
+  hosts: facthost1
+  gather_subset: '!min,local'
+  tasks:
+    - block:
+        - name: 'check gather_subset fact'
+          fail:
+            msg: "expected: ['!min', 'local'], encountered: {{ gather_subset }}"
+          when: "gather_subset|symmetric_difference(['!min', 'local'])"
+
+        - name: 'check that os_family fact is not defined (due to gather_subset play value)'
+          fail:
+          when: ansible_os_family is defined
+
+        - name: "check that setup has been called once"
+          fail:
+            msg: uuids must be equal
+          when: "uuid_first_play != ansible_local.uuid"
+
+      always:
+        - name: remove test local facts
+          file:
+            path: /etc/ansible/facts.d/uuid.fact
+            state: absent
+
+# gather_subset at setup task: ['!min', 'local']
+# gather_subset at play: ['local', '!min']
+# => setup is called once
+- name: "use 'gather_subset' keyword at play level, value is a list"
+  hosts: facthost2
+  gather_subset:
+    # items are not in the same order than gather_subset task value
+    - 'local'
+    - '!min'
+  tasks:
+    - block:
+        - name: 'check gather_subset fact'
+          fail:
+            msg: "expected: ['!min', 'local'], encountered: {{ gather_subset }}"
+          when: "gather_subset|symmetric_difference(['!min', 'local'])"
+
+        - name: 'check that os_family fact is not defined (due to gather_subset play value)'
+          fail:
+          when: ansible_os_family is defined
+
+        - name: "check that setup has been called once"
+          fail:
+            msg: uuids must be equal
+          when: "uuid_first_play != ansible_local.uuid"
+
+      always:
+        - name: remove test local facts
+          file:
+            path: /etc/ansible/facts.d/uuid.fact
+            state: absent
+
+# gather_subset at setup task: ['!min', 'local']
+# gather_subset at play: ['local', 'virtual', '!min']
+# => setup is called twice
+- name: "use 'gather_subset' keyword at play level, one item added"
+  hosts: facthost3
+  gather_subset:
+    # one item added ('virtual')
+    - 'local'
+    - 'virtual'
+    - '!min'
+  tasks:
+    - block:
+        - name: 'check gather_subset fact'
+          fail:
+            msg: "expected: ['local', 'virtual', '!min'], encountered: {{ gather_subset }}"
+          when: "gather_subset|symmetric_difference(['local', 'virtual', '!min'])"
+
+        - name: 'check that os_family fact is not defined (due to gather_subset play value)'
+          fail:
+          when: ansible_os_family is defined
+
+        - name: check that setup has been called twice
+          fail:
+            msg: uuids must not be equal
+          when: "uuid_first_play == ansible_local.uuid"
+
+      always:
+        - name: remove test local facts
+          file:
+            path: /etc/ansible/facts.d/uuid.fact
+            state: absent
+
+# gather_subset at setup task: ['!min', 'local']
+# gather_subset at play: ['!min']
+# => setup is called once
+- name: "use 'gather_subset' keyword at play level, one item removed, setup
+        isn't called again, facts already gathered are kept"
+  hosts: facthost4
+  gather_subset:
+    # one item removed ('local')
+    - '!min'
+  tasks:
+    - block:
+        - name: 'check gather_subset fact ("local" facts still there)'
+          fail:
+            msg: "expected: ['!min', 'local'], encountered: {{ gather_subset }}"
+          when: "gather_subset|symmetric_difference(['!min', 'local'])"
+
+        - name: 'check that os_family fact still not defined'
+          fail:
+          when: ansible_os_family is defined
+
+        - name: 'check that local facts have been kept'
+          fail:
+          when: "ansible_local is not defined or 'uuid' not in ansible_local"
+
+        - name: "check that setup hasn't been called"
+          fail:
+            msg: uuids must be equal
+          when: "uuid_first_play != ansible_local.uuid"
+
+      always:
+        - name: remove test local facts
+          file:
+            path: /etc/ansible/facts.d/uuid.fact
+            state: absent
+
+# gather_subset at setup task: ['!min', 'local']
+# gather_subset at play: ['local']
+# => setup is called twice
+- hosts: facthost5
+  gather_subset:
+    # one item removed ('!min')
+    - 'local'
+  tasks:
+    - block:
+        - name: 'check gather_subset fact'
+          fail:
+            msg: "expected: ['local'], encountered: {{ gather_subset }}"
+          when: "gather_subset != ['local']"
+
+        - name: 'check that os_family fact is defined'
+          fail:
+          when: ansible_os_family is not defined
+
+        - name: 'check that local fact is present'
+          fail:
+          when: "ansible_local is not defined or 'uuid' not in ansible_local"
+
+        - name: "check that setup has been called twice"
+          fail:
+            msg: uuids must not be equal
+          when: "uuid_first_play == ansible_local.uuid"
+
+      always:
+        - name: remove test local facts
+          file:
+            path: /etc/ansible/facts.d/uuid.fact
+            state: absent
+
+###############################################################################
+# gather_subset at setup task: all
+# gather_subset at play: 'local'
+# => setup is called once
+- hosts: facthost6
+  gather_facts: no
+  tasks:
+    - name: check that smart gathering is enabled
+      run_once: true
+      fail:
+        msg: smart gathering must be enabled
+      when: 'lookup("env", "ANSIBLE_GATHERING") != "smart"'
+
+    - name: install test local facts
+      copy:
+        src: uuid.fact
+        dest: /etc/ansible/facts.d/
+        mode: 0755
+
+    - block:
+        - name: "explicit call to setup (default value of gather_subset)"
+          setup:
+
+        - name: save uuid custom fact
+          set_fact:
+            uuid_first_play: '{{ ansible_local.uuid }}'
+
+        - name: 'check that os_family fact is defined (due to setup task)'
+          fail:
+          when: ansible_os_family is not defined
+
+      rescue:
+        - name: remove test local facts
+          file:
+            path: /etc/ansible/facts.d/uuid.fact
+            state: absent
+
+- name: "'gather_subset' at play level is included in fact subsets used by
+        setup task: setup isn't called again, facts already gathered are kept"
+  hosts: facthost6
+  gather_subset:
+    - 'local'
+  tasks:
+    - block:
+        - name: 'check gather_subset fact ("local" facts still there)'
+          fail:
+            msg: "expected: ['all'], encountered: {{ gather_subset }}"
+          when: "gather_subset != ['all']"
+
+        - name: 'check that os_family fact is defined (due to gather_subset setup value)'
+          fail:
+          when: ansible_os_family is not defined
+
+        - name: 'check that local facts have been kept'
+          fail:
+          when: "ansible_local is not defined or 'uuid' not in ansible_local"
+
+        - name: "check that setup hasn't been called"
+          fail:
+            msg: uuids must be equal
+          when: "uuid_first_play != ansible_local.uuid"
+
+      always:
+        - name: remove test local facts
+          file:
+            path: /etc/ansible/facts.d/uuid.fact
+            state: absent


### PR DESCRIPTION
##### SUMMARY

When smart gathering is enabled: facts aren't gathered if `setup` module had been called before.

Test play (use `ANSIBLE_GATHERING=smart ansible-playbook play.yml`):
```yaml
- hosts: localhost
  gather_facts: false
  tasks:
    - setup:
        gather_subset:
          - '!min'
- hosts: localhost
  tasks:
    - debug:
        msg:
          "{{ ansible_distribution_release }}"
```
This pull request modify smart fact gathering behavior (when smart fact gathering is enabled):
1. facts aren't gathered when facts already available are a superset of requested facts
2. facts are gathered in all other cases


Notes:
- require #44008 (44008 should be merged before this one)
- integration tests included

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
gather_facts

##### ANSIBLE VERSION
```
2.7
```