### PR TITLE
Correct the default doc for attached in ec2_eni

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -69,16 +69,19 @@ options:
       - Force detachment of the interface. This applies either when explicitly detaching the interface by setting instance_id
         to None or when deleting an interface with state=absent.
     default: 'no'
+    type: bool
   delete_on_termination:
     description:
       - Delete the interface when the instance it is attached to is terminated. You can only specify this flag when the
         interface is being modified, not on creation.
     required: false
+    type: bool
   source_dest_check:
     description:
       - By default, interfaces perform source/destination checks. NAT instances however need this check to be disabled.
         You can only specify this flag when the interface is being modified, not on creation.
     required: false
+    type: bool
   secondary_private_ip_addresses:
     description:
       - A list of IP addresses to assign as secondary IP addresses to the network interface.
@@ -90,6 +93,7 @@ options:
       - To be used with I(secondary_private_ip_addresses) to determine whether or not to remove any secondary IP addresses other than those specified.
         Set secondary_private_ip_addresses to an empty list to purge all secondary addresses.
     default: no
+    type: bool
     version_added: 2.5
   secondary_private_ip_address_count:
     description:
@@ -102,6 +106,7 @@ options:
         to be reassigned to the specified network interface.
     required: false
     default: 'no'
+    type: bool
     version_added: 2.7
 extends_documentation_fragment:
     - aws

--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -60,9 +60,8 @@ options:
     default: 0
   attached:
     description:
-      - Specifies if network interface should be attached or detached from instance. If ommited, attachment status
+      - Specifies if network interface should be attached or detached from instance. If omitted, attachment status
         won't change
-    default: 'yes'
     version_added: 2.2
     type: bool
   force_detach:

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -54,7 +54,6 @@ lib/ansible/modules/cloud/amazon/ec2_elb.py E326
 lib/ansible/modules/cloud/amazon/ec2_elb_facts.py E323
 lib/ansible/modules/cloud/amazon/ec2_elb_lb.py E324
 lib/ansible/modules/cloud/amazon/ec2_elb_lb.py E325
-lib/ansible/modules/cloud/amazon/ec2_eni.py E324
 lib/ansible/modules/cloud/amazon/ec2_eni.py E325
 lib/ansible/modules/cloud/amazon/ec2_group.py E322
 lib/ansible/modules/cloud/amazon/ec2_group.py E325

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -54,7 +54,6 @@ lib/ansible/modules/cloud/amazon/ec2_elb.py E326
 lib/ansible/modules/cloud/amazon/ec2_elb_facts.py E323
 lib/ansible/modules/cloud/amazon/ec2_elb_lb.py E324
 lib/ansible/modules/cloud/amazon/ec2_elb_lb.py E325
-lib/ansible/modules/cloud/amazon/ec2_eni.py E325
 lib/ansible/modules/cloud/amazon/ec2_group.py E322
 lib/ansible/modules/cloud/amazon/ec2_group.py E325
 lib/ansible/modules/cloud/amazon/ec2_instance.py E324


### PR DESCRIPTION
Also corrected a typo in the summary

##### SUMMARY

The `default:` documentation for `ec2_eni` erroneously claimed that the default was `yes` but it is in fact `None`

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME

`ec2_eni`

##### ANSIBLE VERSION

`devel`

##### ADDITIONAL INFORMATION

[Someone discovered](https://stackoverflow.com/questions/51848457/ansible-ec2-eni-cannot-attach-interface/) that if they omitted `attached: yes` it causes the `ec2_eni` module to do nothing after creating the ENI, and that question is likely because the docs claim the default is `yes`.
