### PR TITLE
Lenovo image refactor

### DIFF
--- a/lib/ansible/module_utils/network/cnos/cnos.py
+++ b/lib/ansible/module_utils/network/cnos/cnos.py
@@ -74,7 +74,8 @@ cnos_argument_spec = {
 command_spec = {
     'command': dict(key=True),
     'prompt': dict(),
-    'answer': dict()
+    'answer': dict(),
+    'check_all':dict()
 }
 
 
@@ -1326,137 +1327,6 @@ def interfaceLevel2Config(module, cmd, prompt, answer):
     return retVal
 # EOM
 
-
-# Utility Method to download an image from FTP/TFTP server to device.
-# This method supports only FTP or TFTP
-# Tuning of timeout parameter is pending
-
-
-def doImageTransfer(
-    protocol, timeout, imgServerIp, imgPath, imgType, imgServerUser,
-        imgServerPwd, obj):
-    # server = "10.241.106.118"
-    server = imgServerIp
-    # username = "root"
-    username = imgServerUser
-    # password = "root123"
-    password = imgServerPwd
-
-    type = "os"
-    if(imgType is not None):
-        type = imgType.lower()
-
-    if((imgPath is None) or (imgPath is "")):
-        imgPath = "cnos_images"
-
-    retVal = ""
-
-    # Image transfer command happens here
-    if(protocol == "ftp"):
-        command = "cp " + protocol + " " + protocol + "://" + username + \
-            "@" + server + "/" + imgPath + " system-image " + type + \
-            " vrf management\n"
-    elif(protocol == "tftp"):
-        command = "cp " + protocol + " " + protocol + "://" + server + \
-            "/" + imgPath + " system-image " + type + " vrf management\n"
-    else:
-        return "Error-110"
-    # debugOutput(command)
-    response = waitForDeviceResponse(command, "[n]", 3, obj)
-    if(response.lower().find('error-101')):
-        retVal = retVal
-    else:
-        retVal = retVal + response
-
-    # Confirmation command happens here
-    command = "y\n"
-    # debugOutput(command)
-    if(protocol == "ftp"):
-        retVal = retVal + waitForDeviceResponse(command, "Password:", 3, obj)
-        # Password entry happens here Only for FTP
-        command = password + " \n"
-        # debugOutput(command)
-    # Change to standby image y
-    retVal = retVal + waitForDeviceResponse(command, "[n]", timeout, obj)
-    command = "y\n"
-    # debugOutput(command)
-    retVal = retVal + waitForDeviceResponse(command, "#", timeout, obj)
-    return retVal
-# EOM
-
-# Utility Method to download an image from SFTP/SCP server to device.
-# This method supports only SCP or SFTP
-# Tuning of timeout parameter is pending
-
-
-def doSecureImageTransfer(
-    protocol, timeout, imgServerIp, imgPath, imgType, imgServerUser,
-        imgServerPwd, obj):
-    # server = "10.241.105.214"
-    server = imgServerIp
-    # username = "pbhosale"
-    username = imgServerUser
-    # password = "Lab4man1"
-    password = imgServerPwd
-
-    type = "scp"
-    if(imgType is not None):
-        type = imgType.lower()
-
-    if((imgPath is None) or (imgPath is "")):
-        imgPath = "cnos_images"
-
-    retVal = ""
-
-    # Image transfer command happens here
-    command = "cp " + protocol + " " + protocol + "://" + username + "@" + \
-        server + "/" + imgPath + " system-image " + type + " vrf management \n"
-    # debugOutput(command)
-    response = waitForDeviceResponse(command, "[n]", 3, obj)
-    if(response.lower().find('error-101')):
-        retVal = retVal
-    else:
-        retVal = retVal + response
-    # Confirmation command happens here
-    if(protocol == "scp"):
-        command = "y\n"
-        # debugOutput(command)
-        response = waitForDeviceResponse(command, "(yes/no)?", 3, obj)
-        if(response.lower().find('error-101')):
-            retVal = retVal
-        else:
-            retVal = retVal + response
-        command = "Yes\n"
-        # debugOutput(command)
-        retVal = retVal + waitForDeviceResponse(command, "timeout:", 3, obj)
-        command = "0\n"
-        # debugOutput(command)
-        retVal = retVal + waitForDeviceResponse(command, "Password:", 3, obj)
-    elif(protocol == "sftp"):
-        command = "y\n"
-        # debugOutput(command)
-        response = waitForDeviceResponse(command, "(yes/no)?", 3, obj)
-        if(response.lower().find('error-101')):
-            retVal = retVal
-        else:
-            retVal = retVal + response
-
-        command = "Yes\n"
-        # debugOutput(command)
-        retVal = retVal + waitForDeviceResponse(command, "Password:", 3, obj)
-    else:
-        return "Error-110"
-
-    # Password entry happens here
-    command = password + "\n"
-    # debugOutput(command)
-    retVal = retVal + waitForDeviceResponse(command, "[n]", timeout, obj)
-    # Change to standby image y
-    command = "y\n"
-    # debugOutput(command)
-    retVal = retVal + waitForDeviceResponse(command, "#", timeout, obj)
-    return retVal
-# EOM
 
 # Method Method for enter enable mode
 #

--- a/lib/ansible/module_utils/network/cnos/cnos.py
+++ b/lib/ansible/module_utils/network/cnos/cnos.py
@@ -75,7 +75,7 @@ command_spec = {
     'command': dict(key=True),
     'prompt': dict(),
     'answer': dict(),
-    'check_all':dict()
+    'check_all': dict()
 }
 
 

--- a/lib/ansible/modules/network/cnos/cnos_image.py
+++ b/lib/ansible/modules/network/cnos/cnos_image.py
@@ -33,37 +33,47 @@ DOCUMENTATION = '''
 ---
 module: cnos_image
 author: "Anil Kumar Muraleedharan (@amuraleedhar)"
-short_description: Perform firmware upgrade/download from a remote server on devices running Lenovo CNOS
+short_description: Perform firmware upgrade/download from a remote server on
+                   devices running Lenovo CNOS
 description:
-    - This module allows you to work with switch firmware images. It provides a way to download a firmware image
-     to a network device from a remote server using FTP, SFTP, TFTP, or SCP. The first step is to create a directory
-     from where the remote server can be reached. The next step is to provide the full file path of the image's
-     location. Authentication details required by the remote server must be provided as well. By default, this
-     method makes the newly downloaded firmware image the active image, which will be used by the switch during the
-     next restart.
+    - This module allows you to work with switch firmware images. It provides a
+     way to download a firmware image to a network device from a remote server
+     using FTP, SFTP, TFTP, or SCP. The first step is to create a directory
+     from where the remote server can be reached. The next step is to provide
+     the full file path of the image's location. Authentication details
+     required by the remote server must be provided as well. By default, this
+     method makes the newly downloaded firmware image the active image, which
+     will be used by the switch during the next restart.
      This module uses SSH to manage network device configuration.
      The results of the operation will be placed in a directory named 'results'
-     that must be created by the user in their local directory to where the playbook is run.
-     For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_image.html)
+     that must be created by the user in their local directory to where the
+     playbook is run.
+     For more information about this module from Lenovo and customizing it
+     usage for your use cases, please visit
+     U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_image.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options:
     protocol:
         description:
-            - This refers to the protocol used by the network device to interact with the remote server from where
-             to download the firmware image. The choices are FTP, SFTP, TFTP, or SCP. Any other protocols will
-             result in error. If this parameter is not specified, there is no default value to be used.
+            - This refers to the protocol used by the network device to
+             interact with the remote server from where to download the
+             firmware image. The choices are FTP, SFTP, TFTP, or SCP. Any other
+             protocols will result in error. If this parameter is not specified
+             there is no default value to be used.
         required: true
         choices: [SFTP, SCP, FTP, TFTP]
     serverip:
         description:
-            - This specifies the IP Address of the remote server from where the software image will be downloaded.
+            - This specifies the IP Address of the remote server from where the
+             software image will be downloaded.
         required: true
     imgpath:
         description:
-            - This specifies the full file path of the image located on the remote server. In case the relative path
-             is used as the variable value, the root folder for the user of the server needs to be specified.
+            - This specifies the full file path of the image located on the
+             remote server. In case the relative path is used as the variable
+             value, the root folder for the user of the server needs to be
+             specified.
         required: true
     imgtype:
         description:
@@ -72,14 +82,15 @@ options:
         choices: [all, boot, os, onie]
     serverusername:
         description:
-            - Specify the username for the server relating to the protocol used.
+            - Specify the username for the server relating to the protocol used
         required: true
     serverpassword:
         description:
-            - Specify the password for the server relating to the protocol used.
+            - Specify the password for the server relating to the protocol used
 '''
 EXAMPLES = '''
-Tasks : The following are examples of using the module cnos_image. These are written in the main.yml file of the tasks directory.
+Tasks : The following are examples of using the module cnos_image. These are
+  written in the main.yml file of the tasks directory.
 ---
 - name: Test Image transfer
   cnos_image:
@@ -120,17 +131,13 @@ msg:
 '''
 
 import sys
-try:
-    import paramiko
-    HAS_PARAMIKO = True
-except ImportError:
-    HAS_PARAMIKO = False
 import time
 import socket
 import array
 import json
 import time
 import re
+import os
 try:
     from ansible.module_utils.network.cnos import cnos
     HAS_LIB = True
@@ -138,6 +145,65 @@ except:
     HAS_LIB = False
 from ansible.module_utils.basic import AnsibleModule
 from collections import defaultdict
+
+
+def doImageDownload(module, prompt, answer):
+    protocol = module.params['protocol'].lower()
+    server = module.params['serverip']
+    imgPath = module.params['imgpath']
+    imgType = module.params['imgtype']
+    username = module.params['serverusername']
+    password = module.params['serverpassword']
+    retVal = ''
+    command = "copy " + protocol + " " + protocol + "://" + username + "@"
+    command = command + server + "/" + imgPath + " system-image "
+    command = command + imgType + " vrf management"
+    # cnos.debugOutput(command + "\n")
+    cmd = []
+    if(protocol == "scp"):
+        prompt = ['timeout', 'Confirm download operation', 'Password',
+                  'Do you want to change that to the standby image']
+        answer = ['240', 'y', password, 'y']
+        scp_cmd = [{'command': command, 'prompt': prompt, 'answer': answer,
+                    'check_all': True}]
+        cmd.extend(scp_cmd)
+        # cnos.debugOutput(cmd)
+        retVal = retVal + str(cnos.run_cnos_commands(module, cmd))
+    elif(protocol == "sftp"):
+        prompt = ['Confirm download operation', 'Password',
+                  'Do you want to change that to the standby image']
+        answer = ['y', password, 'y']
+        sftp_cmd = [{'command': command, 'prompt': prompt, 'answer': answer,
+                     'check_all': True}]
+        cmd.extend(sftp_cmd)
+        # cnos.debugOutput(cmd)
+        retVal = retVal + str(cnos.run_cnos_commands(module, cmd))
+    elif(protocol == "ftp"):
+        prompt = ['Confirm download operation', 'Password',
+                  'Do you want to change that to the standby image']
+        answer = ['y', password, 'y']
+        ftp_cmd = [{'command': command, 'prompt': prompt, 'answer': answer,
+                    'check_all': True}]
+        cmd.extend(ftp_cmd)
+        # cnos.debugOutput(cmd)
+        retVal = retVal + str(cnos.run_cnos_commands(module, cmd))
+    elif(protocol == "tftp"):
+        command = "copy " + protocol + " " + protocol + "://" + server
+        command = command + "/" + imgPath + " system-image " + imgType
+        command = command + + " vrf management"
+        prompt = ['Confirm download operation',
+                  'Do you want to change that to the standby image']
+        answer = ['y', 'y']
+        tftp_cmd = [{'command': command, 'prompt': prompt, 'answer': answer,
+                     'check_all': True}]
+        cmd.extend(tftp_cmd)
+        # cnos.debugOutput(cmd)
+        retVal = retVal + str(cnos.run_cnos_commands(module, cmd))
+    else:
+        return "Error-110"
+
+    return retVal
+# EOM
 
 
 def main():
@@ -157,58 +223,24 @@ def main():
             serverpassword=dict(required=False, no_log=True),),
         supports_check_mode=False)
 
