### PR TITLE
Update lightsail.py

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lightsail.py
+++ b/lib/ansible/modules/cloud/amazon/lightsail.py
@@ -82,7 +82,7 @@ EXAMPLES = '''
     msg: "Name is {{ my_instance.instance.name }}"
 
 - debug:
-    msg: "IP is {{ my_instance.instance.publicIpAddress }}"
+    msg: "IP is {{ my_instance.instance.public_ip_address }}"
 
 # Delete an instance if present
 - lightsail:


### PR DESCRIPTION
##### SUMMARY
Correcting variable to show lightsail public IP address

Example was throwing an error saying dict object has no attribute for publicIpAddress.  This commit changes the example to use public_ip_address and correct the issue.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lightsail.py

##### ANSIBLE VERSION
```
ansible 2.7.0.a1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.7.0a1-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

```
vagrant@jenkins:/vagrant/library/wcx_lightsail$ ansible-playbook provision.yml
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] ************************************************************************************************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************************************************************************************************
ok: [localhost]

TASK [lightsail] ************************************************************************************************************************************************************************************
ok: [localhost]

TASK [debug] ****************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "Name is myinstance"
}

TASK [debug] ****************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'public_Ip_Address'\n\nThe error appears to have been in '/vagrant/library/wcx_lightsail/provision.yml': line 27, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - debug:\n      ^ here\n"}
	to retry, use: --limit @/vagrant/library/wcx_lightsail/provision.retry

PLAY RECAP ******************************************************************************************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=1
```

```
vagrant@jenkins:/vagrant/library/wcx_lightsail$ ansible-playbook provision.yml
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] ************************************************************************************************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************************************************************************************************
ok: [localhost]

TASK [lightsail] ************************************************************************************************************************************************************************************
ok: [localhost]

TASK [debug] ****************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "Name is myinstance"
}

TASK [debug] ****************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "IP is 13.238.154.1"
}

PLAY RECAP ******************************************************************************************************************************************************************************************
localhost                  : ok=4    changed=0    unreachable=0    failed=0

```
