### PR TITLE
Bug Fixes for ontap_ntp.py

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_ntp.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_ntp.py
@@ -18,7 +18,7 @@ short_description: Create/Delete/modify_version ONTAP NTP server
 extends_documentation_fragment:
     - netapp.na_ontap
 version_added: '2.6'
-author: Suhas Bangalore Shekar (bsuhas@netapp.com), Archana Ganesan (garchana@netapp.com)
+author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
 - Create or delete or modify ntp server in ONTAP
 options:


### PR DESCRIPTION
##### SUMMARY
Bug Fixes for ontap_ntp.py

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
- na_ontap_ntp.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
bash-3.2# ansible --version
ansible 2.7.0.dev0 (sf_commonfiles caf71e24dd) last updated 2018/08/06 10:46:57 (GMT -700)
  config file = None
  configured module search path = [u'/Users/chrisarchibald/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /private/tmp/ansible/lib/ansible
  executable location = /private/tmp/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 11 2016, 05:20:59) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
