### PR TITLE
Handle !!binary data from YAML in JSON conversion

### DIFF
--- a/lib/ansible/parsing/ajson.py
+++ b/lib/ansible/parsing/ajson.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import base64
 import json
 
 from collections import Mapping
@@ -67,6 +68,8 @@ class AnsibleJSONEncoder(json.JSONEncoder):
         elif isinstance(o, (date, datetime)):
             # date object
             value = o.isoformat()
+        elif isinstance(o, bytes):
+            value = base64.b64encode(o).decode('ascii')
         else:
             # use default encoder
             value = super(AnsibleJSONEncoder, self).default(o)


### PR DESCRIPTION
!!binary data from YAML [1] should be converted back to
it's original base64 encoded form for output

[1] http://yaml.org/type/binary.html

Closes: #45098

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (ansible-json-bytes ee72b8ac8a) last updated 2018/09/03 16:03:17 (GMT +1100)
  config file = None
  configured module search path = ['/home/iwienand/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/iwienand/programs/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 3.6.6 (default, Jul 19 2018, 14:25:17) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]

```
