### PR TITLE
[stable-2.4] Fix another corner case of too many warnings for world readable current working directory

### DIFF
--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -163,10 +163,14 @@ def find_ini_config_file(warnings=None):
     try:
         cwd = os.getcwd()
         perms = os.stat(cwd)
+        cwd_cfg = os.path.join(cwd, "ansible.cfg")
         if perms.st_mode & stat.S_IWOTH:
-            warn_cmd_public = True
+            # Working directory is world writable so we'll skip it.
+            # Still have to look for a file here, though, so that we know if we have to warn
+            if os.path.exists(cwd_cfg):
+                warn_cmd_public = True
         else:
-            potential_paths.append(os.path.join(cwd, "ansible.cfg"))
+            potential_paths.append(cwd_cfg)
     except OSError:
         # If we can't access cwd, we'll simply skip it as a possible config source
         pass


### PR DESCRIPTION

There should be no warning if there is no ansible.cfg file i nthe
current working directory.
(cherry picked from commit f46c943)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>


##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/config/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```
