### PR TITLE
Fixes handling of terminal_initial_prompt on dellos6 and dellos9 devices

### DIFF
--- a/lib/ansible/plugins/terminal/dellos6.py
+++ b/lib/ansible/plugins/terminal/dellos6.py
@@ -51,7 +51,7 @@ class TerminalModule(TerminalBase):
     ]
 
     terminal_initial_prompt = br"\(y/n\)"
-   
+
     terminal_initial_answer = b"y"
 
     terminal_inital_prompt_newline = False

--- a/lib/ansible/plugins/terminal/dellos6.py
+++ b/lib/ansible/plugins/terminal/dellos6.py
@@ -50,6 +50,12 @@ class TerminalModule(TerminalBase):
 
     ]
 
+    terminal_initial_prompt = br"\(y/n\)"
+   
+    terminal_initial_answer = b"y"
+
+    terminal_inital_prompt_newline = False
+
     def on_become(self, passwd=None):
         if self._get_prompt().endswith('#'):
             return

--- a/lib/ansible/plugins/terminal/dellos9.py
+++ b/lib/ansible/plugins/terminal/dellos9.py
@@ -45,6 +45,10 @@ class TerminalModule(TerminalBase):
         re.compile(br"'[^']' +returned error code: ?\d+"),
     ]
 
+    terminal_initial_prompt = br"\[y/n\]:"
+
+    terminal_initial_answer = b"y"
+
     def on_open_shell(self):
         try:
             self._exec_cli_command(b'terminal length 0')


### PR DESCRIPTION
##### SUMMARY
Fixes handling of  terminal_initial_prompt in dellos6 and dellos9 devices.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/terminal/dellos6.py
plugins/terminal/dellos9.py

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (Fix_terminal_initial_prompt 83952ad249) last updated 2018/09/06 13:38:36 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/manju/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/abirami/Supp_initial_prompt/ansible/lib/ansible
  executable location = /home/abirami/Supp_initial_prompt/ansible/bin/ansible

```
