### PR TITLE
Fix diff_ignore_lines option issue in {eos,ios,nxos}_config module

### DIFF
--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -273,7 +273,7 @@ from ansible.module_utils.network.eos.eos import check_args
 
 
 def get_candidate(module):
-    candidate = NetworkConfig(indent=3, ignore_lines=module.params['diff_ignore_lines'])
+    candidate = NetworkConfig(indent=3)
     if module.params['src']:
         candidate.load(module.params['src'])
     elif module.params['lines']:

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -364,7 +364,7 @@ def get_running_config(module, current_config=None, flags=None):
 
 
 def get_candidate(module):
-    candidate = NetworkConfig(indent=1, ignore_lines=module.params['diff_ignore_lines'])
+    candidate = NetworkConfig(indent=1)
     banners = {}
 
     if module.params['src']:

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -300,7 +300,7 @@ def get_running_config(module, config=None):
 
 
 def get_candidate(module):
-    candidate = NetworkConfig(indent=2, ignore_lines=module.params['diff_ignore_lines'])
+    candidate = NetworkConfig(indent=2)
     if module.params['src']:
         if module.params['replace'] != 'config':
             candidate.load(module.params['src'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* diff_ignore_lines option is to handle the running config fetch from
  remote host and ignore the lines that are auto updated eg: commit time and date
* This option should not be used while processing candidate (input) configuration
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos_config
ios_config
nxos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
