### PR TITLE
[2.6] docker_container: allow arbitrary log_driver 

### DIFF
--- a/changelogs/fragments/33579-docker_container-log_driver.yaml
+++ b/changelogs/fragments/33579-docker_container-log_driver.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Allow arbitrary ``log_driver`` for docker_container (https://github.com/ansible/ansible/pull/33579)."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -175,16 +175,9 @@ options:
       - List of name aliases for linked containers in the format C(container_name:alias)
   log_driver:
     description:
-      - Specify the logging driver. Docker uses json-file by default.
-    choices:
-      - none
-      - json-file
-      - syslog
-      - journald
-      - gelf
-      - fluentd
-      - awslogs
-      - splunk
+      - Specify the logging driver. Docker uses I(json-file) by default.
+      - See L(here,https://docs.docker.com/config/containers/logging/configure/) for possible choices.
+    required: false
   log_options:
     description:
       - Dictionary of options specific to the chosen log_driver. See https://docs.docker.com/engine/admin/logging/overview/
@@ -2046,9 +2039,7 @@ def main():
         kill_signal=dict(type='str'),
         labels=dict(type='dict'),
         links=dict(type='list'),
-        log_driver=dict(type='str',
-                        choices=['none', 'json-file', 'syslog', 'journald', 'gelf', 'fluentd', 'awslogs', 'splunk'],
-                        default=None),
+        log_driver=dict(type='str'),
         log_options=dict(type='dict', aliases=['log_opt']),
         mac_address=dict(type='str'),
         memory=dict(type='str', default='0'),


### PR DESCRIPTION
##### SUMMARY
Allows to configure arbitrary `log_driver` for `docker_container`. Backport of #33579.

CC @kassiansun 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.6.3
```
