### PR TITLE
Removes f5-sdk code from bigip modules

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_device_trust.py
+++ b/lib/ansible/modules/network/f5/bigip_device_trust.py
@@ -69,8 +69,6 @@ options:
     choices:
       - absent
       - present
-requirements:
-  - netaddr
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
@@ -115,6 +113,7 @@ try:
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.ipaddress import is_valid_ip
     try:
         from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     except ImportError:
@@ -126,16 +125,11 @@ except ImportError:
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     try:
         from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
     except ImportError:
         HAS_F5SDK = False
-
-try:
-    import netaddr
-    HAS_NETADDR = True
-except ImportError:
-    HAS_NETADDR = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -171,13 +165,11 @@ class Parameters(AnsibleF5Parameters):
     def peer_server(self):
         if self._values['peer_server'] is None:
             return None
-        try:
-            result = str(netaddr.IPAddress(self._values['peer_server']))
-            return result
-        except netaddr.core.AddrFormatError:
-            raise F5ModuleError(
-                "The provided 'peer_server' parameter is not an IP address."
-            )
+        if is_valid_ip(self._values['peer_server']):
+            return self._values['peer_server']
+        raise F5ModuleError(
+            "The provided 'peer_server' parameter is not an IP address."
+        )
 
     @property
     def peer_hostname(self):
@@ -334,8 +326,6 @@ def main():
     )
     if not HAS_F5SDK:
         module.fail_json(msg="The python f5-sdk module is required")
-    if not HAS_NETADDR:
-        module.fail_json(msg="The python netaddr module is required")
 
     try:
         client = F5Client(**module.params)

--- a/lib/ansible/modules/network/f5/bigip_gtm_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_pool.py
@@ -177,12 +177,7 @@ options:
           - This parameter is only relevant when a C(type) of C(require) is used.
           - This parameter will be ignored if a type of either C(all) or C(at_least) is used.
     version_added: 2.6
-notes:
-  - Requires the netaddr Python package on the host. This is as easy as
-    pip install netaddr.
 extends_documentation_fragment: f5
