### PR TITLE
Add support for Sangoma linux to hostname module

### DIFF
--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -679,6 +679,12 @@ class AmazonLinuxHostname(Hostname):
     strategy_class = RedHatStrategy
 
 
+class SangomaLinuxHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Derived from red hat enterprise linux '
+    strategy_class = RedHatStrategy
+
+
 class DebianHostname(Hostname):
     platform = 'Linux'
     distribution = 'Debian'


### PR DESCRIPTION
##### SUMMARY
Add support for Sangoma linux which is derived from CentOS. Fixes [45300](https://github.com/ansible/ansible/issues/45300)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hostname module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
I'm not sure that adding a class for every derivative of RedHat linux to the hostname module is the best course of action long term.


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
