### PR TITLE
Fix bug of interface-mode in Junos

### DIFF
--- a/lib/ansible/modules/network/junos/junos_l2_interface.py
+++ b/lib/ansible/modules/network/junos/junos_l2_interface.py
@@ -48,7 +48,7 @@ options:
     description:
       - Native VLAN to be configured in trunk port. The value of C(native_vlan)
         should be vlan id.
-  enhenced_layer:
+  enhanced_layer:
     description:
       - True if your device has Enhanced Layer 2 Software (ELS).
     default: True
@@ -178,7 +178,7 @@ def main():
         trunk_vlans=dict(type='list'),
         unit=dict(default=0, type='int'),
         description=dict(),
-        enhenced_layer=dict(default=True, type='bool'),
+        enhanced_layer=dict(default=True, type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
         active=dict(default=True, type='bool')
     )
@@ -243,7 +243,7 @@ def main():
         validate_param_values(module, param_to_xpath_map, param=item)
 
         param_to_xpath_map['mode']['xpath'] = \
-            'interface-mode' if param['enhenced_layer'] else 'port-mode'
+            'interface-mode' if param['enhanced_layer'] else 'port-mode'
 
         want = map_params_to_obj(module, param_to_xpath_map, param=item)
         requests.append(map_obj_to_ele(module, want, top, param=item))

--- a/lib/ansible/modules/network/junos/junos_l2_interface.py
+++ b/lib/ansible/modules/network/junos/junos_l2_interface.py
@@ -48,6 +48,12 @@ options:
     description:
       - Native VLAN to be configured in trunk port. The value of C(native_vlan)
         should be vlan id.
+  enhenced_layer:
+    description:
+      - True if your device has Enhanced Layer 2 Software (ELS).
+    default: True
+    type: bool
+    version_added: "2.7"
   unit:
     description:
       - Logical interface number. Value of C(unit) should be of type
@@ -172,6 +178,7 @@ def main():
         trunk_vlans=dict(type='list'),
         unit=dict(default=0, type='int'),
         description=dict(),
+        enhenced_layer=dict(default=True, type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
         active=dict(default=True, type='bool')
     )
@@ -234,6 +241,9 @@ def main():
         item = param.copy()
 
         validate_param_values(module, param_to_xpath_map, param=item)
+
+        param_to_xpath_map['mode']['xpath'] = \
+            'interface-mode' if param['enhenced_layer'] else 'port-mode'
 
         want = map_params_to_obj(module, param_to_xpath_map, param=item)
         requests.append(map_obj_to_ele(module, want, top, param=item))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes bug #43867

I think that the fastest way to fix this bug is to add additional option `enhenced_layer = True`.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
junos_l2_interface


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = /project/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jul 31 2018, 23:03:52) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

I have test this code with Juniper EX3300 and EX4300.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
