### PR TITLE
junos_vlan: Add Vlan ID Range in description (#41855)

### DIFF
--- a/lib/ansible/modules/network/junos/junos_vlan.py
+++ b/lib/ansible/modules/network/junos/junos_vlan.py
@@ -28,7 +28,7 @@ options:
     required: true
   vlan_id:
     description:
-      - ID of the VLAN.
+      - ID of the VLAN. Range 1-4094.
     required: true
   description:
     description:


### PR DESCRIPTION
(cherry picked from commit f968fcd288dc5b320b68b0dbf627acc79d5bd5ad)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport  VLAN ID range.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
junos_vlan
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
