### PR TITLE
Reword documentation for IOS L2/L3 interface modules

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -19,7 +19,7 @@ extends_documentation_fragment: ios
 version_added: "2.5"
 short_description: Manage Layer-2 interface on Cisco IOS devices.
 description:
-  - This module provides declarative management of Layer-2 interface on
+  - This module provides declarative management of Layer-2 interfaces on
     Cisco IOS devices.
 author:
   - Nathaniel Case (@qalthos)

--- a/lib/ansible/modules/network/ios/ios_l3_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interface.py
@@ -17,33 +17,33 @@ DOCUMENTATION = """
 module: ios_l3_interface
 version_added: "2.5"
 author: "Ganesh Nalawade (@ganeshrn)"
-short_description: Manage L3 interfaces on Cisco IOS network devices.
+short_description: Manage Layer-3 interfaces on Cisco IOS network devices.
 description:
-  - This module provides declarative management of L3 interfaces
+  - This module provides declarative management of Layer-3 interfaces
     on IOS network devices.
 notes:
   - Tested against IOS 15.2
 options:
   name:
     description:
-      - Name of the L3 interface to be configured eg. GigabitEthernet0/2
+      - Name of the Layer-3 interface to be configured eg. GigabitEthernet0/2
   ipv4:
     description:
-      - IPv4 address to be set for the L3 interface mentioned in I(name) option.
+      - IPv4 address to be set for the Layer-3 interface mentioned in I(name) option.
         The address format is <ipv4 address>/<mask>, the mask is number
         in range 0-32 eg. 192.168.0.1/24
   ipv6:
     description:
-      - IPv6 address to be set for the L3 interface mentioned in I(name) option.
+      - IPv6 address to be set for the Layer-3 interface mentioned in I(name) option.
         The address format is <ipv6 address>/<mask>, the mask is number
         in range 0-128 eg. fd5d:12c9:2201:1::1/64
   aggregate:
     description:
-      - List of L3 interfaces definitions. Each of the entry in aggregate list should
+      - List of Layer-3 interfaces definitions. Each of the entry in aggregate list should
         define name of interface C(name) and a optional C(ipv4) or C(ipv6) address.
   state:
     description:
-      - State of the L3 interface configuration. It indicates if the configuration should
+      - State of the Layer-3 interface configuration. It indicates if the configuration should
         be present or absent on remote device.
     default: present
     choices: ['present', 'absent']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There was a slight discrepency between wording choices in the documentation for the `ios_l2_interface` and `ios_l3_interface` modules. This PR just makes their wording more cohesive and also fixes a typo.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
ios_l2_interface
ios_l3_interface
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/breaker/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
N/A
<!--- Paste verbatim command output below, e.g. before and after your change -->
