### PR TITLE
fix archive module can not compress a single file in a tar file

### DIFF
--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -426,7 +426,10 @@ def main():
                         arcfile.write(path, path[len(arcroot):])
                         arcfile.close()
                         state = 'archive'  # because all zip files are archives
-
+                    elif format == 'tar':
+                        arcfile = tarfile.open(dest, 'w')
+                        arcfile.add(path)
+                        arcfile.close()
                     else:
                         f_in = open(path, 'rb')
 


### PR DESCRIPTION
##### SUMMARY
Before this commit the archive module source code doesn't contains the code to create a tar archive of a single file. Before this PR an OSError exception is [raised](https://github.com/ansible/ansible/blob/5c9241fa7c60f3aa731368971d4e0a481bbf63d6/lib/ansible/modules/files/archive.py#L440) because the code included between the lines 424 and 438 doesn't manage the case "format == 'tar'".

I have also verified that 'tar' is a valid value for the [format](https://github.com/ansible/ansible/blob/5c9241fa7c60f3aa731368971d4e0a481bbf63d6/lib/ansible/modules/files/archive.py#L34) parameter.

The code added to manage single file tar archives is similar to the same code present in the module used to manage multiple file tar archives starting from line [319](https://github.com/ansible/ansible/blob/5c9241fa7c60f3aa731368971d4e0a481bbf63d6/lib/ansible/modules/files/archive.py#L319).


Fixes #44968

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
archive

##### ANSIBLE VERSION
```
$ ./bin/ansible --version
ansible 2.8.0.dev0 (pull-issue-44968 a793a3d109) last updated 2018/09/03 15:58:34 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/gsciorti/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gsciorti/PycharmProjects/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**BEFORE THIS COMMIT**
```
$ ./bin/ansible localhost -m archive -a "path=/etc/hosts dest=/tmp/hosts.tar format=tar"
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: OSError: Invalid format
localhost | FAILED! => {
    "changed": false, 
    "dest": "/tmp/hosts.tar", 
    "gid": 0, 
    "group": "root", 
    "mode": "0644", 
    "msg": "Unable to write to compressed file: Invalid format", 
    "owner": "root", 
    "path": "/etc/hosts", 
    "secontext": "system_u:object_r:net_conf_t:s0", 
    "size": 4552, 
    "state": "file", 
    "uid": 0
}
```

**AFTER THIS COMMIT**
```
$ ./bin/ansible localhost -m archive -a "path=/etc/hosts dest=/tmp/hosts.tar format=tar"
localhost | CHANGED => {
    "archived": [
        "/etc/hosts"
    ], 
    "arcroot": "/etc/", 
    "changed": true, 
    "dest": "/tmp/hosts.tar", 
    "expanded_exclude_paths": [], 
    "expanded_paths": [
        "/etc/hosts"
    ], 
    "gid": 1000, 
    "group": "gsciorti", ```

    "missing": [], 
    "mode": "0664", 
    "owner": "gsciorti", 
    "secontext": "unconfined_u:object_r:user_tmp_t:s0", 
    "size": 10240, 
    "state": "file", 
    "uid": 1000
}
```