### PR TITLE
added missing public ip address alias

### DIFF
--- a/test/integration/targets/azure_rm_publicipaddress/aliases
+++ b/test/integration/targets/azure_rm_publicipaddress/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 shippable/azure/group1
 destructive
+azure_rm_publicipaddress_facts


### PR DESCRIPTION
##### SUMMARY

Adding missing azure_publicipaddress_facts alias in the the integration test

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

azure_rm_publicipaddress
azure_rm_publicipaddress_facts

##### ANSIBLE VERSION
2.7

##### ADDITIONAL INFORMATION

