### PR TITLE
Fix grammar and clarify 'list' description for ABE

### DIFF
--- a/lib/ansible/modules/windows/win_share.py
+++ b/lib/ansible/modules/windows/win_share.py
@@ -41,7 +41,7 @@ options:
       - Share description.
   list:
     description:
-      - Specify whether to allow or deny file listing, in case user got no permission on share.
+      - Specify whether to allow or deny file listing, in case user has no permission on share. Also known as Access-Based Enumeration.
     type: bool
     default: 'no'
   read:


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Grammar on the description for option 'list' was grammatically incorrect. Suggest to add wording that clarifies that 'list' is indeed Access-Based Enumeration.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
win_share 

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
N/A
```
