### PR TITLE
azure_rm_virtualmachine: Add 'accept_terms'

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -149,6 +149,7 @@ try:
     from azure.mgmt.dns import DnsManagementClient
     from azure.mgmt.web import WebSiteManagementClient
     from azure.mgmt.containerservice import ContainerServiceClient
+    from azure.mgmt.marketplaceordering import MarketplaceOrderingAgreements
     from azure.storage.cloudstorageaccount import CloudStorageAccount
     from adal.authentication_context import AuthenticationContext
     from azure.mgmt.rdbms.postgresql import PostgreSQLManagementClient
@@ -275,6 +276,7 @@ class AzureRMModuleBase(object):
         self._compute_client = None
         self._dns_client = None
         self._web_client = None
+        self._marketplace_client = None
         self._containerservice_client = None
         self._mysql_client = None
         self._postgresql_client = None
@@ -1099,3 +1101,11 @@ class AzureRMModuleBase(object):
                                                                       api_version='2018-06-01')
 
         return self._containerinstance_client
+
+    @property
+    def marketplace_client(self):
+        self.log('Getting marketplace agreement client')
+        if not self._marketplace_client:
+            self._marketplace_client = self.get_mgmt_svc_client(MarketplaceOrderingAgreements,
+                                                                base_url=self._cloud_environment.endpoints.resource_manager)
+        return self._marketplace_client

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
@@ -51,6 +51,7 @@ options:
             - Premium_LRS
             - Standard_GRS
             - Standard_LRS
+            - StandardSSD_LRS
             - Standard_RAGRS
             - Standard_ZRS
         aliases:
@@ -158,7 +159,8 @@ class AzureRMStorageAccount(AzureRMModuleBase):
     def __init__(self):
 
         self.module_arg_spec = dict(
-            account_type=dict(type='str', choices=[], aliases=['type']),
+            account_type=dict(type='str', choices=['Premium_LRS', 'Standard_GRS', 'Standard_LRS', 'StandardSSD_LRS', 'Standard_RAGRS', 'Standard_ZRS'],
+                              aliases=['type']),
             custom_domain=dict(type='dict'),
             location=dict(type='str'),
             name=dict(type='str', required=True),

--- a/packaging/requirements/requirements-azure.txt
+++ b/packaging/requirements/requirements-azure.txt
@@ -10,6 +10,7 @@ azure-mgmt-containerregistry==2.0.0
 azure-mgmt-containerservice==3.0.1
 azure-mgmt-dns==1.2.0
 azure-mgmt-keyvault==0.40.0
+azure-mgmt-marketplaceordering==0.1.0
 azure-mgmt-network==1.7.1
 azure-mgmt-nspkg==2.0.0
 azure-mgmt-rdbms==1.2.0

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -403,3 +403,57 @@
         name: invalid-image
   register: fail_missing_custom_image_dict
   failed_when: fail_missing_custom_image_dict.msg != "Error could not find image with name invalid-image"
+
+## Tests possible when CI user acccount setup with required authority
+#- name: Set test facts
+  #set_fact:
+    #image_paid:
+      #publisher: cognosys
+      #offer: ubuntu-14-04-lts
+      #sku: hardened-ubuntu-14-04
+      #version: latest
+    #plan_paid:
+      #name: hardened-ubuntu-14-04
+      #product: ubuntu-14-04-lts
+      #publisher: cognosys
+      
+#- name: Create virtual machine with image and plan which requires acceptance of terms
+  #azure_rm_virtualmachine:
+      #resource_group: "{{ resource_group }}"
+      #name: testvm009
+      #vm_size: Standard_A0
+      #storage_account: "{{ storage_account }}"
+      #storage_container: testvm001
+      #storage_blob: testvm003.vhd
+      #admin_username: adminuser
+      #admin_password: Password123!
+      #short_hostname: testvm
+      #os_type: Linux
+      #availability_set: "avbs{{ resource_group | hash('md5') | truncate(7, True, '') }}"
+      #image: "{{ image_paid }}"
+      #plan_paid: "{{ plan_paid }}"
+  #register: output
+
+#- assert:
+    #that:
+      #- output.changed
+      #- output.ansible_facts.azure_vm.properties.storageProfile.imageReference.publisher == image_paid.publisher
+
+#- name: Should be idempotent with image and plan which requires acceptance of terms
+  #azure_rm_virtualmachine:
+      #resource_group: "{{ resource_group }}"
+      #name: testvm009
+      #vm_size: Standard_A0
+      #storage_account: "{{ storage_account }}"
+      #storage_container: testvm001
+      #storage_blob: testvm003.vhd
+      #admin_username: adminuser
+      #admin_password: Password123!
+      #short_hostname: testvm
+      #os_type: Linux
+      #availability_set: "avbs{{ resource_group | hash('md5') | truncate(7, True, '') }}"
+      #image: "{{ image_paid }}"
+      #plan_paid: "{{ plan_paid }}"
+
+#- assert:
+    #that: not output.changed

--- a/test/runner/requirements/integration.cloud.azure.txt
+++ b/test/runner/requirements/integration.cloud.azure.txt
@@ -10,6 +10,7 @@ azure-mgmt-containerregistry==2.0.0
 azure-mgmt-containerservice==3.0.1
 azure-mgmt-dns==1.2.0
 azure-mgmt-keyvault==0.40.0
+azure-mgmt-marketplaceordering==0.1.0
 azure-mgmt-network==1.7.1
 azure-mgmt-nspkg==2.0.0
 azure-mgmt-rdbms==1.2.0


### PR DESCRIPTION
azure_rm_virtualmachine: Add 'accept_terms' for accepting terms when deploying paid marketplace images

##### SUMMARY
Paid Azure Marketplace images requiring accepting the terms of the `image` and `plan` before being deployed. Usually this takes place in the Azure web frontend or via `az` cli prior to provisioning.
 
As `azure_rm_virtualmachine` is for programatically deploying VM images it should have the capacity to accept these terms at the time of deployment. The `accept_terms` (`True`) does just this.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine

##### ANSIBLE VERSION
```
2.7.0
```


##### ADDITIONAL INFORMATION
Tests are included, but commented out as special CI permissions are required.