### PR TITLE
[aws] ec2_metadata_facts URL encode the metadata URL (#43394)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
@@ -423,7 +423,7 @@ import time
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
 from ansible.module_utils.urls import fetch_url
-
+from ansible.module_utils.six.moves.urllib.parse import quote
 
 socket.setdefaulttimeout(5)
 
@@ -444,13 +444,14 @@ class Ec2Metadata(object):
         self._prefix = 'ansible_ec2_%s'
 
     def _fetch(self, url):
-        response, info = fetch_url(self.module, url, force=True)
+        encoded_url = quote(url, safe='%/:=&?~#+!$,;\'@()*[]')
+        response, info = fetch_url(self.module, encoded_url, force=True)
 
         if info.get('status') not in (200, 404):
             time.sleep(3)
             # request went bad, retry once then raise
             self.module.warn('Retrying query to metadata service. First attempt failed: {0}'.format(info['msg']))
-            response, info = fetch_url(self.module, url, force=True)
+            response, info = fetch_url(self.module, encoded_url, force=True)
             if info.get('status') not in (200, 404):
                 # fail out now
                 self.module.fail_json(msg='Failed to retrieve metadata from AWS: {0}'.format(info['msg']), response=info)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #42371 and #43378.

If a field has a space in it, the resulting constructed URL would be invalid. This change URL encodes the URL correctly so that the metadata service will return a 404 which will be safely ignored (since the field with the SSH key name doesn't actually return any data).

(cherry picked from commit 4ce09ea62da1741a3852ad51b4a565821ab50565)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
