### PR TITLE
[WIP] Add RouterOS API support to routeros_command module

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1461,7 +1461,7 @@ MAX_FILE_SIZE_FOR_DIFF:
   type: int
 NETWORK_GROUP_MODULES:
   name: Network module families
-  default: [eos, nxos, ios, iosxr, junos, enos, ce, vyos, sros, dellos9, dellos10, dellos6, asa, aruba, aireos, bigip, ironware, onyx, netconf]
+  default: [eos, nxos, ios, iosxr, junos, enos, ce, vyos, sros, dellos9, dellos10, dellos6, asa, aruba, aireos, bigip, ironware, onyx, netconf, routeros]
   description: 'TODO: write it'
   env: [{name: NETWORK_GROUP_MODULES}]
   ini:

--- a/lib/ansible/module_utils/network/routeros/routeros.py
+++ b/lib/ansible/module_utils/network/routeros/routeros.py
@@ -25,13 +25,30 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
+import ssl
 import json
+
+from ast import literal_eval
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network.common.utils import to_list, ComplexList
-from ansible.module_utils.connection import Connection
+from ansible.module_utils.connection import Connection, ConnectionError
 
 _DEVICE_CONFIGS = {}
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+try:
+    import librouteros
+    HAS_LIBROUTEROS = True
+except ImportError as e:
+    display.debug('IMPORT ERROR: %s' % e)
+    HAS_LIBROUTEROS = False
 
 routeros_provider_spec = {
     'host': dict(),
@@ -39,9 +56,19 @@ routeros_provider_spec = {
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
     'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
-    'timeout': dict(type='int')
+
+    'timeout': dict(type='int'),
+    'use_ssl': dict(type='bool', default=True),
+    'validate_certs': dict(type='bool', default=False),
+    'ca_certs': dict(type='list', default=[]),
+    'certfile': dict(type='path'),
+    'keyfile': dict(type='path'),
+
+    'transport': dict(default='api', choices=['api', 'cli'])
 }
-routeros_argument_spec = {}
+routeros_argument_spec = {
+    'provider': dict(type='dict', options=routeros_provider_spec),
+}
 
 
 def get_provider_argspec():
@@ -49,26 +76,15 @@ def get_provider_argspec():
 
 
 def get_connection(module):
-    if hasattr(module, '_routeros_connection'):
-        return module._routeros_connection
+    if hasattr(module, '_connection'):
+        return module._connection
 
-    capabilities = get_capabilities(module)
-    network_api = capabilities.get('network_api')
-    if network_api == 'cliconf':
-        module._routeros_connection = Connection(module._socket_path)
+    if is_api(module):
+        module._connection = Api(module)
     else:
-        module.fail_json(msg='Invalid connection type %s' % network_api)
+        module._connection = Cli(module)
 
-    return module._routeros_connection
-
-
-def get_capabilities(module):
-    if hasattr(module, '_routeros_capabilities'):
-        return module._routeros_capabilities
-
-    capabilities = Connection(module._socket_path).get_capabilities()
-    module._routeros_capabilities = json.loads(capabilities)
-    return module._routeros_capabilities
+    return module._connection
 
 
 def get_defaults_flag(module):
@@ -110,47 +126,195 @@ def get_config(module, flags=None):
         return cfg
 
 
-def to_commands(module, commands):
-    spec = {
-        'command': dict(key=True),
-        'prompt': dict(),
-        'answer': dict()
-    }
-    transform = ComplexList(spec, module)
-    return transform(commands)
-
-
 def run_commands(module, commands, check_rc=True):
-    responses = list()
     connection = get_connection(module)
-
-    for cmd in to_list(commands):
-        if isinstance(cmd, dict):
-            command = cmd['command']
-            prompt = cmd['prompt']
-            answer = cmd['answer']
-        else:
-            command = cmd
-            prompt = None
-            answer = None
-
-        try:
-            out = connection.get(command, prompt, answer)
-        except ConnectionError as exc:
-            module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
-
-        try:
-            out = to_text(out, errors='surrogate_or_strict')
-        except UnicodeError:
-            module.fail_json(
-                msg=u'Failed to decode output from %s: %s' % (cmd, to_text(out)))
-
-        responses.append(out)
-
-    return responses
+    return connection.run_commands(commands)
 
 
 def load_config(module, commands):
     connection = get_connection(module)
-
     out = connection.edit_config(commands)
+
+
+def is_api(module):
+    display.debug(module.params)
+    transport = module.params['transport']
+    provider_transport = (module.params['provider'] or {}).get('transport')
+    return 'api' in (transport, provider_transport)
+
+
+def to_api(command):
+    """Takes a RouterOS CLI command (like "/system identity set name=foo")
+    and yields the librouteros command dict (like {"cmd": "/system/identity/set", "name": "foo"})
+    """
+
+    # Strip off preceding '/' if present
+    if command.startswith('/'):
+        command = command[1:]
+
+    # Figuring out where the command ends and where the attributes begin is
+    # tough; the command's "verb" actually appears in the middle of the command
+    # statement, but right before any attributes, which are USUALLY (but not
+    # always) key=value pairs.
+    #
+    # So, we'll look for either a recognized verb, or a '=' signifying an
+    # attribute
+    KNOWN_VERBS = frozenset([
+        'add', 'cancel', 'comment', 'disable', 'downgrade', 'edit', 'enable',
+        'export', 'find', 'get', 'getall', 'listen', 'print', 'remove', 'set',
+        'uninstall', 'unschedule', 'upgrade'
+    ])
+
+    split_command = command.split()
+
+    verb_index = -1
+    for i, word in enumerate(split_command):
+        if word in KNOWN_VERBS:
+            verb_index = i
+            break
+        elif '=' in word:
+            verb_index = i - 1
+            break
+
+    cmd = '/'.join([''] + split_command[:verb_index] + [split_command[verb_index]])
+
+    attributes = {}
+    for attribute in split_command[verb_index + 1:]:
+        if '=' in attribute:
+            k, v = attribute.split('=', 1)
+        else:
+            k = attribute
+            v = None
+
+        attributes[k] = v
+
+    attributes['cmd'] = cmd
+    return attributes
+
+
+class Cli:
+
+    def __init__(self, module):
+        self._module = module
+        self._connection = None
+        self._capabilities = None
+
+    def get_capabilities(self):
+        if hasattr(self, '_capabilities'):
+            return self._capabilities
+
+        capabilities = Connection(self._module._socket_path).get_capabilities()
+        self._module._capabilities = json.loads(capabilities)
+        return self._module._capabilities
+
+    def _get_connection(self):
+        if hasattr(self, '_connection'):
+            return self._connection
+
+        capabilities = self.get_capabilities()
+        network_api = capabilities.get('network_api')
+
+        if network_api == 'cliconf':
+            self._connection = Connection(self._module._socket_path)
+        else:
+            self._module.fail_json(msg='Invalid connection type %s' % network_api)
+
+        return self._connection
+
+    def run_commands(self, commands, output='text'):
+        """Run list of commands on remote device and return results
+        """
+        responses = list()
+        connection = self._get_connection()
+
+        for cmd in to_list(commands):
+            if isinstance(cmd, dict):
+                command = cmd['command']
+                prompt = cmd['prompt']
+                answer = cmd['answer']
+            else:
+                command = cmd
+                prompt = None
+                answer = None
+
+            try:
+                out = connection.get(command, prompt, answer)
+            except ConnectionError as exc:
+                self._module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
+
+            try:
+                out = to_text(out, errors='surrogate_or_strict')
+            except UnicodeError:
+                self._module.fail_json(msg=u'Failed to decode output from %s: %s' % (cmd, to_text(out)))
+
+            responses.append(out)
+
+        return responses
+
+
+class Api:
+
+    def __init__(self, module):
+        self._module = module
+        self._connection = None
+
+        host = module.params['provider']['host']
+        # port = module.params['provider']['port']
+        username = module.params['provider']['username']
+        password = module.params['provider']['password']
+
+        self._args = dict(host=host, username=username, password=password)
+
+        if module.params['provider']['use_ssl']:
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.set_ciphers('ADH')
+
+            if module.params['provider']['validate_certs']:
+                ctx.verify_mode = ssl.CERT_REQUIRED
+                ctx.ca_certs = module.params['provider']['ca_certs']
+                ctx.certfile = module.params['provider']['certfile']
+                ctx.keyfile = module.params['provider']['keyfile']
+            else:
+                ctx.verify_mode = ssl.CERT_NONE
+
+            self._args['ssl_wrapper'] = ctx.wrap_socket
+            self._args['port'] = 8729
+
+        display.debug(self._args, 'self._args')
+
+    def _get_connection(self):
+        if not HAS_LIBROUTEROS:
+            self._module.fail_json(msg="librouteros is required but does not appear to be installed.  " +
+                                   "It can be installed using `pip install librouteros`")
+
+        if not self._connection:
+            self._connection = librouteros.connect(**self._args)
+
+        return self._connection
+
+    # TODO: Should I do something about output='json' here?
+    def send_request(self, commands, output='json'):
+        connection = self._get_connection()
+        commands = to_api(commands)
+
+        try:
+            results = connection(**commands)
+        except librouteros.exceptions.LibError as e:
+            self._module.fail_json(msg=str(e))
+
+        display.debug('-> results', results)
+        return list(results)
+
+    def run_commands(self, commands, check_rc=True):
+        responses = list()
+
+        for cmd in to_list(commands):
+            out = self.send_request(cmd)
+            responses.append(out)
+
+        return responses
+
+    @property
+    def supports_sessions(self):
+        return False

--- a/lib/ansible/module_utils/network/routeros/routeros.py
+++ b/lib/ansible/module_utils/network/routeros/routeros.py
@@ -76,15 +76,10 @@ def get_provider_argspec():
 
 
 def get_connection(module):
-    if hasattr(module, '_connection'):
-        return module._connection
-
     if is_api(module):
-        module._connection = Api(module)
+        return Api(module)
     else:
-        module._connection = Cli(module)
-
-    return module._connection
+        return Cli(module)
 
 
 def get_defaults_flag(module):
@@ -200,7 +195,7 @@ class Cli:
         self._capabilities = None
 
     def get_capabilities(self):
-        if hasattr(self, '_capabilities'):
+        if self._capabilities:
             return self._capabilities
 
         capabilities = Connection(self._module._socket_path).get_capabilities()
@@ -208,7 +203,7 @@ class Cli:
         return self._module._capabilities
 
     def _get_connection(self):
-        if hasattr(self, '_connection'):
+        if self._connection:
             return self._connection
 
         capabilities = self.get_capabilities()

--- a/lib/ansible/module_utils/network/routeros/routeros.py
+++ b/lib/ansible/module_utils/network/routeros/routeros.py
@@ -28,6 +28,7 @@
 
 import ssl
 import json
+import shlex
 
 from ast import literal_eval
 from ansible.module_utils._text import to_text
@@ -160,7 +161,7 @@ def to_api(command):
         'uninstall', 'unschedule', 'upgrade'
     ])
 
