### PR TITLE
Add missing entry to package_data, fix warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -254,6 +254,7 @@ static_setup_params = dict(
             'galaxy/data/*/*/*.*',
             'galaxy/data/*/tests/inventory',
             'config/base.yml',
+            'config/module_defaults.yml',
         ],
     },
     classifiers=[


### PR DESCRIPTION
##### SUMMARY
Someone made some change and @sivel informs me they forgot to include this entry in package_data in the setup

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible --version
ansible 2.7.0.dev0
  config file = None
  configured module search path = [u'/Users/alancoding/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.7.0.dev0-py2.7.egg/ansible
  executable location = /Users/alancoding/.virtualenvs/ansible/bin/ansible
  python version = 2.7.11 (default, Oct 17 2016, 14:59:40) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```


##### ADDITIONAL INFORMATION
before:
```
ansible-playbook -i localhost, cloud_module_testing.yml -e 'ansible_python_interpreter: /usr/bin/env python' --tags=ec2
Could not load module_defaults_groups: AnsibleError: Missing base YAML definition file (bad install?): /Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.7.0.dev0-py2.7.egg/ansible/config/module_defaults.yml


PLAY [intentionally run modules, and do not provide auth (for testing credentials)] *************************************************************************************************

TASK [Provision a set of instances] *************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "boto required for this module"}
	to retry, use: --limit @/Users/alancoding/Documents/repos/utility-playbooks/cloud_module_testing.retry

PLAY RECAP **************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   
```

after

```
ansible-playbook -i localhost, cloud_module_testing.yml -e 'ansible_python_interpreter: /usr/bin/env python' --tags=ec2

PLAY [intentionally run modules, and do not provide auth (for testing credentials)] *************************************************************************************************

TASK [Provision a set of instances] *************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "boto required for this module"}
	to retry, use: --limit @/Users/alancoding/Documents/repos/utility-playbooks/cloud_module_testing.retry

PLAY RECAP **************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1  
```
