### PR TITLE
botmeta: scaleway isn't core

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -949,6 +949,11 @@ files:
     labels: cloud
   $module_utils/jboss/:
     maintainers: $team_jboss
+  $module_utils/scaleway.py: &scaleway
+    maintainers: sieben hekonsek
+    labels:
+      - cloud
+    support: community
   lib/ansible/playbook/handler.py:
     keywords:
     - handlers
@@ -1078,10 +1083,7 @@ files:
     labels:
       - ovirt
       - cloud
-  lib/ansible/plugins/inventory/scaleway.py:
-    maintainers: sieben hekonsek
-    labels:
-      - cloud
+  lib/ansible/plugins/inventory/scaleway.py: *scaleway
   lib/ansible/plugins/filter/network.py:
     maintainers: $team_networking
     labels: networking


### PR DESCRIPTION
##### SUMMARY
scaleway isn't core: update `support` keyword for scaleway `module_utils` and inventory plugin.

cc @sieben 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel 613a53c114) last updated 2018/08/22 16:51:02 (GMT +200)
```