### PR TITLE
Backport 2.7 - Select image facts by region

### DIFF
--- a/lib/ansible/modules/cloud/scaleway/scaleway_image_facts.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_image_facts.py
@@ -26,7 +26,7 @@ extends_documentation_fragment: scaleway
 options:
 
   region:
-    version_added: "2.8"
+    version_added: "2.7"
     description:
     - Scaleway compute zone
     required: true

--- a/lib/ansible/modules/cloud/scaleway/scaleway_image_facts.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_image_facts.py
@@ -22,11 +22,25 @@ author:
   - "Yanis Guenane (@Spredzy)"
   - "Remy Leone (@sieben)"
 extends_documentation_fragment: scaleway
+
+options:
+
+  region:
+    version_added: "2.8"
+    description:
+    - Scaleway compute zone
+    required: true
+    choices:
+      - ams1
+      - EMEA-NL-EVS
+      - par1
+      - EMEA-FR-PAR1
 '''
 
 EXAMPLES = r'''
 - name: Gather Scaleway images facts
   scaleway_image_facts:
+    region: par1
 '''
 
 RETURN = r'''
@@ -72,8 +86,7 @@ scaleway_image_facts:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.scaleway import (
-    Scaleway, ScalewayException, scaleway_argument_spec
-)
+    Scaleway, ScalewayException, scaleway_argument_spec, SCALEWAY_LOCATION)
 
 
 class ScalewayImageFacts(Scaleway):
@@ -82,10 +95,17 @@ class ScalewayImageFacts(Scaleway):
         super(ScalewayImageFacts, self).__init__(module)
         self.name = 'images'
 
+        region = module.params["region"]
+        self.module.params['api_url'] = SCALEWAY_LOCATION[region]["api_endpoint"]
+
 
 def main():
+    argument_spec = scaleway_argument_spec()
+    argument_spec.update(dict(
+        region=dict(required=True, choices=SCALEWAY_LOCATION.keys()),
+    ))
     module = AnsibleModule(
-        argument_spec=scaleway_argument_spec(),
+        argument_spec=argument_spec,
         supports_check_mode=True,
     )
 

--- a/test/legacy/roles/scaleway_image_facts/tasks/main.yml
+++ b/test/legacy/roles/scaleway_image_facts/tasks/main.yml
@@ -1,5 +1,9 @@
+# SCW_API_KEY='XXX' ansible-playbook ./test/legacy/scaleway.yml --tags test_scaleway_image_facts
+
+
 - name: Get image informations and register it in a variable
   scaleway_image_facts:
+    region: par1
   register: images
 
 - name: Display images variable
@@ -10,3 +14,17 @@
   assert:
     that:
       - images is success
+
+- name: Get image informations from ams1 and register it in a variable
+  scaleway_image_facts:
+    region: ams1
+  register: images_ams1
+
+- name: Display images variable from ams1
+  debug:
+    var: images_ams1
+
+- name: Ensure retrieval of images facts is success
+  assert:
+    that:
+      - images_ams1 is success


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/44965

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- lib/ansible/modules/cloud/scaleway/scaleway_image_facts.py

##### ANSIBLE VERSION

```
ansible 2.7.0.dev0
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible-2.7.0.dev0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```