### PR TITLE
Use runtime instead of datetime for test output.

### DIFF
--- a/test/sanity/code-smell/shebang.py
+++ b/test/sanity/code-smell/shebang.py
@@ -27,6 +27,7 @@ def main():
     skip = set([
         'test/integration/targets/win_module_utils/library/legacy_only_new_way_win_line_ending.ps1',
         'test/integration/targets/win_module_utils/library/legacy_only_old_way_win_line_ending.ps1',
+        'test/utils/shippable/timing.py',
     ])
 
     for path in sys.argv[1:] or sys.stdin.read().splitlines():

--- a/test/utils/shippable/timing.py
+++ b/test/utils/shippable/timing.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import sys
+import time
+
+start = time.time()
+
+for line in sys.stdin:
+    seconds = time.time() - start
+    sys.stdout.write('%02d:%02d %s' % (seconds // 60, seconds % 60, line))

--- a/test/utils/shippable/timing.sh
+++ b/test/utils/shippable/timing.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eux
+#!/bin/bash -eu
 
 set -o pipefail
 
-"$@" 2>&1 | gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0; fflush(); }'
+"$@" 2>&1 | "$(dirname "$0")/timing.py"


### PR DESCRIPTION
##### SUMMARY

Use runtime instead of datetime for test output.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Shippable

##### ANSIBLE VERSION

N/A