### PR TITLE
rabbitmq_user: authenticate_user may return non-zero rc

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -140,12 +140,12 @@ class RabbitMqUser(object):
         self._permissions = []
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
 
-    def _exec(self, args, run_in_check_mode=False):
+    def _exec(self, args, run_in_check_mode=False, check_rc=True):
         if not self.module.check_mode or run_in_check_mode:
             cmd = [self._rabbitmqctl, '-q']
             if self.node is not None:
                 cmd.extend(['-n', self.node])
-            rc, out, err = self.module.run_command(cmd + args, check_rc=True)
+            rc, out, err = self.module.run_command(cmd + args, check_rc=check_rc)
             return out.splitlines()
         return list()
 
@@ -188,7 +188,7 @@ class RabbitMqUser(object):
         return perms_list
 
     def check_password(self):
-        return self._exec(['authenticate_user', self.username, self.password], True)
+        return self._exec(['authenticate_user', self.username, self.password], True, False)
 
     def add(self):
         if self.password is not None:


### PR DESCRIPTION
##### SUMMARY
authenticate_user may return non-zero rc.
In such case it caused module to fail, instead of changing password.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0
  config file = /opt/personal-ansible/kmagosa/ansible.cfg
  configured module search path = [u'/opt/personal-ansible/kmagosa/extensions/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
Module failed in case when password was not set yet.
