### PR TITLE
win_group_membership - fix random issue with CI on 2012 R2

### DIFF
--- a/changelogs/fragments/win_group_membership-com-marshal.yaml
+++ b/changelogs/fragments/win_group_membership-com-marshal.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_group_membership - fix intermittent issue where it failed to convert the ADSI object to the .NET object after using it once


### PR DESCRIPTION
##### SUMMARY
As part of https://github.com/ansible/ansible/pull/45334, I found that win_group_membership occasionally fails to cast the ADSI object object when getting the group membership with

```
Cannot convert value "System.__ComObject" to type "System.DirectoryServices.DirectoryEntry". Error: "COM object that has been separated from its underlying RCW cannot be used."
At line:51 char:58
+     $current_members = $Group.psbase.Invoke("Members") | ForEach-Object {
+                                                          ~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [ForEach-Object], RuntimeException
    + FullyQualifiedErrorId : InvalidCastConstructorException,Microsoft.PowerShell.Commands.ForEachObjectCommand
ScriptStackTrace:
at <ScriptBlock>, <No file>: line 54
at Get-GroupMember, <No file>: line 51
at <ScriptBlock>, <No file>: line 106
```

Changing the method to cast it just once before running the `InvokeGet` methods fixed this issue in that branch. Creating a separate PR so I can backport the changes without relying on a feature PR.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_group_membership

##### ANSIBLE VERSION
```paste below
devel
```