### PR TITLE
Allows imports dynamic inventories

### DIFF
--- a/contrib/inventory/brook.py
+++ b/contrib/inventory/brook.py
@@ -254,8 +254,6 @@ class BrookInventory:
 
         return hostvars
 
-
-# Run the script
-#
-brook = BrookInventory()
-print(json.dumps(brook.inventory))
+if __name__ == '__main__':
+    brook = BrookInventory()
+    print(json.dumps(brook.inventory))

--- a/contrib/inventory/cloudforms.py
+++ b/contrib/inventory/cloudforms.py
@@ -479,5 +479,5 @@ class CloudFormsInventory(object):
         else:
             return json.dumps(data)
 
-
-CloudFormsInventory()
+if __name__ == '__main__':
+    CloudFormsInventory()

--- a/contrib/inventory/cobbler.py
+++ b/contrib/inventory/cobbler.py
@@ -309,5 +309,5 @@ class CobblerInventory(object):
         else:
             return json.dumps(data)
 
-
-CobblerInventory()
+if __name__ == '__main__':
+    CobblerInventory()

--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -525,5 +525,5 @@ class ConsulConfig(dict):
                 token = 'anonymous'
         return consul.Consul(host=host, port=port, token=token, scheme=scheme)
 
-
-ConsulInventory()
+if __name__ == '__main__':
+    ConsulInventory()

--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -548,4 +548,5 @@ class DigitalOceanInventory(object):
 
 ###########################################################################
 # Run the script
-DigitalOceanInventory()
+if __name__ == '__main__':
+    DigitalOceanInventory()

--- a/contrib/inventory/docker.py
+++ b/contrib/inventory/docker.py
@@ -889,5 +889,5 @@ def main():
 
     DockerInventory().run()
 
-
-main()
+if __name__ == '__main__':
+    main()

--- a/contrib/inventory/fleet.py
+++ b/contrib/inventory/fleet.py
@@ -73,35 +73,40 @@ def get_a_ssh_config(box_name):
     return config
 
 
-# List out servers that vagrant has running
-# ------------------------------
-if options.list:
-    ssh_config = get_ssh_config()
-    hosts = {'coreos': []}
+def main():
+    # List out servers that vagrant has running
+    # ------------------------------
+    if options.list:
+        ssh_config = get_ssh_config()
+        hosts = {'coreos': []}
 
-    for data in ssh_config:
-        hosts['coreos'].append(data['Host'])
+        for data in ssh_config:
+            hosts['coreos'].append(data['Host'])
 
-    print(json.dumps(hosts))
-    sys.exit(1)
+        print(json.dumps(hosts))
+        sys.exit(1)
 
-# Get out the host details
-# ------------------------------
-elif options.host:
-    result = {}
-    ssh_config = get_ssh_config()
+    # Get out the host details
+    # ------------------------------
+    elif options.host:
+        result = {}
+        ssh_config = get_ssh_config()
 
-    details = filter(lambda x: (x['Host'] == options.host), ssh_config)
-    if len(details) > 0:
-        # pass through the port, in case it's non standard.
-        result = details[0]
+        details = filter(lambda x: (x['Host'] == options.host), ssh_config)
+        if len(details) > 0:
+            # pass through the port, in case it's non standard.
+            result = details[0]
 
-    print(json.dumps(result))
-    sys.exit(1)
+        print(json.dumps(result))
+        sys.exit(1)
 
 
-# Print out help
-# ------------------------------
-else:
-    parser.print_help()
-    sys.exit(1)
+    # Print out help
+    # ------------------------------
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/contrib/inventory/jail.py
+++ b/contrib/inventory/jail.py
@@ -21,17 +21,18 @@ from subprocess import Popen, PIPE
 import sys
 import json
 
-result = {}
-result['all'] = {}
+if __name__ == '__main__':
+    result = {}
+    result['all'] = {}
 
-pipe = Popen(['jls', '-q', 'name'], stdout=PIPE, universal_newlines=True)
-result['all']['hosts'] = [x[:-1] for x in pipe.stdout.readlines()]
-result['all']['vars'] = {}
-result['all']['vars']['ansible_connection'] = 'jail'
+    pipe = Popen(['jls', '-q', 'name'], stdout=PIPE, universal_newlines=True)
+    result['all']['hosts'] = [x[:-1] for x in pipe.stdout.readlines()]
+    result['all']['vars'] = {}
+    result['all']['vars']['ansible_connection'] = 'jail'
 
