### PR TITLE
Docs: Make docsite rebuilds smarter/faster

### DIFF
--- a/docs/bin/dump_config.py
+++ b/docs/bin/dump_config.py
@@ -6,7 +6,8 @@ import sys
 import yaml
 
 from jinja2 import Environment, FileSystemLoader
-from ansible.utils.plugin_docs import update_file_if_different
+from ansible.module_utils._text import to_bytes
+from ansible.utils._build_helpers import update_file_if_different
 
 DEFAULT_TEMPLATE_FILE = 'config.rst.j2'
 
@@ -63,7 +64,7 @@ def main(args):
     output_name = os.path.join(output_dir, template_file.replace('.j2', ''))
     temp_vars = {'config_options': config_options}
 
-    data = template.render(temp_vars).encode('utf-8')
+    data = to_bytes(template.render(temp_vars))
     update_file_if_different(output_name, data)
 
     return 0

--- a/docs/bin/dump_config.py
+++ b/docs/bin/dump_config.py
@@ -68,9 +68,9 @@ def main(args):
     # Check if the destionation file is different, if not, return
     write_out = True
     if os.path.exists(output_name):
-        sha1_new = sha1(data).hexdigest()
-        sha1_old = sha1(open(output_name).read()).hexdigest()
-        if sha1_new == sha1_old:
+        with open(output_name) as f:
+            data_old = f.read()
+        if data_old == data:
             write_out = False
 
     if write_out:

--- a/docs/bin/dump_config.py
+++ b/docs/bin/dump_config.py
@@ -5,6 +5,7 @@ import os
 import sys
 import yaml
 
+from hashlib import sha1
 from jinja2 import Environment, FileSystemLoader
 
 DEFAULT_TEMPLATE_FILE = 'config.rst.j2'
@@ -62,8 +63,19 @@ def main(args):
     output_name = os.path.join(output_dir, template_file.replace('.j2', ''))
     temp_vars = {'config_options': config_options}
 
-    with open(output_name, 'wb') as f:
-        f.write(template.render(temp_vars).encode('utf-8'))
+    data = template.render(temp_vars).encode('utf-8')
+
+    # Check if the destionation file is different, if not, return
+    write_out = True
+    if os.path.exists(output_name):
+        sha1_new = sha1(data).hexdigest()
+        sha1_old = sha1(open(output_name).read()).hexdigest()
+        if sha1_new == sha1_old:
+            write_out = False
+
+    if write_out:
+        with open(output_name, 'wb') as f:
+            f.write(data)
 
     return 0
 

--- a/docs/bin/dump_config.py
+++ b/docs/bin/dump_config.py
@@ -5,8 +5,8 @@ import os
 import sys
 import yaml
 
-from hashlib import sha1
 from jinja2 import Environment, FileSystemLoader
+from ansible.utils.plugin_docs import update_file_if_different
 
 DEFAULT_TEMPLATE_FILE = 'config.rst.j2'
 
@@ -64,18 +64,7 @@ def main(args):
     temp_vars = {'config_options': config_options}
 
     data = template.render(temp_vars).encode('utf-8')
-
-    # Check if the destionation file is different, if not, return
-    write_out = True
-    if os.path.exists(output_name):
-        with open(output_name) as f:
-            data_old = f.read()
-        if data_old == data:
-            write_out = False
-
-    if write_out:
-        with open(output_name, 'wb') as f:
-            f.write(data)
+    update_file_if_different(output_name, data)
 
     return 0
 

--- a/docs/bin/dump_keywords.py
+++ b/docs/bin/dump_keywords.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python
 
 import optparse
-import os
 import re
 from distutils.version import LooseVersion
 
 import jinja2
 import yaml
-from hashlib import sha1
 from jinja2 import Environment, FileSystemLoader
 
+from ansible.module_utils._text import to_bytes
 from ansible.playbook import Play
 from ansible.playbook.block import Block
 from ansible.playbook.role import Role
 from ansible.playbook.task import Task
+from ansible.utils.plugin_docs import update_file_if_different
 
 template_file = 'playbooks_keywords.rst.j2'
 oblist = {}
@@ -81,14 +81,4 @@ if LooseVersion(jinja2.__version__) < LooseVersion('2.10'):
     # jinja2 < 2.10's indent filter indents blank lines.  Cleanup
     keyword_page = re.sub(' +\n', '\n', keyword_page)
 
