### PR TITLE
Improve error condition handling for dnf module

### DIFF
--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -87,12 +87,30 @@ class YumDnf(with_metaclass(ABCMeta, object)):
 
         # It's possible someone passed a comma separated string since it used
         # to be a string type, so we should handle that
-        if self.enablerepo and len(self.enablerepo) == 1 and ',' in self.enablerepo:
-            self.enablerepo = self.module.params['enablerepo'].split(',')
-        if self.disablerepo and len(self.disablerepo) == 1 and ',' in self.disablerepo:
-            self.disablerepo = self.module.params['disablerepo'].split(',')
-        if self.exclude and len(self.exclude) == 1 and ',' in self.exclude:
-            self.exclude = self.module.params['exclude'].split(',')
+        self.names = self.listify_comma_sep_strings_in_list(self.names)
+        self.disablerepo = self.listify_comma_sep_strings_in_list(self.disablerepo)
+        self.enablerepo = self.listify_comma_sep_strings_in_list(self.enablerepo)
+        self.exclude = self.listify_comma_sep_strings_in_list(self.exclude)
+
+    def listify_comma_sep_strings_in_list(self, some_list):
+        """
+        method to accept a list of strings as the parameter, find any strings
+        in that list that are comma separated, remove them from the list and add
+        their comma separated elements to the original list
+        """
+        new_list = []
+        remove_from_original_list = []
+        for element in some_list:
+            if ',' in element:
+                remove_from_original_list.append(element)
+                new_list.extend([e.strip() for e in element.split(',')])
+
+        for element in remove_from_original_list:
+            some_list.remove(element)
+
+        some_list.extend(new_list)
+
+        return some_list
 
     @abstractmethod
     def run(self):

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -461,7 +461,7 @@
     that:
         - "dnf_result is failed"
         - "'non-existent-rpm' in dnf_result['failures'][0]"
-        - "'no package matched' in dnf_result['failures'][0]"
+        - "'No package non-existent-rpm available' in dnf_result['failures'][0]"
         - "'Failed to install some of the specified packages' in dnf_result['msg']"
 
 - name: use latest to install httpd


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
- Fix comma separated list handling for package names
- Fix error message for unavailable/unknown package install attempt
- Fix pkg install result output generation

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
dnf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.a1.post0 (modules/dnf ca9e80847f) last updated 2018/08/28 09:47:15 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


