### PR TITLE
maven_artifact: check if maven-metadata.xml exists for non-unique snapshots.

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -300,7 +300,7 @@ class MavenDownloader:
 
         metadata_path = "/%s/%s" % (artifact.path(), self.metadata_file_name)
 
-        if artifact.is_snapshot() and self._url_exists(self.base + metadata_path):
+        if artifact.is_snapshot() and (self._request(self.base + metadata_path, failmsg="", force=False) is not None):
             if self.local:
                 return self._uri_for_artifact(artifact, artifact.version)
 
@@ -373,14 +373,6 @@ class MavenDownloader:
         if force:
             raise ValueError(failmsg + " because of " + info['msg'] + "for URL " + url_to_use)
         return None
-
-    def _url_exists(self, url):
-        req_timeout = self.module.params.get('timeout')
-        response, info = fetch_url(self.module, url, timeout=req_timeout)
-
-        if info['status'] == 200:
-            return True
-        return False
 
     def download(self, tmpdir, artifact, verify_download, filename=None):
         if not artifact.version or artifact.version == "latest":


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This pull request fixes the download of a maven 2 non-unique snapshots, when the `maven-metadata.xml` file does not exist.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
maven_artifact

##### ANSIBLE VERSION

```
2.8
2.7
2.6
2.5
```
