### PR TITLE
Fix for ovirt_disk Can't Update Disk Name Independently (#44371)

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -513,6 +513,7 @@ class DisksModule(BaseModule):
 
     def _update_check(self, entity):
         return (
+            equal(self._module.params.get('name'), entity.name) and
             equal(self._module.params.get('description'), entity.description) and
             equal(self.param('quota_id'), getattr(entity.quota, 'id', None)) and
             equal(convert_to_bytes(self._module.params.get('size')), entity.provisioned_size) and

--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -181,6 +181,13 @@ EXAMPLES = '''
     format: cow
     interface: virtio
 
+# Change Disk Name
+- ovirt_disk:
+    id: 00000000-0000-0000-0000-000000000000
+    storage_domain: data
+    name: "new disk name"
+    vm_name: rhel7
+
 # Upload local image to disk and attach it to vm:
 # Since Ansible 2.3
 - ovirt_disk:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding name parameter to _update_check function. This way the ovirt_disk module can update the name parameter of a disk independent of other changes.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
ovirt_disk

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/chris/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
One line fix to resolve issue #44371 