### PR TITLE
K8s retry merge

### DIFF
--- a/lib/ansible/modules/clustering/k8s/k8s.py
+++ b/lib/ansible/modules/clustering/k8s/k8s.py
@@ -49,10 +49,12 @@ options:
       want to use C(merge) if you see "strategic merge patch format is not supported"
     - See U(https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment)
     - Requires openshift >= 0.6.2
+    - If more than one merge_type is given, the merge_types will be tried in order
     choices:
     - json
     - merge
     - strategic-merge
+    type: list
     version_added: "2.7"
 
 requirements:

--- a/test/integration/targets/k8s/files/crd-resource.yml
+++ b/test/integration/targets/k8s/files/crd-resource.yml
@@ -1,0 +1,20 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: acme-crt
+spec:
+  secretName: acme-crt-secret
+  dnsNames:
+  - foo.example.com
+  - bar.example.com
+  acme:
+    config:
+    - ingressClass: nginx
+      domains:
+      - foo.example.com
+      - bar.example.com
+  issuerRef:
+    name: letsencrypt-prod
+    # We can reference ClusterIssuers by changing the kind here.
+    # The default value is Issuer (i.e. a locally namespaced Issuer)
+    kind: Issuer

--- a/test/integration/targets/k8s/files/setup-crd.yml
+++ b/test/integration/targets/k8s/files/setup-crd.yml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.certmanager.k8s.io
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: Certificate
+    plural: certificates
+    shortNames:
+      - cert
+      - certs

--- a/test/integration/targets/k8s/tasks/main.yml
+++ b/test/integration/targets/k8s/tasks/main.yml
@@ -1,292 +1,402 @@
 # TODO: This is the only way I could get the kubeconfig, I don't know why. Running the lookup outside of debug seems to return an empty string
-- debug: msg={{ lookup('env', 'K8S_AUTH_KUBECONFIG') }}
-  register: kubeconfig
+#- debug: msg={{ lookup('env', 'K8S_AUTH_KUBECONFIG') }}
+#  register: kubeconfig
 
 # Kubernetes resources
-- name: Create a namespace
-  k8s:
-    name: testing
-    kind: namespace
-  register: output
 
-- debug: msg={{ lookup("k8s", kind="Namespace", api_version="v1", resource_name='testing', kubeconfig=kubeconfig.msg) }}
+- block:
+    - name: Create a namespace
+      k8s:
+        name: testing
+        kind: namespace
+      register: output
 
-- name: show output
-  debug:
-    var: output
+    - name: show output
+      debug:
+        var: output
 
-- name: Create a service
-  k8s:
-    state: present
-    resource_definition: &svc
-      apiVersion: v1
-      kind: Service
-      metadata:
-        name: web
-        namespace: testing
-        labels:
-          app: galaxy
-          service: web
-      spec:
-        selector:
-          app: galaxy
-          service: web
-        ports:
-        - protocol: TCP
-          targetPort: 8000
-          name: port-8000-tcp
-          port: 8000
-  register: output
-
-- name: show output
-  debug:
-    var: output
-
-- name: Create the service again
-  k8s:
-    state: present
-    resource_definition: *svc
-  register: output
-
-- name: Service creation should be idempotent
-  assert:
-    that: not output.changed
-
-- name: Create PVC
-  k8s:
-    state: present
-    inline: &pvc
-      apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
-        name: elastic-volume
-        namespace: testing
-      spec:
-        resources:
-          requests:
-            storage: 5Gi
-        accessModes:
-        - ReadWriteOnce
-
-- name: Show output
-  debug:
-    var: output
-
-- name: Create the PVC again
-  k8s:
-    state: present
-    inline: *pvc
-
-- name: PVC creation should be idempotent
-  assert:
-    that: not output.changed
-
-- name: Create deployment
-  k8s:
-    state: present
-    inline: &deployment
-      apiVersion: apps/v1beta1
-      kind: Deployment
-      metadata:
-        name: elastic
-        labels:
-          app: galaxy
-          service: elastic
-        namespace: testing
-      spec:
-        template:
+    - name: Create a service
+      k8s:
+        state: present
+        resource_definition: &svc
+          apiVersion: v1
+          kind: Service
           metadata:
