### PR TITLE
Add more informative error message to setup.py install symlink error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ def _maintain_symlinks(symlink_type, base_path):
             # cache now.  Will work if we're running directly from a git
             # checkout or from an sdist created earlier.
             symlink_data = {'script': _find_symlinks('bin'),
-                            'library': _find_symlinks('lib', '.py')
+                            'library': _find_symlinks('lib', '.py'),
                             }
 
             # Sanity check that something we know should be a symlink was

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ def _maintain_symlinks(symlink_type, base_path):
         # checkout or from an sdist created earlier.
         symlink_data = {'script': _find_symlinks('bin'),
                         'library': _find_symlinks('lib', '.py')}
-    
+
         # Sanity check that something we know should be a symlink was
         # found.  We'll take that to mean that the current directory
         # structure properly reflects symlinks in the git repo
@@ -86,7 +86,7 @@ def _maintain_symlinks(symlink_type, base_path):
         else:
             raise RuntimeError("Symlinks in ./bin appear "
                                "to be missing or broken")
-    
+
     symlinks = symlink_data[symlink_type]
 
     for source in symlinks:

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,8 @@ def _maintain_symlinks(symlink_type, base_path):
             # cache now.  Will work if we're running directly from a git
             # checkout or from an sdist created earlier.
             symlink_data = {'script': _find_symlinks('bin'),
-                            'library': _find_symlinks('lib', '.py')}
+                            'library': _find_symlinks('lib', '.py')
+                            }
 
             # Sanity check that something we know should be a symlink was
             # found.  We'll take that to mean that the current directory
@@ -82,7 +83,6 @@ def _maintain_symlinks(symlink_type, base_path):
                                    "to be missing or broken")
         else:
             raise
-
     symlinks = symlink_data[symlink_type]
 
     for source in symlinks:

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ def _cache_symlinks(symlink_data):
 
 def _maintain_symlinks(symlink_type, base_path):
     """Switch a real file into a symlink"""
-    missing_symlink_cache = False
     try:
         # Try the cache first because going from git checkout to sdist is the
         # only time we know that we're going to cache correctly
@@ -67,25 +66,22 @@ def _maintain_symlinks(symlink_type, base_path):
     except (IOError, OSError) as e:
         # IOError on py2, OSError on py3.  Both have errno
         if e.errno == 2:
-            missing_symlink_cache = True
+            # SYMLINKS_CACHE doesn't exist.  Fallback to trying to create the
+            # cache now.  Will work if we're running directly from a git
+            # checkout or from an sdist created earlier.
+            symlink_data = {'script': _find_symlinks('bin'),
+                            'library': _find_symlinks('lib', '.py')}
+
+            # Sanity check that something we know should be a symlink was
+            # found.  We'll take that to mean that the current directory
+            # structure properly reflects symlinks in the git repo
+            if 'ansible-playbook' in symlink_data['script']['ansible']:
+                _cache_symlinks(symlink_data)
+            else:
+                raise RuntimeError("Symlinks in ./bin appear "
+                                   "to be missing or broken")
         else:
             raise
-
-    if missing_symlink_cache:
-        # SYMLINKS_CACHE doesn't exist.  Fallback to trying to create the
-        # cache now.  Will work if we're running directly from a git
-        # checkout or from an sdist created earlier.
-        symlink_data = {'script': _find_symlinks('bin'),
-                        'library': _find_symlinks('lib', '.py')}
-
-        # Sanity check that something we know should be a symlink was
-        # found.  We'll take that to mean that the current directory
-        # structure properly reflects symlinks in the git repo
-        if 'ansible-playbook' in symlink_data['script']['ansible']:
-            _cache_symlinks(symlink_data)
-        else:
-            raise RuntimeError("Symlinks in ./bin appear "
-                               "to be missing or broken")
 
     symlinks = symlink_data[symlink_type]
 

--- a/setup.py
+++ b/setup.py
@@ -306,7 +306,13 @@ def main():
         category=UserWarning,
         module='distutils.dist',
     )
-    setup(**setup_params)
+    try:
+        setup(**setup_params)
+    except RuntimeError as err:
+        if os.getenv('ANSIBLE_DEBUG'):
+            raise
+        print('A fatal runtime error happened: %s' % str(err), file=sys.stderr)
+        sys.exit(1)
     warnings.resetwarnings()
 
 

--- a/setup.py
+++ b/setup.py
@@ -79,8 +79,11 @@ def _maintain_symlinks(symlink_type, base_path):
             if 'ansible-playbook' in symlink_data['script']['ansible']:
                 _cache_symlinks(symlink_data)
             else:
-                raise RuntimeError("Symlinks in ./bin appear "
-                                   "to be missing or broken")
+                raise RuntimeError(
+                    "Pregenerated symlink list was not present and expected "
+                    "symlinks in ./bin were missing or broken. "
+                    "Perhaps this isn't a git checkout?"
+                )
         else:
             raise
     symlinks = symlink_data[symlink_type]

--- a/setup.py
+++ b/setup.py
@@ -306,13 +306,7 @@ def main():
         category=UserWarning,
         module='distutils.dist',
     )
-    try:
-        setup(**setup_params)
-    except RuntimeError as err:
-        if os.getenv('ANSIBLE_DEBUG'):
-            raise
-        print('A fatal runtime error happened: %s' % str(err), file=sys.stderr)
-        sys.exit(1)
+    setup(**setup_params)
     warnings.resetwarnings()
 
 


### PR DESCRIPTION
##### SUMMARY
Currently when symlinks are missing from the cloned repository, the `setup.py install` process raises:

    [Errno 2] No such file or directory: 'SYMLINK_CACHE.json'

Which is not really indicative of the underlying problem of missing symlinks.

This PR adds a more descriptive Exception to be raised.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.8.0.dev0
  config file = None
  configured module search path = ['/Users/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /private/tmp/venv/test/lib/python3.7/site-packages/ansible-2.8.0.dev0-py3.7.egg/ansible
  executable location = /private/tmp/venv/test/bin/ansible
  python version = 3.7.0 (default, Sep  4 2018, 12:11:50) [Clang 9.1.0 (clang-902.0.39.2)]

```


##### ADDITIONAL INFORMATION

Problem arose when cloning on a Windows machine, which silently clobbered all the symlinks, and then moving to a *nix machine and installing into a fresh virtualenv.

With a broken `ansible-playbook`, without PR change:

```
$ python setup.py install
running install
running bdist_egg
...
running install_lib
running build_py
error: [Errno 2] No such file or directory: 'SYMLINK_CACHE.json'
```

After change:

```
$ python setup.py install
running install
running bdist_egg
...
RuntimeError: Symlinks in ./bin appear to be missing or broken
```

