### PR TITLE
Implement allow_empty flag for vars_prompt

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -112,6 +112,7 @@ class PlaybookExecutor:
                             vname = var['name']
                             prompt = var.get("prompt", vname)
                             default = var.get("default", None)
+                            allow_empty = boolean(var.get("allow_empty", True))
                             private = boolean(var.get("private", True))
                             confirm = boolean(var.get("confirm", False))
                             encrypt = var.get("encrypt", None)
@@ -120,8 +121,10 @@ class PlaybookExecutor:
 
                             if vname not in self._variable_manager.extra_vars:
                                 if self._tqm:
-                                    self._tqm.send_callback('v2_playbook_on_vars_prompt', vname, private, prompt, encrypt, confirm, salt_size, salt, default)
-                                    play.vars[vname] = display.do_var_prompt(vname, private, prompt, encrypt, confirm, salt_size, salt, default)
+                                    self._tqm.send_callback('v2_playbook_on_vars_prompt', vname, private, prompt, encrypt, confirm,
+                                                            salt_size, salt, default, allow_empty)
+                                    play.vars[vname] = display.do_var_prompt(vname, private, prompt, encrypt, confirm,
+                                                                             salt_size, salt, default, allow_empty)
                                 else:  # we are either in --list-<option> or syntax check
                                     play.vars[vname] = default
 

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -296,7 +296,8 @@ class CallbackBase(AnsiblePlugin):
     def playbook_on_task_start(self, name, is_conditional):
         pass
 
-    def playbook_on_vars_prompt(self, varname, private=True, prompt=None, encrypt=None, confirm=False, salt_size=None, salt=None, default=None):
+    def playbook_on_vars_prompt(self, varname, private=True, prompt=None, encrypt=None, confirm=False,
+                                salt_size=None, salt=None, default=None, empty_not_allowed=None):
         pass
 
     def playbook_on_setup(self):
@@ -380,8 +381,9 @@ class CallbackBase(AnsiblePlugin):
     def v2_playbook_on_handler_task_start(self, task):
         pass  # no v1 correspondence
 
-    def v2_playbook_on_vars_prompt(self, varname, private=True, prompt=None, encrypt=None, confirm=False, salt_size=None, salt=None, default=None):
-        self.playbook_on_vars_prompt(varname, private, prompt, encrypt, confirm, salt_size, salt, default)
+    def v2_playbook_on_vars_prompt(self, varname, private=True, prompt=None, encrypt=None, confirm=False,
+                                   salt_size=None, salt=None, default=None, allow_empty=None):
+        self.playbook_on_vars_prompt(varname, private, prompt, encrypt, confirm, salt_size, salt, default, allow_empty)
 
     # FIXME: not called
     def v2_playbook_on_import_for_host(self, result, imported_file):

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -303,7 +303,8 @@ class Display:
         else:
             return input(prompt_string)
 
-    def do_var_prompt(self, varname, private=True, prompt=None, encrypt=None, confirm=False, salt_size=None, salt=None, default=None):
+    def do_var_prompt(self, varname, private=True, prompt=None, encrypt=None, confirm=False,
+                      salt_size=None, salt=None, default=None, allow_empty=None):
 
         result = None
         if sys.__stdin__.isatty():
@@ -321,11 +322,22 @@ class Display:
                 while True:
                     result = do_prompt(msg, private)
                     second = do_prompt("confirm " + msg, private)
-                    if result == second:
+
+                    if allow_empty and result == second:
                         break
-                    self.display("***** VALUES ENTERED DO NOT MATCH ****")
+                    elif not allow_empty and not all((result, second)):
+                        self.display("***** RESPONSES CANNOT BE EMPTY ****")
+                    elif result != second:
+                        self.display("***** VALUES ENTERED DO NOT MATCH ****")
+                    else:
+                        break
             else:
