### PR TITLE
Fix update in gce labels with diff

### DIFF
--- a/lib/ansible/modules/cloud/google/gce_labels.py
+++ b/lib/ansible/modules/cloud/google/gce_labels.py
@@ -314,6 +314,12 @@ def main():
     if update_needed:
         changed, err = _set_labels(client, new_labels, module, resource_info,
                                    fingerprint)
+        if module._diff:
+            json_output['diff'] = {
+                'before': resource_info['labels'],
+                'after': new_labels
+            }
+
     json_output['changed'] = changed
 
     # TODO(erjohnso): probably want to re-fetch the resource to return the

--- a/lib/ansible/modules/cloud/google/gce_labels.py
+++ b/lib/ansible/modules/cloud/google/gce_labels.py
@@ -297,8 +297,16 @@ def main():
                     module.fail_json(msg="Could not remove unmatched label pair '%s':'%s'" % (k, v))
     else:
         for k, v in module.params['labels'].items():
+            # If the label is missing entirely mark for update
             if k not in new_labels:
                 update_needed = True
+
+            # Also if the label is present, but not set to the correct value, mark it for update
+            if k in new_labels:
+                if new_labels[k] != v:
+                    update_needed = True
+
+            if update_needed:
                 new_labels[k] = v
 
     changed = False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
* Fixes an issue with `gce_labels.py` wherein labels which already existed on a resource, but were set to the wrong value, would not be updated with the desired value.
* Also adds support for `--diff` mode, showing the changes made to the labels when necessary.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
modules/cloud/google/gce_labels.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (fix-update-in-gce-labels-with-diff ec99adefca) last updated 2018/08/21 17:04:49 (GMT +100)
  config file = None
  configured module search path = [u'/Users/ryan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/ryan/code/rylon-ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.14 (default, Mar 27 2018, 16:13:06) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION

Before, if a label existed already on a resource, such as a GCP instance, but the user had specified a different value for the label in their playbook, the task would report "OK", but the label would not be updated. The label was only set if it did not already exist.

I also added support for `--diff` mode, so the actual changes are shown if the user has that mode enabled.