### PR TITLE
Fix sshkeyfilename is None not str (#44893)

### DIFF
--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -256,7 +256,7 @@ class Connection(NetworkConnectionBase):
 
         self.key_filename = self._play_context.private_key_file or self.get_option('private_key_file')
         if self.key_filename:
-            self.key_filename = os.path.expanduser(self.key_filename)
+            self.key_filename = str(os.path.expanduser(self.key_filename))
 
         if self._network_os == 'default':
             for cls in netconf_loader.all(class_only=True):
@@ -279,7 +279,7 @@ class Connection(NetworkConnectionBase):
                 port=self._play_context.port or 830,
                 username=self._play_context.remote_user,
                 password=self._play_context.password,
-                key_filename=str(self.key_filename),
+                key_filename=self.key_filename,
                 hostkey_verify=self.get_option('host_key_checking'),
                 look_for_keys=self.get_option('look_for_keys'),
                 device_params=device_params,


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix bug of NETCONF cannot read ssh_key in ssh_config file.
Merged to devel https://github.com/ansible/ansible/pull/44893
(cherry picked from commit 177fbea35167eb4914c89ae77f0ead568823ac09)

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### BUG DESCRIPTION

`ansible.cfg`
```
NETCONF_SSH_CONFIG(/project/ansible.cfg) = 1
```

`hosts.yml`
```
switch:
    hosts:
        switch1:
            ansible_host: switch1
            ansible_network_os: junos
            ansible_connection: netconf
            ansible_port: 22
```

`~/.ssh/config`
```
Host switch1
    HostName 192.168.200.1
    IdentityFile ~/.ssh/privkey
    User linnil1
```

And run with `ansible -vvv switch1 -a ping`
It give out error:
```
  File "/usr/local/lib/python2.7/site-packages/ncclient/transport/ssh.py", line 497, in _auth
    raise AuthenticationError(repr(saved_exception))
AuthenticationError: AuthenticationException('Authentication failed.',)

switch1 | FAILED | rc=-1 >>
AuthenticationException('Authentication failed.',)
```

After looking up document,
https://ncclient.readthedocs.io/en/latest/transport.html#ncclient.transport.SSHSession.connect

`key_filename` should be `None` not `str(None)`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
plugins/connection/netconf.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.dev0 (detached HEAD fadf8a2d09)
  config file = /project/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /ansible/lib/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jul 31 2018, 23:03:52) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
