### PR TITLE
proxmox_template: Prevent utf-8 codec error in py3

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox_template.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_template.py
@@ -136,7 +136,7 @@ def get_template(proxmox, node, storage, content_type, template):
 
 
 def upload_template(module, proxmox, api_host, node, storage, content_type, realpath, timeout):
-    taskid = proxmox.nodes(node).storage(storage).upload.post(content=content_type, filename=open(realpath))
+    taskid = proxmox.nodes(node).storage(storage).upload.post(content=content_type, filename=open(realpath, 'rb'))
     while timeout:
         task_status = proxmox.nodes(api_host.split('.')[0]).tasks(taskid).status.get()
         if task_status['status'] == 'stopped' and task_status['exitstatus'] == 'OK':


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Cannot upload templates in Python 3.x. Gives `utf-8 codec` error.
Fixes this by opening the template file in binary mode.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
 - proxmox_template.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (Bug_Fixes_for_proxmox_template.py 273fea557f) last updated 2018/08/15 20:48:44 (GMT +200)
  config file = None
  configured module search path = ['/Users/boriel/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/boriel/Documents/src/ansible/lib/ansible
  executable location = /Users/boriel/.virtualenvs/gramlover-ansible-dev-py3/bin/ansible
  python version = 3.6.1 (default, Apr 19 2017, 20:46:54) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.41)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
