### PR TITLE
Add check for existence of key in the old config.

### DIFF
--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -458,7 +458,7 @@ class LXDContainerManagement(object):
         if key == 'config':
             old_configs = dict((k, v) for k, v in self.old_container_json['metadata'][key].items() if not k.startswith('volatile.'))
             for k, v in self.config['config'].items():
-                if old_configs[k] != v:
+                if k in old_configs and old_configs[k] != v:
                     return True
             return False
         else:


### PR DESCRIPTION
In the case of volatile config options, it made the module crash.

##### SUMMARY
Fixes the update of container configs that contained volatile config options.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloud/lxd-container module 

##### ANSIBLE VERSION

```
ansible 2.6.4
  config file = /home/my/somepath/ansible.cfg
  configured module search path = ['/home/my/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.0 (default, Jul 15 2018, 10:44:58) [GCC 8.1.1 20180531]

```