### PR TITLE
Fixes authentication error when ansible_user is a local account and computer is already joined to domain

### DIFF
--- a/lib/ansible/modules/windows/win_domain_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_membership.ps1
@@ -46,11 +46,11 @@ Function Get-DomainMembershipMatch {
         return $domain_match
     }
     catch [System.Security.Authentication.AuthenticationException] {
-        Write-DebugLog "Checking to see if ansible_user account is local and attempt a different method."
+        Write-DebugLog "Failed to get computer domain.  Attempting a different method."
         Add-Type -AssemblyName System.DirectoryServices.AccountManagement            
-        $UserPrincipal = [System.DirectoryServices.AccountManagement.UserPrincipal]::Current
-        If ($UserPrincipal.ContextType -eq "Machine") {
-            $current_dns_domain = (Get-WmiObject -Class Win32_ComputerSystem).Domain
+        $user_principal = [System.DirectoryServices.AccountManagement.UserPrincipal]::Current
+        If ($user_principal.ContextType -eq "Machine") {
+            $current_dns_domain = (Get-CimInstance -ClassName Win32_ComputerSystem -Property Domain).Domain
             
             $domain_match = $current_dns_domain -eq $dns_domain_name
 
@@ -59,7 +59,7 @@ Function Get-DomainMembershipMatch {
             return $domain_match
         }
         Else {
-            Fail-Json -obj $result -message "The ansible_user or ansible_password is incorrect and cannot acccess the domain."
+            Fail-Json -obj $result -message "Failed to authenticate with domain controller and cannot retrieve the existing domain name: $($_.Exception.Message)"
         }
     }
     Catch [System.DirectoryServices.ActiveDirectory.ActiveDirectoryObjectNotFoundException] {


### PR DESCRIPTION
##### SUMMARY
Fixes authentication error when ansible_user is a local account and computer is already joined to the desired domain.

The 
```powershell
[System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Name
```
method works fine when the ansible_user account is local and the computer is not joined to a domain.  However, once the computer is joined to the desired domain and this module is ran it results in an error (below).


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_domain_membership

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (win_domain_membership_fix 5c6f35eaaf) last updated 2018/08/16 14:55:40 (GMT +000)
  config file = /data01/home/hit/tools/ansible/ansible.cfg
  configured module search path = [u'/home/mklebolt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mklebolt/ansible/lib/ansible
  executable location = /home/mklebolt/ansible/bin/ansible
  python version = 2.7.5 (default, May 31 2018, 09:41:32) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
Tested against 2012 R2 and 2016.

```yaml
- name: Join to domain
  win_domain_membership:
   dns_domain_name: "{{ domain }}"
   domain_admin_user: "{{ username }}"
   domain_admin_password: "{{  password }}"
   state: domain
```
Steps to reproduce:
1. On a computer that is already joined to the desired domain, run the win_domain_membership module with ansible_user that is local user account and not a domain account.
2.  Receive the following error:

Before Change:
```Powershell
DEBUG: 2018-08-16 14:54:54Z calling GetComputerDomain()
Exception calling "GetComputerDomain" with "0" argument(s): "The user name or password is incorrect.
"
At line:27 char:9
+         $current_dns_domain = [System.DirectoryServices.ActiveDirecto ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : AuthenticationException
```

After Change:
```Powershell
DEBUG: 2018-08-16 15:18:26Z calling GetComputerDomain()
DEBUG: 2018-08-16 15:18:27Z Checking to see if ansible_user account is local and attempt a different m
ethod.
DEBUG: 2018-08-16 15:18:29Z current domain domain.name matches domain.name: True
True
```