### PR TITLE
Add support for multiple prompt answers in network_cli

### DIFF
--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -124,7 +124,10 @@ class CliconfBase(AnsiblePlugin):
             else:
                 kwargs['prompt'] = to_bytes(prompt)
         if answer is not None:
-            kwargs['answer'] = to_bytes(answer)
+            if isinstance(answer, list):
+                kwargs['answer'] = [to_bytes(p) for p in answer]
+            else:
+                kwargs['answer'] = to_bytes(answer)
 
         resp = self._connection.send(**kwargs)
 

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -404,19 +404,22 @@ class Connection(NetworkConnectionBase):
 
         :arg resp: Byte string containing the raw response from the remote
         :arg prompts: Sequence of byte strings that we consider prompts for input
-        :arg answer: Byte string to send back to the remote if we find a prompt.
+        :arg answer: Sequence of Byte string to send back to the remote if we find a prompt.
                 A carriage return is automatically appended to this string.
         :returns: True if a prompt was found in ``resp``.  False otherwise
         '''
         if not isinstance(prompts, list):
             prompts = [prompts]
+        if not isinstance(answer, list):
+            answer = [answer]
         prompts = [re.compile(r, re.I) for r in prompts]
-        for regex in prompts:
+        for index, regex in enumerate(prompts):
             match = regex.search(resp)
             if match:
                 # if prompt_retry_check is enabled to check if same prompt is
                 # repeated don't send answer again.
                 if not prompt_retry_check:
+                    answer = answer[index] if len(answer) > index else answer[0]
                     self._ssh_shell.sendall(b'%s' % answer)
                     if newline:
                         self._ssh_shell.sendall(b'\r')


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Currently network_cli support multiple prompts
  single answer as a response. This PR adds support for multiple answers.
* In case of multiple prompts and multiple answers the
  index of a particular prompt in the prompts list should
  match with the index of the expected answer in the answer list.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
plugins/connection/network_cli.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
