### PR TITLE
win_nssm: tests and several bug fixes

### DIFF
--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -27,7 +27,7 @@ $startMode = Get-AnsibleParam -obj $params -name "start_mode" -type "str" -defau
 
 $stdoutFile = Get-AnsibleParam -obj $params -name "stdout_file" -type "str"
 $stderrFile = Get-AnsibleParam -obj $params -name "stderr_file" -type "str"
-$dependencies = Get-AnsibleParam -obj $params -name "dependencies" -type "str"
+$dependencies = Get-AnsibleParam -obj $params -name "dependencies" -type "list"
 
 $user = Get-AnsibleParam -obj $params -name "user" -type "str"
 $password = Get-AnsibleParam -obj $params -name "password" -type "str"
@@ -431,11 +431,11 @@ Function Nssm-Update-Dependencies
         Throw "Error updating dependencies for service ""$name"""
     }
 
-    $dependencies_array = @($dependencies.split(" ") | where { $_ -ne '' })
     $current_dependencies = @($nssm_result.stdout.split("`n`r") | where { $_ -ne '' })
 
-    If (@(Compare-Object -ReferenceObject $current_dependencies -DifferenceObject $dependencies_array).Length -ne 0) {
-        $cmd = "set ""$name"" DependOnService $dependencies"
+    If (@(Compare-Object -ReferenceObject $current_dependencies -DifferenceObject $dependencies).Length -ne 0) {
+        $dependencies_str = Argv-ToString -arguments $dependencies
+        $cmd = "set ""$name"" DependOnService $dependencies_str"
         $nssm_result = Nssm-Invoke $cmd
 
         if ($nssm_result.rc -ne 0)

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -6,6 +6,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #Requires -Module Ansible.ModuleUtils.Legacy
+#Requires -Module Ansible.ModuleUtils.CommandUtil
 
 $ErrorActionPreference = "Stop"
 
@@ -35,8 +36,6 @@ if (($appParameters -ne $null) -and ($appParametersFree -ne $null))
     Fail-Json $result "Use either app_parameters or app_parameteres_free_form, but not both"
 }
 
-#abstract the calling of nssm because some PowerShell environments
-#mishandle its stdout(which is Unicode) as UTF8
 Function Nssm-Invoke
 {
     [CmdletBinding()]
@@ -44,21 +43,10 @@ Function Nssm-Invoke
         [Parameter(Mandatory=$true)]
         [string]$cmd
     )
-    Try {
-      $encodingWas = [System.Console]::OutputEncoding
-      [System.Console]::OutputEncoding = [System.Text.Encoding]::Unicode
 
-      $nssmOutput = invoke-expression "nssm $cmd"
-      return $nssmOutput
-    }
-    Catch {
-      $ErrorMessage = $_.Exception.Message
-      Fail-Json $result "an exception occurred when invoking NSSM: $ErrorMessage"
-    }
-    Finally {
-      # Set the console encoding back to what it was
-      [System.Console]::OutputEncoding = $encodingWas
-    }
+    $nssm_result = Run-Command -command "nssm $cmd"
+
+    return $nssm_result
 }
 
 Function Service-Exists
