### PR TITLE
DigitalOcean inventory deprecation warning

### DIFF
--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -320,7 +320,7 @@ class DigitalOceanInventory(object):
 
     def read_settings(self):
         """ Reads the settings from the digital_ocean.ini file """
-        config = ConfigParser.SafeConfigParser()
+        config = ConfigParser.ConfigParser()
         config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'digital_ocean.ini')
         config.read(config_path)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
DeprecationWarning for ConfigParser in python3

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #45053 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
contrib/inventory/digital_ocean.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.8.0.dev0 (devel f89d873698) last updated 2018/09/01 16:04:47 (GMT -400)
  config file = /Users/abond/ansible/ansible.cfg
  configured module search path = ['/Users/abond/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/abond/Development/github/ansible/lib/ansible
  executable location = /Users/abond/Development/github/ansible/bin/ansible
  python version = 3.7.0 (default, Aug 22 2018, 15:22:29) [Clang 8.0.0 (clang-800.0.42.1)]
```