### PR TITLE
Fix timeout detection in vmware_deploy_ovf module

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -67,8 +67,9 @@ def wait_for_vm_ip(content, vm, timeout=300):
     facts = dict()
     interval = 15
     while timeout > 0:
-        facts = gather_vm_facts(content, vm)
-        if facts['ipv4'] or facts['ipv6']:
+        _facts = gather_vm_facts(content, vm)
+        if _facts['ipv4'] or _facts['ipv6']:
+            facts = _facts
             break
         time.sleep(interval)
         timeout -= interval


### PR DESCRIPTION
##### SUMMARY
Timeout detection in [`wait_for_vm_ip`](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/vmware.py#L66) is broken. A timeout should be communicated to its caller by returning an empty `dict` (see [vmware_deploy_ovf](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py#L504-L506)). But the function always returns the fully populated facts, regardless of the timeout condition.

With this PR, the facts are only returned if no timeout occurred.

Notes: 
- The `wait_for_vm_ip` function was added in #30309 with the introduction of `vmware_deploy_ovf`, which seems to be the only caller so far.
- I never actually ran into this error condition using the `vmware_deploy_ovf` module, probably because the preceding call to [`wait_for_task`](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py#L502) returns late enough so that the ip address is available anyway.
But the bug might hit other callers, so it should be fixed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
module_utils.vmware

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/eclipse/workspaces/liclipse/ansible/lib/ansible
  executable location = /home/user/eclipse/workspaces/liclipse/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->
To force the bug, uncomment [`wait_for_task`](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py#L502), use a short timeout in [wait_for_vm_ip](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py#L504) and import a template with the `wait_for_ip_address=true` option. This will trigger the timeout condition. The module should fail.
Instead the module returns with `"ipv4": null` but does not fail.