### PR TITLE
fix transport option default value of f5 modules docs

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/f5.py
+++ b/lib/ansible/utils/module_docs_fragments/f5.py
@@ -109,7 +109,7 @@ options:
         choices:
             - rest
             - cli
-        default: cli
+        default: rest
 
 notes:
   - For more information on using Ansible to manage F5 Networks devices see U(https://www.ansible.com/integrations/networks/f5).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

fix `transport` option (under `provider`) default value of f5 modules docs.
from `cli` to `rest` like `transport` option of top level


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
f5 modules docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
- case1: provider > trasport: cli

```yaml
- hosts: 18.191.157.xxx 
  gather_facts: no
  connection: local

  tasks:
    - name: test
      bigip_command:
        commands: show sys version
        provider:
          server: "{{ inventory_hostname }}"
          password: testpass
          user: testuser
          validate_certs: no
          transport: cli    # here
      delegate_to: localhost
```

tcpdump results:
```
[vagrant@centos7 ~]$ sudo tcpdump host 18.191.157.xxx  and port 22
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
02:04:21.208975 IP centos7.52106 > ec2-18-191-157-xxx.us-east-2.compute.amazonaws.com.ssh: Flags [S], seq 763655529, win 29200, options [mss 1460,sackOK,TS val 312049215 ecr 0,nop,wscale 7], length 0
02:04:22.211249 IP centos7.52106 > ec2-18-191-157-xxx.us-east-2.compute.amazonaws.com.ssh: Flags [S], seq 763655529, win 29200, options [mss 1460,sackOK,TS val 312050218 ecr 0,nop,wscale 7], length 0
```
ssh packets are appeared.



- case2: default

```yaml
---
- hosts: 18.191.157.xxx 
  gather_facts: no
  connection: local

  tasks:
    - name: test
      bigip_command:
        commands: show sys version
        provider:
          server: "{{ inventory_hostname }}"
          password: testpass
          user: testuser
          validate_certs: no
      delegate_to: localhost
```

tcpdump results:
```
[vagrant@centos7 ~]$ sudo tcpdump host 18.191.157.xx  and port 22
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
```
ssh packets are NOT appeared.

I noticed bellow code:
https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/action/bigip.py

```python
class ActionModule(_ActionModule):

    def run(self, tmp=None, task_vars=None):
        socket_path = None
        transport = 'rest'

        if self._play_context.connection == 'network_cli':
            provider = self._task.args.get('provider', {})
            if any(provider.values()):
                display.warning("'provider' is unnecessary when using 'network_cli' and will be ignored")
        elif self._play_context.connection == 'local':
            provider = load_provider(f5_provider_spec, self._task.args)
            transport = provider['transport'] or transport
```



