### PR TITLE
Linode: Mark 'name' as required. Fixes #29785

### DIFF
--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -30,6 +30,7 @@ options:
     description:
      - Name to give the instance (alphanumeric, dashes, underscore).
      - To keep sanity on the Linode Web Console, name is prepended with C(LinodeID_).
+    required: true
   displaygroup:
     description:
      - Add the instance to a Display Group in Linode Manager.
@@ -556,7 +557,7 @@ def main():
             state=dict(type='str', default='present',
                        choices=['absent', 'active', 'deleted', 'present', 'restarted', 'started', 'stopped']),
             api_key=dict(type='str', no_log=True),
-            name=dict(type='str'),
+            name=dict(type='str', required=True),
             alert_bwin_enabled=dict(type='bool'),
             alert_bwin_threshold=dict(type='int'),
             alert_bwout_enabled=dict(type='bool'),

--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -149,6 +149,7 @@ author:
 - Vincent Viallet (@zbal)
 notes:
   - C(LINODE_API_KEY) env variable can be used instead.
+  - Please review U(https://www.linode.com/api/linode) for determining the required parameters.
 '''
 
 EXAMPLES = '''

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -31,3 +31,6 @@ xmljson
 
 # requirement for winrm connection plugin tests
 pexpect
+
+# requirement for the linode module
+linode-python

--- a/test/units/modules/cloud/linode/conftest.py
+++ b/test/units/modules/cloud/linode/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.fixture
+def api_key(monkeypatch):
+    monkeypatch.setenv('LINODE_API_KEY', 'foobar')
+
+
+@pytest.fixture
+def auth(monkeypatch):
+    def patched_test_echo(dummy):
+        return []
+    monkeypatch.setattr('linode.api.Api.test_echo', patched_test_echo)

--- a/test/units/modules/cloud/linode/test_linode.py
+++ b/test/units/modules/cloud/linode/test_linode.py
@@ -1,0 +1,15 @@
+from __future__ import (absolute_import, division, print_function)
+
+import pytest
+
+from ansible.modules.cloud.linode import linode
+from units.modules.utils import set_module_args
+
+if not linode.HAS_LINODE:
+    pytestmark = pytest.mark.skip('test_linode.py requires the `linode-python` module')
+
+
+def test_name_is_a_required_parameter(api_key, auth):
+    with pytest.raises(SystemExit):
+        set_module_args({})
+        linode.main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
A fix motivated by https://github.com/ansible/ansible/issues/29785. While I have noted in https://github.com/ansible/ansible/issues/44696#issuecomment-416072275 that different requests require different required paramters (overall, implementing the documentation change in that comment is probably the 'final' paramter requirements fix), the OP in #29785 appears to be saying that `name` is required to use the module in the first place.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
linode

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (mark-name-required-#29785 f112e314b7) last updated 2018/08/27 00:25:34 (GMT +200)
  config file = None
  configured module search path = [u'/home/decentral1se/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/decentral1se/hobby/ansible/lib/ansible
  executable location = /home/decentral1se/hobby/ansible/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

In the running of the test, I can't seem to test against the output but have manually verified:

```
lib/ansible/module_utils/basic.py:2367: SystemExit
-------------------------------------------------------------- Captured stdout call ---------------------------------------------------------------

{"msg": "missing required arguments: name", "failed": true, "invocation": {"module_args": {"payment_term": 1, "displaygroup": "", "state": "present", "wait_timeout": 300, "swap": 512, "watchdog": true, "wait": true}}}
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
