### PR TITLE
fixed parsing issue with openstacksdk and idempotent checking issues

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_recordset.py
+++ b/lib/ansible/modules/cloud/openstack/os_recordset.py
@@ -170,7 +170,7 @@ def main():
         recordset_filter = {'type': recordset_type}
 
         recordsets = cloud.search_recordsets(zone, name_or_id=name, filters=recordset_filter)
- 
+
         if len(recordsets) == 1:
             recordset = recordsets[0]
             try:

--- a/lib/ansible/modules/cloud/openstack/os_recordset.py
+++ b/lib/ansible/modules/cloud/openstack/os_recordset.py
@@ -130,11 +130,11 @@ def _system_state_change(state, records, description, ttl, zone, recordset):
     if state == 'present':
         if recordset is None:
             return True
-        if records is not None and recordset.records != records:
+        if records is not None and recordset['records'] != records:
             return True
-        if description is not None and recordset.description != description:
+        if description is not None and recordset['description'] != description:
             return True
-        if ttl is not None and recordset.ttl != ttl:
+        if ttl is not None and recordset['ttl'] != ttl:
             return True
     if state == 'absent' and recordset:
         return True
@@ -169,8 +169,8 @@ def main():
         recordset_type = module.params.get('recordset_type')
         recordset_filter = {'type': recordset_type}
 
-        recordsets = cloud.search_recordsets(zone, name_or_id=name + '.' + zone, filters=recordset_filter)
-
+        recordsets = cloud.search_recordsets(zone, name_or_id=name, filters=recordset_filter)
+ 
         if len(recordsets) == 1:
             recordset = recordsets[0]
             try:


### PR DESCRIPTION
##### SUMMARY
Fixes #43007 
Fixes #40072
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
os_recordset module

##### ANSIBLE VERSION
```
ansible 2.6.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /etc/ansible/openstack/ansible-cloudlaunch/venv/lib/python2.7/site-packages/ansible
  executable location = /etc/ansible/openstack/ansible-cloudlaunch/venv/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```
##### ADDITIONAL INFORMATION
This change also requires making a change to the openstacksdk in order to properly strip the "recordsets" array that is nested within the results from the function "search_recordsets" by adding "recordsets = recordsets['recordsets']".  This needs to be made in conjunction with the proposed fix to os_recordset.py, otherwise it will not be able to parse for the request_id:

 def search_recordsets(self, zone, name_or_id=None, filters=None):
        recordsets = self.list_recordsets(zone=zone)
        recordsets = recordsets['recordsets']
        return _utils._filter_list(recordsets, name_or_id, filters)

Before:
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_fNWDrF/ansible_module_os_recordset.py", line 236, in <module>
    main()
  File "/tmp/ansible_fNWDrF/ansible_module_os_recordset.py", line 172, in main
    recordsets = cloud.search_recordsets(zone, name_or_id=name + '.' + zone, filters=recordset_filter)
  File "/etc/ansible/openstack/ansible-cloudlaunch/venv/lib/python2.7/site-packages/openstack/cloud/openstackcloud.py", line 8687, in search_recordsets
    return _utils._filter_list(recordsets, name_or_id, filters)
  File "/etc/ansible/openstack/ansible-cloudlaunch/venv/lib/python2.7/site-packages/openstack/cloud/_utils.py", line 113, in _filter_list
    e_id = _make_unicode(e.get('id', None))
AttributeError: 'unicode' object has no attribute 'get'
```

After:
```
ok: [localhost] => (item={u'description': u'Record for example1', u'zone': u'example-project.ic2.example.com.', u'records': [u'10.0.0.2'], u'ttl': 3600, u'recordset_type': u'A', u'name': u'example1'}) => {
    "changed": false,
    "invocation": {
        "module_args": {
            "api_timeout": null,
            "auth": {
                "auth_url": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "project_domain_name": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "project_name": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "user_domain_name": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
            },
            "auth_type": null,
            "availability_zone": null,
            "cacert": null,
            "cert": null,
            "description": "Record for example1",
            "interface": "public",
            "key": null,
            "name": "example1.********.ic2.example.com.",
            "records": [
                "10.0.0.2"
            ],
            "recordset_type": "A",
            "region_name": null,
            "state": "present",
            "timeout": 180,
            "ttl": 3600,
            "verify": null,
            "wait": true,
            "zone": "********.ic2.example.com."
        }
    },
    "item": {
        "description": "Record for example1",
        "name": "example1",
        "records": [
            "10.0.0.2"
        ],
        "recordset_type": "A",
        "ttl": 3600,
        "zone": "example-project.ic2.example.com."
    },
    "recordset": {
        "action": "NONE",
        "created_at": "2018-08-30T18:56:27.000000",
        "description": "Record for example1",
        "id": "93eb1413-1a17-41cd-8760-ca72b4bfaf4f",
        "links": {
            "self": "http://openstack2.example.com:9001/v2/zones/8e59157d-f0f7-4802-b677-e16e0261d06d/recordsets/93eb1413-1a17-41cd-8760-ca72b4bfaf4f"
        },
        "name": "example1.********.ic2.example.com.",
        "project_id": "7d8ca858aa814b1eb334ce8005a9f65b",
        "records": [
            "10.0.0.2"
        ],
        "status": "ACTIVE",
        "ttl": 3600,
        "type": "A",
        "updated_at": null,
        "version": 1,
        "zone_id": "8e59157d-f0f7-4802-b677-e16e0261d06d",
        "zone_name": "********.ic2.example.com."
    }
}
```