### PR TITLE
Add delete_on_termination to all EC2 root volumes

### DIFF
--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/block_devices.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/block_devices.yml
@@ -12,6 +12,9 @@
     image_id: "{{ ec2_ami_image[aws_region] }}"
     vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
     volumes:
+    - device_name: /dev/sda1
+      ebs:
+        delete_on_termination: true
     - device_name: /dev/sdb
       ebs:
         volume_size: 20

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/cpu_options.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/cpu_options.yml
@@ -18,6 +18,10 @@
     cpu_options:
         core_count: 1
         threads_per_core: 1
+    volumes:
+    - device_name: /dev/sda1
+      ebs:
+        delete_on_termination: true
     <<: *aws_connection_info
   register: instance_creation
 
@@ -38,6 +42,10 @@
       TestId: "{{ resource_prefix }}"
     vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
     instance_type: c4.large
+    volumes:
+    - device_name: /dev/sda1
+      ebs:
+        delete_on_termination: true
     cpu_options:
         core_count: 1
         threads_per_core: 2

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/default_vpc_tests.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/default_vpc_tests.yml
@@ -14,6 +14,10 @@
       TestId: "{{ resource_prefix }}"
     security_groups: "{{ sg.group_id }}"
     instance_type: t2.micro
+    volumes:
+    - device_name: /dev/sda1
+      ebs:
+        delete_on_termination: true
     <<: *aws_connection_info
   register: in_default_vpc
 - name: Terminate instance

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/external_resource_attach.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/external_resource_attach.yml
@@ -37,6 +37,10 @@
     availability_zone: '{{ aws_region }}b'
     tags:
       TestId: "{{ resource_prefix }}"
+    volumes:
+    - device_name: /dev/sda1
+      ebs:
+        delete_on_termination: true
     instance_type: t2.micro
     <<: *aws_connection_info
   register: in_test_vpc

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/iam_instance_role.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/iam_instance_role.yml
@@ -32,11 +32,15 @@
 
     - name: Make instance with an instance_role
       ec2_instance:
-        name: "{{ resource_prefix }}-test-default-vpc"
+        name: "{{ resource_prefix }}-test-instance-role"
         image_id: "{{ ec2_ami_image[aws_region] }}"
         security_groups: "{{ sg.group_id }}"
         instance_type: t2.micro
         instance_role: "{{ resource_prefix }}-test-policy"
+        volumes:
+        - device_name: /dev/sda1
+          ebs:
+            delete_on_termination: true
         <<: *aws_connection_info
       register: instance_with_role
 
@@ -46,7 +50,7 @@
 
     - name: Update instance with new instance_role
       ec2_instance:
-        name: "{{ resource_prefix }}-test-default-vpc"
+        name: "{{ resource_prefix }}-test-instance-role"
         image_id: "{{ ec2_ami_image[aws_region] }}"
         security_groups: "{{ sg.group_id }}"
         instance_type: t2.micro

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/tags_and_vpc_settings.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/tags_and_vpc_settings.yml
@@ -22,6 +22,10 @@
       source_dest_check: false
     vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
     instance_type: t2.micro
+    volumes:
+    - device_name: /dev/sda1
+      ebs:
+        delete_on_termination: true
     <<: *aws_connection_info
   register: in_test_vpc
 

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/termination_protection.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/termination_protection.yml
@@ -16,6 +16,10 @@
     vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
     termination_protection: true
     instance_type: t2.micro
+    volumes:
+    - device_name: /dev/sda1
+      ebs:
+        delete_on_termination: true
     <<: *aws_connection_info
   register: in_test_vpc
 - name: Try to terminate the instance


### PR DESCRIPTION
##### SUMMARY
Not terminating volumes on instance deletion causes
unwanted costs

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_instance

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.a1.post0 (devel ed2cd40a5b) last updated 2018/08/29 20:46:42 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
