### PR TITLE
[aws] Remove deprecated `ec2_vpc_dhcp_options_facts` alias

### DIFF
--- a/lib/ansible/modules/cloud/amazon/_ec2_vpc_dhcp_options_facts.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_vpc_dhcp_options_facts.py
@@ -1,1 +1,0 @@
-ec2_vpc_dhcp_option_facts.py

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option_facts.py
@@ -124,10 +124,6 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
-    if module._name == 'ec2_vpc_dhcp_options_facts':
-        module.deprecate("The 'ec2_vpc_dhcp_options_facts' module has been renamed "
-                         "'ec2_vpc_dhcp_option_facts' (option is no longer plural)",
-                         version=2.8)
 
     # Validate Requirements
     if not HAS_BOTO3:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Remove deprecated `ec2_vpc_dhcp_options_facts` alias of `ec2_vpc_dhcp_option_facts` module.

Fixes #44990

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
