### PR TITLE
Add seccomp support to ansible-test.

### DIFF
--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -1,11 +1,11 @@
 default name=ansible/ansible:default@sha256:b651e5964e192c12ef574646a9c724e72fd94615d37d47ffad986408b2097a07
-centos6 name=quay.io/ansible/centos6-test-container:1.4.0
-centos7 name=quay.io/ansible/centos7-test-container:1.4.0
-fedora24 name=quay.io/ansible/fedora24-test-container:1.4.0
-fedora25 name=quay.io/ansible/fedora25-test-container:1.4.0
+centos6 name=quay.io/ansible/centos6-test-container:1.4.0 seccomp=unconfined
+centos7 name=quay.io/ansible/centos7-test-container:1.4.0 seccomp=unconfined
+fedora24 name=quay.io/ansible/fedora24-test-container:1.4.0 seccomp=unconfined
+fedora25 name=quay.io/ansible/fedora25-test-container:1.4.0 seccomp=unconfined
 fedora26py3 name=quay.io/ansible/fedora26py3-test-container:1.4.0
 fedora27py3 name=quay.io/ansible/fedora27py3-test-container:1.4.0
-opensuse42.3 name=quay.io/ansible/opensuse42.3-test-container:1.4.0
-ubuntu1404 name=quay.io/ansible/ubuntu1404-test-container:1.4.0
-ubuntu1604 name=quay.io/ansible/ubuntu1604-test-container:1.4.0
-ubuntu1604py3 name=quay.io/ansible/ubuntu1604py3-test-container:1.4.0
+opensuse42.3 name=quay.io/ansible/opensuse42.3-test-container:1.4.0 seccomp=unconfined
+ubuntu1404 name=quay.io/ansible/ubuntu1404-test-container:1.4.0 seccomp=unconfined
+ubuntu1604 name=quay.io/ansible/ubuntu1604-test-container:1.4.0 seccomp=unconfined
+ubuntu1604py3 name=quay.io/ansible/ubuntu1604py3-test-container:1.4.0 seccomp=unconfined

--- a/test/runner/lib/config.py
+++ b/test/runner/lib/config.py
@@ -11,6 +11,7 @@ from lib.util import (
     docker_qualify_image,
     find_python,
     generate_pip_command,
+    get_docker_completion,
 )
 
 from lib.metadata import (
@@ -46,7 +47,11 @@ class EnvironmentConfig(CommonConfig):
         self.docker_privileged = args.docker_privileged if 'docker_privileged' in args else False  # type: bool
         self.docker_pull = args.docker_pull if 'docker_pull' in args else False  # type: bool
         self.docker_keep_git = args.docker_keep_git if 'docker_keep_git' in args else False  # type: bool
+        self.docker_seccomp = args.docker_seccomp if 'docker_seccomp' in args else None  # type: str
         self.docker_memory = args.docker_memory if 'docker_memory' in args else None
+
+        if self.docker_seccomp is None:
+            self.docker_seccomp = get_docker_completion().get(self.docker_raw, {}).get('seccomp', 'default')
 
         self.tox_sitepackages = args.tox_sitepackages  # type: bool
 

--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -239,6 +239,9 @@ def delegate_docker(args, exclude, require, integration_targets):
 
             docker_socket = '/var/run/docker.sock'
 
+            if args.docker_seccomp != 'default':
+                test_options += ['--security-opt', 'seccomp=%s' % args.docker_seccomp]
+
             if os.path.exists(docker_socket):
                 test_options += ['--volume', '%s:%s' % (docker_socket, docker_socket)]
 

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -651,6 +651,12 @@ def add_extra_docker_options(parser, integration=True):
                         action='store_true',
                         help='transfer git related files into the docker container')
 
+    docker.add_argument('--docker-seccomp',
+                        metavar='SC',
+                        choices=('default', 'unconfined'),
+                        default=None,
+                        help='set seccomp confinement for the test container: %(choices)s')
+
     if not integration:
         return
 


### PR DESCRIPTION
##### SUMMARY

Add seccomp support to ansible-test.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.7.0.a1.post0 (at-seccomp 170a9dd84a) last updated 2018/08/30 11:37:03 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
