### PR TITLE
Fix systemd service checks against rc return code. Fixes #44409.

### DIFF
--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -531,7 +531,7 @@ class LinuxService(Service):
         elif out.startswith('disabled'):
             return False
         # `systemctl is-enabled` returns rc 0 for enabled, 1 for disabled, and 4 for service file not found
-        elif rc > 1 and sysv_exists(service_name): 
+        elif rc > 1 and sysv_exists(service_name):
             return sysv_is_enabled(service_name)
         else:
             return False

--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -530,7 +530,8 @@ class LinuxService(Service):
             return True
         elif out.startswith('disabled'):
             return False
-        elif sysv_exists(service_name):
+        # `systemctl is-enabled` returns rc 0 for enabled, 1 for disabled, and 4 for service file not found
+        elif rc > 1 and sysv_exists(service_name): 
             return sysv_is_enabled(service_name)
         else:
             return False

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -415,7 +415,7 @@ def main():
             # check systemctl result or if it is a init script
             if rc == 0:
                 enabled = True
-            elif rc == 1:
+            elif rc > 1:
                 # if not a user or global user service and both init script and unit file exist stdout should have enabled/disabled, otherwise use rc entries
                 if module.params['scope'] == 'system' and \
                         not module.params['user'] and \


### PR DESCRIPTION
##### SUMMARY
Fixes #44409 .  In short, systemctl returns 0 for a service that is known and enabled and 1 if a service is known and disabled.  There is additional logic in ansible for determining if a service is a valid sysv service but not a systemd service, however, it evaluated this on the basis of an rc of 1 (in the systemd module) or !0 (service module).  A missing system service file will return an rc of 4, not 1.  By evaluating based on 1, Ansible returns a false positive for a service being enabled for services that ship *both* systemd and sysc init files.  Examples include, nginx's official debian packaging and Treasure Data's rpm packaging (see associated issue for source links).
Evaluating rc >1 fixes the false positive while properly retaining the sysv check in the case that a service file is not found as a systemd service, but exists as a sysv service.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
service and systemd modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 15 2018, 15:37:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```
This output is from a Fedora 28 docker container with Ansible built against this commit via rpm.  The same bug has been seen in 2.6.2 and 2.6.3 as reported in the issue.

##### ADDITIONAL INFORMATION
As an example against a remote system with td-agent installed:
```paste below
ansible ... -m 'service' -a 'name=network enabled=yes'
ansible ... -m 'systemd' -a 'name=network enabled=yes'
```
Before fix and after running either of these:
`systemctl is-enabled td-agent.service` reports "disabled"
Ansible shows service is enabled with no change despite reporting `"UnitFileState": "disabled"` with verbose output

After the fix:
`systemctl is-enabled td-agent.service` reports "enabled"
Ansible detects a the service was disabled and reports a change

Also tested:
Proper reporting of various sysv only services in RHEL 7.4 remote target.
