### PR TITLE
jenkins job generator module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
@@ -150,9 +150,21 @@ state:
   sample: "Disabled jenkins job(s): test"
 '''
 
+import logging
 import xml.etree.ElementTree as ET
 
 from ansible.module_utils.basic import AnsibleModule
+
+# To avoid AttributeError: 'module' object has no attribute 'NullHandler' on python 2.6
+try:
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+logging.getLogger(__name__).addHandler(NullHandler())
+# for stevedore module
+logging.getLogger('stevedore').addHandler(NullHandler())
 
 
 # Import Jenkins builder

--- a/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
@@ -19,7 +19,7 @@ module: jenkins_job_generator
 
 short_description: Manage jenkins jobs through YAML config files.
 
-version_added: "0.1"
+version_added: "2.7"
 
 description:
     - Manage jenkins jobs through YAML config files.
@@ -138,6 +138,15 @@ EXAMPLES = '''
     jobs:
       - build
     state: disabled
+'''
+
+RETURN = '''
+---
+state:
+  description: State of the jenkins jobs.
+  returned: success
+  type: string
+  sample: "Disabled jenkins job(s): test"
 '''
 
 import xml.etree.ElementTree as ET
@@ -407,7 +416,7 @@ class ActionRunner(object):
 
         if disabled_jobs:
             self.result['changed'] = True
-            self.result['status'] = "Enabled jenkins job(s): %s" % ", ".join(disabled_jobs)
+            self.result['status'] = "Disabled jenkins job(s): %s" % ", ".join(disabled_jobs)
         else:
             self.result['status'] = "Nothing to enable"
 

--- a/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
@@ -150,21 +150,9 @@ state:
   sample: "Disabled jenkins job(s): test"
 '''
 
-import logging
 import xml.etree.ElementTree as ET
 
 from ansible.module_utils.basic import AnsibleModule
-
-# To avoid AttributeError: 'module' object has no attribute 'NullHandler' on python 2.6
-try:
-    from logging import NullHandler
-except ImportError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-logging.getLogger(__name__).addHandler(NullHandler())
-# for stevedore module
-logging.getLogger('stevedore').addHandler(NullHandler())
 
 
 # Import Jenkins builder

--- a/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
@@ -19,7 +19,7 @@ module: jenkins_job_generator
 
 short_description: Manage jenkins jobs through YAML config files.
 
-version_added: "2.7"
+version_added: "2.8"
 
 description:
     - Manage jenkins jobs through YAML config files.

--- a/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
@@ -155,6 +155,18 @@ import xml.etree.ElementTree as ET
 
 from ansible.module_utils.basic import AnsibleModule
 
+# To avoid AttributeError: 'module' object has no attribute 'NullHandler' on python 2.6
+try:
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+logging.getLogger(__name__).addHandler(NullHandler())
+# for stevedore module
+logging.getLogger('stevedore').addHandler(NullHandler())
+
+
 # Import Jenkins builder
 try:
     from jenkins import NotFoundException
@@ -176,16 +188,6 @@ try:
     is_jenkins_builder_lib = True
 except ImportError as e:
     is_jenkins_builder_lib = False
-
-# To support Python < 2.7 version and avoid AttributeError: 'module' object has no attribute 'NullHandler'
-try:
-    from logging import NullHandler
-except ImportError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-
-logging.getLogger(__name__).addHandler(NullHandler())
 
 
 def test_dependencies(module):

--- a/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
@@ -81,7 +81,8 @@ options:
            - disabled
 
 requirements:
-    - "python-jenkins >= 0.4.12"
+    - "python >= 2.7"
+    - python-jenkins
     - jenkins-job-builder
 
 author: "Aleksei Philippov (@lelik9)"

