### PR TITLE
Fix pip idempotence in check mode

### DIFF
--- a/changelogs/fragments/pip-fix-idempotence-in-check-mode.yaml
+++ b/changelogs/fragments/pip-fix-idempotence-in-check-mode.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "pip - idempotence in check mode now works correctly."

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -213,6 +213,27 @@
     that:
       - "not (q_check_mode is changed)"
 
+# Case with package name that has a different package name case and an
+# underscore instead of a hyphen
+- name: check for Junit-XML package
+  pip:
+    name: Junit-XML
+    virtualenv: "{{ output_dir }}/pipenv"
+    state: present
+
+- name: check for Junit-XML package in check_mode
+  pip:
+    name: Junit-XML
+    virtualenv: "{{ output_dir }}/pipenv"
+    state: present
+  check_mode: True
+  register: diff_case_check_mode
+
+- name: make sure Junit-XML in check_mode doesn't report changed
+  assert:
+    that:
+      - "diff_case_check_mode is not changed"
+
 # ansible#23204
 - name: ensure is a fresh virtualenv
   file:


### PR DESCRIPTION
##### SUMMARY
PIP package names must be case insensitive, and must consider hyphens and underscores to be equivalent (https://www.python.org/dev/peps/pep-0426/#name), because of this the module didn't work correctly in check mode. For example if the passed package name had a different case or an underscore instead of a hyphen (or the other way around) compared to the installed package, check mode reported as changed, even though packages were installed. Now the module ignores case and hyphens/underscores in package names, so check mode works correctly.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0
```