### PR TITLE
Remove bare_deprecated functionality

### DIFF
--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -53,7 +53,7 @@ class ActionModule(ActionBase):
 
             elif 'var' in self._task.args:
                 try:
-                    results = self._templar.template(self._task.args['var'], convert_bare=True, fail_on_undefined=True, bare_deprecated=False)
+                    results = self._templar.template(self._task.args['var'], convert_bare=True, fail_on_undefined=True)
                     if results == self._task.args['var']:
                         # if results is not str/unicode type, raise an exception
                         if not isinstance(results, string_types):

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -429,7 +429,7 @@ class Templar:
         self._cached_result = {}
 
     def template(self, variable, convert_bare=False, preserve_trailing_newlines=True, escape_backslashes=True, fail_on_undefined=None, overrides=None,
-                 convert_data=True, static_vars=None, cache=True, bare_deprecated=True, disable_lookups=False):
+                 convert_data=True, static_vars=None, cache=True, disable_lookups=False):
         '''
         Templates (possibly recursively) any given data as input. If convert_bare is
         set to True, the given data will be wrapped as a jinja2 variable ('{{foo}}')
@@ -446,7 +446,7 @@ class Templar:
 
         try:
             if convert_bare:
-                variable = self._convert_bare_variable(variable, bare_deprecated=bare_deprecated)
+                variable = self._convert_bare_variable(variable)
 
             if isinstance(variable, string_types):
                 result = variable
@@ -587,7 +587,7 @@ class Templar:
                     return True
         return False
 
-    def _convert_bare_variable(self, variable, bare_deprecated):
+    def _convert_bare_variable(self, variable):
         '''
         Wraps a bare string, which may have an attribute portion (ie. foo.bar)
         in jinja2 variable braces so that it is evaluated properly.
@@ -597,10 +597,6 @@ class Templar:
             contains_filters = "|" in variable
             first_part = variable.split("|")[0].split(".")[0].split("[")[0]
             if (contains_filters or first_part in self._available_variables) and self.environment.variable_start_string not in variable:
-                if bare_deprecated:
-                    display.deprecated("Using bare variables is deprecated."
-                                       " Update your playbooks so that the environment value uses the full variable syntax ('%s%s%s')" %
-                                       (self.environment.variable_start_string, variable, self.environment.variable_end_string), version='2.7')
                 return "%s%s%s" % (self.environment.variable_start_string, variable, self.environment.variable_end_string)
 
         # the variable didn't meet the conditions to be converted,

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -117,26 +117,25 @@ class TestTemplarTemplate(BaseTemplar, unittest.TestCase):
         self.assertFalse(res)
 
     def test_template_convert_bare_string(self):
-        # Note: no bare_deprecated=False so we hit the deprecation path
         res = self.templar.template('foo', convert_bare=True)
         self.assertEqual(res, 'bar')
 
     def test_template_convert_bare_nested(self):
-        res = self.templar.template('bam', convert_bare=True, bare_deprecated=False)
+        res = self.templar.template('bam', convert_bare=True)
         self.assertEqual(res, 'bar')
 
     def test_template_convert_bare_unsafe(self):
-        res = self.templar.template('some_unsafe_var', convert_bare=True, bare_deprecated=False)
+        res = self.templar.template('some_unsafe_var', convert_bare=True)
         self.assertEqual(res, 'unsafe_blip')
         # self.assertIsInstance(res, AnsibleUnsafe)
         self.assertTrue(self.is_unsafe(res), 'returned value from template.template (%s) is not marked unsafe' % res)
 
     def test_template_convert_bare_filter(self):
-        res = self.templar.template('bam|capitalize', convert_bare=True, bare_deprecated=False)
+        res = self.templar.template('bam|capitalize', convert_bare=True)
         self.assertEqual(res, 'Bar')
 
     def test_template_convert_bare_filter_unsafe(self):
-        res = self.templar.template('some_unsafe_var|capitalize', convert_bare=True, bare_deprecated=False)
+        res = self.templar.template('some_unsafe_var|capitalize', convert_bare=True)
         self.assertEqual(res, 'Unsafe_blip')
         # self.assertIsInstance(res, AnsibleUnsafe)
         self.assertTrue(self.is_unsafe(res), 'returned value from template.template (%s) is not marked unsafe' % res)


### PR DESCRIPTION
##### SUMMARY
`bare_deprecated` was added to inform people using bare variables in `environment`. The ability to use bare vars in environment was removed in https://github.com/ansible/ansible/commit/df5895e585e18bfbf84af993c152801124332bf0

There are no places other than `debug` calling `template` with `convert_bare=True`.  We should be able to just remove the deprecation functionality.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/template/__init__.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```