-    username = module.params['username']
-    password = module.params['password']
-    enablePassword = module.params['enablePassword']
     outputfile = module.params['outputfile']
-    host = module.params['host']
-    deviceType = module.params['deviceType']
     protocol = module.params['protocol'].lower()
-    imgserverip = module.params['serverip']
-    imgpath = module.params['imgpath']
-    imgtype = module.params['imgtype']
-    imgserveruser = module.params['serverusername']
-    imgserverpwd = module.params['serverpassword']
-    output = ""
-    timeout = 120
-    tftptimeout = 600
-    if not HAS_PARAMIKO:
-        module.fail_json(msg='paramiko is required for this module')
+    output = ''
 
-    # Create instance of SSHClient object
-    remote_conn_pre = paramiko.SSHClient()
-
-    # Automatically add untrusted hosts (make sure okay for security policy in your environment)
-    remote_conn_pre.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
-    # initiate SSH connection with the switch
-    remote_conn_pre.connect(host, username=username, password=password)
-    time.sleep(2)
-
-    # Use invoke_shell to establish an 'interactive session'
-    remote_conn = remote_conn_pre.invoke_shell()
-    time.sleep(2)
-
-    # Enable and then send command
-    output = output + cnos.waitForDeviceResponse("\n", ">", 2, remote_conn)
-
-    output = output + cnos.enterEnableModeForDevice(enablePassword, 3, remote_conn)
-
-    # Make terminal length = 0
-    output = output + cnos.waitForDeviceResponse("terminal length 0\n", "#", 2, remote_conn)
-
-    transfer_status = ""
     # Invoke method for image transfer from server
