### PR TITLE
win_reboot: fix minor issues with the latest refactor

### DIFF
--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -283,9 +283,8 @@ class ActionModule(ActionBase):
 
         if reboot_result['failed']:
             result = reboot_result
-            if 'start' in reboot_result:
-                elapsed = datetime.utcnow() - reboot_result['start']
-                result['elapsed'] = elapsed.seconds
+            elapsed = datetime.utcnow() - reboot_result['start']
+            result['elapsed'] = elapsed.seconds
             return result
 
         # Make sure reboot was successful

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -134,7 +134,16 @@ class ActionModule(ActionBase):
     def run_test_command(self, **kwargs):
         test_command = self._task.args.get('test_command', self.DEFAULT_TEST_COMMAND)
         display.vvv("%s: attempting post-reboot test command '%s'" % (self._task.action, test_command))
-        command_result = self._low_level_execute_command(test_command, sudoable=self.DEFAULT_SUDOABLE)
+        try:
+            command_result = self._low_level_execute_command(test_command, sudoable=self.DEFAULT_SUDOABLE)
+        except Exception:
+            # may need to reset the connection in case another reboot occurred
+            # which has invalidated our connection
+            try:
+                self._connection.reset()
+            except AttributeError:
+                pass
+            raise
 
         result = {}
         if command_result['rc'] != 0:
@@ -274,8 +283,9 @@ class ActionModule(ActionBase):
 
         if reboot_result['failed']:
             result = reboot_result
-            elapsed = datetime.utcnow() - reboot_result['start']
-            result['elapsed'] = elapsed.seconds
+            if 'start' in reboot_result:
+                elapsed = datetime.utcnow() - reboot_result['start']
+                result['elapsed'] = elapsed.seconds
             return result
 
         # Make sure reboot was successful

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -50,6 +50,8 @@ class ActionModule(RebootActionModule, ActionBase):
 
         remote_command = self.construct_command()
         reboot_result = self._low_level_execute_command(remote_command, sudoable=self.DEFAULT_SUDOABLE)
+        result = {}
+        result['start'] = datetime.utcnow()
 
         pre_reboot_delay = int(self._task.args.get('pre_reboot_delay', self._task.args.get('pre_reboot_delay_sec', self.DEFAULT_PRE_REBOOT_DELAY)))
 
@@ -69,7 +71,6 @@ class ActionModule(RebootActionModule, ActionBase):
             stdout += result1['stdout'] + result2['stdout']
             stderr += result1['stderr'] + result2['stderr']
 
-        result = {}
         if reboot_result['rc'] != 0:
             result['failed'] = True
             result['rebooted'] = False
@@ -77,7 +78,6 @@ class ActionModule(RebootActionModule, ActionBase):
             return result
 
         result['failed'] = False
-        result['start'] = datetime.utcnow()
 
         # Get the original connection_timeout option var so it can be reset after
         try:

--- a/test/integration/targets/win_reboot/tasks/main.yml
+++ b/test/integration/targets/win_reboot/tasks/main.yml
@@ -66,7 +66,7 @@
       ansible_password: '{{standard_pass}}'
       ansible_winrm_transport: ntlm
     register: fail_shutdown
-    failed_when: fail_shutdown.msg != "Shutdown command failed, error text was 'Access is denied.(5)\n'"
+    failed_when: "fail_shutdown.msg != 'Shutdown command failed, error was:  Access is denied.(5)'"
 
   always:
   - name: set the original SDDL to the WinRM listener


### PR DESCRIPTION
##### SUMMARY
Fixes a few issues with the recent reboot refactoring and the win_reboot tests;

* resets the connection on `run_test_command` on a failure, this solves the issue where the host si rebooting multiple times and winrm needs to reset the shell id so it starts working again
* only add the elapsed return value if the start key exists (it may not if `perform_reboot()` didn't succeed
* fix the Windows shutdown abort code path now it is using low_level_execute_command

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_reboot

##### ANSIBLE VERSION
```
devel
```
