### PR TITLE
Various updates to macports module

### DIFF
--- a/lib/ansible/modules/packaging/os/macports.py
+++ b/lib/ansible/modules/packaging/os/macports.py
@@ -22,43 +22,67 @@ module: macports
 author: "Jimmy Tang (@jcftang)"
 short_description: Package manager for MacPorts
 description:
-    - Manages MacPorts packages
+    - Manages MacPorts packages (ports)
 version_added: "1.1"
 options:
     name:
         description:
-            - name of package to install/remove
+            - A list of port names.
+        aliases: ['port']
         required: true
     state:
         description:
-            - state of the package
+            - Indicates the desired state of the port.
         choices: [ 'present', 'absent', 'active', 'inactive' ]
         default: present
-    update_cache:
+    update_ports:
         description:
-            - update the package db first
+            - Update the ports tree first.
+        aliases: ['update_cache']
         default: "no"
         type: bool
+    variant:
+        description:
+            - A port variant specification.
+            - 'C(variant) is only supported with state: I(installed)/I(present).'
+        aliases: ['variants']
+        version_added: "2.7"
 '''
 EXAMPLES = '''
-- macports:
+- name: Install the foo port
+  macports:
     name: foo
-    state: present
 
-- macports:
+- name: Install the universal, x11 variant of the foo port
+  macports:
     name: foo
-    state: present
-    update_cache: yes
+    variant: +universal+x11
 
-- macports:
+- name: Install a list of ports
+  macports:
+    name: "{{ ports }}"
+  vars:
+    ports:
+    - foo
+    - foo-tools
+
+- name: Update the ports tree then install the foo port
+  macports:
+    name: foo
+    update_ports: yes
+
+- name: Remove the foo port
+  macports:
     name: foo
     state: absent
 
-- macports:
+- name: Activate the foo port
+  macports:
     name: foo
     state: active
 
