### PR TITLE
[2.6] Set Default values correctly for docker variables

### DIFF
--- a/changelogs/fragments/42641-44812-docker-env-variables.yaml
+++ b/changelogs/fragments/42641-44812-docker-env-variables.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "The docker_* modules respect the DOCKER_* environment variables again (https://github.com/ansible/ansible/pull/42641)."

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -23,7 +23,7 @@ import sys
 import copy
 from distutils.version import LooseVersion
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE, BOOLEANS_FALSE
 
@@ -83,16 +83,16 @@ MIN_DOCKER_VERSION = "1.7.0"
 DEFAULT_TIMEOUT_SECONDS = 60
 
 DOCKER_COMMON_ARGS = dict(
-    docker_host=dict(type='str', aliases=['docker_url'], default=DEFAULT_DOCKER_HOST),
-    tls_hostname=dict(type='str', default=DEFAULT_TLS_HOSTNAME),
-    api_version=dict(type='str', aliases=['docker_api_version'], default='auto'),
-    timeout=dict(type='int', default=DEFAULT_TIMEOUT_SECONDS),
+    docker_host=dict(type='str', aliases=['docker_url'], default=DEFAULT_DOCKER_HOST, fallback=(env_fallback, ['DOCKER_HOST'])),
+    tls_hostname=dict(type='str', default=DEFAULT_TLS_HOSTNAME, fallback=(env_fallback, ['DOCKER_TLS_HOSTNAME'])),
+    api_version=dict(type='str', aliases=['docker_api_version'], default='auto', fallback=(env_fallback, ['DOCKER_API_VERSION'])),
+    timeout=dict(type='int', default=DEFAULT_TIMEOUT_SECONDS, fallback=(env_fallback, ['DOCKER_TIMEOUT'])),
     cacert_path=dict(type='str', aliases=['tls_ca_cert']),
     cert_path=dict(type='str', aliases=['tls_client_cert']),
     key_path=dict(type='str', aliases=['tls_client_key']),
-    ssl_version=dict(type='str'),
-    tls=dict(type='bool', default=DEFAULT_TLS),
-    tls_verify=dict(type='bool', default=DEFAULT_TLS_VERIFY),
+    ssl_version=dict(type='str', fallback=(env_fallback, ['DOCKER_SSL_VERSION'])),
+    tls=dict(type='bool', default=DEFAULT_TLS, fallback=(env_fallback, ['DOCKER_TLS'])),
+    tls_verify=dict(type='bool', default=DEFAULT_TLS_VERIFY, fallback=(env_fallback, ['DOCKER_TLS_VERIFY'])),
     debug=dict(type='bool', default=False)
 )
 
@@ -252,7 +252,7 @@ class AnsibleDockerClient(Client):
             docker_host=self._get_value('docker_host', params['docker_host'], 'DOCKER_HOST',
                                         DEFAULT_DOCKER_HOST),
             tls_hostname=self._get_value('tls_hostname', params['tls_hostname'],
-                                         'DOCKER_TLS_HOSTNAME', 'localhost'),
+                                         'DOCKER_TLS_HOSTNAME', DEFAULT_TLS_HOSTNAME),
             api_version=self._get_value('api_version', params['api_version'], 'DOCKER_API_VERSION',
                                         'auto'),
             cacert_path=self._get_value('cacert_path', params['cacert_path'], 'DOCKER_CERT_PATH', None),

--- a/lib/ansible/utils/module_docs_fragments/docker.py
+++ b/lib/ansible/utils/module_docs_fragments/docker.py
@@ -26,51 +26,71 @@ options:
             - "The URL or Unix socket path used to connect to the Docker API. To connect to a remote host, provide the
               TCP connection string. For example, 'tcp://192.0.2.23:2376'. If TLS is used to encrypt the connection,
               the module will automatically replace 'tcp' in the connection URL with 'https'."
+            - If the value is not specified in the task, the value of environment variable C(DOCKER_HOST) will be used
+              instead. If the environment variable is not set, the default value will be used.
         default: "unix://var/run/docker.sock"
         aliases:
             - docker_url
     tls_hostname:
         description:
             - When verifying the authenticity of the Docker Host server, provide the expected name of the server.
+            - If the value is not specified in the task, the value of environment variable C(DOCKER_TLS_HOSTNAME) will
+              be used instead. If the environment variable is not set, the default value will be used.
         default: localhost
     api_version:
         description:
             - The version of the Docker API running on the Docker Host. Defaults to the latest version of the API
               supported by docker-py.
+            - If the value is not specified in the task, the value of environment variable C(DOCKER_API_VERSION) will be
+              used instead. If the environment variable is not set, the default value will be used.
         default: 'auto'
         aliases:
             - docker_api_version
     timeout:
         description:
             - The maximum amount of time in seconds to wait on a response from the API.
+            - If the value is not specified in the task, the value of environment variable C(DOCKER_TIMEOUT) will be used
+              instead. If the environment variable is not set, the default value will be used.
         default: 60
     cacert_path:
         description:
             - Use a CA certificate when performing server verification by providing the path to a CA certificate file.
+            - If the value is not specified in the task and the environment variable C(DOCKER_CERT_PATH) is set,
+              the file C(ca.pem) from the directory specified in the environment variable C(DOCKER_CERT_PATH) will be used.
         aliases:
             - tls_ca_cert
     cert_path:
         description:
             - Path to the client's TLS certificate file.
+            - If the value is not specified in the task and the environment variable C(DOCKER_CERT_PATH) is set,
+              the file C(cert.pem) from the directory specified in the environment variable C(DOCKER_CERT_PATH) will be used.
         aliases:
             - tls_client_cert
     key_path:
         description:
             - Path to the client's TLS key file.
+            - If the value is not specified in the task and the environment variable C(DOCKER_CERT_PATH) is set,
+              the file C(key.pem) from the directory specified in the environment variable C(DOCKER_CERT_PATH) will be used.
         aliases:
             - tls_client_key
     ssl_version:
         description:
             - Provide a valid SSL version number. Default value determined by ssl.py module.
+            - If the value is not specified in the task, the value of environment variable C(DOCKER_SSL_VERSION) will be
+              used instead.
     tls:
         description:
             -  Secure the connection to the API by using TLS without verifying the authenticity of the Docker host
                server.
+            - If the value is not specified in the task, the value of environment variable C(DOCKER_TLS) will be used
+              instead. If the environment variable is not set, the default value will be used.
         default: false
         type: bool
     tls_verify:
         description:
             - Secure the connection to the API by using TLS and verifying the authenticity of the Docker host server.
+            - If the value is not specified in the task, the value of environment variable C(DOCKER_TLS_VERIFY) will be
+              used instead. If the environment variable is not set, the default value will be used.
         default: false
         type: bool
     debug:


### PR DESCRIPTION
##### SUMMARY
Backport of #42641 and #44812: now the `docker_*` modules use the `DOCKER_*` environment variables again. (Fixes #43176.)

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/docker_common.py
lib/ansible/utils/module_docs_fragments/docker.py

##### ANSIBLE VERSION
```
2.6.3
```
