### PR TITLE
Provide NETCONF support for network_os "dellos10"

### DIFF
--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -201,6 +201,7 @@ logging.getLogger('ncclient').setLevel(logging.INFO)
 NETWORK_OS_DEVICE_PARAM_MAP = {
     "nxos": "nexus",
     "ios": "default",
+    "dellos10": "default",
     "sros": "alu",
     "ce": "huawei"
 }


### PR DESCRIPTION
##### SUMMARY
This change enables to have default NETCONF support for "dellos10" network_os.

##### ISSUE TYPE
 - Bugfix Pull Request(Enhancement)

##### COMPONENT NAME
ansible/lib/ansible/plugins/connection/netconf.py

##### ANSIBLE VERSION
```
ansible 2.7.0.dev0 (devel 899eddf9e4) last updated 2018/08/29 15:38:53 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admin/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /home/admin/abirami/2.7ansible-dev/ansible/lib/ansible
  executable location = /home/admin/abirami/2.7ansible-dev/ansible/bin/ansible
  python version = 2.7.9 (default, Apr  2 2015, 15:33:21) [GCC 4.9.2]
```


