### PR TITLE
elb_target_group - prevent a KeyError exception (#45169)

### DIFF
--- a/changelogs/fragments/elb_target_group_fix_KeyError.yaml
+++ b/changelogs/fragments/elb_target_group_fix_KeyError.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- elb_target_group - cast target ports to integers before making API calls after the key 'Targets' is in params.

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -481,6 +481,10 @@ def create_or_update_target_group(connection, module):
             if module.params.get("targets"):
                 params['Targets'] = module.params.get("targets")
 
+                # Correct type of target ports
+                for target in params['Targets']:
+                    target['Port'] = int(target.get('Port', module.params.get('port')))
+
                 # get list of current target instances. I can't see anything like a describe targets in the doco so
                 # describe_target_health seems to be the only way to get them
 


### PR DESCRIPTION
Ensure ports to integers after allowing the key 'Targets' to be available in params

(cherry picked from commit 038fd0d0f24475604deea3f2eb58303710a69a0c)

##### SUMMARY
Backport #45169

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
elb_target_group

##### ANSIBLE VERSION
```
ansible 2.6.3.post0
```
