### PR TITLE
[stable-2.7] Don't pass file_name to DataLoader.load in script inventory plugin (#45428)

### DIFF
--- a/changelogs/fragments/script-module-no-file-path.yaml
+++ b/changelogs/fragments/script-module-no-file-path.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- script inventory plugin - Don't pass file_name to DataLoader.load, which will prevent misleading error messages (https://github.com/ansible/ansible/issues/34164)

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -120,7 +120,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                     raise AnsibleError("Inventory {0} contained characters that cannot be interpreted as UTF-8: {1}".format(path, to_native(e)))
 
                 try:
-                    self._cache[cache_key] = self.loader.load(data, file_name=path)
+                    self._cache[cache_key] = self.loader.load(data)
                 except Exception as e:
                     raise AnsibleError("failed to parse executable inventory script results from {0}: {1}\n{2}".format(path, to_native(e), err))
 


### PR DESCRIPTION
* Don't pass file_name to DataLoader.load in script inventory plugin. Fixes #34164

* Add changelog fragment
(cherry picked from commit 263b9fa)


Co-authored-by: Matt Martz <matt@sivel.net>