### PR TITLE
Replace invalid_params with ValueError

### DIFF
--- a/lib/ansible/plugins/cliconf/exos.py
+++ b/lib/ansible/plugins/cliconf/exos.py
@@ -54,7 +54,7 @@ class Cliconf(CliconfBase):
 
     def get_config(self, source='running', flags=None):
         if source not in ('running', 'startup'):
-            return self.invalid_params("fetching configuration from %s is not supported" % source)
+            raise ValueError("fetching configuration from %s is not supported" % source)
         if source == 'running':
             cmd = 'show configuration'
         else:

--- a/lib/ansible/plugins/cliconf/ironware.py
+++ b/lib/ansible/plugins/cliconf/ironware.py
@@ -51,7 +51,7 @@ class Cliconf(CliconfBase):
     @enable_mode
     def get_config(self, source='running', format='text', flags=None):
         if source not in ('running', 'startup'):
-            return self.invalid_params("fetching configuration from %s is not supported" % source)
+            raise ValueError("fetching configuration from %s is not supported" % source)
 
         if source == 'running':
             cmd = b'show running-config'
@@ -61,7 +61,7 @@ class Cliconf(CliconfBase):
         else:
             cmd = b'show configuration'
             if flags is not None:
-                return self.invalid_params("flags are only supported with running-config")
+                raise ValueError("flags are only supported with running-config")
 
         return self.send_command(cmd)
 

--- a/lib/ansible/plugins/cliconf/nos.py
+++ b/lib/ansible/plugins/cliconf/nos.py
@@ -58,7 +58,7 @@ class Cliconf(CliconfBase):
 
     def get_config(self, source='running', flags=None):
         if source not in 'running':
-            return self.invalid_params("fetching configuration from %s is not supported" % source)
+            raise ValueError("fetching configuration from %s is not supported" % source)
         if source == 'running':
             cmd = 'show running-config'
 

--- a/lib/ansible/plugins/cliconf/slxos.py
+++ b/lib/ansible/plugins/cliconf/slxos.py
@@ -60,7 +60,7 @@ class Cliconf(CliconfBase):
 
     def get_config(self, source='running', flags=None):
         if source not in ('running', 'startup'):
-            return self.invalid_params("fetching configuration from %s is not supported" % source)
+            raise ValueError("fetching configuration from %s is not supported" % source)
         if source == 'running':
             cmd = 'show running-config'
         else:

--- a/lib/ansible/plugins/cliconf/voss.py
+++ b/lib/ansible/plugins/cliconf/voss.py
@@ -35,7 +35,7 @@ class Cliconf(CliconfBase):
     @enable_mode
     def get_config(self, source='running', flags=None, format=None):
         if source not in ('running', 'startup'):
-            return self.invalid_params("fetching configuration from %s is not supported" % source)
+            raise ValueError("fetching configuration from %s is not supported" % source)
 
         if format:
             raise ValueError("'format' value %s is not supported for get_config" % format)


### PR DESCRIPTION
##### SUMMARY

Extreme networking modules returned `self.invalid_params` - this was not valid, and the new pattern is to use `raise ValueError()` - see https://github.com/ansible/ansible/pull/43643

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/cliconf/exos.py
plugins/cliconf/ironware.py
plugins/cliconf/nos.py
plugins/cliconf/slxos.py
plugins/cliconf/voss.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (invalid_params 98115727e8) last updated 2018/08/22 16:35:18 (GMT -700)
  config file = /Users/lhill/github/ansible-extreme/slxos/playbooks/ansible.cfg
  configured module search path = [u'/Users/lhill/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/lhill/github/ansible/lib/ansible
  executable location = /Users/lhill/github/ansible/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION

Also fixes pylint warning `E: 57,19: Instance of 'Cliconf' has no 'invalid_params' member (no-member)`