### PR TITLE
DCI devel iosxr fix : on-device diffs does not work always

### DIFF
--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -104,9 +104,9 @@ class Cliconf(CliconfBase):
             requests.append(cmd)
 
         if commit:
-           self.commit(comment=comment, label=label, replace=replace)
+            self.commit(comment=comment, label=label, replace=replace)
         else:
-           self.discard_changes()
+            self.discard_changes()
 
         self.abort(admin=admin)
 

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -103,14 +103,10 @@ class Cliconf(CliconfBase):
             results.append(self.send_command(**line))
             requests.append(cmd)
 
-        diff = self.get_diff(admin=admin)
-        config_diff = diff.get('config_diff')
-        if config_diff or replace:
-            resp['diff'] = config_diff
-            if commit:
-                self.commit(comment=comment, label=label, replace=replace)
-            else:
-                self.discard_changes()
+        if commit:
+           self.commit(comment=comment, label=label, replace=replace)
+        else:
+           self.discard_changes()
 
         self.abort(admin=admin)
 


### PR DESCRIPTION
##### SUMMARY
IOSXR's on device diff functionality is buggy. It does not work in some situations like the one we hit on dci nodepool iosxr. If you try to unconfigure a per-configure interface "show commit changes diff" shows nothing so we do not commit it and device is left with old configurations

```
RP/0/0/CPU0:iosxr01#show running-config interface
Thu Aug 16 10:49:47.838 UTC
interface Loopback888
 description test for ansible
 shutdown
!
interface MgmtEth0/0/CPU0/0
 ipv4 address dhcp
!
interface GigabitEthernet0/0/0/1
 shutdown
!
interface preconfigure GigabitEthernet0/0/0/2
 description test-interface-2
 mtu 516
 speed 100
 duplex full
 shutdown
!
interface preconfigure GigabitEthernet0/0/0/3
 description test-interface-1
 mtu 256
 speed 100
 duplex full
 shutdown
!
interface preconfigure GigabitEthernet0/0/0/4
 description test_interface_1
!
interface preconfigure GigabitEthernet0/0/0/5
 description test_interface_2
!


RP/0/0/CPU0:iosxr01#conf t
Thu Aug 16 10:49:56.378 UTC
RP/0/0/CPU0:iosxr01(config)#no interface gigabitEthernet 0/0/0/4
RP/0/0/CPU0:iosxr01(config)#no interface gigabitEthernet 0/0/0/5
RP/0/0/CPU0:iosxr01(config)#show commit changes diff
Thu Aug 16 10:50:34.265 UTC
Building configuration...
!! IOS XR Configuration 6.1.2
end

RP/0/0/CPU0:iosxr01(config)#
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
iosxr_*

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
DCI 's failed test case passes with this change
```
nodepool@nodepool:~/debug/ansible$ ansible-test network-integration --inventory /tmp//invent iosxr_interface -vvvv
--
PLAY RECAP *************************************************************************************************************************
iosxr01                    : ok=187  changed=61   unreachable=0    failed=0


```