### PR TITLE
Generalize config retrieval in ios_l3_interface module

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l3_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interface.py
@@ -218,7 +218,7 @@ def map_obj_to_commands(updates, module):
 
 
 def map_config_to_obj(module):
-    config = get_config(module, flags=['| section interface'])
+    config = get_config(module)
     configobj = NetworkConfig(indent=1, contents=config)
 
     match = re.findall(r'^interface (\S+)', config, re.M)


### PR DESCRIPTION
##### SUMMARY
In order to compare the wanted changes with the current state `ios_l3_interface` gets the current switch configuration by running `show running-config  | section interface`. But the `section` filter is not provided on Cisco 3750E switches. Thus, ansible exits with error
```
fatal: [switch]: FAILED! => {"changed": false, "msg": "show running-config | section interface\r\n                                ^\r\n% Invalid input detected at '^' marker.\r\n\r\nswitch#"}
```

As far as I can see, the configuration parsing in `map_config_to_obj(module)` ignores whether the whole switch configuration or only interface sections are provided. So, removing the filter part `| section interface` seems to be a valid fix.

The reviewers should make sure that this modification doesn't introduce a regression with other switch models.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ios_l3_interface

##### ANSIBLE VERSION
```paste below
ansible 2.8.0.dev0 (devel e07f82a682) last updated 2018/09/06 09:28:17 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ry28/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ry28/Workspace/ansible/ansible-switch/.ansible/lib/ansible
  executable location = /home/ry28/Workspace/ansible/ansible-switch/.ansible/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
This issue resembles https://github.com/ansible/ansible/issues/39011
