### PR TITLE
Fix a comparison with a string and a byte in flatpak_remote

### DIFF
--- a/lib/ansible/modules/packaging/os/flatpak_remote.py
+++ b/lib/ansible/modules/packaging/os/flatpak_remote.py
@@ -120,7 +120,6 @@ stdout:
 
 import subprocess
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text
 
 
 def add_remote(module, binary, name, flatpakrepo_url, method):
@@ -148,7 +147,7 @@ def remote_exists(module, binary, name, method):
     output = _flatpak_command(module, False, command)
     for line in output.splitlines():
         listed_remote = line.split()
-        if to_text(listed_remote[0]) == to_text(name):
+        if listed_remote[0] == name:
             return True
     return False
 
@@ -206,7 +205,7 @@ def main():
     if not binary:
         module.fail_json(msg="Executable '%s' was not found on the system." % executable, **result)
 
-    remote_already_exists = remote_exists(module, binary, name, method)
+    remote_already_exists = remote_exists(module, binary, bytes(name, 'utf-8'), method)
 
     if state == 'present' and not remote_already_exists:
         add_remote(module, binary, name, flatpakrepo_url, method)

--- a/lib/ansible/modules/packaging/os/flatpak_remote.py
+++ b/lib/ansible/modules/packaging/os/flatpak_remote.py
@@ -120,14 +120,8 @@ stdout:
 
 import subprocess
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
 
-
-def compare(a, b, encoding='utf-8'):
-    if isinstance(a, bytes):
-        a = a.decode(encoding)
-    if isinstance(b, bytes):
-        b = b.decode(encoding)
-    return a == b
 
 def add_remote(module, binary, name, flatpakrepo_url, method):
     """Add a new remote."""
@@ -154,7 +148,7 @@ def remote_exists(module, binary, name, method):
     output = _flatpak_command(module, False, command)
     for line in output.splitlines():
         listed_remote = line.split()
-        if compare(listed_remote[0], name):
+        if to_text(listed_remote[0]) == to_text(name):
             return True
     return False
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Use bytes for the comparison, avoid to compare a string with a byte because with Python 3, we will get an issue.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
flatpak_remote

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0
  config file = None
  configured module search path = ['/home/stephane/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/stephane/.local/lib/python3.6/site-packages/ansible
  executable location = /home/stephane/.local/bin/ansible
  python version = 3.6.6 (default, Jul 19 2018, 14:25:17) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
Use `flatpak_remote` with ansible and python3 and the plugin can not handle the case because the output of `subprocess.Popen` is in `bytes` and it's not the case for the name of the repository (string).

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
