### PR TITLE
[stable-2.5] Ensure loop with delegate_to can short circuit the same as without delegate_to. Fixes #45189 (#45231).

### DIFF
--- a/changelogs/fragments/loop_undefined_delegate_to.yaml
+++ b/changelogs/fragments/loop_undefined_delegate_to.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- loop - Ensure that a loop with a when condition that evaluates to false and delegate_to, will short circuit if the
+  loop references an undefined variable. This matches the behavior in the same scenario without delegate_to
+  (https://github.com/ansible/ansible/issues/45189)

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -500,7 +500,12 @@ class VariableManager:
             else:
                 raise AnsibleError("Failed to find the lookup named '%s' in the available lookup plugins" % task.loop_with)
         elif task.loop is not None:
-            items = templar.template(task.loop)
+            try:
+                items = templar.template(task.loop)
+            except AnsibleUndefinedVariable:
+                # This task will be skipped later due to this, so we just setup
+                # a dummy array for the later code so it doesn't fail
+                items = [None]
         else:
             items = [None]
 

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -202,3 +202,22 @@
     that:
       - "output.results[0]['_ansible_item_label'] == 'looped_var foo_label'"
       - "output.results[1]['_ansible_item_label'] == 'looped_var bar_label'"
+
+# https://github.com/ansible/ansible/issues/45189
+- name: with_X conditional delegate_to shortcircuit on templating error
+  debug:
+    msg: "loop"
+  when: false
+  delegate_to: localhost
+  with_list: "{{ fake_var }}"
+  register: result
+  failed_when: result is not skipped
+
+- name: loop conditional delegate_to shortcircuit on templating error
+  debug:
+    msg: "loop"
+  when: false
+  delegate_to: localhost
+  loop: "{{ fake_var }}"
+  register: result
+  failed_when: result is not skipped


### PR DESCRIPTION
(cherry picked from commit 2ac647def88a300403659a13e6ec4097baa1cdce)


Co-authored-by: Matt Martz <matt@sivel.net>