### PR TITLE
Fix systemd service is already masked issue

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -369,7 +369,7 @@ def main():
                 is_masked = 'LoadState' in result['status'] and result['status']['LoadState'] == 'masked'
 
                 # Check for loading error
-                if (is_systemd and not is_masked) and 'LoadError' in result['status']:
+                if is_systemd and not is_masked and 'LoadError' in result['status']:
                     module.fail_json(msg="Error loading unit file '%s': %s" % (unit, result['status']['LoadError']))
         else:
             # Check for systemctl command

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -366,8 +366,10 @@ def main():
 
                 is_systemd = 'LoadState' in result['status'] and result['status']['LoadState'] != 'not-found'
 
+                is_masked = 'LoadState' in result['status'] and result['status']['LoadState'] == 'masked'
+
                 # Check for loading error
-                if is_systemd and 'LoadError' in result['status']:
+                if (is_systemd and not is_masked) and 'LoadError' in result['status']:
                     module.fail_json(msg="Error loading unit file '%s': %s" % (unit, result['status']['LoadError']))
         else:
             # Check for systemctl command


### PR DESCRIPTION
##### SUMMARY
Newer versions of Systemd now report a 'LoadError' when the unit file
is masked. This causes the play to fail with an error stating that the
service is already masked.

Now the systemd module checks if the service is masked and doesn't
fail if it's masked and 'LoadError' is reported.

Fixes issue #42384.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
systemd

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel da355055cb) last updated 2018/08/27 20:14:41 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/fubar/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.0 (default, Jul 15 2018, 10:44:58) [GCC 8.1.1 20180531]
```

##### ADDITIONAL INFORMATION

Before:
```
TASK [laptop : Mask systemd radio service] ****************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Error loading unit file 'systemd-rfkill.service': org.freedesktop.systemd1.UnitMasked \"Unit systemd-rfkill.service is masked.\""}

```

After:
```
TASK [laptop : Mask systemd radio service] ****************************************************************************************************************************************************
ok: [localhost]
```