### PR TITLE
Bug fixes for ontap_export_policy.py

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_export_policy.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_export_policy.py
@@ -17,7 +17,7 @@ short_description: Manage NetApp ONTAP export-policy
 extends_documentation_fragment:
     - netapp.na_ontap
 version_added: '2.6'
-author: Archana Ganesan (garchana@netapp.com), Suhas Bangalore Shekar (bsuhas@netapp.com)
+author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
 - Create or destroy or rename export-policies on ONTAP
 options:
@@ -30,7 +30,7 @@ options:
     description:
     - The name of the export-policy to manage.
     required: true
-  new_name:
+  from_name:
     description:
     - The name of the export-policy to be renamed.
   vserver:
@@ -50,9 +50,9 @@ EXAMPLES = """
     - name: Rename Export Policy
       na_ontap_export_policy:
         action: present
-        name: ansiblePolicyName
+        from_name: ansiblePolicyName
         vserver: vs_hack
-        new_name: newPolicyName
+        name: newPolicyName
         hostname: "{{ netapp_hostname }}"
         username: "{{ netapp_username }}"
         password: "{{ netapp_password }}"
@@ -88,7 +88,7 @@ class NetAppONTAPExportPolicy(object):
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
             name=dict(required=True, type='str'),
-            new_name=dict(required=False, type='str', default=None),
+            from_name=dict(required=False, type='str', default=None),
             vserver=dict(required=False, type='str')
         ))
         self.module = AnsibleModule(
@@ -102,7 +102,7 @@ class NetAppONTAPExportPolicy(object):
         # set up state variables
         self.state = parameters['state']
         self.name = parameters['name']
-        self.new_name = parameters['new_name']
+        self.from_name = parameters['from_name']
         self.vserver = parameters['vserver']
 
         if HAS_NETAPP_LIB is False:
@@ -110,7 +110,7 @@ class NetAppONTAPExportPolicy(object):
         else:
             self.server = netapp_utils.setup_na_ontap_zapi(module=self.module, vserver=self.vserver)
 
-    def get_export_policy(self):
+    def get_export_policy(self, name=None):
         """
         Return details about the export-policy
         :param:
@@ -118,9 +118,11 @@ class NetAppONTAPExportPolicy(object):
         :return: Details about the export-policy. None if not found.
         :rtype: dict
         """
+        if name is None:
+            name = self.name
         export_policy_iter = netapp_utils.zapi.NaElement('export-policy-get-iter')
         export_policy_info = netapp_utils.zapi.NaElement('export-policy-info')
-        export_policy_info.add_new_child('policy-name', self.name)
+        export_policy_info.add_new_child('policy-name', name)
         query = netapp_utils.zapi.NaElement('query')
         query.add_child_elem(export_policy_info)
         export_policy_iter.add_child_elem(query)
@@ -169,8 +171,8 @@ class NetAppONTAPExportPolicy(object):
         Rename the export-policy.
         """
         export_policy_rename = netapp_utils.zapi.NaElement.create_node_with_children(
-            'export-policy-rename', **{'policy-name': self.name,
-                                       'new-policy-name': self.new_name})
+            'export-policy-rename', **{'policy-name': self.from_name,
+                                       'new-policy-name': self.name})
         try:
             self.server.invoke_successfully(export_policy_rename,
                                             enable_tunneling=True)
@@ -190,29 +192,29 @@ class NetAppONTAPExportPolicy(object):
         export_policy_details = self.get_export_policy()
         if export_policy_details:
             export_policy_exists = True
-            if self.state == 'present':
-                if self.new_name is not None:
-                    if self.new_name != self.name and self.new_name != export_policy_details['policy-name']:  # rename
-                        changed = True
-                        rename_flag = True
-            elif self.state == 'absent':  # delete
+            if self.state == 'absent':  # delete
                 changed = True
         else:
-            if self.state == 'present':  # create
-                changed = True
+            if self.state == 'present':  # create or rename
+                if self.from_name is not None:
+                    if self.get_export_policy(self.from_name):
+                        changed = True
+                        rename_flag = True
+                    else:
+                        self.module.fail_json(msg='Error renaming export-policy %s: does not exists' % self.from_name)
+                else:  # create
+                    changed = True
         if changed:
             if self.module.check_mode:
                 pass
             else:
-                if self.state == 'present':  # execute create
-                    if not export_policy_exists:
+                if self.state == 'present':  # execute create or rename_export_policy
+                    if rename_flag:
+                        self.rename_export_policy()
+                    else:
                         self.create_export_policy()
-                    else:  # execute rename
-                        if rename_flag:
-                            self.rename_export_policy()
                 elif self.state == 'absent':  # execute delete
                     self.delete_export_policy()
-
         self.module.exit_json(changed=changed)
 
 

--- a/lib/ansible/modules/storage/netapp/na_ontap_export_policy.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_export_policy.py
@@ -33,6 +33,7 @@ options:
   from_name:
     description:
     - The name of the export-policy to be renamed.
+    version_added: '2.7'
   vserver:
     description:
     - Name of the vserver to use.


### PR DESCRIPTION
##### SUMMARY
Bug fixes for ontap_export_policy.py

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
- na_ontap_export_policy.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
bash-3.2# ansible --version
ansible 2.7.0.dev0 (sf_commonfiles caf71e24dd) last updated 2018/08/06 10:46:57 (GMT -700)
  config file = None
  configured module search path = [u'/Users/chrisarchibald/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /private/tmp/ansible/lib/ansible
  executable location = /private/tmp/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 11 2016, 05:20:59) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
