### PR TITLE
iosxr dci failure on devel/2.7 (#45268)

### DIFF
--- a/test/integration/targets/iosxr_config/tests/cli_config/cli_basic.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli_config/cli_basic.yaml
@@ -5,8 +5,8 @@
   cli_config: &rm
     config: |
       interface Loopback999
-      no description
-      no shutdown
+       no description
+       no shutdown
   become: yes
 
 - name: configure device with config


### PR DESCRIPTION
(cherry picked from commit 23d54ed1d4cf642f765b2b52968e914054e0e67b)

##### SUMMARY
Fixing iosxr DCI Failure

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

