### PR TITLE
Restore repos after zypper_repository test runs.

### DIFF
--- a/test/integration/targets/zypper_repository/tasks/main.yml
+++ b/test/integration/targets/zypper_repository/tasks/main.yml
@@ -17,5 +17,5 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- include: 'zypper_repository.yml'
+- include: 'test.yml'
   when: ansible_os_family == 'Suse'

--- a/test/integration/targets/zypper_repository/tasks/test.yml
+++ b/test/integration/targets/zypper_repository/tasks/test.yml
@@ -1,0 +1,33 @@
+- name: collect repo configuration before test
+  shell: "grep . /etc/zypp/repos.d/*"
+  register: before
+
+- name: ensure zypper ref works
+  command: zypper -n ref
+
+- block:
+    - include: 'zypper_repository.yml'
+  always:
+    - name: remove repositories added during test
+      zypper_repository:
+        name: "{{item}}"
+        state: absent
+      with_items:
+        - chrome1
+        - chrome2
+        - test
+        - testrefresh
+        - testprio
+        - Apache_Modules
+
+    - name: collect repo configuration after test
+      shell: "grep . /etc/zypp/repos.d/*"
+      register: after
+
+    - name: verify repo configuration has been restored
+      assert:
+        that:
+          - before.stdout == after.stdout
+
+    - name: ensure zypper ref still works
+      command: zypper -n ref

--- a/test/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/test/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -1,8 +1,3 @@
----
-
-- name: ensure zypper ref works
-  command: zypper -n ref
-
 - name: Delete test repo
   zypper_repository:
     name: test
@@ -15,8 +10,6 @@
     state: present
     repo: http://dl.google.com/linux/chrome/rpm/stable/x86_64
   register: zypper_result
-
-- debug: var=zypper_result
 
 - name: verify repo addition
   assert:
@@ -47,17 +40,12 @@
     that:
       - "zypper_result.changed"
 
-- name: Remove repo by name (also to not mess up later tasks)
-  zypper_repository:
-    name: test
-    state: absent
-
 - name: use refresh option
   zypper_repository:
     name: testrefresh
     refresh: no
     state: present
-    repo: http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/
+    repo: http://download.videolan.org/pub/vlc/SuSE/Leap_{{ ansible_distribution_version }}/
 
 - name: check refreshoption
   command: zypper -x lr testrefresh
@@ -72,7 +60,7 @@
     name: testprio
     priority: 55
     state: present
-    repo: http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/
+    repo: http://download.videolan.org/pub/vlc/SuSE/Leap_{{ ansible_distribution_version }}/
 
 - name: check refreshoption
   command: zypper -x lr testprio
@@ -86,18 +74,18 @@
   zypper_repository:
     name: "{{item}}"
     state: present
-    repo: http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/
+    repo: http://dl.google.com/linux/chrome/rpm/stable/x86_64
   with_items:
-    - oss1
-    - oss2
+    - chrome1
+    - chrome2
 
 - name: check repo is updated by url
-  command: zypper lr oss1
+  command: zypper lr chrome1
   register: zypper_result1
   ignore_errors: yes
 
 - name: check repo is updated by url
-  command: zypper lr oss2
+  command: zypper lr chrome2
   register: zypper_result2
 
 - assert:
@@ -105,16 +93,7 @@
       - "zypper_result1.rc == 6"
       - "'not found' in zypper_result1.stderr"
       - "zypper_result2.rc == 0"
-      - "'http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/' in zypper_result2.stdout"
-
-
-- name: reset oss repo (to not break zypper later)
-  zypper_repository:
-    name: OSS
-    state: present
-    repo: http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/
-    priority: 99
-    refresh: yes
+      - "'http://dl.google.com/linux/chrome/rpm/stable/x86_64' in zypper_result2.stdout"
 
 - name: add two repos with same name
   zypper_repository:
@@ -139,9 +118,6 @@
     repo: http://download.opensuse.org/repositories/devel:/languages:/ruby/openSUSE_Leap_{{ ansible_distribution_version }}/
     state: absent
 
-- name: ensure zypper ref still works
-  command: zypper -n ref
-
 - name: "Test adding a repo with custom GPG key"
   zypper_repository:
     name: "Apache_Modules"
@@ -149,6 +125,3 @@
     priority: 100
     auto_import_keys: true
     state: "present"
-
-- name: ensure zypper ref still works
-  command: zypper -n ref


### PR DESCRIPTION
##### SUMMARY

Restore repos after zypper_repository test runs.

This also allows the test to run on newer containers by not manipulating any of the pre-configured repositories.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

zypper_repository integration test

##### ANSIBLE VERSION

```
ansible 2.7.0.a1.post0 (zypper-repository-test-fix da4b8f0a87) last updated 2018/08/29 10:53:07 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
