### PR TITLE
Add parameter and remove netaddr

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_monitor_http.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_http.py
@@ -28,7 +28,11 @@ options:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(http)
         parent on the C(Common) partition.
-    default: "/Common/http"
+    default: /Common/http
+  description:
+    description:
+      - The description of the monitor.
+    version_added: 2.7
   send:
     description:
       - The send string for the monitor call. When creating a new monitor, if
@@ -100,6 +104,7 @@ notes:
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
+  - Wojciech Wypior (@wojtek0806)
 '''
 
 EXAMPLES = r'''
@@ -140,6 +145,11 @@ parent:
   returned: changed
   type: string
   sample: http
+description:
+  description: The description of the monitor.
+  returned: changed
+  type: str
+  sample: Important_Monitor
 ip:
   description: The new IP of IP/port definition.
   returned: changed
@@ -173,6 +183,7 @@ try:
     from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.ipaddress import is_valid_ip
     try:
         from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     except ImportError:
@@ -185,16 +196,11 @@ except ImportError:
     from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     try:
         from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
     except ImportError:
         HAS_F5SDK = False
-
-try:
-    import netaddr
-    HAS_NETADDR = True
-except ImportError:
-    HAS_NETADDR = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -207,17 +213,17 @@ class Parameters(AnsibleF5Parameters):
 
     api_attributes = [
         'timeUntilUp', 'defaultsFrom', 'interval', 'timeout', 'recv', 'send',
-        'destination', 'username', 'password', 'recvDisable'
+        'destination', 'username', 'password', 'recvDisable', 'description'
     ]
 
     returnables = [
         'parent', 'send', 'receive', 'ip', 'port', 'interval', 'timeout',
-        'time_until_up', 'receive_disable'
+        'time_until_up', 'receive_disable', 'description'
     ]
 
     updatables = [
         'destination', 'send', 'receive', 'interval', 'timeout', 'time_until_up',
-        'target_username', 'target_password', 'receive_disable'
+        'target_username', 'target_password', 'receive_disable', 'description'
     ]
 
     def to_return(self):
@@ -266,12 +272,11 @@ class Parameters(AnsibleF5Parameters):
     def ip(self):
         if self._values['ip'] is None:
             return None
-        try:
-            if self._values['ip'] in ['*', '0.0.0.0']:
-                return '*'
-            result = str(netaddr.IPAddress(self._values['ip']))
-            return result
-        except netaddr.core.AddrFormatError:
+        if self._values['ip'] in ['*', '0.0.0.0']:
+            return '*'
+        elif is_valid_ip(self._values['ip']):
+            return self._values['ip']
+        else:
             raise F5ModuleError(
                 "The provided 'ip' parameter is not an IP address."
             )
@@ -545,6 +550,7 @@ class ArgumentSpec(object):
         argument_spec = dict(
             name=dict(required=True),
             parent=dict(default='/Common/http'),
+            description=dict(),
             send=dict(),
             receive=dict(),
             receive_disable=dict(required=False),
@@ -578,8 +584,6 @@ def main():
     )
     if not HAS_F5SDK:
         module.fail_json(msg="The python f5-sdk module is required")
-    if not HAS_NETADDR:
-        module.fail_json(msg="The python netaddr module is required")
 
     try:
         client = F5Client(**module.params)

--- a/lib/ansible/modules/network/f5/bigip_monitor_snmp_dca.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_snmp_dca.py
@@ -129,6 +129,7 @@ notes:
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
+  - Wojciech Wypior (@wojtek0806)
 '''
 
 EXAMPLES = r'''
@@ -157,6 +158,11 @@ parent:
   returned: changed
   type: string
   sample: snmp_dca
+description:
+  description: The description of the monitor.
+  returned: changed
+  type: str
+  sample: Important Monitor
 interval:
   description: The new interval in which to run the monitor check.
   returned: changed
