### PR TITLE
Add 'Wait for' example to asa_command module 

### DIFF
--- a/lib/ansible/modules/network/asa/asa_command.py
+++ b/lib/ansible/modules/network/asa/asa_command.py
@@ -68,17 +68,6 @@ options:
 """
 
 EXAMPLES = """
-# Note: examples below use the following group_vars/asa.yaml file to handle
-#       transport and authentication to the node.
----
-ansible_connection: network_cli
-ansible_network_os: asa
-ansible_user: ansible
-ansible_become: yes
-ansible_become_method: enable
-ansible_become_pass: cisco
-command_timeout: 60
-
 
 ---
 - name: "Show the ASA version"

--- a/lib/ansible/modules/network/asa/asa_command.py
+++ b/lib/ansible/modules/network/asa/asa_command.py
@@ -68,48 +68,36 @@ options:
 """
 
 EXAMPLES = """
-# Note: examples below use the following provider dict to handle
+# Note: examples below use the following group_vars/asa.yaml file to handle
 #       transport and authentication to the node.
 ---
-vars:
-  cli:
-    host: "{{ inventory_hostname }}"
-    username: cisco
-    password: cisco
-    authorize: yes
-    auth_pass: cisco
-    transport: cli
+ansible_connection: network_cli
+ansible_network_os: asa
+ansible_user: ansible
+ansible_become: yes
+ansible_become_method: enable
+ansible_become_pass: cisco
+command_timeout: 60
+
 
 ---
 - name: "Show the ASA version"
   asa_command:
     commands:
       - show version
-    provider: "{{ cli }}"
 
 - name: "Show ASA drops and memory"
   asa_command:
     commands:
       - show asp drop
       - show memory
-    provider: "{{ cli }}"
-
-- name: "Show the ASA version for the system context mode"
-  asa_command:
-    commands:
-      - show version
-    provider: "{{ cli }}"
-    context: system
 
 - name: "Send repeat pings and wait for the result to pass 100%"
   asa_command:
     commands:
       - ping 8.8.8.8 repeat 20 size 350
-    authorize: yes
-    auth_pass: "{{ ansible_become_pass }}"
     wait_for:
       - result[0] contains 100
-    timeout: 60
     retries: 2
 """
 

--- a/lib/ansible/modules/network/asa/asa_command.py
+++ b/lib/ansible/modules/network/asa/asa_command.py
@@ -81,31 +81,35 @@ vars:
     transport: cli
 
 ---
-- asa_command:
+- name: "Show the ASA version"
+  asa_command:
     commands:
       - show version
     provider: "{{ cli }}"
 
-- asa_command:
+- name: "Show ASA drops and memory"
+  asa_command:
     commands:
       - show asp drop
       - show memory
     provider: "{{ cli }}"
 
-- asa_command:
+- name: "Show the ASA version for the system context mode"
+  asa_command:
     commands:
       - show version
     provider: "{{ cli }}"
     context: system
 
-- asa_command:
+- name: "Send repeat pings and wait for the result to pass 100%"
+  asa_command:
     commands:
-      - ping 8.8.8.8 repeat 101 size 350
+      - ping 8.8.8.8 repeat 20 size 350
     authorize: yes
     auth_pass: "{{ ansible_become_pass }}"
     wait_for:
       - result[0] contains 100
-    timeout: 100
+    timeout: 60
     retries: 2
 """
 

--- a/lib/ansible/modules/network/asa/asa_command.py
+++ b/lib/ansible/modules/network/asa/asa_command.py
@@ -97,6 +97,16 @@ vars:
       - show version
     provider: "{{ cli }}"
     context: system
+
+- asa_command:
+    commands:
+      - ping 8.8.8.8 repeat 101 size 350
+    authorize: yes
+    auth_pass: "{{ ansible_become_pass }}"
+    wait_for:
+      - result[0] contains 100
+    timeout: 100
+    retries: 2
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Pulls in example from PR41069 with the addition of names for each task, and removes deprecated items.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
asa_command
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
a$ ansible --version
ansible 2.7.0.dev0
  config file = /home/samccann/.ansible.cfg
  configured module search path = [u'/home/samccann/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May 31 2018, 09:41:32) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Used the following playbook to verify all asa_command examples:

---
- name: "Test all ASA examples"
  hosts: asa
  connection: network_cli
  gather_facts: no

  tasks:

  - name: "Show the ASA version"
    asa_command:
      commands:
        - show version

  - name: "Show ASA drops and memory"
    asa_command:
      commands:
        - show asp drop
        - show memory

  - name: "Send repeat pings and wait for the result to pass 100%"
    asa_command:
      commands:
        - ping 10.8.38.76 repeat 20 size 350
      wait_for:
        - result[0] contains 100
      retries: 2


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible-playbook -i inventory -k all-asa-examples.yml 
SSH password: 
/usr/lib/python2.7/site-packages/requests/__init__.py:91: RequestsDependencyWarning: urllib3 (1.15.1) or chardet (3.0.4) doesn't match a supported version!
  RequestsDependencyWarning)

PLAY [Test all ASA examples] ***************************************************

TASK [Show the ASA version] ****************************************************
ok: [test]

TASK [Show ASA drops and memory] ***********************************************
ok: [test]

TASK [Send repeat pings and wait for the result to pass 100%] ******************
ok: [test]

PLAY RECAP *********************************************************************
test                       : ok=3    changed=0    unreachable=0    failed=0   


```
