### PR TITLE
Fix enable_snat parameter (#44418)

### DIFF
--- a/changelogs/fragments/fix-os_router.yaml
+++ b/changelogs/fragments/fix-os_router.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+    - fix the enable_snat parameter that is only supposed to be used by an user
+      with the right policies. https://github.com/ansible/ansible/pull/44418

--- a/changelogs/fragments/fix_os_router.yaml
+++ b/changelogs/fragments/fix_os_router.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+    - fix the enable_snat parameter that is only supposed to be used by an user
+      with the right policies. https://github.com/ansible/ansible/pull/44418

--- a/changelogs/fragments/fix_os_router.yaml
+++ b/changelogs/fragments/fix_os_router.yaml
@@ -1,3 +1,0 @@
-bugfixes:
-    - fix the enable_snat parameter that is only supposed to be used by an user
-      with the right policies. https://github.com/ansible/ansible/pull/44418

--- a/lib/ansible/modules/cloud/openstack/os_router.py
+++ b/lib/ansible/modules/cloud/openstack/os_router.py
@@ -42,7 +42,6 @@ options:
      description:
         - Enable Source NAT (SNAT) attribute.
      type: bool
-     default: 'yes'
    network:
      description:
         - Unique name or ID of the external gateway network.
@@ -307,7 +306,8 @@ def _build_kwargs(cloud, module, router, network):
     if network:
         kwargs['ext_gateway_net_id'] = network['id']
         # can't send enable_snat unless we have a network
-        kwargs['enable_snat'] = module.params['enable_snat']
+        if module.params['enable_snat']:
+            kwargs['enable_snat'] = module.params['enable_snat']
 
     if module.params['external_fixed_ips']:
         kwargs['ext_fixed_ips'] = []
@@ -371,7 +371,7 @@ def main():
         state=dict(default='present', choices=['absent', 'present']),
         name=dict(required=True),
         admin_state_up=dict(type='bool', default=True),
-        enable_snat=dict(type='bool', default=True),
+        enable_snat=dict(type='bool'),
         network=dict(default=None),
         interfaces=dict(type='list', default=None),
         external_fixed_ips=dict(type='list', default=None),


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes the issue #44285
(cherry picked from commit b7139782cfa7d631a204c38021e4ed59e9e5d956)

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
os_router
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
