### PR TITLE
Update the description of azure_rm_virtualmachine.py

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -37,6 +37,9 @@ description:
       must contain a virtual network with at least one subnet.
     - Currently requires an image found in the Azure Marketplace. Use azure_rm_virtualmachineimage_facts module
       to discover the publisher, offer, sku and version of a particular image.
+    - If you need to use the custom_data option, some images in the marketplace are not cloud-init ready. Thus, data 
+      sent to the custom_data option will be ignored. If the image you are attempting to use is not in [this list](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/using-cloud-init#cloud-init-overview),
+      you will need to follow the instructions [here](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cloudinit-prepare-custom-image) to prepare an image to use cloud-init.
 
 options:
     resource_group:


### PR DESCRIPTION

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
```
lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
```
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.6.3
```

##### SUMMARY
A lot of Azure images are not cloud-init ready and need to be prepared manually before attempting to use the custom_data option of this module. Adding a line to the description to make others aware. If, like me, they are used to working with AWS AMIs that all seem to have cloud-init baked in, this could prevent some troubleshooting as to why their custom_data scripts aren't running in Azure.
