### PR TITLE
Correct Jinja2 plugin math filter symmetric_difference() to operate on lists w/ > 1000 entries

### DIFF
--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -65,7 +65,8 @@ def symmetric_difference(a, b):
     if isinstance(a, collections.Hashable) and isinstance(b, collections.Hashable):
         c = set(a) ^ set(b)
     else:
-        c = unique([x for x in union(a, b) if x not in intersect(a, b)])
+        isect = intersect(a, b)
+        c = [x for x in union(a, b) if x not in isect]
     return c
 
 


### PR DESCRIPTION
##### SUMMARY
Correct Jinja2 plugin math filter symmetric_difference() to not repeatedly
build its intersection set and unnecessarily unique the final result.

The prior use of the intersect() function within the list comprehension
conditional leads to the function being called for every value in the input
list being processed, not efficient.  When the input lists a,b are large,
the Ansible run time and resource utilization wildly increases generally
never completing the operation.

Unique of the intersection result is unnecessary as the source list union()
is already unique.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Filter plugin set theory functions

##### ANSIBLE VERSION
```
Python 2.7
2.6.3
```


##### ADDITIONAL INFORMATION
In environments that work data involving 10s of thousands of entries, e.g. data recovered from JSON APIs, that require comparison of thousands of items, the symmetric_difference() filter will indefinitely hang Ansible.

Create a file with 1000 random 36 characters strings formatted as a JSON list.
```
---
- name: symmetric_difference sadness
  hosts: localhost
  tasks:
    - name: Make facts.
      set_fact:
        data1: "{{lookup('file', '/path/to/the/random_data.json')|from_json}}"
        data2: "{{lookup('file', '/path/to/the/random_data.json')|from_json}}"
    - name: Confirm data is as expected.
      debug:
        msg: "LENGTH: {{data1|length}}"
    - name: This takes a long while.
      when: data1|symmetric_difference(data2)
      debug:
        msg: "You were patient."
```