### PR TITLE
DNS made easy module: add sandbox parameter to utilize sandbox API

### DIFF
--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -383,6 +383,7 @@ class DME2(object):
 
         if sandbox:
             self.baseurl = 'https://api.sandbox.dnsmadeeasy.com/V2.0/'
+            self.module.warn(warning="Sandbox is enabled. All actions are made against the URL %s" % self.baseurl)
         else:
             self.baseurl = 'https://api.dnsmadeeasy.com/V2.0/'
 

--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -37,6 +37,13 @@ options:
         resolution
     required: true
 
+  sandbox:
+    description:
+      - Decides if the sandbox API should be used. Otherwise (default) the production API of DNS Made Easy is used.
+    type: bool
+    default: 'no'
+    version_added: 2.7
+
   record_name:
     description:
       - Record name to get/create/delete/update. If record_name is not specified; all records for the domain will be returned in "result" regardless
@@ -368,12 +375,17 @@ from ansible.module_utils.six import string_types
 
 class DME2(object):
 
-    def __init__(self, apikey, secret, domain, module):
+    def __init__(self, apikey, secret, domain, sandbox, module):
         self.module = module
 
         self.api = apikey
         self.secret = secret
-        self.baseurl = 'https://api.dnsmadeeasy.com/V2.0/'
+
+        if sandbox:
+            self.baseurl = 'https://api.sandbox.dnsmadeeasy.com/V2.0/'
+        else:
+            self.baseurl = 'https://api.dnsmadeeasy.com/V2.0/'
+
         self.domain = str(domain)
         self.domain_map = None      # ["domain_name"] => ID
         self.record_map = None      # ["record_name"] => ID
@@ -537,6 +549,7 @@ def main():
             account_key=dict(required=True),
             account_secret=dict(required=True, no_log=True),
             domain=dict(required=True),
+            sandbox=dict(default='no', type='bool'),
             state=dict(required=True, choices=['present', 'absent']),
             record_name=dict(required=False),
             record_type=dict(required=False, choices=[
@@ -575,7 +588,7 @@ def main():
     sensitivities = dict(Low=8, Medium=5, High=3)
 
     DME = DME2(module.params["account_key"], module.params[
-               "account_secret"], module.params["domain"], module)
+               "account_secret"], module.params["domain"], module.params["sandbox"], module)
     state = module.params["state"]
     record_name = module.params["record_name"]
     record_type = module.params["record_type"]


### PR DESCRIPTION
##### SUMMARY
This introduces the boolean parameter sandbox. It causes the module to utilize the sandbox API of DNS made easy. It is the DNS made easy recommended way for development and testing API calls.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
dnsmadeeasy module

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
