### PR TITLE
Stat: Change ignore MD5 example to generic checksum

### DIFF
--- a/lib/ansible/modules/files/stat.py
+++ b/lib/ansible/modules/files/stat.py
@@ -121,10 +121,10 @@ EXAMPLES = '''
     msg: "Path exists and is a directory"
   when: p.stat.isdir is defined and p.stat.isdir
 
-# Don't do md5 checksum
+# Don't do checksum
 - stat:
     path: /path/to/myhugefile
-    get_md5: no
+    get_checksum: no
 
 # Use sha256 to calculate checksum
 - stat:


### PR DESCRIPTION
##### SUMMARY
Update the example to exclude the checksum. The current example does not change the output at all since get_md5 is not the default.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
stat

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/sbin/ansible
  python version = 3.7.0 (default, Jul 15 2018, 10:44:58) [GCC 8.1.1 20180531]
```