### PR TITLE
Use runtime instead of datetime for test output.

### DIFF
--- a/test/sanity/code-smell/shebang.sh
+++ b/test/sanity/code-smell/shebang.sh
@@ -9,6 +9,7 @@ grep '^#!' -rIn . \
     -e '^\./test/integration/targets/[^/]*/library/[^/]*:#!/usr/bin/python$' \
     -e '^\./test/integration/targets/module_precedence/.*lib.*:#!/usr/bin/python$' \
     -e '^\./hacking/cherrypick.py:#!/usr/bin/env python3$' \
+    -e '^\./test/utils/shippable/timing.py:#!/usr/bin/env python3$' \
     -e ':#!/bin/sh$' \
     -e ':#!/bin/bash( -[eux]|$)' \
     -e ':#!/usr/bin/make -f$' \

--- a/test/utils/shippable/timing.py
+++ b/test/utils/shippable/timing.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import sys
+import time
+
+start = time.time()
+
+for line in sys.stdin:
+    seconds = time.time() - start
+    sys.stdout.write('%02d:%02d %s' % (seconds // 60, seconds % 60, line))

--- a/test/utils/shippable/timing.sh
+++ b/test/utils/shippable/timing.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eux
+#!/bin/bash -eu
 
 set -o pipefail
 
-"$@" 2>&1 | gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0; fflush(); }'
+"$@" 2>&1 | "$(dirname "$0")/timing.py"


### PR DESCRIPTION
##### SUMMARY

Use runtime instead of datetime for test output.

(cherry picked from commit 31a5b874a158b1379733cf2ea17b0688c587780d)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Shippable

##### ANSIBLE VERSION

N/A