### PR TITLE
fixed proxmox_kvm documentation

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -513,7 +513,7 @@ EXAMPLES = '''
     api_host    : helldorado
     name        : spynal
     node        : sabrewulf
-    cpu         : 8
+    cores       : 8
     memory      : 16384
     update      : yes
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The documentation defines `cpu` as:

```
default cpu type
default value: kvm64
```

Therefore defining `cpu` with `8` in the `examples` section makes no
sense. So changing to `cores`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
**proxmox_kvm**

##### ANSIBLE VERSION
not needed


##### ADDITIONAL INFORMATION
not needed
