### PR TITLE
Remove runtime usage of pkg_resources.

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -22,15 +22,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 __requires__ = ['ansible']
-try:
-    import pkg_resources
-except Exception:
-    # Use pkg_resources to find the correct versions of libraries and set
-    # sys.path appropriately when there are multiversion installs.  But we
-    # have code that better expresses the errors in the places where the code
-    # is actually used (the deps are optional for many code paths) so we don't
-    # want to fail here.
-    pass
+
 
 import os
 import shutil

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -6,10 +6,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 __requires__ = ['ansible']
 
-try:
-    import pkg_resources
-except Exception:
-    pass
 
 import fcntl
 import hashlib

--- a/changelogs/fragments/drop-pkg_resources.yaml
+++ b/changelogs/fragments/drop-pkg_resources.yaml
@@ -1,0 +1,8 @@
+---
+minor_changes:
+  - Drop the use of pkg_resources.  Importing pkg_resources was the costliest
+    part of startup time for Ansible.  pkg_resources was used so that platforms
+    with old versions of PyCrypto and Jinja2 could use parallel installed,
+    updated versions.  Since we no longer support Python-2.6 on the controller
+    side, we no longer have to support parallel installation to work around
+    those old stacks.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ jinja2
 PyYAML
 paramiko
 cryptography
-setuptools


### PR DESCRIPTION
This should provide a startup time speed boost at the expense of making
it harder to get ansible to use newer versions of packages than are
provided by the platform.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
bin/ansible

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION
This is possible because we're no longer supporting Python-2.6 on the controller and Python-2.6 is where we had to deal with old versions of packages (pycrypto and jinja2).

alikins performed timings of startup time and found that importing pkg_resources was the most costly piece of startup.