### PR TITLE
[2.6] docker_container: improve description of default network removal.

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -233,6 +233,9 @@ options:
        - If included, C(links) or C(aliases) are lists.
        - For examples of the data structure and usage see EXAMPLES below.
        - To remove a container from one or more networks, use the C(purge_networks) option.
+       - Note that as opposed to C(docker run ...), M(docker_container) does not remove the default
+         network if C(networks) is specified. You need to explicity use C(purge_networks) to enforce
+         the removal of the default network (and all other networks not explicitly mentioned in C(networks)).
      version_added: "2.2"
   oom_killer:
     description:


### PR DESCRIPTION
##### SUMMARY
Backport of #44861: improves description of default network removal to decrease user confusion.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.6.3
```
