### PR TITLE
ec2_eip: migrate to boto3

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -166,7 +166,7 @@ public_ip:
 try:
     import botocore
 except ImportError:
-    pass # Handled by AnsibleAWSModule
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import (
@@ -271,7 +271,7 @@ class AnsibleEc2Eip(object):
         if len(devices) > 1:
             self._module.fail_json_aws(
                 None,
-                msg='More than one device was returned with id, aborting'.format(self.device_id))
+                msg='More than one device was returned with id {0}, aborting'.format(self.device_id))
         elif devices:
             device = camel_dict_to_snake_dict(devices[0])
         return device


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
AWS boto only modules present issues with corporate internet proxies. Migrate to boto3 solves problems.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #44889

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- lib/ansible/modules/cloud/amazon/ec2_eip.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
2.5 and 2.6
```
