### PR TITLE
command modules: optional stdin_add_newline

### DIFF
--- a/changelogs/fragments/command-stdin-no-newline.yaml
+++ b/changelogs/fragments/command-stdin-no-newline.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+- command/shell - new `stdin_add_newline` arg allows suppression of
+  automatically-added newline `\n` character to the specified in the `stdin`
+  arg.

--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -58,6 +58,12 @@ options:
     description:
       - Set the stdin of the command directly to the specified value.
     version_added: "2.4"
+  stdin_add_newline:
+    type: bool
+    default: yes
+    description:
+      - If set to C(yes), append a newline to stdin data.
+    version_added: "2.8"
 notes:
     -  If you want to run a command through the shell (say you are using C(<), C(>), C(|), etc), you actually want the M(shell) module instead.
        Parsing shell metacharacters can lead to unexpected commands being executed if quoting is not done correctly so it is more secure to
@@ -189,6 +195,7 @@ def main():
             # The default for this really comes from the action plugin
             warn=dict(type='bool', default=True),
             stdin=dict(required=False),
+            stdin_add_newline=dict(type='bool', default=True),
         ),
         supports_check_mode=True,
     )
@@ -201,6 +208,7 @@ def main():
     removes = module.params['removes']
     warn = module.params['warn']
     stdin = module.params['stdin']
+    stdin_add_newline = module.params['stdin_add_newline']
 
     if not shell and executable:
         module.warn("As of Ansible 2.4, the parameter 'executable' is no longer supported with the 'command' module. Not using '%s'." % executable)
@@ -255,7 +263,7 @@ def main():
     startd = datetime.datetime.now()
 
     if not module.check_mode:
-        rc, out, err = module.run_command(args, executable=executable, use_unsafe_shell=shell, encoding=None, data=stdin)
+        rc, out, err = module.run_command(args, executable=executable, use_unsafe_shell=shell, encoding=None, data=stdin, binary_data=(not stdin_add_newline))
     elif creates or removes:
         rc = 0
         out = err = b'Command would have run if not in check mode'

--- a/lib/ansible/modules/commands/shell.py
+++ b/lib/ansible/modules/commands/shell.py
@@ -60,6 +60,12 @@ options:
     description:
       - Set the stdin of the command directly to the specified value.
     version_added: "2.4"
+  stdin_add_newline:
+    type: bool
+    default: yes
+    description:
+      - If set to C(yes), append a newline to stdin data.
+    version_added: "2.8"
 notes:
   -  If you want to execute a command securely and predictably, it may be
      better to use the M(command) module instead. Best practices when writing

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -338,5 +338,51 @@
     - shell_result7.cmd == 'cat <<EOF\nOne\n  Two\n    Three\nEOF\n'
     - shell_result7.stdout == 'One\n  Two\n    Three'
 
+- name: execute a shell command with no trailing newline to stdin
+  shell: cat > {{output_dir_test | expanduser}}/afile.txt
+  args:
+    stdin: test
+    stdin_add_newline: no
+
+- name: make sure content matches expected
+  copy:
+    dest: "{{output_dir_test | expanduser}}/afile.txt"
+    content: test
+  register: shell_result7
+  failed_when:
+    - shell_result7 is failed or
+      shell_result7 is changed
+
+- name: execute a shell command with trailing newline to stdin
+  shell: cat > {{output_dir_test | expanduser}}/afile.txt
+  args:
+    stdin: test
+    stdin_add_newline: yes
+
+- name: make sure content matches expected
+  copy:
+    dest: "{{output_dir_test | expanduser}}/afile.txt"
+    content: |
+        test
+  register: shell_result8
+  failed_when:
+    - shell_result8 is failed or
+      shell_result8 is changed
+
+- name: execute a shell command with trailing newline to stdin, default
+  shell: cat > {{output_dir_test | expanduser}}/afile.txt
+  args:
+    stdin: test
+
+- name: make sure content matches expected
+  copy:
+    dest: "{{output_dir_test | expanduser}}/afile.txt"
+    content: |
+        test
+  register: shell_result9
+  failed_when:
+    - shell_result9 is failed or
+      shell_result9 is changed
+
 - name: remove the previously created file
   file: path={{output_dir_test}}/afile.txt state=absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When using the `stdin` option to the `command` or `shell` modules, ansible automatically adds a newline to the value provided.  Some programs, notably cryptsetup, use the entirety of stdin when setting a password, including any newlines.  This makes it impossible to unlock a partition created in this manner.  

I'd prefer to switch this behavior, but since `command` is labeled `stableinterface`, I've instead added a new option to switch the behavior, with a default keeping the previous behavior.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
command

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0.a1.post0 (command-stdin-no-newline 5a92eb274e) last updated 2018/09/04 09:49:34 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/ansible-ansible/lib/ansible
  executable location = /home/user/ansible-ansible/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
