### PR TITLE
Unify terms and UI between 1Password lookups and facts module

### DIFF
--- a/lib/ansible/modules/identity/onepassword_facts.py
+++ b/lib/ansible/modules/identity/onepassword_facts.py
@@ -295,7 +295,7 @@ class OnePasswordFacts(object):
     def assert_logged_in(self):
         try:
             rc, out, err = self._run(['get', 'account'], ignore_errors=True)
-            if rc != 1:
+            if rc == 0:
                 self.logged_in = True
             if not self.logged_in:
                 self.get_token()

--- a/lib/ansible/modules/identity/onepassword_facts.py
+++ b/lib/ansible/modules/identity/onepassword_facts.py
@@ -145,16 +145,23 @@ import re
 
 from subprocess import Popen, PIPE
 
-from ansible.errors import AnsibleModuleError
 from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.basic import AnsibleModule
+
+
+class AnsibleModuleError(Exception):
+    def __init__(self, results):
+        self.results = results
+
+    def __repr__(self):
+        return self.results
 
 
 class OnePasswordFacts(object):
 
     def __init__(self):
         self.cli_path = module.params.get('cli_path')
-        self.config_file_path = os.path.expanduser('~/.op/config')
+        self.config_file_path = '~/.op/config'
         self.auto_login = module.params.get('auto_login')
         self.logged_in = False
         self.token = None

--- a/lib/ansible/modules/identity/onepassword_facts.py
+++ b/lib/ansible/modules/identity/onepassword_facts.py
@@ -22,10 +22,10 @@ author:
     - Ryan Conway (@rylon)
 version_added: "2.7"
 requirements:
