### PR TITLE
Update windows_winrm.rst

### DIFF
--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -465,7 +465,7 @@ The ``requests-credssp`` wrapper can be installed using ``pip``:
 
 .. code-block:: bash
 
-    pip install pywinrm[credssp]
+    pip install requests-credssp
 
 CredSSP and TLS 1.2
 +++++++++++++++++++


### PR DESCRIPTION

+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The pip packet `pywinrm[credssp]` does not exist - `requests-credssp` does. 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
windows_winrm.rst 

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = /home/kristian/ansible/ansible.cfg
  configured module search path = [u'/home/kristian/ansible/modules', u'/etc/ansible/modules']
  ansible python module location = /home/kristian/ansible/venv/local/lib/python2.7/site-packages/ansible
  executable location = /home/kristian/ansible/venv/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
