### PR TITLE
backport: module_utils_service: Fix glob path of rc.d

### DIFF
--- a/changelogs/fragments/service.yml
+++ b/changelogs/fragments/service.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- Fix glob path of rc.d
+  Some distribtuions like SUSE has the rc%.d directories under /etc/init.d

--- a/lib/ansible/module_utils/service.py
+++ b/lib/ansible/module_utils/service.py
@@ -48,8 +48,12 @@ def sysv_is_enabled(name, runlevel=None):
     :kw runlevel: runlevel to check (default: None)
     '''
     if runlevel:
+        if not os.path.isdir('/etc/rc0.d/'):
+            return bool(glob.glob('/etc/init.d/rc%s.d/S??%s' % (runlevel, name)))
         return bool(glob.glob('/etc/rc%s.d/S??%s' % (runlevel, name)))
     else:
+        if not os.path.isdir('/etc/rc0.d/'):
+            return bool(glob.glob('/etc/init.d/rc?.d/S??%s' % name))
         return bool(glob.glob('/etc/rc?.d/S??%s' % name))
 
 


### PR DESCRIPTION
Backport of #43018 for Ansible 2.6
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Some distribtuions like SUSE has the rc%.d directories under /etc/init.d

Quote of /etc/rc.d.README on SLES11.

"Some people expect the system startup scripts in /etc/rc.d/.
We use a slightly different structure for better LSB compliance."

(cherry picked from commit c7d0e3b1666ff96eb0397bdf8c3bd3d144bbd7b0)
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
