### PR TITLE
yum also parse obsolete package output

### DIFF
--- a/changelogs/fragments/yum-handle-obsoletes-check-update.yaml
+++ b/changelogs/fragments/yum-handle-obsoletes-check-update.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "yum - when checking for updates, now properly include Obsoletes (both old and new) package data in the module JSON output, fixes https://github.com/ansible/ansible/issues/39978"

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1111,14 +1111,15 @@ class YumModule(YumDnf):
             # ignore irrelevant lines
             # '*' in line matches lines like mirror lists:
             #      * base: mirror.corbina.net
-            # len(line) != 3 could be junk or a continuation
+            # len(line) != 3 or 6 could be junk or a continuation
+            # len(line) = 6 is package obsoletes
             #
             # FIXME: what is  the '.' not in line  conditional for?
 
-            if '*' in line or len(line) != 3 or '.' not in line[0]:
+            if '*' in line or len(line) not in [3, 6] or '.' not in line[0]:
                 continue
             else:
-                pkg, version, repo = line
+                pkg, version, repo = line[0], line[1], line[2]
                 name, dist = pkg.rsplit('.', 1)
                 updates.update({name: {'version': version, 'dist': dist, 'repo': repo}})
         return updates

--- a/test/units/modules/packaging/os/test_yum.py
+++ b/test/units/modules/packaging/os/test_yum.py
@@ -3,6 +3,7 @@
 from ansible.compat.tests import unittest
 
 from ansible.modules.packaging.os.yum import YumModule
