### PR TITLE
ovirt: minor typo in documentation

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_affinity_label_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_affinity_label_facts.py
@@ -83,7 +83,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_affinity_labels:
-    description: "List of dictionaries describing the affinity labels. Affinity labels attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the affinity labels. Affinity labels attributes are mapped to dictionary keys,
                   all affinity labels attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/affinity_label."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_cluster_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_cluster_facts.py
@@ -58,7 +58,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_clusters:
-    description: "List of dictionaries describing the clusters. Cluster attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the clusters. Cluster attributes are mapped to dictionary keys,
                   all clusters attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/cluster."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_datacenter_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_datacenter_facts.py
@@ -56,7 +56,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_datacenters:
-    description: "List of dictionaries describing the datacenters. Datacenter attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the datacenters. Datacenter attributes are mapped to dictionary keys,
                   all datacenters attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/data_center."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_group_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_group_facts.py
@@ -56,7 +56,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_groups:
-    description: "List of dictionaries describing the groups. Group attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the groups. Group attributes are mapped to dictionary keys,
                   all groups attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/group."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_hosts_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_hosts_facts.py
@@ -64,7 +64,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_hosts:
-    description: "List of dictionaries describing the hosts. Host attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the hosts. Host attributes are mapped to dictionary keys,
                   all hosts attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/host."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_networks_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_networks_facts.py
@@ -58,7 +58,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_networks:
-    description: "List of dictionaries describing the networks. Network attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the networks. Network attributes are mapped to dictionary keys,
                   all networks attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/network."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_nics_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_nics_facts.py
@@ -60,7 +60,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_nics:
-    description: "List of dictionaries describing the network interfaces. NIC attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the network interfaces. NIC attributes are mapped to dictionary keys,
                   all NICs attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/nic."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_permissions_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_permissions_facts.py
@@ -68,7 +68,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_permissions:
-    description: "List of dictionaries describing the permissions. Permission attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the permissions. Permission attributes are mapped to dictionary keys,
                   all permissions attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/permission."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_quotas_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_quotas_facts.py
@@ -60,7 +60,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_quotas:
-    description: "List of dictionaries describing the quotas. Quota attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the quotas. Quota attributes are mapped to dictionary keys,
                   all quotas attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/quota."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_scheduling_policies_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_scheduling_policies_facts.py
@@ -60,7 +60,7 @@ EXAMPLES = '''
 RETURN = '''
 ovirt_scheduling_policies:
     description: "List of dictionaries describing the scheduling policies.
-                  Scheduling policies attribues are mapped to dictionary keys,
+                  Scheduling policies attributes are mapped to dictionary keys,
                   all scheduling policies attributes can be found at following
                   url: https://ovirt.example.com/ovirt-engine/api/model#types/scheduling_policy."
     returned: On success.

--- a/lib/ansible/modules/cloud/ovirt/ovirt_snapshots_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_snapshots_facts.py
@@ -64,7 +64,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_snapshots:
-    description: "List of dictionaries describing the snapshot. Snapshot attribtues are mapped to dictionary keys,
+    description: "List of dictionaries describing the snapshot. Snapshot attributes are mapped to dictionary keys,
                   all snapshot attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/snapshot."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains_facts.py
@@ -58,7 +58,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_storage_domains:
-    description: "List of dictionaries describing the storage domains. Storage_domain attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the storage domains. Storage_domain attributes are mapped to dictionary keys,
                   all storage domains attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/storage_domain."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_templates_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_templates_facts.py
@@ -58,7 +58,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_storage_templates:
-    description: "List of dictionaries describing the Templates. Template attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the Templates. Template attributes are mapped to dictionary keys,
                   all Templates attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/template."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_vms_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_vms_facts.py
@@ -57,7 +57,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_storage_vms:
-    description: "List of dictionaries describing the VMs. VM attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the VMs. VM attributes are mapped to dictionary keys,
                   all VMs attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/vm."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_tags_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_tags_facts.py
@@ -73,7 +73,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_tags:
-    description: "List of dictionaries describing the tags. Tags attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the tags. Tags attributes are mapped to dictionary keys,
                   all tags attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/tag."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates_facts.py
@@ -58,7 +58,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_templates:
-    description: "List of dictionaries describing the templates. Template attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the templates. Template attributes are mapped to dictionary keys,
                   all templates attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/template."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_users_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_users_facts.py
@@ -56,7 +56,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_users:
-    description: "List of dictionaries describing the users. User attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the users. User attributes are mapped to dictionary keys,
                   all users attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/user."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vmpools_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vmpools_facts.py
@@ -56,7 +56,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_vm_pools:
-    description: "List of dictionaries describing the vmpools. Vm pool attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the vmpools. Vm pool attributes are mapped to dictionary keys,
                   all vmpools attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/vm_pool."
     returned: On success.
     type: list

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms_facts.py
@@ -68,7 +68,7 @@ EXAMPLES = '''
 
 RETURN = '''
 ovirt_vms:
-    description: "List of dictionaries describing the VMs. VM attribues are mapped to dictionary keys,
+    description: "List of dictionaries describing the VMs. VM attributes are mapped to dictionary keys,
                   all VMs attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/vm."
     returned: On success.
     type: list


### PR DESCRIPTION
##### SUMMARY
Fixed "attribues" to "attributes"

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
lib/ansible/modules/cloud/ovirt/ovirt_affinity_label_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_cluster_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_datacenter_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_group_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_hosts_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_networks_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_nics_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_permissions_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_quotas_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_scheduling_policies_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_snapshots_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_storage_domains_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_storage_templates_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_storage_vms_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_tags_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_templates_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_users_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_vmpools_facts.py
lib/ansible/modules/cloud/ovirt/ovirt_vms_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```