### PR TITLE
test: cloudstack-test-container v1.2.0

### DIFF
--- a/test/runner/lib/cloud/cs.py
+++ b/test/runner/lib/cloud/cs.py
@@ -53,7 +53,7 @@ class CsCloudProvider(CloudProvider):
         super(CsCloudProvider, self).__init__(args, config_extension='.ini')
 
         # The simulator must be pinned to a specific version to guarantee CI passes with the version used.
-        self.image = 'quay.io/ansible/cloudstack-test-container:1.1.0'
+        self.image = 'quay.io/ansible/cloudstack-test-container:1.2.0'
         self.container_name = ''
         self.endpoint = ''
         self.host = ''
@@ -163,7 +163,7 @@ class CsCloudProvider(CloudProvider):
             docker_pull(self.args, self.image)
             docker_run(self.args, self.image, ['-d', '-p', '8888:8888', '--name', self.container_name])
             if not self.args.explain:
-                display.notice('The CloudStack simulator will probably be ready in 5 - 10 minutes.')
+                display.notice('The CloudStack simulator will probably be ready in 2 - 4 minutes.')
 
         container_id = get_docker_container_id()
 
@@ -233,7 +233,7 @@ class CsCloudProvider(CloudProvider):
             except SubprocessError:
                 pass
 
-            time.sleep(30)
+            time.sleep(10)
 
         raise ApplicationError('Timeout waiting for CloudStack service.')
 
@@ -255,7 +255,7 @@ class CsCloudProvider(CloudProvider):
                 except HttpError as ex:
                     display.error(ex)
 
-            time.sleep(30)
+            time.sleep(10)
 
         raise ApplicationError('Timeout waiting for CloudStack credentials.')
 


### PR DESCRIPTION
##### SUMMARY
new cloudstack test container addresses issue with simulator not in supported hypervisor list, see #37015 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
cloudstack

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
