### PR TITLE
In expect module documentation add `no_log` to password change example

### DIFF
--- a/lib/ansible/modules/commands/expect.py
+++ b/lib/ansible/modules/commands/expect.py
@@ -77,6 +77,8 @@ EXAMPLES = r'''
     command: passwd username
     responses:
       (?i)password: "MySekretPa$$word"
+  # you don’t want to show passwords in your logs
+  no_log: true
 
 - name: Generic question with multiple different responses
   expect:

--- a/lib/ansible/modules/commands/expect.py
+++ b/lib/ansible/modules/commands/expect.py
@@ -77,7 +77,7 @@ EXAMPLES = r'''
     command: passwd username
     responses:
       (?i)password: "MySekretPa$$word"
-  # you don’t want to show passwords in your logs
+  # you don't want to show passwords in your logs
   no_log: true
 
 - name: Generic question with multiple different responses


### PR DESCRIPTION
Recommend not showing passwords in the logs

+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If you don't know that ansible logs into /var/log/messages you could be leaking passwords in your logs. This makes you aware in the same place that most typically you use passwords in your commands.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
expect

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.3
  config file = ~/srv/ansible/playbooks/gnu_linux/ansible.cfg
  configured module search path = [u'~/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ~/.local/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Example modified adding `no_log`:

<!--- Paste verbatim command output below, e.g. before and after your change -->
``` yaml
 - name: Case insensitive password string match
   expect:
    command: passwd username
    responses:
      (?i)password: "MySekretPa$$word"
  # you don’t want to show passwords in your logs
  no_log: true
```
