### PR TITLE
Minor typo fix in package module documentation

### DIFF
--- a/lib/ansible/modules/packaging/os/package.py
+++ b/lib/ansible/modules/packaging/os/package.py
@@ -32,7 +32,7 @@ options:
     required: true
   state:
     description:
-      - Whether to install (C(present), or remove (C(absent)) a package. Other states depend on the underlying package module, i.e C(latest).
+      - Whether to install (C(present)), or remove (C(absent)) a package. Other states depend on the underlying package module, i.e C(latest).
     required: true
   use:
     description:


### PR DESCRIPTION
##### SUMMARY
Added missing round bracket

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
lib/ansible/modules/packaging/os/package.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7-devel
```