### PR TITLE
add myself to yum and dnf for BOTMETA

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -552,7 +552,7 @@ files:
   $modules/packaging/os/apt_key.py: jvantuyl
   $modules/packaging/os/apt_repository.py: $team_ansible sashka
   $modules/packaging/os/apt_rpm.py: evgkrsk
-  $modules/packaging/os/dnf.py: DJMuggs berenddeschouwer ignatenkobrain
+  $modules/packaging/os/dnf.py: DJMuggs berenddeschouwer ignatenkobrain maxamillion
   $modules/packaging/os/dpkg_selections.py: brian-brazil
   $modules/packaging/os/homebrew.py: andrew-d danieljaouen indrajitr
   $modules/packaging/os/homebrew_cask.py: danieljaouen enriclluelles indrajitr
@@ -587,7 +587,7 @@ files:
   $modules/packaging/os/swdepot.py: melodous
   $modules/packaging/os/swupd.py: albertomurillo
   $modules/packaging/os/urpmi.py: pmakowski
-  $modules/packaging/os/yum.py: $team_ansible berenddeschouwer verm666 kustodian
+  $modules/packaging/os/yum.py: $team_ansible berenddeschouwer verm666 kustodian maxamillion
   $modules/packaging/os/yum_repository.py: jtyr
   $modules/packaging/os/zypper.py:
     ignored: dirtyharrycallahan


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
Since I did the heavy refactor for the `yum` and `dnf` modules, I figured I should be on the hook for issues filed against them.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
botmeta

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (botmeta 23fc95f55b) last updated 2018/08/20 09:09:11 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```

