### PR TITLE
Clarifiy the usage of env_file in the docker_container module

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -98,7 +98,7 @@ options:
   env_file:
     version_added: "2.2"
     description:
-      - Path to a file containing environment variables I(FOO=BAR).
+      - Path to a file, present on the target, containing environment variables I(FOO=BAR).
       - If variable also present in C(env), then C(env) value will override.
   entrypoint:
     description:
@@ -573,6 +573,12 @@ EXAMPLES = '''
   docker_container:
     name: sleepy
     purge_networks: yes
+
+- name: Start a container and use an env file
+  docker_container:
+    name: agent
+    image: jenkinsci/ssh-slave
+    env_file: /var/tmp/jenkins/agent.env
 
 - name: Create a container with limited capabilities
   docker_container:


### PR DESCRIPTION
##### SUMMARY
Clarified the usage of `env_file` and provided an example of the same.

This is a new version of #42211, without merge commits. @ntwrkguru, the original author, agreed to have it resubmitted here.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.6.3
```
