### PR TITLE
Revert "Disabled failing k8s integration test."

### DIFF
--- a/test/integration/targets/k8s/aliases
+++ b/test/integration/targets/k8s/aliases
@@ -1,3 +1,2 @@
 cloud/openshift
 shippable/cloud/group1
-disabled


### PR DESCRIPTION
This reverts commit 9cc16ca9d8c5f8a0b577108b9363998a29d2c9f8.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Improper pinning in the openshift client caused a newer, incompatible version of the kubernetes package to be pulled in. A new version of the openshift client (0.6.3) has been added which fixes this.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
closes #44328 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
k8s

@mattclay 