### PR TITLE
If import_tasks is transitioned to dynamic, ensure we handle it later

### DIFF
--- a/changelogs/fragments/import-tasks-dynamic.yaml
+++ b/changelogs/fragments/import-tasks-dynamic.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- import_tasks - Prevent connection error message if file is missing and import_tasks is transitioned to dynamic (https://github.com/ansible/ansible/issues/44822)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -492,7 +492,7 @@ class TaskExecutor:
 
         # if this task is a TaskInclude, we just return now with a success code so the
         # main thread can expand the task list for the given host
-        if self._task.action in ('include', 'include_tasks'):
+        if self._task.action in ('include', 'include_tasks', 'import_tasks'):
             include_variables = self._task.args.copy()
             include_file = include_variables.pop('_raw_params', None)
             if not include_file:

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -61,7 +61,7 @@ class IncludedFile:
             original_host = res._host
             original_task = res._task
 
-            if original_task.action in ('include', 'include_tasks', 'include_role'):
+            if original_task.action in ('include', 'include_tasks', 'include_role', 'import_tasks'):
                 if original_task.loop:
                     if 'results' not in res._result:
                         continue
@@ -92,7 +92,7 @@ class IncludedFile:
                     if index_var and index_var in include_result:
                         task_vars[index_var] = include_variables[index_var] = include_result[index_var]
 
-                    if original_task.action in ('include', 'include_tasks'):
+                    if original_task.action in ('include', 'include_tasks', 'import_tasks'):
                         include_file = None
                         if original_task:
                             if original_task.static:


### PR DESCRIPTION
##### SUMMARY
If `import_tasks` is transitioned to dynamic, ensure we handle it later. Fixes #44822

This PR should be fully reviewed.

This is not a backport of a change to 2.7. The change to 2.7 is completely different due to a change in deprecated functionality.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_executor.py
lib/ansible/playbook/included_file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION
Before:
```
fatal: [vivo]: FAILED! => {"changed": false, "module_stderr": "Shared connection to vivo closed.\r\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 0}
```

After:
```
fatal: [vivo]: FAILED! => {
    "reason": "Unable to retrieve file contents\nCould not find or access '/Users/matt/projects/ansibledev/playbooks/44822/create_foobaz.yml' on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"
}
```