### PR TITLE
ldap_passwd: Fix #44329

### DIFF
--- a/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
@@ -117,7 +117,7 @@ class LdapPasswd(LdapGeneric):
 
         # Change the password (or throw an exception)
         try:
-            self.connection.passwd_set(self.dn, None, self.passwd)
+            self.connection.passwd_s(self.dn, None, self.passwd)
         except ldap.LDAPError as e:
             self.fail("Unable to set password", e)
 


### PR DESCRIPTION
##### SUMMARY
This is a backport of the fix provided by @drewburr in #44336.
The ldap_passwd module is entirely unuseable without it.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ldap_passwd

##### ANSIBLE VERSION
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/nicoo/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, Jul 28 2018, 11:29:29) [GCC 8.1.0]
```

##### ADDITIONAL INFORMATION
The fix is already merged in `devel`, but @drewburr pointed out it was worth backporting to 2.6