### PR TITLE
[2.7] Add ambiguous command check as the error message is not persistent on nexus devices

### DIFF
--- a/changelogs/fragments/nxos_ambiguous_command_check.yaml
+++ b/changelogs/fragments/nxos_ambiguous_command_check.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Add ambiguous command check as the error message is not persistent on nexus devices (https://github.com/ansible/ansible/pull/45337).

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -161,7 +161,7 @@ class Cli:
 
                 if network_api == 'cliconf' and out:
                     for index, resp in enumerate(out):
-                        if 'Invalid command at' in resp and 'json' in resp:
+                        if ('Invalid command at' in resp or 'Ambiguous command at' in resp) and 'json' in resp:
                             if commands[index]['output'] == 'json':
                                 commands[index]['output'] = 'text'
                                 out = connection.run_commands(commands, check_rc)

--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -27,7 +27,8 @@ options:
     description:
       - The config to be pushed to the network device. This argument
         is mutually exclusive with C(rollback) and either one of the
-        option should be given as input.
+        option should be given as input. The config should have
+        indentation that the device uses.
     type: 'str'
   commit:
     description:
@@ -120,10 +121,7 @@ EXAMPLES = """
 
 - name: Use diff_match
   cli_config:
-    config: |
-      interface loopback999
-      no description
-      shutdown
+    config: "{{ lookup('file', 'interface_config') }}"
     diff_match: none
 
 - name: nxos replace config


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
