### PR TITLE
VMware: remove blank from ntp server list

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
@@ -118,6 +118,7 @@ class VmwareNtpConfigManager(PyVmomi):
         host_date_time_manager = host.configManager.dateTimeSystem
         if host_date_time_manager:
             available_ntp_servers = host_date_time_manager.dateTimeInfo.ntpConfig.server
+            available_ntp_servers = list(filter(None, available_ntp_servers))
             if operation == 'add':
                 available_ntp_servers = available_ntp_servers + ntp_servers
             elif operation == 'delete':


### PR DESCRIPTION
##### SUMMARY
Due to blank line returned from vCenter, wrong values were appended
to NTP server list. This fix adds filter for such blank values of NTP servers.

Fixes: #44183

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_host_ntp.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```