### PR TITLE
windows async: return pipeline output in case of a failure

### DIFF
--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -1417,6 +1417,9 @@ Function Run($payload) {
 
             $result.failed = $true
             $result.msg = "failed to parse module output: $excep"
+            # return the output back to Ansible to help with debugging errors
+            $result.stdout = $job_output | Out-String
+            $result.stderr = $job_error | Out-String
         }
 
         # TODO: determine success/fail, or always include stderr if nonempty?


### PR DESCRIPTION
##### SUMMARY
If an async process fails in an expectant way there may be no job output (or not a valid output) for the async watchdog to parse. To help with troubleshooting these issues this PR will return both the output and error streams from the async task which should help us identify what may have gone wrong.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
powershell.py

##### ANSIBLE VERSION
```
devel
```