### PR TITLE
IOSXR dci test failure on devel/2.7

### DIFF
--- a/test/integration/targets/iosxr_config/tests/cli_config/cli_basic.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli_config/cli_basic.yaml
@@ -5,8 +5,8 @@
   cli_config: &rm
     config: |
       interface Loopback999
-      no description
-      no shutdown
+       no description
+       no shutdown
   become: yes
 
 - name: configure device with config


### PR DESCRIPTION
##### SUMMARY
Fix the DCI Failures of IOSXR test cases.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION
TASK [iosxr_config : debug] *************************************************************************************************************************************************
task path: /macos/ansible/test/integration/targets/iosxr_config/tests/cli_config/cli_basic.yaml:33
ok: [iosxr01] => {
    "msg": "END cli_config/cli_basic.yaml on connection=network_cli"
}
META: ran handlers
META: ran handlers

PLAY RECAP ******************************************************************************************************************************************************************
iosxr01                    : ok=16   changed=3    unreachable=0    failed=0
