### PR TITLE
fixed network automation index issues (#44732)

### DIFF
--- a/docs/docsite/rst/index.rst
+++ b/docs/docsite/rst/index.rst
@@ -71,7 +71,6 @@ Ansible releases a new major release of Ansible approximately every two months. 
    :caption: Ansible for Network Automation
 
    network/index
-   network/getting_started/index
 
 .. toctree::
    :maxdepth: 2

--- a/docs/docsite/rst/network/getting_started/index.rst
+++ b/docs/docsite/rst/network/getting_started/index.rst
@@ -1,6 +1,8 @@
-**************************************************
-An Introduction to Network Automation with Ansible
-**************************************************
+.. _network_getting_started:
+
+***************************************************
+Getting Started with Ansible for Network Automation
+***************************************************
 
 Ansible modules support a wide range of vendors, device types, and actions, so you can manage your entire network with a single automation tool. With Ansible, you can:
 
@@ -10,14 +12,20 @@ Ansible modules support a wide range of vendors, device types, and actions, so y
 - Benefit from community and vendor-generated sample playbooks and roles to help accelerate network automation projects
 - Communicate securely with network hardware over SSH or HTTPS
 
-Who should use this guide?
-================================================================================
+**Who should use this guide?**
 
 This guide is intended for network engineers using Ansible for the first time. If you understand networks but have never used Ansible, work through the guide from start to finish.
 
 This guide is also useful for experienced Ansible users automating network tasks for the first time. You can use Ansible commands, playbooks and modules to configure hubs, switches, routers, bridges and other network devices. But network modules are different from Linux/Unix and Windows modules, and you must understand some network-specific concepts to succeed. If you understand Ansible but have never automated a network task, start with the second section.
 
-This guide introduces basic Ansible concepts and guides you through your first Ansible commands, playbooks and inventory entries. 
+This guide introduces basic Ansible concepts and guides you through your first Ansible commands, playbooks and inventory entries.
 
 .. toctree::
    :maxdepth: 2
+   :caption: Getting Started Guide
+
+   basic_concepts
+   network_differences
+   first_playbook
+   first_inventory
+   intermediate_concepts

--- a/docs/docsite/rst/network/index.rst
+++ b/docs/docsite/rst/network/index.rst
@@ -4,36 +4,14 @@
 Ansible for Network Automation
 ******************************
 
-Introduction
-============
-
 Ansible Network modules extend the benefits of simple, powerful, agentless automation to network administrators and teams. Ansible Network modules can configure your network stack, test and validate existing network state, and discover and correct network configuration drift.
 
-If you're new to Ansible, or new to using Ansible for network management, start with the Getting Started Guide.
+If you're new to Ansible, or new to using Ansible for network management, start with :ref:`network_getting_started`. If you are already familiar with network automation with Ansible, see :ref:`network_advanced`.
 
 For documentation on using a particular network module, consult the :ref:`list of all network modules<network_modules>`. Some network modules are maintained by the Ansible community - here's a list of :ref:`network modules maintained by the Ansible Network Team<network_supported>`.
 
 .. toctree::
    :maxdepth: 3
-   :caption: Getting Started
 
    getting_started/index
-   getting_started/basic_concepts
-   getting_started/network_differences
-   getting_started/first_playbook
-   getting_started/first_inventory
-   getting_started/intermediate_concepts
-
-
-
-
-.. toctree::
-   :maxdepth: 3
-   :caption: User Guide
-
    user_guide/index
-   user_guide/faq
-   user_guide/network_best_practices_2.5
-   user_guide/network_debug_troubleshooting
-   user_guide/network_working_with_command_output
-   user_guide/platform_index

--- a/docs/docsite/rst/network/user_guide/index.rst
+++ b/docs/docsite/rst/network/user_guide/index.rst
@@ -1,15 +1,23 @@
-************************************************
-User Guide to to Network Automation with Ansible
-************************************************
+.. _network_advanced:
 
-More content coming soon!
+***************************************************
+Advanced Topics with Ansible for Network Automation
+***************************************************
 
-Who should use this guide?
-================================================================================
+Once you have mastered the basics of network automation with Ansible, as presented in :ref:`network_getting_started`, use this guide understand platform-specific details, optimization, and troubleshooting tips for Ansible for network automation.
+
+**Who should use this guide?**
 
 This guide is intended for network engineers using Ansible for automation. It covers advanced topics. If you understand networks and Ansible, this guide is for you. You may read through the entire guide if you choose, or use the links below to find the specific information you need.
 
-If you're new to Ansible, or new to using Ansible for network automation, start with the :doc:`Getting Started Guide<../getting_started/index>`.
+If you're new to Ansible, or new to using Ansible for network automation, start with the :ref:`network_getting_started`.
 
 .. toctree::
    :maxdepth: 2
+   :caption: Advanced Topics
+
+   faq
+   network_best_practices_2.5
+   network_debug_troubleshooting
+   network_working_with_command_output
+   platform_index


### PR DESCRIPTION
* fixed network automation index issues

* replace :doc: with :ref:

* fixed anchor misspelling

* fix toc/nav issue -do not put toctree under a subheader

(cherry picked from commit 1c42198f1ee9109db65a1c1f02399dc2536808a2)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
