### PR TITLE
[junos] Tag prepare tasks as netconf so they can be skipped for cli-only tests

### DIFF
--- a/test/integration/targets/prepare_junos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_junos_tests/tasks/main.yml
@@ -5,7 +5,9 @@
   junos_netconf:
     state: present
   connection: network_cli
+  tags: netconf
 
 - name: wait for netconf server to come up
   pause:
     seconds: 10
+  tags: netconf


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
junos

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```
