### PR TITLE
VPC peer module unhandled exception on bad peering ID

### DIFF
--- a/changelogs/fragments/ec2_vpc_peer_describe_peer_with_exception_handling.yaml
+++ b/changelogs/fragments/ec2_vpc_peer_describe_peer_with_exception_handling.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Handle ClientError exceptions when describing VPC peering connections.

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
@@ -333,7 +333,7 @@ def peer_status(client, module):
     try:
         vpc_peering_connection = client.describe_vpc_peering_connections(**params)
         return vpc_peering_connection['VpcPeeringConnections'][0]['Status']['Code']
-    except is_boto3_error_code('InvalidVpcPeeringConnectionId.Malformed') as e:
+    except is_boto3_error_code('InvalidVpcPeeringConnectionId.Malformed') as e:  # pylint: disable=duplicate-except
         module.fail_json(msg='Malformed connection ID: {0}'.format(e), traceback=traceback.format_exc())
     except botocore.exceptions.ClientError as e:
         module.fail_json(msg='Error while describing peering connection by peering_id: {0}'.format(e), traceback=traceback.format_exc())

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
@@ -335,7 +335,7 @@ def peer_status(client, module):
         return vpc_peering_connection['VpcPeeringConnections'][0]['Status']['Code']
     except is_boto3_error_code('InvalidVpcPeeringConnectionId.Malformed') as e:  # pylint: disable=duplicate-except
         module.fail_json(msg='Malformed connection ID: {0}'.format(e), traceback=traceback.format_exc())
-    except botocore.exceptions.ClientError as e:
+    except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
         module.fail_json(msg='Error while describing peering connection by peering_id: {0}'.format(e), traceback=traceback.format_exc())
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
 <!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
The ec2_vpc_peer module fails when a non-existent or malformed `peering_id` is specified

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vpc_peer

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (vpc_peer_exc_handling 5e7144fd10) last updated 2018/09/06 14:22:08 (GMT -400)
  config file = None
  configured module search path = ['/home/ryansb/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ryansb/code/ansible/lib/ansible
  executable location = /home/ryansb/code/ansible/bin/ansible
  python version = 3.6.3 (default, Dec 11 2017, 12:52:46) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

# Before 
  File "/tmp/ansible_ec2_vpc_peer_payload_2qy0k5d_/__main__.py", line 422, in <module>
  File "/tmp/ansible_ec2_vpc_peer_payload_2qy0k5d_/__main__.py", line 417, in main                      
  File "/tmp/ansible_ec2_vpc_peer_payload_2qy0k5d_/__main__.py", line 339, in accept_reject             
  File "/tmp/ansible_ec2_vpc_peer_payload_2qy0k5d_/__main__.py", line 331, in peer_status
  File "/usr/local/lib/python3.6/dist-packages/botocore/client.py", line 314, in _api_call              
    return self._make_api_call(operation_name, kwargs)                                                  
  File "/usr/local/lib/python3.6/dist-packages/botocore/client.py", line 612, in _make_api_call         
    raise error_class(parsed_response, operation_name)                                                  
botocore.exceptions.ClientError: An error occurred (InvalidVpcPeeringConnectionId.Malformed) when calling
 the DescribeVpcPeeringConnections operation: Invalid id: "foobar" (expecting "pcx-...")  

# After

msg: Malformed Connection ID: An error occurred (InvalidVpcPeeringConnectionId.Malformed) when calling the DescribeVpcPeeringConnections operation: Invalid id: "foobar" (expecting "pcx-...")  
```
