### PR TITLE
Handle special service where package is not available

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_service_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_service_facts.py
@@ -83,16 +83,18 @@ class VmwareServiceManager(PyVmomi):
             if host_service_system:
                 services = host_service_system.serviceInfo.service
                 for service in services:
-                    host_service_facts.append(dict(key=service.key,
-                                                   label=service.label,
-                                                   required=service.required,
-                                                   uninstallable=service.uninstallable,
-                                                   running=service.running,
-                                                   policy=service.policy,
-                                                   source_package_name=service.sourcePackage.sourcePackageName,
-                                                   source_package_desc=service.sourcePackage.description,
-                                                   )
-                                              )
+                    host_service_facts.append(
+                        dict(
+                            key=service.key,
+                            label=service.label,
+                            required=service.required,
+                            uninstallable=service.uninstallable,
+                            running=service.running,
+                            policy=service.policy,
+                            source_package_name=service.sourcePackage.sourcePackageName if service.sourcePackage else 'NA',
+                            source_package_desc=service.sourcePackage.description if service.sourcePackage else 'NA',
+                        )
+                    )
             hosts_facts[host.name] = host_service_facts
         return hosts_facts
 
@@ -108,7 +110,8 @@ def main():
         argument_spec=argument_spec,
         required_one_of=[
             ['cluster_name', 'esxi_hostname'],
-        ]
+        ],
+        supports_check_mode=True,
     )
 
     vmware_host_service_config = VmwareServiceManager(module)


### PR DESCRIPTION
##### SUMMARY
There are several services e.g. vmware-fdm, which does not have package name and
package description which will raise a error if queried for.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_host_service_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.8-devel
```