### PR TITLE
ACME: improve tests (new Pebble version, strict mode)

### DIFF
--- a/test/integration/targets/acme_account/tasks/impl.yml
+++ b/test/integration/targets/acme_account/tasks/impl.yml
@@ -100,72 +100,23 @@
 - name: Parse account key (to ease debugging some test failures)
   command: openssl ec -in {{ output_dir }}/accountkey2.pem -noout -text
 
-# Note that pebble has no change key endpoint implemented yet!
-# When it has (and the container was updated), uncomment the
-# uncomment the following tests, and delete the ones below the
-# out-commented ones.
-
-# - name: Change account key
-#   acme_account:
-#     select_crypto_backend: "{{ select_crypto_backend }}"
-#     account_key_src: "{{ output_dir }}/accountkey.pem"
-#     acme_version: 2
-#     acme_directory: https://{{ acme_host }}:14000/dir
-#     validate_certs: no
-#     new_account_key_src: "{{ output_dir }}/accountkey2.pem"
-#     state: changed_key
-#     contact:
-#     - mailto:example@example.com
-#   register: account_change_key
-
-# - name: Deactivate account
-#   acme_account:
-#     select_crypto_backend: "{{ select_crypto_backend }}"
-#     account_key_src: "{{ output_dir }}/accountkey2.pem"
-#     acme_version: 2
-#     acme_directory: https://{{ acme_host }}:14000/dir
-#     validate_certs: no
-#     state: absent
-#   register: account_deactivate
-
-# - name: Deactivate account (idempotent)
-#   acme_account:
-#     select_crypto_backend: "{{ select_crypto_backend }}"
-#     account_key_src: "{{ output_dir }}/accountkey2.pem"
-#     acme_version: 2
-#     acme_directory: https://{{ acme_host }}:14000/dir
-#     validate_certs: no
-#     state: absent
-#   register: account_deactivate_idempotent
-
-# - name: Do not try to create account II
-#   acme_account:
-#     select_crypto_backend: "{{ select_crypto_backend }}"
-#     account_key_src: "{{ output_dir }}/accountkey2.pem"
-#     acme_version: 2
-#     acme_directory: https://{{ acme_host }}:14000/dir
-#     validate_certs: no
-#     state: present
-#     allow_creation: no
-#   ignore_errors: yes
-#   register: account_not_created_2
-
-# - name: Do not try to create account III
-#   acme_account:
-#     select_crypto_backend: "{{ select_crypto_backend }}"
-#     account_key_src: "{{ output_dir }}/accountkey.pem"
-#     acme_version: 2
-#     acme_directory: https://{{ acme_host }}:14000/dir
-#     validate_certs: no
-#     state: present
-#     allow_creation: no
-#   ignore_errors: yes
-#   register: account_not_created_3
+- name: Change account key
+  acme_account:
+    select_crypto_backend: "{{ select_crypto_backend }}"
+    account_key_src: "{{ output_dir }}/accountkey.pem"
+    acme_version: 2
+    acme_directory: https://{{ acme_host }}:14000/dir
+    validate_certs: no
+    new_account_key_src: "{{ output_dir }}/accountkey2.pem"
+    state: changed_key
+    contact:
+    - mailto:example@example.com
+  register: account_change_key
 
 - name: Deactivate account
   acme_account:
     select_crypto_backend: "{{ select_crypto_backend }}"
-    account_key_src: "{{ output_dir }}/accountkey.pem"
+    account_key_src: "{{ output_dir }}/accountkey2.pem"
     acme_version: 2
     acme_directory: https://{{ acme_host }}:14000/dir
     validate_certs: no
@@ -175,7 +126,7 @@
 - name: Deactivate account (idempotent)
   acme_account:
     select_crypto_backend: "{{ select_crypto_backend }}"
-    account_key_src: "{{ output_dir }}/accountkey.pem"
+    account_key_src: "{{ output_dir }}/accountkey2.pem"
     acme_version: 2
     acme_directory: https://{{ acme_host }}:14000/dir
     validate_certs: no
@@ -185,7 +136,7 @@
 - name: Do not try to create account II
   acme_account:
     select_crypto_backend: "{{ select_crypto_backend }}"
-    account_key_src: "{{ output_dir }}/accountkey.pem"
+    account_key_src: "{{ output_dir }}/accountkey2.pem"
     acme_version: 2
     acme_directory: https://{{ acme_host }}:14000/dir
     validate_certs: no
@@ -193,3 +144,15 @@
     allow_creation: no
   ignore_errors: yes
   register: account_not_created_2
+
+- name: Do not try to create account III
+  acme_account:
+    select_crypto_backend: "{{ select_crypto_backend }}"
+    account_key_src: "{{ output_dir }}/accountkey.pem"
+    acme_version: 2
+    acme_directory: https://{{ acme_host }}:14000/dir
+    validate_certs: no
+    state: present
+    allow_creation: no
+  ignore_errors: yes
+  register: account_not_created_3

--- a/test/integration/targets/acme_account/tests/validate.yml
+++ b/test/integration/targets/acme_account/tests/validate.yml
@@ -39,38 +39,11 @@
       - account_modified_2_idempotent is not changed
       - account_modified_2_idempotent.account_uri is not none
 
-# Note that pebble has no change key endpoint implemented yet!
-# When it has (and the container was updated), uncomment the
-# following validations, and delete the ones below the
-# out-commented ones:
-
-#- name: Validate that the account key was changed
-#  assert:
-#    that:
-#      - account_change_key is changed
-#      - account_change_key.account_uri is not none
-#
-#- name: Validate that the account was deactivated
-#  assert:
-#    that:
-#      - account_deactivate is changed
-#      - account_deactivate.account_uri is not none
-#
-#- name: Validate that the account was really deactivated (idempotency)
-#  assert:
-#    that:
-#      - account_deactivate_idempotent is not changed
-#      - account_deactivate_idempotent.account_uri is not none
-#
-#- name: Validate that the account is gone (new account key)
-#  assert:
-#    that:
-#      - account_not_created_2 is failed
-#
-#- name: Validate that the account is gone (old account key)
-#  assert:
-#    that:
-#      - account_not_created_3 is failed
+- name: Validate that the account key was changed
+  assert:
+    that:
+      - account_change_key is changed
+      - account_change_key.account_uri is not none
 
 - name: Validate that the account was deactivated
   assert:
@@ -84,7 +57,12 @@
       - account_deactivate_idempotent is not changed
       - account_deactivate_idempotent.account_uri is not none
 
-- name: Validate that the account is gone
+- name: Validate that the account is gone (new account key)
   assert:
     that:
       - account_not_created_2 is failed
+
+- name: Validate that the account is gone (old account key)
+  assert:
+    that:
+      - account_not_created_3 is failed

--- a/test/runner/lib/cloud/acme.py
+++ b/test/runner/lib/cloud/acme.py
@@ -50,7 +50,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:1.2.0'
+            self.image = 'quay.io/ansible/acme-test-container:1.3.0'
         self.container_name = ''
 
     def _wait_for_service(self, protocol, acme_host, port, local_part, name):


### PR DESCRIPTION
##### SUMMARY
This updates the ACME tests to use the newest ACME test container (see ansible/acme-test-container#8). It includes some new Pebble features (authz deactivation, key rollover support, support for new TLS-ALPN-01 draft) and enables Pebble's strict mode.

##### ISSUE TYPE
 - Feature Pull Request

(There should be a category "Test Pull Request" :) )

##### COMPONENT NAME
test/runner/lib/cloud/acme.py
acme_account

##### ANSIBLE VERSION
```
2.7.0
```
