### PR TITLE
Add 'chars' parameter support to passwordstore lookup plugin

### DIFF
--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -54,7 +54,7 @@ DOCUMENTATION = """
       chars:
         description:
            - Define comma separated list of names that compose a custom character set in the generated passwords.
-           - 'By default generated passwords contain a random mix of upper and lowercase ASCII letters, the numbers 0-9 and punctuation (". , : - _").'
+           - 'By default generated passwords contain a random mix of upper and lowercase ASCII letters, the numbers 0-9 and these punctuation characters (". , : - _").'
            - "They can be either parts of Python's string module attributes (ascii_letters,digits, etc) or are used literally ( :, -)."
            - "To enter comma use two commas ',,' somewhere - preferably at the end. Quotes and double quotes are not supported."
         type: string

--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -110,6 +110,7 @@ from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.utils.encrypt import random_password
 from ansible.plugins.lookup import LookupBase
 
+
 def _gen_candidate_chars(characters):
     '''Generate a string containing all valid chars as defined by ``characters``
 
@@ -141,6 +142,7 @@ def _gen_candidate_chars(characters):
                      errors='strict'))
     chars = u''.join(chars).replace(u'"', u'').replace(u"'", u'')
     return chars
+
 
 # backhacked check_output with input for python 2.7
 # http://stackoverflow.com/questions/10103551/passing-data-to-subprocess-check-output


### PR DESCRIPTION
##### SUMMARY
The `password` lookup plugin has a `chars` parameter, which allows you to specify allowable characters in the passwords it generates.  The `passwordstore` lookup plugin lacks this parameter.  This PR adds the equivalent `chars` parameter to the `passwordstore` plugin.

##### ISSUE TYPE
Feature Pull Request


##### COMPONENT NAME
passwordstore lookup plugin

##### ANSIBLE VERSION
```
devel
```


##### ADDITIONAL INFORMATION
The new feature is identical to the `chars` parameter in the `password` plugin, and takes the same values.  I added an example to demonstrate its use in the `EXAMPLES` variable.

This is my first submission to Ansible.  If this requires changes to be merged and someone from the community can provide guidance, I'd be very grateful!