### PR TITLE
"encountered" is an adj. here, need vb. "are"

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse_includes.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_includes.rst
@@ -9,7 +9,7 @@ Includes vs. Imports
 As noted in :doc:`playbooks_reuse`, include and import statements are very similar, however the Ansible executor engine treats them very differently.
 
 - All ``import*`` statements are pre-processed at the time playbooks are parsed.
-- All ``include*`` statements are processed as they encountered during the execution of the playbook.
+- All ``include*`` statements are processed as they are encountered during the execution of the playbook.
 
 Please refer to  :doc:`playbooks_reuse` for documentation concerning the trade-offs one may encounter when using each type.
 


### PR DESCRIPTION
<!--- Your description here -->

+label: docsite_pr

##### SUMMARY
The word "encountered" is an adjective here, so it needs a preceding verb to make sense. In this case, "are encountered".

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

 - Docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Ansible 2.6 Documentation, https://docs.ansible.com/ansible/2.6/user_guide/playbooks_reuse_includes.html
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
