### PR TITLE
Fix KeyError on update when principal is an account number

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda_policy.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_policy.py
@@ -239,11 +239,11 @@ def extract_statement(policy, sid):
             try:
                 policy_statement['principal'] = statement['Principal']['Service']
             except KeyError:
-               pass
+                pass
             try:
                 policy_statement['principal'] = statement['Principal']['AWS']
             except KeyError:
-               pass
+                pass
             try:
                 policy_statement['source_arn'] = statement['Condition']['ArnLike']['AWS:SourceArn']
             except KeyError:

--- a/lib/ansible/modules/cloud/amazon/lambda_policy.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_policy.py
@@ -236,7 +236,14 @@ def extract_statement(policy, sid):
     for statement in policy['Statement']:
         if statement['Sid'] == sid:
             policy_statement['action'] = statement['Action']
-            policy_statement['principal'] = statement['Principal']['Service']
+            try:
+                policy_statement['principal'] = statement['Principal']['Service']
+            except KeyError:
+               pass
+            try:
+                policy_statement['principal'] = statement['Principal']['AWS']
+            except KeyError:
+               pass
             try:
                 policy_statement['source_arn'] = statement['Condition']['ArnLike']['AWS:SourceArn']
             except KeyError:


### PR DESCRIPTION
##### SUMMARY
When lambda_policy is used to attach a policy allowing cross-account access for an account principal, a KeyError is encountered if the statement id already exists (on subsequent runs of task after initial creation of policy).  The module assumes that the Principal type is `Service`, when `AWS` is also allowed.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lambda_policy

##### ANSIBLE VERSION
```
ansible 2.6.1
  config file = None
  configured module search path = [u'/home/devops/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/act/python2.7/site-packages/ansible-2.6.1-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->


[AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html#access-control-resource-based-example-cross-account-scenario) showing valid use of account number as a principal type

<!--- Paste verbatim command output below, e.g. before and after your change -->

Example playbook
```
---
- hosts: localhost
  vars:
    function: "lambda-test"
    statement: "statement-1"
    action: "lambda:InvokeFunction"
    principal: "999999999999"  # principal is an AWS account number

  tasks:
    - lambda_policy:
        state: present
        function_name: "{{ function }}"
        statement_id: "{{ statement }}"
        action: "{{ action }}"
        principal: "{{ principal }}"

```
Example results
```
< TASK [deploy lambda policy] >
 -----------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'Service'
fatal: [localhost]: FAILED! => {
    "changed": false,
    "rc": 1
}

MSG:

MODULE FAILURE


MODULE_STDERR:

Traceback (most recent call last):
  File "/tmp/ansible_KhFeaD/ansible_module_lambda_policy.py", line 430, in <module>
    main()
  File "/tmp/ansible_KhFeaD/ansible_module_lambda_policy.py", line 424, in main
    results = manage_state(module, client)
  File "/tmp/ansible_KhFeaD/ansible_module_lambda_policy.py", line 362, in manage_state
    current_policy_statement = get_policy_statement(module, lambda_client)
  File "/tmp/ansible_KhFeaD/ansible_module_lambda_policy.py", line 290, in get_policy_statement
    return extract_statement(policy, sid)
  File "/tmp/ansible_KhFeaD/ansible_module_lambda_policy.py", line 239, in extract_statement
    policy_statement['principal'] = statement['Principal']['Service']
KeyError: 'Service'

```