-if len(sys.argv) == 2 and sys.argv[1] == '--list':
-    print(json.dumps(result))
-elif len(sys.argv) == 3 and sys.argv[1] == '--host':
-    print(json.dumps({'ansible_connection': 'jail'}))
-else:
-    sys.stderr.write("Need an argument, either --list or --host <host>\n")
+    if len(sys.argv) == 2 and sys.argv[1] == '--list':
+        print(json.dumps(result))
+    elif len(sys.argv) == 3 and sys.argv[1] == '--host':
+        print(json.dumps({'ansible_connection': 'jail'}))
+    else:
+        sys.stderr.write("Need an argument, either --list or --host <host>\n")

--- a/contrib/inventory/libvirt_lxc.py
+++ b/contrib/inventory/libvirt_lxc.py
@@ -21,17 +21,18 @@ from subprocess import Popen, PIPE
 import sys
 import json
 
-result = {}
-result['all'] = {}
+if __name__ == '__main__':
+    result = {}
+    result['all'] = {}
 
-pipe = Popen(['virsh', '-q', '-c', 'lxc:///', 'list', '--name', '--all'], stdout=PIPE, universal_newlines=True)
-result['all']['hosts'] = [x[:-1] for x in pipe.stdout.readlines()]
-result['all']['vars'] = {}
-result['all']['vars']['ansible_connection'] = 'libvirt_lxc'
+    pipe = Popen(['virsh', '-q', '-c', 'lxc:///', 'list', '--name', '--all'], stdout=PIPE, universal_newlines=True)
+    result['all']['hosts'] = [x[:-1] for x in pipe.stdout.readlines()]
+    result['all']['vars'] = {}
+    result['all']['vars']['ansible_connection'] = 'libvirt_lxc'
 
-if len(sys.argv) == 2 and sys.argv[1] == '--list':
-    print(json.dumps(result))
-elif len(sys.argv) == 3 and sys.argv[1] == '--host':
-    print(json.dumps({'ansible_connection': 'libvirt_lxc'}))
-else:
-    sys.stderr.write("Need an argument, either --list or --host <host>\n")
+    if len(sys.argv) == 2 and sys.argv[1] == '--list':
+        print(json.dumps(result))
+    elif len(sys.argv) == 3 and sys.argv[1] == '--host':
+        print(json.dumps({'ansible_connection': 'libvirt_lxc'}))
+    else:
+        sys.stderr.write("Need an argument, either --list or --host <host>\n")

--- a/contrib/inventory/linode.py
+++ b/contrib/inventory/linode.py
@@ -344,5 +344,5 @@ class LinodeInventory(object):
         else:
             return json.dumps(data)
 
-
-LinodeInventory()
+if __name__ == '__main__':
+    LinodeInventory()

--- a/contrib/inventory/lxd.py
+++ b/contrib/inventory/lxd.py
@@ -32,72 +32,76 @@ try:
 except:
     from six.moves import configparser
 
-# Set up defaults
-resource = 'local:'
-group = 'lxd'
-connection = 'lxd'
-hosts = {}
-result = {}
+def main():
+    # Set up defaults
+    resource = 'local:'
+    group = 'lxd'
+    connection = 'lxd'
+    hosts = {}
+    result = {}
 
-# Read the settings from the lxd.ini file
-config = configparser.SafeConfigParser()
-config.read(os.path.dirname(os.path.realpath(__file__)) + '/lxd.ini')
-if config.has_option('lxd', 'resource'):
-    resource = config.get('lxd', 'resource')
-if config.has_option('lxd', 'group'):
-    group = config.get('lxd', 'group')
-if config.has_option('lxd', 'connection'):
-    connection = config.get('lxd', 'connection')
+    # Read the settings from the lxd.ini file
+    config = configparser.SafeConfigParser()
+    config.read(os.path.dirname(os.path.realpath(__file__)) + '/lxd.ini')
+    if config.has_option('lxd', 'resource'):
+        resource = config.get('lxd', 'resource')
+    if config.has_option('lxd', 'group'):
+        group = config.get('lxd', 'group')
+    if config.has_option('lxd', 'connection'):
+        connection = config.get('lxd', 'connection')
 
-# Ensure executable exists
-if distutils.spawn.find_executable('lxc'):
+    # Ensure executable exists
+    if distutils.spawn.find_executable('lxc'):
 
-    # Set up containers result and hosts array
-    result[group] = {}
-    result[group]['hosts'] = []
+        # Set up containers result and hosts array
+        result[group] = {}
+        result[group]['hosts'] = []
 
