### PR TITLE
Add AWS WAF Regional support for AWS ALBs

### DIFF
--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -72,6 +72,14 @@ groupings:
   - aws
   aws_waf_web_acl:
   - aws
+  aws_waf_regional_condition:
+  - aws
+  aws_waf_regional_facts:
+  - aws
+  aws_waf_regional_rule:
+  - aws
+  aws_waf_regional_web_acl:
+  - aws
   cloudformation:
   - aws
   cloudformation_facts:

--- a/lib/ansible/module_utils/aws/waf_regional.py
+++ b/lib/ansible/module_utils/aws/waf_regional.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2017 Will Thames
+#
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+"""
+This module adds shared support for Web Application Firewall modules
+"""
+
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry
+
+try:
+    import botocore
+except ImportError:
+    pass  # caught by imported HAS_BOTO3
+
+
+MATCH_LOOKUP = {
+    'byte': {
+        'method': 'byte_match_set',
+        'conditionset': 'ByteMatchSet',
+        'conditiontuple': 'ByteMatchTuple',
+        'type': 'ByteMatch'
+    },
+    'geo': {
+        'method': 'geo_match_set',
+        'conditionset': 'GeoMatchSet',
+        'conditiontuple': 'GeoMatchConstraint',
+        'type': 'GeoMatch'
+    },
+    'ip': {
+        'method': 'ip_set',
+        'conditionset': 'IPSet',
+        'conditiontuple': 'IPSetDescriptor',
+        'type': 'IPMatch'
+    },
+    'regex': {
+        'method': 'regex_match_set',
+        'conditionset': 'RegexMatchSet',
+        'conditiontuple': 'RegexMatchTuple',
+        'type': 'RegexMatch'
+    },
+    'size': {
+        'method': 'size_constraint_set',
+        'conditionset': 'SizeConstraintSet',
+        'conditiontuple': 'SizeConstraint',
+        'type': 'SizeConstraint'
+    },
+    'sql': {
+        'method': 'sql_injection_match_set',
+        'conditionset': 'SqlInjectionMatchSet',
+        'conditiontuple': 'SqlInjectionMatchTuple',
+        'type': 'SqlInjectionMatch',
+    },
+    'xss': {
+        'method': 'xss_match_set',
+        'conditionset': 'XssMatchSet',
+        'conditiontuple': 'XssMatchTuple',
+        'type': 'XssMatch'
+    },
+}
+
+
+@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+def get_rule_with_backoff(client, rule_id):
+    return client.get_rule(RuleId=rule_id)['Rule']
+
+
+@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+def get_byte_match_set_with_backoff(client, byte_match_set_id):
+    return client.get_byte_match_set(ByteMatchSetId=byte_match_set_id)['ByteMatchSet']
+
+
+@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+def get_ip_set_with_backoff(client, ip_set_id):
+    return client.get_ip_set(IPSetId=ip_set_id)['IPSet']
+
+
+@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+def get_size_constraint_set_with_backoff(client, size_constraint_set_id):
+    return client.get_size_constraint_set(SizeConstraintSetId=size_constraint_set_id)['SizeConstraintSet']
+
+
+@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+def get_sql_injection_match_set_with_backoff(client, sql_injection_match_set_id):
+    return client.get_sql_injection_match_set(SqlInjectionMatchSetId=sql_injection_match_set_id)['SqlInjectionMatchSet']
+
+
+@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+def get_xss_match_set_with_backoff(client, xss_match_set_id):
+    return client.get_xss_match_set(XssMatchSetId=xss_match_set_id)['XssMatchSet']
+
+
+def get_rule(client, module, rule_id):
+    try:
+        rule = get_rule_with_backoff(client, rule_id)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't obtain waf rule")
+
+    match_sets = {
+        'ByteMatch': get_byte_match_set_with_backoff,
+        'IPMatch': get_ip_set_with_backoff,
+        'SizeConstraint': get_size_constraint_set_with_backoff,
+        'SqlInjectionMatch': get_sql_injection_match_set_with_backoff,
+        'XssMatch': get_xss_match_set_with_backoff
+    }
+    if 'Predicates' in rule:
+        for predicate in rule['Predicates']:
+            if predicate['Type'] in match_sets:
+                predicate.update(match_sets[predicate['Type']](client, predicate['DataId']))
+                # replaced by Id from the relevant MatchSet
+                del(predicate['DataId'])
+    return rule
+
+
+@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+def get_web_acl_with_backoff(client, web_acl_id):
+    return client.get_web_acl(WebACLId=web_acl_id)['WebACL']
+
+
+def get_web_acl(client, module, web_acl_id):
+    try:
+        web_acl = get_web_acl_with_backoff(client, web_acl_id)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't obtain web acl")
+
+    if web_acl:
+        try:
+            for rule in web_acl['Rules']:
+                rule.update(get_rule(client, module, rule['RuleId']))
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't obtain web acl rule")
+    return camel_dict_to_snake_dict(web_acl)
+
+
+@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+def list_rules_with_backoff(client):
+    return client.list_rules()['Rules']
+
+
+@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+def list_web_acls_with_backoff(client):
+    return client.list_web_acls()['WebACLs']
+
+def list_web_acls(client, module):
+    try:
+        return list_web_acls_with_backoff(client)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't obtain web acls")
+
+
+def get_change_token(client, module):
+    try:
+        token = client.get_change_token()
+        return token['ChangeToken']
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't obtain change token")
+
+
+@AWSRetry.backoff(tries=10, delay=2, backoff=2.0, catch_extra_error_codes=['WAFStaleDataException'])
+def run_func_with_change_token_backoff(client, module, params, func):
+    params['ChangeToken'] = get_change_token(client, module)
+    return func(**params)

