### PR TITLE
VMware: Add cluster fact in vmware_vm_facts

### DIFF
--- a/test/integration/targets/vmware_vm_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vm_facts/tasks/main.yml
@@ -50,5 +50,13 @@
   assert:
     that:
       - "{{ item | basename in vm_facts_0001['virtual_machines'].keys()}}"
+      - "vm_facts_0001['virtual_machines'][item | basename]['cluster'] is defined"
+      - "vm_facts_0001['virtual_machines'][item | basename]['esxi_hostname'] is defined"
+      - "vm_facts_0001['virtual_machines'][item | basename]['guest_fullname'] is defined"
+      - "vm_facts_0001['virtual_machines'][item | basename]['ip_address'] is defined"
+      - "vm_facts_0001['virtual_machines'][item | basename]['mac_address'] is defined"
+      - "vm_facts_0001['virtual_machines'][item | basename]['power_state'] is defined"
+      - "vm_facts_0001['virtual_machines'][item | basename]['uuid'] is defined"
+      - "vm_facts_0001['virtual_machines'][item | basename]['vm_network'] is defined"
   with_items:
     - "{{ host_info_result['json'] }}"


### PR DESCRIPTION
##### SUMMARY
This fix adds an additional fact about cluster in VM facts.

Fixes: #44101

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
test/integration/targets/vmware_vm_facts/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```