### PR TITLE
docker_container: add felixfontein as maintainer

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -222,7 +222,7 @@ files:
   $modules/cloud/dimensiondata/dimensiondata_network.py: aimonb tintoy
   $modules/cloud/docker/docker_container.py:
     ignored: ThomasSteinbach
-    maintainers: $team_ansible cove dusdanig kassiansun softzilla zfil
+    maintainers: $team_ansible cove dusdanig felixfontein kassiansun softzilla zfil
   $modules/cloud/docker/docker_image.py: $team_ansible softzilla
   $modules/cloud/docker/docker_image_facts.py: $team_ansible
   $modules/cloud/docker/docker_login.py: olsaki


### PR DESCRIPTION
##### SUMMARY
`docker_container` module: add @felixfontein  as maintainer:
 * @felixfontein [expressed interest in being `docker_container` maintainer](https://github.com/ansible/ansible/pull/43874#issuecomment-414447042)
 * one docker maintainer [backs it](https://github.com/ansible/ansible/pull/43874#issuecomment-412266988).

List of contributions from @felixfontein to docker modules
* merged: 42457 (and the associated backport: 42877)
* open pull requests approved by another docker maintainer:
  * 43238
  * 42380
* pull request reviewed: 16748

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml

##### ANSIBLE VERSION
```
2.7
```

cc @kassiansun 