### PR TITLE
Ensure that target group ports are cast to int on creation

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -429,6 +429,10 @@ def create_or_update_target_group(connection, module):
         if params['TargetType'] == 'ip':
             fail_if_ip_target_type_not_supported(module)
 
+    # Correct type of target ports
+    for target in params['Targets']:
+        target['Port'] = int(target.get('Port', module.params.get('port')))
+
     # Get target group
     tg = get_target_group(connection, module)
 
@@ -515,7 +519,7 @@ def create_or_update_target_group(connection, module):
                     instances_to_add = []
                     for target in params['Targets']:
                         if target['Id'] in add_instances:
-                            instances_to_add.append({'Id': target['Id'], 'Port': int(target.get('Port', module.params.get('port')))})
+                            instances_to_add.append({'Id': target['Id'], 'Port': target['Port']})
 
                     changed = True
                     try:


### PR DESCRIPTION
##### SUMMARY
A previous fix fixed this for existing target groups but not
for new target groups

Fixes #37368
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_target_group

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 3921f34253) last updated 2018/08/20 20:53:37 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
