### PR TITLE
Fix mixed output from ansible and lxd when using the lxd connection plugin

### DIFF
--- a/lib/ansible/plugins/connection/lxd.py
+++ b/lib/ansible/plugins/connection/lxd.py
@@ -106,7 +106,6 @@ class Connection(ConnectionBase):
         process = Popen(local_cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
         process.communicate()
 
-
     def fetch_file(self, in_path, out_path):
         """ fetch a file from lxd to local """
         super(Connection, self).fetch_file(in_path, out_path)

--- a/lib/ansible/plugins/connection/lxd.py
+++ b/lib/ansible/plugins/connection/lxd.py
@@ -31,7 +31,7 @@ DOCUMENTATION = """
 
 import os
 from distutils.spawn import find_executable
-from subprocess import call, Popen, PIPE
+from subprocess import Popen, PIPE
 
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
 from ansible.module_utils._text import to_bytes, to_text
@@ -103,7 +103,9 @@ class Connection(ConnectionBase):
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
 
-        call(local_cmd)
+        process = Popen(local_cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        process.communicate()
+
 
     def fetch_file(self, in_path, out_path):
         """ fetch a file from lxd to local """
@@ -115,7 +117,8 @@ class Connection(ConnectionBase):
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
 
-        call(local_cmd)
+        process = Popen(local_cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        process.communicate()
 
     def close(self):
         """ close the connection (nothing to do here) """


### PR DESCRIPTION
##### SUMMARY
This PR aims to fix messed output in ansible using the lxd connection plugin with a recent LXD version.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
 lib/ansible/plugins/connection/lxd.py

##### ANSIBLE VERSION
I put the latest version here, but it affects all versions of ansible with the lxd connection plugin.
```
ansible 2.6.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
When using ansible with the lxd connection plugin (so far I believe it to be on LXD versions > 3.2, I use 3.4) you get thoses outputs :

```SHELL
$ ansible --version | head -1
ansible 2.6.3

$ ansible -m shell -a "whoami" container
Pushing /var/lib/snapd/hostfs/home/nani/.ansible/tmp/ansible-local-32343V1QKb5/tmp29oY9u to /root/.ansible/tmp/ansible-tmp-1536167
Pushing /var/lib/snapd/hostfs/home/nani/.ansible/tmp/ansible-local-32343V1QKb5/tmp29oY9u to /root/.ansible/tmp/ansible-tmp-1536167
Pushing /var/lib/snapd/hostfs/home/nani/.ansible/tmp/ansible-local-32343V1QKb5/tmp29oY9u to /root/.ansible/tmp/ansible-tmp-1536167

container | SUCCESS | rc=0 >>
root
```

It messes the output the exact same way in playbooks. I had a rough time finding where thoses outputs comes from, I initially thought it was ansible.

It appears that the lxc command line for LXD features a one line progress output :

```SHELL
$ lxc file push a_file container/tmp/
Pushing /var/lib/snapd/hostfs/etc/ansible/a_file to /tmp/a_file: 100% (145.18MB/s)
```

The connection plugin appears to use the `call` method from `subprocess` when uploading files on the container, and this explains why we see mixed output from lxd and ansible.

After replacing `call` operations with `Popen`, this is what I got when running it from my branch `pip install git+https://github.com/Nani-o/ansible@lxd_connection_plugin_fix_output` :

```SHELL
$ ansible --version | head -1
ansible 2.8.0.dev0

$ ansible -m shell -a "whoami" container
container | CHANGED | rc=0 >>
root
```