### PR TITLE
VMware: Return Disk UUID information

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
@@ -25,7 +25,8 @@ version_added: 2.6
 author:
     - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
 notes:
-    - Tested on vSphere 6.0 and 6.5
+    - Tested on vSphere 6.0 and 6.5.
+    - Disk UUID information is added in version 2.8.
 requirements:
     - "python >= 2.6"
     - PyVmomi
@@ -149,6 +150,7 @@ class PyVmomiHelper(PyVmomi):
                     backing_disk_mode=disk.backing.diskMode,
                     backing_writethrough=disk.backing.writeThrough,
                     backing_thinprovisioned=disk.backing.thinProvisioned,
+                    backing_uuid=disk.backing.uuid,
                     backing_eagerlyscrub=bool(disk.backing.eagerlyScrub),
                     controller_key=disk.controllerKey,
                     unit_number=disk.unitNumber,
@@ -167,8 +169,11 @@ def main():
         folder=dict(type='str'),
         datacenter=dict(type='str', required=True),
     )
-    module = AnsibleModule(argument_spec=argument_spec,
-                           required_one_of=[['name', 'uuid']])
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_one_of=[['name', 'uuid']],
+        supports_check_mode=True,
+    )
 
     if module.params['folder']:
         # FindByInventoryPath() does not require an absolute path

--- a/test/integration/targets/vmware_guest_disk_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_disk_facts/tasks/main.yml
@@ -37,16 +37,37 @@
 
 - debug: var=vm1
 
-- name: create new VMs with non-existent network
+- name: Gather facts about virtual machine disks
   vmware_guest_disk_facts:
-    validate_certs: False
+    validate_certs: no
     hostname: "{{ vcsim }}"
     username: "{{ vcsim_instance['json']['username'] }}"
     password: "{{ vcsim_instance['json']['password'] }}"
     name: "{{ vm1 }}"
     datacenter: "{{ (vm1 | basename).split('_')[0] }}"
   register: disk_facts
-- debug: var=disk_facts
+
+- debug:
+    msg: '{{ disk_facts }}'
+
+- name: assert that no changes were made
+  assert:
+    that:
+        - "not disk_facts.changed"
+
+- name: Gather facts about virtual machine disks in check mode
+  vmware_guest_disk_facts:
+    validate_certs: no
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ vm1 }}"
+    datacenter: "{{ (vm1 | basename).split('_')[0] }}"
+  register: disk_facts
+  check_mode: yes
+
+- debug:
+    msg: '{{ disk_facts }}'
 
 - name: assert that no changes were made
   assert:


### PR DESCRIPTION
##### SUMMARY
This fix adds feature of disk uuid for given virtual machine disk.

Fixes: #45149

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
test/integration/targets/vmware_guest_disk_facts/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.8-devel
```