### PR TITLE
Set defaults from params after loading files, allowing params to override

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -139,46 +139,37 @@ class K8sAnsibleMixin(object):
         auth_params = auth_params or getattr(self, 'params', {})
         auth = copy.deepcopy(auth_params)
 
-        configuration = kubernetes.client.Configuration()
+        # Pull authorization settings from environment variables
         for key, value in iteritems(auth_params):
+            if key in auth_args and value is None:
+                env_value = os.getenv('K8S_AUTH_{0}'.format(key.upper()), None)
+                if env_value is not None:
+                    auth[key] = env_value
+
+        if ((auth.get('username') and auth.get('password') and auth.get('host')) or
+            (auth.get('api_key') and auth.get('host'))):
+            pass
+        elif auth.get('kubeconfig') or auth.get('context'):
+            kubernetes.config.load_kube_config(auth.get('kubeconfig'), auth.get('context'))
+        else:
+            # First try to do incluster config, then kubeconfig
+            try:
+                kubernetes.config.load_incluster_config()
+            except kubernetes.config.ConfigException:
+                kubernetes.config.load_kube_config(auth.get('kubeconfig'), auth.get('context'))
+
+
+        configuration = kubernetes.client.Configuration()
+        for key, value in iteritems(auth):
             if key in auth_args and value is not None:
                 if key == 'api_key':
                     setattr(configuration, key, {'authorization': "Bearer {0}".format(value)})
                 else:
                     setattr(configuration, key, value)
-            elif key in auth_args and value is None:
-                env_value = os.getenv('K8S_AUTH_{0}'.format(key.upper()), None)
-                if env_value is not None:
-                    if key == 'api_key':
-                        setattr(configuration, key, {'authorization': "Bearer {0}".format(env_value)})
-                    else:
-                        setattr(configuration, key, env_value)
-                        auth[key] = env_value
 
         kubernetes.client.Configuration.set_default(configuration)
+        return DynamicClient(kubernetes.client.ApiClient(configuration))
 
-        if auth.get('username') and auth.get('password') and auth.get('host'):
-            auth_method = 'params'
-        elif auth.get('api_key') and auth.get('host'):
-            auth_method = 'params'
-        elif auth.get('kubeconfig') or auth.get('context'):
-            auth_method = 'file'
-        else:
-            auth_method = 'default'
-
-        # First try to do incluster config, then kubeconfig
-        if auth_method == 'default':
-            try:
-                kubernetes.config.load_incluster_config()
-                return DynamicClient(kubernetes.client.ApiClient())
-            except kubernetes.config.ConfigException:
-                return DynamicClient(self.client_from_kubeconfig(auth.get('kubeconfig'), auth.get('context')))
-
-        if auth_method == 'file':
-            return DynamicClient(self.client_from_kubeconfig(auth.get('kubeconfig'), auth.get('context')))
-
-        if auth_method == 'params':
-            return DynamicClient(kubernetes.client.ApiClient(configuration))
 
     def client_from_kubeconfig(self, config_file, context):
         try:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I think this should give parameters to the module priority over incluster/kubeconfig-based authentication.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

Fixes #43845 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
k8s
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (k8s-reorder-auth fd7b1b14ce) last updated 2018/08/14 16:29:11 (GMT -400)
  config file = /home/fabian/tmp/reproducer/ansible/ansible.cfg
  configured module search path = [u'/home/fabian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/fabian/tmp/reproducer/ansible/lib/ansible
  executable location = /home/fabian/tmp/reproducer/ansible/bin/ansible
  python version = 2.7.15 (default, May 15 2018, 15:37:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]

```