### PR TITLE
Bump sudo/su deprecation to 2.9

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -344,7 +344,7 @@ class CLI(with_metaclass(ABCMeta, object)):
         self.options.become_user = self.options.become_user or self.options.sudo_user or self.options.su_user or C.DEFAULT_BECOME_USER
 
         def _dep(which):
-            display.deprecated('The %s command line option has been deprecated in favor of the "become" command line arguments' % which, '2.6')
+            display.deprecated('The %s command line option has been deprecated in favor of the "become" command line arguments' % which, '2.9')
 
         if self.options.become:
             pass

--- a/lib/ansible/playbook/become.py
+++ b/lib/ansible/playbook/become.py
@@ -78,7 +78,7 @@ class Become:
                 ds['become_user'] = ds['sudo_user']
                 del ds['sudo_user']
 
-            display.deprecated("Instead of sudo/sudo_user, use become/become_user and make sure become_method is 'sudo' (default)", '2.6')
+            display.deprecated("Instead of sudo/sudo_user, use become/become_user and make sure become_method is 'sudo' (default)", '2.9')
 
         elif 'su' in ds or 'su_user' in ds:
             ds['become_method'] = 'su'
@@ -90,6 +90,6 @@ class Become:
                 ds['become_user'] = ds['su_user']
                 del ds['su_user']
 
-            display.deprecated("Instead of su/su_user, use become/become_user and set become_method to 'su' (default is sudo)", '2.6')
+            display.deprecated("Instead of su/su_user, use become/become_user and set become_method to 'su' (default is sudo)", '2.9')
 
         return ds


### PR DESCRIPTION
##### SUMMARY
Bump sudo/su deprecation to 2.9

We purposefully didn't remove these in 2.6 due to it being a stability release.  It won't happen in 2.7, so we'll bump removal to 2.9 to line up with become plugins being introduced.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
multiple

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```