### PR TITLE
VMware: Add error checking for networking

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -804,6 +804,9 @@ class PyVmomiHelper(PyVmomi):
         self.configspec = None
         self.change_detected = False
         self.customspec = None
+        if self.params['networks'] is not None:
+                if self.params['datacenter'] is None:
+                        self.module.fail_json(msg="Please input a datacenter in order to modify network")
         self.cache = PyVmomiCache(self.content, dc_name=self.params['datacenter'])
 
     def gather_facts(self, vm):
@@ -2319,7 +2322,7 @@ def main():
         cdrom=dict(type='dict', default={}),
         hardware=dict(type='dict', default={}),
         force=dict(type='bool', default=False),
-        datacenter=dict(type='str', default='ha-datacenter'),
+        datacenter=dict(type='str'),
         esxi_hostname=dict(type='str'),
         cluster=dict(type='str'),
         wait_for_ip_address=dict(type='bool', default=False),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -232,7 +232,6 @@ options:
     description:
     - Destination datacenter for the deploy operation.
     - This parameter is case sensitive.
-    default: ha-datacenter
   cluster:
     description:
     - The cluster name where the virtual machine will run.


### PR DESCRIPTION

##### SUMMARY
If a datacenter is not set, then self.params will fail to correctly get information. It will then state that networks do not exist if you attempt to add new ones or edit existing ones.

Example:
If you have 
```
  - name: change Nic network
    vmware_guest:
      hostname: '{{ vsphere_host }}'
      validate_certs: no
      name: '{{ inventory_hostname }}'
      networks:
      - name: 'NPDNetwork'
        device_type: 'vmxnet3'
        type: 'dhcp'
```
you will get an error that "Network 'NPDNetwork' does not exist.". If you do:
```
  - name: change Nic network
    vmware_guest:
      hostname: '{{ vsphere_host }}'
      validate_certs: no
      datacenter: "DATACENTER"
      name: '{{ inventory_hostname }}'
      networks:
      - name: 'NPDNetwork'
        device_type: 'vmxnet3'
        type: 'dhcp'
```
Then the nic will change networks without issues.
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```
