### PR TITLE
[aws] s3_lifecycle fix backwards compatibility without providing prefix

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_lifecycle.py
+++ b/lib/ansible/modules/cloud/amazon/s3_lifecycle.py
@@ -207,7 +207,7 @@ def create_lifecycle_rule(client, module):
     noncurrent_version_transition_days = module.params.get("noncurrent_version_transition_days")
     noncurrent_version_transitions = module.params.get("noncurrent_version_transitions")
     noncurrent_version_storage_class = module.params.get("noncurrent_version_storage_class")
-    prefix = module.params.get("prefix")
+    prefix = module.params.get("prefix") or ""
     rule_id = module.params.get("rule_id")
     status = module.params.get("status")
     storage_class = module.params.get("storage_class")
@@ -280,7 +280,9 @@ def create_lifecycle_rule(client, module):
     if current_lifecycle_rules:
         # If rule ID exists, use that for comparison otherwise compare based on prefix
         for existing_rule in current_lifecycle_rules:
-            if rule['Filter']['Prefix'] == existing_rule['Filter']['Prefix']:
+            if rule.get('ID') == existing_rule.get('ID') and rule['Filter']['Prefix'] != existing_rule.get('Filter', {}).get('Prefix', ''):
+                existing_rule.pop('ID')
+            elif rule_id is None and rule['Filter']['Prefix'] == existing_rule.get('Filter', {}).get('Prefix', ''):
                 existing_rule.pop('ID')
             if rule.get('ID') == existing_rule.get('ID'):
                 changed_, appended_ = update_or_append_rule(rule, existing_rule, purge_transitions, lifecycle_configuration)
@@ -361,9 +363,9 @@ def merge_transitions(updated_rule, updating_rule):
     # in updating_rule to updated_rule
     updated_transitions = {}
     updating_transitions = {}
-    for transition in updated_rule['Transitions']:
+    for transition in updated_rule.get('Transitions', []):
         updated_transitions[transition['StorageClass']] = transition
-    for transition in updating_rule['Transitions']:
+    for transition in updating_rule.get('Transitions', []):
         updating_transitions[transition['StorageClass']] = transition
     for storage_class, transition in updating_transitions.items():
         if updated_transitions.get(storage_class) is None:

--- a/test/integration/targets/s3_lifecycle/tasks/main.yml
+++ b/test/integration/targets/s3_lifecycle/tasks/main.yml
@@ -30,7 +30,7 @@
       s3_lifecycle:
         name: "{{ resource_prefix }}-testbucket-ansible"
         expiration_days: 300
-        prefix: /pre
+        prefix: ''
         <<: *aws_connection_info
       register: output
 
@@ -42,7 +42,6 @@
       s3_lifecycle:
         name: "{{ resource_prefix }}-testbucket-ansible"
         expiration_days: 300
-        prefix: /pre
         <<: *aws_connection_info
       register: output
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Because boto3 does more parameter validation than boto, use .get() instead of assuming a rule has a Transitions or Filter key (both of which are optional)

Fixes #44557

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
