### PR TITLE
Fix incorrect default value for shutdown_command

### DIFF
--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -71,7 +71,7 @@ class ActionModule(ActionBase):
         uname_result = self._low_level_execute_command('uname')
         distribution = uname_result['stdout'].strip().lower()
 
-        shutdown_command = self.SHUTDOWN_COMMANDS.get(distribution, self.SHUTDOWN_COMMAND_ARGS['linux'])
+        shutdown_command = self.SHUTDOWN_COMMANDS.get(distribution, self.SHUTDOWN_COMMANDS['linux'])
         shutdown_command_args = self.SHUTDOWN_COMMAND_ARGS.get(distribution, self.SHUTDOWN_COMMAND_ARGS['linux'])
 
         pre_reboot_delay = int(self._task.args.get('pre_reboot_delay', self.DEFAULT_PRE_REBOOT_DELAY))


### PR DESCRIPTION
##### SUMMARY
Fix the new reboot action plugin so that the default value for `shutdown_command` is pulled from `SHUTDOWN_COMMANDS` instead of `SHUTDOWN_COMMAND_ARGS`.

The reboot action was just merged in #35205 so I doubt anyone has encountered this issue yet.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
Reboot action plugin.

