### PR TITLE
Prefer io.BytesIO over six; available on all supported Pythons

### DIFF
--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -140,9 +140,11 @@ options:
       - name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT
 """
 
+from io import BytesIO
+
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_bytes
-from ansible.module_utils.six import PY3, BytesIO
+from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import cPickle
 from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 from ansible.module_utils.urls import open_url

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -166,9 +166,10 @@ import re
 import os
 import socket
 import traceback
+from io import BytesIO
 
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils.six import BytesIO, PY3
+from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import cPickle
 from ansible.module_utils.network.common.utils import to_list
 from ansible.module_utils._text import to_bytes, to_text

--- a/test/units/plugins/httpapi/test_ftd.py
+++ b/test/units/plugins/httpapi/test_ftd.py
@@ -18,6 +18,7 @@
 
 import json
 import os
+from io import BytesIO
 
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 
@@ -28,7 +29,7 @@ from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.network.ftd.common import HTTPMethod, ResponseParams
 from ansible.module_utils.network.ftd.fdm_swagger_client import SpecProp, FdmSwaggerParser
-from ansible.module_utils.six import BytesIO, PY3, StringIO
+from ansible.module_utils.six import PY3, StringIO
 from ansible.plugins.httpapi.ftd import HttpApi
 
 if PY3:


### PR DESCRIPTION
On all supported Pythons, the `io.BytesIO` is always a stream implementation using an in-memory bytes buffer. Makes code slightly more forward compatible by reducing use of the six module.