-    split_command = command.split()
+    split_command = shlex.split(command)
 
     verb_index = -1
     for i, word in enumerate(split_command):

--- a/lib/ansible/modules/network/routeros/routeros_command.py
+++ b/lib/ansible/modules/network/routeros/routeros_command.py
@@ -127,6 +127,7 @@ failed_conditions:
 """
 
 import re
+import json
 import time
 
 from ansible.module_utils.network.routeros.routeros import run_commands
@@ -135,6 +136,12 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import ComplexList
 from ansible.module_utils.network.common.parsing import Conditional
 from ansible.module_utils.six import string_types
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
 
 
 def to_lines(stdout):
@@ -149,6 +156,7 @@ def main():
     """
     argument_spec = dict(
         commands=dict(type='list', required=True),
+        transport=dict(default='cli', choices=['api', 'cli']),
 
         wait_for=dict(type='list'),
         match=dict(default='all', choices=['all', 'any']),

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -127,7 +127,4 @@ class ActionModule(_ActionModule):
         if provider.get('password') is None:
             provider['password'] = play_context.password
 
-        if provider.get('authorize') is None:
-            provider['authorize'] = False
-
         return provider

--- a/lib/ansible/plugins/action/routeros.py
+++ b/lib/ansible/plugins/action/routeros.py
@@ -1,0 +1,87 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import sys
+import copy
+
+from ansible import constants as C
+from ansible.module_utils._text import to_text
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.routeros.routeros import routeros_provider_spec
+from ansible.plugins.action.normal import ActionModule as _ActionModule
+from ansible.module_utils.network.common.utils import load_provider
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+
+class ActionModule(_ActionModule):
+
+    def run(self, tmp=None, task_vars=None):
+        del tmp  # tmp no longer has any effect
+
+        socket_path = None
+
+        if self._play_context.connection == 'network_cli':
+            provider = self._task.args.get('provider', {})
+            if any(provider.values()):
+                display.warning('provider is unnecessary when using %s and will be ignored' % self._play_context.connection)
+                del self._task.args['provider']
+            if self._task.args.get('transport'):
+                display.warning('transport is unnecessary when using %s and will be ignored' % self._play_context.connection)
+                del self._task.args['transport']
+        elif self._play_context.connection == 'local':
+            provider = load_provider(routeros_provider_spec, self._task.args)
+            transport = provider['transport'] or 'api'
+
+            display.vvvv('connection transport is %s' % transport, self._play_context.remote_addr)
+
+            self._task.args['provider'] = ActionModule.routeros_api_implementation(provider, self._play_context)
+        else:
+            return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
+
+        result = super(ActionModule, self).run(task_vars=task_vars)
+        return result
+
+    @staticmethod
+    def routeros_api_implementation(provider, play_context):
+        provider['transport'] = 'api'
+
+        if provider.get('host') is None:
+            provider['host'] = play_context.remote_addr
+
+        if provider.get('port') is None:
+            default_port = 443 if provider['use_ssl'] else 80
+            provider['port'] = int(play_context.port or default_port)
+
+        if provider.get('timeout') is None:
+            provider['timeout'] = C.PERSISTENT_COMMAND_TIMEOUT
+
+        if provider.get('username') is None:
+            provider['username'] = play_context.connection_user
+
+        if provider.get('password') is None:
+            provider['password'] = play_context.password
+
+        return provider


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This pull request adds support for issuing commands via RouterOS API and `local` connection type. This is required because of several problems with `network_cli` implementation:
- The output of the command gets wrapped by the RouterOS console and it sometimes makes the command itself appear in the output.
- The output is dependent on the terminal width. If one tries to set terminal width to a very large number, each line of the output will be equally distributed among the available width.
- Some commands with verbose output sometimes do not return values (like `/ip firewall filter print`).

Why use a **provider**? Because RouterOS has a weird and non-standard API. The choice was either to use `connection: local` and a **provider** or create a new module solely for RouterOS API support. After a discussion with **ganeshrn** [in the original `routeros_command` PR](https://github.com/ansible/ansible/pull/41155#discussion_r205900935) it was decided it would be better to use the former.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
- `lib/ansible/module_utils/network/routeros/routeros.py`
- `lib/ansible/modules/network/routeros/routeros_command.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (routeros_api 790c0bf2b3) last updated 2018/08/26 11:31:57 (GMT +300)
  config file = None
  configured module search path = ['/Users/heuels/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/heuels/GitHub/ansible/lib/ansible
  executable location = /Users/heuels/GitHub/ansible/bin/ansible
  python version = 3.6.5 (default, Jun 19 2018, 01:03:38) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