+import q
 
 
 yum_plugin_load_error = """
@@ -127,12 +128,17 @@ glibc.x86_64            2.17-157.el7_3.1  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 
 unwrapped_output_rhel7_obsoletes = unwrapped_output_rhel7 + wrapped_output_rhel7_obsoletes_postfix
-unwrapped_output_rhel7_expected_pkgs = ["NetworkManager-openvpn", "NetworkManager-openvpn-gnome", "cabal-install",
+unwrapped_output_rhel7_expected_new_obsoletes_pkgs = ["ddashboard", "python-bugzilla", "python2-futures", "python2-pip",
+                                         "python2-pyxdg", "python2-simplejson"]
+unwrapped_output_rhel7_expected_old_obsoletes_pkgs = ["developerdashboard", "python-bugzilla-develdashboardfixes",
+                                                      "python-futures", "python-pip", "pyxdg", "python-simplejson"]
+unwrapped_output_rhel7_expected_updated_pkgs = ["NetworkManager-openvpn", "NetworkManager-openvpn-gnome", "cabal-install",
                                         "cgit", "python34-libs", "python34-test", "python34-tkinter",
                                         "python34-tools", "qgit", "rdiff-backup", "stoken-libs", "xlockmore"]
 
 
 class TestYumUpdateCheckParse(unittest.TestCase):
+    @q.t
     def _assert_expected(self, expected_pkgs, result):
 
         for expected_pkg in expected_pkgs:
@@ -141,34 +147,34 @@ class TestYumUpdateCheckParse(unittest.TestCase):
         self.assertIsInstance(result, dict)
 
     def test_empty_output(self):
-        res = YumModule.parse_check_update("")
+        res, obs = YumModule.parse_check_update("")
         expected_pkgs = []
         self._assert_expected(expected_pkgs, res)
 
     def test_longname(self):
-        res = YumModule.parse_check_update(longname)
+        res, obs = YumModule.parse_check_update(longname)
         expected_pkgs = ['xxxxxxxxxxxxxxxxxxxxxxxxxx', 'glibc']
         self._assert_expected(expected_pkgs, res)
 
     def test_plugin_load_error(self):
-        res = YumModule.parse_check_update(yum_plugin_load_error)
+        res, obs = YumModule.parse_check_update(yum_plugin_load_error)
         expected_pkgs = []
         self._assert_expected(expected_pkgs, res)
 
     def test_wrapped_output_1(self):
-        res = YumModule.parse_check_update(wrapped_output_1)
+        res, obs = YumModule.parse_check_update(wrapped_output_1)
         expected_pkgs = ["vms-agent"]
         self._assert_expected(expected_pkgs, res)
 
     def test_wrapped_output_2(self):
-        res = YumModule.parse_check_update(wrapped_output_2)
+        res, obs = YumModule.parse_check_update(wrapped_output_2)
         expected_pkgs = ["empty-empty-empty-empty-empty-empty-empty-empty-empty-empty-empty-empty-empty-empty-empty-empty-empty-empty-empty-empty",
                          "libtiff"]
 
         self._assert_expected(expected_pkgs, res)
 
     def test_wrapped_output_3(self):
-        res = YumModule.parse_check_update(wrapped_output_3)
+        res, obs = YumModule.parse_check_update(wrapped_output_3)
         expected_pkgs = ["ceph", "ceph-base", "ceph-common", "ceph-mds",
                          "ceph-mon", "ceph-osd", "ceph-selinux", "libcephfs1",
                          "librados2", "libradosstriper1", "librbd1", "librgw2",
@@ -176,16 +182,22 @@ class TestYumUpdateCheckParse(unittest.TestCase):
         self._assert_expected(expected_pkgs, res)
 
     def test_wrapped_output_4(self):
-        res = YumModule.parse_check_update(wrapped_output_4)
+        res, obs = YumModule.parse_check_update(wrapped_output_4)
 
         expected_pkgs = ["ipxe-roms-qemu", "quota", "quota-nls", "rdma", "screen",
                          "sos", "sssd-client"]
         self._assert_expected(expected_pkgs, res)
 
     def test_wrapped_output_rhel7(self):
-        res = YumModule.parse_check_update(unwrapped_output_rhel7)
-        self._assert_expected(unwrapped_output_rhel7_expected_pkgs, res)
+        res, obs = YumModule.parse_check_update(unwrapped_output_rhel7)
+        self._assert_expected(unwrapped_output_rhel7_expected_updated_pkgs, res)
 
     def test_wrapped_output_rhel7_obsoletes(self):
-        res = YumModule.parse_check_update(unwrapped_output_rhel7_obsoletes)
-        self._assert_expected(unwrapped_output_rhel7_expected_pkgs, res)
+        res, obs = YumModule.parse_check_update(unwrapped_output_rhel7_obsoletes)
+        q.q(res)
+        q.q(obs)
+        self._assert_expected(
+            unwrapped_output_rhel7_expected_updated_pkgs+unwrapped_output_rhel7_expected_new_obsoletes_pkgs,
+            res
+        )
+        self._assert_expected(unwrapped_output_rhel7_expected_old_obsoletes_pkgs, obs)

--- a/test/units/modules/packaging/os/test_yum.py
+++ b/test/units/modules/packaging/os/test_yum.py
@@ -128,13 +128,19 @@ glibc.x86_64            2.17-157.el7_3.1  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 
 unwrapped_output_rhel7_obsoletes = unwrapped_output_rhel7 + wrapped_output_rhel7_obsoletes_postfix
-unwrapped_output_rhel7_expected_new_obsoletes_pkgs = ["ddashboard", "python-bugzilla", "python2-futures", "python2-pip",
-                                         "python2-pyxdg", "python2-simplejson"]
-unwrapped_output_rhel7_expected_old_obsoletes_pkgs = ["developerdashboard", "python-bugzilla-develdashboardfixes",
-                                                      "python-futures", "python-pip", "pyxdg", "python-simplejson"]
-unwrapped_output_rhel7_expected_updated_pkgs = ["NetworkManager-openvpn", "NetworkManager-openvpn-gnome", "cabal-install",
-                                        "cgit", "python34-libs", "python34-test", "python34-tkinter",
-                                        "python34-tools", "qgit", "rdiff-backup", "stoken-libs", "xlockmore"]
+unwrapped_output_rhel7_expected_new_obsoletes_pkgs = [
+    "ddashboard", "python-bugzilla", "python2-futures", "python2-pip",
+    "python2-pyxdg", "python2-simplejson"
+]
+unwrapped_output_rhel7_expected_old_obsoletes_pkgs = [
+    "developerdashboard", "python-bugzilla-develdashboardfixes",
+    "python-futures", "python-pip", "pyxdg", "python-simplejson"
+]
+unwrapped_output_rhel7_expected_updated_pkgs = [
+    "NetworkManager-openvpn", "NetworkManager-openvpn-gnome", "cabal-install",
+    "cgit", "python34-libs", "python34-test", "python34-tkinter",
+    "python34-tools", "qgit", "rdiff-backup", "stoken-libs", "xlockmore"
+]
 
 
 class TestYumUpdateCheckParse(unittest.TestCase):
@@ -197,7 +203,7 @@ class TestYumUpdateCheckParse(unittest.TestCase):
         q.q(res)
         q.q(obs)
         self._assert_expected(
-            unwrapped_output_rhel7_expected_updated_pkgs+unwrapped_output_rhel7_expected_new_obsoletes_pkgs,
+            unwrapped_output_rhel7_expected_updated_pkgs + unwrapped_output_rhel7_expected_new_obsoletes_pkgs,
             res
         )
         self._assert_expected(unwrapped_output_rhel7_expected_old_obsoletes_pkgs, obs)

--- a/test/units/modules/packaging/os/test_yum.py
+++ b/test/units/modules/packaging/os/test_yum.py
@@ -3,7 +3,6 @@
 from ansible.compat.tests import unittest
 
 from ansible.modules.packaging.os.yum import YumModule
-import q
 
 
 yum_plugin_load_error = """
@@ -144,7 +143,6 @@ unwrapped_output_rhel7_expected_updated_pkgs = [
 
 
 class TestYumUpdateCheckParse(unittest.TestCase):
-    @q.t
     def _assert_expected(self, expected_pkgs, result):
 
         for expected_pkg in expected_pkgs:
@@ -200,8 +198,6 @@ class TestYumUpdateCheckParse(unittest.TestCase):
 
     def test_wrapped_output_rhel7_obsoletes(self):
         res, obs = YumModule.parse_check_update(unwrapped_output_rhel7_obsoletes)
-        q.q(res)
-        q.q(obs)
         self._assert_expected(
             unwrapped_output_rhel7_expected_updated_pkgs + unwrapped_output_rhel7_expected_new_obsoletes_pkgs,
             res


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is a rebase of the patch originally proposed in
https://github.com/ansible/ansible/pull/40001 by machacekondra

Fixes #39978

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (modules/yum b0798d768a) last updated 2018/09/07 14:45:36 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```
