### PR TITLE
improve vmss test

### DIFF
--- a/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
+++ b/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
@@ -117,7 +117,7 @@
 - name: Create VMSS -- test upgrade_policy idempotence
   azure_rm_virtualmachine_scaleset:
     resource_group: "{{ resource_group }}"
-    name:  testVMSS{{ rpfx }}
+    name: testVMSS{{ rpfx }}
     vm_size: Standard_DS1_v2
     admin_username: testuser
     ssh_password_enabled: true

--- a/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
+++ b/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
@@ -81,7 +81,7 @@
 - name: Assert no VMSS created in check mode
   assert:
     that:
-      -  output_scaleset.ansible_facts.azure_vmss | length == 0
+      - output_scaleset.ansible_facts.azure_vmss | length == 0
 
 - name: Create VMSS
   azure_rm_virtualmachine_scaleset:

--- a/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
+++ b/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
@@ -41,7 +41,7 @@
 - name: Create VMSS (check mode)
   azure_rm_virtualmachine_scaleset:
     resource_group: "{{ resource_group }}"
-    name: "{{ vmss_name }}"
+    name: testVMSS{{ rpfx }}
     vm_size: Standard_DS1_v2
     admin_username: testuser
     ssh_password_enabled: true
@@ -74,7 +74,7 @@
 - name: Get VMSS to assert no VMSS is created in check mode
   azure_rm_virtualmachine_scaleset_facts:
     resource_group: "{{ resource_group }}"
-    name: "{{ vmss_name }}"
+    name: testVMSS{{ rpfx }}
     format: curated
   register: output_scaleset
 

--- a/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
+++ b/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
@@ -38,6 +38,51 @@
     resource_group: "{{ resource_group_secondary }}"
     name: testNetworkSecurityGroup2
 
+- name: Create VMSS (check mode)
+  azure_rm_virtualmachine_scaleset:
+    resource_group: "{{ resource_group }}"
+    name: "{{ vmss_name }}"
+    vm_size: Standard_DS1_v2
+    admin_username: testuser
+    ssh_password_enabled: true
+    admin_password: "Password1234!"
+    capacity: 2
+    virtual_network_name: testVnet
+    subnet_name: testSubnet
+    load_balancer: testLB
+    upgrade_policy: Manual
+    tier: Standard
+    managed_disk_type: Standard_LRS
+    os_disk_caching: ReadWrite
+    image:
+      offer: CoreOS
+      publisher: CoreOS
+      sku: Stable
+      version: latest
+    data_disks:
+      - lun: 0
+        disk_size_gb: 64
+        caching: ReadWrite
+        managed_disk_type: Standard_LRS
+  register: results
+  check_mode: yes
+
+- name: Assert that VMSS can be created
+  assert:
+    that: results.changed
+
+- name: Get VMSS to assert no VMSS is created in check mode
+  azure_rm_virtualmachine_scaleset_facts:
+    resource_group: "{{ resource_group }}"
+    name: "{{ vmss_name }}"
+    format: curated
+  register: output_scaleset
+
+- name: Assert no VMSS created in check mode
+  assert:
+    that:
+      -  output_scaleset.ansible_facts.azure_vmss | length == 0
+
 - name: Create VMSS
   azure_rm_virtualmachine_scaleset:
     resource_group: "{{ resource_group }}"
@@ -72,7 +117,7 @@
 - name: Create VMSS -- test upgrade_policy idempotence
   azure_rm_virtualmachine_scaleset:
     resource_group: "{{ resource_group }}"
-    name: testVMSS{{ rpfx }}
+    name:  testVMSS{{ rpfx }}
     vm_size: Standard_DS1_v2
     admin_username: testuser
     ssh_password_enabled: true
@@ -134,85 +179,6 @@
 - name: Assert that VMSS was updated
   assert:
     that: not results.changed
