### PR TITLE
Added private_ipv4 to the hostvars in Scaleway dynamic inventory

### DIFF
--- a/lib/ansible/plugins/inventory/scaleway.py
+++ b/lib/ansible/plugins/inventory/scaleway.py
@@ -180,6 +180,9 @@ class InventoryModule(BaseInventoryPlugin):
             self.inventory.set_variable(host, "public_ipv4", extract_public_ipv4(server_info=server_info))
             self.inventory.set_variable(host, "ansible_host", extract_public_ipv4(server_info=server_info))
 
+        if extract_private_ipv4(server_info=server_info):
+            self.inventory.set_variable(host, "private_ipv4", extract_private_ipv4(server_info=server_info))
+
     def _get_zones(self, config_zones):
         return set(SCALEWAY_LOCATION.keys()).intersection(config_zones)
 


### PR DESCRIPTION
##### SUMMARY

This PR adds `private_ipv4` to the ansible hostvars of each hosts

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

- scaleway_dynamic_inventory

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (private_ipv4_hostvars 7ae34d5da1) last updated 2018/08/14 16:51:17 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

