### PR TITLE
test: cs_template: fix missing cross_zone in tests

### DIFF
--- a/test/integration/targets/cs_template/tasks/test2.yml
+++ b/test/integration/targets/cs_template/tasks/test2.yml
@@ -4,6 +4,7 @@
     name: ansible-template-test2
     display_text: first template
     state: absent
+    cross_zones: yes
     template_find_options: display_text
   register: template
 - name: verify setup template first template
@@ -16,6 +17,7 @@
     name: ansible-template-test2
     display_text: second template
     state: absent
+    cross_zones: yes
     template_find_options: display_text
   register: template
 - name: verify setup template second template
@@ -66,6 +68,7 @@
   cs_template:
     name: ansible-template-test2
     state: absent
+    cross_zones: yes
   register: template
   ignore_errors: yes
 - name: verify test multiple template same name absent without find options
@@ -146,6 +149,7 @@
     name: ansible-template-test2
     display_text: first template
     state: absent
+    cross_zones: yes
     template_find_options: display_text
   register: template
 - name: verify test delete first template
@@ -163,6 +167,7 @@
     name: ansible-template-test2
     display_text: second template
     state: absent
+    cross_zones: yes
     template_find_options: display_text
   register: template
 - name: verify test delete second template


### PR DESCRIPTION
##### SUMMARY
fix missing cross_zones in some tests, makes it reliable (e.g. deletion of template was in one zone only). follow up of  #37015 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
cs_template

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
