### PR TITLE
Flatpak modules: Fix Python 2/3 compatility

### DIFF
--- a/lib/ansible/modules/packaging/os/flatpak.py
+++ b/lib/ansible/modules/packaging/os/flatpak.py
@@ -125,9 +125,9 @@ stdout:
 '''
 
 import subprocess
-import codecs
-from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves.urllib.parse import urlparse
+from ansible.module_utils._text import to_bytes, to_text
 
 
 def install_flat(module, binary, remote, name, method):
@@ -154,9 +154,9 @@ def flatpak_exists(module, binary, name, method):
     """Check if the flatpak is installed."""
     command = "{0} list --{1} --app".format(binary, method)
     output = _flatpak_command(module, False, command)
-    name = _parse_flatpak_name(name).lower()
+    parsed_name = _parse_flatpak_name(name).lower()
     # Convert name to byte-like object (For Python 2/3 compatibility)
-    byte_name = codecs.encode(name, 'utf-8')
+    byte_name = to_bytes(parsed_name, errors='surrogate_or_strict')
     if byte_name in output.lower():
         return True
     return False
@@ -171,12 +171,12 @@ def _match_installed_flat_name(module, binary, name, method):
     output = _flatpak_command(module, False, command)
     parsed_name = _parse_flatpak_name(name)
     # Convert name to byte-like object (For Python 2/3 compatibility)
-    byte_parsed_name = codecs.encode(parsed_name, 'utf-8')
+    byte_parsed_name = to_bytes(parsed_name, errors='surrogate_or_strict')
     for line in output.splitlines():
         if byte_parsed_name.lower() in line.lower():
             matched_name = line.split()[0]
             # decode the byte-like object into a string
-            return codecs.decode(matched_name, 'utf-8')
+            return to_text(matched_name, errors='surrogate_or_strict')
 
     result['msg'] = "Flatpak removal failed: Could not match any installed flatpaks to " +\
         "the name `{0}`. ".format(_parse_flatpak_name(name)) +\

--- a/lib/ansible/modules/packaging/os/flatpak_remote.py
+++ b/lib/ansible/modules/packaging/os/flatpak_remote.py
@@ -119,6 +119,7 @@ stdout:
 '''
 
 import subprocess
+import codecs
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -145,9 +146,11 @@ def remote_exists(module, binary, name, method):
     command = "{0} remote-list -d --{1}".format(binary, method)
     # The query operation for the remote needs to be run even in check mode
     output = _flatpak_command(module, False, command)
+    # Convert name to byte-like object (For Python 2/3 compatibility)
+    byte_name = codecs.encode(name, 'utf-8')
     for line in output.splitlines():
         listed_remote = line.split()
-        if listed_remote[0] == name:
+        if listed_remote[0] == byte_name:
             return True
     return False
 
@@ -205,7 +208,7 @@ def main():
     if not binary:
         module.fail_json(msg="Executable '%s' was not found on the system." % executable, **result)
 
-    remote_already_exists = remote_exists(module, binary, bytes(name, 'utf-8'), method)
+    remote_already_exists = remote_exists(module, binary, name, method)
 
     if state == 'present' and not remote_already_exists:
         add_remote(module, binary, name, flatpakrepo_url, method)

