### PR TITLE
Backport: Correct version_added for strategy host_pinned (#45333)

### DIFF
--- a/lib/ansible/plugins/strategy/host_pinned.py
+++ b/lib/ansible/plugins/strategy/host_pinned.py
@@ -28,7 +28,7 @@ DOCUMENTATION = '''
           Ansible will not wait for other hosts to finish the current task before queuing the next task for a host that has finished.
           Once a host is done with the play, it opens it's slot to a new host that was waiting to start.
           Other than that, it behaves just like the "free" strategy.
-    version_added: "2.0"
+    version_added: "2.7"
     author: Ansible Core Team
 '''
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport https://github.com/ansible/ansible/pull/45333

(cherry picked from commit 97fcc3ef6634282099e3fb9faf6513678ca63fe3)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
host_pinned

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION
