### PR TITLE
Fix for issue 34185 ovs fail-mode

### DIFF
--- a/lib/ansible/modules/network/ovs/openvswitch_bridge.py
+++ b/lib/ansible/modules/network/ovs/openvswitch_bridge.py
@@ -50,12 +50,14 @@ options:
         version_added: 2.0
         description:
             - A dictionary of external-ids. Omitting this parameter is a No-op.
-              To  clear all external-ids pass an empty value.
+              To clear all external-ids pass an empty value.
     fail_mode:
         version_added: 2.0
         choices : [secure, standalone]
         description:
             - Set bridge fail-mode. The default value (None) is a No-op.
+              Omitting this parameter is a No-op.
+              To clear previously set fail_mode pass an empty value.
     set:
         version_added: 2.3
         description:
@@ -132,6 +134,11 @@ def map_obj_to_commands(want, have, module):
                         templatized_command = ("%(ovs-vsctl)s -t %(timeout)s"
                                                " set-fail-mode %(bridge)s"
                                                " %(fail_mode)s")
+                    else:
+                        # if fail-mode is specified, but empty it means user
+                        # wants to reset the fail-mode, so clear it off
+                        templatized_command = ("%(ovs-vsctl)s -t %(timeout)s"
+                                               " del-fail-mode %(bridge)s")
 
                     command = templatized_command % module.params
                     commands.append(command)

--- a/lib/ansible/modules/network/ovs/openvswitch_bridge.py
+++ b/lib/ansible/modules/network/ovs/openvswitch_bridge.py
@@ -123,12 +123,18 @@ def map_obj_to_commands(want, have, module):
             commands.append(command)
     else:
         if have:
-            if want['fail_mode'] != have['fail_mode']:
-                templatized_command = ("%(ovs-vsctl)s -t %(timeout)s"
-                                       " set-fail-mode %(bridge)s"
-                                       " %(fail_mode)s")
-                command = templatized_command % module.params
-                commands.append(command)
+            wanted_fail_mode = want['fail_mode']
+            have_fail_mode = have['fail_mode']
+            if wanted_fail_mode != have_fail_mode:
+                if wanted_fail_mode is not None:
+                    if wanted_fail_mode.strip():
+                        # only set the fail-mode if specified and not empty
+                        templatized_command = ("%(ovs-vsctl)s -t %(timeout)s"
+                                               " set-fail-mode %(bridge)s"
+                                               " %(fail_mode)s")
+
+                    command = templatized_command % module.params
+                    commands.append(command)
 
             if want['external_ids'] != have['external_ids']:
                 templatized_command = ("%(ovs-vsctl)s -t %(timeout)s"

--- a/lib/ansible/modules/network/ovs/openvswitch_bridge.py
+++ b/lib/ansible/modules/network/ovs/openvswitch_bridge.py
@@ -128,7 +128,7 @@ def map_obj_to_commands(want, have, module):
             wanted_fail_mode = want['fail_mode']
             have_fail_mode = have['fail_mode']
             if wanted_fail_mode != have_fail_mode:
-                if wanted_fail_mode is not None:
+                if wanted_fail_mode is not None and wanted_fail_mode != 'None':
                     if wanted_fail_mode.strip():
                         # only set the fail-mode if specified and not empty
                         templatized_command = ("%(ovs-vsctl)s -t %(timeout)s"


### PR DESCRIPTION
This patch fixes issue #34185
This is related to ovs fail-mode when there is already a fail-mode on the ovs and appears in 'have' and unspecified or none in the request ('want'), as per the default in ovs.

Signed-off-by: Ashish Billore <ashish.billore@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is related to ovs fail-mode when there is already a fail-mode on the ovs and appears in 'have' and unspecified or none in the request ('want'), as per the default in ovs.

https://github.com/ansible/ansible/issues/34185
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #34185
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openvswitch_bridge_module
https://docs.ansible.com/ansible/2.6/modules/openvswitch_bridge_module.html

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.4.0.0 and above
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

This patch adds a check to see if there is already fail-mode set on the ovs and the request specified has the fail-mode or not. If the fail-mode is specified in the request it works as earlier, just apply the fail-mode in 'want'. If there is no fail-mode specified in the 'want' or the request and if there is already a fail-mode set on the ovs, it resets the fail-mode on the ovs bridge, which is the default in ovs.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Please refer: #34185

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

Before the patch is applied:

[root@osc]# ansible master -i inventory.yaml -m openvswitch_bridge -a "bridge=br-int state=present"
128.90.0.54 | FAILED! => {
    "changed": false, 
    "cmd": "/usr/bin/ovs-vsctl -t 5 set-fail-mode br-int None", 
    "failed": true, 
    "msg": "ovs-vsctl: fail-mode must be \"standalone\" or \"secure\"", 
    "rc": 1, 
    "stderr": "ovs-vsctl: fail-mode must be \"standalone\" or \"secure\"\n", 
    "stderr_lines": [
        "ovs-vsctl: fail-mode must be \"standalone\" or \"secure\""
    ], 
    "stdout": "", 
    "stdout_lines": []
}

After applying the path:

[root@osc]# ansible master -i inventory.yaml -m openvswitch_bridge -a "bridge=br-int state=present"
128.90.0.54 | SUCCESS => {
    "changed": true, 
    "commands": [
        "/usr/bin/ovs-vsctl -t 2 del-fail-mode br-int"
    ], 
    "failed": false
}
[root@osc]#
```