-    # Run the command and load json result
-    pipe = Popen(['lxc', 'list', resource, '--format', 'json'], stdout=PIPE, universal_newlines=True)
-    lxdjson = json.load(pipe.stdout)
+        # Run the command and load json result
+        pipe = Popen(['lxc', 'list', resource, '--format', 'json'], stdout=PIPE, universal_newlines=True)
+        lxdjson = json.load(pipe.stdout)
 
-    # Iterate the json lxd output
-    for item in lxdjson:
+        # Iterate the json lxd output
+        for item in lxdjson:
 
-        # Check state and network
-        if 'state' in item and item['state'] is not None and 'network' in item['state']:
-            network = item['state']['network']
+            # Check state and network
+            if 'state' in item and item['state'] is not None and 'network' in item['state']:
+                network = item['state']['network']
 
-            # Check for eth0 and addresses
-            if 'eth0' in network and 'addresses' in network['eth0']:
-                addresses = network['eth0']['addresses']
+                # Check for eth0 and addresses
+                if 'eth0' in network and 'addresses' in network['eth0']:
+                    addresses = network['eth0']['addresses']
 
-                # Iterate addresses
-                for address in addresses:
+                    # Iterate addresses
+                    for address in addresses:
 
-                    # Only return inet family addresses
-                    if 'family' in address and address['family'] == 'inet':
-                        if 'address' in address:
-                            ip = address['address']
-                            name = item['name']
+                        # Only return inet family addresses
+                        if 'family' in address and address['family'] == 'inet':
+                            if 'address' in address:
+                                ip = address['address']
+                                name = item['name']
 
-                            # Add the host to the results and the host array
-                            result[group]['hosts'].append(name)
-                            hosts[name] = ip
+                                # Add the host to the results and the host array
+                                result[group]['hosts'].append(name)
+                                hosts[name] = ip
 
-    # Set the other containers result values
-    result[group]['vars'] = {}
-    result[group]['vars']['ansible_connection'] = connection
+        # Set the other containers result values
+        result[group]['vars'] = {}
+        result[group]['vars']['ansible_connection'] = connection
 
-# Process arguments
-if len(sys.argv) == 2 and sys.argv[1] == '--list':
-    print(json.dumps(result))
-elif len(sys.argv) == 3 and sys.argv[1] == '--host':
-    if sys.argv[2] == 'localhost':
-        print(json.dumps({'ansible_connection': 'local'}))
-    else:
-        if connection == 'lxd':
-            print(json.dumps({'ansible_connection': connection}))
+    # Process arguments
+    if len(sys.argv) == 2 and sys.argv[1] == '--list':
+        print(json.dumps(result))
+    elif len(sys.argv) == 3 and sys.argv[1] == '--host':
+        if sys.argv[2] == 'localhost':
+            print(json.dumps({'ansible_connection': 'local'}))
         else:
-            print(json.dumps({'ansible_connection': connection, 'ansible_host': hosts[sys.argv[2]]}))
-else:
-    print("Need an argument, either --list or --host <host>")
+            if connection == 'lxd':
+                print(json.dumps({'ansible_connection': connection}))
+            else:
+                print(json.dumps({'ansible_connection': connection, 'ansible_host': hosts[sys.argv[2]]}))
+    else:
+        print("Need an argument, either --list or --host <host>")
+
+if __name__ == '__main__':
+    main()

--- a/contrib/inventory/nagios_livestatus.py
+++ b/contrib/inventory/nagios_livestatus.py
@@ -173,5 +173,5 @@ class NagiosLivestatusInventory(object):
         else:
             sys.exit("usage: --list or --host HOSTNAME [--pretty]")
 
-
-NagiosLivestatusInventory()
+if __name__ == '__main__':
+    NagiosLivestatusInventory()

--- a/contrib/inventory/nagios_ndo.py
+++ b/contrib/inventory/nagios_ndo.py
@@ -105,5 +105,5 @@ class NagiosNDOInventory(object):
         else:
             sys.exit("Error: Database configuration is missing. See nagios_ndo.ini.")
 
-
-NagiosNDOInventory()
+if __name__ == '__main__':
+    NagiosNDOInventory()

--- a/contrib/inventory/openshift.py
+++ b/contrib/inventory/openshift.py
@@ -69,32 +69,36 @@ def get_json_from_api(url, username, password):
     return json.loads(response.read())['data']
 
 