-requirements:
-  - netaddr
 author:
   - Tim Rupp (@caphrim007)
 '''
@@ -262,6 +257,7 @@ try:
     from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.ipaddress import is_valid_ip
     try:
         from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from f5.sdk_exception import LazyAttributesRequired
@@ -275,17 +271,12 @@ except ImportError:
     from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     try:
         from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from f5.sdk_exception import LazyAttributesRequired
     except ImportError:
         HAS_F5SDK = False
-
-try:
-    from netaddr import IPAddress, AddrFormatError
-    HAS_NETADDR = True
-except ImportError:
-    HAS_NETADDR = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -384,14 +375,9 @@ class Parameters(AnsibleF5Parameters):
             return 'any'
         if self._values['fallback_ip'] == 'any6':
             return 'any6'
-        try:
-            address = IPAddress(self._values['fallback_ip'])
-            if address.version == 4:
-                return str(address.ip)
-            elif address.version == 6:
-                return str(address.ip)
-            return None
-        except AddrFormatError:
+        if is_valid_ip(self._values['fallback_ip']):
+            return self._values['fallback_ip']
+        else:
             raise F5ModuleError(
                 'The provided fallback address is not a valid IPv4 address'
             )
@@ -1123,8 +1109,6 @@ def main():
     )
     if not HAS_F5SDK:
         module.fail_json(msg="The python f5-sdk module is required")
-    if not HAS_NETADDR:
-        module.fail_json(msg="The python netaddr module is required")
 
     try:
         client = F5Client(**module.params)

--- a/lib/ansible/modules/network/f5/bigip_gtm_virtual_server.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_virtual_server.py
@@ -252,6 +252,8 @@ try:
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import compare_dictionary
     from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.ipaddress import is_valid_ip
+    from library.module_utils.network.f5.ipaddress import validate_ip_v6_address
     try:
         from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from f5.sdk_exception import LazyAttributesRequired
@@ -266,17 +268,13 @@ except ImportError:
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import compare_dictionary
     from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.ipaddress import is_valid_ip
+    from ansible.module_utils.network.f5.ipaddress import validate_ip_v6_address
     try:
         from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from f5.sdk_exception import LazyAttributesRequired
     except ImportError:
         HAS_F5SDK = False
-
-try:
-    import netaddr
-    HAS_NETADDR = True
-except ImportError:
-    HAS_NETADDR = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -357,8 +355,11 @@ class ApiParameters(Parameters):
         else:
             # IPv4
             parts = self._values['destination'].split(':')
-        addr = netaddr.IPAddress(parts[0])
-        return str(addr)
+        if is_valid_ip(parts[0]):
+            return str(parts[0])
+        raise F5ModuleError(
+            "'address' parameter from API was not an IP address."
+        )
 
     @property
     def port(self):
@@ -532,8 +533,11 @@ class ModuleParameters(Parameters):
     def address(self):
         if self._values['address'] is None:
             return None
-        addr = netaddr.IPAddress(self._values['address'])
-        return str(addr)
+        if is_valid_ip(self._values['address']):
+            return self._values['address']
+        raise F5ModuleError(
+            "Specified 'address' is not an IP address."
+        )
 
     @property
     def port(self):
@@ -549,11 +553,10 @@ class ModuleParameters(Parameters):
             return None
         if self.port is None:
             return None
-        addr = netaddr.IPAddress(self.address)
-        if addr.version == 4:
-            result = '{0}:{1}'.format(self.address, self.port)
-        else:
+        if validate_ip_v6_address(self.address):
             result = '{0}.{1}'.format(self.address, self.port)
+        else:
+            result = '{0}:{1}'.format(self.address, self.port)
         return result
 
     @property
@@ -1061,8 +1064,6 @@ def main():
     )
     if not HAS_F5SDK:
         module.fail_json(msg="The python f5-sdk module is required")
-    if not HAS_NETADDR:
-        module.fail_json(msg="The python netaddr module is required")
 
     try:
         client = F5Client(**module.params)

--- a/lib/ansible/modules/network/f5/bigip_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_pool.py
@@ -144,7 +144,6 @@ options:
       - minimum_active_members
     version_added: 2.6
 notes:
-  - Requires BIG-IP software version >= 12.
   - To add members do a pool, use the C(bigip_pool_member) module. Previously, the
     C(bigip_pool) module allowed the management of users, but this has been removed
     in version 2.5 of Ansible.
@@ -363,12 +362,6 @@ except ImportError:
         from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
     except ImportError:
         HAS_F5SDK = False
-
-try:
-    from netaddr import IPAddress, AddrFormatError
-    HAS_NETADDR = True
-except ImportError:
-    HAS_NETADDR = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -947,8 +940,6 @@ def main():
     )
     if not HAS_F5SDK:
         module.fail_json(msg="The python f5-sdk module is required")
-    if not HAS_NETADDR:
-        module.fail_json(msg="The python netaddr module is required")
 
     try:
         client = F5Client(**module.params)

--- a/lib/ansible/modules/network/f5/bigip_remote_syslog.py
+++ b/lib/ansible/modules/network/f5/bigip_remote_syslog.py
@@ -45,12 +45,7 @@ options:
     choices:
       - absent
       - present
-notes:
-  - Requires the netaddr Python package on the host. This is as easy as pip
-    install netaddr.
 extends_documentation_fragment: f5
-requirements:
-  - netaddr
 author:
   - Tim Rupp (@caphrim007)
 '''
@@ -101,6 +96,7 @@ try:
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.ipaddress import is_valid_ip
     try:
         from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     except ImportError:
@@ -112,16 +108,11 @@ except ImportError:
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     try:
         from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
     except ImportError:
         HAS_F5SDK = False
-
-try:
-    import netaddr
-    HAS_NETADDR = True
-except ImportError:
-    HAS_NETADDR = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -146,17 +137,13 @@ class Parameters(AnsibleF5Parameters):
 
     @property
     def remote_host(self):
-        try:
-            # Check for valid IPv4 or IPv6 entries
-            netaddr.IPAddress(self._values['remote_host'])
+        if is_valid_ip(self._values['remote_host']):
             return self._values['remote_host']
