### PR TITLE
Includes support for Reverse-Mapping zone in nios_zone module

### DIFF
--- a/lib/ansible/modules/net_tools/nios/nios_zone.py
+++ b/lib/ansible/modules/net_tools/nios/nios_zone.py
@@ -65,7 +65,7 @@ options:
       - If set to true, causes the NIOS DNS service to restart and load the
         new zone configuration
     type: bool
-  format:
+  zone_format:
     version_added: "2.7"
     description:
       - Create an authorative Reverse-Mapping Zone which is an area of network
@@ -125,7 +125,7 @@ EXAMPLES = '''
 - name: configure a reverse mapping zone on the system using IPV4 zone format
   nios_zone:
     name: 10.10.10.0/24
-    format: IPV4
+    zone_format: IPV4
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"
@@ -135,7 +135,7 @@ EXAMPLES = '''
 - name: configure a reverse mapping zone on the system using IPV6 zone format
   nios_zone:
     name: 100::1/128
-    format: IPV6
+    zone_format: IPV6
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"
@@ -166,7 +166,7 @@ EXAMPLES = '''
 - name: remove the reverse mapping dns zone from the system with IPV4 zone format
   nios_zone:
     name: 10.10.10.0/24
-    format: IPV4
+    zone_format: IPV4
     state: absent
     provider:
       host: "{{ inventory_hostname_short }}"
@@ -191,7 +191,7 @@ def main():
 
     ib_spec = dict(
         fqdn=dict(required=True, aliases=['name'], ib_req=True, update=False),
-        zone_format=dict(default='FORWARD', aliases=['format'], ib_req=False),
+        zone_format=dict(default='FORWARD', aliases=['zone_format'], ib_req=False),
         view=dict(default='default', aliases=['dns_view'], ib_req=True),
 
         grid_primary=dict(type='list', elements='dict', options=grid_spec),

--- a/lib/ansible/modules/net_tools/nios/nios_zone.py
+++ b/lib/ansible/modules/net_tools/nios/nios_zone.py
@@ -65,10 +65,10 @@ options:
       - If set to true, causes the NIOS DNS service to restart and load the
         new zone configuration
     type: bool
-  zone_format:
+  format:
     version_added: "2.7"
     description:
-      - Create an authorative Reverse-Mapping Zone which is an area of network 
+      - Create an authorative Reverse-Mapping Zone which is an area of network
         space for which one or more name servers-primary and secondary-have the
         responsibility to respond to address-to-name queries. It supports
         reverse-mapping zones for both IPv4 and IPv6 addresses.

--- a/lib/ansible/modules/net_tools/nios/nios_zone.py
+++ b/lib/ansible/modules/net_tools/nios/nios_zone.py
@@ -65,6 +65,14 @@ options:
       - If set to true, causes the NIOS DNS service to restart and load the
         new zone configuration
     type: bool
+  zone_format:
+    version_added: "2.7"
+    description:
+      - Create an authorative Reverse-Mapping Zone which is an area of network 
+        space for which one or more name servers-primary and secondary-have the
+        responsibility to respond to address-to-name queries. It supports
+        reverse-mapping zones for both IPv4 and IPv6 addresses.
+    default: FORWARD
   extattrs:
     description:
       - Allows for the configuration of Extensible Attributes on the
@@ -103,12 +111,31 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-
 - name: configure a zone on the system using a name server group
   nios_zone:
     name: ansible.com
     ns_group: examplensg
     restart_if_needed: true
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+- name: configure a reverse mapping zone on the system using IPV4 zone format
+  nios_zone:
+    name: 10.10.10.0/24
+    format: IPV4
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+- name: configure a reverse mapping zone on the system using IPV6 zone format
+  nios_zone:
+    name: 100::1/128
+    format: IPV6
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"
@@ -136,6 +163,16 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
+- name: remove the reverse mapping dns zone from the system with IPV4 zone format
+  nios_zone:
+    name: 10.10.10.0/24
+    format: IPV4
+    state: absent
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
 '''
 
 RETURN = ''' # '''
