### PR TITLE
Remove deprecated ec2_facts

### DIFF
--- a/changelogs/fragments/ec2-facts.yaml
+++ b/changelogs/fragments/ec2-facts.yaml
@@ -1,0 +1,2 @@
+removed_features:
+- ec2_facts - deprecated module removed (https://github.com/ansible/ansible/pull/44536)

--- a/lib/ansible/modules/cloud/amazon/_ec2_facts.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_facts.py
@@ -1,1 +1,0 @@
-ec2_metadata_facts.py

--- a/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
@@ -541,9 +541,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ec2_facts':
-        module.deprecate("The 'ec2_facts' module is being renamed 'ec2_metadata_facts'", version=2.7)
-
     ec2_metadata_facts = Ec2Metadata(module).run()
     ec2_metadata_facts_result = dict(changed=False, ansible_facts=ec2_metadata_facts)
 


### PR DESCRIPTION
##### SUMMARY
Remove deprecated ec2_facts

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/_ec2_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```