### PR TITLE
ec2: add “IAM Role” to instance_profile_name

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -141,7 +141,7 @@ options:
   instance_profile_name:
     version_added: "1.3"
     description:
-      - Name of the IAM instance profile to use. Boto library must be 2.5.0+
+      - Name of the IAM instance profile (i.e. what the EC2 console refers to as an “IAM Role”) to use. Boto library must be 2.5.0+
   instance_ids:
     version_added: "1.3"
     description:

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+# -*- coding: utf-8
+#
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
The AWS API and console docs are inconsistent about whether EC2 instances have IAM profiles or roles. Things which follow the API tend to use profile but the console uses “IAM Role”. This adds that term to the help text so it's searchable.


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ec2

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.3
  config file = /Users/cadams/.ansible.cfg
  configured module search path = [u'/Users/cadams/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.6.3/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```
