### PR TITLE
replaced 'ansible_os_platform' to 'ansible_os_family'

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -46,9 +46,9 @@ Other YAML files may be included in certain directories. For example, it is comm
     # roles/example/tasks/main.yml
     - name: added in 2.4, previously you used 'include'
       import_tasks: redhat.yml
-      when: ansible_os_platform|lower == 'redhat'
+      when: ansible_os_family|lower == 'redhat'
     - import_tasks: debian.yml
-      when: ansible_os_platform|lower == 'debian'
+      when: ansible_os_family|lower == 'debian'
 
     # roles/example/tasks/redhat.yml
     - yum:


### PR DESCRIPTION

##### SUMMARY
replaced 'ansible_os_platform' to 'ansible_os_family' as 'ansible_os_platform' variable is no longer available in ansible setup module.

##### ISSUE TYPE
 - Docs Pull Request

##### ANSIBLE VERSION
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Dec 14 2017, 15:51:29) [GCC 6.4.0]
