### PR TITLE
Module win_domain_computer fix delete computer with child

### DIFF
--- a/changelogs/fragments/44500-win_domain_computer.yaml
+++ b/changelogs/fragments/44500-win_domain_computer.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain_computer - fixed deletion of computer active directory object that have dependent objects (https://github.com/ansible/ansible/pull/44500)

--- a/lib/ansible/modules/windows/win_domain_computer.ps1
+++ b/lib/ansible/modules/windows/win_domain_computer.ps1
@@ -129,8 +129,9 @@ Function Add-ConstructedState($desired_state) {
 # ------------------------------------------------------------------------------
 Function Remove-ConstructedState($initial_state) {
   Try {
-    Remove-ADComputer `
-      -Identity $initial_state.name `
+    Get-ADComputer $initial_state.name `
+    | Remove-ADObject `
+      -Recursive `
       -Confirm:$False `
       -WhatIf:$check_mode
   } Catch {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When a machine is in hyper-V an leaf object is created: CN=Windows Virtual Machine under the machine in AD. Remove-ADComputer gives an error: Remove-ADComputer : The directory service can perform the requested operation only on a leaf object.

This fix the problem
Get-ADComputer "Computername" | remove-ADObject -Recursive

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #44444

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
win_domain_computer
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.3
  config file = ~/.ansible.cfg
  configured module search path = [u'~/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ~/.local/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Works for me, but I have no way to test it in `hyper-V`. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
