### PR TITLE
Fix verify_file check in Scaleway dynamic inventory

### DIFF
--- a/lib/ansible/plugins/inventory/scaleway.py
+++ b/lib/ansible/plugins/inventory/scaleway.py
@@ -155,9 +155,6 @@ extractors = {
 class InventoryModule(BaseInventoryPlugin):
     NAME = 'scaleway'
 
-    def verify_file(self, path):
-        return "scaleway" in path
-
     def _fill_host_variables(self, host, server_info):
         targeted_attributes = (
             "arch",


### PR DESCRIPTION
##### SUMMARY

Fix verify_file check in Scaleway dynamic inventory

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- scaleway_dynamic_inventory

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (verify_file 3157bcf7c2) last updated 2018/08/20 12:19:08 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

