### PR TITLE
docker_image: add network parameter

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -87,6 +87,11 @@ options:
     required: false
     version_added: "2.1"
     type: bool
+  network:
+    description:
+      - The network to use for RUN build instructions.
+    required: false
+    version_added: "2.8"
   nocache:
     description:
       - Do not use cache when building an image.
@@ -280,6 +285,7 @@ class ImageManager(DockerBaseClass):
         self.force = parameters.get('force')
         self.load_path = parameters.get('load_path')
         self.name = parameters.get('name')
+        self.network = parameters.get('network')
         self.nocache = parameters.get('nocache')
         self.path = parameters.get('path')
         self.pull = parameters.get('pull')
@@ -510,6 +516,7 @@ class ImageManager(DockerBaseClass):
             tag=self.name,
             rm=self.rm,
             nocache=self.nocache,
+            network_mode=self.network,
             timeout=self.http_timeout,
             pull=self.pull,
             forcerm=self.rm,
@@ -582,6 +589,7 @@ def main():
         http_timeout=dict(type='int'),
         load_path=dict(type='path'),
         name=dict(type='str', required=True),
+        network=dict(type='str'),
         nocache=dict(type='bool', default=False),
         path=dict(type='path', aliases=['build_path']),
         pull=dict(type='bool', default=True),


### PR DESCRIPTION
##### SUMMARY
Add a network parameter to the docker_image module to specify the network to use for RUN commands.

Fixes #21433

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
docker_image

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.8.0.dev0 (devel d7b27e0a68) last updated 2018/09/03 16:07:17 (GMT -400)
  config file = /Users/filippo/src/filippo.io/misc/fleet/ansible.cfg
  configured module search path = [u'/Users/filippo/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/filippo/src/github.com/ansible/ansible/lib/ansible
  executable location = /Users/filippo/src/github.com/ansible/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```


##### ADDITIONAL INFORMATION
Called it network instead of network_mode as the latter seems like a
legacy of when there were just a few default options to choose from,
while now the name of an arbitrary network can be specified.