### PR TITLE
ec2_asg_facts: Add in support for Launch Templates

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
@@ -19,7 +19,9 @@ description:
   - Gather facts about ec2 Auto Scaling Groups (ASGs) in AWS
 version_added: "2.2"
 requirements: [ boto3 ]
-author: "Rob White (@wimnat)"
+author:
+- "Nathan Webster (@nathanwebsterdotme)"
+- "Rob White (@wimnat)"
 options:
   name:
     description:
@@ -363,8 +365,10 @@ def find_asgs(conn, module, name=None, tags=None):
         if matched_name and matched_tags:
             asg = camel_dict_to_snake_dict(asg)
             # compatibility with ec2_asg module
-            asg['launch_config_name'] = asg['launch_configuration_name']
-            # workaround for https://github.com/ansible/ansible/pull/25015
+            if 'launch_configuration_name' in asg:
+                asg['launch_config_name'] = asg['launch_configuration_name']
+                # workaround for https://github.com/ansible/ansible/pull/25015
+
             if 'target_group_ar_ns' in asg:
                 asg['target_group_arns'] = asg['target_group_ar_ns']
                 del(asg['target_group_ar_ns'])

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
@@ -20,7 +20,6 @@ description:
 version_added: "2.2"
 requirements: [ boto3 ]
 author:
-- "Nathan Webster (@nathanwebsterdotme)"
 - "Rob White (@wimnat)"
 options:
   name:
@@ -146,6 +145,15 @@ launch_configuration_name:
     returned: success
     type: str
     sample: "public-webapp-production-1"
+launch_template:
+    description: Dict of Launch Template associated with the ASG.
+    returned: success
+    type: dict
+    sample: {
+        "launch_template_id": "lt-1234456789",
+        "launch_template_name": "a_launch_template_name",
+        "version": "1"
+    }
 load_balancer_names:
     description: List of load balancers names attached to the ASG.
     returned: success


### PR DESCRIPTION
##### SUMMARY
- Conditional check for "launch_configuration_name" which enables support for Auto Scaling Groups that have Launch Templates attached instead of Launch Configurations.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_asg_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (ec2_asg_facts_launch_templates 877661bce8) last updated 2018/09/10 14:38:56 (GMT +100)
  config file = None
  configured module search path = [u'/Users/nathan.webster/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/nathan.webster/git/ansible/lib/ansible
  executable location = /Users/nathan.webster/git/ansible/bin/ansible
  python version = 2.7.15 (default, Aug 22 2018, 16:45:09) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
