### PR TITLE
 fix: ensure than all item of a list of excluded files aren't checked 

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -271,7 +271,7 @@ class ZipArchive(object):
                                 exclude_flag = True
                                 break
                     if not exclude_flag:
-                        self._files_in_archive.append(to_native(member)) 
+                        self._files_in_archive.append(to_native(member))
             except:
                 archive.close()
                 raise UnarchiveError('Unable to list files in the archive')

--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -264,12 +264,14 @@ class ZipArchive(object):
         else:
             try:
                 for member in archive.namelist():
+                    exclude_flag = False
                     if self.excludes:
                         for exclude in self.excludes:
-                            if not fnmatch.fnmatch(member, exclude):
-                                self._files_in_archive.append(to_native(member))
-                    else:
-                        self._files_in_archive.append(to_native(member))
+                            if fnmatch.fnmatch(member, exclude):
+                                exclude_flag = True
+                                break
+                    if not exclude_flag:
+                        self._files_in_archive.append(to_native(member)) 
             except:
                 archive.close()
                 raise UnarchiveError('Unable to list files in the archive')
@@ -664,11 +666,14 @@ class TgzArchive(object):
             if filename.startswith('/'):
                 filename = filename[1:]
 
+            exclude_flag = False
             if self.excludes:
                 for exclude in self.excludes:
-                    if not fnmatch.fnmatch(filename, exclude):
-                        self._files_in_archive.append(to_native(filename))
-            else:
+                    if fnmatch.fnmatch(filename, exclude):
+                        exclude_flag = True
+                        break
+
+            if not exclude_flag:
                 self._files_in_archive.append(to_native(filename))
 
         return self._files_in_archive

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -225,11 +225,13 @@
     - zip
     - tar
 
-- name: Unpack archive file excluding glob files.
+- name: Unpack archive file excluding regular and glob files.
   unarchive:
     src: "{{ output_dir }}/unarchive-00.{{item}}"
     dest: "{{ output_dir }}/exclude-{{item}}"
-    exclude: "exclude/exclude-*.txt"
+    exclude: 
+      - "exclude/exclude-*.txt"
+      - "other/exclude-1.ext"
   with_items:
     - zip
     - tar
@@ -245,6 +247,7 @@
   assert:
     that:
       - "'exclude/exclude-1.txt' not in item.stdout"
+      - "'other/exclude-1.ext' not in item.stdout"
   with_items:
     - "{{ unarchive00.results }}"
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
This ensures than if we provide a list of excluded files for ```unarchive```, those files aren't checked. 

Fixes #45101

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
unarchive
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /home/lb/Ansible/unarchive/ansible.cfg
  configured module search path = [u'/home/lb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Using this playbook :
```yaml
---

- name: unarchive test
  hosts: localhost
  become: true

  tasks:
  - name: Creates test directory
    file: path=/tmp/demo_bug_unarchive state=directory

  - name: Unarchive a file from github
    unarchive:
      src: https://github.com/ansible/ansiconv/archive/master.zip
      dest: /tmp/demo_bug_unarchive
      exclude:
        - ansiconv-master/LICENSE
        - ansiconv-master/README.md
      owner: mail
      group: root
      remote_src: yes
```
Before change :
```
TASK [Unarchive a file from github] ***************************************************
task path: /home/lb/Ansible/unarchive/test_unarchive.yml:11
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: lb
<localhost> EXEC /bin/sh -c 'echo ~lb && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/lb/.ansible/tmp/ansible-tmp-1535963865.61-237231228210012 `" && echo ansible-tmp-1535963865.61-237231228210012="` echo /home/lb/.ansible/tmp/ansible-tmp-1535963865.61-237231228210012 `" ) && sleep 0'
Using module file /usr/lib/python2.7/site-packages/ansible/modules/files/stat.py
<localhost> EXEC /bin/sh -c 'sudo -H -S  -p "[sudo via ansible, key=wegrsatzchbcwmxeijjhvoqyvqefluub] password: " -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-wegrsatzchbcwmxeijjhvoqyvqefluub; /usr/bin/python'"'"' && sleep 0'
Using module file /usr/lib/python2.7/site-packages/ansible/modules/files/unarchive.py
<localhost> EXEC /bin/sh -c 'sudo -H -S  -p "[sudo via ansible, key=eaoosxzwolkheusfrifcqqpzscpxjcdd] password: " -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-eaoosxzwolkheusfrifcqqpzscpxjcdd; /usr/bin/python'"'"' && sleep 0'
<localhost> EXEC /bin/sh -c 'rm -f -r /home/lb/.ansible/tmp/ansible-tmp-1535963865.61-237231228210012/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
  File "/tmp/ansible_3I6k8h/ansible_modlib.zip/ansible/module_utils/basic.py", line 1076, in selinux_context
    ret = selinux.lgetfilecon_raw(to_native(path, errors='surrogate_or_strict'))

fatal: [localhost]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "attributes": null, 
            "backup": null, 
            "content": null, 
            "creates": null, 
            "delimiter": null, 
            "dest": "/tmp/demo_bug_unarchive", 
            "directory_mode": null, 
            "exclude": [
                "ansiconv-master/LICENSE", 
                "ansiconv-master/README.md"
            ], 
            "extra_opts": [], 
            "follow": false, 
            "force": null, 
            "group": "root", 
            "keep_newer": false, 
            "list_files": false, 
            "mode": null, 
            "owner": "mail", 
            "regexp": null, 
            "remote_src": true, 
            "selevel": null, 
            "serole": null, 
            "setype": null, 
            "seuser": null, 
            "src": "https://github.com/ansible/ansiconv/archive/master.zip", 
            "unsafe_writes": null, 
            "validate_certs": true
        }
    }, 
    "msg": "path /tmp/demo_bug_unarchive/ansiconv-master/LICENSE does not exist", 
    "path": "/tmp/demo_bug_unarchive/ansiconv-master/LICENSE", 
    "state": "absent"
}

PLAY RECAP ****************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=1   
```

After change : 
```
SUDO password:

PLAY [unarchive test] **********************************************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************
ok: [localhost]

TASK [Creates test directory] **************************************************************************************************************************************************
changed: [localhost]

TASK [Unarchive a file from github] ********************************************************************************************************************************************
changed: [localhost]

PLAY RECAP *********************************************************************************************************************************************************************
localhost                  : ok=3    changed=2    unreachable=0    failed=0 

```