### PR TITLE
win_nssm: add AppDirectory, AppEnvironmentExtra

### DIFF
--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -21,6 +21,7 @@ $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "prese
 $application = Get-AnsibleParam -obj $params -name "application" -type "str"
 $appParameters = Get-AnsibleParam -obj $params -name "app_parameters" -type "str"
 $appParametersFree  = Get-AnsibleParam -obj $params -name "app_parameters_free_form" -type "str"
+$appEnvironmentExtra = Get-AnsibleParam -obj $params -name "app_environment_extra"
 $appDirectory  = Get-AnsibleParam -obj $params -name "app_directory" -type "path"
 $startMode = Get-AnsibleParam -obj $params -name "start_mode" -type "str" -default "auto" -validateset "auto","delayed","manual","disabled" -resultobj $result
 
@@ -242,6 +243,26 @@ Function Nssm-Update-AppParameters
     $result.nssm_single_line_app_parameters = $singleLineParams
 
     Nssm-Update -name $name -parameter "AppParameters" -value $singleLineParams
+}
+
+Function Nssm-Update-AppEnvironmentExtra
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$name,
+        $appEnvironmentExtra
+    )
+
+    $singleLine = ""
+    if ($appEnvironmentExtra) {
+        $appEnvironmentExtra.GetEnumerator() | ForEach-Object {
+            $singleLine = $singleLine + $_.Name + "=""" + $_.Value + """ "
+        }
+    }
+    $result.nssm_app_environment_extra = $appEnvironmentExtra
+    $result.nssm_single_line_app_environment_extra = $singleLine
+    Nssm-Update -name $name -parameter "AppEnvironmentExtra" $singleLine
 }
 
 Function Nssm-Update
@@ -589,6 +610,7 @@ Function NssmProcedure
 {
     Nssm-Install -name $name -application $application
     Nssm-Update-AppParameters -name $name -appParameters $appParameters -appParametersFree $appParametersFree
+    Nssm-Update-AppEnvironmentExtra -name $name -appEnvironmentExtra $appEnvironmentExtra
     Nssm-Update -name $name -parameter "AppDirectory" -value $appDirectory
     Nssm-Update -name $name -parameter "AppStdout" -value $stdoutFile
     Nssm-Update -name $name -parameter "AppStderr" -value $stderrFile

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -60,6 +60,10 @@ options:
     version_added: "2.7.0"
     description:
       -  The startup directory (defaults to the directory containing the program)
+  app_environment_extra:
+    version_added: "2.7.0"
+    description:
+      - Environment variables to set in addition to the system environment.
   dependencies:
     description:
       - Service dependencies that has to be started to trigger startup, separated by comma.

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -56,6 +56,10 @@ options:
     description:
       - Single string of parameters to be passed to the service.
       - Use either this or C(app_parameters), not both.
+  app_directory:
+    version_added: "2.7.0"
+    description:
+      -  The startup directory (defaults to the directory containing the program)
   dependencies:
     description:
       - Service dependencies that has to be started to trigger startup, separated by comma.
@@ -78,6 +82,7 @@ author:
   - George Frank (@georgefrank)
   - Hans-Joachim Kliemeck (@h0nIg)
   - Michael Wild (@themiwi)
+  - Simon Legner (@simon04)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -95,6 +95,15 @@ EXAMPLES = r'''
     name: foo
     application: C:\windows\foo.exe
 
+# Install and start the foo service with an application directory and environment specified:
+# This will set CLASSPATH=baz.jar and start java.exe in C:\bar\
+- win_nssm:
+    name: foo
+    application: java.exe
+    app_directory: C:\bar\
+    app_environment_extra:
+      CLASSPATH: baz.jar
+
 # Install and start the foo service with a key-value pair argument
 # This will yield the following command: C:\windows\foo.exe bar "true"
 - win_nssm:


### PR DESCRIPTION
##### SUMMARY
This PR adds support for the `AppDirectory`, `AppEnvironmentExtra` parameters in win_nssm: https://nssm.cc/commands

Fixes #33159.


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_nssm

##### ANSIBLE VERSION
```
ansible 2.7.0.a1.post0 (nssm e1fbdd11bb) last updated 2018/08/31 14:42:50 (GMT +200)
  config file = None
  configured module search path = ['/home/simon/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/simon/src/ansible/lib/ansible
  executable location = bin/ansible
  python version = 3.7.0 (default, Jul 15 2018, 10:44:58) [GCC 8.1.1 20180531]

```
