### PR TITLE
handle yum and dnf lockfiles - fixes #44120

### DIFF
--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -104,7 +104,7 @@ class YumDnf(with_metaclass(ABCMeta, object)):
 
     def wait_for_lock(self):
         '''Poll until the lock is removed if interval is a positive number'''
-        if os.path.isfile(self.lockfile) and self.lock_timeout > 0:
+        if (os.path.isfile(self.lockfile) or glob.glob(self.lockfile)) and self.lock_timeout > 0:
             for iteration in range(0, self.lock_timeout):
                 time.sleep(self.lock_poll)
                 if not os.path.isfile(self.lockfile) or not glob.glob(self.lockfile):

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -184,6 +184,22 @@ options:
     default: "no"
     type: bool
     version_added: "2.7"
+  lock_poll:
+    description:
+      - Poll interval to wait for the dnf lockfile to be freed.
+      - "By default this is set to -1, if you set it to a positive integer it will enable to polling"
+    required: false
+    default: -1
+    type: int
+    version_added: "2.8"
+  lock_timeout:
+    description:
+      - Amount of time to wait for the dnf lockfile to be freed
+      - This should be set along with C(lock_poll) to enable the lockfile polling.
+    required: false
+    default: 10
+    type: int
+    version_added: "2.8"
 notes:
   - When used with a `loop:` each package will be processed individually, it is much more efficient to pass the list directly to the `name` option.
   - Group removal doesn't work if the group was installed with Ansible because
@@ -286,6 +302,8 @@ class DnfModule(YumDnf):
         super(DnfModule, self).__init__(module)
 
         self._ensure_dnf()
+        self.lockfile = "/var/cache/dnf/*_lock.pid"
+        self.pkg_mgr_name = "dnf"
 
     def _sanitize_dnf_error_msg(self, spec, error):
         """


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
handle yum and dnf lockfiles

Fixes #44120

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum
dnf
yumdnf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (modules/yumdnf 8cf47310a6) last updated 2018/09/07 12:15:42 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```
