### PR TITLE
Add a guide for using Online with Ansible

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_online.rst
+++ b/docs/docsite/rst/scenario_guides/guide_online.rst
@@ -1,0 +1,36 @@
+*************************
+Using Ansible with Online
+*************************
+
+Introduction
+============
+
+Online is a French hosting company mainly known for providing bare-metal servers named Dedibox.
+Check it out: `https://www.online.net/en <https://www.online.net/en>_`
+
+Dynamic inventory for Online resources
+--------------------------------------
+
+Ansible has a dynamic inventory plugin that can list your resources.
+
+1. Create a YAML configuration such as ``online_inventory.yml`` with this content:
+
+.. code-block:: yaml
+
+    plugin: online
+
+2. Set your ``ONLINE_TOKEN`` environment variable with your token.
+    You need to open an account and log into it before you can get a token.
+    You can find your token at the following page: `https://console.online.net/en/api/access <https://console.online.net/en/api/access>_`
+
+3. You can test that your inventory is working by running: ``ansible-inventory -v -i online_inventory.yml --list``
+
+4. Now you can run your playbook or any other module with this inventory:
+
+::
+
+    $ ansible all -i online_inventory.yml -m ping
+    sd-96735 | SUCCESS => {
+        "changed": false,
+        "ping": "pong"
+    }


### PR DESCRIPTION
##### SUMMARY

Add a guide for using Online with Ansible

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

- online plugins

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (guide_online e224ba86e6) last updated 2018/09/06 11:37:46 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```