+            name: web
+            namespace: testing
+            labels:
+              app: galaxy
+              service: web
+          spec:
+            selector:
+              app: galaxy
+              service: web
+            ports:
+            - protocol: TCP
+              targetPort: 8000
+              name: port-8000-tcp
+              port: 8000
+      register: output
+
+    - name: show output
+      debug:
+        var: output
+
+    - name: Create the service again
+      k8s:
+        state: present
+        resource_definition: *svc
+      register: output
+
+    - name: Service creation should be idempotent
+      assert:
+        that: not output.changed
+
+    - name: Create PVC
+      k8s:
+        state: present
+        inline: &pvc
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: elastic-volume
+            namespace: testing
+          spec:
+            resources:
+              requests:
+                storage: 5Gi
+            accessModes:
+            - ReadWriteOnce
+
+    - name: Show output
+      debug:
+        var: output
+
+    - name: Create the PVC again
+      k8s:
+        state: present
+        inline: *pvc
+
+    - name: PVC creation should be idempotent
+      assert:
+        that: not output.changed
+
+    - name: Create deployment
+      k8s:
+        state: present
+        inline: &deployment
+          apiVersion: apps/v1beta1
+          kind: Deployment
+          metadata:
+            name: elastic
             labels:
               app: galaxy
               service: elastic
+            namespace: testing
           spec:
-            containers:
-              - name: elastic
-                volumeMounts:
-                - mountPath: /usr/share/elasticsearch/data
-                  name: elastic-volume
-                command: ['elasticsearch']
-                image: 'ansible/galaxy-elasticsearch:2.4.6'
-            volumes:
-            - name: elastic-volume
-              persistentVolumeClaim:
-                claimName: elastic-volume
-        replicas: 1
-        strategy:
-          type: RollingUpdate
-  register: output
+            template:
+              metadata:
+                labels:
+                  app: galaxy
+                  service: elastic
+              spec:
+                containers:
+                  - name: elastic
+                    volumeMounts:
+                    - mountPath: /usr/share/elasticsearch/data
+                      name: elastic-volume
+                    command: ['elasticsearch']
+                    image: 'ansible/galaxy-elasticsearch:2.4.6'
+                volumes:
+                - name: elastic-volume
+                  persistentVolumeClaim:
+                    claimName: elastic-volume
+            replicas: 1
+            strategy:
+              type: RollingUpdate
+      register: output
 
-- name: Show output
-  debug:
-    var: output
+    - name: Show output
+      debug:
+        var: output
 
-- name: Create deployment again
-  k8s:
-    state: present
-    inline: *deployment
-  register: output
+    - name: Create deployment again
+      k8s:
+        state: present
+        inline: *deployment
+      register: output
 
-- name: Deployment creation should be idempotent
-  assert:
-    that: not output.changed
+    - name: Deployment creation should be idempotent
+      assert:
+        that: not output.changed
 
-# OpenShift Resources
-- name: Create a project
-  k8s:
-    name: testing
-    kind: project
-    api_version: v1
-  register: output
+    # OpenShift Resources
+    - name: Create a project
+      k8s:
+        name: testing
+        kind: project
+        api_version: v1
+      register: output
 
-- name: show output
-  debug:
-    var: output
+    - name: show output
+      debug:
+        var: output
 
-- name: Create deployment config
-  k8s:
-    state: present
-    inline: &dc
-      apiVersion: v1
-      kind: DeploymentConfig
-      metadata:
-        name: elastic
-        labels:
-          app: galaxy
-          service: elastic
-        namespace: testing
-      spec:
-        template:
+    - name: Create deployment config
+      k8s:
+        state: present
+        inline: &dc
+          apiVersion: v1
+          kind: DeploymentConfig
           metadata:
+            name: elastic
             labels:
               app: galaxy
               service: elastic
+            namespace: testing
           spec:
-            containers:
-              - name: elastic
-                volumeMounts:
-                - mountPath: /usr/share/elasticsearch/data
-                  name: elastic-volume
-                command: ['elasticsearch']
-                image: 'ansible/galaxy-elasticsearch:2.4.6'
-            volumes:
-            - name: elastic-volume
-              persistentVolumeClaim:
-                claimName: elastic-volume
-        replicas: 1
-        strategy:
-          type: Rolling
-  register: output
+            template:
+              metadata:
+                labels:
+                  app: galaxy
+                  service: elastic
+              spec:
+                containers:
+                  - name: elastic
+                    volumeMounts:
+                    - mountPath: /usr/share/elasticsearch/data
+                      name: elastic-volume
+                    command: ['elasticsearch']
+                    image: 'ansible/galaxy-elasticsearch:2.4.6'
+                volumes:
+                - name: elastic-volume
+                  persistentVolumeClaim:
+                    claimName: elastic-volume
+            replicas: 1
+            strategy:
+              type: Rolling
+      register: output
 