@@ -154,6 +191,7 @@ def main():
 
     ib_spec = dict(
         fqdn=dict(required=True, aliases=['name'], ib_req=True, update=False),
+        zone_format=dict(default='FORWARD', aliases=['format'], ib_req=False),
         view=dict(default='default', aliases=['dns_view'], ib_req=True),
 
         grid_primary=dict(type='list', elements='dict', options=grid_spec),

--- a/test/runner/lib/cloud/nios.py
+++ b/test/runner/lib/cloud/nios.py
@@ -31,7 +31,7 @@ class NiosProvider(CloudProvider):
 
     DOCKER_SIMULATOR_NAME = 'nios-simulator'
 
-    DOCKER_IMAGE = 'quay.io/ansible/nios-test-container:1.2.0'
+    DOCKER_IMAGE = 'quay.io/ansible/nios-test-container:1.3.0'
     """Default image to run the nios simulator.
 
     The simulator must be pinned to a specific version

--- a/test/units/modules/net_tools/nios/test_nios_zone.py
+++ b/test/units/modules/net_tools/nios/test_nios_zone.py
@@ -139,8 +139,8 @@ class TestNiosZoneModule(TestNiosModule):
         )
         test_spec = {
             "fqdn": {"ib_req": True},
-            "grid_primary": {},#{"options":grid_spec},
-            "grid_secondaries": {},#{"options":grid_spec},
+            "grid_primary": {},
+            "grid_secondaries": {},
             "restart_if_needed": {},
             "comment": {},
             "extattrs": {}

--- a/test/units/modules/net_tools/nios/test_nios_zone.py
+++ b/test/units/modules/net_tools/nios/test_nios_zone.py
@@ -124,3 +124,164 @@ class TestNiosZoneModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
+
+    def test_nios_zone_create_using_grid_primary_secondaries(self):
+        self.module.params = {'provider': None, 'state': 'present', 'fqdn': 'ansible.com',
+                              'grid_primary': [{"name": "gridprimary.grid.com"}],
+                              'grid_secondaries': [{"name": "gridsecondary1.grid.com"},
+                                                   {"name": "gridsecondary2.grid.com"}],
+                              'restart_if_needed': True,
+                              'comment': None, 'extattrs': None}
+
+        test_object = None
+        grid_spec = dict(
+            name=dict(required=True),
+        )
+        test_spec = {
+            "fqdn": {"ib_req": True},
+            "grid_primary": {},#{"options":grid_spec},
+            "grid_secondaries": {},#{"options":grid_spec},
+            "restart_if_needed": {},
+            "comment": {},
+            "extattrs": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        print("WAPI: ", wapi)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.create_object.assert_called_once_with('testobject', {'fqdn': 'ansible.com',
+                                                                  "grid_primary": [{"name": "gridprimary.grid.com"}],
+                                                                  "grid_secondaries": [{"name": "gridsecondary1.grid.com"},
+                                                                                       {"name": "gridsecondary2.grid.com"}],
+                                                                  "restart_if_needed": True
+                                                                  })
+
+    def test_nios_zone_remove_using_grid_primary_secondaries(self):
+        self.module.params = {'provider': None, 'state': 'absent', 'fqdn': 'ansible.com',
+                              'grid_primary': [{"name": "gridprimary.grid.com"}],
+                              'grid_secondaries': [{"name": "gridsecondary1.grid.com"},
+                                                   {"name": "gridsecondary2.grid.com"}],
+                              'restart_if_needed': True,
+                              'comment': None, 'extattrs': None}
+
+        ref = "zone/ZG5zLm5ldHdvcmtfdmlldyQw:ansible/false"
+
+        test_object = [{
+            "comment": "test comment",
+            "_ref": ref,
+            "fqdn": "ansible.com",
+            "grid_primary": [{"name": "gridprimary.grid.com"}],
+            "grid_secondaries": [{"name": "gridsecondary1.grid.com"}, {"name": "gridsecondary2.grid.com"}],
+            "restart_if_needed": True,
+            "extattrs": {'Site': {'value': 'test'}}
+        }]
+
+        test_spec = {
+            "fqdn": {"ib_req": True},
+            "grid_primary": {},
+            "grid_secondaries": {},
+            "restart_if_needed": {},
+            "comment": {},
+            "extattrs": {}
+        }
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ref)
+
+    def test_nios_zone_create_using_name_server_group(self):
+        self.module.params = {'provider': None, 'state': 'present', 'fqdn': 'ansible.com',
+                              'ns_group': 'examplensg', 'comment': None, 'extattrs': None}
+
+        test_object = None
+
+        test_spec = {
+            "fqdn": {"ib_req": True},
+            "ns_group": {},
+            "comment": {},
+            "extattrs": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        print("WAPI: ", wapi)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.create_object.assert_called_once_with('testobject', {'fqdn': 'ansible.com',
+                                                                  'ns_group': 'examplensg'})
+
+    def test_nios_zone_remove_using_name_server_group(self):
+        self.module.params = {'provider': None, 'state': 'absent', 'fqdn': 'ansible.com',
+                              'ns_group': 'examplensg', 'comment': None, 'extattrs': None}
+
+        ref = "zone/ZG5zLm5ldHdvcmtfdmlldyQw:ansible/false"
+
+        test_object = [{
+            "comment": "test comment",
+            "_ref": ref,
+            "fqdn": "ansible.com",
+            "ns_group": "examplensg",
+            "extattrs": {'Site': {'value': 'test'}}
+        }]
+
+        test_spec = {
+            "fqdn": {"ib_req": True},
+            "ns_group": {},
+            "comment": {},
+            "extattrs": {}
+        }
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ref)
+
+    def test_nios_zone_create_using_zone_format(self):
+        self.module.params = {'provider': None, 'state': 'present', 'fqdn': '10.10.10.in-addr.arpa',
+                              'zone_format': 'IPV4', 'comment': None, 'extattrs': None}
+
+        test_object = None
+
+        test_spec = {
+            "fqdn": {"ib_req": True},
+            "zone_format": {},
+            "comment": {},
+            "extattrs": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        print("WAPI: ", wapi)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.create_object.assert_called_once_with('testobject', {'fqdn': '10.10.10.in-addr.arpa',
+                                                                  'zone_format': 'IPV4'})
+
+    def test_nios_zone_remove_using_using_zone_format(self):
+        self.module.params = {'provider': None, 'state': 'absent', 'fqdn': 'ansible.com',
+                              'zone_format': 'IPV4', 'comment': None, 'extattrs': None}
+
+        ref = "zone/ZG5zLm5ldHdvcmtfdmlldyQw:ansible/false"
+
+        test_object = [{
+            "comment": "test comment",
+            "_ref": ref,
+            "fqdn": "ansible.com",
+            "zone_format": "IPV4",
+            "extattrs": {'Site': {'value': 'test'}}
+        }]
+
+        test_spec = {
+            "fqdn": {"ib_req": True},
+            "zone_format": {},
+            "comment": {},
+            "extattrs": {}
+        }
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ref)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR is raised to resolve PR #41869 and now with respective support addition, users can now create reverse mapping zone via nios_zone module in Infoblox DDI server. Also, also along with unit and integration tests for the support of reverse-mapping this PR also includes nios_zone missing test cases.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
nios
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
