### PR TITLE
[2.7] docker_*: changelogs

### DIFF
--- a/changelogs/fragments/16748-docker_container-memory.yaml
+++ b/changelogs/fragments/16748-docker_container-memory.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+- "docker_container: makes unit parsing for memory sizes more consistent, and
+   fixes idempotency problem when ``kernel_memory`` is set (see
+   https://github.com/ansible/ansible/pull/16748 and
+   https://github.com/ansible/ansible/issues/42692)"

--- a/changelogs/fragments/33579-docker_container-log_driver.yaml
+++ b/changelogs/fragments/33579-docker_container-log_driver.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Allow arbitrary ``log_driver`` for docker_container (https://github.com/ansible/ansible/pull/33579)."

--- a/changelogs/fragments/42380-docker_container-check-mode.yaml
+++ b/changelogs/fragments/42380-docker_container-check-mode.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "fixes docker_container check and debug mode (https://github.com/ansible/ansible/pull/42380)"

--- a/changelogs/fragments/42641-44812-docker-env-variables.yaml
+++ b/changelogs/fragments/42641-44812-docker-env-variables.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "The docker_* modules respect the DOCKER_* environment variables again (https://github.com/ansible/ansible/pull/42641)."

--- a/changelogs/fragments/42857-docker_container-working_dir.yaml
+++ b/changelogs/fragments/42857-docker_container-working_dir.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container: fixing ``working_dir`` idempotency problem (https://github.com/ansible/ansible/pull/42857)"

--- a/changelogs/fragments/44808-docker_container-idempotency.yaml
+++ b/changelogs/fragments/44808-docker_container-idempotency.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "improves docker_container idempotency (https://github.com/ansible/ansible/pull/44808)"


### PR DESCRIPTION
##### SUMMARY
For recent `docker_*` bugfixes, I only added changelogs to the 2.6 backport PRs, but not to the original PRs. In case they should also appear in the 2.7 changelog, here they are :) @abadger Please merge or close (or request changes), as you prefer.

The 2.6 backport PRs (none merged yet) are #44879, #44817, #44760, #44563, #44521, #44522.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docker_container
lib/ansible/module_utils/docker_common.py
(probably some more docker modules as well)

##### ANSIBLE VERSION
```
2.7.0
```
