### PR TITLE
WIP: Add support for assigning a volume to a compute instance

### DIFF
--- a/test/legacy/roles/scaleway_volume/tasks/main.yml
+++ b/test/legacy/roles/scaleway_volume/tasks/main.yml
@@ -29,6 +29,42 @@
       - server_creation_check_task is success
       - server_creation_check_task is changed
 
+- name: Assign the volume to a server
+  scaleway_volume:
+    name: ansible-test-volume
+    server: 42
+  register: volume_assignation_task
+
+- debug: var=volume_assignation_task
+
+- assert:
+    that:
+      - volume_assignation_task is success
+      - volume_assignation_task is changed
+
+- name: Unassign the volume to a server
+  scaleway_volume:
+    name: ansible-test-volume
+    server: 42
+  register: volume_unassignation_task
+
+- debug: var=volume_unassignation_task
+
+- assert:
+    that:
+      - volume_unassignation_task is success
+      - volume_unassignation_task is changed
+
+- name: Delete server
+  register: delete_server_task
+
+- debug: var=server_deletion_task
+
+- assert:
+    that:
+      - server_deletion_task is success
+      - server_deletion_task is changed
+
 - name: Make sure volume is deleted
   scaleway_volume:
     name: ansible-test-volume


### PR DESCRIPTION
##### SUMMARY

Add support for assigning a volume to a compute instance

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

- scaleway_volume

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (attach_volume_server 543fd0352a) last updated 2018/09/03 18:00:02 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```