### PR TITLE
fix variable names in vars file example

### DIFF
--- a/docs/docsite/rst/network/user_guide/platform_eos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_eos.rst
@@ -107,8 +107,8 @@ Example eAPI ``group_vars/eos.yml``
    ansible_network_os: eos
    ansible_user: myuser
    ansible_ssh_pass: !vault... 
-   become: yes
-   become_method: enable
+   ansible_become: yes
+   ansible_become_method: enable
    proxy_env:
      http_proxy: http://proxy.example.com:8080
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fix variable names in vars file example.
from `become` to `ansible_become` like other vars file examples.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
EOS Platform Doc

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
- case1: invalid variable names
```yaml
ansible_connection: httpapi
ansible_network_os: eos
ansible_user: vagrant
ansible_ssh_pass: vagrant
become: yes
become_method: enable
```
```yaml
    - name: a
      eos_config:
        lines: ntp server 10.0.0.123
```

```
TASK [a] *******************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.module_utils.connection.ConnectionError: operation requires privilege escalation
fatal: [172.16.0.5]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File\"/tmp/ansible_7OHaYP/ansible_module_eos_config.py\", line 480, in <module>\n    main()\n  File \"/tmp/ansible_7OHaYP/ansible_module_eos_config.py\", line 381, in main\n    config_text = get_running_config(module)\n  File \"/tmp/ansible_7OHaYP/ansible_module_eos_config.py\", line 294, in get_running_config\n    contents = get_config(module, flags=flags)\n  File \"/tmp/ansible_7OHaYP/ansible_modlib.zip/ansible/module_utils/network/eos/eos.py\",line 435, in get_config\n  File \"/tmp/ansible_7OHaYP/ansible_modlib.zip/ansible/module_utils/network/eos/eos.py\", line 158, in get_config\n  File \"/tmp/ansible_7OHaYP/ansible_modlib.zip/ansible/module_utils/connection.py\", line 149, in __rpc__\nansible.module_utils.connection.ConnectionError: operation requires privilege escalation\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
```

- case2:  VALID variable names
```yaml
ansible_connection: httpapi
ansible_network_os: eos
ansible_user: vagrant
ansible_ssh_pass: vagrant
ansible_become: yes
ansible_become_method: enable
```

```
TASK [a] *************************************************************************************
changed: [172.16.0.5]
```
