### PR TITLE
Fix module name in error text at parse_xml filter

### DIFF
--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -324,7 +324,7 @@ def _extract_param(template, root, attrs, value):
 
 def parse_xml(output, tmpl):
     if not os.path.exists(tmpl):
-        raise AnsibleError('unable to locate parse_cli template: %s' % tmpl)
+        raise AnsibleError('unable to locate parse_xml template: %s' % tmpl)
 
     if not isinstance(output, string_types):
         raise AnsibleError('parse_xml works on string input, but given input of : %s' % type(output))

--- a/test/units/plugins/filter/test_network.py
+++ b/test/units/plugins/filter/test_network.py
@@ -76,7 +76,7 @@ class TestNetworkParseFilter(unittest.TestCase):
 
         with self.assertRaises(Exception) as e:
             parse_xml(output_xml, 'junk_path')
-        self.assertEqual("unable to locate parse_cli template: junk_path", str(e.exception))
+        self.assertEqual("unable to locate parse_xml template: junk_path", str(e.exception))
 
         with self.assertRaises(Exception) as e:
             parse_xml(output, spec_file_path)


### PR DESCRIPTION
##### SUMMARY
Looks like error text in parse_xml filter was not changed after copy-pasting parse_cli filter. This pull request fixes module name in error text.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
parse_xml filter

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = None
  configured module search path = ['/home/al/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.5/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
While doing task with parse_xml filter, before:
```
fatal: [host.name]: FAILED! => {"msg": "unable to locate parse_cli template: /path/to/non/existing/template.yml"}
```
After:
```
fatal: [host.name]: FAILED! => {"msg": "unable to locate parse_xml template: /path/to/non/existing/template.yml"}
```