### PR TITLE
fix: check execute_lock boolean, not lock string var

### DIFF
--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -350,7 +350,7 @@ def main():
                 result['changed'] = True
                 module.exit_json(**result)
 
-            if lock:
+            if execute_lock:
                 conn.lock(target=target)
                 locked = True
             if before is None:


### PR DESCRIPTION
##### SUMMARY
Check boolean var set earlier, instead of string as passed in
Might help in future to use more explicit var names e.g. lock_type, should_execute_lock etc

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modules/network/netconf/netconf_config.py

##### ANSIBLE VERSION
```
2.8.0.dev0
```