-    if(protocol == "tftp" or protocol == "ftp"):
-        transfer_status = cnos.doImageTransfer(protocol, tftptimeout, imgserverip, imgpath, imgtype, imgserveruser, imgserverpwd, remote_conn)
-    elif(protocol == "sftp" or protocol == "scp"):
-        transfer_status = cnos.doSecureImageTransfer(protocol, timeout, imgserverip, imgpath, imgtype, imgserveruser, imgserverpwd, remote_conn)
+    if(protocol == "tftp" or protocol == "ftp" or protocol == "sftp" or
+       protocol == "scp"):
+        transfer_status = doImageDownload(module, None, None)
     else:
         transfer_status = "Invalid Protocol option"
 
     output = output + "\n Image Transfer status \n" + transfer_status
 
     # Save it into the file
+    path = outputfile.rsplit('/', 1)
+    # cnos.debugOutput(path[0])
+    if not os.path.exists(path[0]):
+        os.makedirs(path[0])
     file = open(outputfile, "a")
     file.write(output)
     file.close()

--- a/lib/ansible/modules/network/cnos/cnos_image.py
+++ b/lib/ansible/modules/network/cnos/cnos_image.py
@@ -158,7 +158,6 @@ def doImageDownload(module, prompt, answer):
     command = "copy " + protocol + " " + protocol + "://" + username + "@"
     command = command + server + "/" + imgPath + " system-image "
     command = command + imgType + " vrf management"
