### PR TITLE
Backport #38534 for 2.5 - Remove python-keyczar dependency

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -16,11 +16,8 @@ pkgdesc='Ansible IT Automation'
 arch=('any')
 url='https://www.ansible.com'
 license=('GPL3')
-depends=('python2' 'python2-paramiko' 'python2-jinja' 'python2-yaml')
-makedepends=('git' 'asciidoc' 'fakeroot')
-optdepends=('python2-pyasn1: needed for accelerated mode'
-            'python2-crypto: needed for accelerated mode'
-            'python2-keyczar: needed for accelerated mode')
+depends=('python2' 'python2-paramiko' 'python2-jinja' 'python2-yaml', 'python2-crypto')
+makedepends=('git' 'docutils' 'fakeroot')
 conflicts=('ansible')
 provides=('ansible')
 backup=('etc/ansible/ansible.cfg')

--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -25,7 +25,6 @@ BuildRequires: python26-setuptools
 Requires: python26-PyYAML
 Requires: python26-paramiko
 Requires: python26-jinja2
-Requires: python26-keyczar
 Requires: python26-httplib2
 Requires: python26-setuptools
 Requires: python26-six
@@ -59,7 +58,6 @@ BuildRequires: python-setuptools
 Requires: PyYAML
 Requires: python-paramiko
 Requires: python-jinja2
-Requires: python-keyczar
 Requires: python-httplib2
 Requires: python-setuptools
 Requires: python-six
@@ -71,7 +69,6 @@ BuildRequires: python-devel
 BuildRequires: python-setuptools
 Requires: python-paramiko
 Requires: python-jinja2
-Requires: python-keyczar
 Requires: python-yaml
 Requires: python-httplib2
 Requires: python-setuptools


### PR DESCRIPTION
##### SUMMARY

Backport of #38534 for Ansible 2.5

This helps out OpenStack folks building from the source RPM.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
`ansible.spec`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
Changes to `arch/PKGBUILD` were to resolve merge conflict. They match what is in `devel`.
