### PR TITLE
vmware_guest test - Use the cluster name instead of the path

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -135,7 +135,7 @@
     folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
     name: CDROM-Test-38679
     datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
-    cluster: "{{ clusterlist['json'][0] }}"
+    cluster: "{{ clusterlist['json'][0].split('/')[-1] }}"
     resource_pool: Resources
     guest_id: centos64Guest
     hardware:


### PR DESCRIPTION
##### SUMMARY
Fixes test error:

"msg": "Unable to find cluster \"/DC0/host/DC0_C0\""

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
vmware_guest integration test

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
devel
```