-# Check if the destionation file is different, if not, return
-write_out = True
-if os.path.exists(outputname):
-    with open(outputname) as f:
-        keyword_page_old = f.read()
-    if keyword_page_old == keyword_page:
-        write_out = False
-
-if write_out:
-    with open(outputname, 'w') as f:
-        f.write(keyword_page)
+update_file_if_different(outputname, to_bytes(keyword_page))

--- a/docs/bin/dump_keywords.py
+++ b/docs/bin/dump_keywords.py
@@ -84,9 +84,9 @@ if LooseVersion(jinja2.__version__) < LooseVersion('2.10'):
 # Check if the destionation file is different, if not, return
 write_out = True
 if os.path.exists(outputname):
-    sha1_new = sha1(keyword_page.encode('utf-8')).hexdigest()
-    sha1_old = sha1(open(outputname).read()).hexdigest()
-    if sha1_new == sha1_old:
+    with open(outputname) as f:
+        keyword_page_old = f.read()
+    if keyword_page_old == keyword_page:
         write_out = False
 
 if write_out:

--- a/docs/bin/dump_keywords.py
+++ b/docs/bin/dump_keywords.py
@@ -13,7 +13,7 @@ from ansible.playbook import Play
 from ansible.playbook.block import Block
 from ansible.playbook.role import Role
 from ansible.playbook.task import Task
-from ansible.utils.plugin_docs import update_file_if_different
+from ansible.utils._build_helpers import update_file_if_different
 
 template_file = 'playbooks_keywords.rst.j2'
 oblist = {}

--- a/docs/bin/dump_keywords.py
+++ b/docs/bin/dump_keywords.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
 import optparse
+import os
 import re
 from distutils.version import LooseVersion
 
 import jinja2
 import yaml
+from hashlib import sha1
 from jinja2 import Environment, FileSystemLoader
 
 from ansible.playbook import Play
@@ -79,5 +81,14 @@ if LooseVersion(jinja2.__version__) < LooseVersion('2.10'):
     # jinja2 < 2.10's indent filter indents blank lines.  Cleanup
     keyword_page = re.sub(' +\n', '\n', keyword_page)
 
-with open(outputname, 'w') as f:
-    f.write(keyword_page)
+# Check if the destionation file is different, if not, return
+write_out = True
+if os.path.exists(outputname):
+    sha1_new = sha1(keyword_page.encode('utf-8')).hexdigest()
+    sha1_old = sha1(open(outputname).read()).hexdigest()
+    if sha1_new == sha1_old:
+        write_out = False
+
+if write_out:
+    with open(outputname, 'w') as f:
+        f.write(keyword_page)

--- a/docs/bin/generate_man.py
+++ b/docs/bin/generate_man.py
@@ -5,6 +5,7 @@ import os
 import pprint
 import sys
 
+from hashlib import sha1
 from jinja2 import Environment, FileSystemLoader
 
 from ansible.module_utils._text import to_bytes
@@ -275,6 +276,15 @@ if __name__ == '__main__':
         manpage = template.render(tvars)
         filename = os.path.join(output_dir, doc_name_formats[output_format] % tvars['cli_name'])
 
-        with open(filename, 'wb') as f:
-            f.write(to_bytes(manpage))
-            print("Wrote doc to %s" % filename)
+        # Check if the destionation file is different, if not, return
+        write_out = True
+        if os.path.exists(filename):
+            sha1_new = sha1(manpage.encode('utf-8')).hexdigest()
+            sha1_old = sha1(open(filename).read()).hexdigest()
+            if sha1_new == sha1_old:
+                write_out = False
+
+        if write_out:
+            with open(filename, 'wb') as f:
+                f.write(to_bytes(manpage))
+                print("Wrote doc to %s" % filename)

--- a/docs/bin/generate_man.py
+++ b/docs/bin/generate_man.py
@@ -2,13 +2,12 @@
 
 import optparse
 import os
-import pprint
 import sys
 
-from hashlib import sha1
 from jinja2 import Environment, FileSystemLoader
 
 from ansible.module_utils._text import to_bytes
+from ansible.utils.plugin_docss import update_file_if_different
 
 
 def generate_parser():
@@ -273,18 +272,6 @@ if __name__ == '__main__':
         if '-i' in tvars['options']:
             print('uses inventory')
 
-        manpage = to_bytes(template.render(tvars))
+        manpage = template.render(tvars)
         filename = os.path.join(output_dir, doc_name_formats[output_format] % tvars['cli_name'])
