### PR TITLE
Add extended error message. issue#: 44340 

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -752,7 +752,7 @@ class TgzArchive(object):
             return False, 'Command "%s" could not handle archive.' % self.cmd_path
         # Errors and no files in archive assume that we weren't able to
         # properly unarchive it
-        return False, 'Command "%s" found no files in archive.' % self.cmd_path
+        return False, 'Command "%s" found no files in archive. Unarchiving empty archive file is not supported yet.' % self.cmd_path
 
 
 # Class to handle tar files that aren't compressed


### PR DESCRIPTION
Fixes #44340, where a user is trying to unarchive an empty archive. This commit adds an extended message of not supporting unarchiving of empty archive files.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
