### PR TITLE
[2.6] Add ambiguous command check as the error message is not persistent on nexus devices

### DIFF
--- a/changelogs/fragments/nxos_ambiguous_command_check.yaml
+++ b/changelogs/fragments/nxos_ambiguous_command_check.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Add ambiguous command check as the error message is not persistent on nexus devices (https://github.com/ansible/ansible/pull/45337).

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -156,7 +156,7 @@ class Cli:
 
                 if network_api == 'cliconf' and out:
                     for index, resp in enumerate(out):
-                        if 'Invalid command at' in resp and 'json' in resp:
+                        if ('Invalid command at' in resp or 'Ambiguous command at' in resp) and 'json' in resp:
                             if commands[index]['output'] == 'json':
                                 commands[index]['output'] = 'text'
                                 out = connection.run_commands(commands, check_rc)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
