### PR TITLE
maven_artifact: enforce required params (fixes #44823)

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -444,8 +444,8 @@ class MavenDownloader:
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            group_id=dict(default=None),
-            artifact_id=dict(default=None),
+            group_id=dict(required=True),
+            artifact_id=dict(required=True),
             version=dict(default="latest"),
             classifier=dict(default=''),
             extension=dict(default='jar'),
@@ -454,7 +454,7 @@ def main():
             password=dict(default=None, no_log=True, aliases=['aws_secret_access_key']),
             state=dict(default="present", choices=["present", "absent"]),  # TODO - Implement a "latest" state
             timeout=dict(default=10, type='int'),
-            dest=dict(type="path", default=None),
+            dest=dict(type="path", required=True),
             validate_certs=dict(required=False, default=True, type='bool'),
             keep_name=dict(required=False, default=False, type='bool'),
             verify_checksum=dict(required=False, default='download', choices=['never', 'download', 'change', 'always'])


### PR DESCRIPTION
##### SUMMARY
Now set required params as `required`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
maven_artifact

##### ANSIBLE VERSION
```
ansible 2.6.3
  config file = None
  configured module search path = [u'/Users/turb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.6.3/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```
