### PR TITLE
Deprecates bigip_facts

### DIFF
--- a/lib/ansible/modules/network/f5/_bigip_facts.py
+++ b/lib/ansible/modules/network/f5/_bigip_facts.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''
@@ -32,6 +32,13 @@ notes:
   - This module is deprecated. Use the C(bigip_device_facts) module instead.
 requirements:
   - bigsuds
+deprecated:
+  removed_in: '2.11'
+  alternative: bigip_device_facts
+  why: >
+    The bigip_facts module relies on SOAP to communicate with the BIG-IP,
+    and has a large amount of code that does not conform to existing F5 standards.
+    The M(bigip_device_facts) module is easier to maintain and use.
 options:
   session:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This module has been superceded by the bigip_device_facts module

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
bigip_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = /here/test/integration/ansible.cfg
  configured module search path = ['/here/library/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.6 (default, Jul 17 2018, 11:12:33) [GCC 6.3.0 20170516]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
