### PR TITLE
ovirt_vms: Search template also by cluster

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -916,7 +916,9 @@ class VmsModule(BaseModule):
         template = None
         templates_service = self._connection.system_service().templates_service()
         if self.param('template'):
-            templates = templates_service.list(search='name=%s' % self.param('template'))
+            templates = templates_service.list(
+                search='name=%s and cluster=%s' % (self.param('template'), self.param('cluster'))
+            )
             if self.param('template_version'):
                 templates = [
                     t for t in templates
@@ -924,9 +926,10 @@ class VmsModule(BaseModule):
                 ]
             if not templates:
                 raise ValueError(
-                    "Template with name '%s' and version '%s' was not found'" % (
+                    "Template with name '%s' and version '%s' in cluster '%s' was not found'" % (
                         self.param('template'),
-                        self.param('template_version')
+                        self.param('template_version'),
+                        self.param('cluster')
                     )
                 )
             template = sorted(templates, key=lambda t: t.version.version_number, reverse=True)[0]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR fixes the search of template, which is used to create new virtual machine. It's possible that there are templates with same names in different data centers, so we must filter the template also based on cluster/dc.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
ovirt_vms

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6.2
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
