### PR TITLE
fix version number because this was backported

### DIFF
--- a/lib/ansible/modules/cloud/scaleway/scaleway_image_facts.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_image_facts.py
@@ -26,7 +26,7 @@ extends_documentation_fragment: scaleway
 options:
 
   region:
-    version_added: "2.8"
+    version_added: "2.7"
     description:
     - Scaleway compute zone
     required: true


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
fix version number because the fix was backported https://github.com/ansible/ansible/pull/45297

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
scaleway_image_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (modules/cloud/scaleway/scaleway_image_facts 20da50b499) last updated 2018/09/06 12:40:34 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```

