### PR TITLE
Fix ios_l2_interface vlan bug CP in 2.6

### DIFF
--- a/changelogs/fragments/fix_ios_l2_interface_vlan.yaml
+++ b/changelogs/fragments/fix_ios_l2_interface_vlan.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios_l2_interface - fix bug when list of vlans ends with comma (https://github.com/ansible/ansible/pull/43879)

--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -303,11 +303,12 @@ def vlan_range_to_list(vlans):
         for part in vlans.split(','):
             if part.lower() == 'none':
                 break
-            if '-' in part:
-                start, stop = (int(i) for i in part.split('-'))
-                result.extend(range(start, stop + 1))
-            else:
-                result.append(int(part))
+            if part:
+                if '-' in part:
+                    start, stop = (int(i) for i in part.split('-'))
+                    result.extend(range(start, stop + 1))
+                else:
+                    result.append(int(part))
     return sorted(result)
 
 


### PR DESCRIPTION
##### SUMMARY
- (cherry picked from commit 401c453)
- Fixes #43878 

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
ios_l2_interface.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
stable-2.6
```
