### PR TITLE
IPA: Add option to specify timeout

### DIFF
--- a/lib/ansible/module_utils/ipa.py
+++ b/lib/ansible/module_utils/ipa.py
@@ -44,6 +44,7 @@ class IPAClient(object):
         self.protocol = protocol
         self.module = module
         self.headers = None
+        self.timeout = module.params.get('ipa_timeout')
 
     def get_base_url(self):
         return '%s://%s/ipa' % (self.protocol, self.host)
@@ -58,7 +59,7 @@ class IPAClient(object):
                    'Content-Type': 'application/x-www-form-urlencoded',
                    'Accept': 'text/plain'}
         try:
-            resp, info = fetch_url(module=self.module, url=url, data=to_bytes(data), headers=headers)
+            resp, info = fetch_url(module=self.module, url=url, data=to_bytes(data), headers=headers, timeout=self.timeout)
             status_code = info['status']
             if status_code not in [200, 201, 204]:
                 self._fail('login', info['msg'])
@@ -104,7 +105,7 @@ class IPAClient(object):
             data['params'] = [[name], item]
 
         try:
-            resp, info = fetch_url(module=self.module, url=url, data=to_bytes(json.dumps(data)), headers=self.headers)
+            resp, info = fetch_url(module=self.module, url=url, data=to_bytes(json.dumps(data)), headers=self.headers, timeout=self.timeout)
             status_code = info['status']
             if status_code not in [200, 201, 204]:
                 self._fail(method, info['msg'])
@@ -184,5 +185,6 @@ def ipa_argument_spec():
         ipa_port=dict(type='int', default=443, fallback=(env_fallback, ['IPA_PORT'])),
         ipa_user=dict(type='str', default='admin', fallback=(env_fallback, ['IPA_USER'])),
         ipa_pass=dict(type='str', required=True, no_log=True, fallback=(env_fallback, ['IPA_PASS'])),
+        ipa_timeout=dict(type='int', default=10, fallback=(env_fallback, ['IPA_TIMEOUT'])),
         validate_certs=dict(type='bool', default=True),
     )

--- a/lib/ansible/utils/module_docs_fragments/ipa.py
+++ b/lib/ansible/utils/module_docs_fragments/ipa.py
@@ -50,5 +50,13 @@ options:
     - This should only set to C(no) used on personally controlled sites using self-signed certificates.
     default: true
     type: bool
+  ipa_timeout:
+    description:
+    - Specifies idle timeout (in seconds) for the connection.
+    - For bulk operations, you may want to increase this in order to avoid timeout from IPA server.
+    - If the value is not specified in the task, the value of environment variable C(IPA_TIMEOUT) will be used instead.
+    - If both the environment variable C(IPA_TIMEOUT) and the value are not specified in the task, then default value is set.
+    default: 10
+    version_added: 2.7
 
 '''


### PR DESCRIPTION
##### SUMMARY
This fix allows user to specify idle timeout for fetch_url used
internally in IPA connection and post_json call.

Fixes: #44304 

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/ipa.py
lib/ansible/utils/module_docs_fragments/ipa.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```