### PR TITLE
Addresses comments in #38971

### DIFF
--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -170,8 +170,21 @@ def do_ini(module, filename, section=None, option=None, value=None,
         ini_lines[-1] += '\n'
         changed = True
 
-    # append a fake section line to simplify the logic
+    # append fake section lines to simplify the logic
+    # At top:
+    # Fake random section to do not match any other in the file
+    # Using commit hash as fake section name
+    fake_section_name = "ad01e11446efb704fcdbdb21f2c43757423d91c5"
+
+    # Insert it at the beginning
+    ini_lines.insert(0, '[%s]' % fake_section_name)
+
+    # At botton:
     ini_lines.append('[')
+
+    # If no section is defined, fake section is used
+    if not section:
+        section = fake_section_name
 
     within_section = not section
     section_start = 0
@@ -240,6 +253,7 @@ def do_ini(module, filename, section=None, option=None, value=None,
                         break
 
     # remove the fake section line
+    del ini_lines[0]
     del ini_lines[-1:]
 
     if not within_section and option and state == 'present':

--- a/test/integration/targets/ini_file/tasks/main.yml
+++ b/test/integration/targets/ini_file/tasks/main.yml
@@ -61,11 +61,11 @@
       - result2.changed == False
       - result2.msg == 'OK'
 
-- name: Ensure "hate=coke" is in section "[drinks]"
+- name: Ensure "beverage=coke" is in section "[drinks]"
   ini_file:
     path: "{{ output_file }}"
     section: drinks
-    option: hate
+    option: beverage
     value: coke
   register: result3
 
@@ -75,7 +75,7 @@
 
       [drinks]
       fav = lemonade
-      hate = coke
+      beverage = coke
     content3: "{{ lookup('file', output_file) }}"
 
 - name: assert 'changed' is true and content is OK
@@ -85,11 +85,11 @@
       - result3.msg == 'option added'
       - content3 == expected3
 
-- name: Remove option "hate=coke"
+- name: Remove option "beverage=coke"
   ini_file:
     path: "{{ output_file }}"
     section: drinks
-    option: hate
+    option: beverage
     state: absent
   register: result4
 
@@ -258,17 +258,17 @@
     dest: "{{ output_file }}"
     force: yes
 
-- name: Ensure "hate=coke" is created within no section
+- name: Ensure "beverage=coke" is created within no section
   ini_file:
     section:
     path: "{{ output_file }}"
-    option: hate
+    option: beverage
     value: coke
   register: result11
 
 - name: set expected content and get current ini file content
   set_fact:
-    expected11: "hate = coke"
+    expected11: "beverage = coke"
     content11: "{{ lookup('file', output_file) }}"
 
 - name: assert 'changed' is true and content is OK (no section)
@@ -278,17 +278,17 @@
       - result11.msg == 'option added'
       - content11 == expected11
 
-- name: Ensure "hate=coke" is modified as "hate=water" within no section
+- name: Ensure "beverage=coke" is modified as "beverage=water" within no section
   ini_file:
     path: "{{ output_file }}"
-    option: hate
+    option: beverage
     value: water
     section:
   register: result12
 
 - name: set expected content and get current ini file content
   set_fact:
-    expected12: "hate = water"
+    expected12: "beverage = water"
 
     content12: "{{ lookup('file', output_file) }}"
 
@@ -299,11 +299,11 @@
       - result12.msg == 'option changed'
       - content12 == expected12
 
-- name: remove option 'hate' within no section
+- name: remove option 'beverage' within no section
   ini_file:
     section:
     path: "{{ output_file }}"
-    option: hate
+    option: beverage
     state: absent
   register: result13
 
@@ -324,7 +324,7 @@
       ini_file:
         path: "{{ output_file }}"
         section: drinks
-        option: hate
+        option: beverage
         value: water
     - name: Add option without section
       ini_file:
@@ -339,7 +339,7 @@
       like = tea
 
       [drinks]
-      hate = water
+      beverage = water
     content14: "{{ lookup('file', output_file) }}"
 
 - name: Verify content of ini file is as expected

--- a/test/integration/targets/ini_file/tasks/main.yml
+++ b/test/integration/targets/ini_file/tasks/main.yml
@@ -251,3 +251,92 @@
       - result10.changed == True
       - result10.msg == 'option changed'
       - content10 == expected10
+
+- name: Ensure "hate=coke" is created within no section
+  ini_file:
+    section:
+    path: "{{ output_file }}"
+    option: hate
+    value: coke
+  register: result11
+
+- name: set expected content and get current ini file content
+  set_fact:
+    expected11: "hate = coke"
+    content11: "{{ lookup('file', output_file) }}"
+
+- name: assert 'changed' is true and content is OK (no section)
+  assert:
+    that:
+      - result11 is changed
+      - result11.msg == 'option added'
+      - content11 == expected11
+
+- name: Ensure "hate=coke" is modified as "hate=water" within no section
+  ini_file:
+    path: "{{ output_file }}"
+    option: hate
+    value: water
+    section:
+  register: result12
+
+- name: set expected content and get current ini file content
+  set_fact:
+    expected12: "hate = water"
+
+    content12: "{{ lookup('file', output_file) }}"
+
+- name: assert 'changed' is true and content is OK (no section)
+  assert:
+    that:
+      - result12 is changed
+      - result12.msg == 'option changed'
+      - content12 == expected12
+
+- name: remove option 'hate' within no section
+  ini_file:
+    section:
+    path: "{{ output_file }}"
+    option: hate
+    state: absent
+  register: result13
+
+- name: get current ini file content
+  set_fact:
+    content13: "{{ lookup('file', output_file) }}"
+
+- name: assert changed (no section)
+  assert:
+    that:
+      - result13 is changed
+      - result13.msg == 'option changed'
+      - content13 == ""
+
+- name: Check add option without section before existing section
+  block:
+    - name: Add option with section
+      ini_file:
+        path: "{{ output_file }}"
+        section: drinks
+        option: hate
+        value: water
+    - name: Add option without section
+      ini_file:
+        path: "{{ output_file }}"
+        section:
+        option: like
+        value: tea
+
+- name: set expected content and get current ini file content
+  set_fact:
+    expected14: |-
+      like = tea
+
+      [drinks]
+      hate = water
+    content14: "{{ lookup('file', output_file) }}"
+
+- name: Verify content of ini file is as expected
+  assert:
+    that:
+      - content14 == expected14

--- a/test/integration/targets/ini_file/tasks/main.yml
+++ b/test/integration/targets/ini_file/tasks/main.yml
@@ -252,6 +252,12 @@
       - result10.msg == 'option changed'
       - content10 == expected10
 
+- name: Clean test file
+  copy:
+    content: ""
+    dest: "{{ output_file }}"
+    force: yes
+
 - name: Ensure "hate=coke" is created within no section
   ini_file:
     section:


### PR DESCRIPTION
##### SUMMARY
Fixes PR #38971 

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME

- ini_file

##### ANSIBLE VERSION

```
ansible --version
ansible 2.6.3
  config file = /Users/codylane/prj/ansible/codylane.splunk/tests/ansible.cfg
  configured module search path = [u'/Users/codylane/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/codylane/.pyenv/versions/2.7.15/envs/codylane.splunk-2.7.15/lib/python2.7/site-packages/ansible
  executable location = /Users/codylane/.pyenv/versions/codylane.splunk-2.7.15/bin/ansible
  python version = 2.7.15 (default, Jun 26 2018, 23:55:05) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
