### PR TITLE
ACME: add support for POST-as-GET if GET fails with 405.

### DIFF
--- a/changelogs/fragments/44988-acme-post-as-get.yaml
+++ b/changelogs/fragments/44988-acme-post-as-get.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ACME modules support `POST-as-GET <https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380>`__ and will be able to access Let's Encrypt ACME v2 endpoint after November 1st, 2019."

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -686,9 +686,8 @@ class ACMEAccount(object):
             # try POST-as-GET first (draft-15 or newer)
             data = None
             result, info = self.send_signed_request(self.uri, data)
-            # check whether that failed with a malformedRequest error
-            if info['status'] >= 400 and result.get('type') in ('urn:ietf:params:acme:error:malformed',
-                                                                'urn:ietf:params:acme:error:malformedRequest'):
+            # check whether that failed with a malformed request error
+            if info['status'] >= 400 and result.get('type') == 'urn:ietf:params:acme:error:malformed':
                 # retry as a regular POST (with no changed data) for pre-draft-15 ACME servers
                 data = {}
                 result, info = self.send_signed_request(self.uri, data)

--- a/test/runner/lib/cloud/acme.py
+++ b/test/runner/lib/cloud/acme.py
@@ -43,7 +43,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:1.4.0'
+            self.image = 'quay.io/ansible/acme-test-container:1.4.1'
         self.container_name = ''
 
     def _wait_for_service(self, protocol, acme_host, port, local_part, name):

--- a/test/runner/lib/cloud/acme.py
+++ b/test/runner/lib/cloud/acme.py
@@ -43,7 +43,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:1.3.0'
+            self.image = 'quay.io/ansible/acme-test-container:1.4.0'
         self.container_name = ''
 
     def _wait_for_service(self, protocol, acme_host, port, local_part, name):


### PR DESCRIPTION
##### SUMMARY
This is a WIP version implementing [POST-as-GET](https://tools.ietf.org/html/draft-ietf-acme-acme-16#section-6.3) of draft-15 and draft-16.

This was originally a Feature Pull Request since it appeared as if a new ACME v3 endpoint would be added ([announcement](https://community.letsencrypt.org/t/acme-breaking-change-most-gets-become-posts/71025)), but has been changed to another announcement that the ACME v2 endpoint will adopt POST-as-GET, and the old unauthenticated GET method [will be disabled on November 1st, 2019](https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380).

This PR modifies the current ACME handling to support both the current (unauthenticated GET) implementation, as well as the new POST-as-GET implementation. My plan is to deploy this and backport it, so that the ACME modules of Ansible 2.6 and 2.7 will remain working after November 1st, 2019, and then later (as soon as Let's Encrypt enables full POST-as-GET suppport) to change the `devel` implementation (i.e. for Ansible 2.8) to only use authenticated POST-as-GET calls for ACME v2.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/acme.py
acme_certificate

##### ANSIBLE VERSION
```
2.7.1
```
