### PR TITLE
Update import_playbook.py

### DIFF
--- a/lib/ansible/modules/utilities/logic/import_playbook.py
+++ b/lib/ansible/modules/utilities/logic/import_playbook.py
@@ -29,6 +29,7 @@ options:
       - The name of the imported playbook is specified directly without any other option.
 notes:
   - This is a core feature of Ansible, rather than a module, and cannot be overridden like a module.
+  - Note that including an empty playbook in a master playbook, will result in an error.
 '''
 
 EXAMPLES = """

--- a/lib/ansible/modules/utilities/logic/import_playbook.py
+++ b/lib/ansible/modules/utilities/logic/import_playbook.py
@@ -29,7 +29,7 @@ options:
       - The name of the imported playbook is specified directly without any other option.
 notes:
   - This is a core feature of Ansible, rather than a module, and cannot be overridden like a module.
-  - Note that including an empty playbook in a master playbook, will result in an error.
+  - Note that including an empty playbook in a master playbook, will result in a not obvious error: "ERROR! playbooks must be a list of plays"
 '''
 
 EXAMPLES = """

--- a/lib/ansible/modules/utilities/logic/import_playbook.py
+++ b/lib/ansible/modules/utilities/logic/import_playbook.py
@@ -29,7 +29,7 @@ options:
       - The name of the imported playbook is specified directly without any other option.
 notes:
   - This is a core feature of Ansible, rather than a module, and cannot be overridden like a module.
-  - Note that including an empty playbook in a master playbook, will result in a not obvious error: "ERROR! playbooks must be a list of plays"
+  - Note that including an empty playbook in a master playbook, will result in a not obvious error C(ERROR! playbooks must be a list of plays)
 '''
 
 EXAMPLES = """


### PR DESCRIPTION
Added a small note about what happens when importing a (still) empty playbook in a master playbook. You then get: "ERROR! playbooks must be a list of plays",  which is rather ambiguous. It's correct behaviour, but when setting up a new project, people tend to put the structure in first, while not actually putting any useful tasks in the playbook. (or at least, we do :-p )

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
