### PR TITLE
List quay.io images during Shippable run.

### DIFF
--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -10,6 +10,7 @@ script="${args[0]}"
 test="$1"
 
 docker images ansible/ansible
+docker images quay.io/ansible/*
 docker ps
 
 for container in $(docker ps --format '{{.Image}} {{.ID}}' | grep -v '^drydock/' | sed 's/^.* //'); do


### PR DESCRIPTION
##### SUMMARY

List quay.io images during Shippable run.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Shippable

##### ANSIBLE VERSION

```
ansible 2.7.0.a1.post0 (shippable-images 0d30e8fef8) last updated 2018/08/29 16:05:29 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
