### PR TITLE
Update and correct iSCSI facts collection

### DIFF
--- a/changelogs/fragments/iscsi_facts_hp-ux_aix.yaml
+++ b/changelogs/fragments/iscsi_facts_hp-ux_aix.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - setup - gather iSCSI facts for HP-UX (https://github.com/ansible/ansible/pull/44644)
+bugfixes:
+  - setup - properly gather iSCSI information for AIX (https://github.com/ansible/ansible/pull/44644)

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -18,8 +18,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import subprocess
 import sys
+import subprocess
 
 from ansible.module_utils.facts.utils import get_file_content
 from ansible.module_utils.facts.network.base import NetworkCollector
@@ -45,11 +45,28 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
         # lsattr -E -l iscsi0
         disc_filename  /etc/iscsi/targets            Configuration file                            False
         disc_policy    file                          Discovery Policy                              True
-        initiator_name iqn.localhost.hostid.7f000001 iSCSI Initiator Name                          True
+        initiator_name iqn.localhost.hostid.7f000002 iSCSI Initiator Name                          True
         isns_srvnames  auto                          iSNS Servers IP Addresses                     True
         isns_srvports                                iSNS Servers Port Numbers                     True
         max_targets    16                            Maximum Targets Allowed                       True
         num_cmd_elems  200                           Maximum number of commands to queue to driver True
+
+        Example of output from the HP-UX iscsiutil command:
+
+        #iscsiutil -l
+        Initiator Name             : iqn.1986-03.com.hp:mcel_VMhost3.1f355cf6-e2db-11e0-a999-b44c0aef5537
+        Initiator Alias            :
+
+        Authentication Method      : None
+        CHAP Method                : CHAP_UNI
+        Initiator CHAP Name        :
+        CHAP Secret                :
+        NAS Hostname               :
+        NAS Secret                 :
+        Radius Server Hostname     :
+        Header Digest              : None, CRC32C (default)
+        Data Digest                : None, CRC32C (default)
+        SLP Scope list for iSLPD   :
         """
 
         iscsi_facts = {}
@@ -62,8 +79,24 @@ class IscsiInitiatorNetworkCollector(NetworkCollector):
                     iscsi_facts['iscsi_iqn'] = line.split('=', 1)[1]
                     break
         elif sys.platform.startswith('aix'):
-            aixcmd = '/usr/sbin/lsattr -E -l iscsi0 | grep initiator_name'
-            aixret = subprocess.check_output(aixcmd, shell=True)
-            if aixret[0].isalpha():
-                iscsi_facts['iscsi_iqn'] = aixret.split()[1].rstrip()
+            if module is not None:
+                rc, out, err = module.run_command('/usr/sbin/lsattr -E -l iscsi0 | grep initiator_name')
+                if out:
+                    iscsi_facts['iscsi_iqn'] = out.split()[1].rstrip()
+            else:
+                aixcmd = '/usr/sbin/lsattr -E -l iscsi0 | grep initiator_name'
+                aixret = subprocess.check_output(aixcmd, shell=True)
+                if aixret[0].isalpha():
+                    iscsi_facts['iscsi_iqn'] = aixret.split()[1].rstrip()
+        elif sys.platform.startswith('hp-ux'):
+            if module is not None:
+                rc, out, err = module.run_command("/opt/iscsi/bin/iscsiutil -l | grep 'Initiator Name'",
+                                                  use_unsafe_shell=True)
+                if out:
+                    iscsi_facts['iscsi_iqn'] = out.split(":", 1)[1].rstrip()
+            else:
+                hpuxcmd = "/opt/iscsi/bin/iscsiutil -l | grep 'Initiator Name'"
+                hpuxret = subprocess.check_output(hpuxcmd, shell=True)
+                if hpuxret[0].isalpha():
+                    iscsi_facts['iscsi_iqn'] = hpuxret.split(":", 1)[1].rstrip()
         return iscsi_facts


### PR DESCRIPTION
##### SUMMARY
Update the iSCSI facts collection module
Fix bug in the AIX collection and add support for HP-UX

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module/facts/network/iscsi.py

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.7.0.dev0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```

##### ADDITIONAL INFORMATION
Try calling in a more approved method (as per the AIX and HP-UX hardware modules)
Add support for HP-UX iSCSI as we don't want them to feel left out :)