### PR TITLE
[AWS] cloudfront_distribution - call a method that exists

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -1813,7 +1813,7 @@ class CloudFrontValidationManager(object):
 
     def wait_until_processed(self, client, wait_timeout, distribution_id, caller_reference):
         if distribution_id is None:
-            distribution_id = self.validate_distribution_id_from_caller_reference(caller_reference=caller_reference)
+            distribution_id = self.validate_distribution_from_caller_reference(caller_reference=caller_reference)['Id']
 
         try:
             waiter = client.get_waiter('distribution_deployed')


### PR DESCRIPTION
##### SUMMARY
Fix method name from 'validate_distribution_id_from_caller_reference' to 'validate_distribution_from_caller_reference' and set distribution_id to the distribution's key 'Id'.

Fixes #45496

Should be backported as well.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudfront_distribution.py

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
```
