### PR TITLE
Fix dangerous elb_application_lb state

### DIFF
--- a/changelogs/fragments/elb_application_lb_fix_state_default.yml
+++ b/changelogs/fragments/elb_application_lb_fix_state_default.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- elb_application_lb - Fix a dangerous behavior of deleting an ELB if state was omitted from the task.
+  Now state defaults to 'present', which is typical throughout AWS modules.

--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -102,7 +102,7 @@ options:
   state:
     description:
       - Create or destroy the load balancer.
-    required: true
+    default: present
     choices: [ 'present', 'absent' ]
   tags:
     description:
@@ -528,7 +528,7 @@ def main():
             subnets=dict(type='list'),
             security_groups=dict(type='list'),
             scheme=dict(default='internet-facing', choices=['internet-facing', 'internal']),
-            state=dict(choices=['present', 'absent'], type='str'),
+            state=dict(choices=['present', 'absent'], default='present'),
             tags=dict(type='dict'),
             wait_timeout=dict(type='int'),
             wait=dict(default=False, type='bool'),


### PR DESCRIPTION
##### SUMMARY
Backport candidate. Right now if state is omitted and the ELB exists it is deleted.
Fixes #44576

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_application_lb

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0
```
