### PR TITLE
Add single quotes around package name

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_azure.rst
+++ b/docs/docsite/rst/scenario_guides/guide_azure.rst
@@ -12,7 +12,7 @@ installed on the host running Ansible.
 
 .. code-block:: bash
 
-    $ pip install ansible[azure]
+    $ pip install 'ansible[azure]'
 
 If you are running Ansible from source, you can install the dependencies from the
 root directory of the Ansible repo.


### PR DESCRIPTION
<!--- Your description here -->
`pip install ansible[azure]` results in `zsh: no matches found: ansible[azure]` at least in my computer (zsh on Ubuntu). I don't know if it is the case with all shells, but at least for me it is. Since square brackets `[]` are special characters in bash, I propose adding single quotes to make sure that package name is always interpreted as literal. The same error is also resolvable by setting noglob.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6.3
```


