### PR TITLE
win_say - fix up syntax and test issues

### DIFF
--- a/changelogs/fragments/win_say-fix.yaml
+++ b/changelogs/fragments/win_say-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_say - fix syntax error in module and get tests working

--- a/lib/ansible/modules/windows/win_say.ps1
+++ b/lib/ansible/modules/windows/win_say.ps1
@@ -21,7 +21,7 @@ $result = @{
 
 $words = $null
 
-f ($speech_speed -lt -10 -or $speech_speed -gt 10) {
+if ($speech_speed -lt -10 -or $speech_speed -gt 10) {
    Fail-Json $result "speech_speed needs to a integer in the range -10 to 10.  The value $speech_speed is outside this range."
 }
 

--- a/test/integration/targets/win_say/tasks/main.yml
+++ b/test/integration/targets/win_say/tasks/main.yml
@@ -1,18 +1,24 @@
+# CI hosts don't have a valid Speech package so we rely on check mode for basic
+# sanity tests
+---
 - name: Warn of impending deployment
   win_say:
     msg: Warning, deployment commencing in 5 minutes, please log out.
+  check_mode: yes
 
 - name: Using a different voice and a start sound
   win_say:
     msg: Warning, deployment commencing in 5 minutes, please log out.
     start_sound_path: C:\Windows\Media\ding.wav
     voice: Microsoft Hazel Desktop
+  check_mode: yes
 
 - name: Example with start and end sound
   win_say:
     msg: New software installed
     start_sound_path: C:\Windows\Media\Windows Balloon.wav
     end_sound_path: C:\Windows\Media\chimes.wav
+  check_mode: yes
 
 - name: Create message file
   win_copy:
@@ -24,6 +30,7 @@
     msg_file: C:\Windows\Temp\win_say_message.txt
     start_sound_path: C:\Windows\Media\Windows Balloon.wav
     end_sound_path: C:\Windows\Media\chimes.wav
+  check_mode: yes
 
 - name: Remove message file
   win_file:
@@ -34,3 +41,4 @@
   win_say:
     speech_speed: 5
     msg: Stay calm and proceed to the closest fire exit.
+  check_mode: yes


### PR DESCRIPTION
##### SUMMARY
Fix syntax issue in win_say and get broken tests working. Technically the tests work but will start failing with https://github.com/ansible/ansible/pull/45334 due to the trap that is added. This trap picks up the current silent failure in CI when the speech package is not available.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_say

##### ANSIBLE VERSION
```paste below
devel
```