### PR TITLE
fix yum install with disablerepo

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1384,7 +1384,8 @@ class YumModule(YumDnf):
             my = self.yum_base()
             try:
                 if self.disablerepo:
-                    my.repos.disableRepo(self.disablerepo)
+                    for rid in self.disablerepo:
+                        my.repos.disableRepo(rid)
                 current_repos = my.repos.repos.keys()
                 if self.enablerepo:
                     try:


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
Fix yum install operation with `disablerepo` argument(s) that was broken during the yum code refactor.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
yum

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.7.0.dev0 (modules/yum 9cc5ec2dd3) last updated 2018/08/27 15:41:09 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```



