### PR TITLE
Add support for MySQL plugin authentication

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -403,7 +403,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted, plugin, plugin_h
         # Handle plugin authentication
 
         if plugin:
-            cursor.execute("SELECT plugin, authentication_string FROM mysql.user WHERE user = %s AND host = %s", (user, host))```
+            cursor.execute("SELECT plugin, authentication_string FROM mysql.user WHERE user = %s AND host = %s", (user, host))
             current_plugin = cursor.fetchone()
 
             update = False
@@ -711,7 +711,7 @@ def main():
             try:
                 if update_password == 'always':
                     changed, msg = user_mod(cursor, user, host, host_all, password, encrypted, plugin, plugin_hash_string, plugin_auth_string,
-                                       priv, append_privs, module)
+                                            priv, append_privs, module)
                 else:
                     changed, msg = user_mod(cursor, user, host, host_all, None, encrypted, plugin, plugin_hash_string, plugin_auth_string,
                                        priv, append_privs, module)

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -714,7 +714,7 @@ def main():
                                             priv, append_privs, module)
                 else:
                     changed, msg = user_mod(cursor, user, host, host_all, None, encrypted, plugin, plugin_hash_string, plugin_auth_string,
-                                       priv, append_privs, module)
+                                            priv, append_privs, module)
 
             except (SQLParseError, InvalidPrivsError, mysql_driver.Error) as e:
                 module.fail_json(msg=to_native(e))

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -34,15 +34,15 @@ options:
   plugin:
     description:
       - Set the user's plugin used to authenticate C(CREATE USER user IDENTIFIED WITH plugin).
-    version_added: "2.8"
+    version_added: "2.9"
   plugin_hash_string:
     description:
       - Set the user's plugin hash string C(CREATE USER user IDENTIFIED WITH plugin AS plugin_hash_string).
-    version_added: "2.8"
+    version_added: "2.9"
   plugin_auth_string:
     description:
       - Set the user's plugin auth_string C(CREATE USER user IDENTIFIED WITH plugin BY plugin_auth_string).
-    version_added: "2.8"
+    version_added: "2.9"
   encrypted:
     description:
       - Indicate that the 'password' field is a `mysql_native_password` hash.

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -114,7 +114,10 @@ notes:
      the new root credentials. Subsequent runs of the playbook will then succeed by reading the new credentials from
      the file."
 
-author: "Jonathan Mainguy (@Jmainguy), Lukasz Tomaszkiewicz (@tomaszkiewicz)"
+author:
+- Jonathan Mainguy (@Jmainguy)
+- Benjamin Malynovytch (@bmalynovytch)
+- Lukasz Tomaszkiewicz (@tomaszkiewicz)
 
 extends_documentation_fragment: mysql
 '''
@@ -400,7 +403,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted, plugin, plugin_h
         # Handle plugin authentication
 
         if plugin:
-            cursor.execute("SELECT plugin, authentication_string FROM user WHERE user = %s AND host = %s", (user, host))
+            cursor.execute("SELECT plugin, authentication_string FROM mysql.user WHERE user = %s AND host = %s", (user, host))```
             current_plugin = cursor.fetchone()
 
             update = False
@@ -707,10 +710,10 @@ def main():
         if user_exists(cursor, user, host, host_all):
             try:
                 if update_password == 'always':
-                    changed = user_mod(cursor, user, host, host_all, password, encrypted, plugin, plugin_hash_string, plugin_auth_string,
+                    changed, msg = user_mod(cursor, user, host, host_all, password, encrypted, plugin, plugin_hash_string, plugin_auth_string,
                                        priv, append_privs, module)
                 else:
-                    changed = user_mod(cursor, user, host, host_all, None, encrypted, plugin, plugin_hash_string, plugin_auth_string,
+                    changed, msg = user_mod(cursor, user, host, host_all, None, encrypted, plugin, plugin_hash_string, plugin_auth_string,
                                        priv, append_privs, module)
 
             except (SQLParseError, InvalidPrivsError, mysql_driver.Error) as e:

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -34,15 +34,15 @@ options:
   plugin:
     description:
       - Set the user's plugin used to authenticate C(CREATE USER user IDENTIFIED WITH plugin).
-    version_added: "2.9"
+    version_added: '2.10'
   plugin_hash_string:
     description:
       - Set the user's plugin hash string C(CREATE USER user IDENTIFIED WITH plugin AS plugin_hash_string).
-    version_added: "2.9"
+    version_added: '2.10'
   plugin_auth_string:
     description:
       - Set the user's plugin auth_string C(CREATE USER user IDENTIFIED WITH plugin BY plugin_auth_string).
-    version_added: "2.9"
+    version_added: '2.10'
   encrypted:
     description:
       - Indicate that the 'password' field is a `mysql_native_password` hash.
@@ -140,12 +140,16 @@ EXAMPLES = r'''
     priv: '*.*:ALL'
     state: present
 # Create database user with name 'bob' authenticated with 'AWSAuthenticationPlugin' (with proper hash_string) with all database privileges
-- mysql_user:
+
+# Create database user with name 'bob' authenticated with 'AWSAuthenticationPlugin' (with proper hash_string) with all database privileges
+- name:Create database user
+  mysql_user:
     name: bob
     plugin: AWSAuthenticationPlugin
     plugin_hash_string: RDS
     priv: '*.*:ALL'
     state: present
+
 - name: Create database user using hashed password with all database privileges
   mysql_user:
     name: bob


### PR DESCRIPTION
##### SUMMARY
The change adds support for MySQL plugin authentication, eg. AWS RDS IAM Authentication plugin.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
MySQL

##### ANSIBLE VERSION
```
ansible 2.6.2
  config file = /home/luktom/.ansible.cfg
  configured module search path = [u'/home/luktom/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
