### PR TITLE
Scaleway inventory: allows to connect via private IP

### DIFF
--- a/lib/ansible/plugins/inventory/scaleway.py
+++ b/lib/ansible/plugins/inventory/scaleway.py
@@ -166,7 +166,6 @@ class InventoryModule(BaseInventoryPlugin):
             "organization",
             "state",
             "hostname",
-            "state"
         )
         for attribute in targeted_attributes:
             self.inventory.set_variable(host, attribute, server_info[attribute])


### PR DESCRIPTION
##### SUMMARY
`ansible_host` value was hardcoded with public IPv4 address.

With this PR:
* private IPv4 or public IPv6 can be used
* by default `ansible_host` isn't defined (then `inventory_hostname` is used, meaning value of `hostnames` parameter)
* other host variables can be defined, values of these variables are templates which can reference data send by Scaleway API:

    ```yaml
    plugin: scaleway
    hostnames:
      - hostname
    variables:
      ansible_host: private_ip
      state: state
      image: image.name
    regions:
      - ams1
    ```

    inventory will look like:

    ```json
        {
            "_meta": {
                "hostvars": {
                    "testhost": {
                        "ansible_host": "10.1.1.1",
                        "arch": "x86_64",
                        "commercial_type": "START1-M",
                        "hostname": "testhost",
                        "id": "af669464-0c74-4c89-8573-9fe763028448",
                        "image": "CentOS 7.4",
                        "organization": "2cc9a115-380d-4ac0-ba4b-8947eee71325",
                        "public_ipv4": "163.172.1.1",
                        "public_ipv6": "2001:bc8::1",
                        "state": "running",
                        "tags": [
                            "testtag"
                        ]
                    }
                }
            },
            [...]
        }
    ```

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/scaleway.py

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel bb553f138b) last updated 2018/08/15 01:37:30 (GMT +200)
```