### PR TITLE
Ensure our CSS files are being used

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -151,7 +151,7 @@ html_title = 'Ansible Documentation'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['.static']
+html_static_path = ['../_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
##### SUMMARY
Without this change, our own pygments.css (and others) are not being
used when generating docs.

After comparing online docs and locally generated docs, I don't see a
difference except the new pygments CSS being used.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docsite CSS

##### ANSIBLE VERSION
v2.7 and older