-
-        # Check if the destionation file is different, if not, return
-        write_out = True
-        if os.path.exists(filename):
-            with open(filename) as f:
-                manpage_old = f.read()
-            if manpage_old == manpage:
-                write_out = False
-
-        if write_out:
-            with open(filename, 'wb') as f:
-                f.write(to_bytes(manpage))
-                print("Wrote doc to %s" % filename)
+        update_file_if_different(filename, to_bytes(manpage))

--- a/docs/bin/generate_man.py
+++ b/docs/bin/generate_man.py
@@ -7,7 +7,7 @@ import sys
 from jinja2 import Environment, FileSystemLoader
 
 from ansible.module_utils._text import to_bytes
-from ansible.utils.plugin_docss import update_file_if_different
+from ansible.utils._build_helpers import update_file_if_different
 
 
 def generate_parser():

--- a/docs/bin/generate_man.py
+++ b/docs/bin/generate_man.py
@@ -273,15 +273,15 @@ if __name__ == '__main__':
         if '-i' in tvars['options']:
             print('uses inventory')
 
-        manpage = template.render(tvars)
+        manpage = to_bytes(template.render(tvars))
         filename = os.path.join(output_dir, doc_name_formats[output_format] % tvars['cli_name'])
 
         # Check if the destionation file is different, if not, return
         write_out = True
         if os.path.exists(filename):
-            sha1_new = sha1(manpage.encode('utf-8')).hexdigest()
-            sha1_old = sha1(open(filename).read()).hexdigest()
-            if sha1_new == sha1_old:
+            with open(filename) as f:
+                manpage_old = f.read()
+            if manpage_old == manpage:
                 write_out = False
 
         if write_out:

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -187,9 +187,9 @@ def write_data(text, output_dir, outputname, module=None):
 
         # Check if the destionation file is different, if not, return
         if os.path.exists(fname):
-            sha1_new = sha1(text.encode('utf-8')).hexdigest()
-            sha1_old = sha1(open(fname).read()).hexdigest()
-            if sha1_new == sha1_old:
+            with open(fname, 'r') as f:
+                text_old = f.read()
+            if text_old == text:
                 return
 
         with open(fname, 'wb') as f:

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -56,7 +56,7 @@ from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.loader import fragment_loader
 from ansible.utils import plugin_docs
 from ansible.utils.display import Display
-from ansible.utils.plugin_docs import update_file_if_different
+from ansible.utils._build_helpers import update_file_if_different
 
 
 #####################################################################################

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -48,7 +48,6 @@ import jinja2
 import yaml
 from jinja2 import Environment, FileSystemLoader
 from six import iteritems, string_types
-from hashlib import sha1
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_text
@@ -57,6 +56,7 @@ from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.loader import fragment_loader
 from ansible.utils import plugin_docs
 from ansible.utils.display import Display
+from ansible.utils.plugin_docs import update_file_if_different
 
 
 #####################################################################################
@@ -185,15 +185,7 @@ def write_data(text, output_dir, outputname, module=None):
         fname = os.path.join(output_dir, outputname)
         fname = fname.replace(".py", "")
 
-        # Check if the destionation file is different, if not, return
-        if os.path.exists(fname):
-            with open(fname, 'r') as f:
-                text_old = f.read()
-            if text_old == text:
-                return
-
-        with open(fname, 'wb') as f:
-            f.write(to_bytes(text))
+        update_file_if_different(fname, to_bytes(text))
     else:
         print(text)
 

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -48,6 +48,7 @@ import jinja2
 import yaml
 from jinja2 import Environment, FileSystemLoader
 from six import iteritems, string_types
+from hashlib import sha1
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_text
@@ -183,6 +184,14 @@ def write_data(text, output_dir, outputname, module=None):
             os.makedirs(output_dir)
         fname = os.path.join(output_dir, outputname)
         fname = fname.replace(".py", "")
+
+        # Check if the destionation file is different, if not, return
+        if os.path.exists(fname):
+            sha1_new = sha1(text.encode('utf-8')).hexdigest()
+            sha1_old = sha1(open(fname).read()).hexdigest()
+            if sha1_new == sha1_old:
+                return
+
         with open(fname, 'wb') as f:
             f.write(to_bytes(text))
     else:

--- a/docs/bin/testing_formatter.sh
+++ b/docs/bin/testing_formatter.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -eu
 
-cat <<- EOF > ../docsite/rst/dev_guide/testing/sanity/index.rst
+FILENAME=../docsite/rst/dev_guide/testing/sanity/index.rst
+
+cat <<- EOF >$FILENAME.new
 Sanity Tests
 ============
 
