### PR TITLE
Broken assume role for multiple regions

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -577,7 +577,7 @@ class Ec2Inventory(object):
             self.boto_fix_security_token_in_profile(connect_args)
 
         if self.iam_role:
-            sts_conn = sts.connect_to_region(region, **connect_args)
+            sts_conn = sts.connect_to_region(region)
             role = sts_conn.assume_role(self.iam_role, 'ansible_dynamic_inventory')
             connect_args['aws_access_key_id'] = role.credentials.access_key
             connect_args['aws_secret_access_key'] = role.credentials.secret_key


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Trying to assume role for multiple regions end up with permission denied -

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
Dynamic EC2 inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/centos/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
