### PR TITLE
Vultr: Ensure self.returns is the source of truth

### DIFF
--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -237,6 +237,10 @@ class Vultr:
         self.module.fail_json(msg="Could not find %s with %s: %s" % (resource, key, value))
 
     def normalize_result(self, resource):
+        fields_to_remove = set(resource.keys()) - set(self.returns.keys())
+        for field in fields_to_remove:
+            resource.pop(field)
+
         for search_key, config in self.returns.items():
             if search_key in resource:
                 if 'convert_to' in config:

--- a/lib/ansible/modules/cloud/vultr/vultr_startup_script.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_startup_script.py
@@ -142,7 +142,7 @@ class AnsibleVultrStartupScript(Vultr):
         self.returns = {
             'SCRIPTID': dict(key='id'),
             'type': dict(key='script_type'),
-            'name': dict(key='name'),
+            'name': dict(),
             'script': dict(),
             'date_created': dict(),
             'date_modified': dict(),


### PR DESCRIPTION
##### SUMMARY

As of today, self.returns it not the source of truth. If the return
value from querying the resource contains more values than the one
listed in self.returns, those value will be returned even though not
explicitly specified in self.returns.

This commit ensures that only the values listed on self.returns are
actually returned. The other values not listed are supressed.

##### ISSUE TYPE

 - Feature Pull Request


##### COMPONENT NAME

  - module_utls/vultr.py

##### ANSIBLE VERSION

  - devel


##### ADDITIONAL INFORMATION

  - N/A