### PR TITLE
k8s_facts should not throw exceptions when not found

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -205,10 +205,14 @@ class K8sAnsibleMixin(object):
 
     def kubernetes_facts(self, kind, api_version, name=None, namespace=None, label_selectors=None, field_selectors=None):
         resource = self.find_resource(kind, api_version)
-        result = resource.get(name=name,
-                              namespace=namespace,
-                              label_selector=','.join(label_selectors),
-                              field_selector=','.join(field_selectors)).to_dict()
+        try:
+            result = resource.get(name=name,
+                                  namespace=namespace,
+                                  label_selector=','.join(label_selectors),
+                                  field_selector=','.join(field_selectors)).to_dict()
+        except openshift.dynamic.exceptions.NotFoundError:
+            return dict(items=[])
+
         if 'items' in result:
             return result
         else:


### PR DESCRIPTION
##### SUMMARY
Handle the case where a resource is not found by catching
the exception and returning an empty result set.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
k8s_facts

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel 5b78b1032b) last updated 2018/08/21 12:04:50 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/opensource/ansible/lib/ansible
  executable location = /Users/will/src/opensource/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```


##### ADDITIONAL INFORMATION