@@ -84,15 +72,15 @@ Function Nssm-Remove
     {
         if ((Get-Service -Name $name).Status -ne "Stopped") {
             $cmd = "stop ""$name"""
-            $results = Nssm-Invoke $cmd
+            $nssm_result = Nssm-Invoke $cmd
         }
         $cmd = "remove ""$name"" confirm"
-        $results = Nssm-Invoke $cmd
+        $nssm_result = Nssm-Invoke $cmd
 
-        if ($LastExitCode -ne 0)
+        if ($nssm_result.rc -ne 0)
         {
             $result.nssm_error_cmd = $cmd
-            $result.nssm_error_log = "$results"
+            $result.nssm_error_log = $nssm_result.stderr
             Throw "Error removing service ""$name"""
         }
 
@@ -122,12 +110,12 @@ Function Nssm-Install
 
     if (!(Service-Exists -name $name))
     {
-        $results = Nssm-Invoke "install ""$name"" ""$application"""
+        $nssm_result = Nssm-Invoke "install ""$name"" ""$application"""
 
-        if ($LastExitCode -ne 0)
+        if ($nssm_result.rc -ne 0)
         {
             $result.nssm_error_cmd = $cmd
-            $result.nssm_error_log = "$results"
+            $result.nssm_error_log = $nssm_result.stderr
             Throw "Error installing service ""$name"""
         }
 
@@ -135,25 +123,25 @@ Function Nssm-Install
         $result.changed = $true
 
      } else {
-        $results = Nssm-Invoke "get ""$name"" Application"
+        $nssm_result = Nssm-Invoke "get ""$name"" Application"
 
-        if ($LastExitCode -ne 0)
+        if ($nssm_result.rc -ne 0)
         {
             $result.nssm_error_cmd = $cmd
-            $result.nssm_error_log = "$results"
+            $result.nssm_error_log = $nssm_result.stderr
             Throw "Error installing service ""$name"""
         }
 
-        if ($results -cnotlike $application)
+        if ($nssm_result.stdout -cnotlike $application)
         {
             $cmd = "set ""$name"" Application ""$application"""
 
-            $results = Nssm-Invoke $cmd
+            $nssm_result = Nssm-Invoke $cmd
 
-            if ($LastExitCode -ne 0)
+            if ($nssm_result.rc -ne 0)
             {
                 $result.nssm_error_cmd = $cmd
-                $result.nssm_error_log = "$results"
+                $result.nssm_error_log = $nssm_result.stderr
                 Throw "Error installing service ""$name"""
             }
             $result.application = "$application"
@@ -166,14 +154,14 @@ Function Nssm-Install
      if ($result.changed)
      {
         $applicationPath = (Get-Item $application).DirectoryName
-        $cmd = "nssm set ""$name"" AppDirectory ""$applicationPath"""
+        $cmd = "set ""$name"" AppDirectory ""$applicationPath"""
 
-        $results = invoke-expression $cmd
+        $nssm_result = Nssm-Invoke $cmd
 
-        if ($LastExitCode -ne 0)
+        if ($nssm_result.rc -ne 0)
         {
             $result.nssm_error_cmd = $cmd
-            $result.nssm_error_log = "$results"
+            $result.nssm_error_log = $nssm_result.stderr
             Throw "Error installing service ""$name"""
         }
      }
@@ -207,12 +195,12 @@ Function Nssm-Update-AppParameters
     )
 
     $cmd = "get ""$name"" AppParameters"
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 
-    if ($LastExitCode -ne 0)
+    if ($nssm_result.rc -ne 0)
     {
         $result.nssm_error_cmd = $cmd
-        $result.nssm_error_log = "$results"
+        $result.nssm_error_log = $nssm_result.stderr
         Throw "Error updating AppParameters for service ""$name"""
     }
 
@@ -250,7 +238,7 @@ Function Nssm-Update-AppParameters
     $result.nssm_app_parameters = $appParameters
     $result.nssm_single_line_app_parameters = $singleLineParams
 
-    if ($results -ne $singleLineParams)
+    if ($nssm_result.stdout -ne $singleLineParams)
     {
         if ($appParameters -or $appParametersFree)
         {
@@ -258,12 +246,12 @@ Function Nssm-Update-AppParameters
         } else {
             $cmd = "set ""$name"" AppParameters '""""'"
         }
-        $results = Nssm-Invoke $cmd
+        $nssm_result = Nssm-Invoke $cmd
 
-        if ($LastExitCode -ne 0)
+        if ($nssm_result.rc -ne 0)
         {
             $result.nssm_error_cmd = $cmd
-            $result.nssm_error_log = "$results"
+            $result.nssm_error_log = $nssm_result.stderr
             Throw "Error updating AppParameters for service ""$name"""
         }
 
@@ -283,16 +271,16 @@ Function Nssm-Set-Output-Files
     )
 
     $cmd = "get ""$name"" AppStdout"
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 
-    if ($LastExitCode -ne 0)
+    if ($nssm_result.rc -ne 0)
     {
         $result.nssm_error_cmd = $cmd
-        $result.nssm_error_log = "$results"
+        $result.nssm_error_log = $nssm_result.stderr
         Throw "Error retrieving existing stdout file for service ""$name"""
     }
 
-    if ($results -cnotlike $stdout)
+    if ($nssm_result.stdout -cnotlike $stdout)
     {
         if (!$stdout)
         {
@@ -301,12 +289,12 @@ Function Nssm-Set-Output-Files
             $cmd = "set ""$name"" AppStdout $stdout"
         }
 
-        $results = Nssm-Invoke $cmd
+        $nssm_result = Nssm-Invoke $cmd
 
-        if ($LastExitCode -ne 0)
+        if ($nssm_result.rc -ne 0)
         {
             $result.nssm_error_cmd = $cmd
-            $result.nssm_error_log = "$results"
+            $result.nssm_error_log = $nssm_result.stderr
             Throw "Error setting stdout file for service ""$name"""
         }
 
@@ -315,36 +303,36 @@ Function Nssm-Set-Output-Files
     }
 
     $cmd = "get ""$name"" AppStderr"
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 
-    if ($LastExitCode -ne 0)
+    if ($nssm_result.rc -ne 0)
     {
         $result.nssm_error_cmd = $cmd
-        $result.nssm_error_log = "$results"
+        $result.nssm_error_log = $nssm_result.stderr
         Throw "Error retrieving existing stderr file for service ""$name"""
     }
 
-    if ($results -cnotlike $stderr)
+    if ($nssm_result.stdout -cnotlike $stderr)
     {
         if (!$stderr)
         {
             $cmd = "reset ""$name"" AppStderr"
-            $results = Nssm-Invoke $cmd
+            $nssm_result = Nssm-Invoke $cmd
 
-            if ($LastExitCode -ne 0)
+            if ($nssm_result.rc -ne 0)
             {
                 $result.nssm_error_cmd = $cmd
-                $result.nssm_error_log = "$results"
+                $result.nssm_error_log = $nssm_result.stderr
                 Throw "Error clearing stderr file setting for service ""$name"""
             }
         } else {
             $cmd = "set ""$name"" AppStderr $stderr"
-            $results = Nssm-Invoke $cmd
+            $nssm_result = Nssm-Invoke $cmd
 
-            if ($LastExitCode -ne 0)
+            if ($nssm_result.rc -ne 0)
             {
                 $result.nssm_error_cmd = $cmd
-                $result.nssm_error_log = "$results"
+                $result.nssm_error_log = $nssm_result.stderr
                 Throw "Error setting stderr file for service ""$name"""
             }
         }
@@ -359,27 +347,27 @@ Function Nssm-Set-Output-Files
 
     #set files to overwrite
     $cmd = "set ""$name"" AppStdoutCreationDisposition 2"
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 
     $cmd = "set ""$name"" AppStderrCreationDisposition 2"
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 
     #enable file rotation
     $cmd = "set ""$name"" AppRotateFiles 1"
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 
     #don't rotate until the service restarts
     $cmd = "set ""$name"" AppRotateOnline 0"
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 
     #both of the below conditions must be met before rotation will happen
     #minimum age before rotating
     $cmd = "set ""$name"" AppRotateSeconds 86400"
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 
     #minimum size before rotating
     $cmd = "set ""$name"" AppRotateBytes 104858"
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 }
 
 Function Nssm-Update-Credentials
@@ -395,12 +383,12 @@ Function Nssm-Update-Credentials
     )
 
     $cmd = "get ""$name"" ObjectName"
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 
-    if ($LastExitCode -ne 0)
+    if ($nssm_result.rc -ne 0)
     {
         $result.nssm_error_cmd = $cmd
-        $result.nssm_error_log = "$results"
+        $result.nssm_error_log = $nssm_result.stderr
         Throw "Error updating credentials for service ""$name"""
     }
 
@@ -414,14 +402,14 @@ Function Nssm-Update-Credentials
                 $fullUser = ".\" + $user
             }
 
