### PR TITLE
multiline_delimiter should be True ios cliconf

### DIFF
--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -188,7 +188,7 @@ class Cliconf(CliconfBase):
             'supports_defaults': True,
             'supports_onbox_diff': False,
             'supports_commit_comment': False,
-            'supports_multiline_delimiter': False,
+            'supports_multiline_delimiter': True,
             'supports_diff_match': True,
             'supports_diff_ignore_lines': True,
             'supports_generate_diff': True,


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
plugins/cliconf/ios.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```