### PR TITLE
Ignore error when /etc/ansible isn't readable

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -636,8 +636,11 @@ class SSLValidationHandler(urllib_request.BaseHandler):
         # and compile them into single temp file for use
         # in the ssl check to speed up the test
         for path in paths_checked:
-            if os.path.exists(path) and os.path.isdir(path):
+            try:
                 dir_contents = os.listdir(path)
+            except OSError:
+                pass
+            else:
                 for f in dir_contents:
                     full_path = os.path.join(path, f)
                     if os.path.isfile(full_path) and os.path.splitext(f)[1] in ('.crt', '.pem'):


### PR DESCRIPTION
##### SUMMARY
`module_utils.urls.SSLValidationHandler`: ignore `Permission denied: '/etc/ansible'` error when `/etc/ansible` exists but isn't readable.

In order to reproduce, create a `/etc/ansible` directory which can not be read by current user and use a module calling fetch_url
```
$ ansible localhost -m scaleway_sshkey -a"state=absent ssh_pub_key=''"

localhost | FAILED! => {
    "changed": false,
    "msg": "Connection failure: [Errno 13] Permission denied: '/etc/ansible'"
}
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 lib/ansible/module_utils/urls.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel bb553f138b) last updated 2018/08/15 01:37:30 (GMT +200)
```