### PR TITLE
elb_target_group - prevent a KeyError exception

### DIFF
--- a/changelogs/fragments/elb_target_group_fix_KeyError.yaml
+++ b/changelogs/fragments/elb_target_group_fix_KeyError.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-- elb_target_group - Use .get instead as the key Targets may not exist.
+- elb_target_group - cast target ports to integers before making API calls after the key 'Targets' is in params.

--- a/changelogs/fragments/elb_target_group_fix_KeyError.yaml
+++ b/changelogs/fragments/elb_target_group_fix_KeyError.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- elb_target_group - Use .get instead as the key Targets may not exist.

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -429,10 +429,6 @@ def create_or_update_target_group(connection, module):
         if params['TargetType'] == 'ip':
             fail_if_ip_target_type_not_supported(module)
 
-    # Correct type of target ports
-    for target in params.get('Targets', []):
-        target['Port'] = int(target.get('Port', module.params.get('port')))
-
     # Get target group
     tg = get_target_group(connection, module)
 
@@ -495,6 +491,10 @@ def create_or_update_target_group(connection, module):
         if module.params.get("modify_targets"):
             if module.params.get("targets"):
                 params['Targets'] = module.params.get("targets")
+
+                # Correct type of target ports
+                for target in params['Targets']:
+                    target['Port'] = int(target.get('Port', module.params.get('port')))
 
                 # get list of current target instances. I can't see anything like a describe targets in the doco so
                 # describe_target_health seems to be the only way to get them

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -430,7 +430,7 @@ def create_or_update_target_group(connection, module):
             fail_if_ip_target_type_not_supported(module)
 
     # Correct type of target ports
-    for target in params['Targets']:
+    for target in params.get('Targets', []):
         target['Port'] = int(target.get('Port', module.params.get('port')))
 
     # Get target group


### PR DESCRIPTION
##### SUMMARY
Fixes ecs_cluster integration tests that use this module. The tests don't run in CI so it wasn't caught.
Should be backported.

```
The full traceback is:
Traceback (most recent call last):
  File "/Users/shertel/.ansible/tmp/ansible-tmp-1536067282.28-226823377978774/AnsiballZ_elb_target_group.py", line 113, in <module>
    _ansiballz_main()
  File "/Users/shertel/.ansible/tmp/ansible-tmp-1536067282.28-226823377978774/AnsiballZ_elb_target_group.py", line 105, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/Users/shertel/.ansible/tmp/ansible-tmp-1536067282.28-226823377978774/AnsiballZ_elb_target_group.py", line 48, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/tmp/ansible_elb_target_group_payload_cjLRoP/__main__.py", line 720, in <module>
  File "/tmp/ansible_elb_target_group_payload_cjLRoP/__main__.py", line 714, in main
  File "/tmp/ansible_elb_target_group_payload_cjLRoP/__main__.py", line 433, in create_or_update_target_group
KeyError: 'Targets'
```

Introduced in c4303804bff45b0ea53996acf6f71acf2920ffc2

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_target_group.py

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
```