--- a/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
@@ -1,0 +1,474 @@
+#!/usr/bin/python
+#
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: jenkins_job_generator
+
+short_description: Manage jenkins jobs through YAML config files.
+
+version_added: "0.1"
+
+description:
+    - Manage jenkins jobs through YAML config files.
+    - This is a wrapper around jenkins job builder.
+    - Using this module all jobs would be in idempotency state.
+    - "Please use the JJB documentation - https://docs.openstack.org/infra/jenkins-job-builder/
+    to get information about how to write job YAML config files"
+    - "Please note, all YAML configuration files should be on a remote server.
+    Copy them before running this module task"
+
+options:
+    jenkins_server:
+        description:
+            - Jenkins server address. Default is http://127.0.0.1:8080
+        required: false
+        default: http://127.0.0.1:8080
+    user:
+        description:
+            - Username to access jenkins server API
+        required: false
+        default: ''
+    password:
+        description:
+            - User password
+        required: false
+        default: ''
+    jobs:
+        description: "List of jobs which you want to add or delete.
+        Note: In case adding jobs, path variable should be set"
+        required: false
+    path:
+        description:
+            - Path to job configuration files
+        required: true
+    file:
+        description:
+            - File name wth job configuration. You shouldn't set jobs variable with this variable
+        required: true
+    workers:
+        description:
+            - Number of workers
+        required: false
+        default: 1
+    delete_old:
+        description:
+            - Delete old jobs
+        required: false
+        default: false
+        type: bool
+    state:
+        description:
+            - Attribute that specifies the job state (present, absent, enabled, disabled)
+        required: true
+        default: present
+        choices:
+           - present
+           - absent
+           - enabled
+           - disabled
+
+requirements:
+    - "python-jenkins >= 0.4.12"
+    - jenkins-job-builder
+
+author: "Aleksei Philippov (@lelik9)"
+'''
+
+EXAMPLES = '''
+# Copy job configuration from template
+- name: Create job template
+  template:
+    src: jobs/production.yaml.j2
+    dest: /tmp/production.yaml
+
+# Update or create all jobs from file
+- name: Generate jobs
+  jenkins_job_generator:
+    file: production.yaml
+    path: /tmp
+    state: present
+    user: jenkins
+    password: jenkins
+
+# Update or create all jobs in the path with non default jenkins server address
+- name: Generate jobs
+  jenkins_job_generator:
+    path: /tmp
+    state: present
+    user: jenkins
+    password: jenkins
+    jenkins_server: "http://127.0.0.1:8000"
+
+# Update or create selected jobs in the path
+- name: Generate jobs
+  jenkins_job_generator:
+    path: /tmp
+    jobs:
+      - build
+      - test
+    state: present
+    user: jenkins
+    password: jenkins
+
+# Delete particular job
+- name: delete jobs
+  jenkins_job_generator:
+    jobs:
+      - test
+    state: absent
+    user: jenkins
+    password: jenkins
+
+# Disable particular job
+- name: disable jobs
+  jenkins_job_generator:
+    jobs:
+      - build
+    state: disabled
+'''
+
+import xml.etree.ElementTree as ET
+
+from ansible.module_utils.basic import AnsibleModule
+
+# Import Jenkins builder
+try:
+    from jenkins import NotFoundException
+
+    is_jenkins_lib = True
+except ImportError:
+    is_jenkins_lib = False
+
+try:
+    from jenkins_jobs.builder import JenkinsManager
+    from jenkins_jobs.cli.entry import JenkinsJobs
+    from jenkins_jobs.cli.subcommand.update import UpdateSubCommand
+    from jenkins_jobs.parser import YamlParser
+    from jenkins_jobs.registry import ModuleRegistry
+    from jenkins_jobs.xml_config import XmlJobGenerator
+    from jenkins_jobs.xml_config import XmlViewGenerator
+    from jenkins_jobs.errors import JenkinsJobsException
+
+    is_jenkins_builder_lib = True
+except ImportError as e:
+    is_jenkins_builder_lib = False
+
+
+def test_dependencies(module):
+    if not is_jenkins_lib:
+        module.fail_json(msg="python-jenkins required for this module. "
+                             "see http://python-jenkins.readthedocs.io/en/latest/install.html")
+
+    if not is_jenkins_builder_lib:
+        module.fail_json(msg="jenkins-job-builder required for this module. "
+                             "see https://docs.openstack.org/infra/jenkins-job-builder/")
+
+
+def get_job_builder():
+    class JobBuilder(JenkinsManager):
+
+        def changed(self, job):
+            return self._is_job_changed(job=job)
+
+        def xml_compare(self, x1, x2):
+            """
+            Compares two xml etrees
+            :param x1: the first tree
+            :param x2: the second tree
+            :return:
+                True if both files match
+            """
+
+            if x1.tag != x2.tag:
+                return False
+            for name, value in x1.attrib.items():
+                if x2.attrib.get(name) != value:
+                    return False
+            for name in x2.attrib.keys():
+                if name not in x1.attrib:
+                    return False
+            if not self.text_compare(x1.text, x2.text):
+                return False
+            if not self.text_compare(x1.tail, x2.tail):
+                return False
+            cl1 = x1.getchildren()
+            cl2 = x2.getchildren()
+            if len(cl1) != len(cl2):
+                return False
+            i = 0
+            for c1, c2 in zip(cl1, cl2):
+                i += 1
+                if not self.xml_compare(c1, c2):
+                    return False
+            return True
+
+        def is_job_enabled(self, job):
+            return self.jenkins.get_job_info(job).get('buildable')
+
+        def disable_job(self, job):
+            self.jenkins.disable_job(job)
+
+        def enable_job(self, job):
+            self.jenkins.enable_job(job)
+
+        @staticmethod
+        def text_compare(t1, t2):
+            """
+            Compare two text strings
+            :param t1: text one
+            :param t2: text two
+            :return:
+                True if a match
+            """
+            if not t1 and not t2:
+                return True
+            if t1 == '*' or t2 == '*':
+                return True
+            return (t1 or '').strip() == (t2 or '').strip()
+
+        def _is_job_changed(self, job):
+            try:
+                job_config = self.jenkins.get_job_config(job.name)
+            except NotFoundException:
+                return True
+            current_job_config = job.output()
+
+            xml1 = ET.fromstring(job_config)
+            xml2 = ET.fromstring(current_job_config)
+
+            return not self.xml_compare(xml1, xml2)
+
+    return JobBuilder
+
+
+def get_executor():
+    class Executor(UpdateSubCommand):
+        def _generate_xmljobs(self, options, jjb_config=None):
+            job_builder = get_job_builder()
+            builder = job_builder(jjb_config)
+
+            # Generate XML
+            parser = YamlParser(jjb_config)
+            registry = ModuleRegistry(jjb_config, builder.plugins_list)
+            xml_job_generator = XmlJobGenerator(registry)
+            xml_view_generator = XmlViewGenerator(registry)
+
+            parser.load_files(options.path)
+            registry.set_parser_data(parser.data)
+
+            job_data_list, view_data_list = parser.expandYaml(
+                registry, options.names)
+
+            xml_jobs = xml_job_generator.generateXML(job_data_list)
+            xml_views = xml_view_generator.generateXML(view_data_list)
+
+            return builder, xml_jobs, xml_views
+
+        def execute(self, options, jjb_config):
+            if options.n_workers < 0:
+                raise JenkinsJobsException(
+                    'Number of workers must be equal or greater than 0')
+
+            builder, xml_jobs, xml_views = self._generate_xmljobs(
+                options, jjb_config)
+
+            if len(xml_jobs) == 0 and len(xml_views) == 0:
+                raise Exception('No jobs or view found')
+
+            jobs, num_updated_jobs = builder.update_jobs(
+                xml_jobs, n_workers=options.n_workers)
+
+            views, num_updated_views = builder.update_views(
+                xml_views, n_workers=options.n_workers)
+
+            keep_jobs = [job.name for job in xml_jobs]
+            if options.delete_old:
+                builder.delete_old_managed(keep=keep_jobs)
+
+            return num_updated_jobs, num_updated_views
+
+    return Executor()
+
+
+class ActionRunner(object):
+    def __init__(self, jenkins_server, user, password, result, **kwargs):
+        self.result = result
+        self.jenkins_server = jenkins_server
+        self.user = user
+        self.password = password
+        self.options = [
+            '--user', user,
+            '--password', password,
+            '-l debug'
+        ]
+
+    def present(self, delete_old, workers, path=None, file=None, jobs=None, **kwargs):
+        executor = get_executor()
+
+        action_options = [
+            'update',
+            '--workers', str(workers),
+        ]
+
+        if delete_old:
+            action_options.insert(1, '--delete_old')
+
+        if path is not None and jobs is not None:
+            action_options.append(path)
+            action_options.extend(jobs)
+        elif path is not None and file is not None:
+            action_options.append(path + '/' + file)
+        elif path is not None:
+            action_options.append(path)
+        else:
+            raise Exception('Incorrect options. File or path with job files should be provided')
+
+        self.options.extend(action_options)
+
+        jjb_configs = JenkinsJobs(self.options)
+        jjb_configs.jjb_config.jenkins['url'] = self.jenkins_server
+
+        num_updated_jobs, num_updated_views = \
+            executor.execute(options=jjb_configs.options, jjb_config=jjb_configs.jjb_config)
+
+        if num_updated_jobs == 0 & num_updated_views == 0:
+            self.result['status'] = 'Nothing changed'
+        else:
+            self.result['changed'] = True
+            self.result['status'] = 'Changed jobs: %s. Changed views: %s.' % (num_updated_jobs,
+                                                                              num_updated_views)
+        return self.result
+
+    def absent(self, jobs, **kwargs):
+        self.options.append('list')
+
+        job_builder = self._get_job_builder()
+
+        removed_jobs = []
+        for job in jobs:
+            is_job = job_builder.is_job(job, False)
+            if is_job:
+                job_builder.delete_job(job)
+                removed_jobs.append(job)
+        if removed_jobs:
+            self.result['changed'] = True
+            self.result['status'] = "Removed jenkins job(s): %s" % ", ".join(removed_jobs)
+        else:
+            self.result['status'] = "Nothing to delete"
+
+        return self.result
+
+    def enabled(self, jobs, **kwargs):
+        self.options.append('list')
+
+        job_builder = self._get_job_builder()
+
+        enabled_jobs = []
+        for job in jobs:
+            is_enabled = job_builder.is_job_enabled(job)
+
+            if not is_enabled:
+                job_builder.enable_job(job)
+                enabled_jobs.append(job)
+
+        if enabled_jobs:
+            self.result['changed'] = True
+            self.result['status'] = "Enabled jenkins job(s): %s" % ", ".join(enabled_jobs)
+        else:
+            self.result['status'] = "Nothing to enable"
+
+        return self.result
+
+    def disabled(self, jobs, **kwargs):
+        self.options.append('list')
+
+        job_builder = self._get_job_builder()
+
+        disabled_jobs = []
+        for job in jobs:
+            is_enabled = job_builder.is_job_enabled(job)
+
+            if is_enabled:
+                job_builder.disable_job(job)
+                disabled_jobs.append(job)
+
+        if disabled_jobs:
+            self.result['changed'] = True
+            self.result['status'] = "Enabled jenkins job(s): %s" % ", ".join(disabled_jobs)
+        else:
+            self.result['status'] = "Nothing to enable"
+
+        return self.result
+
+    def _get_job_builder(self):
+        jjb_configs = JenkinsJobs(self.options)
+        jjb_configs.jjb_config.jenkins['url'] = self.jenkins_server
+
+        return get_job_builder()(jjb_configs.jjb_config)
+
+
+def run_module():
+    module_args = dict(
+        jenkins_server=dict(type='str', required=False, default='http://127.0.0.1:8080'),
+        user=dict(type='str', required=False, default=''),
+        password=dict(type='str', required=False, default='', no_log=True),
+        jobs=dict(type='list', required=False),
+        path=dict(type='str', required=False),
+        file=dict(type='str', required=False),
+        workers=dict(type='int', required=False, default=1),
+        delete_old=dict(type='bool', required=False, default=False),
+        state=dict(choices=[
+            'present',
+            'absent',
+            'enabled',
+            'disabled'
+        ],
+            default='present'),
+    )
+
+    result = dict(
+        changed=False,
+        status=''
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    if module.check_mode:
+        return result
+
+    test_dependencies(module)
+
+    try:
+        action = ActionRunner(result=result, **module.params)
+
+        result = action.__getattribute__(module.params['state'])(**module.params)
+
+    except Exception as e:
+        result['status'] = str(e)
+        module.fail_json(**result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job_generator.py
@@ -150,6 +150,7 @@ state:
   sample: "Disabled jenkins job(s): test"
 '''
 
