### PR TITLE
Convert Jinja2 plugin math filter set theory operations to always use native Python sets

### DIFF
--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -35,46 +35,23 @@ from ansible.module_utils._text import to_native
 
 
 def unique(a):
-    if isinstance(a, collections.Hashable):
-        c = set(a)
-    else:
-        c = []
-        for x in a:
-            if x not in c:
-                c.append(x)
-    return c
+    return list(set(a))
 
 
 def intersect(a, b):
-    if isinstance(a, collections.Hashable) and isinstance(b, collections.Hashable):
-        c = set(a) & set(b)
-    else:
-        c = unique([x for x in a if x in b])
-    return c
+    return list(set(a) & set(b))
 
 
 def difference(a, b):
-    if isinstance(a, collections.Hashable) and isinstance(b, collections.Hashable):
-        c = set(a) - set(b)
-    else:
-        c = unique([x for x in a if x not in b])
-    return c
+    return list(set(a) - set(b))
 
 
 def symmetric_difference(a, b):
-    if isinstance(a, collections.Hashable) and isinstance(b, collections.Hashable):
-        c = set(a) ^ set(b)
-    else:
-        c = unique([x for x in union(a, b) if x not in intersect(a, b)])
-    return c
+    return list(set(a) ^ set(b))
 
 
 def union(a, b):
-    if isinstance(a, collections.Hashable) and isinstance(b, collections.Hashable):
-        c = set(a) | set(b)
-    else:
-        c = unique(a + b)
-    return c
+    return list(set(a) | set(b))
 
 
 def min(a):


### PR DESCRIPTION
##### SUMMARY
Convert the Jinja2 plugin math filter set theory operations to always use native Python set operations.

I do not understand why the set theory functions have cases specifically for
hashable input lists that use the native Python set operations.  While the
default case uses a local implementation of the set operations.  Given that
set() takes an iterable argument and the local implementation is iterating on
the input lists, all cases should be able to be replaced with a single case
using the native set operations.

This would also solve the bug here:
https://github.com/ansible/ansible/pull/45093

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Filter plugin set theory functions

##### ANSIBLE VERSION
```
Python 2.7
2.6.3
```


##### ADDITIONAL INFORMATION