### PR TITLE
one_host environment variables, Fixes #44163

### DIFF
--- a/lib/ansible/module_utils/opennebula.py
+++ b/lib/ansible/module_utils/opennebula.py
@@ -28,9 +28,9 @@ class OpenNebulaModule:
     """
 
     common_args = dict(
-        api_url=dict(type='str', aliases=['api_endpoint']),
-        api_username=dict(type='str'),
-        api_password=dict(type='str', no_log=True, aliases=['api_token']),
+        api_url=dict(type='str', aliases=['api_endpoint'], default=environ.get("ONE_URL")),
+        api_username=dict(type='str', default=environ.get("ONE_USERNAME")),
+        api_password=dict(type='str', no_log=True, aliases=['api_token'], default=environ.get("ONE_PASSWORD")),
         validate_certs=dict(default=True, type='bool'),
         wait_timeout=dict(type='int', default=300),
     )
@@ -68,18 +68,18 @@ class OpenNebulaModule:
         if not HAS_PYONE:
             self.fail("pyone is required for this module")
 
-        if 'api_url' in self.module.params:
-            url = self.module.params.get("api_url", environ.get("ONE_URL", False))
+        if self.module.params.get("api_url"):
+            url = self.module.params.get("api_url")
         else:
             self.fail("Either api_url or the environment variable ONE_URL must be provided")
 
-        if 'api_username' in self.module.params:
-            username = self.module.params.get("api_username", environ.get("ONE_USERNAME", False))
+        if self.module.params.get("api_username"):
+            username = self.module.params.get("api_username")
         else:
             self.fail("Either api_username or the environment vairable ONE_USERNAME must be provided")
 
-        if 'api_password' in self.module.params:
-            password = self.module.params.get("api_password", environ.get("ONE_PASSWORD", False))
+        if self.module.params.get("api_password"):
+            password = self.module.params.get("api_password")
         else:
             self.fail("Either api_password or the environment vairable ONE_PASSWORD must be provided")
 

--- a/lib/ansible/utils/module_docs_fragments/opennebula.py
+++ b/lib/ansible/utils/module_docs_fragments/opennebula.py
@@ -21,6 +21,7 @@ options:
     api_password:
         description:
             - The password or token for XMLRPC authentication.
+              If not specified then the value of the ONE_PASSWORD environment variable, if any, is used.
         aliases:
             - api_token
     validate_certs:

--- a/test/integration/targets/one_host/tasks/main.yml
+++ b/test/integration/targets/one_host/tasks/main.yml
@@ -72,11 +72,11 @@
   one_host:
     name: badhost
     state: absent
-    api_url: "{{ opennebula_url }}"
-    api_username: "{{ opennebula_username }}"
-    api_password: "{{ opennebula_password }}"
     validate_certs: false
   environment:
+    ONE_URL: "{{ opennebula_url }}"
+    ONE_USERNAME: "{{ opennebula_username }}"
+    ONE_PASSWORD: "{{ opennebula_password }}"
     PYONE_TEST_FIXTURE: "{{ opennebula_test_fixture }}"
     PYONE_TEST_FIXTURE_FILE: /tmp/opennebula-fixtures.json.gz
     PYONE_TEST_FIXTURE_REPLAY: "{{ opennebula_test_fixture_replay }}"


### PR DESCRIPTION
##### SUMMARY
one_host accepts connection parameters via environment variables, however this documented functionality is currently broken as reported in issue #44163 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
one_host

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->

```
ansible 2.7.0.dev0 (devel 2c84022b20) last updated 2018/08/23 15:22:58 (GMT +200)
  config file = None
  configured module search path = [u'/home/rafael/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/rafael/Development/privaz.io/python/ansible/lib/ansible
  executable location = /home/rafael/Development/privaz.io/python/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
A test case has been modified to test this code.
Documentation has also been amended as ONE_PASSWORD was not properly documented.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
