### PR TITLE
Allowing home path expansion on GCP service account files

### DIFF
--- a/changelogs/fragments/gcp_service_account_home_path.yaml
+++ b/changelogs/fragments/gcp_service_account_home_path.yaml
@@ -1,2 +1,2 @@
-minor_change:
+minor_changes:
   - GCP Modules will do home path expansion on service account file paths

--- a/changelogs/fragments/gcp_service_account_home_path.yaml
+++ b/changelogs/fragments/gcp_service_account_home_path.yaml
@@ -1,0 +1,2 @@
+minor_change:
+  - GCP Modules will do home path expansion on service account file paths

--- a/lib/ansible/module_utils/gcp_utils.py
+++ b/lib/ansible/module_utils/gcp_utils.py
@@ -129,8 +129,8 @@ class GcpSession(object):
             credentials, project_id = google.auth.default()
             return credentials
         elif cred_type == 'serviceaccount':
-            return service_account.Credentials.from_service_account_file(
-                self.module.params['service_account_file'])
+            path = os.path.realpath(os.path.expanduser(self.module.params['service_account_file']))
+            return service_account.Credentials.from_service_account_file(path)
         elif cred_type == 'machineaccount':
             return google.auth.compute_engine.Credentials(
                 self.module.params['service_account_email'])


### PR DESCRIPTION
##### SUMMARY
Fixes #42974
Allowing home path expansion on GCP service account files

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
gcp_utils.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
