### PR TITLE
new nos_config module

### DIFF
--- a/lib/ansible/modules/network/nos/nos_config.py
+++ b/lib/ansible/modules/network/nos/nos_config.py
@@ -1,0 +1,386 @@
+#!/usr/bin/python
+#
+# (c) 2018 Extreme Networks Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: nos_config
+version_added: "2.7"
+author: "Lindsay Hill (@LindsayHill)"
+short_description: Manage Extreme Networks NOS configuration sections
+description:
+  - Extreme NOS configurations use a simple block indent file syntax
+    for segmenting configuration into sections. This module provides
+    an implementation for working with NOS configuration sections in
+    a deterministic way.
+notes:
+  - Tested against NOS 7.2.0
+options:
+  lines:
+    description:
+      - The ordered set of commands that should be configured in the
+        section. The commands must be the exact same commands as found
+        in the device running-config. Be sure to note the configuration
+        command syntax as some commands are automatically modified by the
+        device config parser.
+    default: null
+    aliases: ['commands']
+  parents:
+    description:
+      - The ordered set of parents that uniquely identify the section or hierarchy
+        the commands should be checked against. If the parents argument
+        is omitted, the commands are checked against the set of top
+        level or global commands.
+    default: null
+  src:
+    description:
+      - Specifies the source path to the file that contains the configuration
+        or configuration template to load. The path to the source file can
+        either be the full path on the Ansible control host or a relative
+        path from the playbook or role root directory. This argument is mutually
+        exclusive with I(lines), I(parents).
+    default: null
+  before:
+    description:
+      - The ordered set of commands to push on to the command stack if
+        a change needs to be made. This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
+        any changes without affecting how the set of commands are matched
+        against the system.
+    default: null
+  after:
+    description:
+      - The ordered set of commands to append to the end of the command
+        stack if a change needs to be made. Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
+        executed after the command set.
+    default: null
+  match:
+    description:
+      - Instructs the module on the way to perform the matching of
+        the set of commands against the current device config. If
+        match is set to I(line), commands are matched line by line. If
+        match is set to I(strict), command lines are matched with respect
+        to position. If match is set to I(exact), command lines
+        must be an equal match. Finally, if match is set to I(none), the
+        module will not attempt to compare the source configuration with
+        the running configuration on the remote device.
+    default: line
+    choices: ['line', 'strict', 'exact', 'none']
+  replace:
+    description:
+      - Instructs the module on the way to perform the configuration
+        on the device. If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode. If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
+        line is not correct.
+    default: line
+    choices: ['line', 'block']
+  multiline_delimiter:
+    description:
+      - This argument is used when pushing a multiline configuration
+        element to the NOS device. It specifies the character to use
+        as the delimiting character. This only applies to the
+        configuration action.
+    default: "@"
+  backup:
+    description:
+      - This argument will cause the module to create a full backup of
+        the current C(running-config) from the remote device before any
+        changes are made. The backup file is written to the C(backup)
+        folder in the playbook root directory. If the directory does not
+        exist, it is created.
+    default: no
+    type: bool
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source. There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook. The I(running_config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison.
+    default: null
+    aliases: ['config']
+  diff_against:
+    description:
+      - When using the C(ansible-playbook --diff) command line argument
+        the module can generate diffs against different sources.
+      - When this option is configured as I(intended), the module will
+        return the diff of the running-config against the configuration
+        provided in the C(intended_config) argument.
+      - When this option is configured as I(running), the module will
+        return the before and after diff of the running-config with respect
+        to any changes made to the device configuration.
+    choices: ['running', 'intended']
+  diff_ignore_lines:
+    description:
+      - Use this argument to specify one or more lines that should be
+        ignored during the diff. This is used for lines in the configuration
+        that are automatically updated by the system. This argument takes
+        a list of regular expressions or exact line matches.
+  intended_config:
+    description:
+      - The C(intended_config) provides the master configuration that
+        the node should conform to and is used to check the final
+        running-config against. This argument will not modify any settings
+        on the remote device and is strictly used to check the compliance
+        of the current device's configuration against. When specifying this
+        argument, the task should also modify the C(diff_against) value and
+        set it to I(intended).
+"""
+
+EXAMPLES = """
+- name: configure top level configuration
+  nos_config:
+    lines: logging raslog console INFO
+
+- name: configure interface settings
+  nos_config:
+    lines:
+      - description test interface
+      - ip address 172.31.1.1/24
+    parents:
+      - interface TenGigabitEthernet 104/0/1
+
+- name: configure multiple interfaces
+  nos_config:
+    lines:
+      - lacp timeout long
+    parents: "{{ item }}"
+  with_items:
+    - interface TenGigabitEthernet 104/0/1
+    - interface TenGigabitEthernet 104/0/2
+
+- name: load new acl into device
+  nos_config:
+    lines:
+      - seq 10 permit ip host 1.1.1.1 any log
+      - seq 20 permit ip host 2.2.2.2 any log
+      - seq 30 permit ip host 3.3.3.3 any log
+      - seq 40 permit ip host 4.4.4.4 any log
+      - seq 50 permit ip host 5.5.5.5 any log
+    parents: ip access-list extended test
+    before: no ip access-list extended test
+    match: exact
+
+- name: check the running-config against master config
+  nos_config:
+    diff_against: intended
+    intended_config: "{{ lookup('file', 'master.cfg') }}"
+"""
+
+RETURN = """
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['switch-attributes hostname foo', 'router ospf', 'area 0']
+commands:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['switch-attributes hostname foo', 'router ospf', 'area 0']
+backup_path:
+  description: The full path to the backup file
+  returned: when backup is yes
+  type: string
+  sample: /playbooks/ansible/backup/nos_config.2018-02-12@18:26:34
+"""
+import re
+import time
+
+from ansible.module_utils.network.nos.nos import run_commands, get_config, load_config
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.common.parsing import Conditional
+from ansible.module_utils.network.common.config import NetworkConfig, dumps
+from ansible.module_utils.six import iteritems
+
+__metaclass__ = type
+
+
+def check_args(module, warnings):
+    if module.params['multiline_delimiter']:
+        if len(module.params['multiline_delimiter']) != 1:
+            module.fail_json(msg='multiline_delimiter value can only be a '
+                                 'single character')
+
+
+def get_running_config(module, current_config=None):
+    contents = module.params['running_config']
+    if not contents:
+        if current_config:
+            contents = current_config.config_text
+        else:
+            contents = get_config(module)
+    return NetworkConfig(indent=1, contents=contents)
+
+
+def get_candidate(module):
+    candidate = NetworkConfig(indent=1)
+
+    if module.params['src']:
+        src = module.params['src']
+        candidate.load(src)
+
+    elif module.params['lines']:
+        parents = module.params['parents'] or list()
+        candidate.add(module.params['lines'], parents=parents)
+
+    return candidate
+
+
+def main():
+    """ main entry point for module execution
+    """
+    argument_spec = dict(
+        src=dict(type='path'),
+
+        lines=dict(aliases=['commands'], type='list'),
+        parents=dict(type='list'),
+
+        before=dict(type='list'),
+        after=dict(type='list'),
+
+        match=dict(default='line', choices=['line', 'strict', 'exact', 'none']),
+        replace=dict(default='line', choices=['line', 'block']),
+        multiline_delimiter=dict(default='@'),
+
+        running_config=dict(aliases=['config']),
+        intended_config=dict(),
+
+        backup=dict(type='bool', default=False),
+
+        diff_against=dict(choices=['intended', 'running']),
+        diff_ignore_lines=dict(type='list'),
+    )
+
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src')]
+
+    required_if = [('match', 'strict', ['lines']),
+                   ('match', 'exact', ['lines']),
+                   ('replace', 'block', ['lines']),
+                   ('diff_against', 'intended', ['intended_config'])]
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           mutually_exclusive=mutually_exclusive,
+                           required_if=required_if,
+                           supports_check_mode=True)
+
+    result = {'changed': False}
+
+    warnings = list()
+    check_args(module, warnings)
+    result['warnings'] = warnings
+
+    config = None
+
+    if module.params['backup'] or (module._diff and module.params['diff_against'] == 'running'):
+        contents = get_config(module)
+        config = NetworkConfig(indent=1, contents=contents)
+        if module.params['backup']:
+            result['__backup__'] = contents
+
+    if any((module.params['lines'], module.params['src'])):
+        match = module.params['match']
+        replace = module.params['replace']
+        path = module.params['parents']
+
+        candidate = get_candidate(module)
+
+        if match != 'none':
+            config = get_running_config(module, config)
+            path = module.params['parents']
+            configobjs = candidate.difference(config, path=path, match=match, replace=replace)
+        else:
+            configobjs = candidate.items
+
+        if configobjs:
+            commands = dumps(configobjs, 'commands').split('\n')
+
+            if module.params['before']:
+                commands[:0] = module.params['before']
+
+            if module.params['after']:
+                commands.extend(module.params['after'])
+
+            result['commands'] = commands
+            result['updates'] = commands
+
+            # send the configuration commands to the device and merge
+            # them with the current running config
+            if not module.check_mode:
+                if commands:
+                    load_config(module, commands)
+
+            result['changed'] = True
+
+    running_config = None
+
+    diff_ignore_lines = module.params['diff_ignore_lines']
+
+    if module._diff:
+        if not running_config:
+            output = run_commands(module, 'show running-config')
+            contents = output[0]
+        else:
+            contents = running_config.config_text
+
+        # recreate the object in order to process diff_ignore_lines
+        running_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)
+
+        if module.params['diff_against'] == 'running':
+            if module.check_mode:
+                module.warn("unable to perform diff against running-config due to check mode")
+                contents = None
+            else:
+                contents = config.config_text
+
+        elif module.params['diff_against'] == 'intended':
+            contents = module.params['intended_config']
+
+        if contents is not None:
+            base_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)
+
+            if running_config.sha1 != base_config.sha1:
+                if module.params['diff_against'] == 'intended':
+                    before = running_config
+                    after = base_config
+                elif module.params['diff_against'] in ('running'):
+                    before = base_config
+                    after = running_config
+
+                result.update({
+                    'changed': True,
+                    'diff': {'before': str(before), 'after': str(after)}
+                })
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/plugins/action/nos_config.py
+++ b/lib/ansible/plugins/action/nos_config.py
@@ -1,0 +1,113 @@
+#
+# (c) 2018 Extreme Networks Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import re
+import time
+import glob
+
+from ansible.plugins.action.normal import ActionModule as _ActionModule
+from ansible.module_utils._text import to_text
+from ansible.module_utils.six.moves.urllib.parse import urlsplit
+from ansible.utils.vars import merge_hash
+
+PRIVATE_KEYS_RE = re.compile('__.+__')
+
+
+class ActionModule(_ActionModule):
+
+    def run(self, tmp=None, task_vars=None):
+
+        if self._task.args.get('src'):
+            try:
+                self._handle_template()
+            except ValueError as exc:
+                return dict(failed=True, msg=to_text(exc))
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        if self._task.args.get('backup') and result.get('__backup__'):
+            # User requested backup and no error occurred in module.
+            # NOTE: If there is a parameter error, _backup key may not be in results.
+            filepath = self._write_backup(task_vars['inventory_hostname'],
+                                          result['__backup__'])
+
+            result['backup_path'] = filepath
+
+        # strip out any keys that have two leading and two trailing
+        # underscore characters
+        for key in list(result.keys()):
+            if PRIVATE_KEYS_RE.match(key):
+                del result[key]
+
+        return result
+
+    def _get_working_path(self):
+        cwd = self._loader.get_basedir()
+        if self._task._role is not None:
+            cwd = self._task._role._role_path
+        return cwd
+
+    def _write_backup(self, host, contents):
+        backup_path = self._get_working_path() + '/backup'
+        if not os.path.exists(backup_path):
+            os.mkdir(backup_path)
+        for fn in glob.glob('%s/%s*' % (backup_path, host)):
+            os.remove(fn)
+        tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
+        filename = '%s/%s_config.%s' % (backup_path, host, tstamp)
+        open(filename, 'w').write(contents)
+        return filename
+
+    def _handle_template(self):
+        src = self._task.args.get('src')
+        working_path = self._get_working_path()
+
+        if os.path.isabs(src) or urlsplit('src').scheme:
+            source = src
+        else:
+            source = self._loader.path_dwim_relative(working_path, 'templates', src)
+            if not source:
+                source = self._loader.path_dwim_relative(working_path, src)
+
+        if not os.path.exists(source):
+            raise ValueError('path specified in src not found')
+
+        try:
+            with open(source, 'r') as f:
+                template_data = to_text(f.read())
+        except IOError:
+            return dict(failed=True, msg='unable to load src file')
+
+        # Create a template search path in the following order:
+        # [working_path, self_role_path, dependent_role_paths, dirname(source)]
+        searchpath = [working_path]
+        if self._task._role is not None:
+            searchpath.append(self._task._role._role_path)
+            if hasattr(self._task, "_block:"):
+                dep_chain = self._task._block.get_dep_chain()
+                if dep_chain is not None:
+                    for role in dep_chain:
+                        searchpath.append(role._role_path)
+        searchpath.append(os.path.dirname(source))
+        self._templar.environment.loader.searchpath = searchpath
+        self._task.args['src'] = self._templar.template(template_data)

--- a/lib/ansible/plugins/cliconf/nos.py
+++ b/lib/ansible/plugins/cliconf/nos.py
@@ -22,8 +22,6 @@ __metaclass__ = type
 import re
 import json
 
-from itertools import chain
-
 from ansible.module_utils._text import to_text
 from ansible.module_utils.network.common.utils import to_list
 from ansible.plugins.cliconf import CliconfBase
@@ -74,7 +72,8 @@ class Cliconf(CliconfBase):
         resp = {}
         results = []
         requests = []
-        for cmd in chain(['configure terminal'], to_list(command), ['end']):
+        self.send_command('configure terminal')
+        for cmd in to_list(command):
             if isinstance(cmd, dict):
                 command = cmd['command']
                 prompt = cmd['prompt']
@@ -89,6 +88,8 @@ class Cliconf(CliconfBase):
             if cmd != 'end' and cmd[0] != '!':
                 results.append(self.send_command(command, prompt, answer, False, newline))
                 requests.append(cmd)
+
+        self.send_command('end')
 
         resp['request'] = requests
         resp['response'] = results

--- a/test/units/modules/network/nos/fixtures/nos_config_config.cfg
+++ b/test/units/modules/network/nos/fixtures/nos_config_config.cfg
@@ -1,0 +1,31 @@
+!
+hostname router
+!
+interface TenGigabitEthernet 104/0/0
+ ip address 1.2.3.4 255.255.255.0
+ description test string
+!
+interface TenGigabitEthernet 104/0/1
+ ip address 6.7.8.9 255.255.255.0
+ description test string
+ shutdown
+!
+interface TenGigabitEthernet 104/0/10
+ channel-group 20 mode active
+ description Channel Group Member
+!
+interface TenGigabitEthernet 104/0/11
+ channel-group 20 mode active
+ description Channel Group Member
+!
+interface Port-channel 20
+!
+interface TenGigabitEthernet 104/0/9
+ ip address 172.16.128.99 255.255.255.0
+ ipv6 address dead::beaf/64
+ description Bleh
+!
+protocol lldp
+ system-description An Extreme VDX Device
+ disable
+!

--- a/test/units/modules/network/nos/fixtures/nos_config_src.cfg
+++ b/test/units/modules/network/nos/fixtures/nos_config_src.cfg
@@ -1,0 +1,11 @@
+!
+hostname foo
+!
+interface TenGigabitEthernet 104/0/0
+ no ip address
+!
+interface TenGigabitEthernet 104/0/1
+ ip address 6.7.8.9 255.255.255.0
+ description test string
+ shutdown
+!

--- a/test/units/modules/network/nos/test_nos_config.py
+++ b/test/units/modules/network/nos/test_nos_config.py
@@ -1,0 +1,167 @@
+#
+# (c) 2018 Extreme Networks Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.compat.tests.mock import patch
+from ansible.modules.network.nos import nos_config
+from units.modules.utils import set_module_args
+from .nos_module import TestNosModule, load_fixture
+
+
+class TestNosConfigModule(TestNosModule):
+
+    module = nos_config
+
+    def setUp(self):
+        super(TestNosConfigModule, self).setUp()
+
+        self.mock_get_config = patch('ansible.modules.network.nos.nos_config.get_config')
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch('ansible.modules.network.nos.nos_config.load_config')
+        self.load_config = self.mock_load_config.start()
+
+        self.mock_run_commands = patch('ansible.modules.network.nos.nos_config.run_commands')
+        self.run_commands = self.mock_run_commands.start()
+
+    def tearDown(self):
+        super(TestNosConfigModule, self).tearDown()
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+        self.mock_run_commands.stop()
+
+    def load_fixtures(self, commands=None):
+        config_file = 'nos_config_config.cfg'
+        self.get_config.return_value = load_fixture(config_file)
+        self.load_config.return_value = None
+
+    def test_nos_config_unchanged(self):
+        src = load_fixture('nos_config_config.cfg')
+        set_module_args(dict(src=src))
+        self.execute_module()
+
+    def test_nos_config_src(self):
+        src = load_fixture('nos_config_src.cfg')
+        set_module_args(dict(src=src))
+        commands = ['hostname foo', 'interface TenGigabitEthernet 104/0/0',
+                    'no ip address']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_nos_config_backup(self):
+        set_module_args(dict(backup=True))
+        result = self.execute_module()
+        self.assertIn('__backup__', result)
+
+    def test_nos_config_lines_wo_parents(self):
+        set_module_args(dict(lines=['hostname foo']))
+        commands = ['hostname foo']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_nos_config_lines_w_parents(self):
+        set_module_args(dict(lines=['shutdown'], parents=['interface TenGigabitEthernet 104/0/0']))
+        commands = ['interface TenGigabitEthernet 104/0/0', 'shutdown']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_nos_config_before(self):
+        set_module_args(dict(lines=['hostname foo'], before=['test1', 'test2']))
+        commands = ['test1', 'test2', 'hostname foo']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_nos_config_after(self):
+        set_module_args(dict(lines=['hostname foo'], after=['test1', 'test2']))
+        commands = ['hostname foo', 'test1', 'test2']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_nos_config_before_after_no_change(self):
+        set_module_args(dict(lines=['hostname router'],
+                             before=['test1', 'test2'],
+                             after=['test3', 'test4']))
+        self.execute_module()
+
+    def test_nos_config_config(self):
+        config = 'hostname localhost'
+        set_module_args(dict(lines=['hostname router'], config=config))
+        commands = ['hostname router']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_nos_config_replace_block(self):
+        lines = ['description test string', 'test string']
+        parents = ['interface TenGigabitEthernet 104/0/0']
+        set_module_args(dict(lines=lines, replace='block', parents=parents))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands)
+
+    def test_nos_config_match_none(self):
+        lines = ['hostname router']
+        set_module_args(dict(lines=lines, match='none'))
+        self.execute_module(changed=True, commands=lines)
+
+    def test_nos_config_match_none(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string']
+        parents = ['interface TenGigabitEthernet 104/0/0']
+        set_module_args(dict(lines=lines, parents=parents, match='none'))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_nos_config_match_strict(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string',
+                 'shutdown']
+        parents = ['interface TenGigabitEthernet 104/0/0']
+        set_module_args(dict(lines=lines, parents=parents, match='strict'))
+        commands = parents + ['shutdown']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_nos_config_match_exact(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string',
+                 'shutdown']
+        parents = ['interface TenGigabitEthernet 104/0/0']
+        set_module_args(dict(lines=lines, parents=parents, match='exact'))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_nos_config_src_and_lines_fails(self):
+        args = dict(src='foo', lines='foo')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_nos_config_src_and_parents_fails(self):
+        args = dict(src='foo', parents='foo')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_nos_config_match_exact_requires_lines(self):
+        args = dict(match='exact')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_nos_config_match_strict_requires_lines(self):
+        args = dict(match='strict')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_nos_config_replace_block_requires_lines(self):
+        args = dict(replace='block')
+        set_module_args(args)
+        self.execute_module(failed=True)
+
+    def test_nos_config_replace_config_requires_src(self):
+        args = dict(replace='config')
+        set_module_args(args)
+        self.execute_module(failed=True)


### PR DESCRIPTION
##### SUMMARY
New `nos_config` module for managing configuration sections on Extreme VDX switches.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
nos_config
##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (nos_config a3ccdb8e45) last updated 2018/08/14 12:53:08 (GMT -700)
  config file = /home/extreme/.ansible.cfg
  configured module search path = [u'/home/extreme/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/extreme/ansible/lib/ansible
  executable location = /home/extreme/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

New module is similar to `ios_config`, `slxos_config`, etc. 

Note that NOS automatically saves all changes to the running configuration. It does not have a separate does *not* support saving the configuration, or have a separate startup configuration. As such, there are no options for `save_when: modified`, or `save_when: changed`. 

Example playbook:
```yaml
---
- hosts: vdx
  gather_facts: yes

  tasks:
    - name: Storm Control on Te 104/0/15
      nos_config:
        lines: storm-control ingress broadcast limit-percent 5
        parents: interface TenGigabitEthernet 104/0/15
        backup: yes
```

Initial device config:
```shell
sw0(conf-if-te-104/0/15)# do sh run int ten 104/0/15
interface TenGigabitEthernet 104/0/15
 fabric isl enable
 fabric trunk enable
 no shutdown
!
```

Playbook output:
```shell
(venv) extreme@rancid:~/playbooks/nos$ ansible-playbook -vvvv nos_config_parents.yaml
ansible-playbook 2.7.0.dev0 (nos_config a3ccdb8e45) last updated 2018/08/14 12:53:08 (GMT -700)
  config file = /home/extreme/playbooks/nos/ansible.cfg
  configured module search path = [u'/home/extreme/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/extreme/ansible/lib/ansible
  executable location = /home/extreme/ansible/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
Using /home/extreme/playbooks/nos/ansible.cfg as config file
setting up inventory plugins
Parsed /home/extreme/playbooks/hosts inventory source with ini plugin
Loading callback plugin default of type stdout, v2.0 from /home/extreme/ansible/lib/ansible/plugins/callback/default.pyc

PLAYBOOK: nos_config_parents.yaml *********************************************************************************************************
1 plays in nos_config_parents.yaml

PLAY [vdx] ********************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************
task path: /home/extreme/playbooks/nos/nos_config_parents.yaml:2
<vdx4> attempting to start connection
<vdx4> using connection plugin network_cli
<vdx4> local domain socket does not exist, starting it
<vdx4> control socket path is /home/extreme/.ansible/pc/0a15507d1b
<vdx4> <vdx4> ESTABLISH CONNECTION FOR USER: admin on PORT 22 TO vdx4
<vdx4> <vdx4> ssh connection done, setting terminal
<vdx4> <vdx4> loaded terminal plugin for network_os nos
<vdx4> <vdx4> loaded cliconf plugin for network_os nos
<vdx4> <vdx4> firing event: on_open_shell()
<vdx4> <vdx4> ssh connection has completed successfully
<vdx4> connection to remote device started successfully
<vdx4> local domain socket listeners started successfully
<vdx4>
<vdx4> local domain socket path is /home/extreme/.ansible/pc/0a15507d1b
<vdx4> ESTABLISH LOCAL CONNECTION FOR USER: extreme
<vdx4> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/ansible-tmp-1534278223.61-139810993521980 `" && echo ansible-tmp-1534278223.61-139810993521980="` echo /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/ansible-tmp-1534278223.61-139810993521980 `" ) && sleep 0'
Using module file /home/extreme/ansible/lib/ansible/modules/system/setup.py
<vdx4> PUT /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/tmpdV6PHp TO /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/ansible-tmp-1534278223.61-139810993521980/AnsiballZ_setup.py
<vdx4> EXEC /bin/sh -c 'chmod u+x /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/ansible-tmp-1534278223.61-139810993521980/ /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/ansible-tmp-1534278223.61-139810993521980/AnsiballZ_setup.py && sleep 0'
<vdx4> EXEC /bin/sh -c '/usr/bin/python /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/ansible-tmp-1534278223.61-139810993521980/AnsiballZ_setup.py && sleep 0'
<vdx4> EXEC /bin/sh -c 'rm -f -r /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/ansible-tmp-1534278223.61-139810993521980/ > /dev/null 2>&1 && sleep 0'
ok: [vdx4]
META: ran handlers

TASK [Storm Control on Te 104/0/15] *******************************************************************************************************
task path: /home/extreme/playbooks/nos/nos_config_parents.yaml:6
<vdx4> attempting to start connection
<vdx4> using connection plugin network_cli
<vdx4> found existing local domain socket, using it!
<vdx4> updating play_context for connection
<vdx4>
<vdx4> local domain socket path is /home/extreme/.ansible/pc/0a15507d1b
<vdx4> ESTABLISH LOCAL CONNECTION FOR USER: extreme
<vdx4> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/ansible-tmp-1534278225.21-52924872925053 `" && echo ansible-tmp-1534278225.21-52924872925053="` echo /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/ansible-tmp-1534278225.21-52924872925053 `" ) && sleep 0'
Using module file /home/extreme/ansible/lib/ansible/modules/network/nos/nos_config.py
<vdx4> PUT /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/tmpt6sWLi TO /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/ansible-tmp-1534278225.21-52924872925053/AnsiballZ_nos_config.py
<vdx4> EXEC /bin/sh -c 'chmod u+x /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/ansible-tmp-1534278225.21-52924872925053/ /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/ansible-tmp-1534278225.21-52924872925053/AnsiballZ_nos_config.py && sleep 0'
<vdx4> EXEC /bin/sh -c '/usr/bin/python /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/ansible-tmp-1534278225.21-52924872925053/AnsiballZ_nos_config.py && sleep 0'
<vdx4> EXEC /bin/sh -c 'rm -f -r /home/extreme/.ansible/tmp/ansible-local-23372W8pipd/ansible-tmp-1534278225.21-52924872925053/ > /dev/null 2>&1 && sleep 0'
changed: [vdx4] => {
    "backup_path": "/home/extreme/playbooks/nos/backup/vdx4_config.2018-08-14@13:23:55",
    "changed": true,
    "commands": [
        "interface TenGigabitEthernet 104/0/15",
        "storm-control ingress broadcast limit-percent 5"
    ],
    "invocation": {
        "module_args": {
            "after": null,
            "backup": true,
            "before": null,
            "diff_against": null,
            "diff_ignore_lines": null,
            "intended_config": null,
            "lines": [
                "storm-control ingress broadcast limit-percent 5"
            ],
            "match": "line",
            "multiline_delimiter": "@",
            "parents": [
                "interface TenGigabitEthernet 104/0/15"
            ],
            "replace": "line",
            "running_config": null,
            "src": null
        }
    },
    "updates": [
        "interface TenGigabitEthernet 104/0/15",
        "storm-control ingress broadcast limit-percent 5"
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP ********************************************************************************************************************************
vdx4                       : ok=2    changed=1    unreachable=0    failed=0

(venv) extreme@rancid:~/playbooks/nos$ head backup/vdx4_config.2018-08-14@13\:23\:55
diag post rbridge-id 104 enable
ntp server 134.141.36.32 use-vrf mgmt-vrf
ntp server 10.6.16.32 use-vrf mgmt-vrf
logging raslog console INFO
logging auditlog class SECURITY
logging auditlog class CONFIGURATION
logging auditlog class FIRMWARE
logging syslog-facility local LOG_LOCAL7
logging syslog-client localip CHASSIS_IP
switch-attributes 104
(venv) extreme@rancid:~/playbooks/nos$
```