### PR TITLE
Fixed an issue when expecting may be, but getting maybe

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -235,7 +235,7 @@ def parse_show_install(data):
             break
 
         # Check for potentially transient conditions
-        if re.search(r'Another install procedure may be in progress', x):
+        if re.search(r'Another install procedure may\s*be in progress', x):
             ud['install_in_progress'] = True
             break
         if re.search(r'Backend processing error', x):


### PR DESCRIPTION
##### SUMMARY
Tested an install on a Nexus 5596 and was failing due that this model will send an output of "Another install procedure maybe in progress" when running the show install all while the install is running. This is how the module knows that an install is being processed. In my case, it will not match that 
conditional statement.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_install_os

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/dgomez/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/dgomez/.local/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, May 23 2018, 14:21:55) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