-username = get_config('ANSIBLE_OPENSHIFT_USERNAME', 'default_rhlogin')
-password = get_config('ANSIBLE_OPENSHIFT_PASSWORD', 'password')
-broker_url = 'https://%s/broker/rest/' % get_config('ANSIBLE_OPENSHIFT_BROKER', 'libra_server')
+def main():
+    username = get_config('ANSIBLE_OPENSHIFT_USERNAME', 'default_rhlogin')
+    password = get_config('ANSIBLE_OPENSHIFT_PASSWORD', 'password')
+    broker_url = 'https://%s/broker/rest/' % get_config('ANSIBLE_OPENSHIFT_BROKER', 'libra_server')
 
 
-response = get_json_from_api(broker_url + '/domains', username, password)
+    response = get_json_from_api(broker_url + '/domains', username, password)
 
-response = get_json_from_api("%s/domains/%s/applications" %
-                             (broker_url, response[0]['id']), username, password)
+    response = get_json_from_api("%s/domains/%s/applications" %
+                                 (broker_url, response[0]['id']), username, password)
 
-result = {}
-for app in response:
+    result = {}
+    for app in response:
 
-    # ssh://520311404832ce3e570000ff@blog-johndoe.example.org
-    (user, host) = app['ssh_url'][6:].split('@')
-    app_name = host.split('-')[0]
+        # ssh://520311404832ce3e570000ff@blog-johndoe.example.org
+        (user, host) = app['ssh_url'][6:].split('@')
+        app_name = host.split('-')[0]
 
-    result[app_name] = {}
-    result[app_name]['hosts'] = []
-    result[app_name]['hosts'].append(host)
-    result[app_name]['vars'] = {}
-    result[app_name]['vars']['ansible_ssh_user'] = user
+        result[app_name] = {}
+        result[app_name]['hosts'] = []
+        result[app_name]['hosts'].append(host)
+        result[app_name]['vars'] = {}
+        result[app_name]['vars']['ansible_ssh_user'] = user
 
-if len(sys.argv) == 2 and sys.argv[1] == '--list':
-    print(json.dumps(result))
-elif len(sys.argv) == 3 and sys.argv[1] == '--host':
-    print(json.dumps({}))
-else:
-    print("Need an argument, either --list or --host <host>")
+    if len(sys.argv) == 2 and sys.argv[1] == '--list':
+        print(json.dumps(result))
+    elif len(sys.argv) == 3 and sys.argv[1] == '--host':
+        print(json.dumps({}))
+    else:
+        print("Need an argument, either --list or --host <host>")
+
+if __name__ == '__main__':
+    main()

--- a/contrib/inventory/openvz.py
+++ b/contrib/inventory/openvz.py
@@ -75,11 +75,11 @@ def get_guests():
 
         return inventory
 
-
-if len(sys.argv) == 2 and sys.argv[1] == '--list':
-    inv_json = get_guests()
-    print(json.dumps(inv_json, sort_keys=True))
-elif len(sys.argv) == 3 and sys.argv[1] == '--host':
-    print(json.dumps({}))
-else:
-    print("Need an argument, either --list or --host <host>")
+if __name__ == '__main__':
+    if len(sys.argv) == 2 and sys.argv[1] == '--list':
+        inv_json = get_guests()
+        print(json.dumps(inv_json, sort_keys=True))
+    elif len(sys.argv) == 3 and sys.argv[1] == '--host':
+        print(json.dumps({}))
+    else:
+        print("Need an argument, either --list or --host <host>")

--- a/contrib/inventory/ovirt.py
+++ b/contrib/inventory/ovirt.py
@@ -284,6 +284,5 @@ class OVirtInventory(object):
         else:
             return json.dumps(data)
 
-
-# Run the script
-OVirtInventory()
+if __name__ == '__main__':
+    OVirtInventory()

--- a/contrib/inventory/packet_net.py
+++ b/contrib/inventory/packet_net.py
@@ -492,5 +492,6 @@ class PacketInventory(object):
             return json.dumps(data)
 
 
-# Run the script
-PacketInventory()
+
+if __name__ == '__main__':
+    PacketInventory()

--- a/contrib/inventory/rackhd.py
+++ b/contrib/inventory/rackhd.py
@@ -73,24 +73,25 @@ except:
     # use default values
     pass
 
-# Use the nodeid specified in the environment to limit the data returned
-# or return data for all available nodes
-nodeids = []
+if __name__ == '__main__':
+    # Use the nodeid specified in the environment to limit the data returned
+    # or return data for all available nodes
+    nodeids = []
 
