### PR TITLE
docker_container: allow to configure comparison for existing containers

### DIFF
--- a/changelogs/fragments/44789-docker_container-comparisons.yaml
+++ b/changelogs/fragments/44789-docker_container-comparisons.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- "The restart/idempotency behavior of docker_container can now be controlled with the new comparisons parameter."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -156,6 +156,7 @@ options:
         container to requested configuration. The evaluation includes the image version. If
         the image version in the registry does not match the container, the container will be
         recreated. Stop this behavior by setting C(ignore_image) to I(True).
+      - I(Warning:) This option is ignored if C(image) or C(*) is used for the C(comparisons) option.
     type: bool
     default: 'no'
     version_added: "2.2"
@@ -2251,6 +2252,9 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
                     comparisons[key_main]['comparison'] = value
                 else:
                     self.fail("Unknown comparison mode '%s'!" % value)
+        # Check legacy values
+        if self.module.params['ignore_image'] and comparisons['image']['comparison'] != 'ignore':
+            self.module.warn('The ignore_image option has been overridden by the comparisons option!')
         self.comparisons = comparisons
 
     def __init__(self, **kwargs):

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -682,7 +682,7 @@ try:
     else:
         from docker.utils.types import Ulimit, LogConfig
     from ansible.module_utils.docker_common import docker_version
-except:
+except Exception as dummy:
     # missing docker-py handled in ansible.module_utils.docker
     pass
 

--- a/test/integration/targets/docker_container/tasks/tests/comparisons.yml
+++ b/test/integration/targets/docker_container/tasks/tests/comparisons.yml
@@ -1,0 +1,365 @@
+---
+- name: Registering container name
+  set_fact:
+    cname: "{{ cname_prefix ~ '-comparisons' }}"
+- name: Registering container name
+  set_fact:
+    cnames: "{{ cnames }} + [cname]"
+
+####################################################################
+## value ###########################################################
+####################################################################
+
+- name: value
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    hostname: example.com
+  register: value_1
+
+- name: value (change, ignore)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    hostname: example.org
+    comparisons:
+      hostname: ignore
+  register: value_2
+
+- name: value (change, strict)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    hostname: example.org
+    stop_timeout: 1
+    comparisons:
+      hostname: strict
+  register: value_3
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    stop_timeout: 1
+
+- assert:
+    that:
+    - value_1 is changed
+    - value_2 is not changed
+    - value_3 is changed
+
+####################################################################
+## list ############################################################
+####################################################################
+
+- name: list
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    dns_servers:
+    - 1.1.1.1
+    - 8.8.8.8
+  register: list_1
+
+- name: list (change, ignore)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    dns_servers:
+    - 9.9.9.9
+    comparisons:
+      dns_servers: ignore
+  register: list_2
+
+- name: list (change, strict)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    dns_servers:
+    - 9.9.9.9
+    comparisons:
+      dns_servers: strict
+    stop_timeout: 1
+  register: list_3
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    stop_timeout: 1
+
+- assert:
+    that:
+    - list_1 is changed
+    - list_2 is not changed
+    - list_3 is changed
+
+####################################################################
+## set #############################################################
+####################################################################
+
+- name: set
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    groups:
+    - 1010
+    - 1011
+  register: set_1
+
+- name: set (change, ignore)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    groups:
+    - 1010
+    - 1011
+    - 1012
+    comparisons:
+      groups: ignore
+  register: set_2
+
+- name: set (change, allow_more_present)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    groups:
+    - 1010
+    - 1011
+    - 1012
+    comparisons:
+      groups: allow_more_present
+    stop_timeout: 1
+  register: set_3
+
+- name: set (change, allow_more_present)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    groups:
+    - 1010
+    - 1012
+    comparisons:
+      groups: allow_more_present
+    stop_timeout: 1
+  register: set_4
+
+- name: set (change, strict)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    groups:
+    - 1010
+    - 1012
+    comparisons:
+      groups: strict
+    stop_timeout: 1
+  register: set_5
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    stop_timeout: 1
+
+- assert:
+    that:
+    - set_1 is changed
+    - set_2 is not changed
+    - set_3 is changed
+    - set_4 is not changed
+    - set_5 is changed
+
+####################################################################
+## set(dict) #######################################################
+####################################################################
+
+- name: set(dict)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    devices:
+    - "/dev/random:/dev/virt-random:rwm"
+    - "/dev/urandom:/dev/virt-urandom:rwm"
+  register: set_dict_1
+
+- name: set(dict) (change, ignore)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    devices:
+    - "/dev/random:/dev/virt-random:rwm"
+    - "/dev/urandom:/dev/virt-urandom:rwm"
+    - "/dev/null:/dev/virt-null:rwm"
+    comparisons:
+      devices: ignore
+  register: set_dict_2
+
+- name: set(dict) (change, allow_more_present)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    devices:
+    - "/dev/random:/dev/virt-random:rwm"
+    - "/dev/urandom:/dev/virt-urandom:rwm"
+    - "/dev/null:/dev/virt-null:rwm"
+    comparisons:
+      devices: allow_more_present
+    stop_timeout: 1
+  register: set_dict_3
+
+- name: set(dict) (change, allow_more_present)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    devices:
+    - "/dev/random:/dev/virt-random:rwm"
+    - "/dev/null:/dev/virt-null:rwm"
+    comparisons:
+      devices: allow_more_present
+    stop_timeout: 1
+  register: set_dict_4
+
+- name: set(dict) (change, strict)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    devices:
+    - "/dev/random:/dev/virt-random:rwm"
+    - "/dev/null:/dev/virt-null:rwm"
+    comparisons:
+      devices: strict
+    stop_timeout: 1
+  register: set_dict_5
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    stop_timeout: 1
+
+- assert:
+    that:
+    - set_dict_1 is changed
+    - set_dict_2 is not changed
+    - set_dict_3 is changed
+    - set_dict_4 is not changed
+    - set_dict_5 is changed
+
+####################################################################
+## dict ############################################################
+####################################################################
+
+- name: dict
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    labels:
+      ansible.test.1: hello
+      ansible.test.2: world
+  register: dict_1
+
+- name: dict (change, ignore)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    labels:
+      ansible.test.1: hello
+      ansible.test.2: world
+      ansible.test.3: ansible
+    comparisons:
+      labels: ignore
+  register: dict_2
+
+- name: dict (change, allow_more_present)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    labels:
+      ansible.test.1: hello
+      ansible.test.2: world
+      ansible.test.3: ansible
+    comparisons:
+      labels: allow_more_present
+    stop_timeout: 1
+  register: dict_3
+
+- name: dict (change, allow_more_present)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    labels:
+      ansible.test.1: hello
+      ansible.test.3: ansible
+    comparisons:
+      labels: allow_more_present
+    stop_timeout: 1
+  register: dict_4
+
+- name: dict (change, strict)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    labels:
+      ansible.test.1: hello
+      ansible.test.3: ansible
+    comparisons:
+      labels: strict
+    stop_timeout: 1
+  register: dict_5
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    stop_timeout: 1
+
+- assert:
+    that:
+    - dict_1 is changed
+    - dict_2 is not changed
+    - dict_3 is changed
+    - dict_4 is not changed
+    - dict_5 is changed

