### PR TITLE
 Raise a nicer error when we cannot execute the editor

### DIFF
--- a/changelogs/fragments/vault-errors.yaml
+++ b/changelogs/fragments/vault-errors.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- vault - fix error message encoding, and ensure we present a friendlier error when the EDITOR is missing (https://github.com/ansible/ansible/pull/44423)

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -856,16 +856,17 @@ class VaultEditor:
         fd, tmp_path = tempfile.mkstemp(suffix=ext)
         os.close(fd)
 
+        cmd = self._editor_shell_command(tmp_path)
         try:
             if existing_data:
                 self.write_data(existing_data, tmp_path, shred=False)
 
             # drop the user into an editor on the tmp file
-            subprocess.call(self._editor_shell_command(tmp_path))
-        except:
+            subprocess.call(cmd)
+        except Exception as e:
             # whatever happens, destroy the decrypted file
             self._shred_file(tmp_path)
-            raise
+            raise AnsibleError('Unable to execute the command "%s": %s' % (' '.join(cmd), to_native(e)))
 
         b_tmpdata = self.read_data(tmp_path)
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -921,7 +921,7 @@ class VaultEditor:
         try:
             plaintext = self.vault.decrypt(ciphertext, filename=filename)
         except AnsibleError as e:
-            raise AnsibleError("%s for %s" % (to_bytes(e), to_bytes(filename)))
+            raise AnsibleError("%s for %s" % (to_native(e), to_native(filename)))
         self.write_data(plaintext, output_file or filename, shred=False)
 
     def create_file(self, filename, secret, vault_id=None):
@@ -955,7 +955,7 @@ class VaultEditor:
             # TODO: return the vault_id that worked?
             plaintext, vault_id_used, vault_secret_used = self.vault.decrypt_and_get_vault_id(vaulttext)
         except AnsibleError as e:
-            raise AnsibleError("%s for %s" % (to_bytes(e), to_bytes(filename)))
+            raise AnsibleError("%s for %s" % (to_native(e), to_native(filename)))
 
         # Figure out the vault id from the file, to select the right secret to re-encrypt it
         # (duplicates parts of decrypt, but alas...)
@@ -984,7 +984,7 @@ class VaultEditor:
             plaintext = self.vault.decrypt(vaulttext, filename=filename)
             return plaintext
         except AnsibleError as e:
-            raise AnsibleVaultError("%s for %s" % (to_bytes(e), to_bytes(filename)))
+            raise AnsibleVaultError("%s for %s" % (to_native(e), to_native(filename)))
 
     # FIXME/TODO: make this use VaultSecret
     def rekey_file(self, filename, new_vault_secret, new_vault_id=None):
@@ -1001,7 +1001,7 @@ class VaultEditor:
         try:
             plaintext, vault_id_used, _dummy = self.vault.decrypt_and_get_vault_id(vaulttext)
         except AnsibleError as e:
-            raise AnsibleError("%s for %s" % (to_bytes(e), to_bytes(filename)))
+            raise AnsibleError("%s for %s" % (to_native(e), to_native(filename)))
 
         # This is more or less an assert, see #18247
         if new_vault_secret is None:


### PR DESCRIPTION
##### SUMMARY

Raise a nicer error when we cannot execute the editor. Fixes #44419 

Additionally, while fixing this, I encountered the following error, and addressed the use of `to_bytes` in building exceptions

```
ERROR! b'Decryption failed (no vault secrets were found that could decrypt)' for b'/Users/matt/projects/ansibledev/playbooks/vault.yml'
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/parsing/vault

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
2.6
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```