### PR TITLE
Correct version_added for strategy host_pinned

### DIFF
--- a/lib/ansible/plugins/strategy/host_pinned.py
+++ b/lib/ansible/plugins/strategy/host_pinned.py
@@ -28,7 +28,7 @@ DOCUMENTATION = '''
           Ansible will not wait for other hosts to finish the current task before queuing the next task for a host that has finished.
           Once a host is done with the play, it opens it's slot to a new host that was waiting to start.
           Other than that, it behaves just like the "free" strategy.
-    version_added: "2.0"
+    version_added: "2.7"
     author: Ansible Core Team
 '''
 


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/ansible/pull/44586 added this strategy, however, it was incorrectly documented to be included since 2.0.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
host_pinned

##### ANSIBLE VERSION
```
2.7
```