### PR TITLE
ec2_vpc_route_table.py: set lookup on id when parameter route_table_i…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -32,8 +32,8 @@ author:
 options:
   lookup:
     description: Look up route table by either tags or by route table ID. Non-unique tag lookup will fail.
-      If no tags are specified then no lookup for an existing route table is performed and a new
-      route table will be created. To change tags of a route table you must look up by id.
+      If tags or route_table_id are not specified, then a new route table will be created.
+      To change tags of a route you can set route_table_id, lookup on id is deprecated.
     default: tag
     choices: [ 'tag', 'id' ]
   propagating_vgw_ids:
@@ -53,7 +53,7 @@ options:
     type: bool
     default: 'no'
   route_table_id:
-    description: The ID of the route table to update or delete.
+    description: The ID of the route table to update or delete. On presence, lookup is set automatically to id.
   routes:
     description: List of routes in the route table.
         Routes are specified as dicts containing the keys 'dest' and one of 'gateway_id',
@@ -119,7 +119,6 @@ EXAMPLES = '''
     vpc_id: vpc-1245678
     region: us-west-1
     route_table_id: "{{ route_table.id }}"
-    lookup: id
     state: absent
 '''
 
@@ -729,6 +728,10 @@ def main():
                                            ['lookup', 'tag', ['vpc_id']],
                                            ['state', 'present', ['vpc_id']]],
                               supports_check_mode=True)
+
+    # lookup is set on id when route_table_id is found
+    if module.params.get('route_table_id'):
+        module.params['lookup'] = 'id'
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -32,8 +32,7 @@ author:
 options:
   lookup:
     description: Look up route table by either tags or by route table ID. Non-unique tag lookup will fail.
-      If tags or route_table_id are not specified, then a new route table will be created.
-      To change tags of a route you can set route_table_id, lookup on id is deprecated.
+      As of Ansible 2.8, I(lookup) is set automatically 'id' if I(route_table_id) is provided.
     default: tag
     choices: [ 'tag', 'id' ]
   propagating_vgw_ids:
@@ -53,7 +52,8 @@ options:
     type: bool
     default: 'no'
   route_table_id:
-    description: The ID of the route table to update or delete. On presence, lookup is set automatically to id.
+    description: The ID of the route table to update or delete.
+      As of Ansible 2.8, if I(route_table_id) is used in conjunction with I(state=present), I(lookup) is set automatically to 'id'.
   routes:
     description: List of routes in the route table.
         Routes are specified as dicts containing the keys 'dest' and one of 'gateway_id',

--- a/test/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -568,6 +568,113 @@
       that:
         - not redestroy_table.changed
 
+  - name: CHECK MODE - create route table for tests with no lookup argument
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      routes:
+      - gateway_id: "{{ nat_gateway.nat_gateway_id }}"
+        dest: 0.0.0.0/0
+      <<: *aws_connection_info
+    check_mode: True
+    register: check_mode_results
+
+  - name: assert the route table for the lookup tests would be created
+    assert:
+      that:
+        - check_mode_results.changed
+
+  - name: create route table for the lookup tests
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      routes:
+      - gateway_id: "{{ nat_gateway.nat_gateway_id }}"
+        dest: 0.0.0.0/0
+      <<: *aws_connection_info
+    register: create_lookup_table
+
+  - name: assert the route table for the lookup tests would be created
+    assert:
+      that:
+        - create_lookup_table.changed
+
+  - name: CHECK MODE - check route_table_id is the reference when lookup param is absent
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      route_table_id: "{{ create_lookup_table.route_table.route_table_id }}"
+      routes:
+      - gateway_id: "{{ nat_gateway.nat_gateway_id }}"
+        dest: 0.0.0.0/0
+      <<: *aws_connection_info
+    check_mode: True
+    register: check_mode_results
+
+  - name: assert route_table_id is the reference when lookup param is asbent
+    assert:
+      that:
+        - not check_mode_results.changed
+
+  - name: ensure route_table_id is the reference when lookup is absent
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      route_table_id: "{{ create_lookup_table.route_table.route_table_id }}"
+      routes:
+      - gateway_id: "{{ nat_gateway.nat_gateway_id }}"
+        dest: 0.0.0.0/0
+      <<: *aws_connection_info
+    register: check_lookup_results
+
+  - name: assert route_table_id is the reference when lookup is absent
+    assert:
+      that:
+        - check_lookup_results.route_table.route_table_id == create_lookup_table.route_table.route_table_id
+        - not check_lookup_results.changed
+
+
+  - name: add a tag based on route_table_id and no lookup param
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      route_table_id: "{{ create_lookup_table.route_table.route_table_id }}"
+      tags:
+         Name: "Lookup test table"
+      routes:
+      - gateway_id: "{{ nat_gateway.nat_gateway_id }}"
+        dest: 0.0.0.0/0
+      <<: *aws_connection_info
+    register: add_tag_to_rtb_id
+
+  - name: assert adding tag based on route_table_id and no lookup param edit existing lookup table
+    assert:
+      that:
+        - add_tag_to_rtb_id.route_table.route_table_id == create_lookup_table.route_table.route_table_id
+        - add_tag_to_rtb_id.route_table.tags.Name == "Lookup test table"
+
+  - name: CHECK MODE - destroy lookup route table by route_table_id
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      route_table_id: "{{ create_lookup_table.route_table.route_table_id }}"
+      state: absent
+      <<: *aws_connection_info
+    check_mode: True
+    register: check_mode_results
+
+  - name: assert lookup route table would be deleted
+    assert:
+      that:
+        check_mode_results.changed
+
+  - name: destroy lookup route table by route_table_id
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      route_table_id: "{{ create_lookup_table.route_table.route_table_id }}"
+      state: absent
+      <<: *aws_connection_info
+    register: destroy_lookup_table
+
+  - name: assert destroy lookup route table worked
+    assert:
+      that:
+        - destroy_lookup_table.changed
+
   - name: destroy NAT GW
     ec2_vpc_nat_gateway:
       state: absent


### PR DESCRIPTION
Fix #43932 

##### SUMMARY

User don't need to specify `lookup: id` anymore when they have already set route_table_id. 

##### COMPONENT NAME

modules/cloud/amazon/ec2_vpc_route_table.py
