### PR TITLE
[aws] Remove deprecated `ec2_vpc_dhcp_options` alias

### DIFF
--- a/lib/ansible/modules/cloud/amazon/_ec2_vpc_dhcp_options.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_vpc_dhcp_options.py
@@ -1,1 +1,0 @@
-ec2_vpc_dhcp_option.py

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option.py
@@ -286,10 +286,6 @@ def main():
     )
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-    if module._name == 'ec2_vpc_dhcp_options':
-        module.deprecate("The 'ec2_vpc_dhcp_options' module has been renamed "
-                         "'ec2_vpc_dhcp_option' (option is no longer plural)",
-                         version=2.8)
 
     params = module.params
     found = False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Remove deprecated `ec2_vpc_dhcp_options` alias. In 2.8 it is removed leaving only `ec2_vpc_dhcp_option`. 

Fixes #44989 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