-            If ($results -ne $fullUser) {
+            If ($nssm_result.stdout -ne $fullUser) {
                 $cmd = "set ""$name"" ObjectName $fullUser '$password'"
-                $results = Nssm-Invoke $cmd
+                $nssm_result = Nssm-Invoke $cmd
 
-                if ($LastExitCode -ne 0)
+                if ($nssm_result.rc -ne 0)
                 {
                     $result.nssm_error_cmd = $cmd
-                    $result.nssm_error_log = "$results"
+                    $result.nssm_error_log = $nssm_result.stderr
                     Throw "Error updating credentials for service ""$name"""
                 }
 
@@ -443,23 +431,23 @@ Function Nssm-Update-Dependencies
     )
 
     $cmd = "get ""$name"" DependOnService"
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 
-    if ($LastExitCode -ne 0)
+    if ($nssm_result.rc -ne 0)
     {
         $result.nssm_error_cmd = $cmd
-        $result.nssm_error_log = "$results"
+        $result.nssm_error_log = $nssm_result.stderr
         Throw "Error updating dependencies for service ""$name"""
     }
 
-    If (($dependencies) -and ($results.Tolower() -ne $dependencies.Tolower())) {
+    If (($dependencies) -and ($nssm_result.stdout.Tolower() -ne $dependencies.Tolower())) {
         $cmd = "set ""$name"" DependOnService $dependencies"
-        $results = Nssm-Invoke $cmd
+        $nssm_result = Nssm-Invoke $cmd
 
-        if ($LastExitCode -ne 0)
+        if ($nssm_result.rc -ne 0)
         {
             $result.nssm_error_cmd = $cmd
-            $result.nssm_error_log = "$results"
+            $result.nssm_error_log = $nssm_result.stderr
             Throw "Error updating dependencies for service ""$name"""
         }
 
@@ -479,25 +467,25 @@ Function Nssm-Update-StartMode
     )
 
     $cmd = "get ""$name"" Start"
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 
-    if ($LastExitCode -ne 0)
+    if ($nssm_result.rc -ne 0)
     {
         $result.nssm_error_cmd = $cmd
-        $result.nssm_error_log = "$results"
+        $result.nssm_error_log = $nssm_result.stderr
         Throw "Error updating start mode for service ""$name"""
     }
 
     $modes=@{"auto" = "SERVICE_AUTO_START"; "delayed" = "SERVICE_DELAYED_AUTO_START"; "manual" = "SERVICE_DEMAND_START"; "disabled" = "SERVICE_DISABLED"}
     $mappedMode = $modes.$mode
-    if ($results -cnotlike $mappedMode) {
+    if ($nssm_result.stdout -cnotlike $mappedMode) {
         $cmd = "set ""$name"" Start $mappedMode"
-        $results = Nssm-Invoke $cmd
+        $nssm_result = Nssm-Invoke $cmd
 
-        if ($LastExitCode -ne 0)
+        if ($nssm_result.rc -ne 0)
         {
             $result.nssm_error_cmd = $cmd
-            $result.nssm_error_log = "$results"
+            $result.nssm_error_log = $nssm_result.stderr
             Throw "Error updating start mode for service ""$name"""
         }
 
@@ -515,9 +503,9 @@ Function Nssm-Get-Status
     )
 
     $cmd = "status ""$name"""
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 
-    return ,$results
+    return $nssm_result
 }
 
 Function Nssm-Start
@@ -530,14 +518,14 @@ Function Nssm-Start
 
     $currentStatus = Nssm-Get-Status -name $name
 
-    if ($LastExitCode -ne 0)
+    if ($currentStatus.rc -ne 0)
     {
         $result.nssm_error_cmd = $cmd
-        $result.nssm_error_log = "$results"
+        $result.nssm_error_log = $currentStatus.stderr
         Throw "Error starting service ""$name"""
     }
 
-    switch ($currentStatus)
+    switch ($currentStatus.stdout)
     {
         "SERVICE_RUNNING" { <# Nothing to do #> }
         "SERVICE_STOPPED" { Nssm-Start-Service-Command -name $name }
@@ -560,12 +548,12 @@ Function Nssm-Start-Service-Command
 
     $cmd = "start ""$name"""
 
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 
-    if ($LastExitCode -ne 0)
+    if ($nssm_result.rc -ne 0)
     {
         $result.nssm_error_cmd = $cmd
-        $result.nssm_error_log = "$results"
+        $result.nssm_error_log = $nssm_result.stderr
         Throw "Error starting service ""$name"""
     }
 
@@ -583,12 +571,12 @@ Function Nssm-Stop-Service-Command
 
     $cmd = "stop ""$name"""
 
-    $results = Nssm-Invoke $cmd
+    $nssm_result = Nssm-Invoke $cmd
 
-    if ($LastExitCode -ne 0)
+    if ($nssm_result.rc -ne 0)
     {
         $result.nssm_error_cmd = $cmd
-        $result.nssm_error_log = "$results"
+        $result.nssm_error_log = $nssm_result.stderr
         Throw "Error stopping service ""$name"""
     }
 
@@ -606,23 +594,23 @@ Function Nssm-Stop
 
     $currentStatus = Nssm-Get-Status -name $name
 
-    if ($LastExitCode -ne 0)
+    if ($currentStatus.rc -ne 0)
     {
         $result.nssm_error_cmd = $cmd
-        $result.nssm_error_log = "$results"
+        $result.nssm_error_log = $currentStatus.stderr
         Throw "Error stopping service ""$name"""
     }
 
-    if ($currentStatus -ne "SERVICE_STOPPED")
+    if ($currentStatus.stdout -ne "SERVICE_STOPPED")
     {
         $cmd = "stop ""$name"""
 
-        $results = Nssm-Invoke $cmd
+        $nssm_result = Nssm-Invoke $cmd
 
-        if ($LastExitCode -ne 0)
+        if ($nssm_result.rc -ne 0)
         {
             $result.nssm_error_cmd = $cmd
-            $result.nssm_error_log = "$results"
+            $result.nssm_error_log = $nssm_result.stderr
             Throw "Error stopping service ""$name"""
         }
 

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -525,16 +525,16 @@ Function Nssm-Start
         Throw "Error starting service ""$name"""
     }
 
-    switch ($currentStatus.stdout)
+    switch -wildcard ($currentStatus.stdout)
     {
-        "SERVICE_RUNNING" { <# Nothing to do #> }
-        "SERVICE_STOPPED" { Nssm-Start-Service-Command -name $name }
+        "*SERVICE_RUNNING*" { <# Nothing to do #> }
+        "*SERVICE_STOPPED*" { Nssm-Start-Service-Command -name $name }
 
-        "SERVICE_CONTINUE_PENDING" { Nssm-Stop-Service-Command -name $name; Nssm-Start-Service-Command -name $name }
-        "SERVICE_PAUSE_PENDING" { Nssm-Stop-Service-Command -name $name; Nssm-Start-Service-Command -name $name }
-        "SERVICE_PAUSED" { Nssm-Stop-Service-Command -name $name; Nssm-Start-Service-Command -name $name }
-        "SERVICE_START_PENDING" { Nssm-Stop-Service-Command -name $name; Nssm-Start-Service-Command -name $name }
-        "SERVICE_STOP_PENDING" { Nssm-Stop-Service-Command -name $name; Nssm-Start-Service-Command -name $name }
+        "*SERVICE_CONTINUE_PENDING*" { Nssm-Stop-Service-Command -name $name; Nssm-Start-Service-Command -name $name }
+        "*SERVICE_PAUSE_PENDING*" { Nssm-Stop-Service-Command -name $name; Nssm-Start-Service-Command -name $name }
+        "*SERVICE_PAUSED*" { Nssm-Stop-Service-Command -name $name; Nssm-Start-Service-Command -name $name }
+        "*SERVICE_START_PENDING*" { Nssm-Stop-Service-Command -name $name; Nssm-Start-Service-Command -name $name }
+        "*SERVICE_STOP_PENDING*" { Nssm-Stop-Service-Command -name $name; Nssm-Start-Service-Command -name $name }
     }
 }
 

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -49,7 +49,7 @@ options:
       - Path to receive error output.
   app_parameters:
     description:
-      - Parameters to be passed to the application when it starts.
+      - A string representing a dictionary of parameters to be passed to the application when it starts.
       - Use either this or C(app_parameters_free_form), not both.
   app_parameters_free_form:
     version_added: "2.3.0"
@@ -87,37 +87,25 @@ EXAMPLES = r'''
     application: C:\windows\foo.exe
 
 # Install and start the foo service with a key-value pair argument
-# This will yield the following command: C:\windows\foo.exe bar "true"
+# This will yield the following command: C:\windows\foo.exe -bar true
 - win_nssm:
     name: foo
     application: C:\windows\foo.exe
-    app_parameters:
-      bar: 'true'
-
-# Install and start the foo service with a key-value pair argument, where the argument needs to start with a dash
-# This will yield the following command: C:\windows\\foo.exe -bar "true"
-- win_nssm:
-    name: foo
-    application: C:\windows\foo.exe
-    app_parameters:
-      "-bar": 'true'
+    app_parameters: -bar=true
 
 # Install and start the foo service with a single parameter
 # This will yield the following command: C:\windows\\foo.exe bar
 - win_nssm:
     name: foo
     application: C:\windows\foo.exe
-    app_parameters:
-      _: bar
+    app_parameters: _=bar
 
 # Install and start the foo service with a mix of single params, and key value pairs
-# This will yield the following command: C:\windows\\foo.exe bar -file output.bat
+# This will yield the following command: C:\windows\\foo.exe bar -file output.bat -foo false
 - win_nssm:
     name: foo
     application: C:\windows\foo.exe
-    app_parameters:
-      _: bar
-      "-file": "output.bat"
+    app_parameters: _=bar; -file=output.bat; -foo=false
 
 # Use the single line parameters option to specify an arbitrary string of parameters
 # for the service executable

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -58,7 +58,7 @@ options:
       - Use either this or C(app_parameters), not both.
   dependencies:
     description:
-      - Service dependencies that has to be started to trigger startup, separated by space.
+      - Service dependencies that has to be started to trigger startup, separated by comma.
   user:
     description:
       - User to be used for service startup.
@@ -140,7 +140,7 @@ EXAMPLES = r'''
 - win_nssm:
     name: foo
     application: C:\windows\foo.exe
-    dependencies: 'adf tcpip'
+    dependencies: 'adf,tcpip'
 
 # Install and start the foo service with dedicated user
 - win_nssm:

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -58,7 +58,7 @@ options:
       - Use either this or C(app_parameters), not both.
   dependencies:
     description:
-      - Service dependencies that has to be started to trigger startup, separated by comma.
+      - Service dependencies that has to be started to trigger startup, separated by space.
   user:
     description:
       - User to be used for service startup.
@@ -140,7 +140,7 @@ EXAMPLES = r'''
 - win_nssm:
     name: foo
     application: C:\windows\foo.exe
-    dependencies: 'adf,tcpip'
+    dependencies: 'adf tcpip'
 
 # Install and start the foo service with dedicated user
 - win_nssm:

--- a/test/integration/targets/win_nssm/aliases
+++ b/test/integration/targets/win_nssm/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group4

--- a/test/integration/targets/win_nssm/defaults/main.yml
+++ b/test/integration/targets/win_nssm/defaults/main.yml
@@ -1,0 +1,1 @@
+test_service_name: ansible_nssm_test

--- a/test/integration/targets/win_nssm/defaults/main.yml
+++ b/test/integration/targets/win_nssm/defaults/main.yml
@@ -1,1 +1,4 @@
 test_service_name: ansible_nssm_test
+test_win_nssm_path: '{{win_output_dir}}\win_nssm'
+test_win_nssm_username: testnssmuser
+test_win_nssm_password: Password123!

--- a/test/integration/targets/win_nssm/tasks/main.yml
+++ b/test/integration/targets/win_nssm/tasks/main.yml
@@ -4,6 +4,19 @@
     name: NSSM
     state: present
 
+- name: ensure testing folder exists
+  win_file:
+    path: '{{test_win_nssm_path}}'
+    state: directory
+
+- name: create test user for service execution
+  win_user:
+    name: '{{test_win_nssm_username}}'
+    password: '{{test_win_nssm_password}}'
+    state: present
+    groups:
+    - Users
+
 # Run actual tests
 - block:
   - include_tasks: tests.yml
@@ -12,6 +25,16 @@
     - name: ensure test service is absent
       win_service:
         name: '{{ test_service_name }}'
+        state: absent
+
+    - name: remove test user
+      win_user:
+        name: '{{test_win_nssm_username}}'
+        state: absent
+
+    - name: cleanup test folder
+      win_file:
+        path: '{{test_win_nssm_path}}'
         state: absent
 
     - name: uninstall NSSM

--- a/test/integration/targets/win_nssm/tasks/main.yml
+++ b/test/integration/targets/win_nssm/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: install NSSM
+  win_chocolatey:
+    name: NSSM
+    state: present
+
+# Run actual tests
+- block:
+  - include_tasks: tests.yml
+
+  always:
+    - name: ensure test service is absent
+      win_service:
+        name: '{{ test_service_name }}'
+        state: absent
+
+    - name: uninstall NSSM
+      win_chocolatey:
+        name: NSSM
+        state: absent
+      failed_when: false

--- a/test/integration/targets/win_nssm/tasks/tests.yml
+++ b/test/integration/targets/win_nssm/tasks/tests.yml
@@ -36,6 +36,26 @@
     - (install_service_actual.stdout|from_json).StartMode == 'Auto'
     - (install_service_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
 
+- name: test install service (idempotent)
+  win_nssm:
+    name: '{{ test_service_name }}'
+    application: C:\Windows\System32\cmd.exe
+    state: present
+  register: install_service_again
+
+- name: get result of install service (idempotent)
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: install_service_again_actual
+
+- name: assert results of install service (idempotent)
+  assert:
+    that:
+    - install_service_again.changed == false
+    - (install_service_again_actual.stdout|from_json).Exists == true
+    - (install_service_again_actual.stdout|from_json).State == 'Stopped'
+    - (install_service_again_actual.stdout|from_json).StartMode == 'Auto'
+    - (install_service_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+
 - name: install and start service
   win_nssm:
     name: '{{ test_service_name }}'
@@ -88,6 +108,39 @@
     - '"Tcpip" in (install_service_complex_actual.stdout|from_json).Dependencies'
     - '"Dnscache" in (install_service_complex_actual.stdout|from_json).Dependencies'
 
+- name: install and start service with more parameters (idempotent)
+  win_nssm:
+    name: '{{ test_service_name }}'
+    application: C:\Windows\System32\cmd.exe
+    start_mode: manual
+    # Dependencies order should not trigger a change
+    dependencies: 'dnscache tcpip'
+    user: '{{ test_win_nssm_username }}'
+    password: '{{ test_win_nssm_password }}'
+    stdout_file: '{{ test_win_nssm_path }}\log.txt'
+    stderr_file: '{{ test_win_nssm_path }}\error.txt'
+    state: started
+  register: install_service_complex_again
+
+- name: get result of install and start service with more parameters (idempotent)
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: install_service_complex_again_actual
+
+- name: assert results of install and start service with more parameters (idempotent)
+  assert:
+    that:
+    - install_service_complex_again.changed == false
+    - (install_service_complex_again_actual.stdout|from_json).Exists == true
+    - (install_service_complex_again_actual.stdout|from_json).State == 'Running'
+    - (install_service_complex_again_actual.stdout|from_json).StartMode == 'Manual'
+    - (install_service_complex_again_actual.stdout|from_json).StartName == '.\\' + test_win_nssm_username
+    - (install_service_complex_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    - (install_service_complex_again_actual.stdout|from_json).Parameters.AppStdout == test_win_nssm_path + '\\log.txt'
+    - (install_service_complex_again_actual.stdout|from_json).Parameters.AppStderr == test_win_nssm_path + '\\error.txt'
+    - (install_service_complex_again_actual.stdout|from_json).Dependencies|length == 2
+    - '"Tcpip" in (install_service_complex_again_actual.stdout|from_json).Dependencies'
+    - '"Dnscache" in (install_service_complex_again_actual.stdout|from_json).Dependencies'
+
 - name: install service with free form parameters
   win_nssm:
     name: '{{ test_service_name }}'
@@ -107,6 +160,26 @@
     - (free_params_actual.stdout|from_json).Exists == true
     - (free_params_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
     - (free_params_actual.stdout|from_json).Parameters.AppParameters == "-v -Dcom.test.string=value test"
+
+- name: install service with free form parameters (idempotent)
+  win_nssm:
+    name: '{{ test_service_name }}'
+    application: C:\Windows\System32\cmd.exe
+    app_parameters_free_form: '-v -Dcom.test.string=value test'
+    state: present
+  register: free_params_again
+
+- name: get result of install service with free form parameters (idempotent)
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: free_params_again_actual
+
+- name: assert results of install service with free form parameters (idempotent)
+  assert:
+    that:
+    - free_params_again.changed == false
+    - (free_params_again_actual.stdout|from_json).Exists == true
+    - (free_params_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    - (free_params_again_actual.stdout|from_json).Parameters.AppParameters == "-v -Dcom.test.string=value test"
 
 - name: install service with dict parameters
   win_nssm:
@@ -130,6 +203,28 @@
     - (mixed_params_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
     - (mixed_params_actual.stdout|from_json).Parameters.AppParameters == "bar -file.out output.bat foo True"
 
+- name: install service with dict parameters (idempotent)
+  win_nssm:
+    name: '{{ test_service_name }}'
+    application: C:\Windows\System32\cmd.exe
+    app_parameters:
+      foo: true
+      '-file.out': 'output.bat'
+      _: bar
+  register: mixed_params_again
+
+- name: get result of install service with dict parameters (idempotent)
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: mixed_params_again_actual
+
+- name: assert results of install service with dict parameters (idempotent)
+  assert:
+    that:
+    - mixed_params_again.changed == false
+    - (mixed_params_again_actual.stdout|from_json).Exists == true
+    - (mixed_params_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    - (mixed_params_again_actual.stdout|from_json).Parameters.AppParameters == "bar -file.out output.bat foo True"
+
 - name: remove service
   win_nssm:
     name: '{{ test_service_name }}'
@@ -145,3 +240,19 @@
     that:
     - remove_service.changed == true
     - (remove_service_actual.stdout|from_json).Exists == false
+
+- name: remove service (idempotent)
+  win_nssm:
+    name: '{{ test_service_name }}'
+    state: absent
+  register: remove_service_again
+
+- name: get result of remove service (idempotent)
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: remove_service_again_actual
+
+- name: assert results of remove service (idempotent)
+  assert:
+    that:
+    - remove_service_again.changed == false
+    - (remove_service_again_actual.stdout|from_json).Exists == false

--- a/test/integration/targets/win_nssm/tasks/tests.yml
+++ b/test/integration/targets/win_nssm/tasks/tests.yml
@@ -145,7 +145,7 @@
   win_nssm:
     name: '{{ test_service_name }}'
     application: C:\Windows\System32\cmd.exe
-    app_parameters_free_form: '-v -Dcom.test.string=value test'
+    app_parameters_free_form: '-v -Dcom.test.string=value "C:\with space\\"'
     state: present
   register: free_params
 
@@ -159,13 +159,14 @@
     - free_params.changed == true
     - (free_params_actual.stdout|from_json).Exists == true
     - (free_params_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
-    - (free_params_actual.stdout|from_json).Parameters.AppParameters == "-v -Dcom.test.string=value test"
+    # Expected value: -v -Dcom.test.string=value "C:\with space\\" (backslashes doubled for jinja)
+    - (free_params_actual.stdout|from_json).Parameters.AppParameters == '-v -Dcom.test.string=value "C:\\with space\\\\"'
 
 - name: install service with free form parameters (idempotent)
   win_nssm:
     name: '{{ test_service_name }}'
     application: C:\Windows\System32\cmd.exe
-    app_parameters_free_form: '-v -Dcom.test.string=value test'
+    app_parameters_free_form: '-v -Dcom.test.string=value "C:\with space\\"'
     state: present
   register: free_params_again
 
@@ -179,7 +180,8 @@
     - free_params_again.changed == false
     - (free_params_again_actual.stdout|from_json).Exists == true
     - (free_params_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
-    - (free_params_again_actual.stdout|from_json).Parameters.AppParameters == "-v -Dcom.test.string=value test"
+    # Expected value: -v -Dcom.test.string=value "C:\with space\\" (backslashes doubled for jinja)
+    - (free_params_again_actual.stdout|from_json).Parameters.AppParameters == '-v -Dcom.test.string=value "C:\\with space\\\\"'
 
 - name: install service with dict parameters
   win_nssm:
@@ -188,6 +190,8 @@
     app_parameters:
       foo: true
       '-file.out': 'output.bat'
+      '-path': 'C:\with space\'
+      '-str': 'test"quotes'
       _: bar
   register: mixed_params
 
@@ -201,7 +205,8 @@
     - mixed_params.changed == true
     - (mixed_params_actual.stdout|from_json).Exists == true
     - (mixed_params_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
-    - (mixed_params_actual.stdout|from_json).Parameters.AppParameters == "bar -file.out output.bat foo True"
+    # Expected value: bar -str "test\"quotes" -file.out output.bat foo True -path "C:\with space\\" (backslashes doubled for jinja)
+    - (mixed_params_actual.stdout|from_json).Parameters.AppParameters == 'bar -str "test\\"quotes" -file.out output.bat foo True -path "C:\\with space\\\\"'
 
 - name: install service with dict parameters (idempotent)
   win_nssm:
@@ -210,6 +215,8 @@
     app_parameters:
       foo: true
       '-file.out': 'output.bat'
+      '-path': 'C:\with space\'
+      '-str': 'test"quotes'
       _: bar
   register: mixed_params_again
 
@@ -223,7 +230,8 @@
     - mixed_params_again.changed == false
     - (mixed_params_again_actual.stdout|from_json).Exists == true
     - (mixed_params_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
-    - (mixed_params_again_actual.stdout|from_json).Parameters.AppParameters == "bar -file.out output.bat foo True"
+    # Expected value: bar -str "test\"quotes" -file.out output.bat foo True -path "C:\with space\\" (backslashes doubled for jinja)
+    - (mixed_params_again_actual.stdout|from_json).Parameters.AppParameters == 'bar -str "test\\"quotes" -file.out output.bat foo True -path "C:\\with space\\\\"'
 
 - name: remove service
   win_nssm:

--- a/test/integration/targets/win_nssm/tasks/tests.yml
+++ b/test/integration/targets/win_nssm/tasks/tests.yml
@@ -81,7 +81,7 @@
     name: '{{ test_service_name }}'
     application: C:\Windows\System32\cmd.exe
     start_mode: manual
-    dependencies: 'tcpip dnscache'
+    dependencies: 'tcpip,dnscache'
     user: '{{ test_win_nssm_username }}'
     password: '{{ test_win_nssm_password }}'
     stdout_file: '{{ test_win_nssm_path }}\log.txt'
@@ -114,7 +114,7 @@
     application: C:\Windows\System32\cmd.exe
     start_mode: manual
     # Dependencies order should not trigger a change
-    dependencies: 'dnscache tcpip'
+    dependencies: 'dnscache,tcpip'
     user: '{{ test_win_nssm_username }}'
     password: '{{ test_win_nssm_password }}'
     stdout_file: '{{ test_win_nssm_path }}\log.txt'

--- a/test/integration/targets/win_nssm/tasks/tests.yml
+++ b/test/integration/targets/win_nssm/tasks/tests.yml
@@ -187,12 +187,7 @@
   win_nssm:
     name: '{{ test_service_name }}'
     application: C:\Windows\System32\cmd.exe
-    app_parameters:
-      foo: true
-      '-file.out': 'output.bat'
-      '-path': 'C:\with space\'
-      '-str': 'test"quotes'
-      _: bar
+    app_parameters: foo=true; -file.out=output.bat; -path=C:\with space\; -str=test"quotes; _=bar
   register: mixed_params
 
 - name: get result of install service with dict parameters
@@ -205,19 +200,14 @@
     - mixed_params.changed == true
     - (mixed_params_actual.stdout|from_json).Exists == true
     - (mixed_params_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
-    # Expected value: bar -str "test\"quotes" -file.out output.bat foo True -path "C:\with space\\" (backslashes doubled for jinja)
-    - (mixed_params_actual.stdout|from_json).Parameters.AppParameters == 'bar -str "test\\"quotes" -file.out output.bat foo True -path "C:\\with space\\\\"'
+    # Expected value: bar -file.out output.bat -str "test\"quotes" foo true -path "C:\with space\\" (backslashes doubled for jinja)
+    - (mixed_params_actual.stdout|from_json).Parameters.AppParameters == 'bar -file.out output.bat -str "test\\"quotes" foo true -path "C:\\with space\\\\"'
 
 - name: install service with dict parameters (idempotent)
   win_nssm:
     name: '{{ test_service_name }}'
     application: C:\Windows\System32\cmd.exe
-    app_parameters:
-      foo: true
-      '-file.out': 'output.bat'
-      '-path': 'C:\with space\'
-      '-str': 'test"quotes'
-      _: bar
+    app_parameters: foo=true; -file.out=output.bat; -path=C:\with space\; -str=test"quotes; _=bar
   register: mixed_params_again
 
 - name: get result of install service with dict parameters (idempotent)
@@ -230,8 +220,8 @@
     - mixed_params_again.changed == false
     - (mixed_params_again_actual.stdout|from_json).Exists == true
     - (mixed_params_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
-    # Expected value: bar -str "test\"quotes" -file.out output.bat foo True -path "C:\with space\\" (backslashes doubled for jinja)
-    - (mixed_params_again_actual.stdout|from_json).Parameters.AppParameters == 'bar -str "test\\"quotes" -file.out output.bat foo True -path "C:\\with space\\\\"'
+    # Expected value: bar -file.out output.bat -str "test\"quotes" foo true -path "C:\with space\\" (backslashes doubled for jinja)
+    - (mixed_params_again_actual.stdout|from_json).Parameters.AppParameters == 'bar -file.out output.bat -str "test\\"quotes" foo true -path "C:\\with space\\\\"'
 
 - name: remove service
   win_nssm:

--- a/test/integration/targets/win_nssm/tasks/tests.yml
+++ b/test/integration/targets/win_nssm/tasks/tests.yml
@@ -61,7 +61,7 @@
     name: '{{ test_service_name }}'
     application: C:\Windows\System32\cmd.exe
     start_mode: manual
-    dependencies: 'tcpip,dnscache'
+    dependencies: 'tcpip dnscache'
     user: '{{ test_win_nssm_username }}'
     password: '{{ test_win_nssm_password }}'
     stdout_file: '{{ test_win_nssm_path }}\log.txt'

--- a/test/integration/targets/win_nssm/tasks/tests.yml
+++ b/test/integration/targets/win_nssm/tasks/tests.yml
@@ -73,7 +73,7 @@
     - install_start_service.changed == true
     - (install_start_service_actual.stdout|from_json).Exists == true
     - (install_start_service_actual.stdout|from_json).State == 'Running'
-    - (install_service_actual.stdout|from_json).StartMode == 'Auto'
+    - (install_start_service_actual.stdout|from_json).StartMode == 'Auto'
     - (install_start_service_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
 
 - name: install and start service with more parameters

--- a/test/integration/targets/win_nssm/tasks/tests.yml
+++ b/test/integration/targets/win_nssm/tasks/tests.yml
@@ -1,0 +1,21 @@
+---
+- name: install service
+  win_nssm:
+    name: '{{ test_service_name }}'
+    application: 'C:\Windows\System32\cmd.exe'
+    app_parameters_free_form: '-Dcom.test.string=value'
+    state: present
+  register: install_service
+
+- name: get result of install service
+  win_shell: |
+    Write-Host ([bool](Get-Service "{{ test_service_name }}" -ErrorAction SilentlyContinue))
+    nssm get "{{ test_service_name }}" AppParameters
+  register: install_service_actual
+
+- name: assert results of install service
+  assert:
+    that:
+    - install_service.changed == true
+    - install_service_actual.stdout_lines[0] == "True"
+    - install_service_actual.stdout_lines[1] == "-Dcom.test.string=value"

--- a/test/integration/targets/win_nssm/tasks/tests.yml
+++ b/test/integration/targets/win_nssm/tasks/tests.yml
@@ -1,21 +1,147 @@
 ---
+- name: get register cmd that will get service info
+  set_fact:
+    test_service_cmd: |
+      $res = @{}
+      $srvobj = Get-WmiObject Win32_Service -Filter "Name=""$service""" | Select Name,PathName,StartMode,StartName,State
+      if ($srvobj) {
+        $srvobj | Get-Member -MemberType *Property | % { $res.($_.name) = $srvobj.($_.name) }
+        $res.Exists = $true
+        $res.Dependencies = Get-WmiObject -Query "Associators of {Win32_Service.Name=""$service""} Where AssocClass=Win32_DependentService" | select -ExpandProperty Name
+        $res.Parameters = @{}
+        $srvkey = "HKLM:\SYSTEM\CurrentControlSet\Services\$service\Parameters"
+        Get-Item "$srvkey" | Select-Object -ExpandProperty property | % { $res.Parameters.$_ = (Get-ItemProperty -Path "$srvkey" -Name $_).$_}
+      } else {
+        $res.Exists = $false
+      }
+      ConvertTo-Json -InputObject $res -Compress
+
 - name: install service
   win_nssm:
     name: '{{ test_service_name }}'
-    application: 'C:\Windows\System32\cmd.exe'
-    app_parameters_free_form: '-Dcom.test.string=value'
+    application: C:\Windows\System32\cmd.exe
     state: present
   register: install_service
 
 - name: get result of install service
-  win_shell: |
-    Write-Host ([bool](Get-Service "{{ test_service_name }}" -ErrorAction SilentlyContinue))
-    nssm get "{{ test_service_name }}" AppParameters
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
   register: install_service_actual
 
 - name: assert results of install service
   assert:
     that:
     - install_service.changed == true
-    - install_service_actual.stdout_lines[0] == "True"
-    - install_service_actual.stdout_lines[1] == "-Dcom.test.string=value"
+    - (install_service_actual.stdout|from_json).Exists == true
+    - (install_service_actual.stdout|from_json).State == 'Stopped'
+    - (install_service_actual.stdout|from_json).StartMode == 'Auto'
+    - (install_service_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+
+- name: install and start service
+  win_nssm:
+    name: '{{ test_service_name }}'
+    application: C:\Windows\System32\cmd.exe
+    state: started
+  register: install_start_service
+
+- name: get result of install and start service
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: install_start_service_actual
+
+- name: assert results of install and start service
+  assert:
+    that:
+    - install_start_service.changed == true
+    - (install_start_service_actual.stdout|from_json).Exists == true
+    - (install_start_service_actual.stdout|from_json).State == 'Running'
+    - (install_service_actual.stdout|from_json).StartMode == 'Auto'
+    - (install_start_service_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+
+- name: install and start service with more parameters
+  win_nssm:
+    name: '{{ test_service_name }}'
+    application: C:\Windows\System32\cmd.exe
+    start_mode: manual
+    dependencies: 'tcpip,dnscache'
+    user: '{{ test_win_nssm_username }}'
+    password: '{{ test_win_nssm_password }}'
+    stdout_file: '{{ test_win_nssm_path }}\log.txt'
+    stderr_file: '{{ test_win_nssm_path }}\error.txt'
+    state: started
+  register: install_service_complex
+
+- name: get result of install and start service with more parameters
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: install_service_complex_actual
+
+- name: assert results of install and start service with more parameters
+  assert:
+    that:
+    - install_service_complex.changed == true
+    - (install_service_complex_actual.stdout|from_json).Exists == true
+    - (install_service_complex_actual.stdout|from_json).State == 'Running'
+    - (install_service_complex_actual.stdout|from_json).StartMode == 'Manual'
+    - (install_service_complex_actual.stdout|from_json).StartName == '.\\' + test_win_nssm_username
+    - (install_service_complex_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    - (install_service_complex_actual.stdout|from_json).Parameters.AppStdout == test_win_nssm_path + '\\log.txt'
+    - (install_service_complex_actual.stdout|from_json).Parameters.AppStderr == test_win_nssm_path + '\\error.txt'
+    - (install_service_complex_actual.stdout|from_json).Dependencies|length == 2
+    - '"Tcpip" in (install_service_complex_actual.stdout|from_json).Dependencies'
+    - '"Dnscache" in (install_service_complex_actual.stdout|from_json).Dependencies'
+
+- name: install service with free form parameters
+  win_nssm:
+    name: '{{ test_service_name }}'
+    application: C:\Windows\System32\cmd.exe
+    app_parameters_free_form: '-v -Dcom.test.string=value test'
+    state: present
+  register: free_params
+
+- name: get result of install service with free form parameters
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: free_params_actual
+
+- name: assert results of install service with free form parameters
+  assert:
+    that:
+    - free_params.changed == true
+    - (free_params_actual.stdout|from_json).Exists == true
+    - (free_params_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    - (free_params_actual.stdout|from_json).Parameters.AppParameters == "-v -Dcom.test.string=value test"
+
+- name: install service with dict parameters
+  win_nssm:
+    name: '{{ test_service_name }}'
+    application: C:\Windows\System32\cmd.exe
+    app_parameters:
+      foo: true
+      '-file.out': 'output.bat'
+      _: bar
+  register: mixed_params
+
+- name: get result of install service with dict parameters
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: mixed_params_actual
+
+- name: assert results of install service with dict parameters
+  assert:
+    that:
+    - mixed_params.changed == true
+    - (mixed_params_actual.stdout|from_json).Exists == true
+    - (mixed_params_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    - (mixed_params_actual.stdout|from_json).Parameters.AppParameters == "bar -file.out output.bat foo True"
+
+- name: remove service
+  win_nssm:
+    name: '{{ test_service_name }}'
+    state: absent
+  register: remove_service
+
+- name: get result of remove service
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: remove_service_actual
+
+- name: assert results of remove service
+  assert:
+    that:
+    - remove_service.changed == true
+    - (remove_service_actual.stdout|from_json).Exists == false

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -64,7 +64,6 @@ lib/ansible/modules/windows/win_iis_website.ps1 PSUseBOMForUnicodeEncodedFile
 lib/ansible/modules/windows/win_iis_website.ps1 PSUseDeclaredVarsMoreThanAssignments
 lib/ansible/modules/windows/win_mapped_drive.ps1 PSAvoidUsingConvertToSecureStringWithPlainText
 lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingCmdletAliases
-lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingInvokeExpression
 lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingPlainTextForPassword
 lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingUserNameAndPassWordParams
 lib/ansible/modules/windows/win_nssm.ps1 PSUseApprovedVerbs


### PR DESCRIPTION
##### SUMMARY
The win_nssm module is full of bugs and is almost not working at all. This PR adds or changes the following to win_nssm:

- integration tests, including indempotence tests
- fix service not started when `state=started`
- fix error with the `dependencies` option when using a comma-separated list of dependent services
- resolve several non-indempotence issues
- drop support of YAML dict for `app_parameters` option as it's broken since 2.3 release
- add missing space between arguments with `app_parameters`
- fix incorrect argument line with `app_parameters` or `app_parameters_free_form` when a parameter contains spaces, quotes or backslashes
- fix extra space added in argument line with `app_parameters` or `app_parameters_free_form` when a parameter start by a dash and is followed by a period (e.g. `-Dcom.test`)

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
win_nssm

##### ANSIBLE VERSION
```
devel
```

##### ADDITIONAL INFORMATION
It's a bit an all-in-one PR because I tried to write a complete set of tests and get it to work.
There are still some issues on special cases that are not solved here and may be dealt with later (for example, it's not possible to set user to LocalSystem without password, as the module throw an error if no password is given).
The module also still lacks check-mode support, but this may be part of another PR after this one.

Fixes #25265
Fixes #44079
Fixes #35442
Fixes #38557
Fixes #20625
And other issues not yet reported
