### PR TITLE
Ignore CentOS 6.10 for passwordstore test.

### DIFF
--- a/test/integration/targets/lookup_passwordstore/vars/main.yml
+++ b/test/integration/targets/lookup_passwordstore/vars/main.yml
@@ -59,4 +59,4 @@ passwordstore_privkey: |
 passwordstore_skip_os:
   Ubuntu: ['12.04']
   RedHat: ['7.4']
-  CentOS: ['6.9']
+  CentOS: ['6.9', '6.10']


### PR DESCRIPTION
##### SUMMARY

Ignore CentOS 6.10 for passwordstore test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

passwordstore integration test

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (fix-passwordstore-test 9bce80acf0) last updated 2018/08/23 15:10:44 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
