### PR TITLE
Add a warning when state=file and file is absent

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -42,8 +42,9 @@ options:
       not exist as the state did not change.
     - If C(directory), all intermediate subdirectories will be created if they
       do not exist. Since Ansible 1.7 they will be created with the supplied permissions.
-    - If C(file), the file will NOT be created if it does not exist; see the C(touch)
-      value or the M(copy) or M(template) module if you want that behavior.
+    - If C(file), the file will NOT be created if it does not exist but this behaviour
+      will be changed in Ansible 2.12; for now, see the C(touch) value or the M(copy) or
+      M(template) module if you want that behavior.
     - If C(hard), the hard link will be created or changed.
     - If C(link), the symbolic link will be created or changed.
     - If C(touch) (new in 1.4), an empty file will be created if the C(path) does not
@@ -500,8 +501,14 @@ def ensure_file_attributes(path, follow, timestamps):
             prev_state = get_state(b_path)
             file_args['path'] = path
 
+    if prev_state == "absent":
+        module.deprecate("The file %s is absent but, in Ansible 2.12, the default behaviour "
+                         "will be to create this file. If you want to determine whether the "
+                         "file exists or not, you should be using the stat module instead." % path,
+                         version=2.12)
+
     if prev_state not in ('file', 'hard'):
-        # file is not absent and any other state is a conflict
+        # any other state is a conflict
         raise AnsibleModuleError(results={'msg': 'file (%s) is %s, cannot continue' % (path, prev_state),
                                           'path': path})
 


### PR DESCRIPTION
##### SUMMARY
In order to change the behaviour of ```state=file``` when file is absent, I added a warning to indicate that the default behaviour will be changed in Ansible 2.12.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
file

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (feat/add-warning-when-using-file-module-and-file-already-exists 755e29681f) last updated 2018/10/25 20:24:12 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/stephen/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/stephen/dev/ansible/lib/ansible
  executable location = /home/stephen/dev/ansible/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
The warning will only be displayed when ```state=file``` and the file is absent.
```
PLAY [test my new module] ********************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [run the new module] ********************************************************************************************************************************************************************************************************************
[DEPRECATION WARNING]: The file /tmp/test.conf is absent but, in Ansible 2.12, the default behaviour will be to create this file. If you want to determine whether the file exists or not, you should be using the stat module instead.. This
 feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
fatal: [localhost]: FAILED! => {"changed": false, "msg": "file (/tmp/test.conf) is absent, cannot continue", "path": "/tmp/test.conf", "state": "absent"}
...ignoring

TASK [dump test output] **********************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": {
        "changed": false, 
        "deprecations": [
            {
                "msg": "The file /tmp/test.conf is absent but, in Ansible 2.12, the default behaviour will be to create this file. If you want to determine whether the file exists or not, you should be using the stat module instead.", 
                "version": 2.12
            }
        ], 
        "failed": true, 
        "msg": "file (/tmp/test.conf) is absent, cannot continue", 
        "path": "/tmp/test.conf", 
        "state": "absent"
    }
}

```