+import logging
 import xml.etree.ElementTree as ET
 
 from ansible.module_utils.basic import AnsibleModule
@@ -175,6 +176,16 @@ try:
     is_jenkins_builder_lib = True
 except ImportError as e:
     is_jenkins_builder_lib = False
+
+# To support Python < 2.7 version and avoid AttributeError: 'module' object has no attribute 'NullHandler'
+try:
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
+logging.getLogger(__name__).addHandler(NullHandler())
 
 
 def test_dependencies(module):

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -36,5 +36,5 @@ pexpect
 linode-python
 
 # requirement for jenkins_job_generator module
-python-jenkins >= 0.4.12
+python-jenkins
 jenkins-job-builder

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -34,3 +34,7 @@ pexpect
 
 # requirement for the linode module
 linode-python
+
+# requirement for jenkins_job_generator module
+python-jenkins >= 0.4.12
+jenkins-job-builder

--- a/test/units/modules/web_infrastructure/test_jenkins_job_generator.py
+++ b/test/units/modules/web_infrastructure/test_jenkins_job_generator.py
@@ -1,16 +1,11 @@
-import jenkins
-import os
 import pytest
-import sys
+import os
 import xml.etree.ElementTree as ET
 
 from mock import patch
 
-from nose.plugins.skip import SkipTest
-if sys.version_info < (2, 7):
-    raise SkipTest("F5 Ansible modules require Python >= 2.7")
-
 from ansible.modules.web_infrastructure.jenkins_job_generator import get_job_builder, ActionRunner
