### PR TITLE
Make mandatory filter error message more verbose

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -299,7 +299,11 @@ def mandatory(a):
 
     ''' Make a variable mandatory '''
     if isinstance(a, Undefined):
-        raise AnsibleFilterError('Mandatory variable not defined.')
+        if a._undefined_name is not None:
+            name = "'%s' " % to_text(a._undefined_name)
+        else:
+            name = ''
+        raise AnsibleFilterError("Mandatory variable %snot defined." % name)
     return a
 
 


### PR DESCRIPTION


##### SUMMARY
...by adding the undefined variable/attribute name, if available.

Provide more information when the mandatory filter fails by giving the name of the undefined variable or attribute.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/filter/core.py`

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (mandatory-with-name f14f45cf0b) last updated 2018/08/14 20:59:04 (GMT +200)
  config file = /home/seb/.ansible.cfg
  configured module search path = [u'/home/seb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /u/seb/ghq/github.com/stoned/ansible/lib/ansible
  executable location = /u/seb/ghq/github.com/stoned/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
