### PR TITLE
basic.py: catch ValueError when trying to import hash algorithms

### DIFF
--- a/changelogs/fragments/fips_md5_import.yaml
+++ b/changelogs/fragments/fips_md5_import.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- basic.py - catch ValueError in case a FIPS enabled platform raises this exception - https://github.com/ansible/ansible/issues/44447

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -138,13 +138,13 @@ try:
         hashlib.md5()
     except ValueError:
         algorithms.pop('md5', None)
-except (ImportError, AttributeError):  # FIPS may raise AttributeError with md5
+except Exception:
     import sha
     AVAILABLE_HASH_ALGORITHMS = {'sha1': sha.sha}
     try:
         import md5
         AVAILABLE_HASH_ALGORITHMS['md5'] = md5.md5
-    except (ImportError, AttributeError):
+    except Exception:
         pass
 
 from ansible.module_utils.common._collections_compat import (

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -132,13 +132,19 @@ try:
         algorithms = ('md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512')
     for algorithm in algorithms:
         AVAILABLE_HASH_ALGORITHMS[algorithm] = getattr(hashlib, algorithm)
-except ImportError:
+
+    # we may have been able to import md5 but it could still not be available
+    try:
+        hashlib.md5()
+    except ValueError:
+        algorithms.pop('md5', None)
+except (ImportError, AttributeError):  # FIPS may raise AttributeError with md5
     import sha
     AVAILABLE_HASH_ALGORITHMS = {'sha1': sha.sha}
     try:
         import md5
         AVAILABLE_HASH_ALGORITHMS['md5'] = md5.md5
-    except ImportError:
+    except (ImportError, AttributeError):
         pass
 
 from ansible.module_utils.common._collections_compat import (


### PR DESCRIPTION
##### SUMMARY
In some cases, hashlib may raise a `ValueError` if md5 is not available, potentially if FIPS is enabled. This PR catches that and ignores the hash if so.

Fixes https://github.com/ansible/ansible/issues/44447

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
basic.py

##### ANSIBLE VERSION
```
devel
2.6
```