### PR TITLE
Renames the security_port_list module

### DIFF
--- a/lib/ansible/modules/network/f5/_bigip_security_port_list.py
+++ b/lib/ansible/modules/network/f5/_bigip_security_port_list.py
@@ -1,0 +1,1 @@
+bigip_firewall_port_list.py

--- a/lib/ansible/modules/network/f5/bigip_firewall_port_list.py
+++ b/lib/ansible/modules/network/f5/bigip_firewall_port_list.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: bigip_security_port_list
+module: bigip_firewall_port_list
 short_description: Manage port lists on BIG-IP AFM
 description:
   - Manages the AFM port lists on a BIG-IP. This module can be used to add
@@ -62,7 +62,7 @@ author:
 
 EXAMPLES = r'''
 - name: Create a simple port list
-  bigip_security_port_list:
+  bigip_firewall_port_list:
     name: foo
     ports:
       - 80
@@ -74,7 +74,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 
 - name: Override the above list of ports with a new list
-  bigip_security_port_list:
+  bigip_firewall_port_list:
     name: foo
     ports:
       - 3389
@@ -87,7 +87,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 
 - name: Create port list with series of ranges
-  bigip_security_port_list:
+  bigip_firewall_port_list:
     name: foo
     port_ranges:
       - 25-30
@@ -100,7 +100,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 
 - name: Use multiple types of port arguments
-  bigip_security_port_list:
+  bigip_firewall_port_list:
     name: foo
     port_ranges:
       - 25-30
@@ -116,7 +116,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 
 - name: Remove port list
-  bigip_security_port_list:
+  bigip_firewall_port_list:
     name: foo
     password: secret
     server: lb.mydomain.com
@@ -125,7 +125,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 
 - name: Create port list from a file with one port per line
-  bigip_security_port_list:
+  bigip_firewall_port_list:
     name: lot-of-ports
     ports: "{{ lookup('file', 'my-large-port-list.txt').split('\n') }}"
     password: secret

--- a/test/units/modules/network/f5/test_bigip_firewall_port_list.py
+++ b/test/units/modules/network/f5/test_bigip_firewall_port_list.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright: (c) 2017, F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+import sys
+
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import Mock
+from ansible.compat.tests.mock import patch
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from library.modules.bigip_firewall_port_list import ApiParameters
+    from library.modules.bigip_firewall_port_list import ModuleParameters
+    from library.modules.bigip_firewall_port_list import ModuleManager
+    from library.modules.bigip_firewall_port_list import ArgumentSpec
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
+    from test.unit.modules.utils import set_module_args
+except ImportError:
+    try:
+        from ansible.modules.network.f5.bigip_firewall_port_list import ApiParameters
+        from ansible.modules.network.f5.bigip_firewall_port_list import ModuleParameters
+        from ansible.modules.network.f5.bigip_firewall_port_list import ModuleManager
+        from ansible.modules.network.f5.bigip_firewall_port_list import ArgumentSpec
+        from ansible.module_utils.network.f5.common import F5ModuleError
+        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+        from units.modules.utils import set_module_args
+    except ImportError:
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+
+fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+fixture_data = {}
+
+
+def load_fixture(name):
+    path = os.path.join(fixture_path, name)
+
+    if path in fixture_data:
+        return fixture_data[path]
+
+    with open(path) as f:
+        data = f.read()
+
+    try:
+        data = json.loads(data)
+    except Exception:
+        pass
+
+    fixture_data[path] = data
+    return data
+
+
+class TestParameters(unittest.TestCase):
+    def test_module_parameters(self):
+        args = dict(
+            name='foo',
+            description='this is a description',
+            ports=[1, 2, 3, 4],
+            port_ranges=['10-20', '30-40', '50-60'],
+            port_lists=['/Common/foo', 'foo']
+        )
+
+        p = ModuleParameters(params=args)
+        assert p.name == 'foo'
+        assert p.description == 'this is a description'
+        assert len(p.ports) == 4
+        assert len(p.port_ranges) == 3
+        assert len(p.port_lists) == 2
+
+    def test_api_parameters(self):
+        args = load_fixture('load_security_port_list_1.json')
+
+        p = ApiParameters(params=args)
+        assert len(p.ports) == 4
+        assert len(p.port_ranges) == 3
+        assert len(p.port_lists) == 1
+        assert sorted(p.ports) == [1, 2, 3, 4]
+        assert sorted(p.port_ranges) == ['10-20', '30-40', '50-60']
+        assert p.port_lists[0] == '/Common/_sys_self_allow_tcp_defaults'
+
+
+class TestManager(unittest.TestCase):
+
+    def setUp(self):
+        self.spec = ArgumentSpec()
+
+    def test_create(self, *args):
+        set_module_args(dict(
+            name='foo',
+            description='this is a description',
+            ports=[1, 2, 3, 4],
+            port_ranges=['10-20', '30-40', '50-60'],
+            port_lists=['/Common/foo', 'foo'],
+            password='password',
+            server='localhost',
+            user='admin'
+        ))
+
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode
+        )
+        mm = ModuleManager(module=module)
+
+        # Override methods to force specific logic in the module to happen
+        mm.exists = Mock(side_effect=[False, True])
+        mm.create_on_device = Mock(return_value=True)
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert 'ports' in results
+        assert 'port_lists' in results
+        assert 'port_ranges' in results
+        assert len(results['ports']) == 4
+        assert len(results['port_ranges']) == 3
+        assert len(results['port_lists']) == 2
+        assert results['description'] == 'this is a description'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Renames the module by adding a symlink, introducing the new module,
and naming the symlink so that it identifies as deprecated.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
bigip_security_port_list

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.6 (default, Jul 17 2018, 11:12:33) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
