### PR TITLE
rds_instance_facts: use correct parameter in example

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds_instance_facts.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance_facts.py
@@ -40,7 +40,7 @@ extends_documentation_fragment:
 EXAMPLES = '''
 # Get facts about an instance
 - rds_instance_facts:
-    name: new-database
+    db_instance_identifier: new-database
   register: new_database_facts
 
 # Get all RDS instances


### PR DESCRIPTION
The example referenced `name:` which is not a supported parameter.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
