### PR TITLE
Fix wait_for_task backoff behavior in vmware modules

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -58,7 +58,7 @@ def wait_for_task(task, max_backoff=64, timeout=3600):
             finally:
                 raise_from(TaskError(error_msg), task.info.error)
         if task.info.state in [vim.TaskInfo.State.running, vim.TaskInfo.State.queued]:
-            sleep_time = min(2 ** failure_counter + randint(1, 1000), max_backoff)
+            sleep_time = min(2 ** failure_counter + randint(1, 1000) / 1000, max_backoff)
             time.sleep(sleep_time)
             failure_counter += 1
 


### PR DESCRIPTION
##### SUMMARY
I stepped into this when I tried `vmware_guest_powerstate` to turn off a running VM in VMware by setting `state=powered-off`. The instance went down almost immediately, but I had to wait another minute for the module task to return.

In #39596, a timer with an exponential backoff algorithm was added:
```python
sleep_time = min(2 ** failure_counter + randint(1, 1000), max_backoff)
```
The intent was obviously to wait for [1,2,4,8,16,32,64,64...] seconds, with some fuzzing added to the seconds. But as it is implemented, the added `randint(1, 1000)` will be greater than `max_backoff` (64) most of the time, resulting in a 93,6% chance that the first wait duration will be 64 seconds.

I assume that the random value was intended to add a slight fuzzing in the range 0..1000 milliseconds.

This PR adjusts the code to that assumption.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/module_utils/vmware.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
sample invocation, credentials specified in environment variables
```bash
hacking/test-module -m lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py -a 'state=powered-off name=some-running-vm'
```
