### PR TITLE
Add comment and confirmed option on all junos modules

### DIFF
--- a/lib/ansible/module_utils/network/junos/junos.py
+++ b/lib/ansible/module_utils/network/junos/junos.py
@@ -37,6 +37,7 @@ ACTIONS = frozenset(['merge', 'override', 'replace', 'update', 'set'])
 JSON_ACTIONS = frozenset(['merge', 'override', 'update'])
 FORMATS = frozenset(['xml', 'text', 'json'])
 CONFIG_FORMATS = frozenset(['xml', 'text', 'json', 'set'])
+DEFAULT_COMMENT = 'configured by junos_config'
 
 junos_provider_spec = {
     'host': dict(),
@@ -49,6 +50,8 @@ junos_provider_spec = {
 }
 junos_argument_spec = {
     'provider': dict(type='dict', options=junos_provider_spec),
+    'confirm': dict(default=0, type='int', version_added="2.8"),
+    'comment': dict(default=DEFAULT_COMMENT, version_added="2.8"),
 }
 junos_top_spec = {
     'host': dict(removed_in_version=2.9),
@@ -443,3 +446,18 @@ def to_param_list(module):
             return aggregate
     else:
         return [module.params]
+
+
+def get_commit_args(module):
+    kwargs = {
+        'comment': module.params['comment']
+    }
+
+    confirm = module.params['confirm']
+    if confirm > 0:
+        kwargs.update({
+            'confirm': True,
+            'confirm_timeout': to_text(confirm, errors='surrogate_then_replace')
+        })
+
+    return kwargs

--- a/lib/ansible/modules/network/junos/junos_banner.py
+++ b/lib/ansible/modules/network/junos/junos_banner.py
@@ -104,7 +104,7 @@ diff.prepared:
 import collections
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring
+from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring, get_commit_args
 from ansible.module_utils.network.junos.junos import load_config, map_params_to_obj, map_obj_to_ele
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes, locked_config
 
@@ -162,7 +162,8 @@ def main():
         commit = not module.check_mode
         if diff:
             if commit:
-                commit_configuration(module)
+                kwargs = get_commit_args(module)
+                commit_configuration(module, **kwargs)
             else:
                 discard_changes(module)
             result['changed'] = True

--- a/lib/ansible/modules/network/junos/junos_interface.py
+++ b/lib/ansible/modules/network/junos/junos_interface.py
@@ -195,7 +195,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.netconf import exec_rpc
 from ansible.module_utils.network.common.utils import remove_default_spec
 from ansible.module_utils.network.common.utils import conditional
-from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring
+from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring, get_commit_args
 from ansible.module_utils.network.junos.junos import load_config, map_params_to_obj, map_obj_to_ele
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes, locked_config, to_param_list
 
@@ -317,7 +317,8 @@ def main():
         commit = not module.check_mode
         if diff:
             if commit:
-                commit_configuration(module)
+                kwargs = get_commit_args(module)
+                commit_configuration(module, **kwargs)
             else:
                 discard_changes(module)
             result['changed'] = True

--- a/lib/ansible/modules/network/junos/junos_l2_interface.py
+++ b/lib/ansible/modules/network/junos/junos_l2_interface.py
@@ -145,7 +145,7 @@ from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
-from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring
+from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring, get_commit_args
 from ansible.module_utils.network.junos.junos import load_config, map_params_to_obj, map_obj_to_ele
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes, locked_config, to_param_list
 
@@ -256,7 +256,8 @@ def main():
         commit = not module.check_mode
         if diff:
             if commit:
-                commit_configuration(module)
+                kwargs = get_commit_args(module)
+                commit_configuration(module, **kwargs)
             else:
                 discard_changes(module)
             result['changed'] = True

--- a/lib/ansible/modules/network/junos/junos_l3_interface.py
+++ b/lib/ansible/modules/network/junos/junos_l3_interface.py
@@ -106,7 +106,7 @@ from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
-from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring
+from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring, get_commit_args
 from ansible.module_utils.network.junos.junos import load_config, map_params_to_obj, map_obj_to_ele
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes, locked_config, to_param_list
 
@@ -186,7 +186,8 @@ def main():
         commit = not module.check_mode
         if diff:
             if commit:
-                commit_configuration(module)
+                kwargs = get_commit_args(module)
+                commit_configuration(module, **kwargs)
             else:
                 discard_changes(module)
             result['changed'] = True

--- a/lib/ansible/modules/network/junos/junos_linkagg.py
+++ b/lib/ansible/modules/network/junos/junos_linkagg.py
@@ -164,7 +164,7 @@ from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
-from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring
+from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring, get_commit_args
 from ansible.module_utils.network.junos.junos import load_config, map_params_to_obj, map_obj_to_ele, to_param_list
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes, locked_config, get_configuration
 
@@ -328,7 +328,8 @@ def main():
         commit = not module.check_mode
         if diff:
             if commit:
-                commit_configuration(module)
+                kwargs = get_commit_args(module)
+                commit_configuration(module, **kwargs)
             else:
                 discard_changes(module)
             result['changed'] = True

--- a/lib/ansible/modules/network/junos/junos_lldp.py
+++ b/lib/ansible/modules/network/junos/junos_lldp.py
@@ -101,7 +101,7 @@ diff.prepared:
 import collections
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring
+from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring, get_commit_args
 from ansible.module_utils.network.junos.junos import load_config, map_params_to_obj, map_obj_to_ele
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes, locked_config
 
@@ -180,7 +180,8 @@ def main():
         commit = not module.check_mode
         if diff:
             if commit:
-                commit_configuration(module)
+                kwargs = get_commit_args(module)
+                commit_configuration(module, **kwargs)
             else:
                 discard_changes(module)
             result['changed'] = True

--- a/lib/ansible/modules/network/junos/junos_lldp_interface.py
+++ b/lib/ansible/modules/network/junos/junos_lldp_interface.py
@@ -96,7 +96,7 @@ diff.prepared:
 import collections
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.junos.junos import junos_argument_spec
+from ansible.module_utils.network.junos.junos import junos_argument_spec, get_commit_args
 from ansible.module_utils.network.junos.junos import load_config, map_params_to_obj, map_obj_to_ele, tostring
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes, locked_config
 
@@ -147,7 +147,8 @@ def main():
         commit = not module.check_mode
         if diff:
             if commit:
-                commit_configuration(module)
+                kwargs = get_commit_args(module)
+                commit_configuration(module, **kwargs)
             else:
                 discard_changes(module)
             result['changed'] = True

--- a/lib/ansible/modules/network/junos/junos_logging.py
+++ b/lib/ansible/modules/network/junos/junos_logging.py
@@ -142,7 +142,7 @@ from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
-from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring
+from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring, get_commit_args
 from ansible.module_utils.network.junos.junos import load_config, map_params_to_obj, map_obj_to_ele, to_param_list
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes, locked_config
 
@@ -269,7 +269,8 @@ def main():
         commit = not module.check_mode
         if diff:
             if commit:
-                commit_configuration(module)
+                kwargs = get_commit_args(module)
+                commit_configuration(module, **kwargs)
             else:
                 discard_changes(module)
             result['changed'] = True

--- a/lib/ansible/modules/network/junos/junos_netconf.py
+++ b/lib/ansible/modules/network/junos/junos_netconf.py
@@ -80,7 +80,7 @@ import re
 from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.junos.junos import junos_argument_spec, get_connection
+from ansible.module_utils.network.junos.junos import junos_argument_spec, get_connection, get_commit_args
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes
 from ansible.module_utils.network.common.utils import to_list
 from ansible.module_utils.six import iteritems
@@ -156,8 +156,8 @@ def load_config(module, config, commit=False):
     diff = resp.get('diff', '')
     if diff:
         if commit:
-            commit_configuration(module)
-
+            kwargs = get_commit_args(module)
+            commit_configuration(module, **kwargs)
         else:
             discard_changes(module)
 

--- a/lib/ansible/modules/network/junos/junos_static_route.py
+++ b/lib/ansible/modules/network/junos/junos_static_route.py
@@ -138,7 +138,7 @@ from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
-from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring
+from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring, get_commit_args
 from ansible.module_utils.network.junos.junos import load_config, map_params_to_obj, map_obj_to_ele, to_param_list
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes, locked_config
 
@@ -221,7 +221,8 @@ def main():
         commit = not module.check_mode
         if diff:
             if commit:
-                commit_configuration(module)
+                kwargs = get_commit_args(module)
+                commit_configuration(module, **kwargs)
             else:
                 discard_changes(module)
             result['changed'] = True

--- a/lib/ansible/modules/network/junos/junos_system.py
+++ b/lib/ansible/modules/network/junos/junos_system.py
@@ -109,7 +109,7 @@ diff.prepared:
 import collections
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring
+from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring, get_commit_args
 from ansible.module_utils.network.junos.junos import load_config, map_params_to_obj, map_obj_to_ele
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes, locked_config
 
@@ -175,7 +175,8 @@ def main():
         commit = not module.check_mode
         if diff:
             if commit:
-                commit_configuration(module)
+                kwargs = get_commit_args(module)
+                commit_configuration(module, **kwargs)
             else:
                 discard_changes(module)
             result['changed'] = True

--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -142,7 +142,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.network.common.utils import remove_default_spec
-from ansible.module_utils.network.junos.junos import junos_argument_spec, get_connection, tostring
+from ansible.module_utils.network.junos.junos import junos_argument_spec, get_connection, tostring, get_commit_args
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes
 from ansible.module_utils.network.junos.junos import load_config, locked_config
 from ansible.module_utils.six import iteritems
@@ -333,7 +333,8 @@ def main():
         commit = not module.check_mode
         if diff:
             if commit:
-                commit_configuration(module)
+                kwargs = get_commit_args(module)
+                commit_configuration(module, **kwargs)
             else:
                 discard_changes(module)
             result['changed'] = True

--- a/lib/ansible/modules/network/junos/junos_vlan.py
+++ b/lib/ansible/modules/network/junos/junos_vlan.py
@@ -126,7 +126,7 @@ from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
-from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring
+from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring, get_commit_args
 from ansible.module_utils.network.junos.junos import load_config, map_params_to_obj, map_obj_to_ele, to_param_list
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes, locked_config
 
@@ -222,7 +222,8 @@ def main():
         commit = not module.check_mode
         if diff:
             if commit:
-                commit_configuration(module)
+                kwargs = get_commit_args(module)
+                commit_configuration(module, **kwargs)
             else:
                 discard_changes(module)
             result['changed'] = True

--- a/lib/ansible/modules/network/junos/junos_vrf.py
+++ b/lib/ansible/modules/network/junos/junos_vrf.py
@@ -173,7 +173,7 @@ from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
-from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring
+from ansible.module_utils.network.junos.junos import junos_argument_spec, tostring, get_commit_args
 from ansible.module_utils.network.junos.junos import load_config, map_params_to_obj, map_obj_to_ele, to_param_list
 from ansible.module_utils.network.junos.junos import commit_configuration, discard_changes, locked_config
 
@@ -256,7 +256,8 @@ def main():
         commit = not module.check_mode
         if diff:
             if commit:
-                commit_configuration(module)
+                kwargs = get_commit_args(module)
+                commit_configuration(module, **kwargs)
             else:
                 discard_changes(module)
             result['changed'] = True

--- a/lib/ansible/utils/module_docs_fragments/junos.py
+++ b/lib/ansible/utils/module_docs_fragments/junos.py
@@ -68,6 +68,25 @@ options:
             used to authenticate the SSH session. If the value is not specified in
             the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
             will be used instead.
+  confirm:
+    description:
+      - The C(confirm) argument will configure a time out value in minutes
+        for the commit to be confirmed before it is automatically
+        rolled back.  If the C(confirm) argument is set to False, this
+        argument is silently ignored.  If the value for this argument
+        is set to 0, the commit is confirmed immediately.
+      - Not work on C(junos_command), C(junos_fact), C(junos_package), C(junos_rpc), C(junos_scp)
+    default: 0
+    version_added: "2.8"
+  comment:
+    description:
+      - The C(comment) argument specifies a text string to be used
+        when committing the configuration.  If the C(confirm) argument
+        is set to False, this argument is silently ignored.
+      - Not work on C(junos_command), C(junos_fact), C(junos_package), C(junos_rpc), C(junos_scp)
+    default: configured by junos_config
+    version_added: "2.8"
+
 notes:
   - For information on using CLI and netconf see the :ref:`Junos OS Platform Options guide <junos_platform_options>`
   - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I move `comment` and `comfirmed` option from `junos_config` to all junos modules.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
junos_*

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
devel
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Because `C(junos_command), C(junos_fact), C(junos_package), C(junos_rpc), C(junos_scp)` not work with these commands, do I need to add somethings to it?
