### PR TITLE
Post validate early, don't template when, template more attrs

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -483,6 +483,9 @@ class TaskExecutor:
             # skipping this task during the conditional evaluation step
             context_validation_error = e
 
+        # Now we do final validation on the task, which sets all fields to their final values.
+        self._task.post_validate(templar=templar)
+
         # Evaluate the conditional (if any) for this task, which we do before running
         # the final task post-validation. We do this before the post validation due to
         # the fact that the conditional may specify that the task be skipped due to a
@@ -521,8 +524,6 @@ class TaskExecutor:
             include_variables = self._task.args.copy()
             return dict(include_variables=include_variables)
 
-        # Now we do final validation on the task, which sets all fields to their final values.
-        self._task.post_validate(templar=templar)
         if '_variable_params' in self._task.args:
             variable_params = self._task.args.pop('_variable_params')
             if isinstance(variable_params, dict):

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -571,13 +571,13 @@ class Base(FieldAttributeBase):
 
     # flags and misc. settings
     _environment = FieldAttribute(isa='list', extend=True, prepend=True)
-    _no_log = FieldAttribute(isa='bool')
-    _run_once = FieldAttribute(isa='bool')
-    _ignore_errors = FieldAttribute(isa='bool')
-    _ignore_unreachable = FieldAttribute(isa='bool')
-    _check_mode = FieldAttribute(isa='bool')
-    _diff = FieldAttribute(isa='bool')
-    _any_errors_fatal = FieldAttribute(isa='bool')
+    _no_log = FieldAttribute(isa='bool', always_post_validate=True)
+    _run_once = FieldAttribute(isa='bool', always_post_validate=True)
+    _ignore_errors = FieldAttribute(isa='bool', always_post_validate=True)
+    _ignore_unreachable = FieldAttribute(isa='bool', always_post_validate=True)
+    _check_mode = FieldAttribute(isa='bool', always_post_validate=True)
+    _diff = FieldAttribute(isa='bool', always_post_validate=True)
+    _any_errors_fatal = FieldAttribute(isa='bool', always_post_validate=True)
 
     # explicitly invoke a debugger on tasks
     _debugger = FieldAttribute(isa='string')

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -66,6 +66,13 @@ class Conditional:
         if not isinstance(value, list):
             setattr(self, name, [value])
 
+    def _post_validate_when(self, attr, value, templar):
+        '''
+        when is evaluated at the execution of the task,
+        and should not be templated during the regular post_validate step.
+        '''
+        return value
+
     def extract_defined_undefined(self, conditional):
         results = []
 


### PR DESCRIPTION
##### SUMMARY
Post validate before when eval, ensure when isn't templated during post_validate, ensure a bunch of attrs are templated

Fixes #44824


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/base.py
lib/ansible/playbook/conditional.py
lib/ansible/executor/task_executor.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```