### PR TITLE
network_cli.py - TypeError: cannot use a string pattern on a bytes-like object

### DIFF
--- a/lib/ansible/plugins/terminal/ce.py
+++ b/lib/ansible/plugins/terminal/ce.py
@@ -28,23 +28,23 @@ from ansible.errors import AnsibleConnectionFailure
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(r'[\r\n]?<.+>(?:\s*)$'),
-        re.compile(r'[\r\n]?\[.+\](?:\s*)$'),
+        re.compile(br'[\r\n]?<.+>(?:\s*)$'),
+        re.compile(br'[\r\n]?\[.+\](?:\s*)$'),
     ]
 
     terminal_stderr_re = [
-        re.compile(r"% ?Error: "),
-        re.compile(r"^% \w+", re.M),
-        re.compile(r"% ?Bad secret"),
-        re.compile(r"invalid input", re.I),
-        re.compile(r"(?:incomplete|ambiguous) command", re.I),
-        re.compile(r"connection timed out", re.I),
-        re.compile(r"[^\r\n]+ not found", re.I),
-        re.compile(r"'[^']' +returned error code: ?\d+"),
-        re.compile(r"syntax error"),
-        re.compile(r"unknown command"),
-        re.compile(r"Error\[\d+\]: ", re.I),
-        re.compile(r"Error:", re.I)
+        re.compile(br"% ?Error: "),
+        re.compile(br"^% \w+", re.M),
+        re.compile(br"% ?Bad secret"),
+        re.compile(br"invalid input", re.I),
+        re.compile(br"(?:incomplete|ambiguous) command", re.I),
+        re.compile(br"connection timed out", re.I),
+        re.compile(br"[^\r\n]+ not found", re.I),
+        re.compile(br"'[^']' +returned error code: ?\d+"),
+        re.compile(br"syntax error"),
+        re.compile(br"unknown command"),
+        re.compile(br"Error\[\d+\]: ", re.I),
+        re.compile(br"Error:", re.I)
     ]
 
     def on_open_shell(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes a type error in _find_prompt of network_cli.py

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudengine (was _network_cli_)

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.1
  config file = None
  configured module search path = ['/home/dpossmann/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib64/python3.5/site-packages/ansible
  executable location = /usr/lib/python-exec/python3.5/ansible
  python version = 3.5.5 (default, Apr 18 2018, 12:00:44) [GCC 6.4.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I'm trying to deploy a Huawei CE6810:
```yaml
- name: CloudEngine facts test
  hosts: huawei
  connection: local
  gather_facts: no
  tasks:
  - name: "Run display version on remote devices"
    ce_command:
      commands: display version
      provider: "{{ cli }}"
```
```yaml
all:
  children:
    muc:
      children:
        huawei: {}
    huawei:
      vars:
        ansible_connection: local
        cli:
          host: "{{ inventory_hostname }}"
          port: 22
          username: "user"
          password: "Password!"
          transport: cli
      hosts:
        `switch10:` {}

```

<!--- Paste verbatim command output below, e.g. before and after your change -->
before:
```
$ ansible-playbook -vvvv --diff -i inventory-huawei/muc.yml huawei.yml 
ansible-playbook 2.6.1
  config file = None
  configured module search path = ['/home/dpossmann/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib64/python3.5/site-packages/ansible
  executable location = /usr/lib/python-exec/python3.5/ansible-playbook
  python version = 3.5.5 (default, Apr 18 2018, 12:00:44) [GCC 6.4.0]
No config file found; using defaults
setting up inventory plugins
Parsed /home/dpossmann/vcs/git.boerse-go.de/ansible/inventory-huawei/muc.yml inventory source with yaml plugin
Loading callback plugin default of type stdout, v2.0 from /usr/lib64/python3.5/site-packages/ansible/plugins/callback/default.py

PLAYBOOK: huawei.yml *********************************************************************************************************************************************************************************************************************************************************
1 plays in huawei.yml

PLAY [CloudEngine facts test] ************************************************************************************************************************************************************************************************************************************************
META: ran handlers

TASK [Run display version on remote devices] *********************************************************************************************************************************************************************************************************************************
task path: /home/dpossmann/vcs/git.boerse-go.de/ansible/huawei.yml:6
<switch10> connection transport is cli
<switch10> using connection plugin network_cli (was local)
<switch10> starting connection from persistent connection plugin
<switch10> local domain socket does not exist, starting it
<switch10> control socket path is /home/dpossmann/.ansible/pc/6d6b1a5022
<switch10> 
The full traceback is:
Traceback (most recent call last):
  File "<string>", line 87, in start
  File "/usr/lib64/python3.5/site-packages/ansible/plugins/connection/network_cli.py", line 325, in _connect
    newline=self._terminal.terminal_inital_prompt_newline)
  File "/usr/lib64/python3.5/site-packages/ansible/plugins/connection/network_cli.py", line 423, in receive
    if self._find_prompt(window):
  File "/usr/lib64/python3.5/site-packages/ansible/plugins/connection/network_cli.py", line 494, in _find_prompt
    if regex.search(response):
TypeError: cannot use a string pattern on a bytes-like object

fatal: [switch10]: FAILED! => {
    "msg": "cannot use a string pattern on a bytes-like object"
}
        to retry, use: --limit @/home/dpossmann/vcs/git.boerse-go.de/ansible/huawei.retry

PLAY RECAP *******************************************************************************************************************************************************************************************************************************************************************
switch10 : ok=0    changed=0    unreachable=0    failed=1
```
With fix:
```
ok: [switch10] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "commands": [
                "display version"
            ],
            "host": "switch10",
            "interval": 1,
            "match": "all",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 22,
            "provider": {
                "host": "switch10",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 22,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "administrator",
                "validate_certs": null
            },
            "retries": 10,
            "ssh_keyfile": null,
            "timeout": null,
            "transport": "cli",
            "use_ssl": null,
            "username": "administrator",
            "validate_certs": null,
            "wait_for": null
        }
    },
    "stdout": [
        "Huawei Versatile Routing Platform Software\nVRP (R) software, Version 8.150 (CE6810LI V200R002C50SPC800)\nCopyright (C) 2012-2017 Huawei Technologies Co., Ltd.\nHUAWEI CE6810-32T16S4Q-LI uptime is 2 days, 22 hours, 49 minutes \nPatch Version: V200R002SPH013\n\nCE6810-32T16S4Q-LI(Master) 1 : uptime is  2 days, 22 hours, 48 minutes\n        StartupTime 2018/09/03   20:26:53\nMemory    Size    : 2048 M bytes\nFlash     Size    : 512 M bytes\nCE6810-32T16S4Q-LI version information                               \n1. PCB    Version : CEM32T16S4QP01    VER A\n2. MAB    Version : 1\n3. Board  Type    : CE6810-32T16S4Q-LI\n4. CPLD1  Version : 102\n6. BIOS   Version : 386\n\nCE6810-32T16S4Q-LI(Standby) 2 : uptime is  2 days, 22 hours, 37 minutes\n        StartupTime 2018/09/03   20:38:25\nMemory    Size    : 2048 M bytes\nFlash     Size    : 512 M bytes\nCE6810-32T16S4Q-LI version information                               \n1. PCB    Version : CEM32T16S4QP01    VER A\n2. MAB    Version : 1\n3. Board  Type    : CE6810-32T16S4Q-LI\n4. CPLD1  Version : 102\n6. BIOS   Version : 386"                                                                                                                                                                                                                                                                
    ],
    "stdout_lines": [
        [
            "Huawei Versatile Routing Platform Software",
            "VRP (R) software, Version 8.150 (CE6810LI V200R002C50SPC800)",
            "Copyright (C) 2012-2017 Huawei Technologies Co., Ltd.",
            "HUAWEI CE6810-32T16S4Q-LI uptime is 2 days, 22 hours, 49 minutes ",
            "Patch Version: V200R002SPH013",
            "",
            "CE6810-32T16S4Q-LI(Master) 1 : uptime is  2 days, 22 hours, 48 minutes",
            "        StartupTime 2018/09/03   20:26:53",
            "Memory    Size    : 2048 M bytes",
            "Flash     Size    : 512 M bytes",
            "CE6810-32T16S4Q-LI version information                               ",
            "1. PCB    Version : CEM32T16S4QP01    VER A",
            "2. MAB    Version : 1",
            "3. Board  Type    : CE6810-32T16S4Q-LI",
            "4. CPLD1  Version : 102",
            "6. BIOS   Version : 386",
            "",
            "CE6810-32T16S4Q-LI(Standby) 2 : uptime is  2 days, 22 hours, 37 minutes",
            "        StartupTime 2018/09/03   20:38:25",
            "Memory    Size    : 2048 M bytes",
            "Flash     Size    : 512 M bytes",
            "CE6810-32T16S4Q-LI version information                               ",
            "1. PCB    Version : CEM32T16S4QP01    VER A",
            "2. MAB    Version : 1",
            "3. Board  Type    : CE6810-32T16S4Q-LI",
            "4. CPLD1  Version : 102",
            "6. BIOS   Version : 386"
        ]
    ]
}

```
