### PR TITLE
Add support for multiple answers in cli_command module

### DIFF
--- a/lib/ansible/modules/network/cli/cli_command.py
+++ b/lib/ansible/modules/network/cli/cli_command.py
@@ -71,7 +71,6 @@ EXAMPLES = """
   loop:
     - configure
     - set system syslog file test any any
-    - commit
     - exit
 
 - name: multiple prompt, multiple answer

--- a/lib/ansible/modules/network/cli/cli_command.py
+++ b/lib/ansible/modules/network/cli/cli_command.py
@@ -30,10 +30,14 @@ options:
       - A single regex pattern or a sequence of patterns to evaluate the expected
         prompt from I(command).
     required: false
+    type: list
   answer:
     description:
-      - The answer to reply with if I(prompt) is matched.
+      - The answer to reply with if I(prompt) is matched. The value can be a single answer
+        or a list of answer for multiple prompts. In case the command execution results in
+        multiple prompts the sequence of the prompt and excepted answer should be in same order.
     required: false
+    type: list
   sendonly:
     description:
       - The boolean value, that when set to true will send I(command) to the
@@ -63,11 +67,24 @@ EXAMPLES = """
     command: "{{ item }}"
     prompt:
       - "Exit with uncommitted changes"
-    answer: yes
+    answer: 'y'
   loop:
     - configure
     - set system syslog file test any any
+    - commit
     - exit
+
+- name: multiple prompt, multiple answer
+  cli_command:
+    command: "copy sftp sftp://user@host//user/test.img"
+    prompt:
+      - "Confirm download operation"
+      - "Password"
+      - "Do you want to change that to the standby image"
+    answer:
+      - 'y'
+      - <password>
+      - 'y'
 """
 
 RETURN = """
@@ -102,7 +119,7 @@ def main():
     argument_spec = dict(
         command=dict(type='str', required=True),
         prompt=dict(type='list', required=False),
-        answer=dict(type='str', required=False),
+        answer=dict(type='list', required=False),
         sendonly=dict(type='bool', default=False, required=False),
     )
     required_together = [['prompt', 'answer']]


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Add multiple answers support for multiple prompts

Depends on PR #44492
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
cli_command
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
