### PR TITLE
Fix referenced before assignment in sysvinit module

### DIFF
--- a/changelogs/fragments/45203-sysvinit-fix-unassigned-variable.yml
+++ b/changelogs/fragments/45203-sysvinit-fix-unassigned-variable.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix referenced before assignment in sysvinit module

--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -175,12 +175,12 @@ def main():
 
     # figure out started status, everyone does it different!
     is_started = False
+    worked = False
 
     # user knows other methods fail and supplied pattern
     if pattern:
-        is_started = get_ps(module, pattern)
+        worked = is_started = get_ps(module, pattern)
     else:
-        worked = False
         if location.get('service'):
             # standard tool that has been 'destandarized' by reimplementation in other OS/distros
             cmd = '%s %s status' % (location['service'], name)


### PR DESCRIPTION
##### SUMMARY
* removed redundant variable initialization

(cherry picked from commit 7538a63f70c331f41f82510864e551fe403382fe)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/45203-sysvinit-fix-unassigned-variable.yml
lib/ansible/modules/system/sysvinit.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
Stable-2.6
```