### PR TITLE
Fixed opensearch double slash issue

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -183,7 +183,7 @@ html_copy_source = False
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-html_use_opensearch = 'https://docs.ansible.com/ansible/latest/'
+html_use_opensearch = 'https://docs.ansible.com/ansible/latest'
 
 # If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
 # html_file_suffix = ''


### PR DESCRIPTION
##### SUMMARY
The Opensearch url currently has an extra slash. note `latest//search.html` below.
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
docs, opensearch

##### ANSIBLE VERSION
n/a

##### ADDITIONAL INFORMATION
view-source:https://docs.ansible.com/ansible/latest/_static/opensearch.xml
```xml
<?xml version="1.0" encoding="UTF-8"?>
<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
  <ShortName>Ansible Documentation</ShortName>
  <Description>Search Ansible Documentation</Description>
  <InputEncoding>utf-8</InputEncoding>
  <Url type="text/html" method="get"
       template="https://docs.ansible.com/ansible/latest//search.html?q={searchTerms}&amp;check_keywords=yes&amp;area=default"/>
  <LongName>Ansible Documentation</LongName>
  
</OpenSearchDescription>
```
http://www.sphinx-doc.org/en/stable/config.html#confval-html_use_opensearch
"(without trailing slash)"

<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
