### PR TITLE
Make vmware_guest honor "wait_for_ip_address" when powering on a VM

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -557,7 +557,7 @@ from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.vmware import (find_obj, gather_vm_facts, get_all_objs,
                                          compile_folder_path_for_object, serialize_spec,
                                          vmware_argument_spec, set_vm_power_state, PyVmomi,
-                                         find_dvs_by_name, find_dvspg_by_name)
+                                         find_dvs_by_name, find_dvspg_by_name, wait_for_vm_ip)
 
 
 class PyVmomiDeviceHelper(object):
@@ -2389,6 +2389,11 @@ def main():
             tmp_result = set_vm_power_state(pyv.content, vm, module.params['state'], module.params['force'], module.params['state_change_timeout'])
             if tmp_result['changed']:
                 result["changed"] = True
+                if module.params['state'] in ['poweredon', 'restarted', 'rebootguest'] and module.params['wait_for_ip_address']:
+                    wait_result = wait_for_vm_ip(pyv.content, vm)
+                    if not wait_result:
+                        module.fail_json(msg='Waiting for IP address timed out')
+                    tmp_result['instance'] = wait_result
             if not tmp_result["failed"]:
                 result["failed"] = False
             result['instance'] = tmp_result['instance']


### PR DESCRIPTION
##### SUMMARY
Fixes #45223

It turned out that the `vmware_guest` module does not check for ip availability at all in the [`desired_operation='set_vm_power_state'`](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/vmware/vmware_guest.py#L2379) case.

This PR adds a call to `wait_for_vm_ip` in the same manner as done in [vmware_dploy_ovf](wait_for_vm_ip).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0b1.post0 (stable-2.7 8a8da98546) last updated 2018/09/03 10:13:33 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/devops/ansible/ansible/lib/ansible
  executable location = /home/user/devops/ansible/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
The return value's `instance` value is updated with the last poll result so that the IP is also available in the module's return value.

This module now uses the same shared function `wait_for_vm_ip` as `vmware_deploy_ovf` does, so it is inherently affected by #45159. As the undetected timeout occurs after 5 minutes, this should not be a big issue in this context.