### PR TITLE
docker_common: improve image finding methods

### DIFF
--- a/changelogs/fragments/44692-docker-find-image.yaml
+++ b/changelogs/fragments/44692-docker-find-image.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container, docker_image, docker_image_facts - also find local image when image name is prefixed with ``docker.io/library/`` or ``docker.io/``."

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -565,10 +565,16 @@ class AnsibleDockerClient(Client):
             # In API <= 1.20 seeing 'docker.io/<name>' as the name of images pulled from docker hub
             registry, repo_name = auth.resolve_repository_name(name)
             if registry == 'docker.io':
-                # the name does not contain a registry, so let's see if docker.io works
-                lookup = "docker.io/%s" % name
-                self.log("Check for docker.io image: %s" % lookup)
-                images = self._image_lookup(lookup, tag)
+                # If docker.io is explicitly there in name, the image
+                # isn't found in some cases (#41509)
+                self.log("Check for docker.io image: %s" % repo_name)
+                images = self._image_lookup(repo_name, tag)
+                if len(images) == 0:
+                    # Last case: if docker.io wasn't there, it can be that
+                    # the image wasn't found either (#15586)
+                    lookup = "%s/%s" % (registry, repo_name)
+                    self.log("Check for docker.io image: %s" % lookup)
+                    images = self._image_lookup(lookup, tag)
 
         if len(images) > 1:
             self.fail("Registry returned more than one result for %s:%s" % (name, tag))

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -569,6 +569,11 @@ class AnsibleDockerClient(Client):
                 # isn't found in some cases (#41509)
                 self.log("Check for docker.io image: %s" % repo_name)
                 images = self._image_lookup(repo_name, tag)
+                if len(images) == 0 and repo_name.startswith('library/'):
+                    # Sometimes library/xxx images are not found
+                    lookup = repo_name[len('library/'):]
+                    self.log("Check for docker.io image: %s" % lookup)
+                    images = self._image_lookup(lookup, tag)
                 if len(images) == 0:
                     # Last case: if docker.io wasn't there, it can be that
                     # the image wasn't found either (#15586)


### PR DESCRIPTION
##### SUMMARY
If `AnsibleDockerClient.find_image()` is called with `name == "docker.io/ubuntu"` or `name == "docker.io/library/ubuntu"` or `name == "docker.io/name/repo"`, it can happen (f.ex. with docker 18.06.0-ce) that the image isn't found. Adds some code to try to leave `docker.io/` away, which makes it work for me. Fixes #41509.

CC @kassiansun @ljesmin

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/docker_common.py

##### ANSIBLE VERSION
```
2.7.0
```