-- name: Show output
-  debug:
-    var: output
+    - name: Show output
+      debug:
+        var: output
 
-- name: Create deployment config again
-  k8s:
-    state: present
-    inline: *dc
-  register: output
+    - name: Create deployment config again
+      k8s:
+        state: present
+        inline: *dc
+      register: output
 
-- name: DC creation should be idempotent
-  assert:
-    that: not output.changed
+    - name: DC creation should be idempotent
+      assert:
+        that: not output.changed
 
-### Type tests
-- name: Create a namespace from a string
-  k8s:
-    definition: |+
-      ---
-      kind: Namespace
-      apiVersion: v1
-      metadata:
+    ### Type tests
+    - name: Create a namespace from a string
+      k8s:
+        definition: |+
+          ---
+          kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: testing1
+
+    - name: Namespace should exist
+      k8s_facts:
+        kind: Namespace
+        api_version: v1
         name: testing1
+      register: k8s_facts_testing1
+      failed_when: not k8s_facts_testing1.resources or k8s_facts_testing1.resources[0].status.phase != "Active"
 
-- name: Namespace should exist
-  assert:
-    that: '{{ lookup("k8s", kind="Namespace", api_version="v1", resource_name="testing1", kubeconfig=kubeconfig.msg).status.phase == "Active" }}'
+    - name: Create resources from a multidocument yaml string
+      k8s:
+        definition: |+
+          ---
+          kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: testing2
+          ---
+          kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: testing3
 
-- name: Create resources from a multidocument yaml string
-  k8s:
-    definition: |+
-      ---
-      kind: Namespace
-      apiVersion: v1
-      metadata:
-        name: testing2
-      ---
-      kind: Namespace
-      apiVersion: v1
-      metadata:
-        name: testing3
+    - name: Lookup namespaces
+      k8s_facts:
+        api_version: v1
+        kind: Namespace
+        name: "{{ item }}"
+      loop:
+        - testing2
+        - testing3
+      register: k8s_namespaces
 
-- name: Resources should exist
-  assert:
-    that: lookup("k8s", kind="Namespace", api_version="v1", resource_name=item, kubeconfig=kubeconfig.msg).status.phase == "Active"
-  loop:
-    - testing2
-    - testing3
+    - name: Resources should exist
+      assert:
+        that: item.resources[0].status.phase == 'Active'
+      loop: "{{ k8s_namespaces.results }}"
 
-- name: Delete resources from a multidocument yaml string
-  k8s:
-    state: absent
-    definition: |+
-      ---
-      kind: Namespace
-      apiVersion: v1
-      metadata:
-        name: testing2
-      ---
-      kind: Namespace
-      apiVersion: v1
-      metadata:
-        name: testing3
+    - name: Delete resources from a multidocument yaml string
+      k8s:
+        state: absent
+        definition: |+
+          ---
+          kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: testing2
+          ---
+          kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: testing3
 
-- name: Resources should not exist
-  assert:
-    that: not ns or ns.status.phase == "Terminating"
-  loop:
-    - testing2
-    - testing3
-  vars:
-    ns: '{{ lookup("k8s", kind="Namespace", api_version="v1", resource_name=item, kubeconfig=kubeconfig.msg) }}'
+    - name: Lookup namespaces
+      k8s_facts:
+        api_version: v1
+        kind: Namespace
+        name: "{{ item }}"
+      loop:
+        - testing2
+        - testing3
+      register: k8s_namespaces
 
-- name: Create resources from a list
-  k8s:
-    definition:
-      - kind: Namespace
-        apiVersion: v1
-        metadata:
-          name: testing4
-      - kind: Namespace
-        apiVersion: v1
-        metadata:
-          name: testing5
+    - name: Resources should not exist
+      assert:
+        that:
+          - not item.resources or item.resources[0].status.phase == "Terminating"
+      loop: "{{ k8s_namespaces.results }}"
 
-- name: Resources should exist
-  assert:
-    that: lookup("k8s", kind="Namespace", api_version="v1", resource_name=item, kubeconfig=kubeconfig.msg).status.phase == "Active"
-  loop:
-    - testing4
-    - testing5
+    - name: Create resources from a list
+      k8s:
+        definition:
+          - kind: Namespace
+            apiVersion: v1
+            metadata:
+              name: testing4
+          - kind: Namespace
+            apiVersion: v1
+            metadata:
+              name: testing5
 
