### PR TITLE
add updated licensing guidelines to docs

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_module_utilities.rst
+++ b/docs/docsite/rst/dev_guide/developing_module_utilities.rst
@@ -3,6 +3,8 @@
 Appendix: Module Utilities
 ``````````````````````````
 
+.. include:: shared_snippets/Licensing.txt
+
 Ansible provides a number of module utilities that provide helper functions that you can use when developing your own modules. The `basic.py` module utility provides the main entry point for accessing the Ansible library, and all Ansible modules must, at minimum, import from basic.py::
 
   from ansible.module_utils.basic import *

--- a/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
@@ -21,6 +21,8 @@ Contributing Modules Checklist
 
 The following  checklist items are important guidelines for people who want to contribute to the development of modules to Ansible on GitHub. Please read the guidelines before you submit your PR/proposal.
 
+.. include:: shared_snippets/Licensing.txt
+
 * The shebang must always be ``#!/usr/bin/python``.  This allows ``ansible_python_interpreter`` to work
 * Modules must be written to support Python 2.6. If this is not possible, required minimum Python version and rationale should be explained in the requirements section in ``DOCUMENTATION``.  In Ansible-2.3 the minimum requirement for modules was Python-2.4.
 * Modules must be written to use proper Python-3 syntax.  At some point in the future we'll come up with rules for running on Python-3 but we're not there yet.  See :doc:`developing_python_3` for help on how to do this.
@@ -117,8 +119,8 @@ Read the complete :ref:`module metadata specification <ansible_metadata_block>` 
   serializable.  A common pitfall is to try returning an object via
   exit_json().  Instead, convert the fields you need from the object into the
   fields of a dictionary and return the dictionary.
-* When fetching URLs, please use either fetch_url or open_url from ansible.module_utils.urls 
-  rather than urllib2; urllib2 does not natively verify TLS certificates and so is insecure for https. 
+* When fetching URLs, please use either fetch_url or open_url from ansible.module_utils.urls
+  rather than urllib2; urllib2 does not natively verify TLS certificates and so is insecure for https.
 * facts modules must return facts in the ansible_facts field of the :ref:`result
   dictionary<common_return_values>`.
 * modules that are purely about fact gathering need to implement check_mode.

--- a/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
@@ -3,6 +3,8 @@ Information for submitting a group of modules
 
 .. contents:: Topics
 
+.. include:: shared_snippets/Licensing.txt
+
 Submitting a group of modules
 `````````````````````````````
 
@@ -21,7 +23,6 @@ Although it's tempting to get straight into coding, there are a few things to be
 * Read though all the pages linked off :doc:`developing_modules`; paying particular focus to the :doc:`developing_modules_checklist`.
 * For new modules going into Ansible 2.4 we are raising the bar so they must be PEP 8 compliant. See :doc:`testing_pep8` for more information.
 * Starting with Ansible version 2.4, all new modules must support Python 2.6 and Python 3.5+. If this is an issue, please contact us (see the "Speak to us" section later in this document to learn how).
-* All modules shipped with Ansible must be done so under the GPLv3 license. Files under the ``lib/ansible/module_utils/`` directory should be done so under the BSD license.
 * Have a look at the existing modules and how they've been named in the :ref:`all_modules`, especially in the same functional area (such as cloud, networking, databases).
 * Shared code can be placed into ``lib/ansible/module_utils/``
 * Shared documentation (for example describing common arguments) can be placed in ``lib/ansible/utils/module_docs_fragments/``.

--- a/docs/docsite/rst/dev_guide/shared_snippets/Licensing.txt
+++ b/docs/docsite/rst/dev_guide/shared_snippets/Licensing.txt
@@ -1,0 +1,12 @@
+.. note::
+   **LICENSING GUIDELINE** - All modules shipped with Ansible must be done so
+   under the GPLv3 license. Files under the ``lib/ansible/module_utils/``
+   directory should be done so under the BSD license. However, some exceptions
+   exist. ``module_utils`` that are for a small set of modules for a specific
+   vendor's hardware, provider, or service are allowed to be under GPLv3+
+   instead of BSD Licensing. ``module_utils`` that are generic in nature (could
+   be used with modules from more than one vendor or project) must be BSD as this
+   allows third party and Galaxy modules to utilize the libraries without
+   dictating their license.  If there's doubt as to which category a
+   ``module_util`` falls into, the Ansible Core Team will decide during an
+   Ansible Core Community Meeting.


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
It was decided during the Ansible Core Developer Community Meeting
on 2018-08-14 that GPLv3 is acceptable for module_utils in specific
scenarios.

https://github.com/ansible/community/issues/329#issuecomment-413005278

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (docs/licensing ee770890d0) last updated 2018/08/14 16:50:49 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/admiller/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 3.6.6 (default, Jul 19 2018, 14:25:17) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```

