### PR TITLE
Fix docker_container module list comparison

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1326,7 +1326,7 @@ class Container(DockerBaseClass):
                         self.log("comparing lists: %s" % key)
                         set_a = set(getattr(self.parameters, key))
                         set_b = set(value)
-                        match = (set_b >= set_a)
+                        match = (set_b == set_a)
                 elif isinstance(getattr(self.parameters, key), list) and not len(getattr(self.parameters, key)) \
                         and value is None:
                     # an empty list and None are ==


### PR DESCRIPTION
##### SUMMARY

Some configuration of a docker container is stored as a list. For example, Port bindings, Mounts and the Cmd. Adding to these lists or modifying the contents of an element will cause the container to be restarted and the changes will be applied as expected. However, removing elements (or reordering the Command string) will pass the match comparison and the container won't be restarted!

This is due to the `a <= b` comparison, which should be `a == b`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
ansible 2.6.2
  config file = /home/andrew/.ansible.cfg
  configured module search path = [u'/home/andrew/deploy/ansible/library']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

To reproduce, create playbook1.yml and playbook2.yml (see below)


First run `ansible-playbook playbook1.yml -vvvv` and you will have varnish deployed locally
then run `ansible-playbook playbook2.yml -vvvv`, which should redeploy varnish with less command options passed in. Unfortunately it doesn't. You can achieve the same incorrect result by creating published ports in playbook1 and attempting to remove them in playbook2.


Running with high verbosity we can see the invocation changes:
```
  invocation:                                                                                                                                                                                                      
    module_args:                                                                                                                                                                                                   
      api_version: auto                                                                                                                                                                                            
      auto_remove: false                                                                                                                                                                                           
      blkio_weight: null                                                                                                                                                                                           
      cacert_path: null                                                                                                                                                                                            
      capabilities: null                                                                                                                                                                                           
      cert_path: null                                                                                                                                                                                              
      cleanup: false                                                                                                                                                                                               
      command: -a :80 -T :6082 -f /etc/varnish/varnish4.vcl -S /etc/varnish/secret -p vcl_dir=/etc/varnish
```
But the task is `changed=false`
```
TASK [docker varnish started] *************************************************************************************************************************************************************************************
task path: /home/andrew/dockerinvestigation/playbook2.yml:9                                                                                                                                          
Friday 17 August 2018  13:27:43 +0000 (0:00:00.042)       0:00:00.042 *********                                                                                                                                    
Using module file /usr/lib/python2.7/dist-packages/ansible/modules/cloud/docker/docker_container.py                                                                                                                
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: andrew                                                                                                                                                           
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python && sleep 0'                                                                                                                                                           
ok: [localhost] => changed=false                                                                                                                                                                                   
  ansible_facts: 

```

And of course, since nothing has changed, the docker container hasn't been restarted and contains the old command
`docker inspect varnish`
```
            "Cmd": [
                "-a",
                ":80",
                "-T",
                ":6082",
                "-f",
                "/etc/varnish/varnish4.vcl",
                "-S",
                "/etc/varnish/secret",
                "-p",
                "vcl_dir=/etc/varnish",
                "-p",
                "vcc_allow_inline_c=true"
```

PLAYBOOKS:

`playbook1.yml`
```
---

- hosts: localhost
  gather_facts: false
  serial: 1

  tasks:

    - name: docker varnish started
      docker_container:
        name: varnish
        image: "eeacms/varnish"
        command: "-a :80 -T :6082 -f /etc/varnish/varnish4.vcl -S /etc/varnish/secret -p vcl_dir=/etc/varnish -p vcc_allow_inline_c=true"
        restart_policy: always
        state: started
```

`playbook2.yml`
```
---

- hosts: localhost
  gather_facts: false
  serial: 1

  tasks:

    - name: docker varnish started
      docker_container:
        name: varnish
        image: "eeacms/varnish"
        command: "-a :80 -T :6082 -f /etc/varnish/varnish4.vcl -S /etc/varnish/secret -p vcl_dir=/etc/varnish"
        restart_policy: always
        state: started
```


