### PR TITLE
asa_config/ios_config: diff strict does not work with multiple parents

### DIFF
--- a/lib/ansible/module_utils/network/common/config.py
+++ b/lib/ansible/module_utils/network/common/config.py
@@ -296,6 +296,13 @@ class NetworkConfig(object):
 
     def _diff_strict(self, other):
         updates = list()
+        # block extracted from other does not have all parents
+        # but the last one. In case of multiple parents we need
+        # to add additional parents.
+        start_other = other[0]
+        if start_other.parents:
+            for parent in start_other.parents:
+                other.insert(0, ConfigLine(parent))
         for index, line in enumerate(self.items):
             try:
                 if str(line).strip() != str(other[index]).strip():

--- a/lib/ansible/module_utils/network/common/config.py
+++ b/lib/ansible/module_utils/network/common/config.py
@@ -299,10 +299,11 @@ class NetworkConfig(object):
         # block extracted from other does not have all parents
         # but the last one. In case of multiple parents we need
         # to add additional parents.
-        start_other = other[0]
-        if start_other.parents:
-            for parent in start_other.parents:
-                other.insert(0, ConfigLine(parent))
+        if other and isinstance(other, list) and len(other) > 0:
+            start_other = other[0]
+            if start_other.parents:
+                for parent in start_other.parents:
+                    other.insert(0, ConfigLine(parent))
         for index, line in enumerate(self.items):
             try:
                 if str(line).strip() != str(other[index]).strip():

--- a/test/integration/targets/asa_config/tests/cli/sublevel_strict_mul_parents.yaml
+++ b/test/integration/targets/asa_config/tests/cli/sublevel_strict_mul_parents.yaml
@@ -1,0 +1,66 @@
+---
+- debug: msg="START cli/sublevel_strict_mul_parents.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  asa_config:
+    lines:
+      - class-map c1
+      - match default-inspection-traffic
+      - policy-map p1
+      - class c1
+    before: ['no policy-map p1', 'no class-map c1']
+    match: none
+
+- name: configure sub level command using strict match
+  asa_config:
+    lines:
+      - inspect ftp
+      - inspect tftp
+    parents: ['policy-map p1', 'class c1']
+    match: strict
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "'inspect ftp' in result.updates"
+      - "'inspect tftp' in result.updates"
+
+- name: change sub level command order and config with strict match
+  asa_config:
+    lines:
+      - inspect tftp
+      - inspect ftp
+    parents: ['policy-map p1', 'class c1']
+    match: strict
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "'inspect ftp' in result.updates"
+      - "'inspect tftp' in result.updates"
+
+- name: Config sub level command with strict match (Idempotency)
+  asa_config:
+    lines:
+#ASA does not change order of class action if reconfigured
+#so we have to use old order for Idempotency
+      - inspect ftp
+      - inspect tftp
+    parents: ['policy-map p1', 'class c1']
+    match: strict
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: teardown
+  asa_config:
+    lines:
+      - no policy-map p1
+      - no class-map c1
+    match: strict
+
+- debug: msg="END cli/sublevel_strict_mul_parents.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_config/tests/cli/sublevel_strict_mul_parents.yaml
+++ b/test/integration/targets/eos_config/tests/cli/sublevel_strict_mul_parents.yaml
@@ -1,0 +1,66 @@
+---
+- debug: msg="START cli/sublevel_strict_mul_parents.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  eos_config:
+    lines:
+      - class-map type qos match-any c1
+      - match ip access-group 10
+      - policy-map type qos p1
+      - class c1
+    before: ['no policy-map type qos p1', 'no class-map type qos match-any c1']
+    match: none
+
+- name: configure sub level command using strict match
+  eos_config:
+    lines:
+      - set cos 1
+      - set dscp 62
+    parents: ['policy-map type qos p1', 'class c1']
+    match: strict
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "'set cos 1' in result.updates"
+      - "'set dscp 62' in result.updates"
+
+- name: change sub level command order and config with strict match
+  eos_config:
+    lines:
+      - set dscp 62
+      - set cos 1
+    parents: ['policy-map type qos p1', 'class c1']
+    match: strict
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "'set cos 1' in result.updates"
+      - "'set dscp 62' in result.updates"
+
+- name: Config sub level command with strict match (Idempotency)
+  eos_config:
+    lines:
+#EOS does not change order of class action if reconfigured
+#so we have to use old order for Idempotency
+      - set cos 1
+      - set dscp 62
+    parents: ['policy-map type qos p1', 'class c1']
+    match: strict
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: teardown
+  eos_config:
+    lines:
+      - no policy-map type qos p1
+      - no class-map type qos match-any c1
+    match: none
+
+- debug: msg="END cli/sublevel_strict_mul_parents.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_config/tests/cli/sublevel_strict_mul_parents.yaml
+++ b/test/integration/targets/eos_config/tests/cli/sublevel_strict_mul_parents.yaml
@@ -10,6 +10,7 @@
       - class c1
     before: ['no policy-map type qos p1', 'no class-map type qos match-any c1']
     match: none
