### PR TITLE
[stable-2.5] HashiVault: fix AttributeError when auth_method != 'token' (#36513)

### DIFF
--- a/changelogs/fragments/hashi_vault_fix_object_has_no_attribute_verify
+++ b/changelogs/fragments/hashi_vault_fix_object_has_no_attribute_verify
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hashi_vault: fix AttributeError when 'auth_method' isn't 'token' (https://github.com/ansible/ansible/pull/36513)

--- a/changelogs/fragments/hashi_vault_fix_object_has_no_attribute_verify
+++ b/changelogs/fragments/hashi_vault_fix_object_has_no_attribute_verify
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - hashi_vault: fix AttributeError when 'auth_method' isn't 'token' (https://github.com/ansible/ansible/pull/36513)
+  - hashi_vault - fix AttributeError when 'auth_method' isn't 'token' (https://github.com/ansible/ansible/pull/36513)

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -122,6 +122,8 @@ class HashiVault:
         else:
             self.secret_field = ''
 
+        self.verify = self.boolean_or_cacert(kwargs.get('validate_certs', True), kwargs.get('cacert', ''))
+
         # If a particular backend is asked for (and its method exists) we call it, otherwise drop through to using
         # token auth. This means if a particular auth backend is requested and a token is also given, then we
         # ignore the token and attempt authentication against the specified backend.
@@ -149,8 +151,6 @@ class HashiVault:
 
             if self.token is None:
                 raise AnsibleError("No Vault Token specified")
-
-            self.verify = self.boolean_or_cacert(kwargs.get('validate_certs', True), kwargs.get('cacert', ''))
 
             self.client = hvac.Client(url=self.url, token=self.token, verify=self.verify)
 


### PR DESCRIPTION
##### SUMMARY
Fixed `'HashiVault' object has no attribute 'verify'` (#36513)

(cherry picked from commit 0ceb717)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hashi_vault lookup

##### ANSIBLE VERSION
```paste below
2.5.X
```