### PR TITLE
Get packages for dnf and yum tests from S3.

### DIFF
--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -411,7 +411,7 @@
 
 - name: try to install from non existing url
   dnf:
-    name: http://non-existing.com/non-existing-1.0.0.fc26.noarch.rpm
+    name: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/dnf/non-existing-1.0.0.fc26.noarch.rpm
     state: present
   register: dnf_result
   ignore_errors: yes
@@ -494,7 +494,7 @@
 
 - name: try to install not compatible arch rpm, should fail
   dnf:
-    name: http://download.fedoraproject.org/pub/epel/7/ppc64le/Packages/b/banner-1.3.4-3.el7.ppc64le.rpm
+    name: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/dnf/banner-1.3.4-3.el7.ppc64le.rpm
     state: present
   register: dnf_result
   ignore_errors: True
@@ -516,7 +516,7 @@
     state: absent
 
 - set_fact:
-    pkg_url: https://download.fedoraproject.org/pub/fedora/linux/releases/27/Everything/x86_64/os/Packages/f/fpaste-0.3.9.1-1.fc27.noarch.rpm
+    pkg_url: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/dnf/fpaste-0.3.9.1-1.fc27.noarch.rpm
 # setup end
 
 - name: download an rpm

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -406,7 +406,7 @@
 
 - name: try to install from non existing url
   yum:
-    name: http://non-existing.com/non-existing-1.0.0.fc26.noarch.rpm
+    name: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/yum/non-existing-1.0.0.fc26.noarch.rpm
     state: present
   register: yum_result
   ignore_errors: yes
@@ -454,7 +454,7 @@
 
 - name: try to install not compatible arch rpm, should fail
   yum:
-    name: http://download.fedoraproject.org/pub/epel/7/ppc64le/Packages/b/banner-1.3.4-3.el7.ppc64le.rpm
+    name: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/yum/banner-1.3.4-3.el7.ppc64le.rpm
     state: present
   register: yum_result
   ignore_errors: True


### PR DESCRIPTION
##### SUMMARY

Get packages for dnf and yum tests from S3.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

dnf and yum integration tests

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0 (yum-dnf-test-updates b87ca0c987) last updated 2018/08/27 21:22:45 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
