### PR TITLE
Add licence and boilerplate to Online module_utils

### DIFF
--- a/lib/ansible/module_utils/online.py
+++ b/lib/ansible/module_utils/online.py
@@ -1,3 +1,8 @@
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import json
 import sys
 


### PR DESCRIPTION
##### SUMMARY

Add licence and boilerplate to Online module_utils

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- lib/ansible/module_utils/online.py

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (licence_modules_utils_online 70dbf102fb) last updated 2018/09/03 11:21:44 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```