@@ -264,7 +270,7 @@ class Parameters(AnsibleF5Parameters):
     api_attributes = [
         'timeUntilUp', 'defaultsFrom', 'interval', 'timeout', 'destination', 'community',
         'version', 'agentType', 'cpuCoefficient', 'cpuThreshold', 'memoryCoefficient',
-        'memoryThreshold', 'diskCoefficient', 'diskThreshold'
+        'memoryThreshold', 'diskCoefficient', 'diskThreshold', 'description'
     ]
 
     returnables = [

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp_half_open.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp_half_open.py
@@ -28,7 +28,11 @@ options:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed. By default, this value is the C(tcp_half_open)
         parent on the C(Common) partition.
-    default: "/Common/tcp_half_open"
+    default: /Common/tcp_half_open
+  description:
+    description:
+      - The description of the monitor.
+    version_added: 2.7
   ip:
     description:
       - IP address part of the IP/port definition. If this parameter is not
@@ -84,6 +88,7 @@ notes:
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
+  - Wojciech Wypior (@wojtek0806)
 '''
 
 EXAMPLES = r'''
@@ -122,6 +127,11 @@ parent:
   returned: changed
   type: string
   sample: tcp
+description:
+  description: The description of the monitor.
+  returned: changed
+  type: str
+  sample: Important Monitor
 ip:
   description: The new IP of IP/port definition.
   returned: changed
@@ -156,6 +166,7 @@ try:
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.ipaddress import is_valid_ip
     try:
         from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     except ImportError:
@@ -167,16 +178,11 @@ except ImportError:
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     try:
         from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
     except ImportError:
         HAS_F5SDK = False
-
-try:
-    import netaddr
-    HAS_NETADDR = True
-except ImportError:
-    HAS_NETADDR = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -187,15 +193,17 @@ class Parameters(AnsibleF5Parameters):
     }
 
     api_attributes = [
-        'timeUntilUp', 'defaultsFrom', 'interval', 'timeout', 'destination'
+        'timeUntilUp', 'defaultsFrom', 'interval', 'timeout', 'destination',
+        'description'
     ]
 
     returnables = [
-        'parent', 'ip', 'port', 'interval', 'timeout', 'time_until_up'
+        'parent', 'ip', 'port', 'interval', 'timeout', 'time_until_up',
+        'description'
     ]
 
     updatables = [
-        'destination', 'interval', 'timeout', 'time_until_up'
+        'destination', 'interval', 'timeout', 'time_until_up', 'description'
     ]
 
     def to_return(self):
@@ -244,15 +252,13 @@ class Parameters(AnsibleF5Parameters):
     def ip(self):
         if self._values['ip'] is None:
             return None
-        try:
-            if self._values['ip'] in ['*', '0.0.0.0']:
-                return '*'
-            result = str(netaddr.IPAddress(self._values['ip']))
-            return result
-        except netaddr.core.AddrFormatError:
-            raise F5ModuleError(
-                "The provided 'ip' parameter is not an IP address."
-            )
+        elif self._values['ip'] in ['*', '0.0.0.0']:
+            return '*'
+        elif is_valid_ip(self._values['ip']):
+            return self._values['ip']
+        raise F5ModuleError(
+            "The provided 'ip' parameter is not an IP address."
+        )
 
     @property
     def port(self):
@@ -514,6 +520,7 @@ class ArgumentSpec(object):
         argument_spec = dict(
             name=dict(required=True),
             parent=dict(default='/Common/tcp_half_open'),
+            description=dict(),
             ip=dict(),
             port=dict(type='int'),
             interval=dict(type='int'),
@@ -542,8 +549,6 @@ def main():
     )
     if not HAS_F5SDK:
         module.fail_json(msg="The python f5-sdk module is required")
-    if not HAS_NETADDR:
-        module.fail_json(msg="The python netaddr module is required")
 
     try:
         client = F5Client(**module.params)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This patch adds a description parameter to most fields. It also removes
netaddr from the modules.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
bigip monitor modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jul 25 2018, 18:19:34) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
