### PR TITLE
Fix ios_user issues

### DIFF
--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -293,7 +293,7 @@ def parse_privilege(data):
 def map_config_to_obj(module):
     data = get_config(module, flags=['| section username'])
 
-    match = re.findall(r'(?:^\s{0}|^\s{2})username (\S+)', data, re.M)
+    match = re.findall(r'(?:^(?:u|\s{2}u))sername (\S+)', data, re.M)
     if not match:
         return list()
 
@@ -446,7 +446,8 @@ def main():
         want_users = [x['name'] for x in want]
         have_users = [x['name'] for x in have]
         for item in set(have_users).difference(want_users):
-            commands.append(user_del_cmd(item))
+            if item != 'admin':
+                commands.append(user_del_cmd(item))
 
     result['commands'] = commands
 

--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -178,7 +178,6 @@ commands:
 from copy import deepcopy
 
 import re
-import json
 import base64
 import hashlib
 
@@ -234,20 +233,22 @@ def map_obj_to_commands(updates, module):
 
     def add_ssh(command, want, x=None):
         command.append('ip ssh pubkey-chain')
-        command.append(' no username %s' % want['name'])
         if x:
-            command.append(' username %s' % want['name'])
-            command.append('  key-hash %s' % x)
-            command.append('  exit')
-        command.append(' exit')
+            command.append('username %s' % want['name'])
+            command.append('key-hash %s' % x)
+            command.append('exit')
+        else:
+            command.append('no username %s' % want['name'])
+        command.append('exit')
 
     for update in updates:
         want, have = update
 
         if want['state'] == 'absent':
-            commands.append(user_del_cmd(want['name']))
-            add_ssh(commands, want)
-            continue
+            if have['sshkey']:
+                add_ssh(commands, want)
+            else:
+                commands.append(user_del_cmd(want['name']))
 
         if needs_update(want, have, 'view'):
             add(commands, want, 'view %s' % want['view'])
@@ -292,7 +293,7 @@ def parse_privilege(data):
 def map_config_to_obj(module):
     data = get_config(module, flags=['| section username'])
 
-    match = re.findall(r'^username (\S+)', data, re.M)
+    match = re.findall(r'(?:^\s{0}|^\s{2})username (\S+)', data, re.M)
     if not match:
         return list()
 
@@ -445,16 +446,9 @@ def main():
         want_users = [x['name'] for x in want]
         have_users = [x['name'] for x in have]
         for item in set(have_users).difference(want_users):
-            if item != 'admin':
-                commands.append(user_del_cmd(item))
+            commands.append(user_del_cmd(item))
 
     result['commands'] = commands
-
-    # the ios cli prevents this by rule so capture it and display
-    # a nice failure message
-    for cmd in commands:
-        if 'no username admin' in cmd:
-            module.fail_json(msg='cannot delete the `admin` account')
 
     if commands:
         if not module.check_mode:

--- a/test/integration/targets/ios_user/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_user/tests/cli/basic.yaml
@@ -80,5 +80,5 @@
     that:
       - 'result.changed == true'
       - '"no username ansibletest1" in result.commands[0]["command"]'
-      - '"no username ansibletest2" in result.commands[4]["command"]'
-      - '"no username ansibletest3" in result.commands[8]["command"]'
+      - '"no username ansibletest2" in result.commands[1]["command"]'
+      - '"no username ansibletest3" in result.commands[2]["command"]'

--- a/test/units/modules/network/ios/test_ios_user.py
+++ b/test/units/modules/network/ios/test_ios_user.py
@@ -61,10 +61,7 @@ class TestIosUserModule(TestIosModule):
             {
                 "command": "no username ansible", "answer": "y", "newline": False,
                 "prompt": "This operation will remove all username related configurations with same name",
-            },
-            'ip ssh pubkey-chain',
-            ' no username ansible',
-            ' exit'
+            }
         ]
 
         result_cmd = []
@@ -124,11 +121,10 @@ class TestIosUserModule(TestIosModule):
         set_module_args(dict(name='ansible', sshkey='dGVzdA=='))
         commands = [
             'ip ssh pubkey-chain',
-            ' no username ansible',
-            ' username ansible',
-            '  key-hash ssh-rsa 098F6BCD4621D373CADE4E832627B4F6',
-            '  exit',
-            ' exit'
+            'username ansible',
+            'key-hash ssh-rsa 098F6BCD4621D373CADE4E832627B4F6',
+            'exit',
+            'exit'
         ]
         result = self.execute_module(changed=True, commands=commands)
         self.assertEqual(result['commands'], commands)


### PR DESCRIPTION
##### SUMMARY
Fixes the following:
- Fixes #44075 [ Unable to delete admin account ]
- The module was not able to detect users configured with sshkey. Fixed regex to mitigate the issue.
- Rearranged code to eliminate duplicate and extra commands that were being executed

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ios_user.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
