### PR TITLE
Documentation fix, decrypt is True by default

### DIFF
--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -40,7 +40,7 @@ description:
 options:
   decrypt:
     description: A boolean to indicate whether to decrypt the parameter.
-    default: false
+    default: true
     type: boolean
   bypath:
     description: A boolean to indicate whether the parameter is provided as a hierarchy.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The aws_ssm lookup actually decrypts values by default, contrary to the docs. This PR assumes that the code is correct and the docs are wrong which is of course a guess on my part. Perhaps it shouldn't decrypt by default? 

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
aws_ssm lookup

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->

```
ansible 2.6.1
  config file = /Users/joakim/ProReNata/Provision/ansible.cfg
  configured module search path = [u'/Users/joakim/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/joakim/Envs/provision/lib/python2.7/site-packages/ansible
  executable location = /Users/joakim/Envs/provision/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
