### PR TITLE
Macports: Add upgrade parameter and replace update_ports with selfupdate

### DIFF
--- a/changelogs/fragments/macports-upgrade-selfupdate.yml
+++ b/changelogs/fragments/macports-upgrade-selfupdate.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - macports - add upgrade parameter and replace update_ports parameter with selfupdate (https://github.com/ansible/ansible/pull/45049)

--- a/lib/ansible/modules/packaging/os/macports.py
+++ b/lib/ansible/modules/packaging/os/macports.py
@@ -29,18 +29,18 @@ options:
         description:
             - A list of port names.
         aliases: ['port']
-        required: true
+    selfupdate:
+        description:
+            - Update Macports and the ports tree, either prior to installing ports or as a separate step.
+            - Equivalent to running C(port selfupdate).
+        aliases: ['update_cache', 'update_ports']
+        default: "no"
+        type: bool
     state:
         description:
             - Indicates the desired state of the port.
         choices: [ 'present', 'absent', 'active', 'inactive' ]
         default: present
-    update_ports:
-        description:
-            - Update the ports tree first.
-        aliases: ['update_cache']
-        default: "no"
-        type: bool
     variant:
         description:
             - A port variant specification.
@@ -66,10 +66,14 @@ EXAMPLES = '''
     - foo
     - foo-tools
 
-- name: Update the ports tree then install the foo port
+- name: Update Macports and the ports tree
+  macports:
+    selfupdate: yes
+
+- name: Update Macports and the ports tree, then install the foo port
   macports:
     name: foo
-    update_ports: yes
+    selfupdate: yes
 
 - name: Remove the foo port
   macports:
@@ -87,17 +91,34 @@ EXAMPLES = '''
     state: inactive
 '''
 
+import re
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import shlex_quote
 
 
-def sync_ports(module, port_path):
-    """ Sync ports tree. """
+def selfupdate(module, port_path):
+    """ Update Macports and the ports tree. """
 
-    rc, out, err = module.run_command("%s sync" % port_path)
+    rc, out, err = module.run_command("%s -v selfupdate" % port_path)
 
-    if rc != 0:
-        module.fail_json(msg="Could not update ports tree", stdout=out, stderr=err)
+    if rc == 0:
+        updated = any(
+            re.search(r'Total number of ports parsed:\s+[^0]', s.strip()) or
+            re.search(r'Installing new Macports release', s.strip())
+            for s in out.split('\n')
+            if s
+        )
+        if updated:
+            changed = True
+            msg = "Macports updated successfully"
+        else:
+            changed = False
+            msg = "Macports already up-to-date"
+
+        return (changed, msg)
+    else:
+        module.fail_json(msg="Failed to update Macports", stdout=out, stderr=err)
 
 
 def query_port(module, port_path, name, state="present"):
@@ -220,9 +241,9 @@ def deactivate_ports(module, port_path, ports):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(aliases=["port"], required=True, type='list'),
+            name=dict(aliases=["port"], type='list'),
+            selfupdate=dict(aliases=["update_cache", "update_ports"], default=False, type='bool'),
             state=dict(default="present", choices=["present", "installed", "absent", "removed", "active", "inactive"]),
-            update_ports=dict(aliases=["update_cache"], default="no", type='bool'),
             variant=dict(aliases=["variants"], default=None, type='str')
         )
     )
@@ -231,8 +252,10 @@ def main():
 
     p = module.params
 
-    if p["update_ports"]:
-        sync_ports(module, port_path)
+    if p["selfupdate"]:
+        (changed, msg) = selfupdate(module, port_path)
+        if not p["name"]:
+            module.exit_json(changed=changed, msg=msg)
 
     pkgs = p["name"]
 


### PR DESCRIPTION
##### SUMMARY

- Add upgrade parameter
  - New upgrade parameter which can be used to upgrade all outdated ports.

- Replace update_ports parameter with selfupdate
  - Macports discourages use of `port sync` and recommends using `port selfupdate` instead.
  - Keep `update_cache` and `update_ports` as aliases.
  - No longer require the `name` parameter so that `selfupdate` can be used in a task by itself.
  - Also provide changed status based on output from `port selfupdate`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
[macports module](https://docs.ansible.com/ansible/latest/modules/macports_module.html)

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.8.0.dev0 (macports-selfupdate-upgrade 29c5f90007) last updated 2018/09/01 12:44:44 (GMT +100)
  config file = None
  configured module search path = ['/Users/newtonne/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/newtonne/Projects/contrib/ansible/lib/ansible
  executable location = /Users/newtonne/Projects/contrib/ansible/bin/ansible
  python version = 3.6.6 (default, Jun 28 2018, 05:43:53) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```