### PR TITLE
scaleway inventory plugin: add namespace maintainers

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1080,6 +1080,10 @@ files:
     labels:
       - ovirt
       - cloud
+  lib/ansible/plugins/inventory/scaleway.py:
+    maintainers: sieben hekonsek
+    labels:
+      - cloud
   lib/ansible/plugins/filter/network.py:
     maintainers: $team_networking
     labels: networking


### PR DESCRIPTION
##### SUMMARY
scaleway inventory plugin:
* add namespace maintainers as maintainers of this plugin
* and use `cloud` label

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
BOTMETA.yml

##### ANSIBLE VERSION
```
2.7
```