### PR TITLE
Add boto3 availability checking for rds_snapshot_facts

### DIFF
--- a/changelogs/fragments/rds-snapshot-facts-boto3-checking.yaml
+++ b/changelogs/fragments/rds-snapshot-facts-boto3-checking.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Print a nice error message when attempting to use rds_snapshot_facts and boto3 is not installed

--- a/lib/ansible/modules/cloud/amazon/rds_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot_facts.py
@@ -285,7 +285,8 @@ cluster_snapshots:
 '''
 
 from ansible.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code
-from ansible.module_utils.ec2 import AWSRetry, boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict
+from ansible.module_utils.ec2 import (AWSRetry, HAS_BOTO3, boto3_tag_list_to_ansible_dict,
+                                      camel_dict_to_snake_dict)
 
 try:
     import botocore
@@ -366,6 +367,9 @@ def main():
         supports_check_mode=True,
         mutually_exclusive=[['db_snapshot_identifier', 'db_instance_identifier', 'db_cluster_identifier', 'db_cluster_snapshot_identifier']]
     )
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
 
     conn = module.client('rds', retry_decorator=AWSRetry.jittered_backoff(retries=10))
     results = dict()


### PR DESCRIPTION
##### SUMMARY
Add boto3 availability checking for rds_snapshot_facts

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/cloud/amazon/rds_snapshot_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8, okay to backport to 2.7 and 2.6
```