### PR TITLE
Add definitive to valid_simple_controls in pamd module

### DIFF
--- a/changelogs/fragments/44278-pamd_valid_simple_controls.yaml
+++ b/changelogs/fragments/44278-pamd_valid_simple_controls.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- lib/ansible/modules/system/pamd.py - Allow for validation of definitive control in pamd module.

--- a/changelogs/fragments/44278-pamd_valid_simple_controls.yaml
+++ b/changelogs/fragments/44278-pamd_valid_simple_controls.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- lib/ansible/modules/system/pamd.py - Allow for validation of definitive control in pamd module.
+- pamd - Allow for validation of definitive control in pamd module.

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -335,7 +335,7 @@ class PamdInclude(PamdLine):
 class PamdRule(PamdLine):
 
     valid_types = ['account', 'auth', 'password', 'session']
-    valid_simple_controls = ['required', 'requisite', 'sufficient', 'optional', 'include', 'substack']
+    valid_simple_controls = ['required', 'requisite', 'sufficient', 'optional', 'include', 'substack', 'definitive']
     valid_control_values = ['success', 'open_err', 'symbol_err', 'service_err', 'system_err', 'buf_err',
                             'perm_denied', 'auth_err', 'cred_insufficient', 'authinfo_unavail', 'user_unknown',
                             'maxtries', 'new_authtok_reqd', 'acct_expired', 'session_err', 'cred_unavail',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add "definitive" to "valid_simple_controls" in pamd module in order to support pam controls present on Solaris.
Without "definitive" it fails validation for default rules already present in pam configuration files.
https://docs.oracle.com/cd/E26502_01/html/E29015/pam-32.html#pam-15
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
pamd
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = /home/parnell/ansible/ansible.cfg
  configured module search path = [u'/home/parnell/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/parnell/.local/lib/python2.7/site-packages/ansible
  executable location = /home/parnell/.local/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
https://github.com/ansible/ansible/issues/44278
```
