### PR TITLE
ensure if we get a non-Task object in _get_delegated_vars, we return early

### DIFF
--- a/changelogs/fragments/delegate-to-get-vars-no-task.yaml
+++ b/changelogs/fragments/delegate-to-get-vars-no-task.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- delegate_to - ensure if we get a non-Task object in _get_delegated_vars, we return early (https://github.com/ansible/ansible/pull/44934)

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -487,6 +487,10 @@ class VariableManager:
         return variables
 
     def _get_delegated_vars(self, play, task, existing_variables):
+        if not hasattr(task, 'loop'):
+            # This "task" is not a Task, so we need to skip it
+            return {}
+
         # we unfortunately need to template the delegate_to field here,
         # as we're fetching vars before post_validate has been called on
         # the task that has been passed in

--- a/test/integration/targets/include_import/apply/include_apply.yml
+++ b/test/integration/targets/include_import/apply/include_apply.yml
@@ -43,3 +43,8 @@
           - include_role2_result is undefined
       tags:
         - always
+
+    - include_role:
+        name: include_role
+        apply:
+          delegate_to: testhost2


### PR DESCRIPTION
##### SUMMARY
ensure if we get a non-Task object in _get_delegated_vars, we return early

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/vars/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.7
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```