### PR TITLE
Fix diff_ignore_lines option issue for candidate configuration

### DIFF
--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -214,7 +214,7 @@ class Cliconf(CliconfBase):
             raise ValueError("'replace' value %s in invalid, valid values are %s" % (diff_replace, ', '.join(option_values['diff_replace'])))
 
         # prepare candidate configuration
-        candidate_obj = NetworkConfig(indent=3, ignore_lines=diff_ignore_lines)
+        candidate_obj = NetworkConfig(indent=3)
         candidate_obj.load(candidate)
 
         if running and diff_match != 'none' and diff_replace != 'config':

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -105,7 +105,7 @@ class Cliconf(CliconfBase):
             raise ValueError("'replace' value %s in invalid, valid values are %s" % (diff_replace, ', '.join(option_values['diff_replace'])))
 
         # prepare candidate configuration
-        candidate_obj = NetworkConfig(indent=1, ignore_lines=diff_ignore_lines)
+        candidate_obj = NetworkConfig(indent=1)
         want_src, want_banners = self._extract_banners(candidate)
         candidate_obj.load(want_src)
 

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -132,7 +132,7 @@ class Cliconf(CliconfBase):
 
         # prepare candidate configuration
         sanitized_candidate = sanitize_config(candidate)
-        candidate_obj = NetworkConfig(indent=1, ignore_lines=diff_ignore_lines)
+        candidate_obj = NetworkConfig(indent=1)
         candidate_obj.load(sanitized_candidate)
 
         if running and diff_match != 'none':

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -115,7 +115,7 @@ class Cliconf(CliconfBase):
             raise ValueError("'replace' value %s in invalid, valid values are %s" % (diff_replace, ', '.join(option_values['diff_replace'])))
 
         # prepare candidate configuration
-        candidate_obj = NetworkConfig(indent=2, ignore_lines=diff_ignore_lines)
+        candidate_obj = NetworkConfig(indent=2)
         candidate_obj.load(candidate)
 
         if running and diff_match != 'none' and diff_replace != 'config':

--- a/test/integration/targets/ios_config/tests/cli/src_basic.yaml
+++ b/test/integration/targets/ios_config/tests/cli/src_basic.yaml
@@ -37,4 +37,34 @@
 # FIXME Bug https://github.com/ansible/ansible/issues/19382
 #      - "result.updates is not defined"
 
+- name: check for empty diff
+  ios_config:
+    running_config: |
+      service timestamps debug datetime msec
+      service timestamps log datetime msec
+    lines:
+      - service timestamps debug datetime msec
+      - service timestamps log datetime msec
+  check_mode: True
+  register: result
+- assert:
+    that:
+      - "result.updates is undefined"
+
+- name: check for diff with ignore lines for running config
+  ios_config:
+    running_config: |
+      service timestamps debug datetime msec
+      service timestamps log datetime msec
+    lines:
+      - service timestamps debug datetime msec
+      - service timestamps log datetime msec
+    diff_ignore_lines: service timestamps log datetime msec
+  check_mode: True
+  register: result
+
+- assert:
+    that:
+      - "'service timestamps log datetime msec' in result.updates"
+
 - debug: msg="END cli/src_basic.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  diff_ignore_lines option is to handle the running config fetch from
   remote host and ignore the lines that are auto-updated eg: commit time and date
*  This option should not be used while processing candidate (input) configuration
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
{eos,ios,nxos,iosxr}_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
