### PR TITLE
[stable-2.5] Use newer is_sequence function instead of MutableSequence (#44331)

### DIFF
--- a/changelogs/fragments/flatten-better-type-check.yml
+++ b/changelogs/fragments/flatten-better-type-check.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- flatten filter - use better method of type checking allowing flattening of mutable and non-mutable sequences (https://github.com/ansible/ansible/pull/44331)

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -34,7 +34,7 @@ import time
 import uuid
 import yaml
 
-from collections import MutableMapping, MutableSequence
+from collections import MutableMapping
 import datetime
 from functools import partial
 from random import Random, SystemRandom, shuffle
@@ -474,7 +474,7 @@ def flatten(mylist, levels=None):
         if element in (None, 'None', 'null'):
             # ignore undefined items
             break
-        elif isinstance(element, MutableSequence):
+        elif is_sequence(element):
             if levels is None:
                 ret.extend(flatten(element))
             elif levels >= 1:

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -176,6 +176,7 @@
         flat_full: '{{orig_list|flatten}}'
         flat_one: '{{orig_list|flatten(levels=1)}}'
         flat_two: '{{orig_list|flatten(levels=2)}}'
+        flat_tuples: '{{ [1,3] | zip([2,4]) | list | flatten }}'
 
     - name: Verify flatten filter works as expected
       assert:
@@ -183,5 +184,6 @@
           - flat_full == [1, 2, 3, 4, 5, 6, 7]
           - flat_one == [1, 2, 3, [4, [5]], 6, 7]
           - flat_two == [1, 2, 3, 4, [5], 6, 7]
+          - flat_tuples == [1, 2, 3, 4]
   vars:
     orig_list: [1, 2, [3, [4, [5]], 6], 7]


### PR DESCRIPTION
* Use newer is_sequence function instead of MutableSequence. Fixes #44327

* Add changelog for #44331

* Update changelog fragment to describe the fix in more detail
(cherry picked from commit 2bf6507)


Co-authored-by: Matt Martz <matt@sivel.net>