### PR TITLE
DNS Made Easy fix locale for date string

### DIFF
--- a/changelogs/fragments/44624-dnsmadeeasy-fix_locale.yaml
+++ b/changelogs/fragments/44624-dnsmadeeasy-fix_locale.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnsmadeeasy - force the date to be rendered with C (POSIX system default) locale as English short date names required by API

--- a/changelogs/fragments/44624-dnsmadeeasy-fix_locale.yaml
+++ b/changelogs/fragments/44624-dnsmadeeasy-fix_locale.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - dnsmadeeasy - force the date to be rendered with C (POSIX system default) locale as English short date names required by API
+  - dnsmadeeasy - force the date to be rendered with C (POSIX system default) locale as English short date names are required by API

--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -367,6 +367,7 @@ EXAMPLES = '''
 import json
 import hashlib
 import hmac
+import locale
 from time import strftime, gmtime
 
 from ansible.module_utils.basic import AnsibleModule
@@ -414,6 +415,7 @@ class DME2(object):
         return headers
 
     def _get_date(self):
+        locale.setlocale(locale.LC_TIME, 'C')
         return strftime("%a, %d %b %Y %H:%M:%S GMT", gmtime())
 
     def _create_hash(self, rightnow):


### PR DESCRIPTION
##### SUMMARY
This fix forces the current date string to be generated in en_US. The DNS Made Easy API requires the date format to be sent with English locale.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
The applies solely to the dnsmadeeasy module.

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (dme_fix_time_locale 3100a7b85b) last updated 2018/08/24 11:04:26 (GMT +200)
```