-        except netaddr.core.AddrFormatError:
-            # else fallback to checking reasonably well formatted hostnames
-            if self.is_valid_hostname(self._values['remote_host']):
-                return str(self._values['remote_host'])
-            raise F5ModuleError(
-                "The provided 'remote_host' is not a valid IP or hostname"
-            )
+        elif self.is_valid_hostname(self._values['remote_host']):
+            return str(self._values['remote_host'])
+        raise F5ModuleError(
+            "The provided 'remote_host' is not a valid IP or hostname"
+        )
 
     def is_valid_hostname(self, host):
         """Reasonable attempt at validating a hostname
@@ -195,10 +182,9 @@ class Parameters(AnsibleF5Parameters):
     def local_ip(self):
         if self._values['local_ip'] in [None, 'none']:
             return None
-        try:
-            ip = netaddr.IPAddress(self._values['local_ip'])
-            return str(ip)
-        except netaddr.core.AddrFormatError:
+        if is_valid_ip(self._values['local_ip']):
+            return self._values['local_ip']
+        else:
             raise F5ModuleError(
                 "The provided 'local_ip' is not a valid IP address"
             )
@@ -422,7 +408,7 @@ class ModuleManager(object):
     def read_current_from_device(self):
         resource = self.client.api.tm.sys.syslog.load()
         attrs = resource.attrs
-        result = Parameters(attrs)
+        result = Parameters(params=attrs)
         return result
 
     def absent(self):
@@ -473,8 +459,6 @@ def main():
     )
     if not HAS_F5SDK:
         module.fail_json(msg="The python f5-sdk module is required")
-    if not HAS_NETADDR:
-        module.fail_json(msg="The python netaddr module is required")
 
     try:
         client = F5Client(**module.params)

--- a/lib/ansible/modules/network/f5/bigip_smtp.py
+++ b/lib/ansible/modules/network/f5/bigip_smtp.py
@@ -93,11 +93,6 @@ options:
       - always
       - on_create
 extends_documentation_fragment: f5
-notes:
-  - Requires the netaddr Python package on the host. This is as easy as
-    C(pip install netaddr).
-requirements:
-  - netaddr
 author:
   - Tim Rupp (@caphrim007)
 '''
@@ -162,6 +157,7 @@ try:
     from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import is_valid_hostname
     from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.ipaddress import is_valid_ip
     try:
         from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
     except ImportError:
@@ -174,16 +170,11 @@ except ImportError:
     from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import is_valid_hostname
     from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     try:
         from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
     except ImportError:
         HAS_F5SDK = False
-
-try:
-    import netaddr
-    HAS_NETADDR = True
-except ImportError:
-    HAS_NETADDR = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -227,19 +218,16 @@ class ModuleParameters(Parameters):
     def local_host_name(self):
         if self._values['local_host_name'] is None:
             return None
-        try:
-            # Check for valid IPv4 or IPv6 entries
-            netaddr.IPNetwork(self._values['local_host_name'])
+        if is_valid_ip(self._values['local_host_name']):
             return self._values['local_host_name']
-        except netaddr.core.AddrFormatError:
+        elif is_valid_hostname(self._values['local_host_name']):
             # else fallback to checking reasonably well formatted hostnames
-            if is_valid_hostname(self._values['local_host_name']):
-                return str(self._values['local_host_name'])
-            raise F5ModuleError(
-                "The provided 'local_host_name' value {0} is not a valid IP or hostname".format(
-                    str(self._values['local_host_name'])
-                )
+            return str(self._values['local_host_name'])
+        raise F5ModuleError(
+            "The provided 'local_host_name' value {0} is not a valid IP or hostname".format(
+                str(self._values['local_host_name'])
             )
+        )
 
     @property
     def authentication_enabled(self):
@@ -512,8 +500,6 @@ def main():
     )
     if not HAS_F5SDK:
         module.fail_json(msg="The python f5-sdk module is required")
-    if not HAS_NETADDR:
-        module.fail_json(msg="The python netaddr module is required")
 
     try:
         client = F5Client(**module.params)

--- a/lib/ansible/modules/network/f5/bigip_snmp.py
+++ b/lib/ansible/modules/network/f5/bigip_snmp.py
@@ -61,11 +61,6 @@ options:
     description:
       - Specifies the description of this system's physical location.
 extends_documentation_fragment: f5
-notes:
-  - Requires the netaddr Python package on the host. This is as easy as
-    C(pip install netaddr).
-requirements:
-  - netaddr
 author:
   - Tim Rupp (@caphrim007)
 '''
@@ -134,6 +129,7 @@ try:
     from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import is_valid_hostname
     from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.compat.ipaddress import ip_network
 
     try:
         from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
@@ -147,17 +143,12 @@ except ImportError:
     from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import is_valid_hostname
     from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.compat.ipaddress import ip_network
 
     try:
         from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
     except ImportError:
         HAS_F5SDK = False
-
-try:
-    import netaddr
-    HAS_NETADDR = True
-except ImportError:
-    HAS_NETADDR = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -221,9 +212,9 @@ class ModuleParameters(Parameters):
         for address in addresses:
             try:
                 # Check for valid IPv4 or IPv6 entries
-                netaddr.IPNetwork(address)
+                ip_network(u'%s' % str(address))
                 result.append(address)
-            except netaddr.core.AddrFormatError:
+            except ValueError:
                 # else fallback to checking reasonably well formatted hostnames
                 if is_valid_hostname(address):
                     result.append(str(address))
@@ -392,8 +383,6 @@ def main():
     )
     if not HAS_F5SDK:
         module.fail_json(msg="The python f5-sdk module is required")
-    if not HAS_NETADDR:
-        module.fail_json(msg="The python netaddr module is required")
 
     try:
         client = F5Client(**module.params)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This patch is part of an ongoing effort to fully remove the f5sdk
from the f5 modules.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
bigip modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = /here/test/integration/ansible.cfg
  configured module search path = [u'/here/library/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jul 25 2018, 18:19:34) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
