### PR TITLE
Add functionality to specify private network

### DIFF
--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -250,8 +250,8 @@ class Vultr:
                         query_by=query_by,
                         params=params,
                         use_cache=use_cache
-                        )
                     )
+                )
             return r_list
         else:
             r_list.append(
@@ -262,8 +262,8 @@ class Vultr:
                     query_by=query_by,
                     params=params,
                     use_cache=use_cache
-                    )
                 )
+            )
             return r_list
 
     @staticmethod

--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -236,6 +236,36 @@ class Vultr:
 
         self.module.fail_json(msg="Could not find %s with %s: %s" % (resource, key, value))
 
+    def query_resources_by_key(self, key, value, resource='regions', query_by='list', params=None, use_cache=False):
+        r_list = list()
+        if not value:
+            return r_list
+        elif isinstance(value, list):
+            for v in value:
+                r_list.append(
+                    self.query_resource_by_key(
+                        key=key,
+                        value=v,
+                        resource=resource,
+                        query_by=query_by,
+                        params=params,
+                        use_cache=use_cache
+                        )
+                    )
+            return r_list
+        else:
+            r_list.append(
+                self.query_resource_by_key(
+                    key=key,
+                    value=value,
+                    resource=resource,
+                    query_by=query_by,
+                    params=params,
+                    use_cache=use_cache
+                    )
+                )
+            return r_list
+
     @staticmethod
     def normalize_result(resource, schema, remove_missing_keys=True):
         if remove_missing_keys:

--- a/lib/ansible/modules/cloud/vultr/vultr_server.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_server.py
@@ -58,7 +58,7 @@ options:
     description:
       - Specifiy an array of private networks to attach to the server.
       - If specified, private_network_enabled is ignored.
-    version_added: "2.7"
+    version_added: "2.8"
 
   auto_backup_enabled:
     description:

--- a/lib/ansible/modules/cloud/vultr/vultr_server.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_server.py
@@ -54,6 +54,10 @@ options:
     description:
       - Whether to enable private networking or not.
     type: bool
+  network_id:
+    description:
+      - Specifiy a Private Network ID to be used.
+      - If specified, private_network_enabled is ignored.
   auto_backup_enabled:
     description:
       - Whether to enable automatic backups or not.
@@ -498,6 +502,10 @@ class AnsibleVultrServer(Vultr):
                 'user_data': self.get_user_data(),
                 'SCRIPTID': self.get_startup_script().get('SCRIPTID'),
             }
+            if self.module.params.get('network_id'):
+                data['NETWORKID'] = self.module.params.get('network_id')
+            else:
+                data['enable_private_network'] = self.get_yes_or_no('private_network_enabled')
             self.api_query(
                 path="/v1/server/create",
                 method="POST",
@@ -835,6 +843,7 @@ def main():
         force=dict(type='bool', default=False),
         notify_activate=dict(type='bool', default=False),
         private_network_enabled=dict(type='bool'),
+        network_id=dict(),
         auto_backup_enabled=dict(type='bool'),
         ipv6_enabled=dict(type='bool'),
         tag=dict(),

--- a/lib/ansible/modules/cloud/vultr/vultr_server.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_server.py
@@ -494,7 +494,6 @@ class AnsibleVultrServer(Vultr):
                 'hostname': self.module.params.get('hostname'),
                 'SSHKEYID': self.get_ssh_key().get('SSHKEYID'),
                 'enable_ipv6': self.get_yes_or_no('ipv6_enabled'),
-                'enable_private_network': self.get_yes_or_no('private_network_enabled'),
                 'auto_backups': self.get_yes_or_no('auto_backup_enabled'),
                 'notify_activate': self.get_yes_or_no('notify_activate'),
                 'tag': self.module.params.get('tag'),

--- a/lib/ansible/modules/cloud/vultr/vultr_server.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_server.py
@@ -58,6 +58,8 @@ options:
     description:
       - Specifiy a Private Network ID to be used.
       - If specified, private_network_enabled is ignored.
+    version_added: "2.7"
+
   auto_backup_enabled:
     description:
       - Whether to enable automatic backups or not.

--- a/lib/ansible/modules/cloud/vultr/vultr_server.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_server.py
@@ -53,11 +53,13 @@ options:
   private_network_enabled:
     description:
       - Whether to enable private networking or not.
+      - Cannot be used with "networks"
     type: bool
   networks:
     description:
-      - Specifiy an array of private networks to attach to the server.
+      - Specifiy a single private network or an array of private networks to attach to the server.
       - If specified, private_network_enabled is ignored.
+    aliases: [ network ]
     version_added: "2.8"
 
   auto_backup_enabled:
@@ -865,7 +867,7 @@ def main():
         force=dict(type='bool', default=False),
         notify_activate=dict(type='bool', default=False),
         private_network_enabled=dict(type='bool'),
-        networks=dict(type='list'),
+        networks=dict(type='list', aliases=['network']),
         auto_backup_enabled=dict(type='bool'),
         ipv6_enabled=dict(type='bool'),
         tag=dict(),
@@ -880,6 +882,9 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
+        mutually_exclusive=[
+            ['networks', 'enable_private_network'],
+        ],
         supports_check_mode=True,
     )
 


### PR DESCRIPTION
##### SUMMARY
Adds the 'network_id' parameter to allow specification of a private network id. This handles the case where a Vultr account has multiple private networks.

This takes into account Vultr's API requirement that only 'NETWORKID' is set or 'enable_private_network', not both.

Does not change current behaviour.

Documentation section updated to reflect change.

##### ISSUE TYPE

 - Feature Pull Request
##### COMPONENT NAME
vultr_server module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/hhynd/.ansible/library']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
The current behaviour doesn't allow you to select a private network to join on server creation. 

If there are more than one private network configured in the Vultr region, Vultr will return as below: 
```
fatal: [localhost -> localhost]: FAILED! => {"changed": true, "msg": "URL https://api.vultr.com/v1/server/create, method POST with data VPSPLANID=201&hostname=[FQDN REMOVED]]&DCID=19&user_data=[API-KEY REMOVED]&notify_activate=no&label=server-build-test2&enable_private_network=yes&SCRIPTID=163879&tag=corporate&FIREWALLGROUPID=96484181&OSID=215. Returned 412, with body: HTTP Error 412: Request Failed Server add failed: No NETWORKID defined, but multiple private networks exist in this location.", "vultr_api": {"api_account": "default", "api_endpoint": "https://api.vultr.com", "api_retries": 5, "api_timeout": 60}, "vultr_server": {}}
```

This change allows NETWORKID specification and honours Vultr's API specification. ie. enable_private_network can be specificied, or NETWORKID, not both.