--- a/lib/ansible/modules/packaging/os/flatpak_remote.py
+++ b/lib/ansible/modules/packaging/os/flatpak_remote.py
@@ -119,8 +119,8 @@ stdout:
 '''
 
 import subprocess
-import codecs
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes
 
 
 def add_remote(module, binary, name, flatpakrepo_url, method):
@@ -147,7 +147,7 @@ def remote_exists(module, binary, name, method):
     # The query operation for the remote needs to be run even in check mode
     output = _flatpak_command(module, False, command)
     # Convert name to byte-like object (For Python 2/3 compatibility)
-    byte_name = codecs.encode(name, 'utf-8')
+    byte_name = to_bytes(name, errors='surrogate_or_strict')
     for line in output.splitlines():
         listed_remote = line.split()
         if listed_remote[0] == byte_name:


### PR DESCRIPTION
##### SUMMARY

This fixes Python 2/3 compatibility for both flatpak modules:

`flatpak` threw a TypeError error when installing a flatpak using Python 3 (comparison between string and bytes)

`flatpak_remote` threw a TypeError when adding flatpak_remote using Python 2 (wrong number of arguments for str() constructor)
A prior attempt at fixing Python 3 compatibility (#44835) lead to broken Python 2 compatibility.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
flatpak
flatpak_remote

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (flatpak_python_23_compatility_fixes 8f3d828a1c) last updated 2018/09/07 19:04:14 (GMT +200)
  config file = None
  configured module search path = [u'/home/alexander/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/alexander/Code/ansible/lib/ansible
  executable location = /home/alexander/Code/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION

The Python 2 and 3 compatibility of this PR has been verified running integration tests using docker:

`flatpak`:

Python 3
```
ansible-test integration -v --docker fedora26py3 --docker-privileged --allow-unsupported --python 3.6 flatpak
```

Python 2
```
ansible-test integration -v --docker fedora25 --docker-privileged --allow-unsupported --python 2.7 flatpak
```

`flatpak_remote`:

~As of this writing, the `flatpak_remote` integration tests have not been merged yet (PR #42315). You would need to merge this branch locally to add them: https://github.com/oolongbrothers/ansible/tree/flatpak_remote_integration_tests~
The `flatpak_remote` integration tests have been merged to devel (and I rebased this branch).

Python 3
```
ansible-test integration -v --docker fedora26py3 --docker-privileged --allow-unsupported --python 3.6 flatpak_remote
```

Python 2
```
ansible-test integration -v --docker fedora25 --docker-privileged --allow-unsupported --python 2.7 flatpak_remote
```

```
$ ansible-test integration -v --docker fedora26py3 --docker-privileged --allow-unsupported --python 3.6 flatpak_remote
PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [flatpak_remote : Install flatpak on Fedora] ******************************
ok: [testhost] => {"changed": false, "msg": "Nothing to do", "rc": 0, "results": ["Installed: flatpak"]}

TASK [flatpak_remote : Activate flatpak ppa on Ubuntu] *************************
skipping: [testhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [flatpak_remote : Install flatpak package on Ubuntu] **********************
skipping: [testhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [flatpak_remote : Install flatpak_remote for testing check mode] **********
changed: [testhost] => {"changed": true, "command": "/usr/bin/flatpak remote-add --system check-mode-test-remote https://dl.flathub.org/repo/flathub.flatpakrepo", "rc": 0, "stderr": "GLib-GIO-Message: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications.\n", "stderr_lines": ["GLib-GIO-Message: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications."], "stdout": "", "stdout_lines": []}

TASK [flatpak_remote : Test executable override] *******************************
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Executable 'nothing-that-exists' was not found on the system."}
...ignoring

TASK [flatpak_remote : Verify executable override test result] *****************
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test addition of absent flatpak remote (check mode)] ****
changed: [testhost] => {"changed": true, "command": "/usr/bin/flatpak remote-add --system flatpak-test https://dl.flathub.org/repo/flathub.flatpakrepo", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               \n", "stdout_lines": ["check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               "]}

TASK [flatpak_remote : Verify addition of absent flatpak remote test result (check mode)] ***
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test non-existent idempotency of addition of absent flatpak remote (check mode)] ***
changed: [testhost] => {"changed": true, "command": "/usr/bin/flatpak remote-add --system flatpak-test https://dl.flathub.org/repo/flathub.flatpakrepo", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               \n", "stdout_lines": ["check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               "]}

TASK [flatpak_remote : Verify non-existent idempotency of addition of absent flatpak remote test result (check mode)] ***
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test removal of absent flatpak remote not doing anything in check mode] ***
ok: [testhost] => {"changed": false, "command": "/usr/bin/flatpak remote-list -d --system", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               \n", "stdout_lines": ["check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               "]}

TASK [flatpak_remote : Verify removal of absent flatpak remote test result (check mode)] ***
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test addition of present flatpak remote (check mode)] ***
ok: [testhost] => {"changed": false, "command": "/usr/bin/flatpak remote-list -d --system", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               \n", "stdout_lines": ["check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               "]}

TASK [flatpak_remote : Verify addition of present flatpak remote test result (check mode)] ***
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test removal of present flatpak remote not doing anything in check mode] ***
changed: [testhost] => {"changed": true, "command": "/usr/bin/flatpak remote-delete --system --force check-mode-test-remote ", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               \n", "stdout_lines": ["check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               "]}

TASK [flatpak_remote : Verify removal of present flatpak remote test result (check mode)] ***
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test non-existent idempotency of removal of present flatpak remote (check mode)] ***
changed: [testhost] => {"changed": true, "command": "/usr/bin/flatpak remote-delete --system --force check-mode-test-remote ", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               \n", "stdout_lines": ["check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               "]}

TASK [flatpak_remote : Verify non-existent idempotency of removal of present flatpak remote test result (check mode)] ***
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test addition - user] ***********************************
changed: [testhost] => {"changed": true, "command": "/usr/bin/flatpak remote-add --user flatpak-test https://dl.flathub.org/repo/flathub.flatpakrepo", "rc": 0, "stderr": "GLib-GIO-Message: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications.\n", "stderr_lines": ["GLib-GIO-Message: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications."], "stdout": "", "stdout_lines": []}

TASK [flatpak_remote : Verify addition test result - user] *********************
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test idempotency of addition - user] ********************
ok: [testhost] => {"changed": false, "command": "/usr/bin/flatpak remote-list -d --user", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "flatpak-test Flathub https://dl.flathub.org/repo/ 1               \n", "stdout_lines": ["flatpak-test Flathub https://dl.flathub.org/repo/ 1               "]}

TASK [flatpak_remote : Verify idempotency of addition test result - user] ******
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test updating remote url does not do anything - user] ***
ok: [testhost] => {"changed": false, "command": "/usr/bin/flatpak remote-list -d --user", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "flatpak-test Flathub https://dl.flathub.org/repo/ 1               \n", "stdout_lines": ["flatpak-test Flathub https://dl.flathub.org/repo/ 1               "]}

TASK [flatpak_remote : Verify updating remote url does not do anything - user] ***
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test removal - user] ************************************
changed: [testhost] => {"changed": true, "command": "/usr/bin/flatpak remote-delete --user --force flatpak-test ", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [flatpak_remote : Verify removal test result - user] **********************
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test idempotency of removal - user] *********************
ok: [testhost] => {"changed": false, "command": "/usr/bin/flatpak remote-list -d --user", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [flatpak_remote : Verify idempotency of removal test result - user] *******
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test addition - system] *********************************
changed: [testhost] => {"changed": true, "command": "/usr/bin/flatpak remote-add --system flatpak-test https://dl.flathub.org/repo/flathub.flatpakrepo", "rc": 0, "stderr": "GLib-GIO-Message: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications.\n", "stderr_lines": ["GLib-GIO-Message: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications."], "stdout": "", "stdout_lines": []}

TASK [flatpak_remote : Verify addition test result - system] *******************
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test idempotency of addition - system] ******************
ok: [testhost] => {"changed": false, "command": "/usr/bin/flatpak remote-list -d --system", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               \nflatpak-test           Flathub https://dl.flathub.org/repo/ 1               \n", "stdout_lines": ["check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               ", "flatpak-test           Flathub https://dl.flathub.org/repo/ 1               "]}

TASK [flatpak_remote : Verify idempotency of addition test result - system] ****
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test updating remote url does not do anything - system] ***
ok: [testhost] => {"changed": false, "command": "/usr/bin/flatpak remote-list -d --system", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               \nflatpak-test           Flathub https://dl.flathub.org/repo/ 1               \n", "stdout_lines": ["check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               ", "flatpak-test           Flathub https://dl.flathub.org/repo/ 1               "]}

TASK [flatpak_remote : Verify updating remote url does not do anything - system] ***
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test removal - system] **********************************
changed: [testhost] => {"changed": true, "command": "/usr/bin/flatpak remote-delete --system --force flatpak-test ", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [flatpak_remote : Verify removal test result - system] ********************
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [flatpak_remote : Test idempotency of removal - system] *******************
ok: [testhost] => {"changed": false, "command": "/usr/bin/flatpak remote-list -d --system", "rc": 0, "stderr": "", "stderr_lines": [], "stdout": "check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               \n", "stdout_lines": ["check-mode-test-remote Flathub https://dl.flathub.org/repo/ 1               "]}

TASK [flatpak_remote : Verify idempotency of removal test result - system] *****
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

PLAY RECAP *********************************************************************
testhost                   : ok=37   changed=9    unreachable=0    failed=0
```
