### PR TITLE
Fix win_domain_computer error when empty description

### DIFF
--- a/changelogs/fragments/44054--win_domain_computer.yaml
+++ b/changelogs/fragments/44054--win_domain_computer.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- win_domain_computer - fixed error when description parameter is empty (https://github.com/ansible/ansible/pull/44054)
+- win_domain_computer - fixed error in diff_support

--- a/lib/ansible/modules/windows/win_domain_computer.ps1
+++ b/lib/ansible/modules/windows/win_domain_computer.ps1
@@ -25,14 +25,14 @@ If (-not $sam_account_name.EndsWith("$")) {
   Fail-Json -obj $result -message "sam_account_name must end in $"
 }
 $enabled = Get-AnsibleParam -obj $params -name "enabled" -type "bool" -default $true
-$description = Get-AnsibleParam -obj $params -name "description" -default ""
+$description = Get-AnsibleParam -obj $params -name "description" -default $null
 $state = Get-AnsibleParam -obj $params -name "state" -ValidateSet "present","absent" -default "present"
 If ($state -eq "present") {
   $dns_hostname = Get-AnsibleParam -obj $params -name "dns_hostname" -failifempty $true -resultobj $result
   $ou = Get-AnsibleParam -obj $params -name "ou" -failifempty $true -resultobj $result
   $distinguished_name = "CN=$name,$ou"
 
-  $desired_state = @{
+  $desired_state = [ordered]@{
     name = $name
     sam_account_name = $sam_account_name
     dns_hostname = $dns_hostname
@@ -43,7 +43,7 @@ If ($state -eq "present") {
     state = $state
   }
 } Else {
-  $desired_state = @{
+  $desired_state = [ordered]@{
     name = $name
     state = $state
   }
@@ -58,7 +58,7 @@ Function Get-InitialState($desired_state) {
       -Properties DistinguishedName,DNSHostName,Enabled,Name,SamAccountName,Description,ObjectClass
   } Catch { $null }
   If ($computer) {
-      $initial_state = @{
+      $initial_state = [ordered]@{
         name = $computer.Name
         sam_account_name = $computer.SamAccountName
         dns_hostname = $computer.DNSHostName
@@ -70,7 +70,7 @@ Function Get-InitialState($desired_state) {
         state = "present"
       }
   } Else {
-    $initial_state = @{
+    $initial_state = [ordered]@{
       name = $desired_state.name
       state = "absent"
     }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Backport of #44054 
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
win_domain_computer
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = ~/.ansible.cfg
  configured module search path = [u'~/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ~/.local/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
