### PR TITLE
deprecated Foreman & Katello modules

### DIFF
--- a/lib/ansible/modules/remote_management/foreman/foreman.py
+++ b/lib/ansible/modules/remote_management/foreman/foreman.py
@@ -8,12 +8,16 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---
 module: foreman
+deprecated:
+  removed_in: "2.9"
+  why: This has been replaced with a collection of other modules.
+  alternative: Use modules from https://github.com/theforeman/foreman-ansible-modules.
 short_description: Manage Foreman Resources
 description:
     - Allows the management of Foreman resources inside your Foreman server.

--- a/lib/ansible/modules/remote_management/foreman/katello.py
+++ b/lib/ansible/modules/remote_management/foreman/katello.py
@@ -8,12 +8,16 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---
 module: katello
+deprecated:
+  removed_in: "2.9"
+  why: This has been replaced with a collection of other modules.
+  alternative: Use modules from https://github.com/theforeman/foreman-ansible-modules.
 short_description: Manage Katello Resources
 description:
     - Allows the management of Katello resources inside your Foreman server.


### PR DESCRIPTION
##### SUMMARY
The modules in https://github.com/theforeman/foreman-ansible-modules are much more feature complete and user-friendly.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
foreman
katello