### PR TITLE
Ovirt add rename functionality

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
@@ -21,7 +21,7 @@ options:
     id:
         description:
             - "ID of the cluster to manage."
-        version_added: "2.7"
+        version_added: "2.8"
     name:
         description:
             - "Name of the cluster to manage."

--- a/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
@@ -18,6 +18,10 @@ author: "Ondra Machacek (@machacekondra)"
 description:
     - "Module to manage clusters in oVirt/RHV"
 options:
+    id:
+        description:
+            - "ID of the cluster to manage."
+        version_added: "2.7"
     name:
         description:
             - "Name of the cluster to manage."
@@ -381,6 +385,7 @@ class ClustersModule(BaseModule):
     def build_entity(self):
         sched_policy = self._get_sched_policy()
         return otypes.Cluster(
+            id=self.param('id'),
             name=self.param('name'),
             comment=self.param('comment'),
             description=self.param('description'),
@@ -543,6 +548,7 @@ class ClustersModule(BaseModule):
 
         return (
             check_custom_scheduling_policy_properties() and
+            equal(self.param('name'), entity.name) and
             equal(self.param('comment'), entity.comment) and
             equal(self.param('description'), entity.description) and
             equal(self.param('switch_type'), str(entity.switch_type)) and
@@ -599,6 +605,7 @@ def main():
             default='present',
         ),
         name=dict(default=None, required=True),
+        id=dict(default=None),
         ballooning=dict(default=None, type='bool', aliases=['balloon']),
         gluster=dict(default=None, type='bool'),
         virt=dict(default=None, type='bool'),

--- a/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
@@ -270,6 +270,11 @@ EXAMPLES = '''
 - ovirt_cluster:
     state: absent
     name: mycluster
+
+# Change cluster Name
+- ovirt_cluster:
+    id: 00000000-0000-0000-0000-000000000000
+    name: "new cluster name"
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
@@ -274,7 +274,7 @@ EXAMPLES = '''
 # Change cluster Name
 - ovirt_cluster:
     id: 00000000-0000-0000-0000-000000000000
-    name: "new cluster name"
+    name: "new_cluster_name"
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/ovirt/ovirt_datacenter.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_datacenter.py
@@ -21,7 +21,7 @@ options:
     id:
         description:
             - "ID of the datacenter to manage."
-        version_added: "2.7"
+        version_added: "2.8"
     name:
         description:
             - "Name of the data center to manage."

--- a/lib/ansible/modules/cloud/ovirt/ovirt_datacenter.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_datacenter.py
@@ -18,6 +18,10 @@ author: "Ondra Machacek (@machacekondra)"
 description:
     - "Module to manage data centers in oVirt/RHV"
 options:
+    id:
+        description:
+            - "ID of the datacenter to manage."
+        version_added: "2.7"
     name:
         description:
             - "Name of the data center to manage."
@@ -77,6 +81,11 @@ EXAMPLES = '''
 - ovirt_datacenter:
     state: absent
     name: mydatacenter
+
+# Change Datacenter Name
+- ovirt_datacenter:
+    id: 00000000-0000-0000-0000-000000000000
+    name: "new datacenter name"
 '''
 
 RETURN = '''
@@ -140,6 +149,7 @@ class DatacentersModule(BaseModule):
     def build_entity(self):
         return otypes.DataCenter(
             name=self._module.params['name'],
+            id=self._module.params['id'],
             comment=self._module.params['comment'],
             description=self._module.params['description'],
             mac_pool=otypes.MacPool(
@@ -162,6 +172,7 @@ class DatacentersModule(BaseModule):
             equal(getattr(self._get_mac_pool(), 'id', None), getattr(entity.mac_pool, 'id', None)) and
             equal(self._module.params.get('comment'), entity.comment) and
             equal(self._module.params.get('description'), entity.description) and
+            equal(self._module.params.get('name'), entity.name) and
             equal(self._module.params.get('quota_mode'), str(entity.quota_mode)) and
             equal(self._module.params.get('local'), entity.local) and
             equal(minor, self.__get_minor(entity.version)) and
@@ -178,6 +189,7 @@ def main():
         name=dict(default=None, required=True),
         description=dict(default=None),
         local=dict(type='bool'),
+        id=dict(default=None),
         compatibility_version=dict(default=None),
         quota_mode=dict(choices=['disabled', 'audit', 'enabled']),
         comment=dict(default=None),

--- a/lib/ansible/modules/cloud/ovirt/ovirt_datacenter.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_datacenter.py
@@ -85,7 +85,7 @@ EXAMPLES = '''
 # Change Datacenter Name
 - ovirt_datacenter:
     id: 00000000-0000-0000-0000-000000000000
-    name: "new datacenter name"
+    name: "new_datacenter_name"
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -185,7 +185,7 @@ EXAMPLES = '''
 - ovirt_disk:
     id: 00000000-0000-0000-0000-000000000000
     storage_domain: data
-    name: "new disk name"
+    name: "new_disk_name"
     vm_name: rhel7
 
 # Upload local image to disk and attach it to vm:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host.py
@@ -18,6 +18,10 @@ author: "Ondra Machacek (@machacekondra)"
 description:
     - "Module to manage hosts in oVirt/RHV"
 options:
+    id:
+        description:
+            - "ID of the nic to manage."
+        version_added: "2.7"
     name:
         description:
             - "Name of the host to manage."
@@ -218,6 +222,11 @@ EXAMPLES = '''
     state: absent
     name: myhost
     force: True
+
+# Change host Name
+- ovirt_host:
+    id: 00000000-0000-0000-0000-000000000000
+    name: "new host name"
 '''
 
 RETURN = '''
@@ -263,6 +272,7 @@ class HostsModule(BaseModule):
 
     def build_entity(self):
         return otypes.Host(
+            id=self._module.params.get('id'),
             name=self.param('name'),
             cluster=otypes.Cluster(
                 name=self.param('cluster')
@@ -295,6 +305,7 @@ class HostsModule(BaseModule):
             equal(self.param('comment'), entity.comment) and
             equal(self.param('kdump_integration'), 'enabled' if entity.power_management.kdump_detection else 'disabled') and
             equal(self.param('spm_priority'), entity.spm.priority) and
+            equal(self.param('name'), entity.name) and
             equal(self.param('power_management_enabled'), entity.power_management.enabled) and
             equal(self.param('override_display'), getattr(entity.display, 'address', None)) and
             equal(
@@ -400,6 +411,7 @@ def main():
             default='present',
         ),
         name=dict(required=True),
+        id=dict(default=None),
         comment=dict(default=None),
         cluster=dict(default=None),
         address=dict(default=None),

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host.py
@@ -20,7 +20,7 @@ description:
 options:
     id:
         description:
-            - "ID of the nic to manage."
+            - "ID of the host to manage."
         version_added: "2.7"
     name:
         description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host.py
@@ -21,7 +21,7 @@ options:
     id:
         description:
             - "ID of the host to manage."
-        version_added: "2.7"
+        version_added: "2.8"
     name:
         description:
             - "Name of the host to manage."

--- a/lib/ansible/modules/cloud/ovirt/ovirt_mac_pool.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_mac_pool.py
@@ -21,7 +21,7 @@ options:
     id:
         description:
             - "ID of the mac pool to manage."
-        version_added: "2.7"
+        version_added: "2.8"
     name:
         description:
             - "Name of the MAC pool to manage."

--- a/lib/ansible/modules/cloud/ovirt/ovirt_mac_pool.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_mac_pool.py
@@ -66,7 +66,7 @@ EXAMPLES = '''
 # Change MAC pool Name
 - ovirt_nic:
     id: 00000000-0000-0000-0000-000000000000
-    name: "new mac pool name"
+    name: "new_mac_pool_name"
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/ovirt/ovirt_mac_pool.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_mac_pool.py
@@ -130,7 +130,7 @@ class MACPoolModule(BaseModule):
         return (
             self._compare_ranges(entity) and
             equal(self._module.params['allow_duplicates'], entity.allow_duplicates) and
-            equal(self._module.params['description'], entity.description) and 
+            equal(self._module.params['description'], entity.description) and
             equal(self._module.params['name'], entity.name)
         )
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_network.py
@@ -33,6 +33,10 @@ author: "Ondra Machacek (@machacekondra)"
 description:
     - "Module to manage logical networks in oVirt/RHV"
 options:
+    id:
+        description:
+            - "ID of the network to manage."
+        version_added: "2.7"
     name:
         description:
             - "Name of the network to manage."
@@ -93,6 +97,12 @@ EXAMPLES = '''
 - ovirt_network:
     state: absent
     name: mynetwork
+
+# Change Network Name
+- ovirt_network:
+    id: 00000000-0000-0000-0000-000000000000
+    name: "new network name"
+    data_center: mydatacenter
 '''
 
 RETURN = '''
@@ -134,6 +144,7 @@ class NetworksModule(BaseModule):
             name=self._module.params['name'],
             comment=self._module.params['comment'],
             description=self._module.params['description'],
+            id=self._module.params['id'],
             data_center=otypes.DataCenter(
                 name=self._module.params['data_center'],
             ) if self._module.params['data_center'] else None,
@@ -168,6 +179,7 @@ class NetworksModule(BaseModule):
         self._update_label_assignments(entity)
         return (
             equal(self._module.params.get('comment'), entity.comment) and
+            equal(self._module.params.get('name'), entity.name) and
             equal(self._module.params.get('description'), entity.description) and
             equal(self._module.params.get('vlan_tag'), getattr(entity.vlan, 'id', None)) and
             equal(self._module.params.get('vm_network'), True if entity.usages else False) and
@@ -226,6 +238,7 @@ def main():
             default='present',
         ),
         data_center=dict(required=True),
+        id=dict(default=None),
         name=dict(required=True),
         description=dict(default=None),
         comment=dict(default=None),

--- a/lib/ansible/modules/cloud/ovirt/ovirt_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_network.py
@@ -101,7 +101,7 @@ EXAMPLES = '''
 # Change Network Name
 - ovirt_network:
     id: 00000000-0000-0000-0000-000000000000
-    name: "new network name"
+    name: "new_network_name"
     data_center: mydatacenter
 '''
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_network.py
@@ -36,7 +36,7 @@ options:
     id:
         description:
             - "ID of the network to manage."
-        version_added: "2.7"
+        version_added: "2.8"
     name:
         description:
             - "Name of the network to manage."

--- a/lib/ansible/modules/cloud/ovirt/ovirt_nic.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_nic.py
@@ -18,6 +18,10 @@ author:
 description:
     - Module to manage network interfaces of Virtual Machines in oVirt/RHV.
 options:
+    id:
+        description:
+            - "ID of the nic to manage."
+        version_added: "2.7"
     name:
         description:
             - Name of the network interface to manage.
@@ -94,6 +98,12 @@ EXAMPLES = '''
     state: absent
     vm: myvm
     name: mynic
+
+# Change NIC Name
+- ovirt_nic:
+    id: 00000000-0000-0000-0000-000000000000
+    name: "new nic name"
+    vm: myvm 
 '''
 
 RETURN = '''
@@ -144,6 +154,7 @@ class EntityNicsModule(BaseModule):
 
     def build_entity(self):
         return otypes.Nic(
+            id=self._module.params.get('id'),
             name=self._module.params.get('name'),
             interface=otypes.NicInterface(
                 self._module.params.get('interface')
@@ -160,12 +171,14 @@ class EntityNicsModule(BaseModule):
         if self._module.params.get('vm'):
             return (
                 equal(self._module.params.get('interface'), str(entity.interface)) and
+                equal(self._module.params.get('name'), str(entity.name)) and
                 equal(self._module.params.get('profile'), get_link_name(self._connection, entity.vnic_profile)) and
                 equal(self._module.params.get('mac_address'), entity.mac.address)
             )
         elif self._module.params.get('template'):
             return (
                 equal(self._module.params.get('interface'), str(entity.interface)) and
+                equal(self._module.params.get('name'), str(entity.name)) and
                 equal(self._module.params.get('profile'), get_link_name(self._connection, entity.vnic_profile))
             )
 
@@ -174,6 +187,7 @@ def main():
     argument_spec = ovirt_full_argument_spec(
         state=dict(type='str', default='present', choices=['absent', 'plugged', 'present', 'unplugged']),
         vm=dict(type='str'),
+        id=dict(default=None),
         template=dict(type='str'),
         name=dict(type='str', required=True),
         interface=dict(type='str'),

--- a/lib/ansible/modules/cloud/ovirt/ovirt_nic.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_nic.py
@@ -102,7 +102,7 @@ EXAMPLES = '''
 # Change NIC Name
 - ovirt_nic:
     id: 00000000-0000-0000-0000-000000000000
-    name: "new nic name"
+    name: "new_nic_name"
     vm: myvm
 '''
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_nic.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_nic.py
@@ -103,7 +103,7 @@ EXAMPLES = '''
 - ovirt_nic:
     id: 00000000-0000-0000-0000-000000000000
     name: "new nic name"
-    vm: myvm 
+    vm: myvm
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/ovirt/ovirt_nic.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_nic.py
@@ -21,7 +21,7 @@ options:
     id:
         description:
             - "ID of the nic to manage."
-        version_added: "2.7"
+        version_added: "2.8"
     name:
         description:
             - Name of the network interface to manage.

--- a/lib/ansible/modules/cloud/ovirt/ovirt_quota.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_quota.py
@@ -18,6 +18,10 @@ author: "Ondra Machacek (@machacekondra)"
 description:
     - "Module to manage datacenter quotas in oVirt/RHV"
 options:
+    id:
+        description:
+            - "ID of the quota to manage."
+        version_added: "2.7"
     name:
         description:
             - "Name of the quota to manage."
@@ -106,6 +110,12 @@ EXAMPLES = '''
     state: absent
     data_center: dcX
     name: quota1
+
+# Change Quota Name
+- ovirt_quota:
+    id: 00000000-0000-0000-0000-000000000000
+    name: "new quota name"
+    data_center: dcX
 '''
 
 RETURN = '''
@@ -146,6 +156,7 @@ class QuotasModule(BaseModule):
         return otypes.Quota(
             description=self._module.params['description'],
             name=self._module.params['name'],
+            id=self._module.params['id'],
             storage_hard_limit_pct=self._module.params.get('storage_grace'),
             storage_soft_limit_pct=self._module.params.get('storage_threshold'),
             cluster_hard_limit_pct=self._module.params.get('cluster_grace'),
@@ -202,6 +213,7 @@ class QuotasModule(BaseModule):
         return (
             self.update_storage_limits(entity) and
             self.update_cluster_limits(entity) and
+            equal(self._module.params.get('name'), entity.name) and
             equal(self._module.params.get('description'), entity.description) and
             equal(self._module.params.get('storage_grace'), entity.storage_hard_limit_pct) and
             equal(self._module.params.get('storage_threshold'), entity.storage_soft_limit_pct) and
@@ -216,6 +228,7 @@ def main():
             choices=['present', 'absent'],
             default='present',
         ),
+        id=dict(default=None),
         name=dict(required=True),
         data_center=dict(required=True),
         description=dict(default=None),

--- a/lib/ansible/modules/cloud/ovirt/ovirt_quota.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_quota.py
@@ -114,7 +114,7 @@ EXAMPLES = '''
 # Change Quota Name
 - ovirt_quota:
     id: 00000000-0000-0000-0000-000000000000
-    name: "new quota name"
+    name: "new_quota_name"
     data_center: dcX
 '''
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_quota.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_quota.py
@@ -21,7 +21,7 @@ options:
     id:
         description:
             - "ID of the quota to manage."
-        version_added: "2.7"
+        version_added: "2.8"
     name:
         description:
             - "Name of the quota to manage."

--- a/lib/ansible/modules/cloud/ovirt/ovirt_tag.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_tag.py
@@ -97,6 +97,11 @@ EXAMPLES = '''
 - ovirt_tag:
     state: absent
     name: mytag
+
+# Change cluster Name
+- ovirt_tag:
+    id: 00000000-0000-0000-0000-000000000000
+    name: "new tag name"
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/ovirt/ovirt_tag.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_tag.py
@@ -101,7 +101,7 @@ EXAMPLES = '''
 # Change cluster Name
 - ovirt_tag:
     id: 00000000-0000-0000-0000-000000000000
-    name: "new tag name"
+    name: "new_tag_name"
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/ovirt/ovirt_tag.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_tag.py
@@ -34,6 +34,10 @@ description:
     - "This module manage tags in oVirt/RHV. It can also manage assignments
        of those tags to entities."
 options:
+    id:
+        description:
+            - "ID of the tag to manage."
+        version_added: "2.7"
     name:
         description:
             - "Name of the tag to manage."
@@ -130,6 +134,7 @@ class TagsModule(BaseModule):
 
     def build_entity(self):
         return otypes.Tag(
+            id=self._module.params['id'],
             name=self._module.params['name'],
             description=self._module.params['description'],
             parent=otypes.Tag(
@@ -195,6 +200,7 @@ class TagsModule(BaseModule):
         self._update_tag_assignments(entity, 'hosts')
         return (
             equal(self._module.params.get('description'), entity.description) and
+            equal(self._module.params.get('name'), entity.name) and
             equal(self._module.params.get('parent'), self._get_parent(entity))
         )
 
@@ -205,6 +211,7 @@ def main():
             choices=['present', 'absent', 'attached', 'detached'],
             default='present',
         ),
+        id=dict(default=None),
         name=dict(required=True),
         description=dict(default=None),
         parent=dict(default=None),

--- a/lib/ansible/modules/cloud/ovirt/ovirt_tag.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_tag.py
@@ -37,7 +37,7 @@ options:
     id:
         description:
             - "ID of the tag to manage."
-        version_added: "2.7"
+        version_added: "2.8"
     name:
         description:
             - "Name of the tag to manage."

--- a/lib/ansible/modules/cloud/ovirt/ovirt_template.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_template.py
@@ -188,7 +188,7 @@ EXAMPLES = '''
 # Change Template Name
 - ovirt_template:
     id: 00000000-0000-0000-0000-000000000000
-    name: "new template name"
+    name: "new_template_name"
 
 # Register template
 - ovirt_template:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_template.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_template.py
@@ -185,7 +185,7 @@ EXAMPLES = '''
     state: absent
     name: mytemplate
 
-# Change Pool Name
+# Change Template Name
 - ovirt_template:
     id: 00000000-0000-0000-0000-000000000000
     name: "new template name"
@@ -294,6 +294,7 @@ class TemplatesModule(BaseModule):
 
     def build_entity(self):
         return otypes.Template(
+            id=self._module.params['id'],
             name=self._module.params['name'],
             cluster=otypes.Cluster(
                 name=self._module.params['cluster']

--- a/lib/ansible/modules/cloud/ovirt/ovirt_template.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_template.py
@@ -185,6 +185,11 @@ EXAMPLES = '''
     state: absent
     name: mytemplate
 
+# Change Pool Name
+- ovirt_template:
+    id: 00000000-0000-0000-0000-000000000000
+    name: "new template name"
+
 # Register template
 - ovirt_template:
   state: registered
@@ -326,6 +331,7 @@ class TemplatesModule(BaseModule):
             equal(self._module.params.get('cluster'), get_link_name(self._connection, entity.cluster)) and
             equal(self._module.params.get('description'), entity.description) and
             equal(self.param('operating_system'), str(entity.os.type)) and
+            equal(self.param('name'), str(entity.name)) and
             equal(convert_to_bytes(self.param('memory_guaranteed')), entity.memory_policy.guaranteed) and
             equal(convert_to_bytes(self.param('memory_max')), entity.memory_policy.max) and
             equal(convert_to_bytes(self.param('memory')), entity.memory) and

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -677,6 +677,11 @@ EXAMPLES = '''
     nics:
       - name: nic1
 
+# Change VM Name
+- ovirt_vmpool:
+    id: 00000000-0000-0000-0000-000000000000
+    name: "new vm name"
+
 - name: Run VM with cloud init
   ovirt_vm:
     name: rhel7
@@ -1166,6 +1171,7 @@ class VmsModule(BaseModule):
             equal(self.param('cpu_threads'), entity.cpu.topology.threads) and
             equal(self.param('cpu_mode'), str(cpu_mode) if cpu_mode else None) and
             equal(self.param('type'), str(entity.type)) and
+            equal(self.param('name'), str(entity.name)) and
             equal(self.param('operating_system'), str(entity.os.type)) and
             equal(self.param('boot_menu'), entity.bios.boot_menu.enabled) and
             equal(self.param('soundcard_enabled'), entity.soundcard_enabled) and

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -678,9 +678,9 @@ EXAMPLES = '''
       - name: nic1
 
 # Change VM Name
-- ovirt_vmpool:
+- ovirt_vm:
     id: 00000000-0000-0000-0000-000000000000
-    name: "new vm name"
+    name: "new_vm_name"
 
 - name: Run VM with cloud init
   ovirt_vm:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vmpool.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vmpool.py
@@ -105,7 +105,7 @@ EXAMPLES = '''
 # Change Pool Name
 - ovirt_vmpool:
     id: 00000000-0000-0000-0000-000000000000
-    name: "new disk name"
+    name: "new_pool_name"
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vmpool.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vmpool.py
@@ -33,6 +33,10 @@ author: "Ondra Machacek (@machacekondra)"
 description:
     - "Module to manage VM pools in oVirt/RHV."
 options:
+    id:
+        description:
+            - "ID of the vmpool to manage."
+        version_added: "2.7"
     name:
         description:
             - "Name of the VM pool to manage."
@@ -97,6 +101,11 @@ EXAMPLES = '''
 - ovirt_vmpool:
     state: absent
     name: myvmpool
+
+# Change Pool Name
+- ovirt_vmpool:
+    id: 00000000-0000-0000-0000-000000000000
+    name: "new disk name"
 '''
 
 RETURN = '''
@@ -136,6 +145,7 @@ class VmPoolsModule(BaseModule):
 
     def build_entity(self):
         return otypes.VmPool(
+            id=self._module.params['id'],
             name=self._module.params['name'],
             description=self._module.params['description'],
             comment=self._module.params['comment'],
@@ -155,6 +165,7 @@ class VmPoolsModule(BaseModule):
 
     def update_check(self, entity):
         return (
+            equal(self._module.params.get('name'), entity.name) and
             equal(self._module.params.get('cluster'), get_link_name(self._connection, entity.cluster)) and
             equal(self._module.params.get('description'), entity.description) and
             equal(self._module.params.get('comment'), entity.comment) and
@@ -166,6 +177,7 @@ class VmPoolsModule(BaseModule):
 
 def main():
     argument_spec = ovirt_full_argument_spec(
+        id=dict(default=None),
         state=dict(
             choices=['present', 'absent'],
             default='present',

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vmpool.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vmpool.py
@@ -36,7 +36,7 @@ options:
     id:
         description:
             - "ID of the vmpool to manage."
-        version_added: "2.7"
+        version_added: "2.8"
     name:
         description:
             - "Name of the VM pool to manage."


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Now you can rename most of ovirt components. When you pass components ID then you can change name.  

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #43236

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
ovirt
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mnecas/Desktop/Projects/Redhat/ansible/lib/ansible/modules/cloud/ovirt']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
