### PR TITLE
Backport/2.5/44984

### DIFF
--- a/changelogs/CHANGELOG-v2.5.rst
+++ b/changelogs/CHANGELOG-v2.5.rst
@@ -21,6 +21,8 @@ Release Summary
 Bugfixes
 --------
 
+- fix for cloudfront module when CloudFrontOriginAccessIdentityList is missing https://github.com/ansible/ansible/pull/44984
+
 - fix for the bundled selectors module (used in the ssh and local connection plugins) when a syscall is restarted after being interrupted by a signal (https://github.com/ansible/ansible/issues/41630)
 
 - Fix the mount module's handling of swap entries in fstab (https://github.com/ansible/ansible/pull/42837)

--- a/lib/ansible/module_utils/aws/cloudfront_facts.py
+++ b/lib/ansible/module_utils/aws/cloudfront_facts.py
@@ -93,7 +93,7 @@ class CloudFrontFactsServiceManager(object):
     def list_origin_access_identities(self):
         try:
             paginator = self.client.get_paginator('list_cloud_front_origin_access_identities')
-            result = paginator.paginate().build_full_result()['CloudFrontOriginAccessIdentityList']
+            result = paginator.paginate().build_full_result().get('CloudFrontOriginAccessIdentityList', {})
             return result.get('Items', [])
         except botocore.exceptions.ClientError as e:
             self.module.fail_json_aws(e, msg="Error listing cloud front origin access identities")


### PR DESCRIPTION
##### SUMMARY
Fixes #40668 added default value for when CloudFrontOriginAccessIdentityList is missing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudfront_origin_access_identity

##### ANSIBLE VERSION

```paste below
ansible 2.8.0.dev0 (issue-40668 6b37ae191a) last updated 2018/08/31 15:56:44 (GMT -400)
  config file = $PROJECT/ansible/ansible.cfg
  configured module search path = [u'$HOME/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = $ANSIBLE_REPO/ansible/lib/ansible
  executable location = $PROJECT/.venv/ansible-cfn/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION