### PR TITLE
Locate prtdiag even when absent from /usr/bin

### DIFF
--- a/changelogs/fragments/solaris-prtdiag-path.yaml
+++ b/changelogs/fragments/solaris-prtdiag-path.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Hardware fact gathering now completes on Solaris 8.  Previously, it aborted with error `Argument 'args' to run_command must be list or string`.

--- a/lib/ansible/module_utils/facts/hardware/sunos.py
+++ b/lib/ansible/module_utils/facts/hardware/sunos.py
@@ -168,14 +168,12 @@ class SunOSHardware(Hardware):
     def get_dmi_facts(self):
         dmi_facts = {}
 
-        prtdiag_path = self.module.get_bin_path("prtdiag")
-
         # On Solaris 8 the prtdiag wrapper is absent from /usr/sbin,
         # but that's okay, because we know where to find the real thing:
-        if not prtdiag_path:
-            rc, platform, err = self.module.run_command('/usr/bin/uname -i')
-            prtdiag_path = '/usr/platform/' + platform.rstrip() + '/sbin/prtdiag'
+        rc, platform, err = self.module.run_command('/usr/bin/uname -i')
+        platform_sbin = '/usr/platform/' + platform.rstrip() + '/sbin'
 
+        prtdiag_path = self.module.get_bin_path("prtdiag", opt_dirs=[platform_sbin])
         rc, out, err = self.module.run_command(prtdiag_path)
         """
         rc returns 1

--- a/lib/ansible/module_utils/facts/hardware/sunos.py
+++ b/lib/ansible/module_utils/facts/hardware/sunos.py
@@ -168,8 +168,15 @@ class SunOSHardware(Hardware):
     def get_dmi_facts(self):
         dmi_facts = {}
 
-        uname_path = self.module.get_bin_path("prtdiag")
-        rc, out, err = self.module.run_command(uname_path)
+        prtdiag_path = self.module.get_bin_path("prtdiag")
+
+        # On Solaris 8 the prtdiag wrapper is absent from /usr/sbin,
+        # but that's okay, because we know where to find the real thing:
+        if not prtdiag_path:
+             rc, platform, err = self.module.run_command('/usr/bin/uname -i')
+             prtdiag_path = '/usr/platform/' + platform.rstrip() + '/sbin/prtdiag'
+
+        rc, out, err = self.module.run_command(prtdiag_path)
         """
         rc returns 1
         """

--- a/lib/ansible/module_utils/facts/hardware/sunos.py
+++ b/lib/ansible/module_utils/facts/hardware/sunos.py
@@ -173,8 +173,8 @@ class SunOSHardware(Hardware):
         # On Solaris 8 the prtdiag wrapper is absent from /usr/sbin,
         # but that's okay, because we know where to find the real thing:
         if not prtdiag_path:
-             rc, platform, err = self.module.run_command('/usr/bin/uname -i')
-             prtdiag_path = '/usr/platform/' + platform.rstrip() + '/sbin/prtdiag'
+            rc, platform, err = self.module.run_command('/usr/bin/uname -i')
+            prtdiag_path = '/usr/platform/' + platform.rstrip() + '/sbin/prtdiag'
 
         rc, out, err = self.module.run_command(prtdiag_path)
         """


### PR DESCRIPTION
##### SUMMARY
On Solaris 8, the `prtdiag` wrapper is absent from `/usr/sbin`, so we must find the real thing ourselves.  This prevents fact collection from aborting.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Hardware facts.

##### ANSIBLE VERSION
```
ansible 2.6.2
  config file = /home/username/etc/ansible/ansible.cfg
  configured module search path = [u'/home/username/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```

##### ADDITIONAL INFORMATION

Before:

```console
$ ansible -m setup solaris-8
solaris-8 | FAILED! => {
    "changed": false, 
    "cmd": null, 
    "msg": "Argument 'args' to run_command must be list or string", 
    "rc": 257
}
```

After:
```console
$ ansible -m setup solaris-8
solaris-8 | SUCCESS => {
...
}
```