-- macports:
+- name: Deactivate the foo port
+  macports:
     name: foo
     state: inactive
 '''
@@ -67,17 +91,17 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import shlex_quote
 
 
-def update_package_db(module, port_path):
-    """ Updates packages list. """
+def sync_ports(module, port_path):
+    """ Sync ports tree. """
 
     rc, out, err = module.run_command("%s sync" % port_path)
 
     if rc != 0:
-        module.fail_json(msg="could not update package db")
+        module.fail_json(msg="Could not update ports tree", stdout=out, stderr=err)
 
 
-def query_package(module, port_path, name, state="present"):
-    """ Returns whether a package is installed or not. """
+def query_port(module, port_path, name, state="present"):
+    """ Returns whether a port is installed or not. """
 
     if state == "present":
 
@@ -97,108 +121,109 @@ def query_package(module, port_path, name, state="present"):
         return False
 
 
-def remove_packages(module, port_path, packages):
-    """ Uninstalls one or more packages if installed. """
+def remove_ports(module, port_path, ports):
+    """ Uninstalls one or more ports if installed. """
 
     remove_c = 0
-    # Using a for loop in case of error, we can report the package that failed
-    for package in packages:
-        # Query the package first, to see if we even need to remove
-        if not query_package(module, port_path, package):
+    # Using a for loop in case of error, we can report the port that failed
+    for port in ports:
+        # Query the port first, to see if we even need to remove
+        if not query_port(module, port_path, port):
             continue
 
-        rc, out, err = module.run_command("%s uninstall %s" % (port_path, package))
+        rc, out, err = module.run_command("%s uninstall %s" % (port_path, port))
 
-        if query_package(module, port_path, package):
-            module.fail_json(msg="failed to remove %s: %s" % (package, out))
+        if query_port(module, port_path, port):
+            module.fail_json(msg="Failed to remove %s: %s" % (port, err))
 
         remove_c += 1
 
     if remove_c > 0:
 
-        module.exit_json(changed=True, msg="removed %s package(s)" % remove_c)
+        module.exit_json(changed=True, msg="Removed %s port(s)" % remove_c)
 
-    module.exit_json(changed=False, msg="package(s) already absent")
+    module.exit_json(changed=False, msg="Port(s) already absent")
 
 
-def install_packages(module, port_path, packages):
-    """ Installs one or more packages if not already installed. """
+def install_ports(module, port_path, ports, variant):
+    """ Installs one or more ports if not already installed. """
 
     install_c = 0
 
-    for package in packages:
-        if query_package(module, port_path, package):
+    for port in ports:
+        if query_port(module, port_path, port):
             continue
 
-        rc, out, err = module.run_command("%s install %s" % (port_path, package))
+        rc, out, err = module.run_command("%s install %s %s" % (port_path, port, variant))
 
-        if not query_package(module, port_path, package):
-            module.fail_json(msg="failed to install %s: %s" % (package, out))
+        if not query_port(module, port_path, port):
+            module.fail_json(msg="Failed to install %s: %s" % (port, err))
 
         install_c += 1
 
     if install_c > 0:
-        module.exit_json(changed=True, msg="installed %s package(s)" % (install_c))
+        module.exit_json(changed=True, msg="Installed %s port(s)" % (install_c))
 
-    module.exit_json(changed=False, msg="package(s) already present")
+    module.exit_json(changed=False, msg="Port(s) already present")
 
 
-def activate_packages(module, port_path, packages):
-    """ Activate a package if it's inactive. """
+def activate_ports(module, port_path, ports):
+    """ Activate a port if it's inactive. """
 
     activate_c = 0
 
-    for package in packages:
-        if not query_package(module, port_path, package):
-            module.fail_json(msg="failed to activate %s, package(s) not present" % (package))
+    for port in ports:
+        if not query_port(module, port_path, port):
+            module.fail_json(msg="Failed to activate %s, port(s) not present" % (port))
 
-        if query_package(module, port_path, package, state="active"):
+        if query_port(module, port_path, port, state="active"):
             continue
 
-        rc, out, err = module.run_command("%s activate %s" % (port_path, package))
+        rc, out, err = module.run_command("%s activate %s" % (port_path, port))
 
-        if not query_package(module, port_path, package, state="active"):
-            module.fail_json(msg="failed to activate %s: %s" % (package, out))
+        if not query_port(module, port_path, port, state="active"):
+            module.fail_json(msg="Failed to activate %s: %s" % (port, err))
 
         activate_c += 1
 
     if activate_c > 0:
-        module.exit_json(changed=True, msg="activated %s package(s)" % (activate_c))
+        module.exit_json(changed=True, msg="Activated %s port(s)" % (activate_c))
 
-    module.exit_json(changed=False, msg="package(s) already active")
+    module.exit_json(changed=False, msg="Port(s) already active")
 
 
-def deactivate_packages(module, port_path, packages):
-    """ Deactivate a package if it's active. """
+def deactivate_ports(module, port_path, ports):
+    """ Deactivate a port if it's active. """
 
     deactivated_c = 0
 
-    for package in packages:
-        if not query_package(module, port_path, package):
-            module.fail_json(msg="failed to activate %s, package(s) not present" % (package))
+    for port in ports:
+        if not query_port(module, port_path, port):
+            module.fail_json(msg="Failed to deactivate %s, port(s) not present" % (port))
 
-        if not query_package(module, port_path, package, state="active"):
+        if not query_port(module, port_path, port, state="active"):
             continue
 
-        rc, out, err = module.run_command("%s deactivate %s" % (port_path, package))
+        rc, out, err = module.run_command("%s deactivate %s" % (port_path, port))
 
-        if query_package(module, port_path, package, state="active"):
-            module.fail_json(msg="failed to deactivated %s: %s" % (package, out))
+        if query_port(module, port_path, port, state="active"):
+            module.fail_json(msg="Failed to deactivate %s: %s" % (port, err))
 
         deactivated_c += 1
 
     if deactivated_c > 0:
-        module.exit_json(changed=True, msg="deactivated %s package(s)" % (deactivated_c))
+        module.exit_json(changed=True, msg="Deactivated %s port(s)" % (deactivated_c))
 
-    module.exit_json(changed=False, msg="package(s) already inactive")
+    module.exit_json(changed=False, msg="Port(s) already inactive")
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(aliases=["pkg"], required=True),
+            name=dict(aliases=["port"], required=True, type='list'),
             state=dict(default="present", choices=["present", "installed", "absent", "removed", "active", "inactive"]),
-            update_cache=dict(default="no", aliases=["update-cache"], type='bool')
+            update_ports=dict(aliases=["update_cache"], default="no", type='bool'),
+            variant=dict(aliases=["variants"], default=None, type='str')
         )
     )
 
@@ -206,22 +231,24 @@ def main():
 
     p = module.params
 
-    if p["update_cache"]:
-        update_package_db(module, port_path)
+    if p["update_ports"]:
+        sync_ports(module, port_path)
 
-    pkgs = p["name"].split(",")
+    pkgs = p["name"]
+
+    variant = p["variant"]
 
     if p["state"] in ["present", "installed"]:
-        install_packages(module, port_path, pkgs)
+        install_ports(module, port_path, pkgs, variant)
 
     elif p["state"] in ["absent", "removed"]:
-        remove_packages(module, port_path, pkgs)
+        remove_ports(module, port_path, pkgs)
 
     elif p["state"] == "active":
-        activate_packages(module, port_path, pkgs)
+        activate_ports(module, port_path, pkgs)
 
     elif p["state"] == "inactive":
-        deactivate_packages(module, port_path, pkgs)
+        deactivate_ports(module, port_path, pkgs)
 
 
 if __name__ == '__main__':

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -992,7 +992,6 @@ lib/ansible/modules/packaging/os/flatpak_remote.py E210
 lib/ansible/modules/packaging/os/homebrew.py E326
 lib/ansible/modules/packaging/os/homebrew_cask.py E326
 lib/ansible/modules/packaging/os/layman.py E322
-lib/ansible/modules/packaging/os/macports.py E322
 lib/ansible/modules/packaging/os/macports.py E326
 lib/ansible/modules/packaging/os/openbsd_pkg.py E326
 lib/ansible/modules/packaging/os/opkg.py E322


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

- Add support for installing specific variants of a port.
- Add support for using yaml lists with `name` parameter, rather than comma-separated lists.
- Add to and clarify documentation and examples.
- Use Macports nomenclature:
  - s/package/port/g
  - Rename `update_cache` to `update_ports` but keep `update_cache` as an alias. Remove undocumented `update-cache` alias.
  - Remove undocumented `pkg` alias for `name`. Replace with `port` alias and document it.
- Print stdout and stderr output if `port sync` fails.
- Print stderr output, rather than stdout, if `port install/uninstall/activate/deactivate` fail.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
[macports module](https://docs.ansible.com/ansible/latest/modules/macports_module.html)

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (macports-various-updates cffffe3a60) last updated 2018/08/24 01:42:11 (GMT +100)
  config file = None
  configured module search path = ['/Users/newtonne/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/newtonne/Projects/ansible/lib/ansible
  executable location = /Users/newtonne/Projects/ansible/bin/ansible
  python version = 3.6.6 (default, Jun 28 2018, 05:43:53) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
I realise there are quite a few changes in here. Let me know if you want me to split them out into separate PRs.