-    - C(op) 1Password command line utility (v0.5.1). See U(https://support.1password.com/command-line/)
+    - C(op) 1Password command line utility. See U(https://support.1password.com/command-line/)
 notes:
     - "Based on the C(onepassword) lookup plugin by Scott Buchanan <sbuchanan@ri.pn>."
-short_description: Fetch facts from 1Password items
+short_description: Gather items from 1Password and set them as facts
 description:
     - M(onepassword_facts) wraps the C(op) command line utility to fetch data about one or more 1Password items and return as Ansible facts.
     - A fatal error occurs if any of the items being searched for can not be found.
@@ -53,22 +53,28 @@ options:
         required: True
     auto_login:
         description:
-            - A dictionary containing authentication details. If this is set, M(onepassword_facts) will attempt to login to 1Password automatically.
-            - The required values can be stored in an Ansible Vault and passed to the module securely that way.
+            - A dictionary containing authentication details. If this is set, M(onepassword_facts) will attempt to sign in to 1Password automatically.
             - Without this option, you must have already logged in via the 1Password CLI before running Ansible.
+            - It is B(highly) recommened to store 1Password credentials in an Ansible Vault. Ensure that the key used to encrypt
+              the Ansible Vault is equal to or greater in strength than the 1Password master password.
         suboptions:
             subdomain:
                 description:
                     - 1Password subdomain name (<subdomain>.1password.com).
+                    - If this is not specified, the most recent subdomain will be used.
             username:
                 description:
                     - 1Password username.
+                    - Only required for initial sign in.
             master_password:
                 description:
                     - The master password for your subdomain.
+                    - This is always required when specifying C(auto_login).
+                required: True
             secret_key:
                 description:
                     - The secret key for your subdomain.
+                    - Only required for initial sign in.
         default: {}
         required: False
     cli_path:
@@ -82,7 +88,7 @@ EXAMPLES = '''
 - name: Get a password
   onepassword_facts:
     search_terms: My 1Password item
-  delegate_to: local
+  delegate_to: localhost
   no_log: true         # Don't want to log the secrets to the console!
 
 # Gather secrets from 1Password, with more advanced search terms:
@@ -93,7 +99,7 @@ EXAMPLES = '''
         field:   Custom field name       # optional, defaults to 'password'
         section: Custom section name     # optional, defaults to 'None'
         vault:   Name of the vault       # optional, only necessary if there is more than 1 Vault available
-  delegate_to: local
+  delegate_to: localhost
   no_log: True                           # Don't want to log the secrets to the console!
 
 # Gather secrets combining simple and advanced search terms to retrieve two items, one of which we fetch two
@@ -109,7 +115,7 @@ EXAMPLES = '''
         section: Custom section name     # optional, defaults to 'None'
         vault:   Name of the vault       # optional, only necessary if there is more than 1 Vault available
       - name: A 1Password item with document attachment
-  delegate_to: local
+  delegate_to: localhost
   no_log: true                           # Don't want to log the secrets to the console!
 '''
 
@@ -136,128 +142,34 @@ import errno
 import json
 import os
 import re
+
 from subprocess import Popen, PIPE
 
+from ansible.errors import AnsibleModuleError
+from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
 
 
 class OnePasswordFacts(object):
 
     def __init__(self):
         self.cli_path = module.params.get('cli_path')
+        self.config_file_path = os.path.expanduser('~/.op/config')
         self.auto_login = module.params.get('auto_login')
-        self.token = {}
+        self.logged_in = False
+        self.token = None
 
         terms = module.params.get('search_terms')
         self.terms = self.parse_search_terms(terms)
 
-    def parse_search_terms(self, terms):
-        processed_terms = []
-
-        for term in terms:
-            if not isinstance(term, dict):
-                term = {'name': term}
-
-            if 'name' not in term:
-                module.fail_json(msg="Missing required 'name' field from search term, got: '%s'" % to_native(term))
-
-            term['field'] = term.get('field', 'password')
-            term['section'] = term.get('section', None)
-            term['vault'] = term.get('vault', None)
-
-            processed_terms.append(term)
-
-        return processed_terms
-
-    def run(self):
-        result = {}
-
-        self.assert_logged_in()
-
-        for term in self.terms:
-            value = self.get_field(term['name'], term['field'], term['section'], term['vault'])
-
-            if term['name'] in result:
-                # If we already have a result for this key, we have to append this result dictionary
-                # to the existing one. This is only applicable when there is a single item
-                # in 1Password which has two different fields, and we want to retrieve both of them.
-                result[term['name']].update(value)
-            else:
-                # If this is the first result for this key, simply set it.
-                result[term['name']] = value
-
-        return result
-
-    def assert_logged_in(self):
-        try:
-            self._run(["get", "account"])
-
-        except OSError as e:
-            if e.errno == errno.ENOENT:
-                module.fail_json(msg="1Password CLI tool not installed in path '%s': %s" % (self.cli_path, to_native(e)))
-            else:
-                module.fail_json(msg="1Password CLI tool failed to execute at path '%s': %s" % (self.cli_path, to_native(e)))
-
-        except Exception as e:
-            # 1Password's CLI doesn't seem to return different error codes, so we need to handle a few of the common
-            # error cases by searching via regex, so we can provide a clearer error message to the user.
-            if re.search(".*You are not currently signed in.*", to_native(e)) is not None:
-                if (self.auto_login is not None):
-                    try:
-                        token = self._run([
-                            "signin",
-                            "%s.1password.com" % self.auto_login['subdomain'],
-                            self.auto_login['username'],
-                            self.auto_login['secret_key'],
-                            self.auto_login['master_password'],
-                            "--shorthand=ansible_%s" % self.auto_login['subdomain'],
-                            "--output=raw"
-                        ])
-                        self.token = {'OP_SESSION_ansible_%s' % self.auto_login['subdomain']: token[0].strip()}
-
-                    except Exception as e:
-                        module.fail_json(msg="Unable to automatically login to 1Password: %s " % e)
-                else:
-                    module.fail_json(msg=(
-                        "Not logged into 1Password: please run '%s signin' first, or see the module docs for "
-                        "how to use automatic login." % self.cli_path)
-                    )
-
-    def get_raw(self, item_id, vault=None):
-        try:
-            args = ["get", "item", item_id]
-            if vault is not None:
-                args += ['--vault={0}'.format(vault)]
-            output, dummy = self._run(args)
-            return output
-
-        except Exception as e:
-            if re.search(".*not found.*", to_native(e)):
-                module.fail_json(msg="Unable to find an item in 1Password named '%s'." % item_id)
-            else:
-                module.fail_json(msg="Unexpected error attempting to find an item in 1Password named '%s': %s" % (item_id, e))
-
-    def get_field(self, item_id, field, section=None, vault=None):
-        output = self.get_raw(item_id, vault)
-        return self._parse_field(output, item_id, field, section) if output != '' else ''
-
-    def _run(self, args, expected_rc=0):
-        # Duplicates the current shell environment before running 'op', so we get the same PATH the user has,
-        # but we merge in the auth token dictionary, allowing the auto-login functionality to work (if enabled).
-        env = {}
-        env.update(os.environ.copy())
-        env.update(self.token)
-
-        p = Popen([self.cli_path] + args, stdout=PIPE, stderr=PIPE, stdin=PIPE, env=env)
-        out, err = p.communicate()
-
+    def _run(self, args, expected_rc=0, command_input=None, ignore_errors=False):
+        command = [self.cli_path] + args
+        p = Popen(command, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+        out, err = p.communicate(input=command_input)
         rc = p.wait()
-
-        if rc != expected_rc:
-            raise Exception(err)
-
-        return out, err
+        if not ignore_errors and rc != expected_rc:
+            raise AnsibleModuleError(to_native(err))
+        return rc, out, err
 
     def _parse_field(self, data_json, item_id, field_name, section_title=None):
         data = json.loads(data_json)
@@ -288,6 +200,129 @@ class OnePasswordFacts(object):
         optional_section_title = '' if section_title is None else " in the section '%s'" % section_title
         module.fail_json(msg="Unable to find an item in 1Password named '%s' with the field '%s'%s." % (item_id, field_name, optional_section_title))
 
+    def parse_search_terms(self, terms):
+        processed_terms = []
+
+        for term in terms:
+            if not isinstance(term, dict):
+                term = {'name': term}
+
+            if 'name' not in term:
+                module.fail_json(msg="Missing required 'name' field from search term, got: '%s'" % to_native(term))
+
+            term['field'] = term.get('field', 'password')
+            term['section'] = term.get('section', None)
+            term['vault'] = term.get('vault', None)
+
+            processed_terms.append(term)
+
+        return processed_terms
+
+    def get_raw(self, item_id, vault=None):
+        try:
+            args = ["get", "item", item_id]
+            if vault is not None:
+                args += ['--vault={0}'.format(vault)]
+            if not self.logged_in:
+                args += [to_bytes('--session=') + self.token]
+            rc, output, dummy = self._run(args)
+            return output
+
+        except Exception as e:
+            if re.search(".*not found.*", to_native(e)):
+                module.fail_json(msg="Unable to find an item in 1Password named '%s'." % item_id)
+            else:
+                module.fail_json(msg="Unexpected error attempting to find an item in 1Password named '%s': %s" % (item_id, to_native(e)))
+
+    def get_field(self, item_id, field, section=None, vault=None):
+        output = self.get_raw(item_id, vault)
+        return self._parse_field(output, item_id, field, section) if output != '' else ''
+
+    def full_login(self):
+        if self.auto_login is not None:
+            if None in [self.auto_login.get('subdomain'), self.auto_login.get('username'),
+                        self.auto_login.get('secret_key'), self.auto_login.get('master_password')]:
+                module.fail_json(msg='Unable to perform initial sign in to 1Password. '
+                                     'subdomain, username, secret_key, and master_password are required to perform initial sign in.')
+
+            args = [
+                'signin',
+                '{0}.1password.com'.format(self.auto_login['subdomain']),
+                to_bytes(self.auto_login['username']),
+                to_bytes(self.auto_login['secret_key']),
+                '--output=raw',
+            ]
+
+            try:
+                rc, out, err = self._run(args, command_input=to_bytes(self.auto_login['master_password']))
+                self.token = out.strip()
+            except AnsibleModuleError as e:
+                module.fail_json(msg="Failed to perform initial sign in to 1Password: %s" % to_native(e))
+        else:
+            module.fail_json(msg="Unable to perform an initial sign in to 1Password. Please run '%s sigin' "
+                                 "or define credentials in 'auto_login'. See the module documentation for details." % self.cli_path)
+
+    def get_token(self):
+        # If the config file exists, assume an initial signin has taken place and try basic sign in
+        if os.path.isfile(self.config_file_path):
+
+            if self.auto_login is not None:
+
+                # Since we are not currently signed in, master_password is required at a minimum
+                if not self.auto_login.get('master_password'):
+                    module.fail_json(msg="Unable to sign in to 1Password. 'auto_login.master_password' is required.")
+
+                # Try signing in using the master_password and a subdomain if one is provided
+                try:
+                    args = ['signin', '--output=raw']
+
+                    if self.auto_login.get('subdomain'):
+                        args = ['signin', self.auto_login['subdomain'], '--output=raw']
+
+                    rc, out, err = self._run(args, command_input=to_bytes(self.auto_login['master_password']))
+                    self.token = out.strip()
+
+                except AnsibleModuleError:
+                    self.full_login()
+
+            else:
+                self.full_login()
+
+        else:
+            # Attempt a full sign in since there appears to be no existing sign in
+            self.full_login()
+
+    def assert_logged_in(self):
+        try:
+            rc, out, err = self._run(['get', 'account'], ignore_errors=True)
+            if rc != 1:
+                self.logged_in = True
+            if not self.logged_in:
+                self.get_token()
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                module.fail_json(msg="1Password CLI tool '%s' not installed in path on control machine" % self.cli_path)
+            raise e
+
+    def run(self):
+        result = {}
+
+        self.assert_logged_in()
+
+        for term in self.terms:
+            value = self.get_field(term['name'], term['field'], term['section'], term['vault'])
+
+            if term['name'] in result:
+                # If we already have a result for this key, we have to append this result dictionary
+                # to the existing one. This is only applicable when there is a single item
+                # in 1Password which has two different fields, and we want to retrieve both of them.
+                result[term['name']].update(value)
+            else:
+                # If this is the first result for this key, simply set it.
+                result[term['name']] = value
+
+        return result
+
 
 def main():
     global module
@@ -295,10 +330,10 @@ def main():
         argument_spec=dict(
             cli_path=dict(type='path', default='op'),
             auto_login=dict(type='dict', options=dict(
-                subdomain=dict(required=True, type='str'),
-                username=dict(required=True, type='str'),
-                master_password=dict(required=True, type='str'),
-                secret_key=dict(required=True, type='str'),
+                subdomain=dict(type='str'),
+                username=dict(type='str'),
+                master_password=dict(required=True, type='str', no_log=True),
+                secret_key=dict(type='str', no_log=True),
             ), default=None),
             search_terms=dict(required=True, type='list')
         ),

--- a/lib/ansible/modules/identity/onepassword_facts.py
+++ b/lib/ansible/modules/identity/onepassword_facts.py
@@ -25,6 +25,9 @@ requirements:
     - C(op) 1Password command line utility. See U(https://support.1password.com/command-line/)
 notes:
     - "Based on the C(onepassword) lookup plugin by Scott Buchanan <sbuchanan@ri.pn>."
+    - This module stores potentially sensitive data from 1Password as Ansible facts.
+      Facts are subject to caching if enabled, which means this data could be stored in clear text
+      on disk or in a database.
 short_description: Gather items from 1Password and set them as facts
 description:
     - M(onepassword_facts) wraps the C(op) command line utility to fetch data about one or more 1Password items and return as Ansible facts.

--- a/lib/ansible/modules/identity/onepassword_facts.py
+++ b/lib/ansible/modules/identity/onepassword_facts.py
@@ -28,6 +28,7 @@ notes:
     - This module stores potentially sensitive data from 1Password as Ansible facts.
       Facts are subject to caching if enabled, which means this data could be stored in clear text
       on disk or in a database.
+      - Tested with C(op) version 0.5.3
 short_description: Gather items from 1Password and set them as facts
 description:
     - M(onepassword_facts) wraps the C(op) command line utility to fetch data about one or more 1Password items and return as Ansible facts.

--- a/lib/ansible/plugins/lookup/onepassword.py
+++ b/lib/ansible/plugins/lookup/onepassword.py
@@ -59,6 +59,9 @@ DOCUMENTATION = """
       - Due to the B(very) sensitive nature of these credentials, it is B(highly) recommeneded that you only pass in the minial credentials
         needed at any given time. Also, store these credentials in an Ansible Vault using a key that is equal to or greater in strength
         to the 1Password master password.
+      - This lookup stores potentially sensitive data from 1Password as Ansible facts.
+        Facts are subject to caching if enabled, which means this data could be stored in clear text
+        on disk or in a database.
 """
 
 EXAMPLES = """

--- a/lib/ansible/plugins/lookup/onepassword.py
+++ b/lib/ansible/plugins/lookup/onepassword.py
@@ -121,12 +121,11 @@ class OnePass(object):
         self.master_password = None
 
     def get_token(self):
-
         # If the config file exists, assume an initial signin has taken place and try basic sign in
         if os.path.isfile(self.config_file_path):
 
             if not self.master_password:
-                raise AnsibleLookupError('Failed to sign in to 1Password. master_password is required.')
+                raise AnsibleLookupError('Unable to sign in to 1Password. master_password is required.')
 
             try:
                 args = ['signin', '--output=raw']
@@ -153,7 +152,7 @@ class OnePass(object):
                 self.get_token()
         except OSError as e:
             if e.errno == errno.ENOENT:
-                raise AnsibleLookupError("1Password CLI tool not installed in path on control machine")
+                raise AnsibleLookupError("1Password CLI tool '%s' not installed in path on control machine" % self.cli_path)
             raise e
 
     def get_raw(self, item_id, vault=None):
@@ -170,9 +169,8 @@ class OnePass(object):
         return self._parse_field(output, field, section) if output != '' else ''
 
     def full_login(self):
-
         if None in [self.subdomain, self.username, self.secret_key, self.master_password]:
-            raise AnsibleLookupError('Failed to perform initial sign in to 1Password. '
+            raise AnsibleLookupError('Unable to perform initial sign in to 1Password. '
                                      'subdomain, username, secret_key, and master_password are required to perform initial sign in.')
 
         args = [

--- a/lib/ansible/plugins/lookup/onepassword.py
+++ b/lib/ansible/plugins/lookup/onepassword.py
@@ -146,7 +146,7 @@ class OnePass(object):
     def assert_logged_in(self):
         try:
             rc, out, err = self._run(['get', 'account'], ignore_errors=True)
-            if rc != 1:
+            if rc == 0:
                 self.logged_in = True
             if not self.logged_in:
                 self.get_token()

--- a/lib/ansible/plugins/lookup/onepassword.py
+++ b/lib/ansible/plugins/lookup/onepassword.py
@@ -62,6 +62,7 @@ DOCUMENTATION = """
       - This lookup stores potentially sensitive data from 1Password as Ansible facts.
         Facts are subject to caching if enabled, which means this data could be stored in clear text
         on disk or in a database.
+      - Tested with C(op) version 0.5.3
 """
 
 EXAMPLES = """

--- a/lib/ansible/plugins/lookup/onepassword_raw.py
+++ b/lib/ansible/plugins/lookup/onepassword_raw.py
@@ -48,6 +48,17 @@ DOCUMENTATION = """
       vault:
         description: Vault containing the item to retrieve (case-insensitive). If absent will search all vaults
         default: None
+    notes:
+      - This lookup will use an existing 1Password session if one exists. If not, and you have already
+        performed an initial sign in (meaning C(~/.op/config exists)), then only the C(master_password) is required.
+        You may optionally specify C(subdomain) in this scenario, otherwise the last used subdomain will be used by C(op).
+      - This lookup can perform an initial login by providing C(subdomain), C(username), C(secret_key), and C(master_password).
+      - Due to the B(very) sensitive nature of these credentials, it is B(highly) recommeneded that you only pass in the minial credentials
+        needed at any given time. Also, store these credentials in an Ansible Vault using a key that is equal to or greater in strength
+        to the 1Password master password.
+      - This lookup stores potentially sensitive data from 1Password as Ansible facts.
+        Facts are subject to caching if enabled, which means this data could be stored in clear text
+        on disk or in a database.
 """
 
 EXAMPLES = """

--- a/lib/ansible/plugins/lookup/onepassword_raw.py
+++ b/lib/ansible/plugins/lookup/onepassword_raw.py
@@ -20,25 +20,34 @@ DOCUMENTATION = """
     version_added: "2.6"
     requirements:
       - C(op) 1Password command line utility. See U(https://support.1password.com/command-line/)
-      - must have already logged into 1Password using op CLI
-    short_description: fetch raw json data from 1Password
+    short_description: fetch an entire item from 1Password
     description:
-      - onepassword_raw wraps C(op) command line utility to fetch an entire item from 1Password
+      - C(onepassword_raw) wraps C(op) command line utility to fetch an entire item from 1Password
     options:
       _terms:
         description: identifier(s) (UUID, name, or domain; case-insensitive) of item(s) to retrieve
         required: True
+      master_password:
+        description: The password used to unlock the specified vault.
+        default: None
+        version_added: '2.7'
+        aliases: ['vault_password']
+      section:
+        description: Item section containing the field to retrieve (case-insensitive). If absent will return first match from any section.
+        default: None
       subdomain:
         description: The 1Password subdomain to authenticate against.
         default: None
         version_added: '2.7'
-      vault:
-        description: vault containing the item to retrieve (case-insensitive); if absent will search all vaults
-        default: None
-      vault_password:
-        description: The password used to unlock the specified vault.
-        default: None
+      username:
+        description: The username used to sign in.
         version_added: '2.7'
+      secret_key:
+        description: The secret key used when performing an initial sign in.
+        version_added: '2.7'
+      vault:
+        description: Vault containing the item to retrieve (case-insensitive). If absent will search all vaults
+        default: None
 """
 
 EXAMPLES = """
@@ -68,8 +77,10 @@ class LookupModule(LookupBase):
         op = OnePass()
 
         vault = kwargs.get('vault')
-        op._subdomain = kwargs.get('subdomain')
-        op._vault_password = kwargs.get('vault_password')
+        op.subdomain = kwargs.get('subdomain')
+        op.username = kwargs.get('username')
+        op.secret_key = kwargs.get('secret_key')
+        op.master_password = kwargs.get('master_password', kwargs.get('vault_password'))
 
         op.assert_logged_in()
 

--- a/lib/ansible/plugins/lookup/onepassword_raw.py
+++ b/lib/ansible/plugins/lookup/onepassword_raw.py
@@ -59,6 +59,7 @@ DOCUMENTATION = """
       - This lookup stores potentially sensitive data from 1Password as Ansible facts.
         Facts are subject to caching if enabled, which means this data could be stored in clear text
         on disk or in a database.
+      - Tested with C(op) version 0.5.3
 """
 
 EXAMPLES = """

--- a/test/units/plugins/lookup/test_onepassword.py
+++ b/test/units/plugins/lookup/test_onepassword.py
@@ -233,45 +233,45 @@ class TestOnePass(unittest.TestCase):
 
     def test_onepassword_get(self):
         op = MockOnePass()
-        op._logged_in = True
+        op.logged_in = True
         query_generator = get_mock_query_generator()
         for dummy, query, dummy, field_name, field_value in query_generator:
             self.assertEqual(field_value, op.get_field(query, field_name))
 
     def test_onepassword_get_raw(self):
         op = MockOnePass()
-        op._logged_in = True
+        op.logged_in = True
         for entry in MOCK_ENTRIES:
             for query in entry['queries']:
                 self.assertEqual(json.dumps(entry['output']), op.get_raw(query))
 
     def test_onepassword_get_not_found(self):
         op = MockOnePass()
-        op._logged_in = True
+        op.logged_in = True
         self.assertEqual('', op.get_field('a fake query', 'a fake field'))
 
     def test_onepassword_get_with_section(self):
         op = MockOnePass()
-        op._logged_in = True
+        op.logged_in = True
         dummy, query, section_title, field_name, field_value = get_one_mock_query()
         self.assertEqual(field_value, op.get_field(query, field_name, section=section_title))
 
     def test_onepassword_get_with_vault(self):
         op = MockOnePass()
-        op._logged_in = True
+        op.logged_in = True
         entry, query, dummy, field_name, field_value = get_one_mock_query()
         for vault_query in [entry['vault_name'], entry['output']['vaultUuid']]:
             self.assertEqual(field_value, op.get_field(query, field_name, vault=vault_query))
 
     def test_onepassword_get_with_wrong_vault(self):
         op = MockOnePass()
-        op._logged_in = True
+        op.logged_in = True
         dummy, query, dummy, field_name, dummy = get_one_mock_query()
         self.assertEqual('', op.get_field(query, field_name, vault='a fake vault'))
 
     def test_onepassword_get_diff_case(self):
         op = MockOnePass()
-        op._logged_in = True
+        op.logged_in = True
         entry, query, section_title, field_name, field_value = get_one_mock_query()
         self.assertEqual(
             field_value,


### PR DESCRIPTION
##### SUMMARY

Unify the terms and interface used for logging in to 1Password  between the facts module and lookup plugins.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`onepassword.py`
`onepassword_raw.py`
`onepassword_facts.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```