### PR TITLE
permission starting from https://

### DIFF
--- a/lib/ansible/modules/cloud/google/gce_instance_template.py
+++ b/lib/ansible/modules/cloud/google/gce_instance_template.py
@@ -347,7 +347,8 @@ def create_instance_template(module, gce):
     bad_perms = []
     if service_account_permissions:
         for perm in service_account_permissions:
-            if perm not in gce.SA_SCOPES_MAP:
+#            if perm not in gce.SA_SCOPES_MAP:
+            if perm not in gce.SA_SCOPES_MAP and not perm.startswith('https://www.googleapis.com/auth'):  
                 bad_perms.append(perm)
         if len(bad_perms) > 0:
             module.fail_json(msg='bad permissions: %s' % str(bad_perms))

--- a/lib/ansible/modules/cloud/google/gce_instance_template.py
+++ b/lib/ansible/modules/cloud/google/gce_instance_template.py
@@ -347,7 +347,6 @@ def create_instance_template(module, gce):
     bad_perms = []
     if service_account_permissions:
         for perm in service_account_permissions:
-#            if perm not in gce.SA_SCOPES_MAP:
             if perm not in gce.SA_SCOPES_MAP and not perm.startswith('https://www.googleapis.com/auth'):  
                 bad_perms.append(perm)
         if len(bad_perms) > 0:

--- a/lib/ansible/modules/cloud/google/gce_instance_template.py
+++ b/lib/ansible/modules/cloud/google/gce_instance_template.py
@@ -347,7 +347,7 @@ def create_instance_template(module, gce):
     bad_perms = []
     if service_account_permissions:
         for perm in service_account_permissions:
-            if perm not in gce.SA_SCOPES_MAP and not perm.startswith('https://www.googleapis.com/auth'):  
+            if perm not in gce.SA_SCOPES_MAP and not perm.startswith('https://www.googleapis.com/auth'):
                 bad_perms.append(perm)
         if len(bad_perms) > 0:
             module.fail_json(msg='bad permissions: %s' % str(bad_perms))


### PR DESCRIPTION
With this change, I could successfully add permissions, which is not defined in the options of service_account_permissions tag.


##### SUMMARY
change the condition in service_account_permissions.
I add this change to my server and confirmed permissions starting from (https:..) is added to instances successfully.
(url type like "https://www.googleapis.com/auth/trace.append" is not defined in the choices. however you could see in the google document)

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
  ==> Not existing issues. (not confirmed)

##### ISSUE TYPE
Not issue.

##### COMPONENT NAME
cloud/google/gce_instance_template

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
-> ansible --version
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/simokawa/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]

```


##### ADDITIONAL INFORMATION
No additional info.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
-> sudo verbatim
sudo: verbatim: command not found
```
