### PR TITLE
Download hello package from S3 for apt test.

### DIFF
--- a/test/integration/targets/apt/tasks/upgrade.yml
+++ b/test/integration/targets/apt/tasks/upgrade.yml
@@ -1,7 +1,7 @@
 ---
 #### Tests for upgrade/download functions in modules/packaging/os/apt.py ####
 - name: download and install old version of hello
-  apt: "deb=https://launchpad.net/ubuntu/+archive/primary/+files/hello_{{ hello_old_version }}_amd64.deb"
+  apt: "deb=https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/apt/hello_{{ hello_old_version }}_amd64.deb"
 
 - name: check hello version
   shell: dpkg -s hello | grep Version | awk '{print $2}'


### PR DESCRIPTION
##### SUMMARY

Download hello package from S3 for apt test.

This should reduce the frequency of download failures for the package.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

apt integration test

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (apt-test-fix 713e700e0f) last updated 2018/08/27 17:35:36 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
