### PR TITLE
homebrew_cask: Pass install_options during uninstall

### DIFF
--- a/lib/ansible/modules/packaging/os/homebrew_cask.py
+++ b/lib/ansible/modules/packaging/os/homebrew_cask.py
@@ -651,10 +651,12 @@ class HomebrewCask(object):
             )
             raise HomebrewCaskException(self.message)
 
-        cmd = [opt
-               for opt in (self.brew_path, 'cask', 'uninstall', self.current_cask)
-               if opt]
+        opts = (
+            [self.brew_path, 'cask', 'uninstall', self.current_cask]
+            + self.install_options
+        )
 
+        cmd = [opt for opt in opts if opt]
         rc, out, err = self.module.run_command(cmd)
 
         if not self._current_cask_is_installed():


### PR DESCRIPTION
##### SUMMARY
Until https://github.com/Homebrew/homebrew-cask/issues/40866 is fixed,
install_options should be passed when uninstalling casks to ensure that
all artefacts are removed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
[homebrew_cask](https://docs.ansible.com/ansible/2.6/modules/homebrew_cask_module.html)
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.a1.post0 (devel ac3781d40b) last updated 2018/08/31 00:53:49 (GMT +100)
  config file = None
  configured module search path = ['/Users/newtonne/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/newtonne/Projects/contrib/ansible/lib/ansible
  executable location = /Users/newtonne/Projects/contrib/ansible/bin/ansible
  python version = 3.6.6 (default, Jun 28 2018, 05:43:53) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```