### PR TITLE
added missing alias in container registry tests

### DIFF
--- a/test/integration/targets/azure_rm_containerregistry/aliases
+++ b/test/integration/targets/azure_rm_containerregistry/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 shippable/azure/group1
 destructive
+azure_rm_containerregistry_facts


### PR DESCRIPTION
##### SUMMARY
This is to make sure that azure_rm_containerregistry_facts changes trigger azure_rm_containerregistry test.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_containerregistry
azure_rm_containerregistry_facts

##### ANSIBLE VERSION
2.6

##### ADDITIONAL INFORMATION