--- a/test/integration/targets/docker_container/tasks/tests/comparisons.yml
+++ b/test/integration/targets/docker_container/tasks/tests/comparisons.yml
@@ -363,3 +363,85 @@
     - dict_3 is changed
     - dict_4 is not changed
     - dict_5 is changed
+
+####################################################################
+## wildcard ########################################################
+####################################################################
+
+- name: Pull hello-world image to make sure wildcard_2 test succeeds
+  # If the image isn't there, it will pull it and return 'changed'.
+  docker_image:
+    name: hello-world
+    pull: true
+
+- name: wildcard
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    hostname: example.com
+    labels:
+      ansible.test.1: hello
+      ansible.test.2: world
+      ansible.test.3: ansible
+  register: wildcard_1
+
+- name: wildcard (change, ignore)
+  docker_container:
+    image: hello-world
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    hostname: example.org
+    labels:
+      ansible.test.1: hello
+      ansible.test.4: ignore
+    comparisons:
+      '*': ignore
+  register: wildcard_2
+
+- name: wildcard (change, strict)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    hostname: example.org
+    stop_timeout: 1
+    labels:
+      ansible.test.1: hello
+      ansible.test.2: world
+      ansible.test.3: ansible
+    comparisons:
+      '*': strict
+  register: wildcard_3
+
+- name: wildcard (no change, strict)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    hostname: example.org
+    stop_timeout: 1
+    labels:
+      ansible.test.1: hello
+      ansible.test.2: world
+      ansible.test.3: ansible
+    comparisons:
+      '*': strict
+  register: wildcard_4
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    stop_timeout: 1
+
+- assert:
+    that:
+    - wildcard_1 is changed
+    - wildcard_2 is not changed
+    - wildcard_3 is changed
+    - wildcard_4 is not changed


### PR DESCRIPTION
##### SUMMARY
Adds a new option `comparison` as [described here](https://github.com/ansible/ansible/issues/43679#issuecomment-416036723), which allows fine-grained configuration of how to do comparisons which decide whether a container will be recreated/restarted or updated.

Fixes #23066, fixes #25974, fixes #43679, supersedes #44311. Also fixes the bug that commands (resp. entrypoints) where one is a subset of the other, but which are not equal, do not trigger a restart.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.7.0
```

##### ADDITIONAL INFORMATION
This is a first implementation. It does pass some basic tests, but I haven't tested it with all the different options you can throw at `docker_container` yet.
