### PR TITLE
GCP: Remove deprecated non-JSON credentials files

### DIFF
--- a/lib/ansible/module_utils/gcp.py
+++ b/lib/ansible/module_utils/gcp.py
@@ -237,7 +237,7 @@ def _validate_credentials_file(module, credentials_file, require_valid_json=True
     :param credentials_file: path to file on disk
     :type credentials_file: ``str``.  Complete path to file on disk.
 
-    :param require_valid_json: If true, require credentials to be valid JSON.  Default is True.
+    :param require_valid_json: This argument is ignored as of Ansible 2.7.
     :type require_valid_json: ``bool``
 
     :params check_libcloud: If true, check the libcloud version available to see if
@@ -263,14 +263,8 @@ def _validate_credentials_file(module, credentials_file, require_valid_json=True
                          credentials_file, changed=False)
         return False
     except ValueError as e:
-        if require_valid_json:
-            module.fail_json(
-                msg='GCP Credentials File %s invalid.  Must be valid JSON.' % credentials_file, changed=False)
-        else:
-            module.deprecate(msg=("Non-JSON credentials file provided. This format is deprecated. "
-                                  " Please generate a new JSON key from the Google Cloud console"),
-                             version=2.5)
-            return True
+        module.fail_json(
+            msg='GCP Credentials File %s invalid.  Must be valid JSON.' % credentials_file, changed=False)
 
 
 def gcp_connect(module, provider, get_driver, user_agent_product, user_agent_version):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

Removes support for non-JSON credentials files. 

@rambleraptor @erjohnso PTAL

Partial fix to https://github.com/ansible/ansible/issues/44538

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
gcp module_utils

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