@@ -12,5 +14,9 @@ This list is also available using \`\`ansible-test sanity --list-tests\`\`.
 
 $(for test in $(../../test/runner/ansible-test sanity --list-tests); do echo "   ${test}"; done)
 
-
 EOF
+
+# Put file into place if it has changed
+if [ "$(sha1sum <$FILENAME)" != "$(sha1sum <$FILENAME.new)" ]; then
+    mv -f $FILENAME.new $FILENAME
+fi

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -35,7 +35,7 @@ endif
 
 all: docs
 
-docs: clean htmldocs
+docs: htmldocs
 
 generate_rst: staticmin config cli keywords modules plugins testing
 

--- a/lib/ansible/utils/_build_helpers.py
+++ b/lib/ansible/utils/_build_helpers.py
@@ -1,0 +1,38 @@
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+"""
+This file contains common code for building ansible. If you want to use code from here at runtime,
+it needs to be moved out of this file and the implementation looked over to figure out whether API
+should be changed before being made public.
+"""
+
+import os.path
+
+
+def update_file_if_different(filename, b_data):
+    '''
+    Replace file content only if content is different.
+
+    This preserves timestamps in case the file content has not changed.  It performs multiple
+    operations on the file so it is not atomic and may be slower than simply writing to the file.
+
+    :arg filename: The filename to write to
+    :b_data: Byte string containing the data to write to the file
+    '''
+    try:
+        with open(filename, 'rb') as f:
+            b_data_old = f.read()
+    except IOError as e:
+        if e.errno != 2:
+            raise
+        # File did not exist, set b_data_old to a sentinel value so that
+        # b_data gets written to the filename
+        b_data_old = None
+
+    if b_data_old != b_data:
+        with open(filename, 'wb') as f:
+            f.write(b_data)

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -4,8 +4,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import os
-
 from collections import MutableMapping, MutableSet, MutableSequence
 
 from ansible.errors import AnsibleError, AnsibleAssertionError
@@ -106,19 +104,3 @@ def get_docstring(filename, fragment_loader, verbose=False, ignore_errors=False)
         add_fragments(data['doc'], filename, fragment_loader=fragment_loader)
 
     return data['doc'], data['plainexamples'], data['returndocs'], data['metadata']
-
-
-def update_file_if_different(filename, data):
-    '''
-    Replace file content only if content is different
-    '''
-
-    if os.path.exists(filename):
-        with open(filename, 'rb') as f:
-            data_old = f.read()
-        if data_old != data:
-            with open(filename, 'wb') as f:
-                f.write(data)
-    else:
-        with open(filename, 'wb') as f:
-            f.write(data)

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -1,24 +1,10 @@
-# (c) 2012, Jan-Piet Mens <jpmens () gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# Copyright: (c) 2012, Jan-Piet Mens <jpmens () gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
+
+import os
 
 from collections import MutableMapping, MutableSet, MutableSequence
 
@@ -120,3 +106,19 @@ def get_docstring(filename, fragment_loader, verbose=False, ignore_errors=False)
         add_fragments(data['doc'], filename, fragment_loader=fragment_loader)
 
     return data['doc'], data['plainexamples'], data['returndocs'], data['metadata']
+
+
+def update_file_if_different(filename, data):
+    '''
+    Replace file content only if content is different
+    '''
+
+    if os.path.exists(filename):
+        with open(filename, 'rb') as f:
+            data_old = f.read()
+        if data_old != data:
+            with open(filename, 'wb') as f:
+                f.write(data)
+    else:
+        with open(filename, 'wb') as f:
+            f.write(data)


### PR DESCRIPTION
##### SUMMARY
The purpose of this PR is to make rebuilding the docsite as fast as possible by ensuring that we only need to rebuild what has changed, rather than rebuild everything all the time.

This PR includes:
- Disable automatic cleanup of generated files (`make clean` becomes explicit)
  - Processed files go **from 2502 to 2092** *(rebuilding the user documentation)*
- Make `plugin_formatter` idempotent (rewrite file only if it has changed)
  - Processed files go **from 2092 to 12** *(rebuilding modules + plugins docs)*
- Make `generate_man.py` idempotent
  - Processed files go **from 12 to 3**
- Make `dump_keywords.py` idempotent
  - Processed files go **from 3 to 2**
- Make `dump_config.py` idempotent
  - Processed files go **from 2 to 1**
- Make `testing_formatter.sh` idempotent
  - Processed files go **from 1 to 0**

PS This means that for e.g. rebuilding the docs for the website, you probably want to run `make clean` explicitly first.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docsite

##### ANSIBLE VERSION
v2.8