### PR TITLE
Adding documentaion example with multiple packages

### DIFF
--- a/lib/ansible/modules/packaging/os/package.py
+++ b/lib/ansible/modules/packaging/os/package.py
@@ -47,6 +47,14 @@ notes:
     - For Windows targets, use the M(win_package) module instead.
 '''
 EXAMPLES = '''
+- name: ensure a list of packages installed
+  package:
+    name: "{{ packages }}"
+  vars:
+    packages:
+    - httpd
+    - httpd-tools
+
 - name: install ntpdate
   package:
     name: ntpdate


### PR DESCRIPTION
Adding documentation example showing how to install multiple packages like it's here: https://docs.ansible.com/ansible/latest/modules/yum_module.html
The reason is to prevent of using loop in the future.

+label: docsite_pr

