### PR TITLE
Adding select version functionality to win_psmodule

### DIFF
--- a/lib/ansible/modules/windows/win_psmodule.ps1
+++ b/lib/ansible/modules/windows/win_psmodule.ps1
@@ -230,8 +230,7 @@ Function Install-PsModule {
             #remove module if needed 
             if ($need_remove -eq $true){
                 try {
-                    #if checkmode true and nuget not installed
-                    Write-Host 'test'
+                    #if checkmode true and nuget not installed'
                     if (!($CheckMode -eq $true -and !($NugetVersion -or $NugetVersion -ge "2.8.5.201"))){
                         Uninstall-Module -Name $Name -Confirm:$false -ErrorAction Stop -AllVersions -WhatIf:$CheckMode | out-null
                     }

--- a/lib/ansible/modules/windows/win_psmodule.ps1
+++ b/lib/ansible/modules/windows/win_psmodule.ps1
@@ -10,7 +10,7 @@
 
 $params = Parse-Args $args -supports_check_mode $true
 
-$name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true 
+$name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
 $repo = Get-AnsibleParam -obj $params -name "repository" -type "str"
 $url = Get-AnsibleParam -obj $params -name "url" -type "str"
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present", "absent", "latest"

--- a/lib/ansible/modules/windows/win_psmodule.ps1
+++ b/lib/ansible/modules/windows/win_psmodule.ps1
@@ -1,10 +1,12 @@
 #!powershell
 
+# Copyright: (c) 2018, Denis Pastukhov <past20005@yandex.ru>
 # Copyright: (c) 2017, Daniele Lazzari <lazzari@mailup.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #Requires -Module Ansible.ModuleUtils.Legacy
-#win_psmodule (Powershell modules Additions/Removal)
+
+# win_psmodule (Powershell modules Additions/Removal)
 
 $params = Parse-Args $args -supports_check_mode $true
 
@@ -111,6 +113,7 @@ Function Install-PsModule {
       [string]$RequiredVersion,
       [bool]$ForceRequiredVersion
     )
+    $need_remove = $false
     $need_update = $false
     $module_version_current = $null
     $ht = @{
@@ -141,9 +144,9 @@ Function Install-PsModule {
         $ht['AllowClobber'] = $AllowClobber;
     }
 
-    #Check if module present and save to variable
+    #Check if module is present and save to variable
     $module = Get-Module -Listavailable|?{$_.name -eq $Name}
-    #If module present, save info about latest version
+    #If module is present, save info about latest version
     if ($module){
         $module_version_current = $module.version | select -First 1
     }
@@ -156,11 +159,11 @@ Function Install-PsModule {
         $ErrorMessage = "Problems searching $($Name) module in repository: $($_.Exception.Message)"
         Fail-Json $result $ErrorMessage
     }
-    #Saving old logic: if module present, and no new parameters - do nothing, no matter which version
+    #Saving old logic: if module is present, and no new parameters are specified - do nothing, no matter which version
     if ($module -and ($Latest -eq $false) -and !($RequiredVersion)){
         $result.output = "Module $($Name) already present"
     }
-    #If module present and latest version needed
+    #If module is present and latest version is needed
     elseif ($module -and $Latest -eq $true) {
         if ($module_version_current -lt $search_result.version) {
             $need_update = $true
@@ -174,7 +177,7 @@ Function Install-PsModule {
             Fail-Json $result $ErrorMessage
         }    
     }
-    #If module present and version is required
+    #If module is present and version is required
     elseif ($module -and $RequiredVersion) {    
         if ($module_version_current -ne $search_result.version) {
             #if current version higher than required
@@ -199,7 +202,7 @@ Function Install-PsModule {
         }
     }
     
-    #if no module installed or update needed
+    #if no module installed or update is needed
     if (!($module) -or $need_update -eq $true){
         try{
             # Install NuGet Provider if needed
@@ -239,7 +242,7 @@ Function Remove-PsModule {
     # If module is present, unistalls it.
     if (Get-Module -Listavailable|?{$_.name -eq $Name}){
       try{
-        #remove all versions, because now we can have multiple versions installed
+        #remove all versions, because now it is possible to have multiple versions installed
         Uninstall-Module -Name $Name -Confirm:$false -Force -ErrorAction Stop -AllVersions -WhatIf:$CheckMode | out-null
         $result.output = "Module $($Name) removed"
         $result.changed = $true

--- a/lib/ansible/modules/windows/win_psmodule.ps1
+++ b/lib/ansible/modules/windows/win_psmodule.ps1
@@ -230,7 +230,6 @@ Function Install-PsModule {
     }           
 }
 
-
 Function Remove-PsModule {
     param(
       [Parameter(Mandatory=$true)]

--- a/lib/ansible/modules/windows/win_psmodule.ps1
+++ b/lib/ansible/modules/windows/win_psmodule.ps1
@@ -4,22 +4,32 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #Requires -Module Ansible.ModuleUtils.Legacy
-
-# win_psmodule (Powershell modules Additions/Removal)
+#win_psmodule (Powershell modules Additions/Removal)
 
 $params = Parse-Args $args -supports_check_mode $true
 
-$name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
+$name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true 
 $repo = Get-AnsibleParam -obj $params -name "repository" -type "str"
 $url = Get-AnsibleParam -obj $params -name "url" -type "str"
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present", "absent"
 $allow_clobber = Get-AnsibleParam -obj $params -name "allow_clobber" -type "bool" -default $false
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false
+$latest = Get-AnsibleParam -obj $params -name "latest" -type "bool" -default $false
+$required_version = Get-AnsibleParam -obj $params -name "required_version" -type "str"
+$force_required_version = Get-AnsibleParam -obj $params -name "force_required_version" -type "bool" -default $false
 
 $result = @{"changed" = $false
             "output" = ""
             "nuget_changed" = $false
             "repository_changed" = $false}
+
+If (($latest -eq $true) -and ($required_version -ne $null)) {
+    Fail-Json $result "latest and required_version are mutually exclusive but have both been set"
+}
+
+If (($force_required_version -eq $true) -and ($required_version -eq $null)) {
+    Fail-Json $result "force_required_version can be used only when required_version is set"
+}
 
 Function Install-NugetProvider {
   param(
@@ -96,44 +106,130 @@ Function Install-PsModule {
       [string]$Name,
       [string]$Repository,
       [bool]$AllowClobber,
-      [bool]$CheckMode
+      [bool]$CheckMode,
+      [bool]$Latest,
+      [string]$RequiredVersion,
+      [bool]$ForceRequiredVersion
     )
-    if (Get-Module -Listavailable|?{$_.name -eq $Name}){
+    $need_update = $false
+    $module_version_current = $null
+    $ht = @{
+        Name      = $Name;
+        WhatIf    = $CheckMode;
+        ErrorAction = "Stop";
+        Force     = $true;
+    };
+
+    $ht_find_module = @{
+        Name      = $Name;
+        ErrorAction = "Stop";
+    }
+
+    # If specified, use repository name to select module source
+    if ($Repository) {
+        $ht["Repository"] = "$Repository";
+        $ht_find_module["Repository"] = "$Repository";
+    }
+    # If specified set required version
+    if ($RequiredVersion) {
+        $ht_find_module["RequiredVersion"] = "$RequiredVersion";
+        $ht["RequiredVersion"] = "$RequiredVersion"
+    }
+
+    # Check Powershell Version (-AllowClobber was introduced in PowerShellGet 1.6.0)
+    if ("AllowClobber" -in ((Get-Command PowerShellGet\Install-Module | Select -ExpandProperty Parameters).Keys)) {
+        $ht['AllowClobber'] = $AllowClobber;
+    }
+
+    #Check if module present and save to variable
+    $module = Get-Module -Listavailable|?{$_.name -eq $Name}
+    #If module present, save info about latest version
+    if ($module){
+        $module_version_current = $module.version | select -First 1
+    }
+
+    #search for latest or required version
+    try {
+        $search_result = Find-Module @ht_find_module
+    }
+    catch {
+        $ErrorMessage = "Problems searching $($Name) module in repository: $($_.Exception.Message)"
+        Fail-Json $result $ErrorMessage
+    }
+    #Saving old logic: if module present, and no new parameters - do nothing, no matter which version
+    if ($module -and ($Latest -eq $false) -and !($RequiredVersion)){
         $result.output = "Module $($Name) already present"
     }
-    else {      
-      try{
-        # Install NuGet Provider if needed
-        Install-NugetProvider -CheckMode $CheckMode;
-
-        $ht = @{
-            Name      = $Name;
-            WhatIf    = $CheckMode;
-            ErrorAction = "Stop";
-            Force     = $true;
-        };
-
-        # If specified, use repository name to select module source
-        if ($Repository) {
-            $ht["Repository"] = "$Repository";
+    #If module present and latest version needed
+    elseif ($module -and $Latest -eq $true) {
+        if ($module_version_current -lt $search_result.version) {
+            $need_update = $true
         }
-
-        # Check Powershell Version (-AllowClobber was introduced in PowerShellGet 1.6.0)
-        if ("AllowClobber" -in ((Get-Command PowerShellGet\Install-Module | Select -ExpandProperty Parameters).Keys)) {
-          $ht['AllowClobber'] = $AllowClobber;
+        elseif ($module_version_current -eq $search_result.version) {
+            $result.output = "Module $($Name):$($module_version_current) already present"
         }
-        
-        Install-Module @ht | out-null;
-        
-        $result.output = "Module $($Name) installed"
-        $result.changed = $true
-      }
-      catch{
-        $ErrorMessage = "Problems installing $($Name) module: $($_.Exception.Message)"
-        Fail-Json $result $ErrorMessage
-      }
+        #when repository has lower version than target computer. Just to be safe
+        else {
+            $ErrorMessage = "Installed version of module $($Name):$($module_version_current) higher than in repository:$($search_result.version)"
+            Fail-Json $result $ErrorMessage
+        }    
     }
+    #If module present and version is required
+    elseif ($module -and $RequiredVersion) {    
+        if ($module_version_current -ne $search_result.version) {
+            #if current version higher than required
+            if ($module_version_current -gt $search_result.version) {
+                # remove all versions and install required when forced
+                if ($force_required_version -eq $true){
+                    $need_remove = $true
+                    $need_update = $true
+                }      
+                else {
+                    Add-Warning -obj $result -message "Current version $($module_version_current) higher than required $($RequiredVersion). No changes have been made. Use force_required_version parameter to downgrade"
+                }
+            }
+            #if current version lower than required - install required
+            if ($module_version_current -lt $search_result.version){
+                $need_update = $true
+            }
+        }
+        #Required version already in use
+        else {
+            $result.output = "Module $($Name):$($RequiredVersion) already present"
+        }
+    }
+    
+    #if no module installed or update needed
+    if (!($module) -or $need_update -eq $true){
+        try{
+            # Install NuGet Provider if needed
+            Install-NugetProvider -CheckMode $CheckMode;
+            #remove module if needed 
+            if ($need_remove -eq $true){
+                try {
+                    Uninstall-Module -Name $Name -Confirm:$false -ErrorAction Stop -AllVersions -WhatIf:$CheckMode | out-null
+                }
+                catch {
+                    $ErrorMessage = "Problems uninstalling $($Name) module: $($_.Exception.Message)"
+                    Fail-Json $result $ErrorMessage
+                }
+            }
+            Install-Module @ht | out-null;
+
+            $result.output = "Module $($Name) installed"
+            $result.changed = $true
+            if ($module_version_current -eq $null){
+                $module_version_current = 'none'
+            }
+            $result.version = "$module_version_current => $($search_result.version)"
+        }
+        catch{
+            $ErrorMessage = "Problems installing $($Name) module: $($_.Exception.Message)"
+            Fail-Json $result $ErrorMessage
+        }   
+    }           
 }
+
 
 Function Remove-PsModule {
     param(
@@ -144,7 +240,8 @@ Function Remove-PsModule {
     # If module is present, unistalls it.
     if (Get-Module -Listavailable|?{$_.name -eq $Name}){
       try{
-        Uninstall-Module -Name $Name -Confirm:$false -Force -ErrorAction Stop -WhatIf:$CheckMode | out-null
+        #remove all versions, because now we can have multiple versions installed
+        Uninstall-Module -Name $Name -Confirm:$false -Force -ErrorAction Stop -AllVersions -WhatIf:$CheckMode | out-null
         $result.output = "Module $($Name) removed"
         $result.changed = $true
       }
@@ -152,7 +249,6 @@ Function Remove-PsModule {
         $ErrorMessage = "Problems removing $($Name) module: $($_.Exception.Message)"
         Fail-Json $result $ErrorMessage
       }
-
     }
     else{
       $result.output = "Module $($Name) not present"
@@ -174,7 +270,7 @@ if ($state -eq "present") {
         $ErrorMessage = "Repository Name and Url are mandatory if you want to add a new repository"
     }
 
-    Install-PsModule -Name $Name -Repository $repo -CheckMode $check_mode -AllowClobber $allow_clobber;
+    Install-PsModule -Name $Name -Repository $repo -CheckMode $check_mode -Latest $latest -RequiredVersion $required_version -AllowClobber $allow_clobber -ForceRequiredVersion $force_required_version;
 }
 else {  
     if ($repo) {   
@@ -184,3 +280,4 @@ else {
 }
 
 Exit-Json $result
+

--- a/lib/ansible/modules/windows/win_psmodule.py
+++ b/lib/ansible/modules/windows/win_psmodule.py
@@ -61,7 +61,7 @@ options:
     version_added: '2.8'
   force_required_version:
     description:
-      - Changes behavior of I(required_version). If there is higher version of a module present all versions will be uninstalled, than selected version will be installed.
+      - Changes behavior of I(required_version). If there is higher version present all versions will be uninstalled, selected version will be installed.
       - Requires I(required_version).
     type: bool
     default: 'no'

--- a/lib/ansible/modules/windows/win_psmodule.py
+++ b/lib/ansible/modules/windows/win_psmodule.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# Copyright: (c) 2018, Denis Pastukhov <past20005@yandex.ru>
 # Copyright: (c) 2017, Daniele Lazzari <lazzari@mailup.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/lib/ansible/modules/windows/win_psmodule.py
+++ b/lib/ansible/modules/windows/win_psmodule.py
@@ -49,6 +49,7 @@ options:
       - Requires I(state=present).
     type: bool
     default: 'no'
+    version_added: '2.8'
   required_version:
     description:
       - Allows to select version of powershell module to install. Requires I(state=present).
@@ -57,12 +58,14 @@ options:
       - If there is higher version present warning will be returned. No changed will be done. I(force_required_version) can be used to change this behavior.
       - This is mutually exclusive with I(latest).
     default: 'null'
+    version_added: '2.8'
   force_required_version:
     description:
       - Changes behavior of I(required_version). If there is higher version of a module present all versions will be uninstalled, than selected version will be installed.
       - Requires I(required_version).
     type: bool
     default: 'no'
+    version_added: '2.8'
 notes:
    -  Powershell 5.0 or higher is needed.
 

--- a/lib/ansible/modules/windows/win_psmodule.py
+++ b/lib/ansible/modules/windows/win_psmodule.py
@@ -38,7 +38,7 @@ options:
   state:
     description:
       - If C(present) a new module is installed.
-      - If C(absent) all versions of a module are removed.
+      - If C(absent) all versions of a module are removed. If I(version) is set - removes only this specific version.
       - >
         If C(latest) searches for new versions in repository. If module present - updates module, else installs latest version. This is mutually
         exclusive with I(version).
@@ -46,7 +46,7 @@ options:
     default: present
   version:
     description:
-      - Allows to select version of powershell module to install. Requires I(state=present).
+      - Allows to select version of powershell module to install or remove.
       - If there is no version present on target host a selected version will be installed.
       - If lower versions of module are present a selected version will be installed.
       - >
@@ -113,6 +113,12 @@ EXAMPLES = '''
   win_psmodule:
     name: PowershellModule
     state: absent
+
+- name: Remove a specific version of powershell module
+  win_psmodule:
+    name: PowershellModule
+    state: absent
+    version: 1.0.0
 
 - name: Remove a powershell module and a repository
   win_psmodule:

--- a/lib/ansible/modules/windows/win_psmodule.py
+++ b/lib/ansible/modules/windows/win_psmodule.py
@@ -39,30 +39,25 @@ options:
     description:
       - If C(present) a new module is installed.
       - If C(absent) all versions of a module are removed.
-    choices: [ absent, present ]
+      - >
+        If C(latest) searches for new versions in repository. If module present - updates module, else installs latest version. This is mutually
+        exclusive with I(version).
+    choices: [ absent, present, latest ]
     default: present
-  latest:
-    description:
-      - If C(yes) searches for new versions in repository.If found updates module, else installs latest version.
-      - If C(no) does not check versions. If module present makes no changes, else installs latest version.
-      - This is mutually exclusive with I(required_version).
-      - Requires I(state=present).
-    type: bool
-    default: 'no'
-    version_added: '2.8'
-  required_version:
+  version:
     description:
       - Allows to select version of powershell module to install. Requires I(state=present).
       - If there is no version present on target host a selected version will be installed.
       - If lower versions of module are present a selected version will be installed.
-      - If there is higher version present warning will be returned. No changed will be done. I(force_required_version) can be used to change this behavior.
-      - This is mutually exclusive with I(latest).
+      - >
+        If there is higher version present warning will be returned. No changed will be done. I(force_version) can be used to change this behavior.
+        This is mutually exclusive with I(state=latest).
     default: 'null'
     version_added: '2.8'
-  force_required_version:
+  force_version:
     description:
-      - Changes behavior of I(required_version). If there is higher version present all versions will be uninstalled, selected version will be installed.
-      - Requires I(required_version).
+      - Changes behavior of I(version). If there is higher version present all versions will be uninstalled, selected version will be installed.
+      - Requires I(version).
     type: bool
     default: 'no'
     version_added: '2.8'
@@ -71,6 +66,7 @@ notes:
 
 author:
 - Daniele Lazzari
+- Denis Pastukhov
 '''
 
 EXAMPLES = '''
@@ -96,23 +92,22 @@ EXAMPLES = '''
 - name: Always install latest version of module when possible
   win_psmodule:
     name: MyCustomModule
-    state: present
-    latest: yes
+    state: latest
 
 - name: Install a specific version of module from a specific repository
   win_psmodule:
     name: MyCustomModule
     repository: MyRepository
     state: present
-    required_version: 1.6.0.0
+    version: 1.6.0.0
 
 - name: Install a specific version of module from a specific repository even if highest version already installed
   win_psmodule:
     name: MyCustomModule
     repository: MyRepository
     state: present
-    required_version: 1.6.0.0
-    force_required_version: yes
+    version: 1.6.0.0
+    force_version: yes
 
 - name: Remove a powershell module
   win_psmodule:
@@ -145,7 +140,7 @@ repository_changed:
   sample: True
 version:
   description: show changes of versions
-  returned: on success
+  returned: on version change
   type: string
   sample: 1.0.0.9 => 1.0.0.5
 '''

--- a/lib/ansible/modules/windows/win_psmodule.py
+++ b/lib/ansible/modules/windows/win_psmodule.py
@@ -37,9 +37,31 @@ options:
   state:
     description:
       - If C(present) a new module is installed.
-      - If C(absent) a module is removed.
+      - If C(absent) all versions of a module are removed.
     choices: [ absent, present ]
     default: present
+  latest:
+    description:
+      - If C(yes) searches for new versions in repository.If found updates module, else installs latest version.
+      - If C(no) does not check versions. If module present makes no changes, else installs latest version.
+      - This is mutually exclusive with I(required_version).
+      - Requires I(state=present).
+    type: bool
+    default: 'no'
+  required_version:
+    description:
+      - Allows to select version of powershell module to install. Requires I(state=present).
+      - If there is no version present on target host a selected version will be installed.
+      - If lower versions of module are present a selected version will be installed.
+      - If there is higher version present warning will be returned. No changed will be done. I(force_required_version) can be used to change this behavior.
+      - This is mutually exclusive with I(latest).
+    default: 'null'
+  force_required_version:
+    description:
+      - Changes behavior of I(required_version). If there is higher version of a module present all versions will be uninstalled, than selected version will be installed.
+      - Requires I(required_version).
+    type: bool
+    default: 'no'
 notes:
    -  Powershell 5.0 or higher is needed.
 
@@ -66,6 +88,27 @@ EXAMPLES = '''
     name: PowershellModule
     repository: MyRepository
     state: present
+
+- name: Always install latest version of module when possible
+  win_psmodule:
+    name: MyCustomModule
+    state: present
+    latest: yes
+
+- name: Install a specific version of module from a specific repository
+  win_psmodule:
+    name: MyCustomModule
+    repository: MyRepository
+    state: present
+    required_version: 1.6.0.0
+
+- name: Install a specific version of module from a specific repository even if highest version already installed
+  win_psmodule:
+    name: MyCustomModule
+    repository: MyRepository
+    state: present
+    required_version: 1.6.0.0
+    force_required_version: yes
 
 - name: Remove a powershell module
   win_psmodule:
@@ -96,4 +139,9 @@ repository_changed:
   returned: always
   type: boolean
   sample: True
+version:
+  description: show changes of versions
+  returned: on success
+  type: string
+  sample: 1.0.0.9 => 1.0.0.5
 '''

--- a/test/integration/targets/win_psmodule/tasks/test.yml
+++ b/test/integration/targets/win_psmodule/tasks/test.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: install module from Powershell Gallery
   win_psmodule:
     name: "{{ powershell_module }}"
@@ -204,3 +203,108 @@
   assert:
     that:
       - "is_package_customrepo.stdout_lines[0] == custom_repo_name"
+
+- name: Uninstall module from local repository and unregister this repository.
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: absent
+    repository: "{{custom_repo_name}}"
+    url: "{{custom_repo_path}}"
+  register: uninstall_module_from_custom_repo
+
+- name: Validate sample module is uninstalled from custom repo
+  assert:
+    that:
+      - "uninstall_module_from_custom_repo is changed"
+
+- name: Get three previous versions of module
+  win_shell: Find-Module "{{ powershell_module }}" -AllVersions | select -First 3 -ExpandProperty version
+  register: module_version_list
+
+- name: Install specific module version
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: present
+    version: "{{module_version_list.stdout_lines[1]}}"
+  register: install_module_specific_version
+
+- name: Validate specific version of module is installed
+  assert:
+    that:
+      - "'=> {{ module_version_list.stdout_lines[1]}}' in install_module_specific_version.version"
+      - "install_module_specific_version is changed"
+      
+- name: Check idempotency installing specific version
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: present
+    version: "{{module_version_list.stdout_lines[1]}}"
+  register: install_module_specific_version_2
+  
+- name: Validate idempotency re-installing specific version
+  assert:
+    that:
+      - "install_module_specific_version_2 is not changed"
+
+- name: Check no changes are made downgrading module without force_version
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: present
+    version: "{{module_version_list.stdout_lines[2]}}"
+  register: install_module_specific_version_3
+
+- name: Validate module is downgraded
+  assert:
+    that:
+      - "install_module_specific_version_3 is not changed"
+
+- name: Downgrade module
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: present
+    version: "{{module_version_list.stdout_lines[2]}}"
+    force_version: yes
+  register: install_module_specific_version_4
+
+- name: Validate module is downgraded
+  assert:
+    that:
+      - "'=> {{ module_version_list.stdout_lines[2]}}' in install_module_specific_version_4.version"
+      - "install_module_specific_version_4 is changed"
+      
+- name: Install latest version of module
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: latest
+  register: install_module_specific_version_5
+
+- name: Validate latest version of module is installed
+  assert:
+    that:
+      - "'=> {{ module_version_list.stdout_lines[0]}}' in install_module_specific_version_5.version"
+      - "install_module_specific_version_5 is changed"
+
+- name: Check idempotency reinstalling latest version
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: latest
+  register: install_module_specific_version_6
+
+- name: Validate idempotency reinstalling latest version
+  assert:
+    that:
+      - "install_module_specific_version_6 is not changed"
+
+- name: Try to install wrong version
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: present
+    version: 99.99.99.99
+  ignore_errors: yes
+  register: install_module_specific_version_7
+
+- name: Validate idempotency reinstalling latest version
+  assert:
+    that:
+      - "install_module_specific_version_7 is not changed"
+      - "install_module_specific_version_7 is failed"

--- a/test/integration/targets/win_psmodule/tasks/test.yml
+++ b/test/integration/targets/win_psmodule/tasks/test.yml
@@ -339,4 +339,3 @@
   assert:
     that:
       - "install_module_specific_version_10 is not changed"
-

--- a/test/integration/targets/win_psmodule/tasks/test.yml
+++ b/test/integration/targets/win_psmodule/tasks/test.yml
@@ -218,7 +218,9 @@
       - "uninstall_module_from_custom_repo is changed"
 
 - name: Get three previous versions of module
-  win_shell: Find-Module "{{ powershell_module }}" -AllVersions | select -First 3 -ExpandProperty version
+  win_shell: |
+    $a = Find-Module powershell-yaml -AllVersions | select version -First 3
+    foreach ($b in $a.version) {$b.tostring()}
   register: module_version_list
 
 - name: Install specific module version
@@ -303,8 +305,38 @@
   ignore_errors: yes
   register: install_module_specific_version_7
 
-- name: Validate idempotency reinstalling latest version
+- name: Validate error installing wrong version
   assert:
     that:
       - "install_module_specific_version_7 is not changed"
       - "install_module_specific_version_7 is failed"
+
+- name: Remove specific version of module
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: absent
+    version: "{{module_version_list.stdout_lines[2]}}"
+  register: install_module_specific_version_8
+
+- name: Check specific version is removed
+  win_shell: Get-Module -ListAvailable |? {$_.name -eq "{{ powershell_module }}" -and $_.Version -eq "{{module_version_list.stdout_lines[2]}}"}
+  register: install_module_specific_version_9
+
+- name: Validate specific version is removed
+  assert:
+    that:
+      - "not install_module_specific_version_9.stdout"
+      - "install_module_specific_version_8 is changed"
+
+- name: Check idempotency removing specific version of module
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: absent
+    version: "{{module_version_list.stdout_lines[2]}}"
+  register: install_module_specific_version_10
+
+- name: Validate idempotency removing specific version of module
+  assert:
+    that:
+      - "install_module_specific_version_10 is not changed"
+

--- a/test/integration/targets/win_psmodule/tasks/test.yml
+++ b/test/integration/targets/win_psmodule/tasks/test.yml
@@ -253,7 +253,7 @@
     version: "{{module_version_list.stdout_lines[2]}}"
   register: install_module_specific_version_3
 
-- name: Validate module is downgraded
+- name: Validate module is not downgraded
   assert:
     that:
       - "install_module_specific_version_3 is not changed"


### PR DESCRIPTION
##### SUMMARY
Previously win_psmodule could only install latest version of powershell module or uninstall it.
Added new functionality to declare needed versions on targets. 

Fixes #39583

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request
- Bugfix Pull Request

##### COMPONENT NAME
win_psmodule

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.2
  config file = /opt/ansible/ansible.cfg
  configured module search path = [u'/opt/ansible/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```
tested on 2.6, should work on all new versions and on all previous up to 2.4

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
New parameters: 

- latest: checks current installed version and available in repository and update if new version available
- required_version: functionality to install specific version. 
- force_required_version: installs specified version even if highest already installed (removes all version, than installs specified).

Other changes:
- Changed remove function to remove all versions of module. 
- Updated docs.
- Fixed bug, when installing nuget asked user input. (Initially planned to fix it as separate PR, but tests failed without it)

Also, there is possible case with ansible check mode, when nuget is not installed:
updated module uses powershell cmdlet Find-Module to get versions of powershell modules from repository. Find-Module requires nuget. So:
 - when nuget is not installed and module is not present yet, win_psmodule will assume, that version of requested module is 1.0.0
 - when nuget is not installed and module is present, win_psmodule will use current version of powershell module to search in repository. 

This applies only when ansible is run with --check. 
I can change this behavior if needed, just did not find a better solution 

<!--- Paste verbatim command output below, e.g. before and after your change -->

