### PR TITLE
adds support for null values to the ternary filter

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1064,7 +1064,7 @@ To use one value on true and another on false (new in version 1.9)::
 
 To use one value on true, one value on false and a third value on null (new in version 2.8)::
 
-   {{ (name == "John") | ternary('Mr', 'Ms', omit) }}
+   {{ enabled == True | ternary('no shutdown', 'shutdown', omit) }}
 
 To concatenate a list into a string::
 

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1062,6 +1062,10 @@ To use one value on true and another on false (new in version 1.9)::
 
     {{ (name == "John") | ternary('Mr','Ms') }}
 
+To use one value on true, one value on false and a third value on null (new in version 2.8)::
+
+   {{ (name == "John") | ternary('Mr', 'Ms', omit) }}
+
 To concatenate a list into a string::
 
     {{ list | join(" ") }}

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1064,7 +1064,7 @@ To use one value on true and another on false (new in version 1.9)::
 
 To use one value on true, one value on false and a third value on null (new in version 2.8)::
 
-   {{ enabled == True | ternary('no shutdown', 'shutdown', omit) }}
+   {{ enabled | ternary('no shutdown', 'shutdown', omit) }}
 
 To concatenate a list into a string::
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -178,9 +178,11 @@ def regex_search(value, regex, *args, **kwargs):
             return items
 
 
-def ternary(value, true_val, false_val):
+def ternary(value, true_val, false_val, none_val=None):
     '''  value ? true_val : false_val '''
-    if bool(value):
+    if value is None and none_val is not None:
+        return none_val
+    elif bool(value):
         return true_val
     else:
         return false_val


### PR DESCRIPTION
This change adds a third optional argument to the ternary filter to
handle a null value.  If the third option is specified null and false
are treated differently.

For instance, take the following example:

{{ enabled | ternary('no shutdown', 'shutdown') }}

If enabled == True, then 'no shutdown' is used.
If enabled in (False, None), then 'shutdown' is used.

With this change the following is possible:

{{ enabled | ternary('no shutdown', 'shutdown', omit) }}

If enabled == True, then 'no shutdown'
If enabled == False, then 'shutdown'
If enabled == None, then omit

