### PR TITLE
Backport package manager detection fixes to stable 2.6

### DIFF
--- a/changelogs/fragments/zypper-on-ubuntu.yaml
+++ b/changelogs/fragments/zypper-on-ubuntu.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - Fixed an issue where ``ansible_facts.pkg_mgr`` would incorrectly set
+    to ``zypper`` on Debian/Ubuntu systems that happened to have the
+    command installed.

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -122,6 +122,10 @@ class PkgMgrFactCollector(BaseFactCollector):
         if collected_facts['ansible_os_family'] == "RedHat":
             if pkg_mgr_name not in ('yum', 'dnf'):
                 pkg_mgr_name = self._check_rh_versions(pkg_mgr_name, collected_facts)
+        elif collected_facts['ansible_os_family'] == 'Debian' and pkg_mgr_name != 'apt':
+            # It's possible to install yum, dnf, zypper, rpm, etc inside of
+            # Debian. Doing so does not mean the system wants to use them.
+            pkg_mgr_name = 'apt'
         elif collected_facts['ansible_os_family'] == 'Altlinux':
             if pkg_mgr_name == 'apt':
                 pkg_mgr_name = 'apt_rpm'

--- a/test/integration/targets/package/tasks/main.yml
+++ b/test/integration/targets/package/tasks/main.yml
@@ -24,11 +24,33 @@
 - name: create our testing sub-directory
   file: path="{{ output_dir_test }}" state=directory
 
+# Verify correct default package manager for Fedora
+# Validates: https://github.com/ansible/ansible/issues/34014
+- block:
+    - name: install apt
+      dnf:
+        name: apt
+        state: present
+    - name: gather facts again
+      setup:
+    - name: validate output
+      assert:
+        that:
+          - 'ansible_pkg_mgr == "dnf"'
+  always:
+    - name: remove apt
+      dnf:
+        name: apt
+        state: absent
+    - name: gather facts again
+      setup:
+  when: ansible_distribution == "Fedora"
+
 ##
 ## package
 ##
 
-- name: define distros to attempt installing at on 
+- name: define distros to attempt installing at on
   set_fact:
     package_distros:
         - RedHat

--- a/test/integration/targets/package/tasks/main.yml
+++ b/test/integration/targets/package/tasks/main.yml
@@ -46,6 +46,30 @@
       setup:
   when: ansible_distribution == "Fedora"
 
+# Verify correct default package manager for Debian/Ubuntu when Zypper installed
+- block:
+    # Just make an executable file called "zypper" - installing zypper itself
+    # consistently is hard - and we're not going to use it
+    - name: install fake zypper
+      file:
+        state: touch
+        mode: 0755
+        path: /usr/bin/zypper
+    - name: gather facts again
+      setup:
+    - name: validate output
+      assert:
+        that:
+          - 'ansible_pkg_mgr == "apt"'
+  always:
+    - name: remove fake zypper
+      file:
+        path: /usr/bin/zypper
+        state: absent
+    - name: gather facts again
+      setup:
+  when: ansible_os_family == "Debian"
+
 ##
 ## package
 ##

--- a/test/units/module_utils/facts/test_ansible_collector.py
+++ b/test/units/module_utils/facts/test_ansible_collector.py
@@ -202,6 +202,8 @@ class TestCollectedFacts(unittest.TestCase):
                       'env']
     not_expected_facts = ['facter', 'ohai']
 
+    collected_facts = {}
+
     def _mock_module(self, gather_subset=None):
         return mock_module(gather_subset=self.gather_subset)
 
@@ -212,7 +214,8 @@ class TestCollectedFacts(unittest.TestCase):
         fact_collector = \
             ansible_collector.AnsibleFactCollector(collectors=collectors,
                                                    namespace=ns)
-        self.facts = fact_collector.collect(module=mock_module)
+        self.facts = fact_collector.collect(module=mock_module,
+                                            collected_facts=self.collected_facts)
 
     def _collectors(self, module,
                     all_collector_classes=None,
@@ -466,10 +469,15 @@ class TestOhaiCollectedFacts(TestCollectedFacts):
 class TestPkgMgrFacts(TestCollectedFacts):
     gather_subset = ['pkg_mgr']
     min_fact_count = 1
-    max_fact_count = 10
+    max_fact_count = 20
     expected_facts = ['gather_subset',
                       'module_setup',
                       'pkg_mgr']
+    collected_facts = {
+        "ansible_distribution": "Fedora",
+        "ansible_distribution_major_version": "28",
+        "ansible_os_family": "RedHat"
+    }
 
 
 class TestOpenBSDPkgMgrFacts(TestPkgMgrFacts):

--- a/test/units/module_utils/facts/test_collectors.py
+++ b/test/units/module_utils/facts/test_collectors.py
@@ -224,8 +224,42 @@ class TestPkgMgrFacts(BaseFactsTest):
     valid_subsets = ['pkg_mgr']
     fact_namespace = 'ansible_pkgmgr'
     collector_class = PkgMgrFactCollector
+    collected_facts = {
+        "ansible_distribution": "Fedora",
+        "ansible_distribution_major_version": "28",
+        "ansible_os_family": "RedHat"
+    }
 
     def test_collect(self):
+        module = self._mock_module()
+        fact_collector = self.collector_class()
+        facts_dict = fact_collector.collect(module=module, collected_facts=self.collected_facts)
+        self.assertIsInstance(facts_dict, dict)
+        self.assertIn('pkg_mgr', facts_dict)
+
+
+def _sanitize_os_path_apt_get(path):
+    if path == '/usr/bin/apt-get':
+        return True
+    else:
+        return False
+
+
+class TestPkgMgrFactsAptFedora(BaseFactsTest):
+    __test__ = True
+    gather_subset = ['!all', 'pkg_mgr']
+    valid_subsets = ['pkg_mgr']
+    fact_namespace = 'ansible_pkgmgr'
+    collector_class = PkgMgrFactCollector
+    collected_facts = {
+        "ansible_distribution": "Fedora",
+        "ansible_distribution_major_version": "28",
+        "ansible_os_family": "RedHat",
+        "ansible_pkg_mgr": "apt"
+    }
+
+    @patch('ansible.module_utils.facts.system.pkg_mgr.os.path.exists', side_effect=_sanitize_os_path_apt_get)
+    def test_collect(self, mock_os_path_exists):
         module = self._mock_module()
         fact_collector = self.collector_class()
         facts_dict = fact_collector.collect(module=module, collected_facts=self.collected_facts)


### PR DESCRIPTION
##### SUMMARY
There are several fixes in master to detection of the package manager to use by the package module. It would be good to get them out to our friends running 2.6, including me.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
BaseFactCollector

##### ANSIBLE VERSION
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible']
  ansible python module location = /usr/local/lib/python3.6/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, Apr  1 2018, 05:46:30) [GCC 7.3.0]

```