### PR TITLE
Inventory plugins move auto before ini

### DIFF
--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -22,7 +22,7 @@ config file that ships with Ansible:
 .. code-block:: ini
 
    [inventory]
-   enable_plugins = host_list, script, yaml, ini, auto
+   enable_plugins = host_list, script, auto, yaml, ini
 
 This list also establishes the order in which each plugin tries to parse an inventory source. Any plugins left out of the list will not be considered, so you can 'optimize' your inventory loading by minimizing it to what you actually use. For example:
 

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -324,7 +324,7 @@
 #any_errors_fatal = False
 
 [inventory]
-# enable inventory plugins, default: 'host_list', 'script', 'yaml', 'ini', 'auto'
+# enable inventory plugins, default: 'host_list', 'script', 'auto', 'yaml', 'ini'
 #enable_plugins = host_list, virtualbox, yaml, constructed
 
 # ignore these extensions when parsing a directory as inventory source

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1408,7 +1408,7 @@ INVENTORY_ANY_UNPARSED_IS_FAILED:
   version_added: "2.7"
 INVENTORY_ENABLED:
   name: Active Inventory plugins
-  default: ['host_list', 'script', 'yaml', 'ini', 'toml', 'auto']
+  default: ['host_list', 'script', 'auto', 'yaml', 'ini', 'toml']
   description: List of enabled inventory plugins, it also determines the order in which they are used.
   env: [{name: ANSIBLE_INVENTORY_ENABLED}]
   ini:

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -263,7 +263,7 @@ class InventoryManager(object):
 
                 if plugin_wants:
                     try:
-                        # in case plugin fails 1/2 way we dont want partial inventory
+                        # FIXME in case plugin fails 1/2 way we have partial inventory
                         plugin.parse(self._inventory, self._loader, source, cache=cache)
                         parsed = True
                         display.vvv('Parsed %s inventory source with %s plugin' % (source, plugin_name))


### PR DESCRIPTION
##### SUMMARY
inventory plugins:
* try `auto` before `ini`
* update a comment

`auto` plugin should run before `ini` to avoid `ini` being able to parse some plugin configuration YAML files successfully. A bit like 4aeca601f473f4c35640a0fb59b5def8f8b93467.

For example, when using scaleway inventory with this plugin configuration file:
```yaml
---
plugin: scaleway
regions:
  - ams1
```
`ini` inventory plugin adds a `---` host (I don't have any server on ams1 region, that's why there isn't any other host, the bug is the same when more hosts exist):

```json
$ ANSIBLE_INVENTORY_ENABLED=ini,auto ansible-inventory -i scaleway.yml  --list --export
{
    "_meta": {
        "hostvars": {
            "---": {}
        }
    },
    "all": {
        "children": [
            "ams1",
            "ungrouped"
        ]
    },
    "ams1": {},
    "ungrouped": {
        "hosts": [
            "---"
        ]
    }
}
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
inventory

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel 91a16990d8) last updated 2018/08/21 02:05:56 (GMT +200)
```