+  become: yes
 
 - name: configure sub level command using strict match
   eos_config:
@@ -19,6 +20,7 @@
     parents: ['policy-map type qos p1', 'class c1']
     match: strict
   register: result
+  become: yes
 
 - assert:
     that:
@@ -34,6 +36,7 @@
     parents: ['policy-map type qos p1', 'class c1']
     match: strict
   register: result
+  become: yes
 
 - assert:
     that:
@@ -51,6 +54,7 @@
     parents: ['policy-map type qos p1', 'class c1']
     match: strict
   register: result
+  become: yes
 
 - assert:
     that:
@@ -62,5 +66,6 @@
       - no policy-map type qos p1
       - no class-map type qos match-any c1
     match: none
+  become: yes
 
 - debug: msg="END cli/sublevel_strict_mul_parents.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/ios_config/tests/cli/sublevel_strict_mul_parents.yaml
+++ b/test/integration/targets/ios_config/tests/cli/sublevel_strict_mul_parents.yaml
@@ -1,0 +1,66 @@
+---
+- debug: msg="START cli/sublevel_strict_mul_parents.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  ios_config:
+    lines:
+      - class-map c1
+      - match precedence 7
+      - policy-map p1
+      - class c1
+    before: ['no policy-map p1', 'no class-map c1']
+    match: none
+
+- name: configure sub level command using strict match
+  ios_config:
+    lines:
+      - set ip precedence 5
+      - police cir percent 10
+    parents: ['policy-map p1', 'class c1']
+    match: strict
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "'set ip precedence 5' in result.updates"
+      - "'police cir percent 10' in result.updates"
+
+- name: change sub level command order and config with strict match
+  ios_config:
+    lines:
+      - police cir percent 10
+      - set ip precedence 5
+    parents: ['policy-map p1', 'class c1']
+    match: strict
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "'set ip precedence 5' in result.updates"
+      - "'police cir percent 10' in result.updates"
+
+- name: Config sub level command with strict match (Idempotency)
+  ios_config:
+    lines:
+#IOS does not change orded of class action if reconfigured
+#so we have to use old order for Idempoteny
+      - set ip precedence 5
+      - police cir percent 10
+    parents: ['policy-map p1', 'class c1']
+    match: strict
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: teardown
+  ios_config:
+    lines:
+      - no policy-map p1
+      - no class-map c1
+    match: none
+
+- debug: msg="END cli/sublevel_strict_mul_parents.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/iosxr_config/tests/cli/sublevel_strict_mul_parents.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/sublevel_strict_mul_parents.yaml
@@ -1,0 +1,67 @@
+---
+- debug: msg="START cli/sublevel_strict_mul_parents.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  iosxr_config:
+    lines:
+      - class-map match-any c1
+      - match precedence 7
+      - policy-map p1
+      - class c1
+      - set precedence 2
+    before: ['no policy-map p1', 'no class-map match-any c1']
+    match: none
+
+- name: configure sub level command using strict match
+  iosxr_config:
+    lines:
+      - set precedence 5
+      - police rate percent 10
+    parents: ['policy-map p1', 'class c1']
+    match: strict
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "'set precedence 5' in result.commands"
+      - "'police rate percent 10' in result.commands"
+
+- name: change sub level command order and config with strict match
+  iosxr_config:
+    lines:
+      - police rate percent 10
+      - set precedence 5
+    parents: ['policy-map p1', 'class c1']
+    match: strict
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "'set precedence 5' in result.commands"
+      - "'police rate percent 10' in result.commands"
+
+- name: Config sub level command with strict match (Idempotency)
+  iosxr_config:
+    lines:
+#IOSxr does not change order of class action if reconfigured
+#so we have to use old order for Idempotency
+      - set precedence 5
+      - police rate percent 10
+    parents: ['policy-map p1', 'class c1']
+    match: strict
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: teardown
+  iosxr_config:
+    lines:
+      - no policy-map p1
+      - no class-map match-any c1
+    match: none
+
+- debug: msg="END cli/sublevel_strict_mul_parents.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
Fixes #39290

This issue is reproducible on asa_config/ios_config module when used following arguments . It should be reproducible on any other OS (verified on ios_config at least)
```
1) > 1 parents in 'parents' arg
2) 'diff' is 'strict'
```
Issue is block used from running-config to diff against did not include all parents. Fix is to use everything in parents hierarchy also to diff against.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
lib/ansible/module_utils/network/common/config.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.8
```


##### ADDITIONAL INFORMATION
Tested fix works on asa_config and ios_config