--- a/lib/ansible/modules/cloud/amazon/aws_waf_regional_associate_elbv2.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_regional_associate_elbv2.py
@@ -1,0 +1,113 @@
+#!/usr/bin/python
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+module: aws_waf_associate_elbv2
+short_description: Associate/disassociate WAF Regional rules with ELBv2 (ALB).
+description:
+  - Associate/disassociate WAF Regional rules with ELBv2 (ALB).
+version_added: "2.6"
+requirements: [ boto3 ]
+options:
+  web_acl_id:
+    description:
+      - Web ACL ID
+  alb_resource_arn:
+    description:
+      - ALB resource ARN
+
+author:
+  - Jaco Engelbrecht (@bje)
+  - Mike Mochan (@mmochan)
+extends_documentation_fragment:
+    - aws
+    - elb_application_lb
+'''
+
+EXAMPLES = '''
+- elb_application_lb_facts:
+    names:
+      - alb-test-webapp
+  register: alb_arn
+
+- aws_waf_regional_facts:
+    name: Drop HTTP requests for abusive API keys
+  register: waf_web_acl_id
+
+- name: Associate WAF Regional Web ACL with an ELBv2 (ALB)
+  aws_waf_regional_associate_elbv2:
+    web_acl_id: "{{ waf_web_acl_id.wafs[0].web_acl_id }}"
+    alb_resource_arn: "{{ alb_arn.load_balancers[0].load_balancer_arn }}"
+    state: present
+
+- name: Disassociate WAF Regional Web ACL with an ELBv2 (ALB)
+  aws_waf_regional_associate_elbv2:
+    web_acl_id: "{{ waf_web_acl_id.wafs[0].web_acl_id }}"
+    alb_resource_arn: "{{ alb_arn.load_balancers[0].load_balancer_arn }}"
+    state: absent
+'''
+
+RETURN = '''
+changed:
+    description: True if change succeeded succesfully.
+    type: bool
+    returned: always
+'''
+
+try:
+    import botocore
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry, compare_policies
+from ansible.module_utils.aws.waf_regional import run_func_with_change_token_backoff, MATCH_LOOKUP
+from ansible.module_utils.aws.waf_regional import get_rule_with_backoff, list_rules_with_backoff
+
+def main():
+    filters_subspec = dict(
+        web_acl_id=dict(),
+        alb_resource_arn=dict(),
+    )
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            web_acl_id=dict(required=True),
+            alb_resource_arn=dict(required=True),
+            state=dict(default='present', choices=['present', 'absent']),
+        ),
+    )
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              required_if=[['state', 'present', ['web_acl_id','alb_resource_arn']]])
+    state = module.params.get('state')
+    web_acl_id = module.params.get('web_acl_id')
+    alb_resource_arn = module.params.get('alb_resource_arn')
+
+    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+    client = boto3_conn(module, conn_type='client', resource='waf-regional', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+
+    results = dict(changed=False)
+
+    if state == 'present':
+        response = client.associate_web_acl(
+            WebACLId=web_acl_id,
+            ResourceArn=alb_resource_arn
+        )
+        results['changed'] = True
+    else:
+        response = client.disassociate_web_acl(
+            ResourceArn=alb_resource_arn
+        )
+        results['changed'] = True
+
+    pretty_results = camel_dict_to_snake_dict(results)
+    module.exit_json(**pretty_results)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/aws_waf_regional_condition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_regional_condition.py
@@ -1,0 +1,657 @@
+#!/usr/bin/python
+# Copyright (c) 2017 Will Thames
+# Copyright (c) 2015 Mike Mochan
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+module: aws_waf_regional_condition
+short_description: create and delete WAF Regional Conditions
+description:
+  - Read the AWS documentation for WAF Regional
+    U(https://aws.amazon.com/documentation/waf/)
+version_added: "2.6"
+
+author:
+  - Will Thames (@willthames)
+  - Mike Mochan (@mmochan)
+  - Jaco Engelbrecht (@bje)
+extends_documentation_fragment:
+  - aws
+  - ec2
+options:
+    name:
+        description: Name of the Web Application Firewall condition to manage
+        required: yes
+    type:
+        description: the type of matching to perform
+        choices:
+        - byte
+        - geo
+        - ip
+        - regex
+        - size
+        - sql
+        - xss
+    filters:
+        description:
+        - A list of the filters against which to match
+        - For I(type)=C(byte), valid keys are C(field_to_match), C(position), C(header), C(transformation)
+        - For I(type)=C(geo), the only valid key is C(country)
+        - For I(type)=C(ip), the only valid key is C(ip_address)
+        - For I(type)=C(regex), valid keys are C(field_to_match), C(transformation) and C(regex_pattern)
+        - For I(type)=C(size), valid keys are C(field_to_match), C(transformation), C(comparison) and C(size)
+        - For I(type)=C(sql), valid keys are C(field_to_match) and C(transformation)
+        - For I(type)=C(xss), valid keys are C(field_to_match) and C(transformation)
+        - I(field_to_match) can be one of C(uri), C(query_string), C(header) C(method) and C(body)
+        - If I(field_to_match) is C(header), then C(header) must also be specified
+        - I(transformation) can be one of C(none), C(compress_white_space), C(html_entity_decode), C(lowercase), C(cmd_line), C(url_decode)
+        - I(position), can be one of C(exactly), C(starts_with), C(ends_with), C(contains), C(contains_word),
+        - I(comparison) can be one of C(EQ), C(NE), C(LE), C(LT), C(GE), C(GT),
+        - I(target_string) is a maximum of 50 bytes
+        - I(regex_pattern) is a dict with a C(name) key and C(regex_strings) list of strings to match
+    purge_filters:
+        description: Whether to remove existing filters from a condition if not passed in I(filters). Defaults to false
+    state:
+        description: Whether the condition should be C(present) or C(absent)
+        choices:
+        - present
+        - absent
+        default: present
+
+'''
+
+EXAMPLES = '''
+  - name: create WAF Regional byte condition
+    aws_waf_regional_condition:
+      name: my_byte_condition
+      filters:
+      - field_to_match: header
+        position: STARTS_WITH
+        target_string: Hello
+        header: Content-type
+      type: byte
+
+  - name: create WAF Regional geo condition
+    aws_waf_regional_condition:
+      name: my_geo_condition
+      filters:
+        - country: US
+        - country: AU
+        - country: AT
+      type: geo
+
+  - name: create IP address condition
+    aws_waf_regional_condition:
+      name: "{{ resource_prefix }}_ip_condition"
+      filters:
+        - ip_address: "10.0.0.0/8"
+        - ip_address: "192.168.0.0/24"
+      type: ip
+
+  - name: create WAF Regional regex condition
+    aws_waf_regional_condition:
+      name: my_regex_condition
+      filters:
+        - field_to_match: query_string
+          regex_pattern:
+            name: greetings
+            regex_strings:
+              - '[hH]ello'
+              - '^Hi there'
+              - '.*Good Day to You'
+      type: regex
+
+  - name: create WAF Regional size condition
+    aws_waf_regional_condition:
+      name: my_size_condition
+      filters:
+        - field_to_match: query_string
+          size: 300
+          comparison: GT
+      type: size
+
+  - name: create WAF Regional sql injection condition
+    aws_waf_regional_condition:
+      name: my_sql_condition
+      filters:
+        - field_to_match: query_string
+          transformation: url_decode
+      type: sql
+
+  - name: create WAF Regional xss condition
+    aws_waf_regional_condition:
+      name: my_xss_condition
+      filters:
+        - field_to_match: query_string
+          transformation: url_decode
+      type: xss
+
+'''
+
+RETURN = '''
+condition:
+  description: condition returned by operation
+  returned: always
+  type: complex
+  contains:
+    condition_id:
+      description: type-agnostic ID for the condition
+      returned: when state is present
+      type: string
+      sample: dd74b1ff-8c06-4a4f-897a-6b23605de413
+    byte_match_set_id:
+      description: ID for byte match set
+      returned: always
+      type: string
+      sample: c4882c96-837b-44a2-a762-4ea87dbf812b
+    byte_match_tuples:
+      description: list of byte match tuples
+      returned: always
+      type: complex
+      contains:
+        field_to_match:
+          description: Field to match
+          returned: always
+          type: complex
+          contains:
+            data:
+              description: Which specific header (if type is header)
+              type: string
+              sample: content-type
+            type:
+              description: Type of field
+              type: string
+              sample: HEADER
+        positional_constraint:
+          description: Position in the field to match
+          type: string
+          sample: STARTS_WITH
+        target_string:
+          description: String to look for
+          type: string
+          sample: Hello
+        text_transformation:
+          description: Transformation to apply to the field before matching
+          type: string
+          sample: NONE
+    geo_match_constraints:
+      description: List of geographical constraints
+      returned: when type is geo and state is present
+      type: complex
+      contains:
+        type:
+          description: Type of geo constraint
+          type: string
+          sample: Country
+        value:
+          description: Value of geo constraint (typically a country code)
+          type: string
+          sample: AT
+    geo_match_set_id:
+      description: ID of the geo match set
+      returned: when type is geo and state is present
+      type: string
+      sample: dd74b1ff-8c06-4a4f-897a-6b23605de413
+    ip_set_descriptors:
+      description: list of IP address filters
+      returned: when type is ip and state is present
+      type: complex
+      contains:
+        type:
+          description: Type of IP address (IPV4 or IPV6)
+          returned: always
+          type: string
+          sample: IPV4
+        value:
+          description: IP address
+          returned: always
+          type: string
+          sample: 10.0.0.0/8
+    ip_set_id:
+      description: ID of condition
+      returned: when type is ip and state is present
+      type: string
+      sample: 78ad334a-3535-4036-85e6-8e11e745217b
+    name:
+      description: Name of condition
+      returned: when state is present
+      type: string
+      sample: my_waf_condition
+    regex_match_set_id:
+      description: ID of the regex match set
+      returned: when type is regex and state is present
+      type: string
+      sample: 5ea3f6a8-3cd3-488b-b637-17b79ce7089c
+    regex_match_tuples:
+      description: List of regex matches
+      returned: when type is regex and state is present
+      type: complex
+      contains:
+        field_to_match:
+          description: Field on which the regex match is applied
+          type: complex
+          contains:
+            type:
+              description: The field name
+              returned: when type is regex and state is present
+              type: string
+              sample: QUERY_STRING
+        regex_pattern_set_id:
+          description: ID of the regex pattern
+          type: string
+          sample: 6fdf7f2d-9091-445c-aef2-98f3c051ac9e
+        text_transformation:
+          description: transformation applied to the text before matching
+          type: string
+          sample: NONE
+    size_constraint_set_id:
+      description: ID of the size constraint set
+      returned: when type is size and state is present
+      type: string
+      sample: de84b4b3-578b-447e-a9a0-0db35c995656
+    size_constraints:
+      description: List of size constraints to apply
+      returned: when type is size and state is present
+      type: complex
+      contains:
+        comparison_operator:
+          description: Comparison operator to apply
+          type: string
+          sample: GT
+        field_to_match:
+          description: Field on which the size constraint is applied
+          type: complex
+          contains:
+            type:
+              description: Field name
+              type: string
+              sample: QUERY_STRING
+        size:
+          description: size to compare against the field
+          type: int
+          sample: 300
+        text_transformation:
+          description: transformation applied to the text before matching
+          type: string
+          sample: NONE
+    sql_injection_match_set_id:
+      description: ID of the SQL injection match set
+      returned: when type is sql and state is present
+      type: string
+      sample: de84b4b3-578b-447e-a9a0-0db35c995656
+    sql_injection_match_tuples:
+      description: List of SQL injection match sets
+      returned: when type is sql and state is present
+      type: complex
+      contains:
+        field_to_match:
+          description: Field on which the SQL injection match is applied
+          type: complex
+          contains:
+            type:
+              description: Field name
+              type: string
+              sample: QUERY_STRING
+        text_transformation:
+          description: transformation applied to the text before matching
+          type: string
+          sample: URL_DECODE
+    xss_match_set_id:
+      description: ID of the XSS match set
+      returned: when type is xss and state is present
+      type: string
+      sample: de84b4b3-578b-447e-a9a0-0db35c995656
+    xss_match_tuples:
+      description: List of XSS match sets
+      returned: when type is xss and state is present
+      type: complex
+      contains:
+        field_to_match:
+          description: Field on which the XSS match is applied
+          type: complex
+          contains:
+            type:
+              description: Field name
+              type: string
+              sample: QUERY_STRING
+        text_transformation:
+          description: transformation applied to the text before matching
+          type: string
+          sample: URL_DECODE
+'''
+
+try:
+    import botocore
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry, compare_policies
+from ansible.module_utils.aws.waf_regional import run_func_with_change_token_backoff, MATCH_LOOKUP
+from ansible.module_utils.aws.waf_regional import get_rule_with_backoff, list_rules_with_backoff
+
+
+class Condition(object):
+
+    def __init__(self, client, module):
+        self.client = client
+        self.module = module
+        self.type = module.params['type']
+        self.method_suffix = MATCH_LOOKUP[self.type]['method']
+        self.conditionset = MATCH_LOOKUP[self.type]['conditionset']
+        self.conditionsets = MATCH_LOOKUP[self.type]['conditionset'] + 's'
+        self.conditionsetid = MATCH_LOOKUP[self.type]['conditionset'] + 'Id'
+        self.conditiontuple = MATCH_LOOKUP[self.type]['conditiontuple']
+        self.conditiontuples = MATCH_LOOKUP[self.type]['conditiontuple'] + 's'
+        self.conditiontype = MATCH_LOOKUP[self.type]['type']
+
+    def format_for_update(self, condition_set_id):
+        # Prep kwargs
+        kwargs = dict()
+        kwargs['Updates'] = list()
+
+        for filtr in self.module.params.get('filters'):
+            # Only for ip_set
+            if self.type == 'ip':
+                # there might be a better way of detecting an IPv6 address
+                if ':' in filtr.get('ip_address'):
+                    ip_type = 'IPV6'
+                else:
+                    ip_type = 'IPV4'
+                condition_insert = {'Type': ip_type, 'Value': filtr.get('ip_address')}
+
+            # Specific for geo_match_set
+            if self.type == 'geo':
+                condition_insert = dict(Type='Country', Value=filtr.get('country'))
+
+            # Common For everything but ip_set and geo_match_set
+            if self.type not in ('ip', 'geo'):
+
+                condition_insert = dict(FieldToMatch=dict(Type=filtr.get('field_to_match').upper()),
+                                        TextTransformation=filtr.get('transformation', 'none').upper())
+
+                if filtr.get('field_to_match').upper() == "HEADER":
+                    if filtr.get('header'):
+                        condition_insert['FieldToMatch']['Data'] = filtr.get('header').lower()
+                    else:
+                        self.module.fail_json(msg=str("DATA required when HEADER requested"))
+
+            # Specific for byte_match_set
+            if self.type == 'byte':
+                condition_insert['TargetString'] = filtr.get('target_string')
+                condition_insert['PositionalConstraint'] = filtr.get('position')
+
+            # Specific for size_constraint_set
+            if self.type == 'size':
+                condition_insert['ComparisonOperator'] = filtr.get('comparison')
+                condition_insert['Size'] = filtr.get('size')
+
+            # Specific for regex_match_set
+            if self.type == 'regex':
+                condition_insert['RegexPatternSetId'] = self.ensure_regex_pattern_present(filtr.get('regex_pattern'))['RegexPatternSetId']
+
+            kwargs['Updates'].append({'Action': 'INSERT', self.conditiontuple: condition_insert})
+
+        kwargs[self.conditionsetid] = condition_set_id
+        return kwargs
+
+    def format_for_deletion(self, condition):
+        return {'Updates': [{'Action': 'DELETE', self.conditiontuple: current_condition_tuple}
+                            for current_condition_tuple in condition[self.conditiontuples]],
+                self.conditionsetid: condition[self.conditionsetid]}
+
+    @AWSRetry.exponential_backoff()
+    def list_regex_patterns_with_backoff(self, **params):
+        return self.client.list_regex_pattern_sets(**params)
+
+    @AWSRetry.exponential_backoff()
+    def get_regex_pattern_set_with_backoff(self, regex_pattern_set_id):
+        return self.client.get_regex_pattern_set(RegexPatternSetId=regex_pattern_set_id)
+
+    def list_regex_patterns(self):
+        # at time of writing(2017-11-20) no regex pattern paginator exists
+        regex_patterns = []
+        params = {}
+        while True:
+            try:
+                response = self.list_regex_patterns_with_backoff(**params)
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                self.module.fail_json_aws(e, msg='Could not list regex patterns')
+            regex_patterns.extend(response['RegexPatternSets'])
+            if 'NextMarker' in response:
+                params['NextMarker'] = response['NextMarker']
+            else:
+                break
+        return regex_patterns
+
+    def get_regex_pattern_by_name(self, name):
+        existing_regex_patterns = self.list_regex_patterns()
+        regex_lookup = dict((item['Name'], item['RegexPatternSetId']) for item in existing_regex_patterns)
+        if name in regex_lookup:
+            return self.get_regex_pattern_set_with_backoff(regex_lookup[name])['RegexPatternSet']
+        else:
+            return None
+
+    def ensure_regex_pattern_present(self, regex_pattern):
+        name = regex_pattern['name']
+
+        pattern_set = self.get_regex_pattern_by_name(name)
+        if not pattern_set:
+            pattern_set = run_func_with_change_token_backoff(self.client, self.module, {'Name': name},
+                                                             self.client.create_regex_pattern_set)['RegexPatternSet']
+        missing = set(regex_pattern['regex_strings']) - set(pattern_set['RegexPatternStrings'])
+        extra = set(pattern_set['RegexPatternStrings']) - set(regex_pattern['regex_strings'])
+        if not missing and not extra:
+            return pattern_set
+        updates = [{'Action': 'INSERT', 'RegexPatternString': pattern} for pattern in missing]
+        updates.extend([{'Action': 'DELETE', 'RegexPatternString': pattern} for pattern in extra])
+        run_func_with_change_token_backoff(self.client, self.module,
+                                           {'RegexPatternSetId': pattern_set['RegexPatternSetId'], 'Updates': updates},
+                                           self.client.update_regex_pattern_set)
+        return self.get_regex_pattern_set_with_backoff(pattern_set['RegexPatternSetId'])['RegexPatternSet']
+
+    def delete_unused_regex_pattern(self, regex_pattern_set_id):
+        try:
+            regex_pattern_set = self.client.get_regex_pattern_set(RegexPatternSetId=regex_pattern_set_id)['RegexPatternSet']
+            updates = list()
+            for regex_pattern_string in regex_pattern_set['RegexPatternStrings']:
+                updates.append({'Action': 'DELETE', 'RegexPatternString': regex_pattern_string})
+            run_func_with_change_token_backoff(self.client, self.module,
+                                               {'RegexPatternSetId': regex_pattern_set_id, 'Updates': updates},
+                                               self.client.update_regex_pattern_set)
+
+            run_func_with_change_token_backoff(self.client, self.module,
+                                               {'RegexPatternSetId': regex_pattern_set_id},
+                                               self.client.delete_regex_pattern_set)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            self.module.fail_json_aws(e, msg='Could not delete regex pattern')
+
+    def get_condition_by_name(self, name):
+        all_conditions = [d for d in self.list_conditions() if d['Name'] == name]
+        if all_conditions:
+            return all_conditions[0][self.conditionsetid]
+
+    @AWSRetry.exponential_backoff()
+    def get_condition_by_id_with_backoff(self, condition_set_id):
+        params = dict()
+        params[self.conditionsetid] = condition_set_id
+        func = getattr(self.client, 'get_' + self.method_suffix)
+        return func(**params)[self.conditionset]
+
+    def get_condition_by_id(self, condition_set_id):
+        try:
+            return self.get_condition_by_id_with_backoff(condition_set_id)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            self.module.fail_json_aws(e, msg='Could not get condition')
+
+    def list_conditions(self):
+        method = 'list_' + self.method_suffix + 's'
+        try:
+            paginator = self.client.get_paginator(method)
+            func = paginator.paginate().build_full_result
+        except botocore.exceptions.OperationNotPageableError:
+            # list_geo_match_sets and list_regex_match_sets do not have a paginator
+            func = getattr(self.client, method)
+        try:
+            return func()[self.conditionsets]
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            self.module.fail_json_aws(e, msg='Could not list %s conditions' % self.type)
+
+    def tidy_up_regex_patterns(self, regex_match_set):
+        all_regex_match_sets = self.list_conditions()
+        all_match_set_patterns = list()
+        for rms in all_regex_match_sets:
+            all_match_set_patterns.extend(conditiontuple['RegexPatternSetId']
+                                          for conditiontuple in self.get_condition_by_id(rms[self.conditionsetid])[self.conditiontuples])
+        for filtr in regex_match_set[self.conditiontuples]:
+            if filtr['RegexPatternSetId'] not in all_match_set_patterns:
+                self.delete_unused_regex_pattern(filtr['RegexPatternSetId'])
+
+    def find_condition_in_rules(self, condition_set_id):
+        rules_in_use = []
+        try:
+            all_rules = list_rules_with_backoff(self.client)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            self.module.fail_json_aws(e, msg='Could not list rules')
+        for rule in all_rules:
+            try:
+                rule_details = get_rule_with_backoff(self.client, rule['RuleId'])
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                self.module.fail_json_aws(e, msg='Could not get rule details')
+            if condition_set_id in [predicate['DataId'] for predicate in rule_details['Predicates']]:
+                rules_in_use.append(rule_details['Name'])
+        return rules_in_use
+
+    def find_and_delete_condition(self, condition_set_id):
+        current_condition = self.get_condition_by_id(condition_set_id)
+        in_use_rules = self.find_condition_in_rules(condition_set_id)
+        if in_use_rules:
+            rulenames = ', '.join(in_use_rules)
+            self.module.fail_json(msg="Condition %s is in use by %s" % (current_condition['Name'], rulenames))
+        if current_condition[self.conditiontuples]:
+            # Filters are deleted using update with the DELETE action
+            func = getattr(self.client, 'update_' + self.method_suffix)
+            params = self.format_for_deletion(current_condition)
+            try:
+                run_func_with_change_token_backoff(self.client, self.module, params, func)
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                self.module.fail_json_aws(e, msg='Could not delete filters from condition')
+        func = getattr(self.client, 'delete_' + self.method_suffix)
+        params = dict()
+        params[self.conditionsetid] = condition_set_id
+        try:
+            run_func_with_change_token_backoff(self.client, self.module, params, func)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            self.module.fail_json_aws(e, msg='Could not delete condition')
+        # tidy up regex patterns
+        if self.type == 'regex':
+            self.tidy_up_regex_patterns(current_condition)
+        return True, {}
+
+    def find_missing(self, update, current_condition):
+        missing = []
+        for desired in update['Updates']:
+            found = False
+            desired_condition = desired[self.conditiontuple]
+            current_conditions = current_condition[self.conditiontuples]
+            for condition in current_conditions:
+                if not compare_policies(condition, desired_condition):
+                    found = True
+            if not found:
+                missing.append(desired)
+        return missing
+
+    def find_and_update_condition(self, condition_set_id):
+        current_condition = self.get_condition_by_id(condition_set_id)
+        update = self.format_for_update(condition_set_id)
+        missing = self.find_missing(update, current_condition)
+        if self.module.params.get('purge_filters'):
+            extra = [{'Action': 'DELETE', self.conditiontuple: current_tuple}
+                     for current_tuple in current_condition[self.conditiontuples]
+                     if current_tuple not in [desired[self.conditiontuple] for desired in update['Updates']]]
+        else:
+            extra = []
+        changed = bool(missing or extra)
+        if changed:
+            update['Updates'] = missing + extra
+            func = getattr(self.client, 'update_' + self.method_suffix)
+            try:
+                run_func_with_change_token_backoff(self.client, self.module, update, func)
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                self.module.fail_json_aws(e, msg='Could not update condition')
+        return changed, self.get_condition_by_id(condition_set_id)
+
+    def ensure_condition_present(self):
+        name = self.module.params['name']
+        condition_set_id = self.get_condition_by_name(name)
+        if condition_set_id:
+            return self.find_and_update_condition(condition_set_id)
+        else:
+            params = dict()
+            params['Name'] = name
+            func = getattr(self.client, 'create_' + self.method_suffix)
+            try:
+                condition = run_func_with_change_token_backoff(self.client, self.module, params, func)
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                self.module.fail_json_aws(e, msg='Could not create condition')
+            return self.find_and_update_condition(condition[self.conditionset][self.conditionsetid])
+
+    def ensure_condition_absent(self):
+        condition_set_id = self.get_condition_by_name(self.module.params['name'])
+        if condition_set_id:
+            return self.find_and_delete_condition(condition_set_id)
+        return False, {}
+
+
+def main():
+    filters_subspec = dict(
+        country=dict(),
+        field_to_match=dict(choices=['uri', 'query_string', 'header', 'method', 'body']),
+        header=dict(),
+        transformation=dict(choices=['none', 'compress_white_space',
+                                     'html_entity_decode', 'lowercase',
+                                     'cmd_line', 'url_decode']),
+        position=dict(choices=['exactly', 'starts_with', 'ends_with',
+                               'contains', 'contains_word']),
+        comparison=dict(choices=['EQ', 'NE', 'LE', 'LT', 'GE', 'GT']),
+        target_string=dict(),  # Bytes
+        size=dict(type='int'),
+        ip_address=dict(),
+        regex_pattern=dict(),
+    )
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(required=True),
+            type=dict(required=True, choices=['byte', 'geo', 'ip', 'regex', 'size', 'sql', 'xss']),
+            filters=dict(type='list'),
+            purge_filters=dict(type='bool', default=False),
+            state=dict(default='present', choices=['present', 'absent']),
+        ),
+    )
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              required_if=[['state', 'present', ['filters']]])
+    state = module.params.get('state')
+
+    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+    client = boto3_conn(module, conn_type='client', resource='waf-regional', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+
+    condition = Condition(client, module)
+
+    if state == 'present':
+        (changed, results) = condition.ensure_condition_present()
+        # return a condition agnostic ID for use by aws_waf_regional_rule
+        results['ConditionId'] = results[condition.conditionsetid]
+    else:
+        (changed, results) = condition.ensure_condition_absent()
+
+    module.exit_json(changed=changed, condition=camel_dict_to_snake_dict(results))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/aws_waf_regional_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_regional_facts.py
@@ -1,0 +1,136 @@
+#!/usr/bin/python
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+module: aws_waf_regional_facts
+short_description: Retrieve facts for WAF Regional ACLs, Rule , Conditions and Filters.
+description:
+  - Retrieve facts for WAF Regional ACLs, Rule , Conditions and Filters.
+version_added: "2.6"
+requirements: [ boto3 ]
+options:
+  name:
+    description:
+      - The name of a Web Application Firewall
+
+author:
+  - Mike Mochan (@mmochan)
+  - Will Thames (@willthames)
+  - Jaco Engelbrecht (@bje)
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+- name: obtain all WAF Regional facts
+  aws_waf_regional_facts:
+
+- name: obtain all facts for a single WAF Regional
+  aws_waf_regional_facts:
+    name: test_waf
+'''
+
+RETURN = '''
+wafs:
+  description: The WAF Regionals that match the passed arguments
+  returned: success
+  type: complex
+  contains:
+    name:
+      description: A friendly name or description of the WebACL
+      returned: always
+      type: string
+      sample: test_waf
+    default_action:
+      description: The action to perform if none of the Rules contained in the WebACL match.
+      returned: always
+      type: int
+      sample: BLOCK
+    metric_name:
+      description: A friendly name or description for the metrics for this WebACL
+      returned: always
+      type: string
+      sample: test_waf_metric
+    rules:
+      description: An array that contains the action for each Rule in a WebACL , the priority of the Rule
+      returned: always
+      type: complex
+      contains:
+        action:
+          description: The action to perform if the Rule matches
+          returned: always
+          type: string
+          sample: BLOCK
+        metric_name:
+          description: A friendly name or description for the metrics for this Rule
+          returned: always
+          type: string
+          sample: ipblockrule
+        name:
+          description: A friendly name or description of the Rule
+          returned: always
+          type: string
+          sample: ip_block_rule
+        predicates:
+          description: The Predicates list contains a Predicate for each
+            ByteMatchSet, IPSet, SizeConstraintSet, SqlInjectionMatchSet or XssMatchSet
+            object in a Rule
+          returned: always
+          type: list
+          sample:
+            [
+              {
+                "byte_match_set_id": "47b822b5-abcd-1234-faaf-1234567890",
+                "byte_match_tuples": [
+                  {
+                    "field_to_match": {
+                      "type": "QUERY_STRING"
+                    },
+                    "positional_constraint": "STARTS_WITH",
+                    "target_string": "bobbins",
+                    "text_transformation": "NONE"
+                  }
+                ],
+                "name": "bobbins",
+                "negated": false,
+                "type": "ByteMatch"
+              }
+            ]
+'''
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
+from ansible.module_utils.aws.waf_regional import list_web_acls, get_web_acl
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(required=False),
+        )
+    )
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+    client = boto3_conn(module, conn_type='client', resource='waf-regional', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+
+    web_acls = list_web_acls(client, module)
+    name = module.params['name']
+    if name:
+        web_acls = [web_acl for web_acl in web_acls if
+                    web_acl['Name'] == name]
+        if not web_acls:
+            module.fail_json(msg="WAF Regional named %s not found" % name)
+    module.exit_json(wafs=[get_web_acl(client, module, web_acl['WebACLId'])
+                           for web_acl in web_acls])
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/aws_waf_regional_rule.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_regional_rule.py
@@ -1,0 +1,319 @@
+#!/usr/bin/python
+# Copyright (c) 2017 Will Thames
+# Copyright (c) 2015 Mike Mochan
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+module: aws_waf_regional_rule
+short_description: create and delete WAF Regional Rules
+description:
+  - Read the AWS documentation for WAF Regional
+    U(https://aws.amazon.com/documentation/waf/)
+version_added: "2.6"
+
+author:
+  - Mike Mochan (@mmochan)
+  - Will Thames (@willthames)
+  - Jaco Engelbrecht (@bje)
+extends_documentation_fragment:
+  - aws
+  - ec2
+options:
+    name:
+        description: Name of the Web Application Firewall rule
+        required: yes
+    metric_name:
+        description:
+        - A friendly name or description for the metrics for the rule
+        - The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace.
+        - You can't change metric_name after you create the rule
+        - Defaults to the same as name with disallowed characters removed
+    state:
+        description: whether the rule should be present or absent
+        choices:
+        - present
+        - absent
+        default: present
+    conditions:
+        description: >
+          list of conditions used in the rule. Each condition should
+          contain I(type): which is one of [C(byte), C(geo), C(ip), C(size), C(sql) or C(xss)]
+          I(negated): whether the condition should be negated, and C(condition),
+          the name of the existing condition. M(aws_waf_regional_condition) can be used to
+          create new conditions
+    purge_conditions:
+        description:
+          - Whether or not to remove conditions that are not passed when updating `conditions`.
+            Defaults to false.
+'''
+
+EXAMPLES = '''
+
+  - name: create WAF Regional rule
+    aws_waf_regional_rule:
+      name: my_waf_rule
+      conditions:
+        - name: my_regex_condition
+          type: regex
+          negated: no
+        - name: my_geo_condition
+          type: geo
+          negated: no
+        - name: my_byte_condition
+          type: byte
+          negated: yes
+
+  - name: remove WAF Regional rule
+    aws_waf_regional_rule:
+      name: "my_waf_rule"
+      state: absent
+
+'''
+
+RETURN = '''
+rule:
+  description: WAF Regional rule contents
+  returned: always
+  type: complex
+  contains:
+    metric_name:
+      description: Metric name for the rule
+      returned: always
+      type: string
+      sample: ansibletest1234rule
+    name:
+      description: Friendly name for the rule
+      returned: always
+      type: string
+      sample: ansible-test-1234_rule
+    predicates:
+      description: List of conditions used in the rule
+      returned: always
+      type: complex
+      contains:
+        data_id:
+          description: ID of the condition
+          returned: always
+          type: string
+          sample: 8251acdb-526c-42a8-92bc-d3d13e584166
+        negated:
+          description: Whether the sense of the condition is negated
+          returned: always
+          type: bool
+          sample: false
+        type:
+          description: type of the condition
+          returned: always
+          type: string
+          sample: ByteMatch
+    rule_id:
+      description: ID of the WAF Regional rule
+      returned: always
+      type: string
+      sample: 15de0cbc-9204-4e1f-90e6-69b2f415c261
+'''
+
+import re
+
+try:
+    import botocore
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible.module_utils.aws.waf_regional import run_func_with_change_token_backoff, list_rules_with_backoff, MATCH_LOOKUP
+from ansible.module_utils.aws.waf_regional import get_web_acl_with_backoff, list_web_acls_with_backoff
+
+
+def get_rule_by_name(client, module, name):
+    rules = [d['RuleId'] for d in list_rules(client, module) if d['Name'] == name]
+    if rules:
+        return rules[0]
+
+
+def get_rule(client, module, rule_id):
+    try:
+        return client.get_rule(RuleId=rule_id)['Rule']
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Could not get WAF Regional rule')
+
+
+def list_rules(client, module):
+    try:
+        return list_rules_with_backoff(client)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Could not list WAF Regional rules')
+
+
+def find_and_update_rule(client, module, rule_id):
+    rule = get_rule(client, module, rule_id)
+    rule_id = rule['RuleId']
+
+    existing_conditions = dict((condition_type, dict()) for condition_type in MATCH_LOOKUP)
+    desired_conditions = dict((condition_type, dict()) for condition_type in MATCH_LOOKUP)
+    all_conditions = dict()
+
+    for condition_type in MATCH_LOOKUP:
+        method = 'list_' + MATCH_LOOKUP[condition_type]['method'] + 's'
+        all_conditions[condition_type] = dict()
+        try:
+            paginator = client.get_paginator(method)
+            func = paginator.paginate().build_full_result
+            #func = client(method)
+        except (KeyError, botocore.exceptions.OperationNotPageableError):
+            # list_geo_match_sets and list_regex_match_sets do not have a paginator
+            # and throw different exceptions
+            func = getattr(client, method)
+        try:
+            pred_results = func()[MATCH_LOOKUP[condition_type]['conditionset'] + 's']
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg='Could not list %s conditions' % condition_type)
+        for pred in pred_results:
+            pred['DataId'] = pred[MATCH_LOOKUP[condition_type]['conditionset'] + 'Id']
+            all_conditions[condition_type][pred['Name']] = camel_dict_to_snake_dict(pred)
+            all_conditions[condition_type][pred['DataId']] = camel_dict_to_snake_dict(pred)
+
+    for condition in module.params['conditions']:
+        desired_conditions[condition['type']][condition['name']] = condition
+
+    reverse_condition_types = dict((v['type'], k) for (k, v) in MATCH_LOOKUP.items())
+    for condition in rule['Predicates']:
+        existing_conditions[reverse_condition_types[condition['Type']]][condition['DataId']] = camel_dict_to_snake_dict(condition)
+
+    insertions = list()
+    deletions = list()
+
+    for condition_type in desired_conditions:
+        for (condition_name, condition) in desired_conditions[condition_type].items():
+            if condition_name not in all_conditions[condition_type]:
+                module.fail_json(msg="Condition %s of type %s does not exist" % (condition_name, condition_type))
+            condition['data_id'] = all_conditions[condition_type][condition_name]['data_id']
+            if condition['data_id'] not in existing_conditions[condition_type]:
+                insertions.append(format_for_insertion(condition))
+
+    if module.params['purge_conditions']:
+        for condition_type in existing_conditions:
+            deletions.extend([format_for_deletion(condition) for condition in existing_conditions[condition_type].values()
+                              if not all_conditions[condition_type][condition['data_id']]['name'] in desired_conditions[condition_type]])
+
+    changed = bool(insertions or deletions)
+    update = {
+        'RuleId': rule_id,
+        'Updates': insertions + deletions
+    }
+    if changed:
+        try:
+            run_func_with_change_token_backoff(client, module, update, client.update_rule)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg='Could not update rule conditions')
+
+    return changed, get_rule(client, module, rule_id)
+
+
+def format_for_insertion(condition):
+    return dict(Action='INSERT',
+                Predicate=dict(Negated=condition['negated'],
+                               Type=MATCH_LOOKUP[condition['type']]['type'],
+                               DataId=condition['data_id']))
+
+
+def format_for_deletion(condition):
+    return dict(Action='DELETE',
+                Predicate=dict(Negated=condition['negated'],
+                               Type=condition['type'],
+                               DataId=condition['data_id']))
+
+
+def remove_rule_conditions(client, module, rule_id):
+    conditions = get_rule(client, module, rule_id)['Predicates']
+    updates = [format_for_deletion(camel_dict_to_snake_dict(condition)) for condition in conditions]
+    try:
+        run_func_with_change_token_backoff(client, module, {'RuleId': rule_id, 'Updates': updates}, client.update_rule)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Could not remove rule conditions')
+
+
+def ensure_rule_present(client, module):
+    name = module.params['name']
+    rule_id = get_rule_by_name(client, module, name)
+    params = dict()
+    if rule_id:
+        return find_and_update_rule(client, module, rule_id)
+    else:
+        params['Name'] = module.params['name']
+        metric_name = module.params['metric_name']
+        if not metric_name:
+            metric_name = re.sub(r'[^a-zA-Z0-9]', '', module.params['name'])
+        params['MetricName'] = metric_name
+        try:
+            new_rule = run_func_with_change_token_backoff(client, module, params, client.create_rule)['Rule']
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg='Could not create rule')
+        return find_and_update_rule(client, module, new_rule['RuleId'])
+
+
+def find_rule_in_web_acls(client, module, rule_id):
+    web_acls_in_use = []
+    try:
+        all_web_acls = list_web_acls_with_backoff(client)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Could not list Web ACLs')
+    for web_acl in all_web_acls:
+        try:
+            web_acl_details = get_web_acl_with_backoff(client, web_acl['WebACLId'])
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg='Could not get Web ACL details')
+        if rule_id in [rule['RuleId'] for rule in web_acl_details['Rules']]:
+            web_acls_in_use.append(web_acl_details['Name'])
+    return web_acls_in_use
+
+
+def ensure_rule_absent(client, module):
+    rule_id = get_rule_by_name(client, module, module.params['name'])
+    in_use_web_acls = find_rule_in_web_acls(client, module, rule_id)
+    if in_use_web_acls:
+        web_acl_names = ', '.join(in_use_web_acls)
+        module.fail_json(msg="Rule %s is in use by Web ACL(s) %s" %
+                         (module.params['name'], web_acl_names))
+    if rule_id:
+        remove_rule_conditions(client, module, rule_id)
+        try:
+            return True, run_func_with_change_token_backoff(client, module, {'RuleId': rule_id}, client.delete_rule)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg='Could not delete rule')
+    return False, {}
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(required=True),
+            metric_name=dict(),
+            state=dict(default='present', choices=['present', 'absent']),
+            conditions=dict(type='list'),
+            purge_conditions=dict(type='bool', default=False)
+        ),
+    )
+    module = AnsibleAWSModule(argument_spec=argument_spec)
+    state = module.params.get('state')
+
+    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+    client = boto3_conn(module, conn_type='client', resource='waf-regional', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+
+    if state == 'present':
+        (changed, results) = ensure_rule_present(client, module)
+    else:
+        (changed, results) = ensure_rule_absent(client, module)
+
+    module.exit_json(changed=changed, rule=camel_dict_to_snake_dict(results))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/aws_waf_regional_web_acl.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_regional_web_acl.py
@@ -1,0 +1,300 @@
+#!/usr/bin/python
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+module: aws_waf_regional_web_acl
+short_description: create and delete WAF Regional Web ACLs
+description:
+  - Read the AWS documentation for WAF Regional
+    U(https://aws.amazon.com/documentation/waf/)
+version_added: "2.6"
+
+author:
+  - Mike Mochan (@mmochan)
+  - Will Thames (@willthames)
+  - Jaco Engelbrecht (@bje)
+extends_documentation_fragment:
+  - aws
+  - ec2
+options:
+    name:
+        description: Name of the Web Application Firewall ACL to manage
+        required: yes
+    default_action:
+        description: The action that you want AWS WAF Regional to take when a request doesn't
+          match the criteria specified in any of the Rule objects that are associated with the WebACL
+        choices:
+        - block
+        - allow
+        - count
+    state:
+        description: whether the Web ACL should be present or absent
+        choices:
+        - present
+        - absent
+        default: present
+    metric_name:
+        description:
+        - A friendly name or description for the metrics for this WebACL
+        - The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace.
+        - You can't change metric_name after you create the WebACL
+        - Metric name will default to I(name) with disallowed characters stripped out
+    rules:
+        description:
+        - A list of rules that the Web ACL will enforce.
+        - Each rule must contain I(name), I(action), I(priority) keys.
+        - Priorities must be unique, but not necessarily consecutive. Lower numbered priorities are evalauted first.
+        - The I(type) key can be passed as C(rate_based), it defaults to C(regular)
+
+    purge_rules:
+        description: Whether to remove rules that aren't passed with C(rules). Defaults to false
+'''
+
+EXAMPLES = '''
+  - name: create web ACL
+    aws_waf_regional_web_acl:
+      name: my_web_acl
+      rules:
+        - name: my_rule
+          priority: 1
+          action: block
+      default_action: block
+      purge_rules: yes
+      state: present
+
+  - name: delete the web acl
+    aws_waf_regional_web_acl:
+      name: my_web_acl
+      state: absent
+'''
+
+RETURN = '''
+web_acl:
+  description: contents of the Web ACL
+  returned: always
+  type: complex
+  contains:
+    default_action:
+      description: Default action taken by the Web ACL if no rules match
+      returned: always
+      type: dict
+      sample:
+        type: BLOCK
+    metric_name:
+      description: Metric name used as an identifier
+      returned: always
+      type: string
+      sample: mywebacl
+    name:
+      description: Friendly name of the Web ACL
+      returned: always
+      type: string
+      sample: my web acl
+    rules:
+      description: List of rules
+      returned: always
+      type: complex
+      contains:
+        action:
+          description: Action taken by the WAF Regional when the rule matches
+          returned: always
+          type: complex
+          sample:
+            type: ALLOW
+        priority:
+          description: priority number of the rule (lower numbers are run first)
+          returned: always
+          type: int
+          sample: 2
+        rule_id:
+          description: Rule ID
+          returned: always
+          type: string
+          sample: a6fc7ab5-287b-479f-8004-7fd0399daf75
+        type:
+          description: Type of rule (either REGULAR or RATE_BASED)
+          returned: always
+          type: string
+          sample: REGULAR
+    web_acl_id:
+      description: Unique identifier of Web ACL
+      returned: always
+      type: string
+      sample: 10fff965-4b6b-46e2-9d78-24f6d2e2d21c
+'''
+
+try:
+    import botocore
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+import re
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict
+from ansible.module_utils.aws.waf_regional import list_rules_with_backoff, list_web_acls_with_backoff, run_func_with_change_token_backoff
+
+
+def get_web_acl_by_name(client, module, name):
+    acls = [d['WebACLId'] for d in list_web_acls(client, module) if d['Name'] == name]
+    if acls:
+        return acls[0]
+    else:
+        return acls
+
+
+def create_rule_lookup(client, module):
+    try:
+        rules = list_rules_with_backoff(client)
+        return dict((rule['Name'], rule) for rule in rules)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Could not list rules')
+
+
+def get_web_acl(client, module, web_acl_id):
+    try:
+        return client.get_web_acl(WebACLId=web_acl_id)['WebACL']
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Could not get Web ACL with id %s' % web_acl_id)
+
+
+def list_web_acls(client, module,):
+    try:
+        return list_web_acls_with_backoff(client)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Could not get Web ACLs')
+
+
+def find_and_update_web_acl(client, module, web_acl_id):
+    acl = get_web_acl(client, module, web_acl_id)
+    rule_lookup = create_rule_lookup(client, module)
+    existing_rules = acl['Rules']
+    desired_rules = [{'RuleId': rule_lookup[rule['name']]['RuleId'],
+                      'Priority': rule['priority'],
+                      'Action': {'Type': rule['action'].upper()},
+                      'Type': rule.get('type', 'regular').upper()}
+                     for rule in module.params['rules']]
+    missing = [rule for rule in desired_rules if rule not in existing_rules]
+    extras = []
+    if module.params['purge_rules']:
+        extras = [rule for rule in existing_rules if rule not in desired_rules]
+
+    insertions = [format_for_update(rule, 'INSERT') for rule in missing]
+    deletions = [format_for_update(rule, 'DELETE') for rule in extras]
+    changed = bool(insertions + deletions)
+
+    # Purge rules before adding new ones in case a deletion shares the same
+    # priority as an insertion.
+    params = {
+        'WebACLId': acl['WebACLId'],
+        'DefaultAction': acl['DefaultAction']
+    }
+    if deletions:
+        try:
+            params['Updates'] = deletions
+            run_func_with_change_token_backoff(client, module, params, client.update_web_acl)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg='Could not update Web ACL')
+    if insertions:
+        try:
+            params['Updates'] = insertions
+            run_func_with_change_token_backoff(client, module, params, client.update_web_acl)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg='Could not update Web ACL')
+    if changed:
+        acl = get_web_acl(client, module, web_acl_id)
+    return changed, acl
+
+
+def format_for_update(rule, action):
+    return dict(
+        Action=action,
+        ActivatedRule=dict(
+            Priority=rule['Priority'],
+            RuleId=rule['RuleId'],
+            Action=dict(
+                Type=rule['Action']['Type']
+            )
+        )
+    )
+
+
+def remove_rules_from_web_acl(client, module, web_acl_id):
+    acl = get_web_acl(client, module, web_acl_id)
+    deletions = [format_for_update(rule, 'DELETE') for rule in acl['Rules']]
+    try:
+        params = {'WebACLId': acl['WebACLId'], 'DefaultAction': acl['DefaultAction'], 'Updates': deletions}
+        run_func_with_change_token_backoff(client, module, params, client.update_web_acl)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Could not remove rule')
+
+
+def ensure_web_acl_present(client, module):
+    changed = False
+    result = None
+    name = module.params['name']
+    web_acl_id = get_web_acl_by_name(client, module, name)
+    if web_acl_id:
+        (changed, result) = find_and_update_web_acl(client, module, web_acl_id)
+    else:
+        metric_name = module.params['metric_name']
+        if not metric_name:
+            metric_name = re.sub(r'[^A-Za-z0-9]', '', module.params['name'])
+        default_action = module.params['default_action'].upper()
+        try:
+            params = {'Name': name, 'MetricName': metric_name, 'DefaultAction': {'Type': default_action}}
+            new_web_acl = run_func_with_change_token_backoff(client, module, params, client.create_web_acl)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg='Could not create Web ACL')
+        (changed, result) = find_and_update_web_acl(client, module, new_web_acl['WebACL']['WebACLId'])
+    return changed, result
+
+
+def ensure_web_acl_absent(client, module):
+    web_acl_id = get_web_acl_by_name(client, module, module.params['name'])
+    if web_acl_id:
+        web_acl = get_web_acl(client, module, web_acl_id)
+        if web_acl['Rules']:
+            remove_rules_from_web_acl(client, module, web_acl_id)
+        try:
+            run_func_with_change_token_backoff(client, module, {'WebACLId': web_acl_id}, client.delete_web_acl)
+            return True, {}
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg='Could not delete Web ACL')
+    return False, {}
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(required=True),
+            default_action=dict(choices=['block', 'allow', 'count']),
+            metric_name=dict(),
+            state=dict(default='present', choices=['present', 'absent']),
+            rules=dict(type='list'),
+            purge_rules=dict(type='bool', default=False)
+        ),
+    )
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              required_if=[['state', 'present', ['default_action', 'rules']]])
+    state = module.params.get('state')
+
+    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+    client = boto3_conn(module, conn_type='client', resource='waf-regional', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+
+    if state == 'present':
+        (changed, results) = ensure_web_acl_present(client, module)
+    else:
+        (changed, results) = ensure_web_acl_absent(client, module)
+
+    module.exit_json(changed=changed, web_acl=camel_dict_to_snake_dict(results))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
Add AWS WAF Regional support for AWS ALBs.

The existing AWS WAF module only works with AWS Cloudfront and not with ALBs.  Instead of extending the existing AWS WAF module, I created new aws_waf_regional* components, since AWS themselves did not extend the `aws waf` CLI tool to support AWS WAF Regional, but instead added a `aws waf-regional` CLI option.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
- aws_waf_regional_condition
- aws_waf_regional_facts
- aws_waf_regional_rule
- aws_waf_regional_web_acl

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2 (v2.6.2-alb-h2-waf-regional cfd25bf55b) last updated 2018/08/30 12:36:19 (GMT +100)
  config file = /Users/bje/devel/launchdarkly/playbooks/ansible.cfg
  configured module search path = [u'/Users/bje/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/bje/devel/launchdarkly/playbooks/src/ansible/lib/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```