### PR TITLE
fix swallowing line no in template syntax errors

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -717,7 +717,8 @@ class Templar:
             try:
                 t = myenv.from_string(data)
             except TemplateSyntaxError as e:
-                raise AnsibleError("template error while templating string: %s. String: %s" % (to_native(e), to_native(data)))
+                raise AnsibleError("template error while templating string: %s. Line: %s, File: %s, String: %s" %
+                                   (to_native(e), e.lineno, e.filename, to_native(data)))
             except Exception as e:
                 if 'recursion' in to_native(e):
                     raise AnsibleError("recursive loop detected in template string: %s" % to_native(data))


### PR DESCRIPTION
I am kind of surprised that this has remained so long...

If you have a multiline template with syntax error, previously you would just get a snippet e.g. Syntax error near '}' and the entire template contents which isn't very helpful.

With this fix, you would get the line no that the error occurs on. 

