### PR TITLE
[backport-2.7] - Integration test fix (#45366)

### DIFF
--- a/test/integration/targets/meraki_mr_l3_firewall/tasks/main.yml
+++ b/test/integration/targets/meraki_mr_l3_firewall/tasks/main.yml
@@ -3,84 +3,89 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Create wireless network
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_name: TestNetWireless
-    type: wireless
-  delegate_to: localhost
-  register: new_net
+- block:
+  - name: Create wireless network
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: TestNetWireless
+      type: wireless
+    delegate_to: localhost
+    register: new_net
 
-- set_fact:
-    net: '{{new_net.data.id}}'
+  - set_fact:
+      net: '{{new_net.data.id}}'
 
-- name: Create single firewall rule
-  meraki_mr_l3_firewall:
-    auth_key: '{{ auth_key }}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_id: '{{net}}'
-    number: 1
-    rules:
-      - comment: Integration test rule
-        policy: allow
-        protocol: tcp
-        dest_port: 80
-        dest_cidr: 192.0.2.0/24
-    allow_lan_access: no
-  delegate_to: localhost
-  register: create_one
+  - name: Create single firewall rule
+    meraki_mr_l3_firewall:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_id: '{{net}}'
+      number: 1
+      rules:
+        - comment: Integration test rule
+          policy: allow
+          protocol: tcp
+          dest_port: 80
+          dest_cidr: 192.0.2.0/24
+      allow_lan_access: no
+    delegate_to: localhost
+    register: create_one
 
-- debug:
-    msg: '{{create_one}}'
+  - debug:
+      msg: '{{create_one}}'
 
-- assert:
-    that:
-      - create_one.data.0.comment == 'Integration test rule'
-      - create_one.data.1.policy == 'deny'
+  - assert:
+      that:
+        - create_one.data.0.comment == 'Integration test rule'
+        - create_one.data.1.policy == 'deny'
 
-- name: Enable local LAN access
-  meraki_mr_l3_firewall:
-    auth_key: '{{ auth_key }}'
-    state: present
-    org_name: '{{test_org_name}}'
-    net_id: '{{net}}'
-    number: 1
-    rules:
-    allow_lan_access: yes
-  delegate_to: localhost
-  register: enable_lan
+  - name: Enable local LAN access
+    meraki_mr_l3_firewall:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_id: '{{net}}'
+      number: 1
+      rules:
+      allow_lan_access: yes
+    delegate_to: localhost
+    register: enable_lan
 
-- assert:
-    that:
-      - enable_lan.data.1.policy == 'allow'
+  - assert:
+      that:
+        - enable_lan.data.1.policy == 'allow'
 
-- name: Query firewall rules
-  meraki_mr_l3_firewall:
-    auth_key: '{{ auth_key }}'
-    state: query
-    org_name: '{{test_org_name}}'
-    net_id: '{{net}}'
-    number: 1
-  delegate_to: localhost
-  register: query
+  - name: Query firewall rules
+    meraki_mr_l3_firewall:
+      auth_key: '{{ auth_key }}'
+      state: query
+      org_name: '{{test_org_name}}'
+      net_id: '{{net}}'
+      number: 1
+    delegate_to: localhost
+    register: query
 
-- debug:
-    msg: '{{query}}'
+  - debug:
+      msg: '{{query}}'
 
-- assert:
-    that:
-      - query.data.1.comment == 'Wireless clients accessing LAN'
-      - query.data.2.comment == 'Default rule'
-      - query.changed == False
+  - assert:
+      that:
+        - query.data.1.comment == 'Wireless clients accessing LAN'
+        - query.data.2.comment == 'Default rule'
+        - query.changed == False
 
-- name: Delete wireless network
-  meraki_network:
-    auth_key: '{{ auth_key }}'
-    state: absent
-    org_name: '{{test_org_name}}'
-    net_id: '{{net}}'
-    number: 1
-  delegate_to: localhost
+############################################################################
+# Tear down starts here
+############################################################################
+  always:
+  - name: Delete wireless network
+    meraki_ssid:
+      auth_key: '{{ auth_key }}'
+      state: absent
+      org_name: '{{test_org_name}}'
+      net_id: '{{net}}'
+      number: 1
+    delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY
* Fix integration test as wrong module was called

* Create block section for failures on integration test for mr_l3_firewall integration test

(cherry picked from commit 6c67674eab4a9120bb5bcf1be994a8c5656f3aa8)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki_network

##### ANSIBLE VERSION
```
ansible 2.7.0rc1.post0 (backport/2.7/45366 efa72b8fbf) last updated 2018/09/10 08:00:08 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]

```