### PR TITLE
ec2_vpc_route_table - allow routes to be created if the CIDR already …

### DIFF
--- a/changelogs/fragments/ec2_vpc_route_table_replace_route_fix.yaml
+++ b/changelogs/fragments/ec2_vpc_route_table_replace_route_fix.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- ec2_vpc_route_table - check the origin before replacing routes.
+  Routes with the origin 'EnableVgwRoutePropagation' may not be replaced.

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -432,8 +432,9 @@ def index_of_matching_route(route_spec, routes_to_match):
     for i, route in enumerate(routes_to_match):
         if route_spec_matches_route(route_spec, route):
             return "exact", i
-        elif route_spec_matches_route_cidr(route_spec, route):
-            return "replace", i
+        elif 'Origin' in route_spec and route_spec['Origin'] != 'EnableVgwRoutePropagation':
+            if route_spec_matches_route_cidr(route_spec, route):
+                return "replace", i
 
 
 def ensure_routes(connection=None, module=None, route_table=None, route_specs=None,


### PR DESCRIPTION
…exists but its 'Origin' is 'EnableVgwRoutePropagation' (which cannot be replaced). (#43417)

Fixes #43415
(cherry picked from commit a6c97f22435924860a02130f976232ae7f891275)

##### SUMMARY
Backport #43417

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.7.0b1.post0
```

