### PR TITLE
Get packages for dnf and yum tests from S3.

### DIFF
--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -374,7 +374,7 @@
 
 - name: try to install from non existing url
   dnf:
-    name: http://non-existing.com/non-existing-1.0.0.fc26.noarch.rpm
+    name: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/dnf/non-existing-1.0.0.fc26.noarch.rpm
     state: present
   register: dnf_result
   ignore_errors: yes

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -411,7 +411,7 @@
 
 - name: try to install from non existing url
   yum:
-    name: http://non-existing.com/non-existing-1.0.0.fc26.noarch.rpm
+    name: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/yum/non-existing-1.0.0.fc26.noarch.rpm
     state: present
   register: yum_result
   ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY

Get packages for dnf and yum tests from S3.

(cherry picked from commit 22d5f5d97fe94c70a80a251b44850876b050b1d6)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

yum and dnf integration tests

##### ANSIBLE VERSION

```
ansible 2.4.6.0 (dnf-fix-2.4 98dc1521e0) last updated 2018/09/05 15:16:46 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
