### PR TITLE
issue:43021 add support for onyx version 3.6.6000 and above

### DIFF
--- a/lib/ansible/modules/network/onyx/onyx_interface.py
+++ b/lib/ansible/modules/network/onyx/onyx_interface.py
@@ -335,14 +335,22 @@ class OnyxInterfaceModule(BaseOnyxModule):
         return get_interfaces_config(self._module, self._interface_type)
 
     def load_current_config(self):
+        self._os_version = self._get_os_version()
         self._current_config = dict()
         config = self._get_interfaces_config()
         if not config:
             return
-
-        for item in config:
-            name = self.get_if_name(item)
-            self._current_config[name] = self._create_if_data(name, item)
+        if self._os_version < self.ONYX_API_VERSION:
+            for if_data in config:
+                if_name = self.get_if_name(if_data)
+                self._current_config[if_name] = self._create_if_data(
+                    if_name, if_data)
+        else:
+            for if_config in config:
+                for if_name, if_data in iteritems(if_config):
+                    if_data = if_data[0]
+                    self._current_config[if_name] = self._create_if_data(
+                        if_name, if_data)
 
     def _generate_no_if_commands(self, req_if, curr_if):
         if self._interface_type == self.IF_TYPE_ETH:

--- a/lib/ansible/modules/network/onyx/onyx_l2_interface.py
+++ b/lib/ansible/modules/network/onyx/onyx_l2_interface.py
@@ -162,6 +162,9 @@ class OnyxL2InterfaceModule(BaseOnyxModule):
             return int(access_vlan)
 
     def _create_switchport_data(self, if_name, if_data):
+        if self._os_version >= self.ONYX_API_VERSION:
+            if_data = if_data[0]
+
         return {
             'name': if_name,
             'mode': self.get_config_attr(if_data, 'Mode'),
@@ -174,6 +177,7 @@ class OnyxL2InterfaceModule(BaseOnyxModule):
 
     def load_current_config(self):
         # called in base class in run function
+        self._os_version = self._get_os_version()
         self._current_config = dict()
         switchports_config = self._get_switchport_config()
         if not switchports_config:

--- a/test/units/modules/network/onyx/test_onyx_interface.py
+++ b/test/units/modules/network/onyx/test_onyx_interface.py
@@ -47,6 +47,7 @@ class TestOnyxInterfaceModule(TestOnyxModule):
         config_file = 'onyx_interfaces_show.cfg'
         self.get_config.return_value = load_fixture(config_file)
         self.load_config.return_value = None
+        self.get_version.return_value = "3.6.5000"
 
     def test_mtu_no_change(self):
         set_module_args(dict(name='Eth1/1', mtu=1500))

--- a/test/units/modules/network/onyx/test_onyx_interface.py
+++ b/test/units/modules/network/onyx/test_onyx_interface.py
@@ -34,6 +34,10 @@ class TestOnyxInterfaceModule(TestOnyxModule):
             'ansible.module_utils.network.onyx.onyx.load_config')
         self.load_config = self.mock_load_config.start()
 
+        self.mock_get_version = patch.object(
+            onyx_interface.OnyxInterfaceModule, "_get_os_version")
+        self.get_version = self.mock_get_version.start()
+
     def tearDown(self):
         super(TestOnyxInterfaceModule, self).tearDown()
         self.mock_get_config.stop()

--- a/test/units/modules/network/onyx/test_onyx_l2_interface.py
+++ b/test/units/modules/network/onyx/test_onyx_l2_interface.py
@@ -53,6 +53,7 @@ class TestOnyxInterfaceModule(TestOnyxModule):
         config_file = 'onyx_l2_interface_show.cfg'
         self.get_config.return_value = load_fixture(config_file)
         self.load_config.return_value = None
+        self.get_version.return_value = "3.6.5000"
 
     def test_access_vlan_no_change(self):
         set_module_args(dict(name='Eth1/11', access_vlan=1))

--- a/test/units/modules/network/onyx/test_onyx_l2_interface.py
+++ b/test/units/modules/network/onyx/test_onyx_l2_interface.py
@@ -40,6 +40,10 @@ class TestOnyxInterfaceModule(TestOnyxModule):
             'ansible.module_utils.network.onyx.onyx.load_config')
         self.load_config = self.mock_load_config.start()
 
+        self.mock_get_version = patch.object(
+            onyx_l2_interface.OnyxL2InterfaceModule, "_get_os_version")
+        self.get_version = self.mock_get_version.start()
+
     def tearDown(self):
         super(TestOnyxInterfaceModule, self).tearDown()
         self.mock_get_config.stop()

--- a/test/units/modules/network/onyx/test_onyx_l3_interface.py
+++ b/test/units/modules/network/onyx/test_onyx_l3_interface.py
@@ -27,6 +27,10 @@ class TestOnyxL3InterfaceModule(TestOnyxModule):
             'ansible.module_utils.network.onyx.onyx.load_config')
         self.load_config = self.mock_load_config.start()
 
+        self.mock_get_version = patch.object(
+            onyx_l3_interface.OnyxL3InterfaceModule, "_get_os_version")
+        self.get_version = self.mock_get_version.start()
+
     def tearDown(self):
         super(TestOnyxL3InterfaceModule, self).tearDown()
         self.mock_get_config.stop()

--- a/test/units/modules/network/onyx/test_onyx_l3_interface.py
+++ b/test/units/modules/network/onyx/test_onyx_l3_interface.py
@@ -56,6 +56,7 @@ class TestOnyxL3InterfaceModule(TestOnyxModule):
     def load_fixture(self, config_file):
         self.get_config.return_value = load_fixture(config_file)
         self.load_config.return_value = None
+        self.get_version.return_value = "3.6.5000"
 
     def load_eth_ifc_fixture(self):
         config_file = 'onyx_l3_interface_show.cfg'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix modules: onyx_interface onyx_l2_interface and onyx_l3_interface to support onyx version 3.6.6000 and above
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #43021
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
onyx_interface
onyx_l2_interface
onyx_l3_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (issue/43021 4d82d1bce2) last updated 2018/08/22 18:44:57 (GMT +000)
  config file = /root/.ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
