### PR TITLE
Avoid duplicate Azure storage account types.

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
@@ -174,7 +174,8 @@ class AzureRMStorageAccount(AzureRMModuleBase):
 
         if HAS_AZURE:
             for key in self.storage_models.SkuName:
-                self.module_arg_spec['account_type']['choices'].append(getattr(key, 'value'))
+                if getattr(key, 'value') not in self.module_arg_spec['account_type']['choices']:
+                    self.module_arg_spec['account_type']['choices'].append(getattr(key, 'value'))
 
         self.results = dict(
             changed=False,


### PR DESCRIPTION
##### SUMMARY

Avoid duplicate Azure storage account types.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

azure_rm_storageaccount

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (azure-sku-fix a5af779c36) last updated 2018/09/11 10:26:02 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