-    # cnos.debugOutput(command + "\n")
     cmd = []
     if(protocol == "scp"):
         prompt = ['timeout', 'Confirm download operation', 'Password',
@@ -167,7 +166,6 @@ def doImageDownload(module, prompt, answer):
         scp_cmd = [{'command': command, 'prompt': prompt, 'answer': answer,
                     'check_all': True}]
         cmd.extend(scp_cmd)
-        # cnos.debugOutput(cmd)
         retVal = retVal + str(cnos.run_cnos_commands(module, cmd))
     elif(protocol == "sftp"):
         prompt = ['Confirm download operation', 'Password',
@@ -176,7 +174,6 @@ def doImageDownload(module, prompt, answer):
         sftp_cmd = [{'command': command, 'prompt': prompt, 'answer': answer,
                      'check_all': True}]
         cmd.extend(sftp_cmd)
-        # cnos.debugOutput(cmd)
         retVal = retVal + str(cnos.run_cnos_commands(module, cmd))
     elif(protocol == "ftp"):
         prompt = ['Confirm download operation', 'Password',
@@ -185,7 +182,6 @@ def doImageDownload(module, prompt, answer):
         ftp_cmd = [{'command': command, 'prompt': prompt, 'answer': answer,
                     'check_all': True}]
         cmd.extend(ftp_cmd)
-        # cnos.debugOutput(cmd)
         retVal = retVal + str(cnos.run_cnos_commands(module, cmd))
     elif(protocol == "tftp"):
         command = "copy " + protocol + " " + protocol + "://" + server
@@ -197,7 +193,6 @@ def doImageDownload(module, prompt, answer):
         tftp_cmd = [{'command': command, 'prompt': prompt, 'answer': answer,
                      'check_all': True}]
         cmd.extend(tftp_cmd)
-        # cnos.debugOutput(cmd)
         retVal = retVal + str(cnos.run_cnos_commands(module, cmd))
     else:
         return "Error-110"
@@ -238,7 +233,6 @@ def main():
 
     # Save it into the file
     path = outputfile.rsplit('/', 1)
-    # cnos.debugOutput(path[0])
     if not os.path.exists(path[0]):
         os.makedirs(path[0])
     file = open(outputfile, "a")

--- a/lib/ansible/modules/network/cnos/cnos_rollback.py
+++ b/lib/ansible/modules/network/cnos/cnos_rollback.py
@@ -189,7 +189,36 @@ except:
 from ansible.module_utils.basic import AnsibleModule
 from collections import defaultdict
 
-
+# The method below is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded inside it by
+# Ansible still belong to the author of the module, and may assign their own
+# license to the complete work.
+#
+# Copyright (C) 2017 Lenovo, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
 # Utility Method to rollback the running config or start up copnfig
 # This method supports only SCP or SFTP or FTP or TFTP
 def doConfigRollBack(module, prompt, answer):

--- a/lib/ansible/modules/network/cnos/cnos_rollback.py
+++ b/lib/ansible/modules/network/cnos/cnos_rollback.py
@@ -300,3 +300,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/lib/ansible/modules/network/cnos/cnos_rollback.py
+++ b/lib/ansible/modules/network/cnos/cnos_rollback.py
@@ -300,4 +300,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/cnos/cnos_rollback.py
+++ b/lib/ansible/modules/network/cnos/cnos_rollback.py
@@ -189,6 +189,7 @@ except:
 from ansible.module_utils.basic import AnsibleModule
 from collections import defaultdict
 
+
 # The method below is part of Ansible, but is an independent component.
 # This particular file snippet, and this file snippet only, is BSD licensed.
 # Modules you write using this snippet, which is embedded inside it by

--- a/lib/ansible/modules/network/cnos/cnos_rollback.py
+++ b/lib/ansible/modules/network/cnos/cnos_rollback.py
@@ -190,36 +190,6 @@ from ansible.module_utils.basic import AnsibleModule
 from collections import defaultdict
 
 
-# The method below is part of Ansible, but is an independent component.
-# This particular file snippet, and this file snippet only, is BSD licensed.
-# Modules you write using this snippet, which is embedded inside it by
-# Ansible still belong to the author of the module, and may assign their own
-# license to the complete work.
-#
-# Copyright (C) 2017 Lenovo, Inc.
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-#  * Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-#  * Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
-#
 # Utility Method to rollback the running config or start up copnfig
 # This method supports only SCP or SFTP or FTP or TFTP
 def doConfigRollBack(module, prompt, answer):

--- a/lib/ansible/plugins/cliconf/cnos.py
+++ b/lib/ansible/plugins/cliconf/cnos.py
@@ -80,8 +80,8 @@ class Cliconf(CliconfBase):
         for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
             self.send_command(cmd)
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/test/integration/targets/cnos_image/README.md
+++ b/test/integration/targets/cnos_image/README.md
@@ -1,0 +1,119 @@
+# Ansible Role: cnos_image_sample - Switch firmware download from a remote server
+---
+<add role description below>
+
+This role is an example of using the *cnos_image.py* Lenovo module in the context of CNOS switch configuration. This module allows you to work with switch firmware images. It provides a way to download a firmware image to a network device from a remote server using FTP, SFTP, TFTP, or SCP.
+
+The first step is to create a directory from where the remote server can be reached. The next step is to provide the full file path of the image location. Authentication details required by the remote server must be provided as well.
+
+By default, this method makes the newly downloaded firmware image the active image, which will be used by the switch during the next restart.
+
+The results of the operation can be viewed in *results* directory.
+
+For more details, see [Lenovo modules for Ansible: cnos_image](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_image.html&cp=0_3_1_0_4_2).
+
+
+## Requirements
+---
+<add role requirements information below>
+
+- Ansible version 2.2 or later ([Ansible installation documentation](http://docs.ansible.com/ansible/intro_installation.html))
+- Lenovo switches running CNOS version 10.2.1.0 or later
+- an SSH connection to the Lenovo switch (SSH must be enabled on the network device)
+
+
+## Role Variables
+---
+<add role variables information below>
+
+Available variables are listed below, along with description.
+
+The following are mandatory inventory variables:
+
+Variable | Description
+--- | ---
+`ansible_connection` | Has to be `network_cli`
+`ansible_network_os` | Has to be `cnos`
+`ansible_ssh_user` | Specifies the username used to log into the switch
+`ansible_ssh_pass` | Specifies the password used to log into the switch
+`enablePassword` | Configures the password used to enter Global Configuration command mode on the switch (this is an optional parameter)
+`hostname` | Searches the hosts file at */etc/ansible/hosts* and identifies the IP address of the switch on which the role is going to be applied
+`deviceType` | Specifies the type of device from where the configuration will be backed up (**g8272_cnos** - G8272, **g8296_cnos** - G8296, **g8332_cnos** - G8332, **NE10032** - NE10032, **NE1072T** - NE1072T, **NE1032** - NE1032, **NE1032T** - NE1032T, **NE2572** - NE2572)
+
+The values of the variables used need to be modified to fit the specific scenario in which you are deploying the solution. To change the values of the variables, you need to visits the *vars* directory of each role and edit the *main.yml* file located there. The values stored in this file will be used by Ansible when the template is executed.
+
+The syntax of *main.yml* file for variables is the following:
+
+```
+<template variable>:<value>
+```
+
+You will need to replace the `<value>` field with the value that suits your topology. The `<template variable>` fields are taken from the template and it is recommended that you leave them unchanged.
+
+Variable | Description
+--- | ---
+`imgType` | Specifies the firmware image type to be downloaded (**all** - both Uboot and OS images, **boot** - only the Uboot image, **os** - only the OS image, **onie** - ONIE image)
+`protocol` | Specifies the protocol used by the network device to interact with the remote server from where to download the firmware image (**ftp** - FTP, **sftp** - SFTP, **tftp** - TFTP, **scp** - SCP)
+`serverip` | Specifies the IP Address of the remote server from where the software image will be downloaded
+`imgpath` | Specifies the full file path of the image located on the remote server (in case the relative path is used as the variable value, the root folder for the user of the server needs to be specified)
+`serverusername` | Configures the username for the server relating to the protocol used
+`serverpassword` | Configures the password for the server relating to the protocol used
+
+
+## Dependencies
+---
+<add dependencies information below>
+
+- username.iptables - Configures the firewall and blocks all ports except those needed for web server and SSH access.
+- username.common - Performs common server configuration.
+- cnos_image.py - This modules needs to be present in the *library* directory of the role.
+- cnos.py - This module needs to be present in the PYTHONPATH environment variable set in the Ansible system.
+- /etc/ansible/hosts - You must edit the */etc/ansible/hosts* file with the device information of the switches designated as leaf switches. You may refer to *cnos_image_sample_hosts* for a sample configuration.
+
+Ansible keeps track of all network elements that it manages through a hosts file. Before the execution of a playbook, the hosts file must be set up.
+
+Open the */etc/ansible/hosts* file with root privileges. Most of the file is commented out by using **#**. You can also comment out the entries you will be adding by using **#**. You need to copy the content of the hosts file for the role into the */etc/ansible/hosts* file. The sample hosts file for the role is located in the main directory.
+
+```
+[cnos_image_sample]
+10.241.107.39   ansible_network_os=cnos ansible_ssh_user=<username> ansible_ssh_pass=<password> deviceType=g8272_cnos
+10.241.107.40   ansible_network_os=cnos ansible_ssh_user=<username> ansible_ssh_pass=<password> deviceType=g8272_cnos
+```
+ 
+**Note:** You need to change the IP addresses to fit your specific topology. You also need to change the `<username>` and `<password>` to the appropriate values used to log into the specific Lenovo network devices.
+
+
+## Example Playbook
+---
+<add playbook samples below>
+
+To execute an Ansible playbook, use the following command:
+
+```
+ansible-playbook cnos_image_sample.yml -vvv
+```
+
+`-vvv` is an optional verbos command that helps identify what is happening during playbook execution. The playbook for each role is located in the main directory of the solution.
+
+```
+  - name: Module to  do image download
+   hosts: cnos_image_sample
+   gather_facts: no
+   connection: local
+   roles:
+    - cnos_image_sample
+```
+
+
+## License
+---
+<add license information below>
+Copyright (C) 2017 Lenovo, Inc.
+
+This file is part of Ansible
+
+Ansible is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+Ansible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with Ansible.  If not, see <http://www.gnu.org/licenses/>.

--- a/test/integration/targets/cnos_image/aliases
+++ b/test/integration/targets/cnos_image/aliases
@@ -1,0 +1,2 @@
+# No Lenovo Switch simulator yet, so not enabled
+unsupported

--- a/test/integration/targets/cnos_image/cnos_image_sample_hosts
+++ b/test/integration/targets/cnos_image/cnos_image_sample_hosts
@@ -1,0 +1,17 @@
+# You have to paste this dummy information  in /etc/ansible/hosts
+#    Notes:
+#    - Comments begin with the '#' character
+#    - Blank lines are ignored
+#    - Groups of hosts are delimited by [header] elements
+#    - You can enter hostnames or ip addresses
+#    - A hostname/ip can be a member of multiple groups
+#
+# In the /etc/ansible/hosts file u have to enter [cnos_image_sample] tag
+# Following you should specify IP Adresses details 
+# Please change <username> and <password> with appropriate value for your switch.
+
+[cnos_image_sample]
+10.241.107.39  ansible_network_os=cnos ansible_ssh_user=<username> ansible_ssh_pass=<password> deviceType=g8272_cnos imgpath=/root/cnos_images/G8272-10.1.0.112.img
+
+#Use this in case its TFTP as tftpboot is the starting point for tftp
+#10.241.107.39  ansible_network_os=cnos ansible_ssh_user=<username> ansible_ssh_pass=<password> deviceType=g8272_cnos imgpath="/anil/G8272-10.2.0.34.img

--- a/test/integration/targets/cnos_image/tasks/main.yml
+++ b/test/integration/targets/cnos_image/tasks/main.yml
@@ -1,0 +1,16 @@
+# This contain sample Image download tasks
+---
+
+- name: Test Image transfer
+  cnos_image: host={{ inventory_hostname }} username={{ hostvars[inventory_hostname]['ansible_ssh_user']}}  password={{ hostvars[inventory_hostname]['ansible_ssh_pass']}} deviceType={{ hostvars[inventory_hostname]['deviceType']}} outputfile=./results/cnos_image_{{ inventory_hostname }}_output.txt protocol='{{item.protocol}}' serverip='{{item.serverip}}' imgpath={{ hostvars[inventory_hostname]['imgpath']}} imgtype='{{item.imgtype}}' serverusername='{{item.serverusername}}' serverpassword='{{item.serverpassword}}'
+  with_items: "{{test_image_data1}}"
+
+#Root folder will be different for SFTP/SCP and TFTP
+#The following task is commented. 
+#Before trying this, please change in /etc/ansible/hosts file 
+#and place an image with reference to your tftp-root folder  
+#- name: Test Image tftp
+#  cnos_image: host={{ inventory_hostname }} username={{ hostvars[inventory_hostname]['ansible_ssh_user']}}  password={{ hostvars[inventory_hostname]['ansible_ssh_pass']}} deviceType={{ hostvars[inventory_hostname]['deviceType']}} outputfile=./results/cnos_image_{{ inventory_hostname }}_output.txt protocol='{{item.protocol}}' serverip='{{item.serverip}}' imgpath={{ hostvars[inventory_hostname]['imgpath']}} imgtype='{{item.imgtype}}'
+#  with_items: "{{test_image_data2}}"
+  
+# Completed file

--- a/test/integration/targets/cnos_image/vars/main.yml
+++ b/test/integration/targets/cnos_image/vars/main.yml
@@ -1,0 +1,6 @@
+---
+test_image_data1:
+  - {protocol: "sftp", serverip: "10.241.106.118", imgtype: "os", serverusername: "root", serverpassword: "root123"}
+
+test_image_data2:
+  - {protocol: "tftp", serverip: "10.241.106.118", imgtype: "os"}


### PR DESCRIPTION
##### SUMMARY
In this PR I am removing the code of paramiko and replace it with persistence connection. This effort is done to cnos_image. The effort involves moving the code in util file to module file so that the size is reduced. At the same time I am updating CLIs to latest CNOS CLIs. I am adding the integration test code which I used to test the network element in my lab.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
llib/ansible/module_utils/network/cnos/cnos.py
lib/ansible/modules/network/cnos/cnos_image.py
lib/ansible/plugins/cliconf/cnos.py
test/integration/targets/cnos_image/README.md
test/integration/targets/cnos_image/aliases
test/integration/targets/cnos_image/cnos_image_sample_hosts
test/integration/targets/cnos_image/tasks/main.yml
test/integration/targets/cnos_image/vars/main.yml

##### ANSIBLE VERSION
ansible 2.7.0.dev0 (devel f9cbdcd) last updated 2018/07/03 14:55:43 (GMT +550)
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /home/ansible/sheru/ansible/lib/ansible
executable location = /home/ansible/sheru/ansible/bin/ansible
python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]

##### ADDITIONAL INFORMATION
Unused code in cnos.py is removed. Tested with CNOS Mars switch for SFTP