### PR TITLE
VMware: Add support in VMWare modules for BIOS and instance UUID's

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -174,7 +174,7 @@ def find_network_by_name(content, network_name):
     return find_object_by_name(content, network_name, [vim.Network])
 
 
-def find_vm_by_id(content, vm_id, vm_id_type="vm_name", vm_uuid_type="bios_uuid", datacenter=None,
+def find_vm_by_id(content, vm_id, vm_id_type="vm_name", datacenter=None,
                   cluster=None, folder=None, match_first=False):
     """ UUID is unique to a VM, every other id returns the first match. """
     si = content.searchIndex
@@ -184,10 +184,9 @@ def find_vm_by_id(content, vm_id, vm_id_type="vm_name", vm_uuid_type="bios_uuid"
         vm = si.FindByDnsName(datacenter=datacenter, dnsName=vm_id, vmSearch=True)
     elif vm_id_type == 'uuid':
         # Search By BIOS UUID rather than instance UUID
-        if vm_uuid_type == 'bios_uuid':
-            vm = si.FindByUuid(datacenter=datacenter, instanceUuid=False, uuid=vm_id, vmSearch=True)
-        elif vm_uuid_type == 'instance_uuid':
-            vm = si.FindByUuid(datacenter=datacenter, instanceUuid=True, uuid=vm_id, vmSearch=True)
+        vm = si.FindByUuid(datacenter=datacenter, instanceUuid=False, uuid=vm_id, vmSearch=True)
+    elif vm_id_type == 'instance_uuid':
+        vm = si.FindByUuid(datacenter=datacenter, instanceUuid=True, uuid=vm_id, vmSearch=True)
     elif vm_id_type == 'ip':
         vm = si.FindByIp(datacenter=datacenter, ip=vm_id, vmSearch=True)
     elif vm_id_type == 'vm_name':
@@ -866,9 +865,11 @@ class PyVmomi(object):
         user_desired_path = None
 
         if self.params['uuid']:
-            vm_obj = find_vm_by_id(self.content, vm_id=self.params['uuid'], vm_id_type="uuid",
-                                   vm_uuid_type=self.params['uuid_type'])
-
+            vm_obj = find_vm_by_id(self.content, vm_id=self.params['uuid'], vm_id_type="uuid")
+        elif self.params['uuid'] and self.params['use_instance_uuid']:
+            vm_obj = find_vm_by_id(self.content,
+                                   vm_id=self.params['uuid'],
+                                   vm_id_type="instance_uuid")
         elif self.params['name']:
             objects = self.get_managed_objects_properties(vim_type=vim.VirtualMachine, properties=['name'])
             vms = []

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -174,7 +174,8 @@ def find_network_by_name(content, network_name):
     return find_object_by_name(content, network_name, [vim.Network])
 
 
-def find_vm_by_id(content, vm_id, vm_id_type="vm_name", datacenter=None, cluster=None, folder=None, match_first=False):
+def find_vm_by_id(content, vm_id, vm_id_type="vm_name", vm_uuid_type="bios_uuid", datacenter=None,
+                  cluster=None, folder=None, match_first=False):
     """ UUID is unique to a VM, every other id returns the first match. """
     si = content.searchIndex
     vm = None
@@ -183,7 +184,10 @@ def find_vm_by_id(content, vm_id, vm_id_type="vm_name", datacenter=None, cluster
         vm = si.FindByDnsName(datacenter=datacenter, dnsName=vm_id, vmSearch=True)
     elif vm_id_type == 'uuid':
         # Search By BIOS UUID rather than instance UUID
-        vm = si.FindByUuid(datacenter=datacenter, instanceUuid=False, uuid=vm_id, vmSearch=True)
+        if vm_uuid_type == 'bios_uuid':
+            vm = si.FindByUuid(datacenter=datacenter, instanceUuid=False, uuid=vm_id, vmSearch=True)
+        elif vm_uuid_type == 'instance_uuid':
+            vm = si.FindByUuid(datacenter=datacenter, instanceUuid=True, uuid=vm_id, vmSearch=True)
     elif vm_id_type == 'ip':
         vm = si.FindByIp(datacenter=datacenter, ip=vm_id, vmSearch=True)
     elif vm_id_type == 'vm_name':
@@ -862,7 +866,8 @@ class PyVmomi(object):
         user_desired_path = None
 
         if self.params['uuid']:
-            vm_obj = find_vm_by_id(self.content, vm_id=self.params['uuid'], vm_id_type="uuid")
+            vm_obj = find_vm_by_id(self.content, vm_id=self.params['uuid'], vm_id_type="uuid",
+                                   vm_uuid_type=self.params['uuid_type'])
 
         elif self.params['name']:
             objects = self.get_managed_objects_properties(vim_type=vim.VirtualMachine, properties=['name'])

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -864,7 +864,7 @@ class PyVmomi(object):
         vm_obj = None
         user_desired_path = None
 
-        if self.params['uuid']:
+        if self.params['uuid'] and not self.params['use_instance_uuid']:
             vm_obj = find_vm_by_id(self.content, vm_id=self.params['uuid'], vm_id_type="uuid")
         elif self.params['uuid'] and self.params['use_instance_uuid']:
             vm_obj = find_vm_by_id(self.content,

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -84,10 +84,10 @@ options:
     - Please note that a supplied UUID will be ignored on virtual machine creation, as VMware creates the UUID internally.
   use_instance_uuid:
     description:
-    - Use the VMWare instance UUID rather than the BIOS UUID.
-    default: 'no'
+    - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+    default: no
     type: bool
-    version_added: 2.7
+    version_added: '2.8'
   template:
     description:
     - Template or existing virtual machine used to create new virtual machine.
@@ -2440,7 +2440,7 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
-        use_instance_uuid=dict(type='bool', default=False, required=False),
+        use_instance_uuid=dict(type='bool', default=False),
         folder=dict(type='str'),
         guest_id=dict(type='str'),
         disk=dict(type='list', default=[]),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -82,6 +82,11 @@ options:
     - This is required if C(name) is not supplied.
     - If virtual machine does not exists, then this parameter is ignored.
     - Please note that a supplied UUID will be ignored on virtual machine creation, as VMware creates the UUID internally.
+  use_instance_uuid:
+    description:
+    - Use the VMWare instance UUID rather than the BIOS UUID.
+    default: False
+    version_added: 2.7
   template:
     description:
     - Template or existing virtual machine used to create new virtual machine.
@@ -2434,6 +2439,7 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
+        use_instance_uuid=dict(type='bool', default=False, required=False),
         folder=dict(type='str'),
         guest_id=dict(type='str'),
         disk=dict(type='list', default=[]),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -85,7 +85,8 @@ options:
   use_instance_uuid:
     description:
     - Use the VMWare instance UUID rather than the BIOS UUID.
-    default: False
+    default: 'no'
+    type: bool
     version_added: 2.7
   template:
     description:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
@@ -38,11 +38,11 @@ options:
      description:
      - UUID of the instance to manage if known, this is VMware's BIOS UUID by default.
      - This is required if C(name) parameter is not supplied.
-   uuid_type:
-     description:
-     - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
-     default: 'bios_uuid'
-     choices: ['bios_uuid', 'instance_uuid']
+   use_instance_uuid:
+        description:
+            - Use the VMWare instance UUID rather than the BIOS UUID.
+        default: False
+        version_added: 2.7
    name_match:
      description:
      - If multiple virtual machines matching the name, use the first or last found.
@@ -98,14 +98,21 @@ class VmBootFactsManager(PyVmomi):
         super(VmBootFactsManager, self).__init__(module)
         self.name = self.params['name']
         self.uuid = self.params['uuid']
-        self.uuid_type = self.params['uuid_type']
+        self.use_instance_uuid = self.params['use_instance_uuid']
         self.vm = None
 
     def _get_vm(self):
         vms = []
 
         if self.uuid:
-            vm_obj = find_vm_by_id(self.content, vm_id=self.uuid, vm_id_type="uuid", vm_uuid_type=self.uuid_type)
+            if self.use_instance_uuid:
+               vm_obj = find_vm_by_id(self.content,
+                                      vm_id=self.uuid,
+                                      vm_id_type="use_instance_uuid")
+            else:
+                vm_obj = find_vm_by_id(self.content,
+                                       vm_id=self.uuid,
+                                       vm_id_type="uuid")
             if vm_obj is None:
                 self.module.fail_json(msg="Failed to find the virtual machine with UUID : %s" % self.uuid)
             vms = [vm_obj]
@@ -161,10 +168,7 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
-        uuid_type=dict(
-            choices=['bios_uuid', 'instance_uuid'],
-            default='bios_uuid'
-        ),
+        use_instance_uuid=dict(type='bool', default=False, required=False),
         name_match=dict(
             choices=['first', 'last'],
             default='first'

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
@@ -107,13 +107,9 @@ class VmBootFactsManager(PyVmomi):
 
         if self.uuid:
             if self.use_instance_uuid:
-               vm_obj = find_vm_by_id(self.content,
-                                      vm_id=self.uuid,
-                                      vm_id_type="use_instance_uuid")
+                vm_obj = find_vm_by_id(self.content, vm_id=self.uuid, vm_id_type="use_instance_uuid")
             else:
-                vm_obj = find_vm_by_id(self.content,
-                                       vm_id=self.uuid,
-                                       vm_id_type="uuid")
+                vm_obj = find_vm_by_id(self.content, vm_id=self.uuid, vm_id_type="uuid")
             if vm_obj is None:
                 self.module.fail_json(msg="Failed to find the virtual machine with UUID : %s" % self.uuid)
             vms = [vm_obj]

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
@@ -39,11 +39,11 @@ options:
      - UUID of the instance to manage if known, this is VMware's BIOS UUID by default.
      - This is required if C(name) parameter is not supplied.
    use_instance_uuid:
-        description:
-            - Use the VMWare instance UUID rather than the BIOS UUID.
-        default: 'no'
-        type: bool
-        version_added: 2.7
+     description:
+     - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+     default: no
+     type: bool
+     version_added: '2.8'
    name_match:
      description:
      - If multiple virtual machines matching the name, use the first or last found.
@@ -165,7 +165,7 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
-        use_instance_uuid=dict(type='bool', default=False, required=False),
+        use_instance_uuid=dict(type='bool', default=False),
         name_match=dict(
             choices=['first', 'last'],
             default='first'

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
@@ -36,8 +36,13 @@ options:
      - This is required if C(uuid) parameter is not supplied.
    uuid:
      description:
-     - UUID of the instance to manage if known, this is VMware's BIOS UUID.
+     - UUID of the instance to manage if known, this is VMware's BIOS UUID by default.
      - This is required if C(name) parameter is not supplied.
+   uuid_type:
+     description:
+     - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
+     default: 'bios_uuid'
+     choices: ['bios_uuid', 'instance_uuid']
    name_match:
      description:
      - If multiple virtual machines matching the name, use the first or last found.
@@ -93,13 +98,14 @@ class VmBootFactsManager(PyVmomi):
         super(VmBootFactsManager, self).__init__(module)
         self.name = self.params['name']
         self.uuid = self.params['uuid']
+        self.uuid_type = self.params['uuid_type']
         self.vm = None
 
     def _get_vm(self):
         vms = []
 
         if self.uuid:
-            vm_obj = find_vm_by_id(self.content, vm_id=self.uuid, vm_id_type="uuid")
+            vm_obj = find_vm_by_id(self.content, vm_id=self.uuid, vm_id_type="uuid", vm_uuid_type=self.uuid_type)
             if vm_obj is None:
                 self.module.fail_json(msg="Failed to find the virtual machine with UUID : %s" % self.uuid)
             vms = [vm_obj]
@@ -155,6 +161,10 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
+        uuid_type=dict(
+            choices=['bios_uuid', 'instance_uuid'],
+            default='bios_uuid'
+        ),
         name_match=dict(
             choices=['first', 'last'],
             default='first'

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
@@ -41,7 +41,8 @@ options:
    use_instance_uuid:
         description:
             - Use the VMWare instance UUID rather than the BIOS UUID.
-        default: False
+        default: 'no'
+        type: bool
         version_added: 2.7
    name_match:
      description:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
@@ -41,7 +41,8 @@ options:
    use_instance_uuid:
      description:
      - Use the VMWare instance UUID rather than the BIOS UUID.
-     default: False
+     default: 'no'
+     type: bool
      version_added: 2.7
    boot_order:
      description:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
@@ -38,6 +38,11 @@ options:
      description:
      - UUID of the instance to manage if known, this is VMware's BIOS UUID.
      - This is required if C(name) parameter is not supplied.
+   uuid_type:
+     description:
+     - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
+     default: 'bios_uuid'
+     choices: ['bios_uuid', 'instance_uuid']
    boot_order:
      description:
      - List of the boot devices.
@@ -158,7 +163,8 @@ class VmBootManager(PyVmomi):
         vms = []
 
         if self.uuid:
-            vm_obj = find_vm_by_id(self.content, vm_id=self.uuid, vm_id_type="uuid")
+            vm_obj = find_vm_by_id(self.content, vm_id=self.uuid, vm_id_type="uuid",
+                                   vm_uuid_type="uuid")
             if vm_obj is None:
                 self.module.fail_json(msg="Failed to find the virtual machine with UUID : %s" % self.uuid)
             vms = [vm_obj]
@@ -314,6 +320,10 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
+        uuid_type=dict(
+            choices=['bios_uuid', 'instance_uuid'],
+            default='uuid'
+        ),
         boot_order=dict(
             type='list',
             default=[],

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
@@ -40,10 +40,10 @@ options:
      - This is required if C(name) parameter is not supplied.
    use_instance_uuid:
      description:
-     - Use the VMWare instance UUID rather than the BIOS UUID.
-     default: 'no'
+     - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+     default: no
      type: bool
-     version_added: 2.7
+     version_added: '2.8'
    boot_order:
      description:
      - List of the boot devices.
@@ -324,7 +324,7 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
-        use_instance_uuid=dict(type='bool', default=False, required=False),
+        use_instance_uuid=dict(type='bool', default=False),
         boot_order=dict(
             type='list',
             default=[],

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
@@ -43,6 +43,7 @@ options:
      - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
      default: 'bios_uuid'
      choices: ['bios_uuid', 'instance_uuid']
+     version_added: 2.7
    boot_order:
      description:
      - List of the boot devices.
@@ -322,7 +323,7 @@ def main():
         uuid=dict(type='str'),
         uuid_type=dict(
             choices=['bios_uuid', 'instance_uuid'],
-            default='uuid'
+            default='bios_uuid'
         ),
         boot_order=dict(
             type='list',

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
@@ -36,7 +36,7 @@ options:
      - This is required if C(uuid) parameter is not supplied.
    uuid:
      description:
-     - UUID of the instance to manage if known, this is VMware's BIOS UUID.
+     - UUID of the instance to manage if known, this is VMware's BIOS UUID by default.
      - This is required if C(name) parameter is not supplied.
    use_instance_uuid:
      description:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
@@ -53,6 +53,7 @@ options:
      - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
      default: 'bios_uuid'
      choices: ['bios_uuid', 'instance_uuid']
+     version_added: 2.7
    folder:
      description:
      - Absolute path to find an existing guest.
@@ -185,6 +186,10 @@ def main():
         name=dict(required=True, type='str'),
         folder=dict(type='str'),
         uuid=dict(type='str'),
+        uuid_type=dict(
+            choices=['bios_uuid', 'instance_uuid'],
+            default='bios_uuid'
+        ),
         state=dict(type='str', default='present',
                    choices=['absent', 'present']),
         attributes=dict(

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
@@ -48,6 +48,11 @@ options:
      description:
      - UUID of the virtual machine to manage if known. This is VMware's unique identifier.
      - This is required parameter, if C(name) is not supplied.
+   uuid_type:
+     description:
+     - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
+     default: 'bios_uuid'
+     choices: ['bios_uuid', 'instance_uuid']
    folder:
      description:
      - Absolute path to find an existing guest.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
@@ -51,7 +51,8 @@ options:
    use_instance_uuid:
      description:
      - Use the VMWare instance UUID rather than the BIOS UUID.
-     default: False
+     default: 'no'
+     type: bool
      version_added: 2.7
    folder:
      description:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
@@ -48,11 +48,10 @@ options:
      description:
      - UUID of the virtual machine to manage if known. This is VMware's unique identifier.
      - This is required parameter, if C(name) is not supplied.
-   uuid_type:
+   use_instance_uuid:
      description:
-     - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
-     default: 'bios_uuid'
-     choices: ['bios_uuid', 'instance_uuid']
+     - Use the VMWare instance UUID rather than the BIOS UUID.
+     default: False
      version_added: 2.7
    folder:
      description:
@@ -186,10 +185,7 @@ def main():
         name=dict(required=True, type='str'),
         folder=dict(type='str'),
         uuid=dict(type='str'),
-        uuid_type=dict(
-            choices=['bios_uuid', 'instance_uuid'],
-            default='bios_uuid'
-        ),
+        use_instance_uuid=dict(type='bool', default=False, required=False),
         state=dict(type='str', default='present',
                    choices=['absent', 'present']),
         attributes=dict(

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
@@ -50,10 +50,10 @@ options:
      - This is required parameter, if C(name) is not supplied.
    use_instance_uuid:
      description:
-     - Use the VMWare instance UUID rather than the BIOS UUID.
-     default: 'no'
+     - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+     default: no
      type: bool
-     version_added: 2.7
+     version_added: '2.8'
    folder:
      description:
      - Absolute path to find an existing guest.
@@ -186,7 +186,7 @@ def main():
         name=dict(required=True, type='str'),
         folder=dict(type='str'),
         uuid=dict(type='str'),
-        use_instance_uuid=dict(type='bool', default=False, required=False),
+        use_instance_uuid=dict(type='bool', default=False),
         state=dict(type='str', default='present',
                    choices=['absent', 'present']),
         attributes=dict(

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
@@ -41,10 +41,10 @@ options:
      - This is required parameter, if parameter C(name) is not supplied.
    use_instance_uuid:
      description:
-     - Use the VMWare instance UUID rather than the BIOS UUID.
-     default: 'no'
+     - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+     default: no
      type: bool
-     version_added: 2.7
+     version_added: '2.8'
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
@@ -172,7 +172,7 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
-        use_instance_uuid=dict(type='bool', default=False, required=False),
+        use_instance_uuid=dict(type='bool', default=False),
         folder=dict(type='str'),
         datacenter=dict(type='str', required=True),
     )

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
@@ -42,7 +42,8 @@ options:
    use_instance_uuid:
      description:
      - Use the VMWare instance UUID rather than the BIOS UUID.
-     default: False
+     default: 'no'
+     type: bool
      version_added: 2.7
    folder:
      description:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
@@ -44,6 +44,7 @@ options:
      - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
      default: 'bios_uuid'
      choices: ['bios_uuid', 'instance_uuid']
+     version_added: 2.7
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
@@ -39,6 +39,11 @@ options:
      description:
      - UUID of the instance to gather facts if known, this is VMware's unique identifier.
      - This is required parameter, if parameter C(name) is not supplied.
+   uuid_type:
+     description:
+     - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
+     default: 'bios_uuid'
+     choices: ['bios_uuid', 'instance_uuid']
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
@@ -166,6 +171,10 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
+        uuid_type=dict(
+            choices=['bios_uuid', 'instance_uuid'],
+            default='bios_uuid'
+        ),
         folder=dict(type='str'),
         datacenter=dict(type='str', required=True),
     )

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
@@ -39,11 +39,10 @@ options:
      description:
      - UUID of the instance to gather facts if known, this is VMware's unique identifier.
      - This is required parameter, if parameter C(name) is not supplied.
-   uuid_type:
+   use_instance_uuid:
      description:
-     - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
-     default: 'bios_uuid'
-     choices: ['bios_uuid', 'instance_uuid']
+     - Use the VMWare instance UUID rather than the BIOS UUID.
+     default: False
      version_added: 2.7
    folder:
      description:
@@ -172,10 +171,7 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
-        uuid_type=dict(
-            choices=['bios_uuid', 'instance_uuid'],
-            default='bios_uuid'
-        ),
+        use_instance_uuid=dict(type='bool', default=False, required=False),
         folder=dict(type='str'),
         datacenter=dict(type='str', required=True),
     )

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -45,10 +45,10 @@ options:
             - This is required if name is not supplied.
    use_instance_uuid:
         description:
-            - Use the VMWare instance UUID rather than the BIOS UUID.
-        default: 'no'
+            - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+        default: no
         type: bool
-        version_added: 2.7
+        version_added: '2.8'
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
@@ -185,7 +185,7 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
-        use_instance_uuid=dict(type='bool', default=False, required=False),
+        use_instance_uuid=dict(type='bool', default=False),
         folder=dict(type='str', default='/vm'),
         datacenter=dict(type='str', required=True),
         tags=dict(type='bool', default=False)

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -43,11 +43,10 @@ options:
         description:
             - UUID of the instance to manage if known, this is VMware's unique identifier.
             - This is required if name is not supplied.
-   uuid_type:
+   use_instance_uuid:
         description:
-            - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
-        default: 'bios_uuid'
-        choices: ['bios_uuid', 'instance_uuid']
+            - Use the VMWare instance UUID rather than the BIOS UUID.
+        default: False
         version_added: 2.7
    folder:
      description:
@@ -185,10 +184,7 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
-        uuid_type=dict(
-            choices=['bios_uuid', 'instance_uuid'],
-            default='bios_uuid'
-        ),
+        use_instance_uuid=dict(type='bool', default=False, required=False),
         folder=dict(type='str', default='/vm'),
         datacenter=dict(type='str', required=True),
         tags=dict(type='bool', default=False)

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -46,7 +46,8 @@ options:
    use_instance_uuid:
         description:
             - Use the VMWare instance UUID rather than the BIOS UUID.
-        default: False
+        default: 'no'
+        type: bool
         version_added: 2.7
    folder:
      description:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -40,9 +40,14 @@ options:
      default: 'first'
      choices: ['first', 'last']
    uuid:
-     description:
-     - UUID of the instance to manage if known, this is VMware's unique identifier.
-     - This is required if name is not supplied.
+        description:
+            - UUID of the instance to manage if known, this is VMware's unique identifier.
+            - This is required if name is not supplied.
+   uuid_type:
+        description:
+            - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
+        default: 'bios_uuid'
+        choices: ['bios_uuid', 'instance_uuid']
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
@@ -179,7 +184,11 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
-        folder=dict(type='str'),
+        uuid_type=dict(
+            choices=['bios_uuid', 'instance_uuid'],
+            default='bios_uuid'
+        ),
+        folder=dict(type='str', default='/vm'),
         datacenter=dict(type='str', required=True),
         tags=dict(type='bool', default=False)
     )

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -48,6 +48,7 @@ options:
             - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
         default: 'bios_uuid'
         choices: ['bios_uuid', 'instance_uuid']
+        version_added: 2.7
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -40,15 +40,15 @@ options:
      default: 'first'
      choices: ['first', 'last']
    uuid:
-        description:
-            - UUID of the instance to manage if known, this is VMware's unique identifier.
-            - This is required if name is not supplied.
+     description:
+     - UUID of the instance to manage if known, this is VMware's unique identifier.
+     - This is required if name is not supplied.
    use_instance_uuid:
-        description:
-            - Whether to use the VMWare instance UUID rather than the BIOS UUID.
-        default: no
-        type: bool
-        version_added: '2.8'
+     description:
+     - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+     default: no
+     type: bool
+     version_added: '2.8'
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
@@ -161,6 +161,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec
 from ansible.module_utils.vmware_rest_client import VmwareRestClient
 try:
+    from com.vmware.vapi.std_client import DynamicID
     from com.vmware.cis.tagging_client import Tag, TagAssociation
     HAS_VCLOUD = True
 except ImportError:
@@ -186,7 +187,7 @@ def main():
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
         use_instance_uuid=dict(type='bool', default=False),
-        folder=dict(type='str', default='/vm'),
+        folder=dict(type='str'),
         datacenter=dict(type='str', required=True),
         tags=dict(type='bool', default=False)
     )

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -65,15 +65,10 @@ options:
         default: vm_name
         choices:
             - 'uuid'
+            - 'instance_uuid'
             - 'dns_name'
             - 'inventory_path'
             - 'vm_name'
-    vm_uuid_type:
-         description:
-            - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
-         default: 'bios_uuid'
-         choices: ['bios_uuid', 'instance_uuid']
-         version_added: 2.7
     vm_username:
         description:
             - The user to login in to the virtual machine.
@@ -200,8 +195,10 @@ class VmwareGuestFileManager(PyVmomi):
         if module.params['vm_id_type'] == 'inventory_path':
             vm = find_vm_by_id(self.content, vm_id=module.params['vm_id'], vm_id_type="inventory_path", folder=folder)
         else:
-            vm = find_vm_by_id(self.content, vm_id=module.params['vm_id'], vm_id_type=module.params['vm_id_type'],
-                               vm_uuid_type=module.params['vm_uuid_type'], datacenter=datacenter,
+            vm = find_vm_by_id(self.content,
+                               vm_id=module.params['vm_id'],
+                               vm_id_type=module.params['vm_id_type'],
+                               datacenter=datacenter,
                                cluster=cluster)
 
         if not vm:
@@ -398,11 +395,7 @@ def main():
         vm_id_type=dict(
             default='vm_name',
             type='str',
-            choices=['inventory_path', 'uuid', 'dns_name', 'vm_name']),
-        vm_uuid_type=dict(
-            choices=['bios_uuid', 'instance_uuid'],
-            default='bios_uuid'
-        ),
+            choices=['inventory_path', 'uuid', 'instance_uuid', 'dns_name', 'vm_name']),
         vm_username=dict(type='str', required=True),
         vm_password=dict(type='str', no_log=True, required=True),
         directory=dict(

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -68,6 +68,11 @@ options:
             - 'dns_name'
             - 'inventory_path'
             - 'vm_name'
+    vm_uuid_type:
+         description:
+            - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
+         default: 'bios_uuid'
+         choices: ['bios_uuid', 'instance_uuid']
     vm_username:
         description:
             - The user to login in to the virtual machine.
@@ -195,7 +200,8 @@ class VmwareGuestFileManager(PyVmomi):
             vm = find_vm_by_id(self.content, vm_id=module.params['vm_id'], vm_id_type="inventory_path", folder=folder)
         else:
             vm = find_vm_by_id(self.content, vm_id=module.params['vm_id'], vm_id_type=module.params['vm_id_type'],
-                               datacenter=datacenter, cluster=cluster)
+                               vm_uuid_type=module.params['vm_uuid_type'], datacenter=datacenter,
+                               cluster=cluster)
 
         if not vm:
             module.fail_json(msg='Unable to find virtual machine.')
@@ -392,6 +398,10 @@ def main():
             default='vm_name',
             type='str',
             choices=['inventory_path', 'uuid', 'dns_name', 'vm_name']),
+        vm_uuid_type=dict(
+            choices=['bios_uuid', 'instance_uuid'],
+            default='bios_uuid'
+        ),
         vm_username=dict(type='str', required=True),
         vm_password=dict(type='str', no_log=True, required=True),
         directory=dict(

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -73,6 +73,7 @@ options:
             - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
          default: 'bios_uuid'
          choices: ['bios_uuid', 'instance_uuid']
+         version_added: 2.7
     vm_username:
         description:
             - The user to login in to the virtual machine.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
@@ -39,7 +39,8 @@ options:
    use_instance_uuid:
         description:
             - Use the VMWare instance UUID rather than the BIOS UUID.
-        default: False
+        default: 'no'
+        type: bool
         version_added: 2.7
    datacenter:
      description:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
@@ -36,6 +36,12 @@ options:
      description:
      - UUID of the instance to manage if known, this is VMware's BIOS UUID.
      - This is required if C(name) parameter is not supplied.
+   uuid_type:
+        description:
+            - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
+        default: 'bios_uuid'
+        choices: ['bios_uuid', 'instance_uuid']
+        version_added: 2.7
    datacenter:
      description:
      - Destination datacenter for the find operation.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
@@ -90,13 +90,14 @@ class PyVmomiHelper(PyVmomi):
         super(PyVmomiHelper, self).__init__(module)
         self.name = self.params['name']
         self.uuid = self.params['uuid']
+        self.uuid_type = self.params['uuid_type']
 
     def getvm_folder_paths(self):
         results = []
         vms = []
 
         if self.uuid:
-            vm_obj = find_vm_by_id(self.content, vm_id=self.uuid, vm_id_type="uuid")
+            vm_obj = find_vm_by_id(self.content, vm_id=self.uuid, vm_id_type="uuid", vm_uuid_type=self.uuid_type)
             if vm_obj is None:
                 self.module.fail_json(msg="Failed to find the virtual machine with UUID : %s" % self.uuid)
             vms = [vm_obj]
@@ -119,6 +120,10 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
+        uuid_type=dict(
+            choices=['bios_uuid', 'instance_uuid'],
+            default='bios_uuid'
+        ),
         datacenter=dict(removed_in_version=2.9, type='str')
     )
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
@@ -37,11 +37,11 @@ options:
      - UUID of the instance to manage if known, this is VMware's BIOS UUID by default.
      - This is required if C(name) parameter is not supplied.
    use_instance_uuid:
-        description:
-            - Use the VMWare instance UUID rather than the BIOS UUID.
-        default: 'no'
-        type: bool
-        version_added: 2.7
+     description:
+     - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+     default: no
+     type: bool
+     version_added: '2.8'
    datacenter:
      description:
      - Destination datacenter for the find operation.
@@ -129,7 +129,7 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
-        use_instance_uuid=dict(type='bool', default=False, required=False),
+        use_instance_uuid=dict(type='bool', default=False),
         datacenter=dict(removed_in_version=2.9, type='str')
     )
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
@@ -42,6 +42,7 @@ options:
             - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
         default: 'bios_uuid'
         choices: ['bios_uuid', 'instance_uuid']
+        version_added: 2.7
    name_match:
         description:
             - If multiple virtual machines matching the name, use the first or last found.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
@@ -37,11 +37,10 @@ options:
         description:
             - UUID of the virtual machine to manage if known, this is VMware's unique identifier.
             - This is required if C(name) is not supplied.
-   uuid_type:
+   use_instance_uuid:
         description:
-            - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
-        default: 'bios_uuid'
-        choices: ['bios_uuid', 'instance_uuid']
+            - Use the VMWare instance UUID rather than the BIOS UUID.
+         default: False
         version_added: 2.7
    name_match:
         description:
@@ -175,10 +174,7 @@ def main():
         name_match=dict(
             type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
-        uuid_type=dict(
-            choices=['bios_uuid', 'instance_uuid'],
-            default='bios_uuid'
-        ),
+        use_instance_uuid=dict(type='bool', default=False, required=False),
         dest_folder=dict(type='str', required=True),
         datacenter=dict(type='str', required=True),
     )

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
@@ -40,7 +40,8 @@ options:
    use_instance_uuid:
         description:
             - Use the VMWare instance UUID rather than the BIOS UUID.
-         default: False
+        default: 'no'
+        type: bool
         version_added: 2.7
    name_match:
         description:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
@@ -37,6 +37,11 @@ options:
         description:
             - UUID of the virtual machine to manage if known, this is VMware's unique identifier.
             - This is required if C(name) is not supplied.
+   uuid_type:
+        description:
+            - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
+        default: 'bios_uuid'
+        choices: ['bios_uuid', 'instance_uuid']
    name_match:
         description:
             - If multiple virtual machines matching the name, use the first or last found.
@@ -169,6 +174,10 @@ def main():
         name_match=dict(
             type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
+        uuid_type=dict(
+            choices=['bios_uuid', 'instance_uuid'],
+            default='bios_uuid'
+        ),
         dest_folder=dict(type='str', required=True),
         datacenter=dict(type='str', required=True),
     )

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
@@ -39,10 +39,10 @@ options:
             - This is required if C(name) is not supplied.
    use_instance_uuid:
         description:
-            - Use the VMWare instance UUID rather than the BIOS UUID.
-        default: 'no'
+            - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+        default: no
         type: bool
-        version_added: 2.7
+        version_added: '2.8'
    name_match:
         description:
             - If multiple virtual machines matching the name, use the first or last found.
@@ -175,7 +175,7 @@ def main():
         name_match=dict(
             type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
-        use_instance_uuid=dict(type='bool', default=False, required=False),
+        use_instance_uuid=dict(type='bool', default=False),
         dest_folder=dict(type='str', required=True),
         datacenter=dict(type='str', required=True),
     )

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
@@ -42,6 +42,11 @@ options:
     description:
     - UUID of the instance to manage if known, this is VMware's unique identifier.
     - This is required if name is not supplied.
+  uuid_type:
+    description:
+    - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
+    default: 'bios_uuid'
+    choices: ['bios_uuid', 'instance_uuid']
   folder:
     description:
     - Destination folder, absolute or relative path to find an existing guest or create the new guest.
@@ -139,6 +144,10 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
+        uuid_type=dict(
+            choices=['bios_uuid', 'instance_uuid'],
+            default='bios_uuid'
+        ),
         folder=dict(type='str', default='/vm'),
         force=dict(type='bool', default=False),
         scheduled_at=dict(type='str'),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
@@ -42,12 +42,12 @@ options:
     description:
     - UUID of the instance to manage if known, this is VMware's unique identifier.
     - This is required if name is not supplied.
-  use_instance_uuid:
-    description:
-    - Use the VMWare instance UUID rather than the BIOS UUID.
-    default: 'no'
-    type: bool
-    version_added: 2.7
+   use_instance_uuid:
+     description:
+     - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+     default: no
+     type: bool
+     version_added: '2.8'
   folder:
     description:
     - Destination folder, absolute or relative path to find an existing guest or create the new guest.
@@ -145,7 +145,7 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
-        use_instance_uuid=dict(type='bool', default=False, required=False),
+        use_instance_uuid=dict(type='bool', default=False),
         folder=dict(type='str', default='/vm'),
         force=dict(type='bool', default=False),
         scheduled_at=dict(type='str'),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
@@ -47,6 +47,7 @@ options:
     - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
     default: 'bios_uuid'
     choices: ['bios_uuid', 'instance_uuid']
+    version_added: 2.7
   folder:
     description:
     - Destination folder, absolute or relative path to find an existing guest or create the new guest.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
@@ -42,12 +42,12 @@ options:
     description:
     - UUID of the instance to manage if known, this is VMware's unique identifier.
     - This is required if name is not supplied.
-   use_instance_uuid:
-     description:
-     - Whether to use the VMWare instance UUID rather than the BIOS UUID.
-     default: no
-     type: bool
-     version_added: '2.8'
+  use_instance_uuid:
+    description:
+    - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+    default: no
+    type: bool
+    version_added: '2.8'
   folder:
     description:
     - Destination folder, absolute or relative path to find an existing guest or create the new guest.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
@@ -42,11 +42,10 @@ options:
     description:
     - UUID of the instance to manage if known, this is VMware's unique identifier.
     - This is required if name is not supplied.
-  uuid_type:
+  use_instance_uuid:
     description:
-    - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
-    default: 'bios_uuid'
-    choices: ['bios_uuid', 'instance_uuid']
+    - Use the VMWare instance UUID rather than the BIOS UUID.
+    default: False
     version_added: 2.7
   folder:
     description:
@@ -145,10 +144,7 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
-        uuid_type=dict(
-            choices=['bios_uuid', 'instance_uuid'],
-            default='bios_uuid'
-        ),
+        use_instance_uuid=dict(type='bool', default=False, required=False),
         folder=dict(type='str', default='/vm'),
         force=dict(type='bool', default=False),
         scheduled_at=dict(type='str'),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
@@ -45,7 +45,8 @@ options:
   use_instance_uuid:
     description:
     - Use the VMWare instance UUID rather than the BIOS UUID.
-    default: False
+    default: 'no'
+    type: bool
     version_added: 2.7
   folder:
     description:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -54,6 +54,11 @@ options:
      description:
      - UUID of the instance to manage if known, this is VMware's unique identifier.
      - This is required parameter, if C(name) is not supplied.
+   uuid_type:
+     description:
+     - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
+     default: 'bios_uuid'
+     choices: ['bios_uuid', 'instance_uuid']
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
@@ -367,6 +372,10 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
+        uuid_type=dict(
+            choices=['bios_uuid', 'instance_uuid'],
+            default='bios_uuid'
+        ),
         folder=dict(type='str'),
         datacenter=dict(required=True, type='str'),
         snapshot_name=dict(type='str'),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -57,7 +57,8 @@ options:
    use_instance_uuid:
         description:
             - Use the VMWare instance UUID rather than the BIOS UUID.
-        default: False
+        default: 'no'
+        type: bool
         version_added: 2.7
    folder:
      description:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -59,6 +59,7 @@ options:
      - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
      default: 'bios_uuid'
      choices: ['bios_uuid', 'instance_uuid']
+     version_added: 2.7
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -55,11 +55,11 @@ options:
      - UUID of the instance to manage if known, this is VMware's BIOS UUID by default.
      - This is required if C(name) parameter is not supplied.
    use_instance_uuid:
-        description:
-            - Use the VMWare instance UUID rather than the BIOS UUID.
-        default: 'no'
-        type: bool
-        version_added: 2.7
+     description:
+     - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+     default: no
+     type: bool
+     version_added: '2.8'
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
@@ -373,7 +373,7 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
-        use_instance_uuid=dict(type='bool', default=False, required=False),
+        use_instance_uuid=dict(type='bool', default=False),
         folder=dict(type='str'),
         datacenter=dict(required=True, type='str'),
         snapshot_name=dict(type='str'),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -52,14 +52,13 @@ options:
      choices: ['first', 'last']
    uuid:
      description:
-     - UUID of the instance to manage if known, this is VMware's unique identifier.
-     - This is required parameter, if C(name) is not supplied.
-   uuid_type:
-     description:
-     - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
-     default: 'bios_uuid'
-     choices: ['bios_uuid', 'instance_uuid']
-     version_added: 2.7
+     - UUID of the instance to manage if known, this is VMware's BIOS UUID by default.
+     - This is required if C(name) parameter is not supplied.
+   use_instance_uuid:
+        description:
+            - Use the VMWare instance UUID rather than the BIOS UUID.
+        default: False
+        version_added: 2.7
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
@@ -373,10 +372,7 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
-        uuid_type=dict(
-            choices=['bios_uuid', 'instance_uuid'],
-            default='bios_uuid'
-        ),
+        use_instance_uuid=dict(type='bool', default=False, required=False),
         folder=dict(type='str'),
         datacenter=dict(required=True, type='str'),
         snapshot_name=dict(type='str'),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot_facts.py
@@ -38,6 +38,11 @@ options:
      - UUID of the instance to manage if known, this value is VMware's unique identifier.
      - This is required if C(name) is not supplied.
      - The C(folder) is ignored, if C(uuid) is provided.
+   uuid_type:
+     description:
+     - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
+     default: 'bios_uuid'
+     choices: ['bios_uuid', 'instance_uuid']
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
@@ -125,6 +130,10 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
+        uuid_type=dict(
+            choices=['bios_uuid', 'instance_uuid'],
+            default='bios_uuid'
+        ),
         folder=dict(type='str'),
         datacenter=dict(required=True, type='str'),
     )

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot_facts.py
@@ -35,14 +35,13 @@ options:
      - This is required if C(uuid) is not supplied.
    uuid:
      description:
-     - UUID of the instance to manage if known, this value is VMware's unique identifier.
-     - This is required if C(name) is not supplied.
+     - UUID of the instance to manage if known, this is VMware's BIOS UUID by default.
+     - This is required if C(name) parameter is not supplied.
      - The C(folder) is ignored, if C(uuid) is provided.
-   uuid_type:
+   use_instance_uuid:
      description:
-     - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
-     default: 'bios_uuid'
-     choices: ['bios_uuid', 'instance_uuid']
+      - Use the VMWare instance UUID rather than the BIOS UUID.
+     default: False
      version_added: 2.7
    folder:
      description:
@@ -131,10 +130,7 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
-        uuid_type=dict(
-            choices=['bios_uuid', 'instance_uuid'],
-            default='bios_uuid'
-        ),
+        use_instance_uuid=dict(type='bool', default=False, required=False),
         folder=dict(type='str'),
         datacenter=dict(required=True, type='str'),
     )

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot_facts.py
@@ -41,7 +41,8 @@ options:
    use_instance_uuid:
      description:
       - Use the VMWare instance UUID rather than the BIOS UUID.
-     default: False
+     default: 'no'
+     type: bool
      version_added: 2.7
    folder:
      description:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot_facts.py
@@ -40,10 +40,10 @@ options:
      - The C(folder) is ignored, if C(uuid) is provided.
    use_instance_uuid:
      description:
-      - Use the VMWare instance UUID rather than the BIOS UUID.
-     default: 'no'
+     - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+     default: no
      type: bool
-     version_added: 2.7
+     version_added: '2.8'
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
@@ -131,7 +131,7 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
-        use_instance_uuid=dict(type='bool', default=False, required=False),
+        use_instance_uuid=dict(type='bool', default=False),
         folder=dict(type='str'),
         datacenter=dict(required=True, type='str'),
     )

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot_facts.py
@@ -43,6 +43,7 @@ options:
      - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
      default: 'bios_uuid'
      choices: ['bios_uuid', 'instance_uuid']
+     version_added: 2.7
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
@@ -56,11 +56,10 @@ options:
      description:
      - UUID of the VM  for which to wait until the tools become available, if known. This is VMware's unique identifier.
      - This is required, if C(name) is not supplied.
-   uuid_type:
+   use_instance_uuid:
      description:
-     - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
-     default: 'bios_uuid'
-     choices: ['bios_uuid', 'instance_uuid']
+     - Use the VMWare instance UUID rather than the BIOS UUID.
+     default: False
      version_added: 2.7
 extends_documentation_fragment: vmware.documentation
 '''
@@ -152,10 +151,7 @@ def main():
         name_match=dict(type='str', default='first', choices=['first', 'last']),
         folder=dict(type='str'),
         uuid=dict(type='str'),
-        uuid_type=dict(
-            choices=['bios_uuid', 'instance_uuid'],
-            default='bios_uuid'
-        ),
+        use_instance_uuid=dict(type='bool', default=False, required=False),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
@@ -61,6 +61,7 @@ options:
      - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
      default: 'bios_uuid'
      choices: ['bios_uuid', 'instance_uuid']
+     version_added: 2.7
 extends_documentation_fragment: vmware.documentation
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
@@ -59,7 +59,8 @@ options:
    use_instance_uuid:
      description:
      - Use the VMWare instance UUID rather than the BIOS UUID.
-     default: False
+     default: 'no'
+     type: bool
      version_added: 2.7
 extends_documentation_fragment: vmware.documentation
 '''

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
@@ -56,6 +56,11 @@ options:
      description:
      - UUID of the VM  for which to wait until the tools become available, if known. This is VMware's unique identifier.
      - This is required, if C(name) is not supplied.
+   uuid_type:
+     description:
+     - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
+     default: 'bios_uuid'
+     choices: ['bios_uuid', 'instance_uuid']
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -146,6 +151,10 @@ def main():
         name_match=dict(type='str', default='first', choices=['first', 'last']),
         folder=dict(type='str'),
         uuid=dict(type='str'),
+        uuid_type=dict(
+            choices=['bios_uuid', 'instance_uuid'],
+            default='bios_uuid'
+        ),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
@@ -58,10 +58,10 @@ options:
      - This is required, if C(name) is not supplied.
    use_instance_uuid:
      description:
-     - Use the VMWare instance UUID rather than the BIOS UUID.
-     default: 'no'
+     - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+     default: no
      type: bool
-     version_added: 2.7
+     version_added: '2.8'
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -152,7 +152,7 @@ def main():
         name_match=dict(type='str', default='first', choices=['first', 'last']),
         folder=dict(type='str'),
         uuid=dict(type='str'),
-        use_instance_uuid=dict(type='bool', default=False, required=False),
+        use_instance_uuid=dict(type='bool', default=False),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
@@ -62,13 +62,7 @@ options:
       description:
       - The VMware identification method by which the virtual machine will be identified.
       default: vm_name
-      choices: ['uuid', 'dns_name', 'inventory_path', 'vm_name']
-    vm_uuid_type:
-         description:
-            - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
-         default: 'bios_uuid'
-         choices: ['bios_uuid', 'instance_uuid']
-         version_added: 2.7
+      choices: ['uuid', 'instance_uuid', 'dns_name', 'inventory_path', 'vm_name']
     vm_username:
       description:
       - The user to login-in to the virtual machine.
@@ -236,7 +230,6 @@ class VMwareShellManager(PyVmomi):
             vm = find_vm_by_id(self.content,
                                vm_id=module.params['vm_id'],
                                vm_id_type=module.params['vm_id_type'],
-                               vm_uuid_type=module.params['vm_uuid_type'],
                                datacenter=datacenter,
                                cluster=cluster)
 
@@ -335,11 +328,11 @@ def main():
             folder=dict(type='str'),
             vm_id=dict(type='str', required=True),
             vm_id_type=dict(default='vm_name', type='str',
-                            choices=['inventory_path', 'uuid', 'dns_name', 'vm_name']),
-            vm_uuid_type=dict(
-                choices=['bios_uuid', 'instance_uuid'],
-                default='bios_uuid'
-            ),
+                            choices=['inventory_path',
+                                     'uuid',
+                                     'instance_uuid',
+                                     'dns_name',
+                                     'vm_name']),
             vm_username=dict(type='str', required=True),
             vm_password=dict(type='str', no_log=True, required=True),
             vm_shell=dict(type='str', required=True),

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
@@ -68,6 +68,7 @@ options:
             - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
          default: 'bios_uuid'
          choices: ['bios_uuid', 'instance_uuid']
+         version_added: 2.7
     vm_username:
       description:
       - The user to login-in to the virtual machine.

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
@@ -63,6 +63,11 @@ options:
       - The VMware identification method by which the virtual machine will be identified.
       default: vm_name
       choices: ['uuid', 'dns_name', 'inventory_path', 'vm_name']
+    vm_uuid_type:
+         description:
+            - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
+         default: 'bios_uuid'
+         choices: ['bios_uuid', 'instance_uuid']
     vm_username:
       description:
       - The user to login-in to the virtual machine.
@@ -230,7 +235,9 @@ class VMwareShellManager(PyVmomi):
             vm = find_vm_by_id(self.content,
                                vm_id=module.params['vm_id'],
                                vm_id_type=module.params['vm_id_type'],
-                               datacenter=datacenter, cluster=cluster)
+                               vm_uuid_type=module.params['vm_uuid_type'],
+                               datacenter=datacenter,
+                               cluster=cluster)
 
         if not vm:
             module.fail_json(msg='Unable to find virtual machine.')
@@ -328,6 +335,10 @@ def main():
             vm_id=dict(type='str', required=True),
             vm_id_type=dict(default='vm_name', type='str',
                             choices=['inventory_path', 'uuid', 'dns_name', 'vm_name']),
+            vm_uuid_type=dict(
+                choices=['bios_uuid', 'instance_uuid'],
+                default='bios_uuid'
+            ),
             vm_username=dict(type='str', required=True),
             vm_password=dict(type='str', no_log=True, required=True),
             vm_shell=dict(type='str', required=True),

--- a/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -47,6 +47,11 @@ options:
       - This is a required parameter, if C(vm_name) is not set.
       aliases: ['uuid']
       version_added: 2.7
+    vm_uuid_type:
+     description:
+        - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
+     default: 'bios_uuid'
+     choices: ['bios_uuid', 'instance_uuid']
     destination_host:
       description:
       - Name of the destination host the virtual machine should be running on.
@@ -118,6 +123,7 @@ class VmotionManager(PyVmomi):
         super(VmotionManager, self).__init__(module)
         self.vm = None
         self.vm_uuid = self.params.get('vm_uuid', None)
+        self.vm_uuid_type = self.params.get('vm_uuid_type', None)
         self.vm_name = self.params.get('vm_name', None)
         result = dict()
 
@@ -255,7 +261,7 @@ class VmotionManager(PyVmomi):
         """
         vms = []
         if self.vm_uuid:
-            vm_obj = find_vm_by_id(self.content, vm_id=self.params['vm_uuid'], vm_id_type="uuid")
+            vm_obj = find_vm_by_id(self.content, vm_id=self.params['vm_uuid'], vm_id_type="uuid",  vm_uuid_type=self.uuid_type)
             vms = [vm_obj]
 
         elif self.vm_name:
@@ -280,6 +286,10 @@ def main():
         dict(
             vm_name=dict(aliases=['vm']),
             vm_uuid=dict(aliases=['uuid']),
+            vm_uuid_type=dict(
+                choices=['bios_uuid', 'instance_uuid'],
+                default='bios_uuid'
+            ),
             destination_host=dict(aliases=['destination']),
             destination_datastore=dict(aliases=['datastore'])
         )

--- a/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -50,7 +50,8 @@ options:
     use_instance_uuid:
       description:
       - Use the VMWare instance UUID rather than the BIOS UUID.
-      default: False
+      default: 'no'
+      type: bool
       version_added: 2.7
     destination_host:
       description:

--- a/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -49,10 +49,10 @@ options:
       version_added: 2.7
     use_instance_uuid:
       description:
-      - Use the VMWare instance UUID rather than the BIOS UUID.
-      default: 'no'
+      - Whether to use the VMWare instance UUID rather than the BIOS UUID.
+      default: no
       type: bool
-      version_added: 2.7
+      version_added: '2.8'
     destination_host:
       description:
       - Name of the destination host the virtual machine should be running on.
@@ -291,7 +291,7 @@ def main():
         dict(
             vm_name=dict(aliases=['vm']),
             vm_uuid=dict(aliases=['uuid']),
-            use_instance_uuid=dict(type='bool', default=False, required=False),
+            use_instance_uuid=dict(type='bool', default=False),
             destination_host=dict(aliases=['destination']),
             destination_datastore=dict(aliases=['datastore'])
         )

--- a/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -52,6 +52,7 @@ options:
         - The type of UUID provided to search against, to use the BIOS UUID or the Instance UUID
      default: 'bios_uuid'
      choices: ['bios_uuid', 'instance_uuid']
+     version_added: 2.7
     destination_host:
       description:
       - Name of the destination host the virtual machine should be running on.
@@ -261,7 +262,10 @@ class VmotionManager(PyVmomi):
         """
         vms = []
         if self.vm_uuid:
-            vm_obj = find_vm_by_id(self.content, vm_id=self.params['vm_uuid'], vm_id_type="uuid",  vm_uuid_type=self.uuid_type)
+            vm_obj = find_vm_by_id(self.content,
+                                   vm_id=self.params['vm_uuid'],
+                                   vm_id_type="uuid",
+                                   vm_uuid_type=self.uuid_type)
             vms = [vm_obj]
 
         elif self.vm_name:

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -79,8 +79,11 @@
       - "guest_facts_0001['instance']['guest_consolidation_needed'] is defined"
       - "'portgroup_portkey' in guest_facts_0001['instance']['hw_eth0']"
       - "'portgroup_key' in guest_facts_0001['instance']['hw_eth0']"
+      - "guest_facts_0002['instance']['instance_uuid'] is defined"
 
 - set_fact: vm1_uuid="{{ guest_facts_0001['instance']['hw_product_uuid'] }}"
+
+- set_fact: vm1_instance_uuid="{{ guest_facts_0001['instance']['instance_uuid'] }}"
 
 - debug: var=vm1_uuid
 
@@ -175,3 +178,35 @@
 #      - "guest_facts_0004['instance']['snapshots'][1]['name'] == 'snap2'"
 #      - "guest_facts_0004['instance']['current_snapshot']['name'] == 'snap2'"
 #      - "guest_facts_0002['instance']['hw_folder'] == vm1 | dirname"
+
+# Testcase 0005: Get details about virtual machines using UUID
+- name: get list of facts about virtual machines using instance UUID
+  vmware_guest_facts:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    datacenter: "{{ dc1 | basename }}"
+    uuid: "{{ vm1_instance_uuid }}"
+    uuid_type: instance_uuid
+  register: guest_facts_0005
+
+- debug: msg="{{ guest_facts_0005 }}"
+
+- assert:
+    that:
+      - "guest_facts_0005['instance']['hw_name'] == vm1 | basename"
+      - "guest_facts_0005['instance']['hw_product_uuid'] is defined"
+      - "guest_facts_0005['instance']['hw_product_uuid'] == vm1_uuid"
+      - "guest_facts_0005['instance']['hw_cores_per_socket'] is defined"
+      - "guest_facts_0005['instance']['hw_datastores'] is defined"
+      - "guest_facts_0005['instance']['hw_esxi_host'] == h1 | basename"
+      - "guest_facts_0005['instance']['hw_files'] is defined"
+      - "guest_facts_0005['instance']['hw_guest_ha_state'] is defined"
+      - "guest_facts_0005['instance']['hw_is_template'] is defined"
+      - "guest_facts_0005['instance']['hw_folder'] is defined"
+      - "guest_facts_0005['instance']['guest_question'] is defined"
+      - "guest_facts_0005['instance']['guest_consolidation_needed'] is defined"
+      - "guest_facts_0005['instance']['instance_uuid'] is defined"
+      - "guest_facts_0005['instance']['instance_uuid'] == vm1_instance_uuid"
+

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -188,7 +188,7 @@
     password: "{{ vcsim_instance['json']['password'] }}"
     datacenter: "{{ dc1 | basename }}"
     uuid: "{{ vm1_instance_uuid }}"
-    uuid_type: instance_uuid
+    use_instance_id: True
   register: guest_facts_0005
 
 - debug: msg="{{ guest_facts_0005 }}"

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -79,7 +79,7 @@
       - "guest_facts_0001['instance']['guest_consolidation_needed'] is defined"
       - "'portgroup_portkey' in guest_facts_0001['instance']['hw_eth0']"
       - "'portgroup_key' in guest_facts_0001['instance']['hw_eth0']"
-      - "guest_facts_0002['instance']['instance_uuid'] is defined"
+      - "guest_facts_0001['instance']['instance_uuid'] is defined"
 
 - set_fact: vm1_uuid="{{ guest_facts_0001['instance']['hw_product_uuid'] }}"
 

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -188,7 +188,7 @@
     password: "{{ vcsim_instance['json']['password'] }}"
     datacenter: "{{ dc1 | basename }}"
     uuid: "{{ vm1_instance_uuid }}"
-    use_instance_id: True
+    use_instance_uuid: True
   register: guest_facts_0005
 
 - debug: msg="{{ guest_facts_0005 }}"

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -209,4 +209,3 @@
       - "guest_facts_0005['instance']['guest_consolidation_needed'] is defined"
       - "guest_facts_0005['instance']['instance_uuid'] is defined"
       - "guest_facts_0005['instance']['instance_uuid'] == vm1_instance_uuid"
-


### PR DESCRIPTION
##### SUMMARY
Adding support for specifying the type of UUID to match against, by default it will continue to use the bios UUID which originally was the only one which worked.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
lib/ansible/module_utils/vmware.py
lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
lib/ansible/modules/cloud/vmware/vmware_guest_find.py
lib/ansible/modules/cloud/vmware/vmware_guest_move.py
lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
lib/ansible/modules/cloud/vmware/vmware_guest_snapshot_facts.py
lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
lib/ansible/modules/cloud/vmware/vmware_vmotion.py
test/integration/targets/vmware_guest_facts/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = None
  configured module search path = [u'/Users/jhill/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```


##### ADDITIONAL INFORMATION
I've put this in (and to every referenced module) to increase the options of how you can refer to a VM. In-house where I work we created a lot of VMWare modules before they were available directly from Ansible so in doing this we personally can migrate to Ansible code more easily. Broadly speaking it seemed logical to support either kind of UUID as in PyVmomi it boils down to a true/false to determine which one it searched on.