### PR TITLE
Update postgresql_user.py

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -48,7 +48,7 @@ options:
       - When passing a hashed password it must be generated with the format
         C('str["md5"] + md5[ password + username ]'), resulting in a total of
         35 characters. An easy way to do this is C(echo "md5$(echo -n
-        'verysecretpasswordJOE' | md5sum | awk 'print $1')").
+        'verysecretpasswordJOE' | md5sum | awk '{print $1}')").
       - Note that if the provided password string is already in MD5-hashed
         format, then it is used as-is, regardless of C(encrypted) parameter.
   db:

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -48,7 +48,7 @@ options:
       - When passing a hashed password it must be generated with the format
         C('str["md5"] + md5[ password + username ]'), resulting in a total of
         35 characters. An easy way to do this is C(echo "md5$(echo -n
-        'verysecretpasswordJOE' | md5sum)").
+        'verysecretpasswordJOE' | md5sum | awk 'print $1')").
       - Note that if the provided password string is already in MD5-hashed
         format, then it is used as-is, regardless of C(encrypted) parameter.
   db:


### PR DESCRIPTION
md5sum generates output with hypen. Something like the following
```
$ echo "md5$(echo -n 'verysecretpasswordJOE' | md5sum)"
md5d011966da94d776cf59bf6dbde240e5d  -
```

We need to remove hyphen from the output. Also the command by itself is incorrect

```
echo "md5$(echo -n 'verysecretpasswordJOE' | md5sum")
```

double quotes must be after right parenthesis

```
echo "md5$(echo -n 'verysecretpasswordJOE' | md5sum)"
```

+label: docsite_pr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
