### PR TITLE
fix typo in check_edit_config_capability method name

### DIFF
--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -402,7 +402,7 @@ class CliconfBase(AnsiblePlugin):
         """
         pass
 
-    def check_edit_config_capabiltiy(self, operations, candidate=None, commit=True, replace=None, comment=None):
+    def check_edit_config_capability(self, operations, candidate=None, commit=True, replace=None, comment=None):
 
         if not candidate and not replace:
             raise ValueError("must provide a candidate or replace to load configuration")

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -96,7 +96,7 @@ class Cliconf(CliconfBase):
     def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
 
         operations = self.get_device_operations()
-        self.check_edit_config_capabiltiy(operations, candidate, commit, replace, comment)
+        self.check_edit_config_capability(operations, candidate, commit, replace, comment)
 
         if (commit is False) and (not self.supports_sessions):
             raise ValueError('check mode is not supported without configuration session')

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -128,7 +128,7 @@ class Cliconf(CliconfBase):
     def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
         resp = {}
         operations = self.get_device_operations()
-        self.check_edit_config_capabiltiy(operations, candidate, commit, replace, comment)
+        self.check_edit_config_capability(operations, candidate, commit, replace, comment)
 
         results = []
         requests = []

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -85,7 +85,7 @@ class Cliconf(CliconfBase):
 
     def edit_config(self, candidate=None, commit=True, admin=False, replace=None, comment=None, label=None):
         operations = self.get_device_operations()
-        self.check_edit_config_capabiltiy(operations, candidate, commit, replace, comment)
+        self.check_edit_config_capability(operations, candidate, commit, replace, comment)
 
         resp = {}
         results = []

--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -90,7 +90,7 @@ class Cliconf(CliconfBase):
     def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
 
         operations = self.get_device_operations()
-        self.check_edit_config_capabiltiy(operations, candidate, commit, replace, comment)
+        self.check_edit_config_capability(operations, candidate, commit, replace, comment)
 
         resp = {}
         results = []

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -151,7 +151,7 @@ class Cliconf(CliconfBase):
     def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
         resp = {}
         operations = self.get_device_operations()
-        self.check_edit_config_capabiltiy(operations, candidate, commit, replace, comment)
+        self.check_edit_config_capability(operations, candidate, commit, replace, comment)
         results = []
         requests = []
 

--- a/lib/ansible/plugins/cliconf/voss.py
+++ b/lib/ansible/plugins/cliconf/voss.py
@@ -119,7 +119,7 @@ class Cliconf(CliconfBase):
     def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
         resp = {}
         operations = self.get_device_operations()
-        self.check_edit_config_capabiltiy(operations, candidate, commit, replace, comment)
+        self.check_edit_config_capability(operations, candidate, commit, replace, comment)
 
         results = []
         requests = []

--- a/lib/ansible/plugins/cliconf/vyos.py
+++ b/lib/ansible/plugins/cliconf/vyos.py
@@ -69,7 +69,7 @@ class Cliconf(CliconfBase):
     def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
         resp = {}
         operations = self.get_device_operations()
-        self.check_edit_config_capabiltiy(operations, candidate, commit, replace, comment)
+        self.check_edit_config_capability(operations, candidate, commit, replace, comment)
 
         results = []
         requests = []

--- a/lib/ansible/plugins/httpapi/nxos.py
+++ b/lib/ansible/plugins/httpapi/nxos.py
@@ -79,7 +79,7 @@ class HttpApi(HttpApiBase):
         resp = list()
 
         operations = self.connection.get_device_operations()
-        self.connection.check_edit_config_capabiltiy(operations, candidate, commit, replace, comment)
+        self.connection.check_edit_config_capability(operations, candidate, commit, replace, comment)
 
         if replace:
             device_info = self.connection.get_device_info()


### PR DESCRIPTION
##### SUMMARY

Fix typo in the network connection method `edit_config_capability` method name

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

plugins/cliconf/__init__.py
plugins/cliconf/eos.py
plugins/cliconf/ios.py
plugins/cliconf/iosxr.py
plugins/cliconf/junos.py
plugins/cliconf/nxos.py
plugins/cliconf/voss.py
plugins/cliconf/vyos.py
plugins/httpapi/nxos.py

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (fix_method_typo c1643dc5c6) last updated 2018/08/13 18:18:37 (GMT -700)
  config file = None
  configured module search path = [u'/Users/lhill/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/lhill/github/ansible/lib/ansible
  executable location = /Users/lhill/github/ansible/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION

Looks like typo was introduced in https://github.com/ansible/ansible/pull/43203