-if (parse_args().host):
-    try:
-        nodeids += parse_args().host.split(',')
-        RackhdInventory(nodeids)
-    except:
-        pass
-if (parse_args().list):
-    try:
-        url = RACKHD_URL + '/api/common/nodes'
-        r = requests.get(url, verify=False)
-        data = json.loads(r.text)
-        for entry in data:
-            if entry['type'] == 'compute':
-                nodeids.append(entry['id'])
-        RackhdInventory(nodeids)
-    except:
-        pass
+    if (parse_args().host):
+        try:
+            nodeids += parse_args().host.split(',')
+            RackhdInventory(nodeids)
+        except:
+            pass
+    if (parse_args().list):
+        try:
+            url = RACKHD_URL + '/api/common/nodes'
+            r = requests.get(url, verify=False)
+            data = json.loads(r.text)
+            for entry in data:
+                if entry['type'] == 'compute':
+                    nodeids.append(entry['id'])
+            RackhdInventory(nodeids)
+        except:
+            pass

--- a/contrib/inventory/rudder.py
+++ b/contrib/inventory/rudder.py
@@ -292,5 +292,6 @@ class RudderInventory(object):
         return re.sub(r'[^A-Za-z0-9\_]', '_', word)
 
 
-# Run the script
-RudderInventory()
+
+if __name__ == '__main__':
+    RudderInventory()

--- a/contrib/inventory/softlayer.py
+++ b/contrib/inventory/softlayer.py
@@ -195,5 +195,5 @@ class SoftLayerInventory(object):
         self.get_virtual_servers()
         self.get_physical_servers()
 
-
-SoftLayerInventory()
+if __name__ == '__main__':
+    SoftLayerInventory()

--- a/contrib/inventory/spacewalk.py
+++ b/contrib/inventory/spacewalk.py
@@ -99,138 +99,141 @@ def spacewalk_report(name):
             yield dict(zip(keys, values))
 
 
-# Options
-# ------------------------------
+def main():
+    # Options
+    # ------------------------------
 
-parser = OptionParser(usage="%prog [options] --list | --host <machine>")
-parser.add_option('--list', default=False, dest="list", action="store_true",
-                  help="Produce a JSON consumable grouping of servers for Ansible")
-parser.add_option('--host', default=None, dest="host",
-                  help="Generate additional host specific details for given host for Ansible")
-parser.add_option('-H', '--human', dest="human",
-                  default=False, action="store_true",
-                  help="Produce a friendlier version of either server list or host detail")
-parser.add_option('-o', '--org', default=None, dest="org_number",
-                  help="Limit to spacewalk organization number")
-parser.add_option('-p', default=False, dest="prefix_org_name", action="store_true",
-                  help="Prefix the group name with the organization number")
-(options, args) = parser.parse_args()
-
-
-# read spacewalk.ini if present
-# ------------------------------
-if os.path.exists(INI_FILE):
-    config = ConfigParser.SafeConfigParser()
-    config.read(INI_FILE)
-    if config.has_option('spacewalk', 'cache_age'):
-        CACHE_AGE = config.get('spacewalk', 'cache_age')
-    if not options.org_number and config.has_option('spacewalk', 'org_number'):
-        options.org_number = config.get('spacewalk', 'org_number')
-    if not options.prefix_org_name and config.has_option('spacewalk', 'prefix_org_name'):
-        options.prefix_org_name = config.getboolean('spacewalk', 'prefix_org_name')
+    parser = OptionParser(usage="%prog [options] --list | --host <machine>")
+    parser.add_option('--list', default=False, dest="list", action="store_true",
+                      help="Produce a JSON consumable grouping of servers for Ansible")
+    parser.add_option('--host', default=None, dest="host",
+                      help="Generate additional host specific details for given host for Ansible")
+    parser.add_option('-H', '--human', dest="human",
+                      default=False, action="store_true",
+                      help="Produce a friendlier version of either server list or host detail")
+    parser.add_option('-o', '--org', default=None, dest="org_number",
+                      help="Limit to spacewalk organization number")
+    parser.add_option('-p', default=False, dest="prefix_org_name", action="store_true",
+                      help="Prefix the group name with the organization number")
+    (options, args) = parser.parse_args()
 
 
-# Generate dictionary for mapping group_id to org_id
-# ------------------------------
-org_groups = {}
-try:
-    for group in spacewalk_report('system-groups'):
-        org_groups[group['spacewalk_group_id']] = group['spacewalk_org_id']
+    # read spacewalk.ini if present
+    # ------------------------------
+    if os.path.exists(INI_FILE):
+        config = ConfigParser.SafeConfigParser()
+        config.read(INI_FILE)
+        if config.has_option('spacewalk', 'cache_age'):
+            CACHE_AGE = config.get('spacewalk', 'cache_age')
+        if not options.org_number and config.has_option('spacewalk', 'org_number'):
+            options.org_number = config.get('spacewalk', 'org_number')
+        if not options.prefix_org_name and config.has_option('spacewalk', 'prefix_org_name'):
+            options.prefix_org_name = config.getboolean('spacewalk', 'prefix_org_name')
 
