### PR TITLE
Make bool filter work as expected

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -96,13 +96,10 @@ def to_nice_json(a, indent=4, *args, **kw):
 
 def to_bool(a):
     ''' return a bool for the arg '''
-    if a is None or isinstance(a, bool):
-        return a
-    if isinstance(a, string_types):
-        a = a.lower()
-    if a in ('yes', 'on', '1', 'true', 1):
-        return True
-    return False
+    if a and isinstance(a, string_types):
+        if a.lower() in ('no', 'off', '0', 'false', 'n', 'f'):
+            return False
+    return bool(a)
 
 
 def to_datetime(string, format="%Y-%m-%d %H:%M:%S"):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The `bool` filter is not implemented in a reasonable way:
```
def to_bool(a):
    ''' return a bool for the arg '''
    if a is None or isinstance(a, bool):
        return a
    if isinstance(a, string_types):
        a = a.lower()
    if a in ('yes', 'on', '1', 'true', 1):
        return True
    return False
```

We will get strange result like this:

```
null|bool --> None  # null return None, not False
2|bool --> False   # any number except 1 will return False
"foo"|bool --> False  # any common string return False
["foo"]|bool  --> False  # any list return False even not empty
{"foo": "bar"}|bool --> False # any dict return False even not empty
```
Here is a simple task to test:
```
- name: debug
  hosts: localhost
  tasks:
    - name: these will all be wrong
      debug: var=item|bool
      loop:
        - null
        - 2
        - 2.0
        - 'foo'
        - ["foo"]
        - {"foo": "bar"}
```

This PR change it to work as expected:
It works mostly like python bool, but still return False for some special string like `no`, `off`, etc.

This will be a breaking change, but the old one is actually not working properly, need to correct it.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

Fixes #21914 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version                                                               
ansible 2.6.2
  config file = /home/joeg/vagrant/ansible.cfg
  configured module search path = ['/home/joeg/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/joeg/.pyenv/versions/3.6.5/envs/ansible/lib/python3.6/site-packages/ansible
  executable location = /home/joeg/.pyenv/versions/ansible/bin/ansible
  python version = 3.6.5 (default, May 21 2018, 16:39:37) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
