### PR TITLE
Fix KeyError in UpdateConfig lookup when service already exists.

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -874,18 +874,22 @@ class DockerServiceManager():
         ds = DockerService()
 
         task_template_data = raw_data['Spec']['TaskTemplate']
-        update_config_data = raw_data['Spec']['UpdateConfig']
+        # Try/Except in case service already exists without UpdateConfig
+        try:
+            update_config_data = raw_data['Spec']['UpdateConfig']
+            ds.update_delay = update_config_data['Delay']
+            ds.update_parallelism = update_config_data['Parallelism']
+            ds.update_failure_action = update_config_data['FailureAction']
+            ds.update_monitor = update_config_data['Monitor']
+            ds.update_max_failure_ratio = update_config_data['MaxFailureRatio']
+            ds.update_order = update_config_data['Order']
+        except Exception as e:
+            pass
 
         ds.image = task_template_data['ContainerSpec']['Image']
         ds.user = task_template_data['ContainerSpec'].get('User', 'root')
         ds.env = task_template_data['ContainerSpec'].get('Env', [])
         ds.args = task_template_data['ContainerSpec'].get('Args', [])
-        ds.update_delay = update_config_data['Delay']
-        ds.update_parallelism = update_config_data['Parallelism']
-        ds.update_failure_action = update_config_data['FailureAction']
-        ds.update_monitor = update_config_data['Monitor']
-        ds.update_max_failure_ratio = update_config_data['MaxFailureRatio']
-        ds.update_order = update_config_data['Order']
 
         dns_config = task_template_data['ContainerSpec'].get('DNSConfig', None)
         if dns_config:


### PR DESCRIPTION
##### SUMMARY
When the `docker_swarm_service` module is used against an existing swarm service which was not created with an UpdateConfig stanza it will result in a KeyError during the lookup of `UpdateConfig` in the docker API return.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_swarm_service.py

##### ANSIBLE VERSION
```
ansible 2.6.3
  config file = /home/admin.witkowski/throtle-ansible/ansible.cfg
  configured module search path = [u'/home/admin.witkowski/throtle-ansible/library']
  ansible python module location = /home/admin.witkowski/throtle-ansible-venv/lib/python2.7/site-packages/ansible
  executable location = /home/admin.witkowski/throtle-ansible-venv/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
If a docker swarm service is created manually or existed prior to a users use of this module and it was created without UpdateConfig settings then the `Spec` field returned by `docker service inspect <service>` will not include a stanza much like the following:
```
            "UpdateConfig": {
                "Parallelism": 1,
                "Delay": 10,
                "FailureAction": "pause",
                "Monitor": 5000000000,
                "MaxFailureRatio": 0,
                "Order": "start-first"
            },
```
In this scenario the existing module code will attempt to lookup the `UpdateConfig` stanza with the expectation that it always exists.  This pull request will change that behavior to accept that sometimes this stanza may not exist.