### PR TITLE
Strip trailing comments from /etc/default/passwd (#43931)

### DIFF
--- a/changelogs/fragments/43931-strip-trailing-comments.yml
+++ b/changelogs/fragments/43931-strip-trailing-comments.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - Strip trailing comments in /etc/default/passwd (https://github.com/ansible/ansible/pull/43931)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -347,6 +347,7 @@ import pwd
 import shutil
 import socket
 import time
+import re
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import load_platform_subclass, AnsibleModule
@@ -1490,6 +1491,9 @@ class SunOS(User):
                 line = line.strip()
                 if (line.startswith('#') or line == ''):
                     continue
+                m = re.match(r'^([^#]*)#(.*)$', line)
+                if m:  # The line contains a hash / comment
+                    line = m.group(1)
                 key, value = line.split('=')
                 if key == "MINWEEKS":
                     minweeks = value.rstrip('\n')


### PR DESCRIPTION
* strip additional comments from /etc/default/passwd

Strip trailling comments from /etc/default/passwd like
MINWEEKS=1 #MINWEEKS=2
MAXWEEKS=12  # MAXWEEKS=8
Which otherwise cause failures with "failed to read /etc/default/passwd: too many values to unpack"

* add changelog fragment for PR 43931

(cherry picked from commit 5c1e62050449914fe209378fdb196e3746e16e36)

##### SUMMARY
Strip trailling comments from /etc/default/passwd like:
MINWEEKS=1 #MINWEEKS=2
MAXWEEKS=12 # MAXWEEKS=8
Which otherwise cause failures with "failed to read /etc/default/passwd: too many values to unpack"

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
user module

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /development/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May 31 2018, 09:41:32) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
Requesting backport of https://github.com/ansible/ansible/pull/43931 from devel into stable-2.6
