### PR TITLE
ec2_vpc_igw: migrate to boto3

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
@@ -252,6 +252,7 @@ class AnsibleEc2Igw(object):
 
         return self._results
 
+
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
AWS boto only modules present issues with corporate internet proxies. Migrate to boto3 solves problems. Code is simplier and more ansible aws helpers are used.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #44889

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.5 and 2.6
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
