### PR TITLE
[stable-2.5] Don't allow import_tasks to transition to dynamic when file is missing. See #44822 (#44836)

### DIFF
--- a/changelogs/fragments/no-dynamic-import-tasks.yaml
+++ b/changelogs/fragments/no-dynamic-import-tasks.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- import_tasks - Do not allow import_tasks to transition to dynamic if the file is missing (https://github.com/ansible/ansible/issues/44822)

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -227,7 +227,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         # nested includes, and we want the include order printed correctly
                         display.vv("statically imported: %s" % include_file)
                     except AnsibleFileNotFound:
-                        if t.static or \
+                        if action != 'include' or t.static or \
                            C.DEFAULT_TASK_INCLUDES_STATIC or \
                            C.DEFAULT_HANDLER_INCLUDES_STATIC and use_handlers:
                             raise

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -227,7 +227,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         # nested includes, and we want the include order printed correctly
                         display.vv("statically imported: %s" % include_file)
                     except AnsibleFileNotFound:
-                        if action != 'include' or t.static or \
+                        if 'include' not in task_ds or t.static or \
                            C.DEFAULT_TASK_INCLUDES_STATIC or \
                            C.DEFAULT_HANDLER_INCLUDES_STATIC and use_handlers:
                             raise


### PR DESCRIPTION
(cherry picked from commit cd2f66f)


Co-authored-by: Matt Martz <matt@sivel.net>