### PR TITLE
Do not double register handlers from includes

### DIFF
--- a/changelogs/fragments/include-double-handler.yaml
+++ b/changelogs/fragments/include-double-handler.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- includes - ensure we do not double register handlers from includes to prevent exception (https://github.com/ansible/ansible/issues/44848)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -239,6 +239,8 @@ class Play(Base, Taggable, Become):
 
         if len(self.roles) > 0:
             for r in self.roles:
+                if r.from_include:
+                    continue
                 block_list.extend(r.get_handler_blocks(play=self))
 
         return block_list


### PR DESCRIPTION
##### SUMMARY
Do not double register handlers from includes. Fixes #44848
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/play.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```