### PR TITLE
win_psexec: fix arg handling when command contains multiple args (#44797)

### DIFF
--- a/changelogs/fragments/win_psexec_command_arg.yaml
+++ b/changelogs/fragments/win_psexec_command_arg.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_psexec - changed code to not escape the command option when building the args - https://github.com/ansible/ansible/issues/43839

--- a/lib/ansible/modules/windows/win_psexec.ps1
+++ b/lib/ansible/modules/windows/win_psexec.ps1
@@ -106,9 +106,12 @@ If ($extra_opts) {
 }
 
 $arguments += "-accepteula"
-$arguments += $command
 
 $argument_string = Argv-ToString -arguments $arguments
+
+# add the command at the end of the argument string, we don't want to escape
+# that as psexec doesn't expect it to be one arg
+$argument_string += " $command"
 
 $start_datetime = [DateTime]::UtcNow
 $result.psexec_command = "$executable $argument_string"

--- a/test/integration/targets/win_psexec/tasks/main.yml
+++ b/test/integration/targets/win_psexec/tasks/main.yml
@@ -67,6 +67,18 @@
 #    - whoami_as_elevated.rc == 0
 #    - whoami_as_elevated.stdout|lower == '{{ ansible_hostname|lower }}\{{ ansible_user_id|lower }}'
 
+- name: Run command with multiple arguments
+  win_psexec:
+    command: powershell.exe -NonInteractive "exit 1"
+  ignore_errors: yes
+  register: whoami_multiple_args
+
+- name: Test command with multiple argumetns
+  assert:
+    that:
+    - whoami_multiple_args.rc == 1
+    - whoami_multiple_args.psexec_command == "psexec.exe -accepteula powershell.exe -NonInteractive \"exit 1\""
+
 - name: Remove sysinternals from PATH
   win_path:
     name: PATH


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/44797

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_psexec

##### ANSIBLE VERSION
```
2.6
```