### PR TITLE
Support PostgreSQL restore modes

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
@@ -53,6 +53,14 @@ options:
     storage_mb:
         description:
             - The maximum storage allowed for a server.
+    backup_retention_days:
+        description:
+            - Backup retention days for the server.
+        type: int
+    geo_redundant_backup:
+        description:
+            - Enable Geo-redundant or not for server backup.
+        type: bool
     version:
         description:
             - Server version.
@@ -182,6 +190,15 @@ class AzureRMServers(AzureRMModuleBase):
             storage_mb=dict(
                 type='int'
             ),
+            geo_redundant_backup=dict(
+                type='bool'
+            ),
+            backup_retention_days=dict(
+                type='int'
+            ),
+            storage_mb=dict(
+                type='int'
+            ),
             version=dict(
                 type='str',
                 choices=['9.5', '9.6', '10']
@@ -247,6 +264,10 @@ class AzureRMServers(AzureRMModuleBase):
                     self.parameters["location"] = kwargs[key]
                 elif key == "storage_mb":
                     self.parameters.setdefault("properties", {}).setdefault("storage_profile", {})["storage_mb"] = kwargs[key]
+                elif key == "geo_redundant_backup":
+                    self.parameters["properties"]["geo_redundant_backup"] = 'Enabled' if kwargs[key] else 'Disabled'
+                elif key == "backup_retention_days":
+                    self.parameters["properties"]["backup_retention_days"] = kwargs[key]
                 elif key == "version":
                     self.parameters["properties"]["version"] = kwargs[key]
                 elif key == "enforce_ssl":

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
@@ -79,9 +79,11 @@ options:
     source_server_id:
         description:
             - Id if the source server if C(create_mode) is not default.
+        version_added: 2.8
     restore_point_in_time:
         description:
             - Restore point in time if C(create_mode) is not set to I(point_in_time_restore).
+        version_added: 2.8
     state:
         description:
             - Assert the state of the PostgreSQL server. Use C(present) to create or update a server and C(absent) to delete it.
@@ -215,7 +217,7 @@ class AzureRMServers(AzureRMModuleBase):
 
         self.resource_group = None
         self.name = None
-        self.parameters = dict()
+        self.parameters = {'properties': { 'create_mode': 'default' }}
         self.tags = None
 
         self.results = dict(changed=False)
@@ -246,21 +248,21 @@ class AzureRMServers(AzureRMModuleBase):
                 elif key == "storage_mb":
                     self.parameters.setdefault("properties", {}).setdefault("storage_profile", {})["storage_mb"] = kwargs[key]
                 elif key == "version":
-                    self.parameters.setdefault("properties", {})["version"] = kwargs[key]
+                    self.parameters["properties"]["version"] = kwargs[key]
                 elif key == "enforce_ssl":
-                    self.parameters.setdefault("properties", {})["ssl_enforcement"] = 'Enabled' if kwargs[key] else 'Disabled'
+                    self.parameters["properties"]["ssl_enforcement"] = 'Enabled' if kwargs[key] else 'Disabled'
                 elif key == "create_mode":
-                    self.parameters.setdefault("properties", {})["create_mode"] = kwargs[key]
+                    self.parameters["properties"]["create_mode"] = kwargs[key]
                 elif key == "admin_username":
-                    self.parameters.setdefault("properties", {})["administrator_login"] = kwargs[key]
+                    self.parameters["properties"]["administrator_login"] = kwargs[key]
                 elif key == "admin_password":
-                    self.parameters.setdefault("properties", {})["administrator_login_password"] = kwargs[key]
+                    self.parameters["properties"]["administrator_login_password"] = kwargs[key]
                 elif key == "source_server_id":
-                    self.parameters.setdefault("properties", {})["source_server_id"] = kwargs[key]
+                    self.parameters["properties"]["source_server_id"] = kwargs[key]
                 elif key == "restore_point_in_time":
-                    self.parameters.setdefault("properties", {})["restore_point_in_time"] = kwargs[key]
+                    self.parameters["properties"]["restore_point_in_time"] = kwargs[key]
                 elif key == "creation_mode":
-                    self.parameters.setdefault("properties", {})["creation_mode"] = kwargs[key]
+                    self.parameters["properties"]["creation_mode"] = kwargs[key]
 
         old_response = None
         response = None

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
@@ -196,9 +196,6 @@ class AzureRMServers(AzureRMModuleBase):
             backup_retention_days=dict(
                 type='int'
             ),
-            storage_mb=dict(
-                type='int'
-            ),
             version=dict(
                 type='str',
                 choices=['9.5', '9.6', '10']

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
@@ -53,14 +53,6 @@ options:
     storage_mb:
         description:
             - The maximum storage allowed for a server.
-    backup_retention_days:
-        description:
-            - Backup retention days for the server.
-        type: int
-    geo_redundant_backup:
-        description:
-            - Enable Geo-redundant or not for server backup.
-        type: bool
     version:
         description:
             - Server version.
@@ -86,11 +78,22 @@ options:
             - point_in_time_restore
     source_server_id:
         description:
-            - Id if the source server if C(create_mode) is not default.
+            - Id if the source server if C(create_mode) is not I(default).
         version_added: 2.8
     restore_point_in_time:
         description:
-            - Restore point in time if C(create_mode) is not set to I(point_in_time_restore).
+            - Restore point creation time (ISO8601 format), specifying the time to restore from.
+            - Required if C(create_mode) is set to I(point_in_time_restore).
+        version_added: 2.8
+    backup_retention_days:
+        description:
+            - Backup retention days for the server.
+        type: int
+        version_added: 2.8
+    geo_redundant_backup:
+        description:
+            - Enable Geo-redundant or not for server backup.
+        type: bool
         version_added: 2.8
     state:
         description:

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
@@ -252,7 +252,7 @@ class AzureRMServers(AzureRMModuleBase):
                 elif key == "enforce_ssl":
                     self.parameters["properties"]["ssl_enforcement"] = 'Enabled' if kwargs[key] else 'Disabled'
                 elif key == "create_mode":
-                    if (kwargs[key] == 'default'):    
+                    if (kwargs[key] == 'default'):
                         self.parameters["properties"]["create_mode"] = 'Default'
                     elif (kwargs[key] == 'point_in_time_restore'):
                         self.parameters["properties"]["create_mode"] = 'PointInTimeRestore'

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
@@ -71,7 +71,7 @@ options:
     create_mode:
         description:
             - Create mode of SQL Server
-        default: Default
+        default: default
         choices:
             - default
             - geo_restore
@@ -252,7 +252,12 @@ class AzureRMServers(AzureRMModuleBase):
                 elif key == "enforce_ssl":
                     self.parameters["properties"]["ssl_enforcement"] = 'Enabled' if kwargs[key] else 'Disabled'
                 elif key == "create_mode":
-                    self.parameters["properties"]["create_mode"] = kwargs[key]
+                    if (kwargs[key] == 'default'):    
+                        self.parameters["properties"]["create_mode"] = 'Default'
+                    elif (kwargs[key] == 'point_in_time_restore'):
+                        self.parameters["properties"]["create_mode"] = 'PointInTimeRestore'
+                    elif (kwargs[key] == 'geo_restore'):
+                        self.parameters["properties"]["create_mode"] = 'GeoRestore'
                 elif key == "admin_username":
                     self.parameters["properties"]["administrator_login"] = kwargs[key]
                 elif key == "admin_password":

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
@@ -72,6 +72,16 @@ options:
         description:
             - Create mode of SQL Server
         default: Default
+        choices:
+            - default
+            - geo_restore
+            - point_in_time_restore
+    source_server_id:
+        description:
+            - Id if the source server if C(create_mode) is not default.
+    restore_point_in_time:
+        description:
+            - Restore point in time if C(create_mode) is not set to I(point_in_time_restore).
     state:
         description:
             - Assert the state of the PostgreSQL server. Use C(present) to create or update a server and C(absent) to delete it.
@@ -180,7 +190,8 @@ class AzureRMServers(AzureRMModuleBase):
             ),
             create_mode=dict(
                 type='str',
-                default='Default'
+                default='default',
+                choices=['default', 'geo_restore', 'point_in_time_restore']
             ),
             admin_username=dict(
                 type='str'
@@ -188,6 +199,12 @@ class AzureRMServers(AzureRMModuleBase):
             admin_password=dict(
                 type='str',
                 no_log=True
+            ),
+            source_server_id=dict(
+                type='str'
+            ),
+            restore_point_in_time=dict(
+                type='str'
             ),
             state=dict(
                 type='str',
@@ -238,6 +255,12 @@ class AzureRMServers(AzureRMModuleBase):
                     self.parameters.setdefault("properties", {})["administrator_login"] = kwargs[key]
                 elif key == "admin_password":
                     self.parameters.setdefault("properties", {})["administrator_login_password"] = kwargs[key]
+                elif key == "source_server_id":
+                    self.parameters.setdefault("properties", {})["source_server_id"] = kwargs[key]
+                elif key == "restore_point_in_time":
+                    self.parameters.setdefault("properties", {})["restore_point_in_time"] = kwargs[key]
+                elif key == "creation_mode":
+                    self.parameters.setdefault("properties", {})["creation_mode"] = kwargs[key]
 
         old_response = None
         response = None

--- a/test/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
+++ b/test/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
@@ -103,8 +103,6 @@
     enforce_ssl: True
     admin_username: zimxyz
     admin_password: Testpasswordxyz12!
-<<<<<<< HEAD
-<<<<<<< HEAD
     tags:
       aaa: bbb
 

--- a/test/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
+++ b/test/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
@@ -103,6 +103,7 @@
     enforce_ssl: True
     admin_username: zimxyz
     admin_password: Testpasswordxyz12!
+<<<<<<< HEAD
     tags:
       aaa: bbb
 
@@ -120,6 +121,10 @@
     admin_password: Testpasswordxyz12!
     tags:
       ccc: ddd
+=======
+    creation_mode: geo_restore
+    source_server_id: whatshoulditbe
+>>>>>>> additional changes for restore
 
 - name: Gather facts PostgreSQL Server
   azure_rm_postgresqlserver_facts:

--- a/test/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
+++ b/test/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
@@ -104,6 +104,7 @@
     admin_username: zimxyz
     admin_password: Testpasswordxyz12!
 <<<<<<< HEAD
+<<<<<<< HEAD
     tags:
       aaa: bbb
 
@@ -121,10 +122,6 @@
     admin_password: Testpasswordxyz12!
     tags:
       ccc: ddd
-=======
-    creation_mode: geo_restore
-    source_server_id: whatshoulditbe
->>>>>>> additional changes for restore
 
 - name: Gather facts PostgreSQL Server
   azure_rm_postgresqlserver_facts:

--- a/test/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
+++ b/test/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
@@ -120,6 +120,8 @@
     admin_password: Testpasswordxyz12!
     tags:
       ccc: ddd
+    create_mode: geo_restore
+    source_server_id: "{{ output.id }}"
 
 - name: Gather facts PostgreSQL Server
   azure_rm_postgresqlserver_facts:


### PR DESCRIPTION
##### SUMMARY

This PR implements new options for PostgreSQL server as requested by users.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_postgresqlserver

##### ANSIBLE VERSION
2.7

##### ADDITIONAL INFORMATION
NOTE: It's not possible to write integration test, as the backup may be not available for several hours after instance is created, so this options can be only tested manually at the moment.