### PR TITLE
Deal with case insensitivy in cloudflare_dns module

### DIFF
--- a/lib/ansible/modules/net_tools/cloudflare_dns.py
+++ b/lib/ansible/modules/net_tools/cloudflare_dns.py
@@ -322,6 +322,12 @@ from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.urls import fetch_url
 
 
+def lowercase_string(param):
+    if not isinstance(param, str):
+        return param
+    return param.lower()
+
+
 class CloudflareAPI(object):
 
     cf_api_endpoint = 'https://api.cloudflare.com/client/v4'
@@ -337,11 +343,11 @@ class CloudflareAPI(object):
         self.key_tag = module.params['key_tag']
         self.port = module.params['port']
         self.priority = module.params['priority']
-        self.proto = module.params['proto']
+        self.proto = lowercase_string(module.params['proto'])
         self.proxied = module.params['proxied']
         self.selector = module.params['selector']
-        self.record = module.params['record']
-        self.service = module.params['service']
+        self.record = lowercase_string(module.params['record'])
+        self.service = lowercase_string(module.params['service'])
         self.is_solo = module.params['solo']
         self.state = module.params['state']
         self.timeout = module.params['timeout']
@@ -349,13 +355,16 @@ class CloudflareAPI(object):
         self.type = module.params['type']
         self.value = module.params['value']
         self.weight = module.params['weight']
-        self.zone = module.params['zone']
+        self.zone = lowercase_string(module.params['zone'])
 
         if self.record == '@':
             self.record = self.zone
 
         if (self.type in ['CNAME', 'NS', 'MX', 'SRV']) and (self.value is not None):
-            self.value = self.value.rstrip('.')
+            self.value = self.value.rstrip('.').lower()
+
+        if (self.type == 'AAAA') and (self.value is not None):
+            self.value = self.value.lower()
 
         if (self.type == 'SRV'):
             if (self.proto is not None) and (not self.proto.startswith('_')):


### PR DESCRIPTION
##### SUMMARY

Cloudflare's DNS API deals with the case insensitivy of DNS names and
IPv6 addresses by forcing them into lower case. To properly be able to
detect changes the Ansible module needs to behave accordingly.

To what extent the API expects sent DNS names to be lower case varies
between record types. Yet, since sending lower case always works, and
since we always get lower case back, it feels cleanest to use lower
case for all DNS names.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudflare_dns

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel 3a15b6512c) last updated 2018/08/19 14:28:18 (GMT +200)
  config file = /home/andreas/labs/ansible/ansible.cfg
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/labs/ansible/devel/lib/ansible
  executable location = /home/andreas/labs/ansible/devel/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION

Below is an example of play where the second round would have failed.

```yaml
---

- hosts: localhost
  vars:
    zone_name: example.net
    record_name: FOO
    record_type: DS
    record_tag: 47809
    record_alg: 8
    record_hash_type: 2
    record_hash_value: 57CC30B3FE75B0FEAD6A899CBAC612BF0D0E39537CCE0511ADBA2E380FEBDD77
  tasks:
    - name: Round one
      cloudflare_dns:
        zone: "{{ zone_name }}"
        record: "{{ record_name }}"
        type: "{{ record_type }}"
        key_tag: "{{ record_tag }}"
        algorithm: "{{ record_alg }}"
        hash_type: "{{ record_hash_type }}"
        value: "{{ record_hash_value }}"
        account_email: "{{ account_mail }}"
        account_api_token: "{{ account_token }}"

    - name: Round two
      cloudflare_dns:
        zone: "{{ zone_name }}"
        record: "{{ record_name }}"
        type: "{{ record_type }}"
        key_tag: "{{ record_tag }}"
        algorithm: "{{ record_alg }}"
        hash_type: "{{ record_hash_type }}"
        value: "{{ record_hash_value }}"
        account_email: "{{ account_mail }}"
        account_api_token: "{{ account_token }}"
```

In the first round we ask for the existence of any DS records named `FOO.example.net`, get told that no such records exists, ask to create one, which ends up being written down as `foo.example.net`.

In the second round we yet again ask for the existence of any DS records named `FOO.example.net`, get told that no such records exists, ask to create one, and fail due to the existing identical DS record `foo.example.net`. The API response being as follows.

```
API bad request; Status: 400; Method: POST: Call: /zones/.../dns_records; Error details: code: 81057, error: The record already exists.; 
```