### PR TITLE
Change the return key of k8s_facts

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -210,9 +210,9 @@ class K8sAnsibleMixin(object):
                               label_selector=','.join(label_selectors),
                               field_selector=','.join(field_selectors)).to_dict()
         if 'items' in result:
-            return result
+            return dict(resources=result['items'])
         else:
-            return dict(items=[result])
+            return dict(resources=[result])
 
     def remove_aliases(self):
         """

--- a/lib/ansible/modules/clustering/k8s/k8s_facts.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_facts.py
@@ -101,7 +101,7 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-items:
+resources:
   description:
   - The object(s) that exists
   returned: success


### PR DESCRIPTION
##### SUMMARY

`items` is a *terrible* return key for ansible as Jinja
will often think it refers to the `items()` function.

Even though you can typically work around this with
`results['items']`, sometimes even that doesn't work:

```
- name: Resources should exist
  assert:
    that: item.status.phase == 'Active'
  loop: "{{ k8s_namespaces['items'] }}"
```

```
fatal: [testhost]: FAILED! => {"msg": "Invalid data passed to 'loop', it
requires a list, got this instead: <built-in method items of dict object
at 0x109dc9c58>. Hint: If you passed a list/dict of just one element,
try adding wantlist=True to your lookup invocation or use q/query
instead of lookup."}
```

Change it now while we still can.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
k8s_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel 3921f34253) last updated 2018/08/20 20:53:37 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
This will conflict with my other k8s_facts PR #44429 but I will resolve the conflicts after whichever gets merged first
