### PR TITLE
-'templateLinkage' set to match Zabbix web interface defaults

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -397,6 +397,9 @@ class Template(object):
                 'createMissing': True,
                 'updateExisting': True
             },
+            'templateLinkage': {
+                'createMissing': True
+            },
             'templateScreens': {
                 'createMissing': True,
                 'updateExisting': True,


### PR DESCRIPTION
##### SUMMARY
Zabbix 3.4 for importing templates via web, by default, sets 'Template Linkage' for 'createMillsing' to true.
Zabbix 3.2 did this as well, as far as I remember. 
Probably, it is a good idea to stick to those defaults instead of Zabbix API defaults.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_template module

##### ANSIBLE VERSION
```
ansible 2.6.3
```

##### ADDITIONAL INFORMATION
Module's 'template_json' parameter may contain child templates to link to one being described in parameter. Current module version does not tell Zabbix to create those links when importing template.
Proposed changes will make it much like default Zabbix web interface behavior.
