### PR TITLE
Ensure loop with delegate_to can short circuit the same as without delegate_to

### DIFF
--- a/changelogs/fragments/loop_undefined_delegate_to.yaml
+++ b/changelogs/fragments/loop_undefined_delegate_to.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- loop - Ensure that a loop with a when condition that evaluates to false and delegate_to, will short circuit if the
+  loop references an undefined variable. This matches the behavior in the same scenario without delegate_to
+  (https://github.com/ansible/ansible/issues/45189)

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -512,7 +512,12 @@ class VariableManager:
             else:
                 raise AnsibleError("Failed to find the lookup named '%s' in the available lookup plugins" % task.loop_with)
         elif task.loop is not None:
-            items = templar.template(task.loop)
+            try:
+                items = templar.template(task.loop)
+            except AnsibleUndefinedVariable:
+                # This task will be skipped later due to this, so we just setup
+                # a dummy array for the later code so it doesn't fail
+                items = [None]
         else:
             has_loop = False
             items = [None]

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -233,3 +233,22 @@
 - assert:
     that:
       - ansible_search_path == loop_search_path.results.0.item
+
+# https://github.com/ansible/ansible/issues/45189
+- name: with_X conditional delegate_to shortcircuit on templating error
+  debug:
+    msg: "loop"
+  when: false
+  delegate_to: localhost
+  with_list: "{{ fake_var }}"
+  register: result
+  failed_when: result is not skipped
+
+- name: loop conditional delegate_to shortcircuit on templating error
+  debug:
+      msg: "loop"
+  when: false
+  delegate_to: localhost
+  loop: "{{ fake_var }}"
+  register: result
+  failed_when: result is not skipped


### PR DESCRIPTION
##### SUMMARY
Ensure loop with delegate_to can short circuit the same as without delegate_to. Fixes #45189

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/vars/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
2.7
2.6
2.5
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```