### PR TITLE
Ensure that apt is always chosen on debian/ubuntu

### DIFF
--- a/changelogs/fragments/zypper-on-ubuntu.yaml
+++ b/changelogs/fragments/zypper-on-ubuntu.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - Fixed an issue where ``ansible_facts.pkg_mgr`` would incorrectly set
+    to ``zypper`` on Debian/Ubuntu systems that happened to have the
+    command installed.

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -122,6 +122,10 @@ class PkgMgrFactCollector(BaseFactCollector):
         if collected_facts['ansible_os_family'] == "RedHat":
             if pkg_mgr_name not in ('yum', 'dnf'):
                 pkg_mgr_name = self._check_rh_versions(pkg_mgr_name, collected_facts)
+        elif collected_facts['ansible_os_family'] == 'Debian' and pkg_mgr_name != 'apt':
+            # It's possible to install yum, dnf, zypper, rpm, etc inside of
+            # Debian. Doing so does not mean the system wants to use them.
+            pkg_mgr_name = 'apt'
         elif collected_facts['ansible_os_family'] == 'Altlinux':
             if pkg_mgr_name == 'apt':
                 pkg_mgr_name = 'apt_rpm'

--- a/test/integration/targets/package/tasks/main.yml
+++ b/test/integration/targets/package/tasks/main.yml
@@ -46,6 +46,30 @@
       setup:
   when: ansible_distribution == "Fedora"
 
+# Verify correct default package manager for Debian/Ubuntu when Zypper installed
+- block:
+    # Just make an executable file called "zypper" - installing zypper itself
+    # consistently is hard - and we're not going to use it
+    - name: install fake zypper
+      file:
+        state: touch
+        mode: 0755
+        path: /usr/bin/zypper
+    - name: gather facts again
+      setup:
+    - name: validate output
+      assert:
+        that:
+          - 'ansible_pkg_mgr == "apt"'
+  always:
+    - name: remove fake zypper
+      file:
+        path: /usr/bin/zypper
+        state: absent
+    - name: gather facts again
+      setup:
+  when: ansible_os_family == "Debian"
+
 ##
 ## package
 ##


### PR DESCRIPTION

##### SUMMARY
One can install alternate packages managers on debuntu machines.
However, doing so doesn't mean you want to suddenly start using them.

Add in a check similar to the fedora yum/dnf check that sets apt as the
pkg_mgr if the ansible_os_family is Debian.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
BaseFactCollector

##### ANSIBLE VERSION
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible']
  ansible python module location = /usr/local/lib/python3.6/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, Apr  1 2018, 05:46:30) [GCC 7.3.0]

```