### PR TITLE
Linode: use dashes not underscores for linode labels

### DIFF
--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -29,7 +29,7 @@ options:
   name:
     description:
      - Name to give the instance (alphanumeric, dashes, underscore).
-     - To keep sanity on the Linode Web Console, name is prepended with C(LinodeID_).
+     - To keep sanity on the Linode Web Console, name is prepended with C(LinodeID-).
     required: true
   displaygroup:
     description:
@@ -350,7 +350,7 @@ def linodeServers(module, api, state, name,
                                         PaymentTerm=payment_term)
                 linode_id = res['LinodeID']
                 # Update linode Label to match name
-                api.linode_update(LinodeId=linode_id, Label='%s_%s' % (linode_id, name))
+                api.linode_update(LinodeId=linode_id, Label='%s-%s' % (linode_id, name))
                 # Update Linode with Ansible configuration options
                 api.linode_update(LinodeId=linode_id, LPM_DISPLAYGROUP=displaygroup, WATCHDOG=watchdog, **kwargs)
                 # Save server


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This is because underscores are illegals in hostnames and users might
want to create the same host names are the name of the Linode machine
(as in the report in #30059).

Closes https://github.com/ansible/ansible/issues/30059.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
linode

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (no-underscore-hostnames-#30059 399c002f8f) last updated 2018/08/27 16:42:52 (GMT +200)
  config file = None
  configured module search path = [u'/home/decentral1se/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/decentral1se/hobby/ansible/lib/ansible
  executable location = /home/decentral1se/hobby/ansible/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
