### PR TITLE
Fix another corner case of too many warnings for world readable current working directory

### DIFF
--- a/changelogs/fragments/more-world-readable-warning-skips.yaml
+++ b/changelogs/fragments/more-world-readable-warning-skips.yaml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+- The fix for `CVE-2018-10875 <https://access.redhat.com/security/cve/cve-2018-10875>`_
+  prints out a warning message about skipping a config file from a world
+  writable current working directory.  However, if the user is in a world
+  writable current working directory which does not contain a config file, it
+  should not print a warning message.  This release fixes that extaneous warning.

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -176,10 +176,14 @@ def find_ini_config_file(warnings=None):
     try:
         cwd = os.getcwd()
         perms = os.stat(cwd)
+        cwd_cfg = os.path.join(cwd, "ansible.cfg")
         if perms.st_mode & stat.S_IWOTH:
-            warn_cmd_public = True
+            # Working directory is world writable so we'll skip it.
+            # Still have to look for a file here, though, so that we know if we have to warn
+            if os.path.exists(cwd_cfg):
+                warn_cmd_public = True
         else:
-            potential_paths.append(os.path.join(cwd, "ansible.cfg"))
+            potential_paths.append(cwd_cfg)
     except OSError:
         # If we can't access cwd, we'll simply skip it as a possible config source
         pass


### PR DESCRIPTION

There should be no warning if there is no ansible.cfg file i nthe
current working directory.


##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
config/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7.0 stable-2.6 stable-2.5 stable-2.4
```
