### PR TITLE
if we already have stderr, we don't need stderr_lines

### DIFF
--- a/lib/ansible/plugins/callback/yaml.py
+++ b/lib/ansible/plugins/callback/yaml.py
@@ -113,6 +113,10 @@ class CallbackModule(Default):
         if 'stdout' in abridged_result and 'stdout_lines' in abridged_result:
             abridged_result['stdout_lines'] = '<omitted>'
 
+        # if we already have stderr, we don't need stderr_lines
+        if 'stderr' in abridged_result and 'stderr_lines' in abridged_result:
+            abridged_result['stderr_lines'] = '<omitted>'
+
         if abridged_result:
             dumped += '\n'
             dumped += to_text(yaml.dump(abridged_result, allow_unicode=True, width=1000, Dumper=AnsibleDumper, default_flow_style=False))


### PR DESCRIPTION
##### SUMMARY

When using yaml callback, we already have a beauty `stderr` message, so I think we don't need `stderr_lines` anymore. And this keeps align with `stdout` and `stdout_lines`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
yaml callback plugin