### PR TITLE
[Junos] Fix bug of setting user password

### DIFF
--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -57,6 +57,11 @@ options:
       - The C(sshkey) argument defines the public SSH key to be configured
         for the user account on the remote system.  This argument must
         be a valid SSH key
+  encrypted_password:
+    description:
+      - The C(encrypted_password) argument set already hashed password
+        for the user account on the remote system.
+    version_added: "2.7"
   purge:
     description:
       - The C(purge) argument instructs the module to consider the
@@ -108,6 +113,13 @@ EXAMPLES = """
     aggregate:
     - name: ansible
     purge: yes
+
+- name: set user password
+  junos_user:
+    name: ansible
+    role: super-user
+    encrypted_password: "{{ 'my-password' | password_hash('sha512') }}"
+    state: present
 
 - name: Create list of users
   junos_user:

--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -218,6 +218,11 @@ def map_obj_to_ele(module, want):
                     ssh_rsa = SubElement(auth, 'ssh-ed25519')
                 key = SubElement(ssh_rsa, 'name').text = item['sshkey']
 
+            if item.get('encrypted_password'):
+                if 'auth' not in locals():
+                    auth = SubElement(user, 'authentication')
+                SubElement(auth, 'encrypted-password').text = item['encrypted_password']
+
     return element
 
 
@@ -267,6 +272,7 @@ def map_params_to_obj(module):
         item.update({
             'full_name': get_value('full_name'),
             'role': get_value('role'),
+            'encrypted_password': get_value('encrypted_password'),
             'sshkey': get_value('sshkey'),
             'state': get_value('state'),
             'active': get_value('active')
@@ -290,6 +296,7 @@ def main():
         name=dict(),
         full_name=dict(),
         role=dict(choices=ROLES),
+        encrypted_password=dict(),
         sshkey=dict(),
         state=dict(choices=['present', 'absent'], default='present'),
         active=dict(type='bool', default=True)

--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -61,7 +61,7 @@ options:
     description:
       - The C(encrypted_password) argument set already hashed password
         for the user account on the remote system.
-    version_added: "2.7"
+    version_added: "2.8"
   purge:
     description:
       - The C(purge) argument instructs the module to consider the


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add user encrypted_password option.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #32683

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
junos_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = /project/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jul 31 2018, 23:03:52) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
