### PR TITLE
ACME: allowing to force account URI

### DIFF
--- a/lib/ansible/modules/crypto/acme/acme_account.py
+++ b/lib/ansible/modules/crypto/acme/acme_account.py
@@ -127,6 +127,7 @@ def main():
         argument_spec=dict(
             account_key_src=dict(type='path', aliases=['account_key']),
             account_key_content=dict(type='str', no_log=True),
+            account_uri=dict(required=False, type='str'),
             acme_directory=dict(required=False, default='https://acme-staging.api.letsencrypt.org/directory', type='str'),
             acme_version=dict(required=False, default=1, choices=[1, 2], type='int'),
             validate_certs=dict(required=False, default=True, type='bool'),

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -869,6 +869,7 @@ def main():
         argument_spec=dict(
             account_key_src=dict(type='path', aliases=['account_key']),
             account_key_content=dict(type='str', no_log=True),
+            account_uri=dict(required=False, type='str'),
             modify_account=dict(required=False, type='bool', default=True),
             acme_directory=dict(required=False, default='https://acme-staging.api.letsencrypt.org/directory', type='str'),
             acme_version=dict(required=False, default=1, choices=[1, 2], type='int'),

--- a/lib/ansible/modules/crypto/acme/acme_certificate_revoke.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate_revoke.py
@@ -95,6 +95,7 @@ def main():
         argument_spec=dict(
             account_key_src=dict(type='path', aliases=['account_key']),
             account_key_content=dict(type='str', no_log=True),
+            account_uri=dict(required=False, type='str'),
             acme_directory=dict(required=False, default='https://acme-staging.api.letsencrypt.org/directory', type='str'),
             acme_version=dict(required=False, default=1, choices=[1, 2], type='int'),
             validate_certs=dict(required=False, default=True, type='bool'),

--- a/lib/ansible/utils/module_docs_fragments/acme.py
+++ b/lib/ansible/utils/module_docs_fragments/acme.py
@@ -46,6 +46,12 @@ options:
          Ansible in the process of moving the module with its argument to
          the node where it is executed."
     version_added: "2.5"
+  account_uri:
+    description:
+      - "If specified, assumes that the account URI is as given. If the
+         account key does not match this account, or an account with this
+         URI does not exist, the module fails."
+    version_added: "2.7"
   acme_version:
     description:
       - "The ACME version of the endpoint."

--- a/test/integration/targets/acme_account/tasks/impl.yml
+++ b/test/integration/targets/acme_account/tasks/impl.yml
@@ -47,6 +47,7 @@
   acme_account:
     select_crypto_backend: "{{ select_crypto_backend }}"
     account_key_src: "{{ output_dir }}/accountkey.pem"
+    account_uri: "{{ account_created.account_uri }}"
     acme_version: 2
     acme_directory: https://{{ acme_host }}:14000/dir
     validate_certs: no
@@ -55,6 +56,19 @@
     contact:
     - mailto:example@example.com
   register: account_modified_idempotent
+
+- name: Cannot access account with wrong URI
+  acme_account:
+    select_crypto_backend: "{{ select_crypto_backend }}"
+    account_key_src: "{{ output_dir }}/accountkey.pem"
+    account_uri: "{{ account_created.account_uri ~ '12345thisdoesnotexist' }}"
+    acme_version: 2
+    acme_directory: https://{{ acme_host }}:14000/dir
+    validate_certs: no
+    state: present
+    contact: []
+  ignore_errors: yes
+  register: account_modified_wrong_uri
 
 - name: Clear contact email addresses
   acme_account:

--- a/test/integration/targets/acme_account/tests/validate.yml
+++ b/test/integration/targets/acme_account/tests/validate.yml
@@ -22,6 +22,11 @@
       - account_modified_idempotent is not changed
       - account_modified_idempotent.account_uri is not none
 
+- name: Make sure that with the wrong account URI, the account cannot be changed
+  assert:
+    that:
+      - account_modified_wrong_uri is failed
+
 - name: Validate that email address was cleared
   assert:
     that:

--- a/test/integration/targets/setup_acme/tasks/obtain-cert.yml
+++ b/test/integration/targets/setup_acme/tasks/obtain-cert.yml
@@ -103,6 +103,7 @@
     acme_directory: https://{{ acme_host }}:14000/dir
     validate_certs: no
     account_key: "{{ output_dir }}/{{ account_key }}.pem"
+    account_uri: "{{ challenge_data.account_uri }}"
     modify_account: "{{ modify_account }}"
     csr: "{{ output_dir }}/{{ certificate_name }}.csr"
     dest: "{{ output_dir }}/{{ certificate_name }}.pem"
@@ -123,6 +124,7 @@
     acme_directory: https://{{ acme_host }}:14000/dir
     validate_certs: no
     account_key_content: "{{ account_key_content }}"
+    account_uri: "{{ challenge_data.account_uri }}"
     modify_account: "{{ modify_account }}"
     csr: "{{ output_dir }}/{{ certificate_name }}.csr"
     dest: "{{ output_dir }}/{{ certificate_name }}.pem"


### PR DESCRIPTION
##### SUMMARY
This adds a new module parameter `account_uri` which allows to force the account URI to a specific value. This can be used to avoid accidental creation of a new account if an old account key is used, or using a wrong account (if a new, different account has been created with the old account key).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
acme_account
acme_certificate
acme_certificate_revoke

##### ANSIBLE VERSION
```
2.7.0
```
