### PR TITLE
Docs: This fixes a weird indentation issue in the menu

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/static/css/theme.css
+++ b/docs/docsite/_themes/sphinx_rtd_theme/static/css/theme.css
@@ -1597,7 +1597,7 @@ code.code-large,.rst-content tt.code-large{font-size:90%}
 .wy-menu-vertical li.divide-top{border-top:solid 1px #404040}
 .wy-menu-vertical li.divide-bottom{border-bottom:solid 1px #404040}
 .wy-menu-vertical li.current{background:#e3e3e3}
-.wy-menu-vertical li.current a{color:gray;border-right:solid 1px #c9c9c9;padding:.4045em 2.427em}
+.wy-menu-vertical li.current a{color:gray;border-right:solid 1px #c9c9c9}
 .wy-menu-vertical li.current a:hover{background:#d6d6d6}
 .wy-menu-vertical li code,.wy-menu-vertical li .rst-content tt,.rst-content .wy-menu-vertical li tt{border:none;background:inherit;color:inherit;padding-left:0;padding-right:0}
 .wy-menu-vertical li span.toctree-expand{display:block;float:left;margin-left:-1.2em;font-size:.8em;line-height:1.6em;color:#4d4d4d}


### PR DESCRIPTION
##### SUMMARY
If you use the documentation menu (toctree), there's a weird padding error.
Because of this error it appears as if the selected item is a sub-item of the previous.

![screenshot from 2018-09-03 01-38-23](https://user-images.githubusercontent.com/388198/44961969-52534700-af1a-11e8-8c60-cac9bfd7c8db.png)

This fix restores the location so this does not happen.

![screenshot from 2018-09-03 01-37-50](https://user-images.githubusercontent.com/388198/44961970-5d0ddc00-af1a-11e8-8680-c54791e968bd.png)

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
docsite

##### ANSIBLE VERSION
v2.7 and earlier