### PR TITLE
Update lineinfile.py

### DIFF
--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -40,15 +40,15 @@ options:
     aliases: [ dest, destfile, name ]
     required: true
   regexp:
-    aliases: [ 'regex' ]
+    aliases: [ regex ]
     description:
-      - The regular expression to look for in every line of the file. For
-        C(state=present), the pattern to replace if found. Only the last line
-        found will be replaced. For C(state=absent), the pattern of the line(s)
-        to remove. If the regular expression is not matched, the line will be
+      - The regular expression to look for in every line of the file.
+      - For C(state=present), the pattern to replace if found. Only the last line found will be replaced.
+      - For C(state=absent), the pattern of the line(s) to remove.
+      - If the regular expression is not matched, the line will be 
         added to the file in keeping with`insertbefore` or `insertafter`
-        settings. Uses Python regular expressions.
-        See U(http://docs.python.org/2/library/re.html).
+        settings.
+      - Uses Python regular expressions. See U(http://docs.python.org/2/library/re.html).
     version_added: '1.7'
   state:
     description:

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -45,7 +45,8 @@ options:
       - The regular expression to look for in every line of the file. For
         C(state=present), the pattern to replace if found. Only the last line
         found will be replaced. For C(state=absent), the pattern of the line(s)
-        to remove. Uses Python regular expressions.
+        to remove. Uses Python regular expressions.  If the regular expression is not matched,
+        the line will be added to the file in keeping with `insertbefore` or `insertafter` settings.  
         See U(http://docs.python.org/2/library/re.html).
     version_added: '1.7'
   state:

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -45,8 +45,9 @@ options:
       - The regular expression to look for in every line of the file. For
         C(state=present), the pattern to replace if found. Only the last line
         found will be replaced. For C(state=absent), the pattern of the line(s)
-        to remove. Uses Python regular expressions.  If the regular expression is not matched,
-        the line will be added to the file in keeping with `insertbefore` or `insertafter` settings.  
+        to remove. If the regular expression is not matched, the line will be
+        added to the file in keeping with`insertbefore` or `insertafter`
+        settings. Uses Python regular expressions.
         See U(http://docs.python.org/2/library/re.html).
     version_added: '1.7'
   state:


### PR DESCRIPTION
The document should call out in the regexp section what regexp does in non-match scenario, not just leave it for the reader to find it under `insertbefore` and `insertafter`.  
+label: docsite_pr

##### SUMMARY

https://github.com/ansible/ansible/issues/34690 . 

This simply adds documentation to clarify the functionality of `regexp` in the case of no matching line.  

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lineinfile

##### ANSIBLE VERSION
```
n/a
```
