### PR TITLE
[2.6] Fix python2.6 `nothing to repeat` nxos terminal plugin bug 

### DIFF
--- a/changelogs/fragments/nxos_terminal_plugin.yaml
+++ b/changelogs/fragments/nxos_terminal_plugin.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix python2.6 `nothing to repeat` nxos terminal plugin bug (https://github.com/ansible/ansible/pull/45271).

--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -30,7 +30,7 @@ from ansible.module_utils._text import to_bytes, to_text
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br'[\r\n](?!\s*<)?(\x1b\S+)*[a-zA-Z_0-9]{1}[a-zA-Z0-9-_.]*[>|#](?:\s*)*(\x1b\S+)*$'),
+        re.compile(br'[\r\n](?!\s*<)?(\x1b\S+)*[a-zA-Z_0-9]{1}[a-zA-Z0-9-_.]*[>|#](?:\s*)(\x1b\S+)*$'),
         re.compile(br'[\r\n]?[a-zA-Z0-9]{1}[a-zA-Z0-9-_.]*\(.+\)#(?:\s*)$')
     ]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
cherry-pick https://github.com/ansible/ansible/commit/c98494d5bf94df78cc8ec41c679b3229688809fc
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

