### PR TITLE
Cross-reference win_reboot and reboot

### DIFF
--- a/lib/ansible/modules/system/reboot.py
+++ b/lib/ansible/modules/system/reboot.py
@@ -53,17 +53,19 @@ options:
       - Message to display to users before reboot.
     default: Reboot initiated by Ansible
     type: str
+notes:
+    - For Windows targets, use the M(win_reboot) module instead.
 author:
     - Matt Davis (@nitzmahone)
     - Sam Doran (@samdoran)
 '''
 
 EXAMPLES = r'''
-# Unconditionally reboot the machine with all defaults
-- reboot:
+- name: Unconditionally reboot the machine with all defaults
+  reboot:
 
-# Reboot a slow machine that might have lots of updates to apply
-- reboot:
+- name: Reboot a slow machine that might have lots of updates to apply
+  reboot:
     reboot_timeout: 3600
 '''
 

--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -60,6 +60,7 @@ options:
     default: Reboot initiated by Ansible
 notes:
 - If a shutdown was already scheduled on the system, C(win_reboot) will abort the scheduled shutdown and enforce its own shutdown.
+- For non-Windows targets, use the M(reboot) module instead.
 author:
     - Matt Davis (@nitzmahone)
 '''


### PR DESCRIPTION
##### SUMMARY
Just like we do for other windows vs non-windows modules.

Also ensure that examples have a proper name set (as we recommend to users).

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
reboot and win_reboot

##### ANSIBLE VERSION
v2.7