### PR TITLE
[backport-2.7] Fix remote checksums when paths have leading dots (#45287)

### DIFF
--- a/changelogs/fragments/45501-get_url-better_checksums.yaml
+++ b/changelogs/fragments/45501-get_url-better_checksums.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- get_url - support remote checksum files with paths specified with leading dots (`./path/to/file`)

--- a/changelogs/fragments/get_url.yaml
+++ b/changelogs/fragments/get_url.yaml
@@ -3,3 +3,4 @@ minor_changes:
 
 bugfixes:
 - get_url - fix the bug that get_url does not change mode when checksum matches (https://github.com/ansible/ansible/issues/29614)
+- get_url - support remote checksum files with paths specified with leading dots (`./path/to/file`)

--- a/changelogs/fragments/get_url.yaml
+++ b/changelogs/fragments/get_url.yaml
@@ -3,4 +3,3 @@ minor_changes:
 
 bugfixes:
 - get_url - fix the bug that get_url does not change mode when checksum matches (https://github.com/ansible/ansible/issues/29614)
-- get_url - support remote checksum files with paths specified with leading dots (`./path/to/file`)

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -449,7 +449,7 @@ def main():
                 os.remove(checksum_tmpsrc)
                 lines = dict(s.split(None, 1) for s in lines)
                 filename = url_filename(url)
-                [checksum] = (k for (k, v) in lines.items() if v == filename)
+                [checksum] = (k for (k, v) in lines.items() if v.strip('./') == filename)
             # Remove any non-alphanumeric characters, including the infamous
             # Unicode zero-width space
             checksum = re.sub(r'\W+', '', checksum).lower()

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -300,6 +300,19 @@
     - '30949cc401e30ac494d695ab8764a9f76aae17c5d73c67f65e9b558f47eff892  not_target1.txt'
     - 'd0dbfc1945bc83bf6606b770e442035f2c4e15c886ee0c22fb3901ba19900b5b  not_target2.txt'
 
+- name: create sha256 checksum file of src with a dot leading path
+  copy:
+    dest: '{{ files_dir }}/sha256sum_with_dot.txt'
+    content: "b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006.  ./27617.txt"
+
+- name: add sha256 checksums with dot leading path not going to be downloaded
+  lineinfile:
+    dest: "{{ files_dir }}/sha256sum_with_dot.txt"
+    line: "{{ item }}"
+  loop:
+    - '30949cc401e30ac494d695ab8764a9f76aae17c5d73c67f65e9b558f47eff892  ./not_target1.txt'
+    - 'd0dbfc1945bc83bf6606b770e442035f2c4e15c886ee0c22fb3901ba19900b5b  ./not_target2.txt'
+
 - copy:
     src: "testserver.py"
     dest: "{{ output_dir }}/testserver.py"
@@ -331,13 +344,26 @@
     path: "{{ output_dir }}/27617.txt"
   register: stat_result_sha256
 
+- name: download src with sha256 checksum url with dot leading paths
+  get_url:
+    url: 'http://localhost:{{ http_port }}/27617.txt'
+    dest: '{{ output_dir }}/27617sha256_with_dot.txt'
+    checksum: 'sha256:http://localhost:{{ http_port }}/sha256sum_with_dot.txt'
+  register: result_sha256_with_dot
+
+- stat:
+    path: "{{ output_dir }}/27617sha256_with_dot.txt"
+  register: stat_result_sha256_with_dot
+
 - name: Assert that the file was downloaded
   assert:
     that:
       - result_sha1 is changed
       - result_sha256 is changed
+      - result_sha256_with_dot is changed
       - "stat_result_sha1.stat.exists == true"
       - "stat_result_sha256.stat.exists == true"
+      - "stat_result_sha256_with_dot.stat.exists == true"
 
 #https://github.com/ansible/ansible/issues/16191
 - name: Test url split with no filename


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backports #45287.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
get_url

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0rc1.post0 (backport/2.7/45287 14b1f2f7d1) last updated 2018/09/11 13:53:32 (GMT -300)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/deivid/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/deivid/Code/ansible/lib/ansible
  executable location = /home/deivid/Code/ansible/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```