-                result = do_prompt(msg, private)
+                while True:
+                    result = do_prompt(msg, private)
+                    if allow_empty or not allow_empty and result != "":
+                        break
+                    else:
+                        self.display("***** RESPONSE CANNOT BE EMPTY ****")
         else:
             result = None
             self.warning("Not prompting as we are not in interactive mode")

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -323,9 +323,7 @@ class Display:
                     result = do_prompt(msg, private)
                     second = do_prompt("confirm " + msg, private)
 
-                    if allow_empty and result == second:
-                        break
-                    elif not allow_empty and not all((result, second)):
+                    if allow_empty and not all((result, second)):
                         self.display("***** RESPONSES CANNOT BE EMPTY ****")
                     elif result != second:
                         self.display("***** VALUES ENTERED DO NOT MATCH ****")

--- a/test/integration/targets/vars_prompt/test-vars_prompt.py
+++ b/test/integration/targets/vars_prompt/test-vars_prompt.py
@@ -109,6 +109,33 @@ tests = [
      'test_spec': [
          [('prompting for host:', 'testhost\r')],
          r'testhost.*ok=1']},
+
+    # Test empty_allowed, both empty and not empty
+    # https://github.com/ansible/ansible/issues/45085
+    {'playbook': 'vars_prompt-8.yml',
+     'test_spec': [
+         [('input:', 'empty allowed\r')],
+         '"input": "empty allowed"']},
+
+    {'playbook': 'vars_prompt-9.yml',
+     'test_spec': [
+         [('input:', '\r'),
+          (r'\*\*\*\*\* RESPONSE CANNOT BE EMPTY \*\*\*\*', ''),
+          ('input:', 'empty not allowed\r')],
+         '"input": "empty not allowed"']},
+
+    {'playbook': 'vars_prompt-10.yml',
+     'test_spec': [
+         [('input:', 'confirm me\r'),
+          ('confirm input:', 'incorrect\r'),
+          (r'\*\*\*\*\* VALUES ENTERED DO NOT MATCH \*\*\*\*', ''),
+          ('input:', '\r'),
+          ('confirm input:', 'confirm me\r'),
+          (r'\*\*\*\*\* RESPONSES CANNOT BE EMPTY \*\*\*\*', ''),
+          ('input:', 'confirm me\r'),
+          ('confirm input:', 'confirm me\r')],
+         '"input": "confirm me"']},
+
 ]
 
 for t in tests:

--- a/test/integration/targets/vars_prompt/vars_prompt-10.yml
+++ b/test/integration/targets/vars_prompt/vars_prompt-10.yml
@@ -1,0 +1,18 @@
+- name: Test vars_prompt confirm
+  hosts: testhost
+  become: no
+  gather_facts: no
+
+  vars_prompt:
+    - name: input
+      confirm: yes
+      allow_empty: no
+
+  tasks:
+    - name:
+      assert:
+        that:
+          - input == 'confirm me'
+
+    - debug:
+        var: input

--- a/test/integration/targets/vars_prompt/vars_prompt-8.yml
+++ b/test/integration/targets/vars_prompt/vars_prompt-8.yml
@@ -1,0 +1,17 @@
+- name: Test vars_prompt allows empty value
+  hosts: testhost
+  become: no
+  gather_facts: no
+
+  vars_prompt:
+    - name: input
+      allow_empty: yes
+
+  tasks:
+    - name:
+      assert:
+        that:
+          - input == 'empty allowed'
+
+    - debug:
+        var: input

--- a/test/integration/targets/vars_prompt/vars_prompt-9.yml
+++ b/test/integration/targets/vars_prompt/vars_prompt-9.yml
@@ -1,0 +1,17 @@
+- name: Test vars_prompt repeats asking given empty responsee
+  hosts: testhost
+  become: no
+  gather_facts: no
+
+  vars_prompt:
+    - name: input
+      allow_empty: no
+
+  tasks:
+    - name:
+      assert:
+        that:
+          - input == 'empty not allowed'
+
+    - debug:
+        var: input


### PR DESCRIPTION
##### SUMMARY
A new `vars_prompt` flag called `allow_empty` to require users to enter a non-empty value.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`vars_prompt`

##### ANSIBLE VERSION
2.5


##### ADDITIONAL INFORMATION
See #45085
