### PR TITLE
facts: suse: fix SLES4SAP12 detection

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -269,6 +269,10 @@ class DistributionFiles:
                     else:
                         release = "0"  # no minor number, so it is the first release
                     suse_facts['distribution_release'] = release
+                # Starting with SLES4SAP12 SP3 NAME reports 'SLES' instead of 'SLES_SAP'
+                # According to SuSe Support (SR101182877871) we should use the CPE_NAME to detect SLES4SAP
+                if re.search("^CPE_NAME=.*sles_sap.*$", line):
+                    suse_facts['distribution'] = 'SLES_SAP'
         elif path == '/etc/SuSE-release':
             if 'open' in data.lower():
                 data = data.splitlines()

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -351,7 +351,64 @@ CPE_NAME="cpe:/o:suse:sles:12:sp1"
             "distribution_version": "12.1",
         }
     },
-
+    {
+        "name": "SLES4SAP 12 SP2",
+        "input": {
+            "/etc/SuSE-release": """
+SUSE Linux Enterprise Server 12 (x86_64)
+VERSION = 12
+PATCHLEVEL = 2
+# This file is deprecated and will be removed in a future service pack or release.
+# Please check /etc/os-release for details about this release.
+""",
+            "/etc/os-release": """
+NAME="SLES_SAP"
+VERSION="12-SP2"
+VERSION_ID="12.2"
+PRETTY_NAME="SUSE Linux Enterprise Server for SAP Applications 12 SP2"
+ID="sles_sap"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles_sap:12:sp2"
+            """,
+        },
+        "platform.dist": ['SuSE', '12', 'x86_64'],
+        "result":{
+            "distribution": "SLES_SAP",
+            "distribution_major_version": "12",
+            "distribution_release": "2",
+            "os_family": "Suse",
+            "distribution_version": "12.2",
+        }
+    },
+    {
+        "name": "SLES4SAP 12 SP3",
+        "input": {
+            "/etc/SuSE-release": """
+SUSE Linux Enterprise Server 12 (x86_64)
+VERSION = 12
+PATCHLEVEL = 3
+# This file is deprecated and will be removed in a future service pack or release.
+# Please check /etc/os-release for details about this release.
+""",
+            "/etc/os-release": """
+NAME="SLES"
+VERSION="12-SP3"
+VERSION_ID="12.3"
+PRETTY_NAME="SUSE Linux Enterprise Server 12 SP3"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles_sap:12:sp3"
+            """,
+        },
+        "platform.dist": ['SuSE', '12', 'x86_64'],
+        "result":{
+            "distribution": "SLES_SAP",
+            "distribution_major_version": "12",
+            "distribution_release": "3",
+            "os_family": "Suse",
+            "distribution_version": "12.3",
+        }
+    },
     {
         "name": "Debian stretch/sid",
         "input": {


### PR DESCRIPTION
##### SUMMARY
Starting with SLES4SAP12 SP3 /etc/os-release NAME reports 'SLES' instead of 'SLES_SAP'.
According to SuSe Support (SR101182877871) we should use the CPE_NAME to detect SLES4SAP.


Before this patch we get this:
````
:~> ansible -i "sles4sap-sp2," -m setup -a filter=ansible_distribution all
sles4sap-sp2 | SUCCESS => {"ansible_facts": {"ansible_distribution": "SLES_SAP"}, "changed": false}

:~> ansible -i "sles4sap-sp3," -m setup -a filter=ansible_distribution all
sles4sap-sp3 | SUCCESS => {"ansible_facts": {"ansible_distribution": "SLES"}, "changed": false}
````

After this patch we get this:
````
:~> ansible -i "sles4sap-sp2," -m setup -a filter=ansible_distribution all
sles4sap-sp2 | SUCCESS => {"ansible_facts": {"ansible_distribution": "SLES_SAP"}, "changed": false}

:~> ansible -i "sles4sap-sp3," -m setup -a filter=ansible_distribution all
sles4sap-sp3 | SUCCESS => {"ansible_facts": {"ansible_distribution": "SLES_SAP"}, "changed": false}
````

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
facts

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel 03a19b239b) last updated 2018/08/20 12:53:08 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/buss18/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/buss18/upstream/ansible/lib/ansible
  executable location = /home/buss18/upstream/ansible/bin/ansible
  python version = 2.6.6 (r266:84292, Aug 18 2016, 15:13:37) [GCC 4.4.7 20120313 (Red Hat 4.4.7-17)]
```