### PR TITLE
Fix ACI unit test on Python 3.7.0.

### DIFF
--- a/test/units/module_utils/network/aci/test_aci.py
+++ b/test/units/module_utils/network/aci/test_aci.py
@@ -261,8 +261,6 @@ class AciRest(unittest.TestCase):
             error_text = to_native(u"Unable to parse output as XML, see 'raw' output. None (line 0)", errors='surrogate_or_strict')
         elif PY2:
             error_text = "Unable to parse output as XML, see 'raw' output. Document is empty, line 1, column 1 (line 1)"
-        elif sys.version_info >= (3, 7):
-            error_text = to_native(u"Unable to parse output as XML, see 'raw' output. None (line 0)", errors='surrogate_or_strict')
         else:
             error_text = "Unable to parse output as XML, see 'raw' output. Document is empty, line 1, column 1 (<string>, line 1)"
 


### PR DESCRIPTION
##### SUMMARY

Fix ACI unit test on Python 3.7.0.

The previous logic was only needed for pre-release versions of 3.7.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ACI unit test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (aci-test-fix 422740054a) last updated 2018/09/11 10:35:39 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
