### PR TITLE
Clarify docs re mode's octal representation

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -62,7 +62,7 @@ options:
       - "Mode the file or directory should be. For those used to I(/usr/bin/chmod) remember that
         modes are actually octal numbers. You must either add a leading zero so that Ansible's
         YAML parser knows it is an octal number (like C(0644) or C(01777)) or quote it
-        (like C('644') or C('0644') so Ansible receives a string and can do its own conversion from
+        (like C('644') or C('1777')) so Ansible receives a string and can do its own conversion from
         string into number.  Giving Ansible a number without following one of these rules will end
         up with a decimal number which will have unexpected results.  As of version 1.8, the mode
         may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).  As of

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -60,8 +60,8 @@ options:
   mode:
     description:
       - "Mode the file or directory should be. For those used to I(/usr/bin/chmod) remember that
-        modes are actually octal numbers.  You must either specify the leading zero so that
-        Ansible's YAML parser knows it is an octal number (like C(0644) or C(01777)) or quote it
+        modes are actually octal numbers. You must either add a leading zero so that Ansible's
+        YAML parser knows it is an octal number (like C(0644) or C(01777)) or quote it
         (like C('644') or C('0644') so Ansible receives a string and can do its own conversion from
         string into number.  Giving Ansible a number without following one of these rules will end
         up with a decimal number which will have unexpected results.  As of version 1.8, the mode

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -79,11 +79,12 @@ options:
 '''
 
 EXAMPLES = '''
-# change file ownership, group and mode. When specifying mode using octal numbers, add a leading 0
+# change file ownership, group and mode
 - file:
     path: /etc/foo.conf
     owner: foo
     group: foo
+    # when specifying mode using octal numbers, add a leading 0
     mode: 0644
 - file:
     path: /work

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -79,12 +79,13 @@ options:
 '''
 
 EXAMPLES = '''
-# change file ownership, group and mode. When specifying mode using octal numbers, first digit should always be 0.
+# change file ownership, group and mode
 - file:
     path: /etc/foo.conf
     owner: foo
     group: foo
     mode: 0644
+# when specifying mode using octal numbers, add a leading 0
 - file:
     path: /work
     owner: root

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -79,13 +79,12 @@ options:
 '''
 
 EXAMPLES = '''
-# change file ownership, group and mode
+# change file ownership, group and mode. When specifying mode using octal numbers, add a leading 0
 - file:
     path: /etc/foo.conf
     owner: foo
     group: foo
     mode: 0644
-# when specifying mode using octal numbers, add a leading 0
 - file:
     path: /work
     owner: root

--- a/lib/ansible/modules/files/template.py
+++ b/lib/ansible/modules/files/template.py
@@ -100,7 +100,7 @@ options:
       - "Mode the file or directory should be. For those used to I(/usr/bin/chmod) remember that
         modes are actually octal numbers.  You must either add a leading zero so that Ansible's
         YAML parser knows it is an octal number (like C(0644) or C(01777)) or quote it
-        (like C('644') or C('0644') so Ansible receives a string and can do its own conversion from
+        (like C('644') or C('1777')) so Ansible receives a string and can do its own conversion from
         string into number.  Giving Ansible a number without following one of these rules will end
         up with a decimal number which will have unexpected results.  As of version 1.8, the mode
         may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).  As of

--- a/lib/ansible/modules/files/template.py
+++ b/lib/ansible/modules/files/template.py
@@ -98,8 +98,8 @@ options:
   mode:
     description:
       - "Mode the file or directory should be. For those used to I(/usr/bin/chmod) remember that
-        modes are actually octal numbers.  You must either specify the leading zero so that
-        Ansible's YAML parser knows it is an octal number (like C(0644) or C(01777)) or quote it
+        modes are actually octal numbers.  You must either add a leading zero so that Ansible's
+        YAML parser knows it is an octal number (like C(0644) or C(01777)) or quote it
         (like C('644') or C('0644') so Ansible receives a string and can do its own conversion from
         string into number.  Giving Ansible a number without following one of these rules will end
         up with a decimal number which will have unexpected results.  As of version 1.8, the mode

--- a/lib/ansible/utils/module_docs_fragments/files.py
+++ b/lib/ansible/utils/module_docs_fragments/files.py
@@ -27,7 +27,7 @@ options:
   mode:
     description:
       - "Mode the file or directory should be. For those used to I(/usr/bin/chmod) remember that modes are actually octal numbers.
-        You must either specify the leading zero so that Ansible's YAML parser knows it is an octal
+        You must either add a leading zero so that Ansible's YAML parser knows it is an octal
         number (like C(0644) or C(01777)) or quote it (like C('644') or C('0644') so Ansible
         receives a string and can do its own conversion from string into number.  Giving Ansible a number
         without following one of these rules will end up with a decimal number which will have unexpected results.

--- a/lib/ansible/utils/module_docs_fragments/files.py
+++ b/lib/ansible/utils/module_docs_fragments/files.py
@@ -28,7 +28,7 @@ options:
     description:
       - "Mode the file or directory should be. For those used to I(/usr/bin/chmod) remember that modes are actually octal numbers.
         You must either add a leading zero so that Ansible's YAML parser knows it is an octal
-        number (like C(0644) or C(01777)) or quote it (like C('644') or C('0644') so Ansible
+        number (like C(0644) or C(01777)) or quote it (like C('644') or C('1777')) so Ansible
         receives a string and can do its own conversion from string into number.  Giving Ansible a number
         without following one of these rules will end up with a decimal number which will have unexpected results.
         As of version 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r))."


### PR DESCRIPTION
I changed the language about how to use mode, calling attention to the
fact that one is *adding* a zero to mark it as octal to Python, rather
than simply including the zero that one might have put there when using
the chmod command on a Unix command line. This makes it more obvious
that using "01777" is not a typo, because the leading zero is not meant
to reflect the way that number might have been given on a command line.

As pointed out in PEP 3127, "The default octal representation of
integers is silently confusing to people unfamiliar with C-like
languages." That PEP is standards track with final status.

See also: issues #5409 #9196 #11385 #13115 #18952 #23491 #23521

 - Docs Pull Request

```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/local/lib/python2.7/dist-packages/ara/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```
