### PR TITLE
pkgng: Return reason on "pkg update" error message

### DIFF
--- a/lib/ansible/modules/packaging/os/pkgng.py
+++ b/lib/ansible/modules/packaging/os/pkgng.py
@@ -209,7 +209,7 @@ def install_packages(module, pkgng_path, packages, cached, pkgsite, dir_arg, sta
         else:
             rc, out, err = module.run_command("%s %s update" % (pkgng_path, dir_arg))
         if rc != 0:
-            module.fail_json(msg="Could not update catalogue")
+            module.fail_json(msg="Could not update catalogue [%d]: %s %s" % (rc, out, err))
 
     for package in packages:
         already_installed = query_package(module, pkgng_path, package, dir_arg)


### PR DESCRIPTION
##### SUMMARY
When installing a package on FreeBSD 11.2 with the pkgng module, it would first perform a `pkg update`. Without `become` set, it failed and returned no additional information:

     "msg": "Could not update catalogue"

Now it passes that reason with the error message:

    {"changed": false, "msg": "Could not update catalogue [77]:  pkg: Insufficient privileges to update the repository catalogue.\n"}


##### ISSUE TYPE
 - Bugfix Pull Request
 
##### COMPONENT NAME
pkgng

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.3
  config file = /Users/allen/src/Biglist/biglist-ansible/ansible.cfg
  configured module search path = [u'/Users/allen/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.6.3/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Aug 22 2018, 16:36:18) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```


##### ADDITIONAL INFORMATION
Installing on FreeBSD11.2 from both FreeBSD 11.2 and OSX/homebrew ansible

```
before:
fatal: [xxxxx]: FAILED! => {"changed": false, "msg": "Could not update catalogue"}

after:
fatal: [xxxxx]: FAILED! => {"changed": false, "msg": "Could not update catalogue [77]:  pkg: Insufficient privileges to update the repository catalogue.\n"}
```
