### PR TITLE
add ovirt attach host devic

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -245,10 +245,14 @@ options:
     custom_compatibility_version:
         description:
             - "Enables a virtual machine to be customized to its own compatibility version. If
-            `C(custom_compatibility_version)` is set, it overrides the cluster's compatibility version
+            'C(custom_compatibility_version)' is set, it overrides the cluster's compatibility version
             for this particular virtual machine."
         version_added: "2.7"
-
+    host_devices:
+        description:
+            - Single Root I/O Virtualization - technology that allows single device to expose multiple endpoints that can be passed to VMs
+            - host_devices is an list which contain dictinary with name and state of device
+        version_added: "2.7"
     delete_protected:
         description:
             - If I(yes) Virtual Machine will be set as delete protected.
@@ -853,6 +857,7 @@ EXAMPLES = '''
       protocol:
         - spice
         - vnc
+
 # Execute remote viever to VM
 - block:
   - name: Create a ticket for console for a running VM
@@ -869,6 +874,19 @@ EXAMPLES = '''
 
   - name: Run remote viewer with file
     command: remote-viewer ~/vvfile.vv
+
+# Default value of host_device state is present
+- name: Attach host devices to virtual machine
+  ovirt_vm:
+    name: myvm
+    host: myhost
+    placement_policy: pinned
+    host_devices:
+      - name: pci_0000_00_06_0
+      - name: pci_0000_00_07_0
+        state: absent
+      - name: pci_0000_00_08_0
+        state: present
 
 '''
 
@@ -1214,6 +1232,7 @@ class VmsModule(BaseModule):
         self.changed = self.__attach_numa_nodes(entity)
         self.changed = self.__attach_watchdog(entity)
         self.changed = self.__attach_graphical_console(entity)
+        self.changed = self.__attach_host_devices(entity)
 
     def pre_remove(self, entity):
         # Forcibly stop the VM, if it's not in DOWN state:
@@ -1608,6 +1627,33 @@ class VmsModule(BaseModule):
             )
         return self._initialization
 
+    def __attach_host_devices(self, entity):
+        vm_service = self._service.service(entity.id)
+        host_devices_service = vm_service.host_devices_service()
+        host_devices = self.param('host_devices')
+        updated = False
+        if host_devices:
+            device_names = [dev.name for dev in host_devices_service.list()]
+            for device in host_devices:
+                device_name = device.get('name')
+                state = device.get('state', 'present')
+                if state == 'absent' and device_name in device_names:
+                    updated = True
+                    if not self._module.check_mode:
+                        device_id = get_id_by_name(host_devices_service, device.get('name'))
+                        host_devices_service.device_service(device_id).remove()
+
+                elif state == 'present' and device_name not in device_names:
+                    updated = True
+                    if not self._module.check_mode:
+                        host_devices_service.add(
+                            otypes.HostDevice(
+                                name=device.get('name'),
+                            )
+                        )
+
+        return updated
+
 
 def _get_role_mappings(module):
     roleMappings = list()
@@ -1925,6 +1971,7 @@ def main():
         numa_nodes=dict(type='list', default=[]),
         custom_properties=dict(type='list'),
         watchdog=dict(type='dict'),
+        host_devices=dict(type='list'),
         graphical_console=dict(type='dict'),
     )
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add attaching ovirts VMs to host devices
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/mnecas/Desktop/Projects/Redhat/ansible/lib/ansible/modules/cloud/ovirt']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, Apr  4 2018, 15:01:18) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
