### PR TITLE
[aws] lambda_policy fix update when principal is an account number (#…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda_policy.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_policy.py
@@ -236,7 +236,14 @@ def extract_statement(policy, sid):
     for statement in policy['Statement']:
         if statement['Sid'] == sid:
             policy_statement['action'] = statement['Action']
-            policy_statement['principal'] = statement['Principal']['Service']
+            try:
+                policy_statement['principal'] = statement['Principal']['Service']
+            except KeyError:
+                pass
+            try:
+                policy_statement['principal'] = statement['Principal']['AWS']
+            except KeyError:
+                pass
             try:
                 policy_statement['source_arn'] = statement['Condition']['ArnLike']['AWS:SourceArn']
             except KeyError:


### PR DESCRIPTION
…44871)

Fix KeyError on update when principal is an account number
(cherry picked from commit 1f3e7ea061c69c81efa09318b21812c5bca7d1a6)

##### SUMMARY
Backport #44871

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lambda_policy

##### ANSIBLE VERSION
```
ansible 2.7.0b1.post0
```
