### PR TITLE
NCLU: Add example for configuration item deletion

### DIFF
--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -106,6 +106,11 @@ EXAMPLES = '''
     atomic: true
     description: "Ansible - add swp1"
 
+- name: Remove IP address from interface swp1
+  nclu:
+    commands:
+        - del int swp1 ip address 1.1.1.1/24
+
 - name: Configure BGP AS and add 2 EBGP neighbors using BGP Unnumbered
   nclu:
     commands:


### PR DESCRIPTION
##### SUMMARY
This change adds an example for deleting a configuration item (in this case, an IP address on an interface) to nclu.py

Referring to ansible/community#311

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
NCLU (Cumulus) 
##### ANSIBLE VERSION
```
ansible 2.6.1
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.4 (default, Apr  6 2018, 05:23:32) [GCC 6.4.0]
```


##### ADDITIONAL INFORMATION
Playbook output:
```
PLAY [Cumulus test playbook] ****************************************************************************************

TASK [Delete address from interface swp1] ***************************************************************************
changed: [Cumulus-1]

PLAY RECAP **********************************************************************************************************
Cumulus-1                  : ok=1    changed=1    unreachable=0    failed=0   
```

Changes on the device:
```
cumulus@Cumulus-1:~$ net show int swp1
    Name    MAC                Speed    MTU    Mode
--  ------  -----------------  -------  -----  ------------
UP  swp1    0c:a6:d0:c3:cf:01  1G       1500   Interface/L3

IP Details
-------------------------  ----------
IP:                        1.1.1.1/24
IP:                        2.2.2.2/24
IP Neighbor(ARP) Entries:  0

Counters      TX    RX
----------  ----  ----
unicast        0     0
broadcast      0     0
multicast      0     0
errors         0     0

cumulus@Cumulus-1:~$ # Playbook runs
cumulus@Cumulus-1:~$ net pending 
--- /etc/network/interfaces	2018-08-20 10:58:52.670866292 +0000
+++ /var/run/nclu/iface/interfaces.tmp	2018-08-20 11:00:41.755867748 +0000
@@ -7,12 +7,11 @@
 auto lo
 iface lo inet loopback
 
 # The primary network interface
 auto eth0
 iface eth0
     address 10.0.0.2/24
 
 auto swp1
 iface swp1
-    address 1.1.1.1/24
     address 2.2.2.2/24



net add/del commands since the last 'net commit'
================================================


User     Timestamp                   Command
-------  --------------------------  --------------------------------------
cumulus  2018-08-20 10:59:27.925331  net del int swp1 ip address 1.1.1.1/24
```