### PR TITLE
Include rds_instance in AWS module-default group

### DIFF
--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -300,6 +300,8 @@ groupings:
   - aws
   rds:
   - aws
+  rds_instance:
+  - aws
   rds_instance_facts:
   - aws
   rds_param_group:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

When adding `rds_instance` we overlooked adding it to the new `module_defaults` group for AWS modules. It accepts all the same group of arguments (region, aws_secret_key, etc) and should be in the group with the rest of the modules. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
amazon module_utils

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
