### PR TITLE
Allow role requirements to have + in their uri

### DIFF
--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -118,7 +118,7 @@ class RoleRequirement(RoleDefinition):
                     role["src"] = "git+" + role["src"]
 
                 if '+' in role["src"]:
-                    (scm, src) = role["src"].split('+')
+                    (scm, src) = role["src"].split('+', 1)
                     role["scm"] = scm
                     role["src"] = src
 

--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -118,7 +118,7 @@ class RoleRequirement(RoleDefinition):
                     role["src"] = "git+" + role["src"]
 
                 if '+' in role["src"]:
-                    role["scm"], _, role["src"] = role["src"].partition('+')
+                    role["scm"], sep, role["src"] = role["src"].partition('+')
 
                 if 'name' not in role:
                     role["name"] = RoleRequirement.repo_url_to_role_name(role["src"])

--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -118,9 +118,7 @@ class RoleRequirement(RoleDefinition):
                     role["src"] = "git+" + role["src"]
 
                 if '+' in role["src"]:
-                    (scm, src) = role["src"].split('+', 1)
-                    role["scm"] = scm
-                    role["src"] = src
+                    role["scm"], _, role["src"] = role["src"].partition('+')
 
                 if 'name' not in role:
                     role["name"] = RoleRequirement.repo_url_to_role_name(role["src"])


### PR DESCRIPTION
Split only first +, since there can be + in other part of the URL like auth token

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #45475

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

ansible-galaxy install

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.6.6 (r266:84292, Aug  9 2016, 06:11:56) [GCC 4.4.7 20120313 (Red Hat 4.4.7-17)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Reproducing and output before the fix : see #45475

After the fix

```
[root@cockpit vagrant]# ansible-galaxy install -r requirements.yml
- extracting company.mysql to /root/.ansible/roles/company.mysql
- company.mysql was installed successfully
```