-
-- name: Delete VMSS
-  azure_rm_virtualmachine_scaleset:
-    resource_group: "{{ resource_group }}"
-    name: testVMSS{{ rpfx }}
-    state: absent
-    remove_on_absent: ['all']
-    vm_size: Standard_DS1_v2
-    capacity: 2
-    image:
-      offer: CoreOS
-      publisher: CoreOS
-      sku: Stable
-      version: latest
-
-- name: Create VMSS (check mode)
-  azure_rm_virtualmachine_scaleset:
-    resource_group: "{{ resource_group }}"
-    name: testVMSS{{ rpfx }}1
-    vm_size: Standard_DS1_v2
-    admin_username: testuser
-    ssh_password_enabled: true
-    admin_password: "Password1234!"
-    capacity: 2
-    virtual_network_name: testVnet
-    subnet_name: testSubnet
-    load_balancer: testLB
-    upgrade_policy: Manual
-    tier: Standard
-    managed_disk_type: Standard_LRS
-    os_disk_caching: ReadWrite
-    image:
-      offer: CoreOS
-      publisher: CoreOS
-      sku: Stable
-      version: latest
-    data_disks:
-      - lun: 0
-        disk_size_gb: 64
-        caching: ReadWrite
-        managed_disk_type: Standard_LRS
-  register: results
-  check_mode: yes
-
-- name: Assert that VMSS can be created
-  assert:
-    that: results.changed
-
-- name: Create VMSS
-  azure_rm_virtualmachine_scaleset:
-    resource_group: "{{ resource_group }}"
-    name: testVMSS{{ rpfx }}1
-    vm_size: Standard_DS1_v2
-    admin_username: testuser
-    ssh_password_enabled: true
-    admin_password: "Password1234!"
-    capacity: 2
-    virtual_network_name: testVnet
-    subnet_name: testSubnet
-    load_balancer: testLB
-    upgrade_policy: Manual
-    tier: Standard
-    managed_disk_type: Standard_LRS
-    os_disk_caching: ReadWrite
-    image:
-      offer: CoreOS
-      publisher: CoreOS
-      sku: Stable
-      version: latest
-    data_disks:
-      - lun: 0
-        disk_size_gb: 64
-        caching: ReadWrite
-        managed_disk_type: Standard_LRS
-  register: results
-
-- name: Assert that VMSS ran
-  assert:
-    that: results.changed
 
 - name: Delete VMSS
   azure_rm_virtualmachine_scaleset:
@@ -282,51 +248,10 @@
       - 'results.ansible_facts.azure_vmss.properties.virtualMachineProfile.networkProfile.networkInterfaceConfigurations.0.properties.enableAcceleratedNetworking == true'
       - 'results.ansible_facts.azure_vmss.properties.virtualMachineProfile.networkProfile.networkInterfaceConfigurations.0.properties.networkSecurityGroup != {}'
 
-- name: Delete VMSS
+- name: update VMSS with security group in different resource group.
   azure_rm_virtualmachine_scaleset:
     resource_group: "{{ resource_group }}"
     name: testVMSS{{ rpfx }}2
-    state: absent
-    remove_on_absent: ['all']
-    vm_size: Standard_D3_v2
-    capacity: 1
-    image:
-      offer: CoreOS
-      publisher: CoreOS
-      sku: Stable
-      version: latest
-
-- name: Create VMSS with security group in different resource group(check mode).
-  azure_rm_virtualmachine_scaleset:
-    resource_group: "{{ resource_group }}"
-    name: testVMSS{{ rpfx }}3
-    vm_size: Standard_DS1_v2
-    capacity: 1
-    virtual_network_name: testVnet
-    subnet_name: testSubnet
-    admin_username: testuser
-    ssh_password_enabled: true
-    admin_password: "Password1234!"
-    image:
-      offer: CoreOS
-      publisher: CoreOS
-      sku: Stable
-      version: latest
-    upgrade_policy: Manual
-    security_group:
-      name: testNetworkSecurityGroup2
-      resource_group: "{{ resource_group_secondary }}"
-  register: results
-  check_mode: yes
-
-- name: Assert that VMSS ran
-  assert:
-    that: results.changed
-
-- name: Create VMSS with security group in different resource group.
-  azure_rm_virtualmachine_scaleset:
-    resource_group: "{{ resource_group }}"
-    name: testVMSS{{ rpfx }}3
     vm_size: Standard_DS1_v2
     capacity: 1
     virtual_network_name: testVnet
@@ -345,7 +270,7 @@
       resource_group: "{{ resource_group_secondary }}"
   register: results
 
-- name: Assert that VMSS ran
+- name: Assert that security group is correct
   assert:
     that:
       - 'results.changed'

--- a/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
+++ b/test/integration/targets/azure_rm_virtualmachine_scaleset/tasks/main.yml
@@ -279,7 +279,7 @@
 - name: Delete VMSS
   azure_rm_virtualmachine_scaleset:
     resource_group: "{{ resource_group }}"
-    name: testVMSS{{ rpfx }}3
+    name: testVMSS{{ rpfx }}2
     state: absent
     remove_on_absent: ['all']
     vm_size: Standard_DS1_v2


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
improve vmss tests.
original test flow:
- create a vmss, assert creation success, test upgrade_policy, delete the vmss.
- create vmss checkmode, assert no vmss, then  create vmss, assert creation success, then delete vmss.
- create vmss with security group in same resource group, assert, then delete vmss
- create vmss with security group in another resource group, assert, then delete vmss

there're redundancy in test resource creation. Improve test scenario as:
- create vmss checkmode, assert no vmss, then create vmss, test upgrade_policy, then delete vmss.
- create vmss with security group in same resource group, assert, update vmss with security group in another resource group, assert, then delete vmss.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