-except (OSError) as e:
-    print('Problem executing the command "%s system-groups": %s' %
-          (SW_REPORT, str(e)), file=sys.stderr)
-    sys.exit(2)
 
-
-# List out the known server from Spacewalk
-# ------------------------------
-if options.list:
-
-    # to build the "_meta"-Group with hostvars first create dictionary for later use
-    host_vars = {}
+    # Generate dictionary for mapping group_id to org_id
+    # ------------------------------
+    org_groups = {}
     try:
-        for item in spacewalk_report('inventory'):
-            host_vars[item['spacewalk_profile_name']] = dict((key, (value.split(';') if ';' in value else value)) for key, value in item.items())
+        for group in spacewalk_report('system-groups'):
+            org_groups[group['spacewalk_group_id']] = group['spacewalk_org_id']
 
     except (OSError) as e:
-        print('Problem executing the command "%s inventory": %s' %
+        print('Problem executing the command "%s system-groups": %s' %
               (SW_REPORT, str(e)), file=sys.stderr)
         sys.exit(2)
 
-    groups = {}
-    meta = {"hostvars": {}}
-    try:
-        for system in spacewalk_report('system-groups-systems'):
-            # first get org_id of system
-            org_id = org_groups[system['spacewalk_group_id']]
 
-            # shall we add the org_id as prefix to the group name:
-            if options.prefix_org_name:
-                prefix = org_id + "-"
-                group_name = prefix + system['spacewalk_group_name']
-            else:
-                group_name = system['spacewalk_group_name']
+    # List out the known server from Spacewalk
+    # ------------------------------
+    if options.list:
 
-            # if we are limited to one organization:
-            if options.org_number:
-                if org_id == options.org_number:
+        # to build the "_meta"-Group with hostvars first create dictionary for later use
+        host_vars = {}
+        try:
+            for item in spacewalk_report('inventory'):
+                host_vars[item['spacewalk_profile_name']] = dict((key, (value.split(';') if ';' in value else value)) for key, value in item.items())
+
+        except (OSError) as e:
+            print('Problem executing the command "%s inventory": %s' %
+                  (SW_REPORT, str(e)), file=sys.stderr)
+            sys.exit(2)
+
+        groups = {}
+        meta = {"hostvars": {}}
+        try:
+            for system in spacewalk_report('system-groups-systems'):
+                # first get org_id of system
+                org_id = org_groups[system['spacewalk_group_id']]
+
+                # shall we add the org_id as prefix to the group name:
+                if options.prefix_org_name:
+                    prefix = org_id + "-"
+                    group_name = prefix + system['spacewalk_group_name']
+                else:
+                    group_name = system['spacewalk_group_name']
+
+                # if we are limited to one organization:
+                if options.org_number:
+                    if org_id == options.org_number:
+                        if group_name not in groups:
+                            groups[group_name] = set()
+
+                        groups[group_name].add(system['spacewalk_server_name'])
+                        if system['spacewalk_server_name'] in host_vars and not system['spacewalk_server_name'] in meta["hostvars"]:
+                            meta["hostvars"][system['spacewalk_server_name']] = host_vars[system['spacewalk_server_name']]
+                # or we list all groups and systems:
+                else:
                     if group_name not in groups:
                         groups[group_name] = set()
 
                     groups[group_name].add(system['spacewalk_server_name'])
                     if system['spacewalk_server_name'] in host_vars and not system['spacewalk_server_name'] in meta["hostvars"]:
                         meta["hostvars"][system['spacewalk_server_name']] = host_vars[system['spacewalk_server_name']]
-            # or we list all groups and systems:
-            else:
-                if group_name not in groups:
-                    groups[group_name] = set()
 
-                groups[group_name].add(system['spacewalk_server_name'])
-                if system['spacewalk_server_name'] in host_vars and not system['spacewalk_server_name'] in meta["hostvars"]:
-                    meta["hostvars"][system['spacewalk_server_name']] = host_vars[system['spacewalk_server_name']]
+        except (OSError) as e:
+            print('Problem executing the command "%s system-groups-systems": %s' %
+                  (SW_REPORT, str(e)), file=sys.stderr)
+            sys.exit(2)
 
-    except (OSError) as e:
-        print('Problem executing the command "%s system-groups-systems": %s' %
-              (SW_REPORT, str(e)), file=sys.stderr)
-        sys.exit(2)
+        if options.human:
+            for group, systems in iteritems(groups):
+                print('[%s]\n%s\n' % (group, '\n'.join(systems)))
+        else:
+            final = dict([(k, list(s)) for k, s in iteritems(groups)])
+            final["_meta"] = meta
+            print(json.dumps(final))
+            # print(json.dumps(groups))
+        sys.exit(0)
 
-    if options.human:
-        for group, systems in iteritems(groups):
-            print('[%s]\n%s\n' % (group, '\n'.join(systems)))
+
+    # Return a details information concerning the spacewalk server
+    # ------------------------------
+    elif options.host:
+
+        host_details = {}
+        try:
+            for system in spacewalk_report('inventory'):
+                if system['spacewalk_hostname'] == options.host:
+                    host_details = system
+                    break
+
+        except (OSError) as e:
+            print('Problem executing the command "%s inventory": %s' %
+                  (SW_REPORT, str(e)), file=sys.stderr)
+            sys.exit(2)
+
+        if options.human:
+            print('Host: %s' % options.host)
+            for k, v in iteritems(host_details):
+                print('  %s: %s' % (k, '\n    '.join(v.split(';'))))
+        else:
+            print(json.dumps(dict((key, (value.split(';') if ';' in value else value)) for key, value in host_details.items())))
+        sys.exit(0)
+
     else:
-        final = dict([(k, list(s)) for k, s in iteritems(groups)])
-        final["_meta"] = meta
-        print(json.dumps(final))
-        # print(json.dumps(groups))
-    sys.exit(0)
+        parser.print_help()
+        sys.exit(1)
 
-
-# Return a details information concerning the spacewalk server
-# ------------------------------
-elif options.host:
-
-    host_details = {}
-    try:
-        for system in spacewalk_report('inventory'):
-            if system['spacewalk_hostname'] == options.host:
-                host_details = system
-                break
-
-    except (OSError) as e:
-        print('Problem executing the command "%s inventory": %s' %
-              (SW_REPORT, str(e)), file=sys.stderr)
-        sys.exit(2)
-
-    if options.human:
-        print('Host: %s' % options.host)
-        for k, v in iteritems(host_details):
-            print('  %s: %s' % (k, '\n    '.join(v.split(';'))))
-    else:
-        print(json.dumps(dict((key, (value.split(';') if ';' in value else value)) for key, value in host_details.items())))
-    sys.exit(0)
-
-else:
-
-    parser.print_help()
-    sys.exit(1)
+if __name__ == '__main__':
+    main()

--- a/contrib/inventory/vagrant.py
+++ b/contrib/inventory/vagrant.py
@@ -52,25 +52,14 @@ _ssh_to_ansible = [('user', 'ansible_ssh_user'),
                    ('identityfile', 'ansible_ssh_private_key_file'),
                    ('port', 'ansible_ssh_port')]
 
-# Options
-# ------------------------------
-
-parser = OptionParser(usage="%prog [options] --list | --host <machine>")
-parser.add_option('--list', default=False, dest="list", action="store_true",
-                  help="Produce a JSON consumable grouping of Vagrant servers for Ansible")
-parser.add_option('--host', default=None, dest="host",
-                  help="Generate additional host specific details for given host for Ansible")
-(options, args) = parser.parse_args()
 
 #
 # helper functions
 #
 
-
 # get all the ssh configs for all boxes in an array of dictionaries.
 def get_ssh_config():
     return dict((k, get_a_ssh_config(k)) for k in list_running_boxes())
-
 
 # list all the running boxes
 def list_running_boxes():
@@ -105,27 +94,41 @@ def get_a_ssh_config(box_name):
 
     return dict((v, host_config[k]) for k, v in _ssh_to_ansible)
 
+if __name__ == '__main__':
+    # Options
+    # ------------------------------
 
-# List out servers that vagrant has running
-# ------------------------------
-if options.list:
-    ssh_config = get_ssh_config()
-    meta = defaultdict(dict)
+    parser = OptionParser(usage="%prog [options] --list | --host <machine>")
+    parser.add_option('--list', default=False, dest="list", action="store_true",
+                      help="Produce a JSON consumable grouping of Vagrant servers for Ansible")
+    parser.add_option('--host', default=None, dest="host",
+                      help="Generate additional host specific details for given host for Ansible")
+    (options, args) = parser.parse_args()
 
-    for host in ssh_config:
-        meta['hostvars'][host] = ssh_config[host]
 
-    print(json.dumps({_group: list(ssh_config.keys()), '_meta': meta}))
-    sys.exit(0)
 
-# Get out the host details
-# ------------------------------
-elif options.host:
-    print(json.dumps(get_a_ssh_config(options.host)))
-    sys.exit(0)
 
-# Print out help
-# ------------------------------
-else:
-    parser.print_help()
-    sys.exit(0)
+
+    # List out servers that vagrant has running
+    # ------------------------------
+    if options.list:
+        ssh_config = get_ssh_config()
+        meta = defaultdict(dict)
+
+        for host in ssh_config:
+            meta['hostvars'][host] = ssh_config[host]
+
+        print(json.dumps({_group: list(ssh_config.keys()), '_meta': meta}))
+        sys.exit(0)
+
+    # Get out the host details
+    # ------------------------------
+    elif options.host:
+        print(json.dumps(get_a_ssh_config(options.host)))
+        sys.exit(0)
+
+    # Print out help
+    # ------------------------------
+    else:
+        parser.print_help()
+        sys.exit(0)

--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -149,5 +149,5 @@ class ZabbixInventory(object):
             print("Error: Configuration of server and credentials are required. See zabbix.ini.", file=sys.stderr)
             sys.exit(1)
 
-
-ZabbixInventory()
+if __name__ == '__main__':
+    ZabbixInventory()

--- a/contrib/inventory/zone.py
+++ b/contrib/inventory/zone.py
@@ -21,23 +21,25 @@ from subprocess import Popen, PIPE
 import sys
 import json
 
-result = {}
-result['all'] = {}
 
-pipe = Popen(['zoneadm', 'list', '-ip'], stdout=PIPE, universal_newlines=True)
-result['all']['hosts'] = []
-for l in pipe.stdout.readlines():
-    # 1:work:running:/zones/work:3126dc59-9a07-4829-cde9-a816e4c5040e:native:shared
-    s = l.split(':')
-    if s[1] != 'global':
-        result['all']['hosts'].append(s[1])
+if __name__ == '__main__':
+    result = {}
+    result['all'] = {}
 
-result['all']['vars'] = {}
-result['all']['vars']['ansible_connection'] = 'zone'
+    pipe = Popen(['zoneadm', 'list', '-ip'], stdout=PIPE, universal_newlines=True)
+    result['all']['hosts'] = []
+    for l in pipe.stdout.readlines():
+        # 1:work:running:/zones/work:3126dc59-9a07-4829-cde9-a816e4c5040e:native:shared
+        s = l.split(':')
+        if s[1] != 'global':
+            result['all']['hosts'].append(s[1])
 
-if len(sys.argv) == 2 and sys.argv[1] == '--list':
-    print(json.dumps(result))
-elif len(sys.argv) == 3 and sys.argv[1] == '--host':
-    print(json.dumps({'ansible_connection': 'zone'}))
-else:
-    sys.stderr.write("Need an argument, either --list or --host <host>\n")
+    result['all']['vars'] = {}
+    result['all']['vars']['ansible_connection'] = 'zone'
+
+    if len(sys.argv) == 2 and sys.argv[1] == '--list':
+        print(json.dumps(result))
+    elif len(sys.argv) == 3 and sys.argv[1] == '--host':
+        print(json.dumps({'ansible_connection': 'zone'}))
+    else:
+        sys.stderr.write("Need an argument, either --list or --host <host>\n")


### PR DESCRIPTION
##### SUMMARY
I would like unify that dynamic inventory codes can be imported or not as result of @webknjaz comment in https://github.com/ansible/ansible/pull/44287/files/86f17122e6698069819d78087d8eb89a6a03f95f#diff-7fa7474b3009ed3eb13fd2bb4f841b53

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

ansible contrib dynamic inventory
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.4
  config file = /home/adas/.ansible.cfg
  configured module search path = [u'/home/adas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adas/.virtualenvs/infra/local/lib/python2.7/site-packages/ansible
  executable location = /home/adas/.virtualenvs/infra/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```