### PR TITLE
Add the ability to specify --root for systemd services

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -312,8 +312,8 @@ def main():
             daemon_reload=dict(type='bool', default=False, aliases=['daemon-reload']),
             user=dict(type='bool', default=False),
             scope=dict(type='str', default='system', choices=['system', 'user', 'global']),
-            no_block=dict(type='bool', default=False),'
-            root=dict(type='str', default='')
+            no_block=dict(type='bool', default=False),
+            root=dict(type='str', default=''),
         ),
         supports_check_mode=True,
         required_one_of=[['state', 'enabled', 'masked', 'daemon_reload']],

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -68,6 +68,11 @@ options:
         type: bool
         default: 'no'
         version_added: "2.3"
+    root:
+      description:
+        - When used with enable/disable/is-enabled (and related commands), use the specified root path when looking for unit files.
+          If this option is present, systemctl will operate on the file system directly, instead of communicating with the systemd daemon to carry out changes.
+      version_added: "2.7"
 notes:
     - Since 2.4, one of the following options is required 'state', 'enabled', 'masked', 'daemon_reload', and all except 'daemon_reload' also require 'name'.
     - Before 2.4 you always required 'name'.
@@ -307,7 +312,8 @@ def main():
             daemon_reload=dict(type='bool', default=False, aliases=['daemon-reload']),
             user=dict(type='bool', default=False),
             scope=dict(type='str', default='system', choices=['system', 'user', 'global']),
-            no_block=dict(type='bool', default=False),
+            no_block=dict(type='bool', default=False),'
+            root=dict(type='str', default='')
         ),
         supports_check_mode=True,
         required_one_of=[['state', 'enabled', 'masked', 'daemon_reload']],
@@ -325,6 +331,8 @@ def main():
         systemctl = systemctl + " --no-block"
     if module.params['force']:
         systemctl = systemctl + " --force"
+    if module.params['root']:
+      systemctl = systemctl + " --root=%s" % root
     unit = module.params['name']
     rc = 0
     out = err = ''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When systemd is not running but changes has to be made such as enabling or disabling services, using `--root` allows us to run systemctl without it.
This PR adds the ability to do just that.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
systemd

##### ANSIBLE VERSION
N/A


##### ADDITIONAL INFORMATION
N/A
