### PR TITLE
Reduce cost of Azure DB tests.

### DIFF
--- a/test/integration/targets/azure_rm_mysqlserver/tasks/main.yml
+++ b/test/integration/targets/azure_rm_mysqlserver/tasks/main.yml
@@ -8,9 +8,9 @@
     resource_group: "{{ resource_group }}"
     name: mysqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     version: 5.6
     enforce_ssl: True
@@ -28,9 +28,9 @@
     resource_group: "{{ resource_group }}"
     name: mysqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     version: 5.6
     enforce_ssl: True
@@ -48,9 +48,9 @@
     resource_group: "{{ resource_group }}"
     name: mysqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     version: 5.6
     enforce_ssl: True
@@ -68,9 +68,9 @@
     resource_group: "{{ resource_group }}"
     name: mysqlsrv{{ rpfx }}second
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     version: 5.6
     enforce_ssl: True

--- a/test/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
+++ b/test/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
@@ -8,9 +8,9 @@
     resource_group: "{{ resource_group }}"
     name: postgresqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     enforce_ssl: True
     admin_username: zimxyz
@@ -27,9 +27,9 @@
     resource_group: "{{ resource_group }}"
     name: postgresqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     enforce_ssl: True
     admin_username: zimxyz
@@ -46,9 +46,9 @@
     resource_group: "{{ resource_group }}"
     name: postgresqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     enforce_ssl: True
     admin_username: zimxyz
@@ -65,9 +65,9 @@
     resource_group: "{{ resource_group }}"
     name: postgresqlsrv{{ rpfx }}second
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     enforce_ssl: True
     admin_username: zimxyz


### PR DESCRIPTION
##### SUMMARY

Reduce cost of Azure DB tests:

- GP_Gen4_2 in westus is currently $0.205/hour
- B_Gen5_1 in westus2 is currently $0.034/hour

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

azure database integration tests

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (azure-test-savings 5ab52c9658) last updated 2018/09/10 13:04:58 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
