### PR TITLE
win_disk_image: return all mount paths in return value

### DIFF
--- a/changelogs/fragments/win_disk_image-mount-paths.yaml
+++ b/changelogs/fragments/win_disk_image-mount-paths.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+- win_disk_image - return a list of mount paths with the return value ``mount_paths``, this will always be a list and contain all mount points in an image
+deprecated_features:
+- win_disk_image - the return value ``mount_path`` is deprecated and will be removed in 2.11, this can be accessed through ``mount_paths[0]`` instead.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -196,6 +196,8 @@ Noteworthy module changes
 
 * The ``interface_name`` module option for ``na_ontap_net_vlan`` has been removed and should be removed from your playbooks
 
+* The ``win_disk_image`` module has deprecated the return value ``mount_path``, use ``mount_paths[0]`` instead. This will
+  be removed in Ansible 2.11.
 
 Plugins
 =======

--- a/lib/ansible/modules/windows/win_disk_image.py
+++ b/lib/ansible/modules/windows/win_disk_image.py
@@ -32,10 +32,15 @@ author:
 
 RETURN = r'''
 mount_path:
-    description: filesystem path where the target image is mounted
+    description: filesystem path where the target image is mounted, this has been deprecated in favour of C(mount_paths)
     returned: when C(state) is C(present)
     type: string
     sample: F:\
+mount_paths:
+    description: a list of filesystem paths mounted from the target image
+    returned: when C(state) is C(present)
+    type: list
+    sample: [ 'E:\', 'F:\' ]
 '''
 
 EXAMPLES = r'''
@@ -48,7 +53,7 @@ EXAMPLES = r'''
 
 - name: Run installer from mounted iso
   win_package:
-    path: '{{ disk_image_out.mount_path }}setup\setup.exe'
+    path: '{{ disk_image_out.mount_paths[0] }}setup\setup.exe'
     product_id: 35a4e767-0161-46b0-979f-e61f282fee21
     state: present
 


### PR DESCRIPTION
##### SUMMARY
If a VHD(X) contains multiple partitions the return value `mount_path` always references the first partition. This PR deprecates `mount_path` and adds a new return value `mount_paths` which returns a list of paths. In this case a user can access both the original value with `{{ res.mount_paths[0] }}` and now see all the other partition mounts.

Supersedes https://github.com/ansible/ansible/pull/41101

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_disk_image

##### ANSIBLE VERSION
```
devel
```