### PR TITLE
Update azure_rm_virtualmachine.py

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -30,7 +30,7 @@ description:
       M(azure_rm_virtualmachineimage_facts). In Ansible 2.5 and newer, custom images can be used as well, see the
       examples for more details.
     - If you need to use the I(custom_data) option, many images in the marketplace are not cloud-init ready. Thus, data
-      sent to I(custom_data) would be ignored. If the image you are attempting to use is not listed in 
+      sent to I(custom_data) would be ignored. If the image you are attempting to use is not listed in
       U(https://docs.microsoft.com/en-us/azure/virtual-machines/linux/using-cloud-init#cloud-init-overview),
       follow these steps U(https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cloudinit-prepare-custom-image).
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -32,8 +32,7 @@ description:
     - If you need to use the I(custom_data) option, many images in the marketplace are not cloud-init ready. Thus, data
       sent to the I(custom_data) would be ignored. If the image you are attempting to use is not in
       L(this list, https://docs.microsoft.com/en-us/azure/virtual-machines/linux/using-cloud-init#cloud-init-overview),
-      you will need to follow the instructions
-      L(here, https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cloudinit-prepare-custom-image).
+      follow L(this, https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cloudinit-prepare-custom-image).
 
 options:
     resource_group:

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -29,9 +29,11 @@ description:
     - Before Ansible 2.5, this required an image found in the Azure Marketplace which can be discovered with
       M(azure_rm_virtualmachineimage_facts). In Ansible 2.5 and newer, custom images can be used as well, see the
       examples for more details.
-    - If you need to use the I(custom_data) option, many images in the marketplace are not cloud-init ready. Thus, data 
-      sent to the I(custom_data) would be ignored. If the image you are attempting to use is not in L(this list, https://docs.microsoft.com/en-us/azure/virtual-machines/linux/using-cloud-init#cloud-init-overview),
-      you will need to follow the instructions L(here, https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cloudinit-prepare-custom-image) to prepare your image to use cloud-init.
+    - If you need to use the I(custom_data) option, many images in the marketplace are not cloud-init ready. Thus, data
+      sent to the I(custom_data) would be ignored. If the image you are attempting to use is not in
+      L(this list, https://docs.microsoft.com/en-us/azure/virtual-machines/linux/using-cloud-init#cloud-init-overview),
+      you will need to follow the instructions
+      L(here, https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cloudinit-prepare-custom-image).
 
 options:
     resource_group:

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -30,9 +30,9 @@ description:
       M(azure_rm_virtualmachineimage_facts). In Ansible 2.5 and newer, custom images can be used as well, see the
       examples for more details.
     - If you need to use the I(custom_data) option, many images in the marketplace are not cloud-init ready. Thus, data
-      sent to I(custom_data) would be ignored. If the image you are attempting to use is not in
-      L(this list, https://docs.microsoft.com/en-us/azure/virtual-machines/linux/using-cloud-init#cloud-init-overview),
-      follow L(these steps, https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cloudinit-prepare-custom-image).
+      sent to I(custom_data) would be ignored. If the image you are attempting to use is not listed in 
+      U(https://docs.microsoft.com/en-us/azure/virtual-machines/linux/using-cloud-init#cloud-init-overview),
+      follow these steps U(https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cloudinit-prepare-custom-image).
 
 options:
     resource_group:

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -30,9 +30,9 @@ description:
       M(azure_rm_virtualmachineimage_facts). In Ansible 2.5 and newer, custom images can be used as well, see the
       examples for more details.
     - If you need to use the I(custom_data) option, many images in the marketplace are not cloud-init ready. Thus, data
-      sent to the I(custom_data) would be ignored. If the image you are attempting to use is not in
+      sent to I(custom_data) would be ignored. If the image you are attempting to use is not in
       L(this list, https://docs.microsoft.com/en-us/azure/virtual-machines/linux/using-cloud-init#cloud-init-overview),
-      follow L(this, https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cloudinit-prepare-custom-image).
+      follow L(these steps, https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cloudinit-prepare-custom-image).
 
 options:
     resource_group:

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -29,6 +29,9 @@ description:
     - Before Ansible 2.5, this required an image found in the Azure Marketplace which can be discovered with
       M(azure_rm_virtualmachineimage_facts). In Ansible 2.5 and newer, custom images can be used as well, see the
       examples for more details.
+    - If you need to use the I(custom_data) option, many images in the marketplace are not cloud-init ready. Thus, data 
+      sent to the I(custom_data) would be ignored. If the image you are attempting to use is not in L(this list, https://docs.microsoft.com/en-us/azure/virtual-machines/linux/using-cloud-init#cloud-init-overview),
+      you will need to follow the instructions L(here, https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cloudinit-prepare-custom-image) to prepare your image to use cloud-init.
 
 options:
     resource_group:


### PR DESCRIPTION
##### SUMMARY
A lot of Azure images are not cloud-init ready and need to be prepared manually before attempting to use the custom_data option of this module. Adding a line to the description to make others aware. If, like me, they are used to working with AWS AMIs that all seem to have cloud-init baked in, this could prevent some troubleshooting as to why their custom_data scripts aren't running in Azure.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
```
lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
``` 
##### ANSIBLE VERSION
```
ansible 2.6.3
```

##### ADDITIONAL INFORMATION
N/A
