### PR TITLE
State is not required, fixes #44615.

### DIFF
--- a/lib/ansible/modules/packaging/os/package.py
+++ b/lib/ansible/modules/packaging/os/package.py
@@ -33,7 +33,7 @@ options:
   state:
     description:
       - Whether to install (C(present), or remove (C(absent)) a package. Other states depend on the underlying package module, i.e C(latest).
-    required: true
+    required: false
   use:
     description:
       - The required package manager module to use (yum, apt, etc). The default 'auto' will use existing facts or try to autodetect it.


### PR DESCRIPTION
##### SUMMARY
As described in #44615, state is not required. It works without this parameter.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
package

##### ANSIBLE VERSION
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/robertdb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```

##### ADDITIONAL INFORMATION
None.