### PR TITLE
Backport/2.6/44984

### DIFF
--- a/changelogs/CHANGELOG-v2.6.rst
+++ b/changelogs/CHANGELOG-v2.6.rst
@@ -21,6 +21,7 @@ Minor Changes
 Bugfixes
 --------
 
+- fix for cloudfront module when CloudFrontOriginAccessIdentityList is missing https://github.com/ansible/ansible/pull/44984
 - Add md5sum check in nxos_file_copy module (https://github.com/ansible/ansible/pull/43423).
 - Allow arbitrary ``log_driver`` for docker_container (https://github.com/ansible/ansible/pull/33579).
 - Fix Python2.6 regex bug terminal plugin nxos, iosxr (https://github.com/ansible/ansible/pull/45135).

--- a/lib/ansible/module_utils/aws/cloudfront_facts.py
+++ b/lib/ansible/module_utils/aws/cloudfront_facts.py
@@ -93,7 +93,7 @@ class CloudFrontFactsServiceManager(object):
     def list_origin_access_identities(self):
         try:
             paginator = self.client.get_paginator('list_cloud_front_origin_access_identities')
-            result = paginator.paginate().build_full_result()['CloudFrontOriginAccessIdentityList']
+            result = paginator.paginate().build_full_result().get('CloudFrontOriginAccessIdentityList', {})
             return result.get('Items', [])
         except botocore.exceptions.ClientError as e:
             self.module.fail_json_aws(e, msg="Error listing cloud front origin access identities")


### PR DESCRIPTION
##### SUMMARY
Fixes #40668 added default value for when CloudFrontOriginAccessIdentityList is missing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudfront_origin_access_identity

##### ANSIBLE VERSION

```paste below
ansible 2.8.0.dev0 (issue-40668 6b37ae191a) last updated 2018/08/31 15:56:44 (GMT -400)
  config file = $PROJECT/ansible/ansible.cfg
  configured module search path = [u'$HOME/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = $ANSIBLE_REPO/ansible/lib/ansible
  executable location = $PROJECT/.venv/ansible-cfn/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION