### PR TITLE
docs: Use GitHub syntax highlighting styles

### DIFF
--- a/docs/docsite/_static/pygments.css
+++ b/docs/docsite/_static/pygments.css
@@ -1,19 +1,23 @@
-.highlight .hll { background-color: #ffffcc }
-.highlight  { background: #eeffcc; }
-.highlight .c { color: #408090; font-style: italic } /* Comment */
-.highlight .err { border: 1px solid #FF0000 } /* Error */
+.highlight { background: #f8f8f8 }
+.highlight .hll { background-color: #ffffcc; border: 1px solid #ccc; padding: 6px 10px; border-radius: 3px }
+.highlight .c { color: #6a737d; font-style: italic } /* Comment */
+.highlight .err { color: #a61717; background-color: #e3d2d2; color: #a61717; border: 1px solid #FF0000 } /* Error */
 .highlight .k { color: #007020; font-weight: bold } /* Keyword */
-.highlight .o { color: #666666 } /* Operator */
-.highlight .cm { color: #408090; font-style: italic } /* Comment.Multiline */
+.highlight .o { color: #666666; font-weight: bold } /* Operator */
+.highlight .ch { color: #6a737d; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #6a737d; font-style: italic } /* Comment.Multiline */
 .highlight .cp { color: #007020 } /* Comment.Preproc */
-.highlight .c1 { color: #408090; font-style: italic } /* Comment.Single */
-.highlight .cs { color: #408090; background-color: #fff0f0 } /* Comment.Special */
-.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .cpf { color: #6a737d; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #6a737d; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #999999; font-weight: bold; font-style: italic; background-color: #fff0f0 } /* Comment.Special */
+.highlight .gd { color: #A00000; background-color: #ffdddd } /* Generic.Deleted */
+.highlight .gd .x { color: #A00000; background-color: #ffaaaa }
 .highlight .ge { font-style: italic } /* Generic.Emph */
-.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gr { color: #aa0000 } /* Generic.Error */
 .highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight .gi { color: #00A000 } /* Generic.Inserted */
-.highlight .go { color: #303030 } /* Generic.Output */
+.highlight .gi { color: #00A000; background-color: #ddffdd } /* Generic.Inserted */
+.highlight .gi .x { color: #00A000; background-color: #aaffaa; }
+.highlight .go { color: #333333 } /* Generic.Output */
 .highlight .gp { color: #c65d09; font-weight: bold } /* Generic.Prompt */
 .highlight .gs { font-weight: bold } /* Generic.Strong */
 .highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
@@ -24,39 +28,49 @@
 .highlight .kp { color: #007020 } /* Keyword.Pseudo */
 .highlight .kr { color: #007020; font-weight: bold } /* Keyword.Reserved */
 .highlight .kt { color: #902000 } /* Keyword.Type */
+.highlight .l { color: #032f62 } /* Literal */
 .highlight .m { color: #208050 } /* Literal.Number */
 .highlight .s { color: #4070a0 } /* Literal.String */
-.highlight .na { color: #4070a0 } /* Name.Attribute */
-.highlight .nb { color: #007020 } /* Name.Builtin */
-.highlight .nc { color: #0e84b5; font-weight: bold } /* Name.Class */
-.highlight .no { color: #60add5 } /* Name.Constant */
+.highlight .n { color: #333333 }
+.highlight .p { font-weight: bold }
+.highlight .na { color: teal } /* Name.Attribute */
+.highlight .nb { color: #0086b3 } /* Name.Builtin */
+.highlight .nc { color: #445588; font-weight: bold } /* Name.Class */
+.highlight .no { color: teal; } /* Name.Constant */
 .highlight .nd { color: #555555; font-weight: bold } /* Name.Decorator */
-.highlight .ni { color: #d55537; font-weight: bold } /* Name.Entity */
-.highlight .ne { color: #007020 } /* Name.Exception */
-.highlight .nf { color: #06287e } /* Name.Function */
+.highlight .ni { color: purple; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #990000; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #990000; font-weight: bold } /* Name.Function */
 .highlight .nl { color: #002070; font-weight: bold } /* Name.Label */
-.highlight .nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
-.highlight .nt { color: #062873; font-weight: bold } /* Name.Tag */
-.highlight .nv { color: #bb60d5 } /* Name.Variable */
+.highlight .nn { color: #555555; font-weight: bold } /* Name.Namespace */
+.highlight .nt { color: #22863a } /* Name.Tag */
+.highlight .nv { color: #9960b5; font-weight: bold } /* Name.Variable */
+.highlight .p { color: font-weight: bold } /* Indicator  */
 .highlight .ow { color: #007020; font-weight: bold } /* Operator.Word */
 .highlight .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight .mf { color: #208050 } /* Literal.Number.Float */
-.highlight .mh { color: #208050 } /* Literal.Number.Hex */
-.highlight .mi { color: #208050 } /* Literal.Number.Integer */
-.highlight .mo { color: #208050 } /* Literal.Number.Oct */
-.highlight .sb { color: #4070a0 } /* Literal.String.Backtick */
-.highlight .sc { color: #4070a0 } /* Literal.String.Char */
-.highlight .sd { color: #4070a0; font-style: italic } /* Literal.String.Doc */
-.highlight .s2 { color: #4070a0 } /* Literal.String.Double */
-.highlight .se { color: #4070a0; font-weight: bold } /* Literal.String.Escape */
-.highlight .sh { color: #4070a0 } /* Literal.String.Heredoc */
-.highlight .si { color: #70a0d0; font-style: italic } /* Literal.String.Interpol */
-.highlight .sx { color: #c65d09 } /* Literal.String.Other */
-.highlight .sr { color: #235388 } /* Literal.String.Regex */
-.highlight .s1 { color: #4070a0 } /* Literal.String.Single */
-.highlight .ss { color: #517918 } /* Literal.String.Symbol */
-.highlight .bp { color: #007020 } /* Name.Builtin.Pseudo */
-.highlight .vc { color: #bb60d5 } /* Name.Variable.Class */
-.highlight .vg { color: #bb60d5 } /* Name.Variable.Global */
-.highlight .vi { color: #bb60d5 } /* Name.Variable.Instance */
-.highlight .il { color: #208050 } /* Literal.Number.Integer.Long */
+.highlight .mb { color: #009999 } /* Literal.Number.Bin */
+.highlight .mf { color: #009999 } /* Literal.Number.Float */
+.highlight .mh { color: #009999 } /* Literal.Number.Hex */
+.highlight .mi { color: #009999 } /* Literal.Number.Integer */
+.highlight .mo { color: #009999 } /* Literal.Number.Oct */
+.highlight .sa { color: #dd1144 } /* Literal.String.Affix */
+.highlight .sb { color: #dd1144 } /* Literal.String.Backtick */
+.highlight .sc { color: #dd1144 } /* Literal.String.Char */
+.highlight .dl { color: #dd1144 } /* Literal.String.Delimiter */
+.highlight .sd { color: #dd1144; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #dd1144 } /* Literal.String.Double */
+.highlight .se { color: #dd1144; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #dd1144 } /* Literal.String.Heredoc */
+.highlight .si { color: #dd1144; font-style: italic } /* Literal.String.Interpol */
+.highlight .sx { color: #dd1144 } /* Literal.String.Other */
+.highlight .sr { color: #009926 } /* Literal.String.Regex */
+.highlight .s1 { color: #dd1144 } /* Literal.String.Single */
+.highlight .ss { color: #990073 } /* Literal.String.Symbol */
+.highlight .bp { color: #999999 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #06287e } /* Name.Function.Magic */
+.highlight .vc { color: teal } /* Name.Variable.Class */
+.highlight .vg { color: teal } /* Name.Variable.Global */
+.highlight .vi { color: teal } /* Name.Variable.Instance */
+.highlight .vm { color: #bb60d5 } /* Name.Variable.Magic */
+.highlight .il { color: #009999 } /* Literal.Number.Integer.Long */
+.highlight .gc { color: #909090; background-color: #eaf2f5 }


### PR DESCRIPTION
##### SUMMARY
This PR changes the CSS stylesheet so the documentation (and module)
examples look more like how they look on GitHub.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
v2.7

##### ADDITIONAL INFORMATION
(Screen shots taken here: https://docs.ansible.com/ansible/devel/modules/aci_rest_module.html)

Before:
![screenshot from 2018-08-21 14-48-05](https://user-images.githubusercontent.com/388198/44402252-7ba2c900-a551-11e8-8e60-e06275784df3.png)

After:
![screenshot from 2018-08-21 14-48-25](https://user-images.githubusercontent.com/388198/44402263-82c9d700-a551-11e8-8f3e-6ca9419459b3.png)