### PR TITLE
Enhance the note about fileglob being local

### DIFF
--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -18,7 +18,8 @@ DOCUMENTATION = """
         required: True
     notes:
       - Patterns are only supported on files, not directory/paths.
-      - Matching is against local system files.
+      - Matching is against local system files on the Ansible controller.
+        To iterate a list of files on a remote node, use the M(find) module.
 """
 
 EXAMPLES = """


### PR DESCRIPTION
Made the note clearer and instructed to use find module for remote operations.
Relating to #34497

##### SUMMARY
Attempted to make the docs clearer.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
fileglob

##### ANSIBLE VERSION


##### ADDITIONAL INFORMATION