### PR TITLE
Add new session parameter to win_psexec

### DIFF
--- a/changelogs/fragments/win_psexec_session-selection.yaml
+++ b/changelogs/fragments/win_psexec_session-selection.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_psexec - Added the ``session`` option to specify a session to start the process in

--- a/lib/ansible/modules/windows/win_psexec.ps1
+++ b/lib/ansible/modules/windows/win_psexec.ps1
@@ -24,6 +24,7 @@ $elevated = Get-AnsibleParam -obj $params -name "elevated" -type "bool" -default
 $limited = Get-AnsibleParam -obj $params -name "limited" -type "bool" -default $false
 $system = Get-AnsibleParam -obj $params -name "system" -type "bool" -default $false
 $interactive = Get-AnsibleParam -obj $params -name "interactive" -type "bool" -default $false
+$session = Get-AnsibleParam -obj $params -name "session" -type "int"
 $priority = Get-AnsibleParam -obj $params -name "priority" -type "str" -validateset "background","low","belownormal","abovenormal","high","realtime"
 $timeout = Get-AnsibleParam -obj $params -name "timeout" -type "int"
 $extra_opts = Get-AnsibleParam -obj $params -name "extra_opts" -type "list"
@@ -83,6 +84,9 @@ If ($system -eq $true) {
 
 If ($interactive -eq $true) {
     $arguments += "-i"
+    If ($session -ne $null) {
+        $arguments += $session
+    }
 }
 
 If ($limited -eq $true) {

--- a/lib/ansible/modules/windows/win_psexec.py
+++ b/lib/ansible/modules/windows/win_psexec.py
@@ -69,6 +69,7 @@ options:
     description:
     - In conjunction with interactive, specify a session for psexec to attach to. Has no effect if interactive is 'no'.
     type: int
+    version_added: '2.7'
   limited:
     description:
     - Run the command as limited user (strips the Administrators group and allows only privileges assigned to the Users group).

--- a/lib/ansible/modules/windows/win_psexec.py
+++ b/lib/ansible/modules/windows/win_psexec.py
@@ -65,6 +65,10 @@ options:
     - Run the program so that it interacts with the desktop on the remote system.
     type: bool
     default: 'no'
+  session:
+    description:
+    - In conjunction with interactive, specify a session for psexec to attach to. Has no effect if interactive is 'no'.
+    type: int
   limited:
     description:
     - Run the command as limited user (strips the Administrators group and allows only privileges assigned to the Users group).

--- a/lib/ansible/modules/windows/win_psexec.py
+++ b/lib/ansible/modules/windows/win_psexec.py
@@ -67,7 +67,9 @@ options:
     default: 'no'
   session:
     description:
-    - In conjunction with interactive, specify a session for psexec to attach to. Has no effect if interactive is 'no'.
+    - Specifies the session ID to use.
+    - This parameter works in conjunction with I(interactive).
+    - It has no effect when I(interactive) is set to C(no).
     type: int
     version_added: '2.7'
   limited:


### PR DESCRIPTION
##### SUMMARY
Allows users to specify the Windows session they would like psexec to interact with, per the documentation for psexec around the -i flag.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_psexec

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = None
  configured module search path = ['/home/xyon/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib64/python3.6/site-packages/ansible
  executable location = /usr/lib/python-exec/python3.6/ansible
  python version = 3.6.5 (default, Jul 24 2018, 10:14:42) [GCC 7.3.0]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Prior to this change, you could only specify "interactive: yes", which would just pass the -i flag to psexec.exe. For many purposes this is sufficient, but on certain boxes this causes the command to attach to the services console session rather than the Desktop (on session 1) as might be expected.

If provided, the value of session is passed to the -i flag, causing psexec to attempt to attach there instead. This proves useful in environments such as Azure, on a Windows 10 machine, when attempting to spawn processes on the desktop.

If no value for session is provided, the behaviour is as before the change.
```
