### PR TITLE
Missing modify_client_match and get_export_policy_rule

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_export_policy_rule.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_export_policy_rule.py
@@ -202,9 +202,9 @@ class NetAppontapExportRule(object):
         rule_info.add_new_child('policy-name', self.policy_name)
         if self.vserver:
             rule_info.add_new_child('vserver-name', self.vserver)
-        else:
-            if self.client_match:
-                rule_info.add_new_child('client-match', self.client_match)
+
+        if self.client_match:
+            rule_info.add_new_child('client-match', self.client_match)
 
         query = netapp_utils.zapi.NaElement('query')
         query.add_child_elem(rule_info)
@@ -253,6 +253,7 @@ class NetAppontapExportRule(object):
             return_value = {
                 'policy-name': self.policy_name
             }
+
         return return_value
 
     def get_export_policy(self):
@@ -422,6 +423,22 @@ class NetAppontapExportRule(object):
                                             enable_tunneling=True)
         except netapp_utils.zapi.NaApiError as error:
             self.module.fail_json(msg='Error modifying super_user_security %s: %s' % (self.super_user_security, to_native(error)),
+                                  exception=traceback.format_exc())
+
+    def modify_client_match(self, rule_index):
+        """
+        Modify client_match.
+        """
+        export_rule_modify_client_match = netapp_utils.zapi.NaElement.create_node_with_children(
+            'export-rule-modify',
+            **{'policy-name': self.policy_name,
+               'rule-index': rule_index,
+               'client-match': str(self.client_match)})
+        try:
+            self.server.invoke_successfully(export_rule_modify_client_match,
+                                            enable_tunneling=True)
+        except netapp_utils.zapi.NaApiError as error:
+            self.module.fail_json(msg='Error modifying client_match %s: %s' % (self.client_match, to_native(error)),
                                   exception=traceback.format_exc())
 
     def modify_allow_suid(self, rule_index):


### PR DESCRIPTION
##### SUMMARY

- Added 'modify_client_match' function. It was not defined at all
- Fixing 'get_export_policy_rule'. Client match was not included in query, so it always matched the first rule. Module was not able to create/modify multiple rules inside one policy 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/storage/netapp/na_ontap_export_policy_rule.py

##### ANSIBLE VERSION
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/brq/mzink/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# Missing function ->
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_aRMrZU/ansible_module_na_ontap_export_policy_rule.py\", line 528, in <module>\n    main()\n  File \"/tmp/ansible_aRMrZU/ansible_module_na_ontap_export_policy_rule.py\", line 524, in main\n    rule_obj.apply()\n  File \"/tmp/ansible_aRMrZU/ansible_module_na_ontap_export_policy_rule.py\", line 512, in apply\n    self.modify_client_match(rule_index)\nAttributeError: 'NetAppontapExportRule' object has no attribute 'modify_client_match'\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1


# Single rule problem
Inventory
            "test20": # Policy
              "na-vsim.brq.redhat.com": # Client-match
                protocol:              nfs # Settings fro cline-match ^
                ro_rule:               sys
                rw_rule:               sys
                super_user_security:   sys
              ".brq.redhat.com":
                protocol:              nfs4
                rw_rule:               krb5p
                super_user_security:   krb5p

Module exited with success, but only the last rule ".brq.redhat.com" was present, not both!
Fixed by changing  'get_export_policy_rule' function.
```