+import jenkins
 
 
 class TestJobBuilder(object):

--- a/test/units/modules/web_infrastructure/test_jenkins_job_generator.py
+++ b/test/units/modules/web_infrastructure/test_jenkins_job_generator.py
@@ -1,11 +1,16 @@
-import pytest
+import jenkins
 import os
+import pytest
+import sys
 import xml.etree.ElementTree as ET
 
 from mock import patch
 
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
+
 from ansible.modules.web_infrastructure.jenkins_job_generator import get_job_builder, ActionRunner
-import jenkins
 
 
 class TestJobBuilder(object):

--- a/test/units/modules/web_infrastructure/test_jenkins_job_generator.py
+++ b/test/units/modules/web_infrastructure/test_jenkins_job_generator.py
@@ -217,16 +217,16 @@ class TestJobBuilder(object):
 </flow-definition>
         """
     test_job_xml2 = test_job_xml
-    empty_xml = """<?xml version="1.0" encoding="UTF-8"?><com.cloudbees.hudson.plugins.folder.Folder 
-    plugin="cloudbees-folder"> <actions/>  <icon 
-    class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/> <views/>  <viewsTabBar 
-    class="hudson.views.DefaultViewsTabBar"/>  <primaryView>All</primaryView>  <healthMetrics/>  <actions/>  
-    <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>  
-    <keepDependencies>false</keepDependencies>  
-    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>  
-    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>  
-    <concurrentBuild>false</concurrentBuild>  <canRoam>true</canRoam>  <properties/>  <scm 
-    class="hudson.scm.NullSCM"/>  <publishers/>  <buildWrappers/></com.cloudbees.hudson.plugins.folder.Folder> 
+    empty_xml = """<?xml version="1.0" encoding="UTF-8"?><com.cloudbees.hudson.plugins.folder.Folder
+plugin="cloudbees-folder"> <actions/>  <icon
+class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/> <views/>  <viewsTabBar
+class="hudson.views.DefaultViewsTabBar"/>  <primaryView>All</primaryView>  <healthMetrics/>  <actions/>
+<description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+<keepDependencies>false</keepDependencies>
+<blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+<blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+<concurrentBuild>false</concurrentBuild>  <canRoam>true</canRoam>  <properties/>  <scm
+class="hudson.scm.NullSCM"/>  <publishers/>  <buildWrappers/></com.cloudbees.hudson.plugins.folder.Folder>
     """
 
     def setup(self):

