### PR TITLE
Don't allow import_tasks to transition to dynamic when file is missing

### DIFF
--- a/changelogs/fragments/no-dynamic-import-tasks.yaml
+++ b/changelogs/fragments/no-dynamic-import-tasks.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- import_tasks - Do not allow import_tasks to transition to dynamic if the file is missing (https://github.com/ansible/ansible/issues/44822)

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -250,7 +250,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         # nested includes, and we want the include order printed correctly
                         display.vv("statically imported: %s" % include_file)
                     except AnsibleFileNotFound:
-                        if t.static or \
+                        if action != 'include' or t.static or \
                            C.DEFAULT_TASK_INCLUDES_STATIC or \
                            C.DEFAULT_HANDLER_INCLUDES_STATIC and use_handlers:
                             raise


### PR DESCRIPTION
##### SUMMARY
Don't allow `import_tasks` to transition to dynamic when file is missing. See #44822

~2.6/2.5 will require a different solution to prevent the errant connection error.~

We originally indicated this functionality would be removed in 2.7, but extended it to 2.12 for `include` (https://github.com/ansible/ansible/commit/0beaea22a4b).  `import_tasks` however should not continue transitioning to dynamic.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/helpers.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION

Before:

```
[DEPRECATION WARNING]: Included file '/Users/matt/projects/ansibledev/playbooks/44822/create_foobaz.yml' not found, however since this include is not explicitly marked as 'static: yes', we will try and include it dynamically later. In
the future, this will be an error unless 'static: no' is used on the include task. If you do not want missing includes to be considered dynamic, use 'static: yes' on the include or set the global ansible.cfg options to make all includes
static for tasks and/or handlers. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

TASK [import_tasks] **************************************************************************************************************************************************************************************************************************
fatal: [vivo]: FAILED! => {"changed": false, "module_stderr": "Shared connection to vivo closed.\r\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 0}
```

After:

```
ERROR! Unable to retrieve file contents
Could not find or access '/Users/matt/projects/ansibledev/playbooks/44822/create_foobaz.yml' on the Ansible Controller.
```