### PR TITLE
Don't pass file_name to DataLoader.load in script inventory plugin

### DIFF
--- a/changelogs/fragments/script-module-no-file-path.yaml
+++ b/changelogs/fragments/script-module-no-file-path.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- script inventory plugin - Don't pass file_name to DataLoader.load, which will prevent misleading error messages (https://github.com/ansible/ansible/issues/34164)

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -120,7 +120,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                     raise AnsibleError("Inventory {0} contained characters that cannot be interpreted as UTF-8: {1}".format(path, to_native(e)))
 
                 try:
-                    self._cache[cache_key] = self.loader.load(data, file_name=path)
+                    self._cache[cache_key] = self.loader.load(data)
                 except Exception as e:
                     raise AnsibleError("failed to parse executable inventory script results from {0}: {1}\n{2}".format(path, to_native(e), err))
 


### PR DESCRIPTION
##### SUMMARY
Don't pass file_name to DataLoader.load in script inventory plugin. Fixes #34164

Passing `file_name` means that if `DataLoader.load` fails to parse the data, it will load the contents of the script, and point to a line/column using the exception information from the parsed data.  This is misleading and wrong, as it seems to indicate an issue with the code of the script, instead of the output.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/script.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.5
2.6
2.7
2.8
```

##### ADDITIONAL INFORMATION
Before:

```
 [WARNING]:  * Failed to parse /Users/matt/projects/ansibledev/playbooks/broken_json.sh with script plugin: failed to parse executable inventory script results from /Users/matt/projects/ansibledev/playbooks/broken_json.sh: Syntax Error
while loading YAML.   expected '<document start>', but found '}'  The error appears to have been in '/Users/matt/projects/ansibledev/playbooks/broken_json.sh': line 16, column 2, but may be elsewhere in the file depending on the exact
syntax problem.  The offending line appears to be:              "127.0.0.1"         ]  ^ here
```

After:

```
 [WARNING]:  * Failed to parse /Users/matt/projects/ansibledev/playbooks/broken_json.sh with script plugin: failed to parse executable inventory script results from /Users/matt/projects/ansibledev/playbooks/broken_json.sh: Syntax Error
while loading YAML.   expected '<document start>', but found '}'  The error appears to have been in '<string>': line 16, column 2, but may be elsewhere in the file depending on the exact syntax problem.
```