-- name: Delete resources from a list
-  k8s:
-    state: absent
-    definition:
-      - kind: Namespace
-        apiVersion: v1
-        metadata:
-          name: testing4
-      - kind: Namespace
-        apiVersion: v1
-        metadata:
-          name: testing5
+    - name: Lookup namespaces
+      k8s_facts:
+        api_version: v1
+        kind: Namespace
+        name: "{{ item }}"
+      loop:
+        - testing4
+        - testing5
+      register: k8s_namespaces
 
-- name: Resources should not exist
-  assert:
-    that: not ns or ns.status.phase == "Terminating"
-  loop:
-    - testing4
-    - testing5
-  vars:
-    ns: '{{ lookup("k8s", kind="Namespace", api_version="v1", resource_name=item, kubeconfig=kubeconfig.msg) }}'
+    - name: Resources should exist
+      assert:
+        that: item.resources[0].status.phase == 'Active'
+      loop: "{{ k8s_namespaces.results }}"
+
+    - name: install custom resource definitions
+      k8s:
+        definition: "{{ lookup('file', role_path + '/files/setup-crd.yml') }}"
+
+    - name: create custom resource definition
+      k8s:
+        definition: "{{ lookup('file', role_path + '/files/crd-resource.yml') }}"
+        namespace: testing4
+      register: create_crd
+
+    - name: recreate custom resource definition
+      k8s:
+        definition: "{{ lookup('file', role_path + '/files/crd-resource.yml') }}"
+        namespace: testing4
+      register: recreate_crd
+      ignore_errors: yes
+
+    - name: assert that recreating crd fails
+      assert:
+        that:
+          - recreate_crd is failed
+
+    - name: recreate custom resource definition with merge_type
+      k8s:
+        definition: "{{ lookup('file', role_path + '/files/crd-resource.yml') }}"
+        merge_type: merge
+        namespace: testing4
+      register: recreate_crd_with_merge
+
+    - name: recreate custom resource definition with merge_type list
+      k8s:
+        definition: "{{ lookup('file', role_path + '/files/crd-resource.yml') }}"
+        merge_type:
+          - strategic-merge
+          - merge
+        namespace: testing4
+      register: recreate_crd_with_merge_list
+
+    - name: remove crd
+      k8s:
+        definition: "{{ lookup('file', role_path + '/files/crd-resource.yml') }}"
+        namespace: testing4
+        state: absent
+
+    - name: Delete resources from a list
+      k8s:
+        state: absent
+        definition:
+          - kind: Namespace
+            apiVersion: v1
+            metadata:
+              name: testing4
+          - kind: Namespace
+            apiVersion: v1
+            metadata:
+              name: testing5
+
+    - k8s_facts:
+        api_version: v1
+        kind: Namespace
+        name: "{{ item }}"
+      loop:
+        - testing4
+        - testing5
+      register: k8s_facts
+
+    - name: Resources are terminating if still in results
+      assert:
+        that: not item.resources or item.resources[0].status.phase == "Terminating"
+      loop: "{{ k8s_facts.results }}"
+
+  always:
+    - name: remove crd
+      k8s:
+        definition: "{{ lookup('file', role_path + '/files/crd-resource.yml') }}"
+        namespace: testing4
+        state: absent
+      ignore_errors: yes
+
+    - name: Delete all namespaces
+      k8s:
+        state: absent
+        definition:
+          - kind: Namespace
+            apiVersion: v1
+            metadata:
+              name: testing1
+          - kind: Namespace
+            apiVersion: v1
+            metadata:
+              name: testing2
+          - kind: Namespace
+            apiVersion: v1
+            metadata:
+              name: testing3
+          - kind: Namespace
+            apiVersion: v1
+            metadata:
+              name: testing4
+          - kind: Namespace
+            apiVersion: v1
+            metadata:
+              name: testing5
+      ignore_errors: yes

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -17,3 +17,4 @@ ntlm-auth >= 1.0.6 # message encryption support
 requests-ntlm >= 1.1.0 # message encryption support
 requests-credssp >= 0.1.0 # message encryption support
 voluptuous >= 0.11.0 # Schema recursion via Self
+openshift >= 0.6.2 # merge_type support


### PR DESCRIPTION
##### SUMMARY
Make merge_type a list and apply merge_type in order
    
Allow use case of preferring strategic-merge and failing
back to merge, or just preferring a different merge type

Improve test suite

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
k8s

##### ANSIBLE VERSION

```
ansible 2.7.0.a1.post0 (devel b35ac8080f) last updated 2018/08/29 21:48:14 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
