### PR TITLE
Fix mail module for python 3.7.0

### DIFF
--- a/changelogs/fragments/44552-mail-py370-compat.yml
+++ b/changelogs/fragments/44552-mail-py370-compat.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- fix mail module for python 3.7.0 (https://github.com/ansible/ansible/pull/44552)

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -248,7 +248,7 @@ def main():
     try:
         if secure != 'never':
             try:
-                smtp = smtplib.SMTP_SSL(timeout=timeout)
+                smtp = smtplib.SMTP_SSL(host=host, timeout=timeout)
                 code, smtpmessage = smtp.connect(host, port=port)
                 secure_state = True
             except ssl.SSLError as e:


### PR DESCRIPTION
In python 3.7.0, changes in `ssl.py` breaks `smtplib.SMTP_SSL`, which
then breaks `mail` module in ansible.

Run this line in python shell:

    import smtplib;smtplib.SMTP_SSL().connect(host='smtp.gmail.com', port=465)

Before python 3.7.0, we will get:

    (220, b'smtp.gmail.com ESMTP j13-v6sm3086685pgq.56 - gsmtp')

In python 3.7.0, we get such error at `lib/python3.7/ssl.py` line 843, method `_create`:

    ValueError: server_hostname cannot be an empty string or start with a leading dot.

The ssl module is using host info on SMTP_SSL instance, which is not set.
The fix/workaround is simple, just pass host info to it:

    import smtplib;smtplib.SMTP_SSL(host='smtp.gmail.com').connect(host='smtp.gmail.com', port=465)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
mail

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (devel fff5fb2077) last updated 2018/08/23 10:50:40 (GMT +1300)
  config file = /home/joeg/vagrant/ansible.cfg
  configured module search path = ['/home/joeg/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/joeg/.pyenv/versions/3.7.0/envs/ansible/src/ansible/lib/ansible
  executable location = /home/joeg/.pyenv/versions/ansible/bin/ansible
  python version = 3.7.0 (default, Jul 23 2018, 11:49:27) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
