### PR TITLE
Populate product_name and system_vendor facts on Solaris

### DIFF
--- a/changelogs/fragments/solaris_system_vendor.yaml
+++ b/changelogs/fragments/solaris_system_vendor.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - On Solaris, the `ansible_product_name` fact is populated for a wider range of older hardware models, and `ansible_system_vendor` fact is populated for certain known vendors.

--- a/lib/ansible/module_utils/facts/hardware/sunos.py
+++ b/lib/ansible/module_utils/facts/hardware/sunos.py
@@ -185,7 +185,7 @@ class SunOSHardware(Hardware):
                 "Sun Microsystems",
                 "VMware, Inc.",
             ]
-            vendor_regexp = "|".join(map(lambda s: re.escape(s), vendors))
+            vendor_regexp = "|".join(map(re.escape, vendors))
             system_conf_regexp = (r'System Configuration:\s+'
                                   + r'(' + vendor_regexp + r')\s+'
                                   + r'(?:sun\w+\s+)?'

--- a/lib/ansible/module_utils/facts/hardware/sunos.py
+++ b/lib/ansible/module_utils/facts/hardware/sunos.py
@@ -181,6 +181,7 @@ class SunOSHardware(Hardware):
             vendors = [
                 "Fujitsu",
                 "Oracle Corporation",
+                "QEMU",
                 "Sun Microsystems",
                 "VMware, Inc.",
             ]

--- a/lib/ansible/module_utils/facts/hardware/sunos.py
+++ b/lib/ansible/module_utils/facts/hardware/sunos.py
@@ -175,10 +175,25 @@ class SunOSHardware(Hardware):
         """
         if out:
             system_conf = out.split('\n')[0]
-            found = re.search(r'(\w+\sEnterprise\s\w+)', system_conf)
 
+            # If you know of any other manufacturers whose names appear in
+            # the first line of prtdiag's output, please add them here:
+            vendors = [
+                "Fujitsu",
+                "Oracle Corporation",
+                "Sun Microsystems",
+                "VMware, Inc.",
+            ]
+            vendor_regexp = "|".join(map(lambda s: re.escape(s), vendors))
+            system_conf_regexp = (r'System Configuration:\s+'
+                                  + r'(' + vendor_regexp + r')\s+'
+                                  + r'(?:sun\w+\s+)?'
+                                  + r'(.+)')
+
+            found = re.match(system_conf_regexp, system_conf)
             if found:
-                dmi_facts['product_name'] = found.group(1)
+                dmi_facts['system_vendor'] = found.group(1)
+                dmi_facts['product_name'] = found.group(2)
 
         return dmi_facts
 


### PR DESCRIPTION
##### SUMMARY
The first line of `prtdiag` on Solaris mentions the manufacturer and model name of the hardware.  Unfortunately, these two fields are not reliably delineated, so some guesswork is required.

The existing code assumes that the model name consists of three words, with the middle word being "Enterprise".  Whilst this is often true for recent Oracle hardware, it isn't true for a lot of other equipment that's still out there.  By using a hard-coded list of known manufacturers, we can make a better attempt at separating the two parts.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Hardware facts.

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (solaris-system-vendor 12a36255d7) last updated 2018/08/14 10:03:25 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/username/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/username/src/ansible/lib/ansible
  executable location = /home/username/src/ansible/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
Before:
```console
$ ansible -m setup sparc-server | egrep 'system_vendor|product_name'
<no output>
```

After:
```console
$ ansible -m setup sparc-server | egrep 'system_vendor|product_name'
        "ansible_product_name": "Sun Fire V120 (UltraSPARC-IIe 648MHz)", 
        "ansible_system_vendor": "Sun Microsystems", 
```
