### PR TITLE
Ensure we only cache the loop when the task had a loop

### DIFF
--- a/changelogs/fragments/loop-cache-fix.yaml
+++ b/changelogs/fragments/loop-cache-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- loop - Ensure we only cache the loop when the task had a loop and delegate_to was templated (https://github.com/ansible/ansible/issues/44874)

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -494,6 +494,7 @@ class VariableManager:
         templar = Templar(loader=self._loader, variables=vars_copy)
 
         items = []
+        has_loop = True
         if task.loop_with is not None:
             if task.loop_with in lookup_loader:
                 try:
@@ -509,6 +510,7 @@ class VariableManager:
         elif task.loop is not None:
             items = templar.template(task.loop)
         else:
+            has_loop = False
             items = [None]
 
         delegated_host_vars = dict()
@@ -583,7 +585,7 @@ class VariableManager:
                 include_hostvars=False,
             )
 
-        if cache_items:
+        if has_loop and cache_items:
             # delegate_to templating produced a change, update task.loop with templated items,
             # this ensures that delegate_to+loop doesn't produce different results than TaskExecutor
             # which may reprocess the loop

--- a/test/integration/targets/delegate_to/test_delegate_to_loop_randomness.yml
+++ b/test/integration/targets/delegate_to/test_delegate_to_loop_randomness.yml
@@ -7,6 +7,7 @@
       add_host:
         name: "foo{{item}}"
         groups: foo
+        ansible_connection: local
       loop: "{{ range(10)|list }}"
 
     # We expect all of the next 3 runs to succeeed
@@ -56,3 +57,16 @@
           - "{{ (result1.results|first) is successful }}"
           - "{{ (result2.results|first) is successful }}"
           - "{{ (result3.results|first) is successful }}"
+
+    - name: Set delegate
+      set_fact:
+        _delegate: '{{ groups.foo[0] }}'
+
+    - command: "true"
+      delegate_to: "{{ _delegate }}"
+      register: result
+
+    - assert:
+        that:
+          - result.stdout is defined
+          - result.results is undefined


### PR DESCRIPTION
##### SUMMARY
Ensure we only cache the loop when the task had a loop. Fixes #44874 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/vars/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```