### PR TITLE
Update default-test-container to 1.1.0.

### DIFF
--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -1,4 +1,4 @@
-default name=quay.io/ansible/default-test-container:1.0.0
+default name=quay.io/ansible/default-test-container:1.1.0
 centos6 name=quay.io/ansible/centos6-test-container:1.4.0 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.4.0 seccomp=unconfined
 fedora24 name=quay.io/ansible/fedora24-test-container:1.4.0 seccomp=unconfined


### PR DESCRIPTION
##### SUMMARY

Update default-test-container to 1.1.0.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (at-default-update cdcc0744e2) last updated 2018/09/07 16:30:39 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