--- a/test/units/modules/web_infrastructure/test_jenkins_job_generator.py
+++ b/test/units/modules/web_infrastructure/test_jenkins_job_generator.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+import sys
 import xml.etree.ElementTree as ET
 
 from mock import patch

--- a/test/units/modules/web_infrastructure/test_jenkins_job_generator.py
+++ b/test/units/modules/web_infrastructure/test_jenkins_job_generator.py
@@ -1,11 +1,11 @@
 import pytest
-import jenkins
 import os
 import xml.etree.ElementTree as ET
 
 from mock import patch
 
 from ansible.modules.web_infrastructure.jenkins_job_generator import get_job_builder, ActionRunner
+import jenkins
 
 
 class TestJobBuilder(object):

--- a/test/units/modules/web_infrastructure/test_jenkins_job_generator.py
+++ b/test/units/modules/web_infrastructure/test_jenkins_job_generator.py
@@ -4,6 +4,10 @@ import xml.etree.ElementTree as ET
 
 from mock import patch
 
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
+
 from ansible.modules.web_infrastructure.jenkins_job_generator import get_job_builder, ActionRunner
 import jenkins
 

--- a/test/units/modules/web_infrastructure/test_jenkins_job_generator.py
+++ b/test/units/modules/web_infrastructure/test_jenkins_job_generator.py
@@ -1,0 +1,361 @@
+import pytest
+import jenkins
+import os
+import xml.etree.ElementTree as ET
+
+from mock import patch
+
+from ansible.modules.web_infrastructure.jenkins_job_generator import get_job_builder, ActionRunner
+
+
+class TestJobBuilder(object):
+    scm_yaml = """
+- scm:
+      name: main-scm
+      scm:
+        - git:
+           url: ssh://git@stash.net/build_authomation.git
+           clean: true
+           branches:
+            - '*/master'
+           credentials-id: cred-id
+    """
+    test_job_yaml = """
+- job:
+    name: 'test'
+    project-type: pipeline
+    pipeline-scm:
+      scm:
+        - main-scm
+      script-path: jenkins/build_and_test.gdsl
+    parameters:
+      - string:
+          name: EASYCONFIG
+          default: f/foss/foss-2017a.eb
+          description: Path to easyconfig file
+      - string:
+          name: BRANCH
+          default: master
+          description:
+      - string:
+          name: TEST_CONTAINER_SIZE
+          default: "4000"
+          description:
+      - choice:
+          name: TEST_CONTAINER_TYPE
+          choices:
+            - minimal
+            - GUI-compatible
+          description: "On which project to run?"
+    """
+    build_job_yaml = """
+- job:
+    name: 'build'
+    project-type: pipeline
+    pipeline-scm:
+      scm:
+        - main-scm
+      script-path: jenkins/build.gdsl
+    sandbox: true
+    parameters:
+      - string:
+          name: EASYCONFIG
+          default: f/foss/foss-2017a.eb
+          description: Path to easyconfig file
+      - string:
+          name: BRANCH
+          default: master
+          description:
+      - bool:
+          name: UPDATE_CONFLUENCE
+          default: true
+          description:
+      - bool:
+          name: KEEP_CONTAINER
+          default: false
+          description:
+    """
+
+    test_job_xml = """<?xml version='1.0' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.14.1">
+    <actions/>
+    <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <hudson.model.ParametersDefinitionProperty>
+            <parameterDefinitions>
+                <hudson.model.StringParameterDefinition>
+                    <name>EASYCONFIG</name>
+                    <description>Path to easyconfig file</description>
+                    <defaultValue>f/foss/foss-2017a.eb</defaultValue>
+                </hudson.model.StringParameterDefinition>
+                <hudson.model.StringParameterDefinition>
+                    <name>BRANCH</name>
+                    <description></description>
+                    <defaultValue>master</defaultValue>
+                </hudson.model.StringParameterDefinition>
+                <hudson.model.StringParameterDefinition>
+                    <name>TEST_CONTAINER_SIZE</name>
+                    <description></description>
+                    <defaultValue>4000</defaultValue>
+                </hudson.model.StringParameterDefinition>
+                <hudson.model.ChoiceParameterDefinition>
+                    <name>TEST_CONTAINER_TYPE</name>
+                    <description>On which project to run?</description>
+                    <choices class="java.util.Arrays$ArrayList">
+                        <a class="string-array">
+                            <string>minimal</string>
+                            <string>GUI-compatible</string>
+                        </a>
+                    </choices>
+                </hudson.model.ChoiceParameterDefinition>
+            </parameterDefinitions>
+        </hudson.model.ParametersDefinitionProperty>
+        <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+    </properties>
+    <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.43">
+        <scm class="hudson.plugins.git.GitSCM" plugin="git@3.5.1">
+            <configVersion>2</configVersion>
+            <userRemoteConfigs>
+                <hudson.plugins.git.UserRemoteConfig>
+                    <name>origin</name>
+                    <refspec>+refs/heads/*:refs/remotes/origin/*</refspec>
+                    <url>ssh://git@stash.net/build_authomation.git</url>
+                    <credentialsId>cred-id</credentialsId>
+                </hudson.plugins.git.UserRemoteConfig>
+            </userRemoteConfigs>
+            <branches>
+                <hudson.plugins.git.BranchSpec>
+                    <name>*/master</name>
+                </hudson.plugins.git.BranchSpec>
+            </branches>
+            <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+            <gitTool>Default</gitTool>
+            <submoduleCfg class="list"/>
+            <extensions>
+                <hudson.plugins.git.extensions.impl.CleanCheckout/>
+                <hudson.plugins.git.extensions.impl.WipeWorkspace/>
+            </extensions>
+        </scm>
+        <scriptPath>jenkins/build_and_test.gdsl</scriptPath>
+        <lightweight>false</lightweight>
+    </definition>
+    <disabled>false</disabled>
+</flow-definition>
+    """
+    build_job_xml = """<?xml version="1.0" encoding="utf-8"?>
+<flow-definition plugin="workflow-job">
+    <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps">
+        <sandbox>true</sandbox>
+        <scm class="hudson.plugins.git.GitSCM">
+            <configVersion>2</configVersion>
+            <userRemoteConfigs>
+                <hudson.plugins.git.UserRemoteConfig>
+                    <name>origin</name>
+                    <refspec>+refs/heads/*:refs/remotes/origin/*</refspec>
+                    <url>ssh://git@stash.net/build_authomation.git</url>
+                    <credentialsId>cred-id</credentialsId>
+                </hudson.plugins.git.UserRemoteConfig>
+            </userRemoteConfigs>
+            <branches>
+                <hudson.plugins.git.BranchSpec>
+                    <name>*/master</name>
+                </hudson.plugins.git.BranchSpec>
+            </branches>
+            <disableSubmodules>false</disableSubmodules>
+            <recursiveSubmodules>false</recursiveSubmodules>
+            <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+            <remotePoll>false</remotePoll>
+            <gitTool>Default</gitTool>
+            <submoduleCfg class="list"/>
+            <reference/>
+            <gitConfigName/>
+            <gitConfigEmail/>
+            <extensions>
+                <hudson.plugins.git.extensions.impl.CleanCheckout/>
+                <hudson.plugins.git.extensions.impl.WipeWorkspace/>
+            </extensions>
+        </scm>
+        <scriptPath>jenkins/build.gdsl</scriptPath>
+    </definition>
+    <actions/>
+    <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+    <keepDependencies>false</keepDependencies>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <concurrentBuild>false</concurrentBuild>
+    <canRoam>true</canRoam>
+    <properties>
+        <hudson.model.ParametersDefinitionProperty>
+            <parameterDefinitions>
+                <hudson.model.StringParameterDefinition>
+                    <name>EASYCONFIG</name>
+                    <description>Path to easyconfig file</description>
+                    <defaultValue>f/foss/foss-2017a.eb</defaultValue>
+                </hudson.model.StringParameterDefinition>
+                <hudson.model.StringParameterDefinition>
+                    <name>BRANCH</name>
+                    <description/>
+                    <defaultValue>master</defaultValue>
+                </hudson.model.StringParameterDefinition>
+                <hudson.model.BooleanParameterDefinition>
+                    <name>UPDATE_CONFLUENCE</name>
+                    <description/>
+                    <defaultValue>true</defaultValue>
+                </hudson.model.BooleanParameterDefinition>
+                <hudson.model.BooleanParameterDefinition>
+                    <name>KEEP_CONTAINER</name>
+                    <description/>
+                    <defaultValue>false</defaultValue>
+                </hudson.model.BooleanParameterDefinition>
+            </parameterDefinitions>
+        </hudson.model.ParametersDefinitionProperty>
+    </properties>
+    <scm class="hudson.scm.NullSCM"/>
+    <publishers/>
+    <buildWrappers/>
+</flow-definition>
+        """
+    test_job_xml2 = test_job_xml
+    empty_xml = """<?xml version="1.0" encoding="UTF-8"?><com.cloudbees.hudson.plugins.folder.Folder 
+    plugin="cloudbees-folder"> <actions/>  <icon 
+    class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/> <views/>  <viewsTabBar 
+    class="hudson.views.DefaultViewsTabBar"/>  <primaryView>All</primaryView>  <healthMetrics/>  <actions/>  
+    <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>  
+    <keepDependencies>false</keepDependencies>  
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>  
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>  
+    <concurrentBuild>false</concurrentBuild>  <canRoam>true</canRoam>  <properties/>  <scm 
+    class="hudson.scm.NullSCM"/>  <publishers/>  <buildWrappers/></com.cloudbees.hudson.plugins.folder.Folder> 
+    """
+
+    def setup(self):
+        def stub(self):
+            pass
+
+        job_builder = get_job_builder()
+        old_init = job_builder.__init__
+        job_builder.__init__ = stub
+        self.job_builder = job_builder()
+        job_builder.__init__ = old_init
+        self.job_files_path = 'jobs'
+
+    def test_xml_cchange_true(self):
+        xml1 = ET.fromstring(self.test_job_xml)
+        xml2 = ET.fromstring(self.test_job_xml2)
+        print(self.job_builder.xml_compare(xml1, xml2))
+        assert self.job_builder.xml_compare(xml1, xml2)
+
+    def test_xml_cchange_false(self):
+        xml1 = ET.fromstring(self.test_job_xml)
+        xml2 = ET.fromstring(self.build_job_xml)
+
+        assert not self.job_builder.xml_compare(xml1, xml2)
+
+    def test_get_action_method(self):
+        result = dict(
+            changed=False,
+            status=''
+        )
+        params = {
+            'jenkins_server': 'http://127.0.0.1',
+            'user': 'jenkins',
+            'password': 'jenkins',
+            'state': 'present'
+        }
+        action = ActionRunner(result=result, **params)
+
+        assert action.__getattribute__(params['state']) is not None
+
+    # Mock tests
+
+    @patch('jenkins.Jenkins.get_job_config')
+    def test_jobs_not_update(self, mock, tmpdir):
+        dir = tmpdir.mkdir(self.job_files_path)
+        result = dict(
+            changed=False,
+            status=''
+        )
+        params = {
+            'jenkins_server': 'http://127.0.0.1:8080',
+            'user': '',
+            'password': '',
+            'jobs': ['build'],
+            'path': str(dir.realpath()),
+            'file': '',
+            'workers': '1',
+            'delete_old': False,
+            'state': 'present'
+        }
+        f = dir.join("job.yml")
+        f.write('\n'.join([self.scm_yaml, self.build_job_yaml, self.test_job_yaml]))
+
+        mock.return_value = self.build_job_xml
+
+        action = ActionRunner(result=result, **params)
+
+        result = action.__getattribute__(params['state'])(**params)
+
+        assert not result['changed']
+
+    @patch('jenkins.Jenkins.get_job_config')
+    @patch('jenkins_jobs.builder.JenkinsManager.update_job')
+    def test_jobs_update(self, update_job_mock, get_job_config_mock, tmpdir):
+        dir = tmpdir.mkdir(self.job_files_path)
+        result = dict(
+            changed=False,
+            status=''
+        )
+        params = {
+            'jenkins_server': 'http://127.0.0.1:8080',
+            'user': '',
+            'password': '',
+            'jobs': ['test', 'build'],
+            'path': str(dir.realpath()),
+            'file': '',
+            'workers': '1',
+            'delete_old': False,
+            'state': 'present'
+        }
+        f = dir.join("job.yaml")
+        f.write('\n'.join([self.scm_yaml, self.build_job_yaml]))
+
+        get_job_config_mock.return_value = self.test_job_xml
+        update_job_mock.return_value = None
+
+        action = ActionRunner(result=result, **params)
+
+        result = action.__getattribute__(params['state'])(**params)
+
+        assert result['changed']
+
+    @patch('jenkins.Jenkins.get_job_config')
+    @patch('jenkins_jobs.builder.JenkinsManager.update_job')
+    def test_jobs_create(self, update_job_mock, get_job_config_mock, tmpdir):
+        dir = tmpdir.mkdir(self.job_files_path)
+        result = dict(
+            changed=False,
+            status=''
+        )
+        params = {
+            'jenkins_server': 'http://127.0.0.1:8080',
+            'user': '',
+            'password': '',
+            'jobs': ['test', 'build'],
+            'path': str(dir.realpath()),
+            'file': '',
+            'workers': '1',
+            'delete_old': False,
+            'state': 'present'
+        }
+        f = dir.join("job.yml")
+        f.write('\n'.join([self.scm_yaml, self.build_job_yaml, self.test_job_yaml]))
+
+        get_job_config_mock.return_value = self.empty_xml
+        update_job_mock.return_value = None
+
+        action = ActionRunner(result=result, **params)
+
+        result = action.__getattribute__(params['state'])(**params)
+
+        assert result['changed']


### PR DESCRIPTION
##### SUMMARY
This module gives ability to manage jenkins jobs through a YAML config files. Unlike of jenkins_job module this module doesn't require to have already created XML configuration files, it generates them by itself from the YAML. With this module possible to use Jinja templates to generate YAML config files. This module is a wrapper for a jenkins-job-builder python module (https://docs.openstack.org/infra/jenkins-job-builder/). But current module provide extra job states (enabled/disabled), and all state are idempotent.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
jenkins_job_generator

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 
```

