### PR TITLE
[aws] ecs_taskdefinition - check for change of role arn (#44942)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -390,8 +390,11 @@ def main():
 
                 return True
 
-            def _task_definition_matches(requested_volumes, requested_containers, existing_task_definition):
+            def _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, existing_task_definition):
                 if td['status'] != "ACTIVE":
+                    return None
+
+                if requested_task_role_arn != td.get('taskRoleArn', ""):
                     return None
 
                 existing_volumes = td.get('volumes', []) or []
@@ -433,9 +436,10 @@ def main():
 
             # No revision explicitly specified. Attempt to find an active, matching revision that has all the properties requested
             for td in existing_definitions_in_family:
-                requested_volumes = module.params.get('volumes', []) or []
-                requested_containers = module.params.get('containers', []) or []
-                existing = _task_definition_matches(requested_volumes, requested_containers, td)
+                requested_volumes = module.params['volumes'] or []
+                requested_containers = module.params['containers'] or []
+                requested_task_role_arn = module.params['task_role_arn']
+                existing = _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, td)
 
                 if existing:
                     break


### PR DESCRIPTION
* check role arn for ecs task definition

If the task role in a ECS task definition changes ansible should create a new revsion of the task definition.

(cherry picked from commit 71c4355d58323297454ff3877fe6469eb36b6347)

##### SUMMARY
Backport #44942

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ecs_taskdefinition

##### ANSIBLE VERSION

```
ansible 2.7.0b1.post0
```
