### PR TITLE
check for change of role arn in ecs task definition

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -390,8 +390,11 @@ def main():
 
                 return True
 
-            def _task_definition_matches(requested_volumes, requested_containers, existing_task_definition):
+            def _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, existing_task_definition):
                 if td['status'] != "ACTIVE":
+                    return None
+
+                if requested_task_role_arn != td.get('taskRoleArn', ""):
                     return None
 
                 existing_volumes = td.get('volumes', []) or []
@@ -435,7 +438,8 @@ def main():
             for td in existing_definitions_in_family:
                 requested_volumes = module.params.get('volumes', []) or []
                 requested_containers = module.params.get('containers', []) or []
-                existing = _task_definition_matches(requested_volumes, requested_containers, td)
+                requested_task_role_arn = module.params.get('task_role_arn', "") or ""
+                existing = _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, td)
 
                 if existing:
                     break

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -436,9 +436,9 @@ def main():
 
             # No revision explicitly specified. Attempt to find an active, matching revision that has all the properties requested
             for td in existing_definitions_in_family:
-                requested_volumes = module.params.get('volumes', []) or []
-                requested_containers = module.params.get('containers', []) or []
-                requested_task_role_arn = module.params.get('task_role_arn', "") or ""
+                requested_volumes = module.params['volumes'] or []
+                requested_containers = module.params['containers'] or []
+                requested_task_role_arn = module.params['task_role_arn']
                 existing = _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, td)
 
                 if existing:


### PR DESCRIPTION
##### SUMMARY
If the task role in a ECS task definition changes Ansible should create a new revision of the task definition.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/cloud/amazon/ecs_taskdefinition

##### ANSIBLE VERSION
```
ansible 2.7.0.a1.post0 (devel dbe30cc050) last updated 2018/08/31 11:28:24 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/amcgilvray/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/amcgilvray/ansible/lib/ansible
  executable location = /Users/amcgilvray/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 13:05:56) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION