### PR TITLE
Fix python 3 compatibility for network id lookup (issue #45408)

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -838,7 +838,7 @@ class DockerService(DockerBaseClass):
         for network_name in self.networks:
             network_id = None
             try:
-                network_id = filter(lambda n: n['name'] == network_name, docker_networks)[0]['id']
+                network_id = list(filter(lambda n: n['name'] == network_name, docker_networks))[0]['id']
             except:
                 pass
             if network_id:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes issue #45408

Due to a change in python 3 filters return filter instead of list. This breaks the network name to id lookup for the docker_swarm_module. By wrapping it in list it ensures it is a list when returned and the id is extracted.
 

Note: I haven't tested this on a target using python 2.7. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
affects 2.7+  See issue ##45408
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See issue ##45408
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
No longer receive error  Exception: no docker networks named which was just a disguise to the actual error of "TypeError: 'filter' object is not subscriptable"
```
