### PR TITLE
[2.7] ACME: fixing typo in acme_certificate docs

### DIFF
--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -49,7 +49,7 @@ notes:
       did not change."
    - "If you want to use the C(tls-alpn-01) challenge, you can use the
       M(acme_challenge_cert_helper) module to prepare the challenge certificate."
-   - "You can use the M(certificate_complet_chain) module to find the root certificate
+   - "You can use the M(certificate_complete_chain) module to find the root certificate
       for the returned fullchain."
 extends_documentation_fragment:
   - acme


### PR DESCRIPTION
##### SUMMARY
Backport of #45082: fixes typo in module cross-reference name, i.e. fixes broken link.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
acme_certificate

##### ANSIBLE VERSION
```
2.7.0
```
