### PR TITLE
Add a table of contents to the generated changelog

### DIFF
--- a/packaging/release/changelogs/changelog.py
+++ b/packaging/release/changelogs/changelog.py
@@ -443,6 +443,7 @@ class ChangelogGenerator(object):
 
         builder = RstBuilder()
         builder.set_title('Ansible %s "%s" Release Notes' % (major_minor_version, codename))
+        builder.add_raw_rst('.. contents:: Topics\n\n')
 
         for version, release in release_entries.items():
             builder.add_section('v%s' % version)


### PR DESCRIPTION
##### SUMMARY


##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
Generated changelog

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel (backport to 2.7 and possibly earlier releases)
```


##### ADDITIONAL INFORMATION
* new rst output: It just has a contents directive: https://gist.githubusercontent.com/abadger/9e3603ada5c06b80cf2cd0767dd121d6/raw/f4e0677e010634e688d92fb4bf35ec5447c07677/CHANGELOG-v2.7.rst

* What the new output looks when rendered:  https://gist.github.com/abadger/9e3603ada5c06b80cf2cd0767dd121d6
