### PR TITLE
Backport #43051 to 2.6 - Pass path to GalaxyRole object

### DIFF
--- a/changelogs/fragments/galaxy_list_all_roles.yaml
+++ b/changelogs/fragments/galaxy_list_all_roles.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - properly list all roles in roles_path (https://github.com/ansible/ansible/issues/43010)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -490,7 +490,7 @@ class GalaxyCLI(CLI):
                 path_files = os.listdir(role_path)
                 path_found = True
                 for path_file in path_files:
-                    gr = GalaxyRole(self.galaxy, path_file)
+                    gr = GalaxyRole(self.galaxy, path_file, path=path)
                     if gr.metadata:
                         install_info = gr.install_info
                         version = None


### PR DESCRIPTION
##### SUMMARY
Backport of #43051 for Ansible 2.6

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
`/lib/ansible/cli/galaxy.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```