### PR TITLE
[ovirt] remove 2.8 deprecations

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/_ovirt_affinity_groups.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_affinity_groups.py
@@ -1,1 +1,0 @@
-ovirt_affinity_group.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_affinity_labels.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_affinity_labels.py
@@ -1,1 +1,0 @@
-ovirt_affinity_label.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_affinity_labels_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_affinity_labels_facts.py
@@ -1,1 +1,0 @@
-ovirt_affinity_label_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_clusters.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_clusters.py
@@ -1,1 +1,0 @@
-ovirt_cluster.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_clusters_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_clusters_facts.py
@@ -1,1 +1,0 @@
-ovirt_cluster_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_datacenters.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_datacenters.py
@@ -1,1 +1,0 @@
-ovirt_datacenter.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_datacenters_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_datacenters_facts.py
@@ -1,1 +1,0 @@
-ovirt_datacenter_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_disks.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_disks.py
@@ -1,1 +1,0 @@
-ovirt_disk.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_external_providers.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_external_providers.py
@@ -1,1 +1,0 @@
-ovirt_external_provider.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_external_providers_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_external_providers_facts.py
@@ -1,1 +1,0 @@
-ovirt_external_provider_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_groups.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_groups.py
@@ -1,1 +1,0 @@
-ovirt_group.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_groups_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_groups_facts.py
@@ -1,1 +1,0 @@
-ovirt_group_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_host_networks.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_host_networks.py
@@ -1,1 +1,0 @@
-ovirt_host_network.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_hosts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_hosts.py
@@ -1,1 +1,0 @@
-ovirt_host.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_hosts_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_hosts_facts.py
@@ -1,1 +1,0 @@
-ovirt_host_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_mac_pools.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_mac_pools.py
@@ -1,1 +1,0 @@
-ovirt_mac_pool.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_networks.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_networks.py
@@ -1,1 +1,0 @@
-ovirt_network.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_networks_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_networks_facts.py
@@ -1,1 +1,0 @@
-ovirt_network_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_nics.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_nics.py
@@ -1,1 +1,0 @@
-ovirt_nic.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_nics_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_nics_facts.py
@@ -1,1 +1,0 @@
-ovirt_nic_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_permissions.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_permissions.py
@@ -1,1 +1,0 @@
-ovirt_permission.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_permissions_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_permissions_facts.py
@@ -1,1 +1,0 @@
-ovirt_permission_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_quotas.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_quotas.py
@@ -1,1 +1,0 @@
-ovirt_quota.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_quotas_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_quotas_facts.py
@@ -1,1 +1,0 @@
-ovirt_quota_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_scheduling_policies_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_scheduling_policies_facts.py
@@ -1,1 +1,0 @@
-ovirt_scheduling_policy_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_snapshots.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_snapshots.py
@@ -1,1 +1,0 @@
-ovirt_snapshot.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_snapshots_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_snapshots_facts.py
@@ -1,1 +1,0 @@
-ovirt_snapshot_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_storage_connections.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_storage_connections.py
@@ -1,1 +1,0 @@
-ovirt_storage_connection.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_storage_domains.py
@@ -1,1 +1,0 @@
-ovirt_storage_domain.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_storage_domains_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_storage_domains_facts.py
@@ -1,1 +1,0 @@
-ovirt_storage_domain_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_storage_templates_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_storage_templates_facts.py
@@ -1,1 +1,0 @@
-ovirt_storage_template_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_storage_vms_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_storage_vms_facts.py
@@ -1,1 +1,0 @@
-ovirt_storage_vm_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_tags.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_tags.py
@@ -1,1 +1,0 @@
-ovirt_tag.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_tags_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_tags_facts.py
@@ -1,1 +1,0 @@
-ovirt_tag_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_templates.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_templates.py
@@ -1,1 +1,0 @@
-ovirt_template.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_templates_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_templates_facts.py
@@ -1,1 +1,0 @@
-ovirt_template_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_users.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_users.py
@@ -1,1 +1,0 @@
-ovirt_user.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_users_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_users_facts.py
@@ -1,1 +1,0 @@
-ovirt_user_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_vmpools.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_vmpools.py
@@ -1,1 +1,0 @@
-ovirt_vmpool.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_vmpools_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_vmpools_facts.py
@@ -1,1 +1,0 @@
-ovirt_vmpool_facts.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_vms.py
@@ -1,1 +1,0 @@
-ovirt_vm.py

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_vms_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_vms_facts.py
@@ -1,1 +1,0 @@
-ovirt_vm_facts.py

--- a/lib/ansible/modules/cloud/ovirt/ovirt_affinity_group.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_affinity_group.py
@@ -265,9 +265,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_affinity_groups':
-        module.deprecate("The 'ovirt_affinity_groups' module is being renamed 'ovirt_affinity_group'", version=2.8)
-
     check_sdk(module)
     try:
         auth = module.params.pop('auth')

--- a/lib/ansible/modules/cloud/ovirt/ovirt_affinity_label.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_affinity_label.py
@@ -181,9 +181,6 @@ def main():
         ],
     )
 
-    if module._name == 'ovirt_affinity_labels':
-        module.deprecate("The 'ovirt_affinity_labels' module is being renamed 'ovirt_affinity_label'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_affinity_label_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_affinity_label_facts.py
@@ -110,9 +110,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_affinity_labels_facts':
-        module.deprecate("The 'ovirt_affinity_labels_facts' module is being renamed 'ovirt_affinity_label_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
@@ -645,9 +645,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_clusters':
-        module.deprecate("The 'ovirt_clusters' module is being renamed 'ovirt_cluster'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_cluster_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_cluster_facts.py
@@ -81,9 +81,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_clusters_facts':
-        module.deprecate("The 'ovirt_clusters_facts' module is being renamed 'ovirt_cluster_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_datacenter.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_datacenter.py
@@ -189,9 +189,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_datacenters':
-        module.deprecate("The 'ovirt_datacenters' module is being renamed 'ovirt_datacenter'", version=2.8)
-
     check_sdk(module)
     check_params(module)
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_datacenter_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_datacenter_facts.py
@@ -64,9 +64,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_datacenters_facts':
-        module.deprecate("The 'ovirt_datacenters_facts' module is being renamed 'ovirt_datacenter_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -584,9 +584,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_disks':
-        module.deprecate("The 'ovirt_disks' module is being renamed 'ovirt_disk'", version=2.8)
-
     check_sdk(module)
     check_params(module)
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_external_provider.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_external_provider.py
@@ -360,9 +360,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_external_providers':
-        module.deprecate("The 'ovirt_external_providers' module is being renamed 'ovirt_external_provider'", version=2.8)
-
     check_sdk(module)
     check_params(module)
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_external_provider_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_external_provider_facts.py
@@ -119,9 +119,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_external_providers_facts':
-        module.deprecate("The 'ovirt_external_providers_facts' module is being renamed 'ovirt_external_provider_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_group.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_group.py
@@ -155,9 +155,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_groups':
-        module.deprecate("The 'ovirt_groups' module is being renamed 'ovirt_group'", version=2.8)
-
     check_sdk(module)
     check_params(module)
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_group_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_group_facts.py
@@ -79,9 +79,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_groups_facts':
-        module.deprecate("The 'ovirt_groups_facts' module is being renamed 'ovirt_group_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host.py
@@ -428,9 +428,6 @@ def main():
         ]
     )
 
-    if module._name == 'ovirt_hosts':
-        module.deprecate("The 'ovirt_hosts' module is being renamed 'ovirt_host'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_facts.py
@@ -74,9 +74,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_hosts_facts':
-        module.deprecate("The 'ovirt_hosts_facts' module is being renamed 'ovirt_host_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -334,9 +334,6 @@ def main():
     )
     module = AnsibleModule(argument_spec=argument_spec)
 
-    if module._name == 'ovirt_host_networks':
-        module.deprecate("The 'ovirt_host_networks' module is being renamed 'ovirt_host_network'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_mac_pool.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_mac_pool.py
@@ -140,9 +140,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_mac_pools':
-        module.deprecate("The 'ovirt_mac_pools' module is being renamed 'ovirt_mac_pool'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_network.py
@@ -240,9 +240,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_networks':
-        module.deprecate("The 'ovirt_networks' module is being renamed 'ovirt_network'", version=2.8)
-
     check_sdk(module)
     check_params(module)
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_network_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_network_facts.py
@@ -81,9 +81,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_networks_facts':
-        module.deprecate("The 'ovirt_networks_facts' module is being renamed 'ovirt_network_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_nic.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_nic.py
@@ -187,9 +187,6 @@ def main():
         required_one_of=[['vm', 'template']],
     )
 
-    if module._name == 'ovirt_nics':
-        module.deprecate("The 'ovirt_nics' module is being renamed 'ovirt_nic'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_nic_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_nic_facts.py
@@ -86,9 +86,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_nics_facts':
-        module.deprecate("The 'ovirt_nics_facts' module is being renamed 'ovirt_nic_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_permission.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_permission.py
@@ -274,9 +274,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_permissions':
-        module.deprecate("The 'ovirt_permissions' module is being renamed 'ovirt_permission'", version=2.8)
-
     check_sdk(module)
 
     if (module.params['object_name'] is None and module.params['object_id'] is None) and module.params['object_type'] != 'system':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_permission_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_permission_facts.py
@@ -123,9 +123,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_permissions_facts':
-        module.deprecate("The 'ovirt_permissions_facts' module is being renamed 'ovirt_permission_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_quota.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_quota.py
@@ -231,9 +231,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_quotas':
-        module.deprecate("The 'ovirt_quotas' module is being renamed 'ovirt_quota'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_quota_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_quota_facts.py
@@ -86,9 +86,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_quotas_facts':
-        module.deprecate("The 'ovirt_quotas_facts' module is being renamed 'ovirt_quota_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_scheduling_policy_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_scheduling_policy_facts.py
@@ -86,9 +86,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_scheduling_policie_facts':
-        module.deprecate("The 'ovirt_scheduling_policie_facts' module is being renamed 'ovirt_scheduling_policy_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_snapshot.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_snapshot.py
@@ -246,9 +246,6 @@ def main():
         ]
     )
 
-    if module._name == 'ovirt_snapshots':
-        module.deprecate("The 'ovirt_snapshots' module is being renamed 'ovirt_snapshot'", version=2.8)
-
     check_sdk(module)
 
     vm_name = module.params.get('vm_name')

--- a/lib/ansible/modules/cloud/ovirt/ovirt_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_snapshot_facts.py
@@ -77,9 +77,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_snapshots_facts':
-        module.deprecate("The 'ovirt_snapshots_facts' module is being renamed 'ovirt_snapshot_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_connection.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_connection.py
@@ -232,9 +232,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_storage_connections':
-        module.deprecate("The 'ovirt_storage_connections' module is being renamed 'ovirt_storage_connection'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domain.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domain.py
@@ -626,9 +626,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_storage_domains':
-        module.deprecate("The 'ovirt_storage_domains' module is being renamed 'ovirt_storage_domain'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domain_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domain_facts.py
@@ -81,9 +81,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_storage_domains_facts':
-        module.deprecate("The 'ovirt_storage_domains_facts' module is being renamed 'ovirt_storage_domain_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_template_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_template_facts.py
@@ -91,9 +91,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_storage_templates_facts':
-        module.deprecate("The 'ovirt_storage_templates_facts' module is being renamed 'ovirt_storage_template_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_vm_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_vm_facts.py
@@ -91,9 +91,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_storage_vms_facts':
-        module.deprecate("The 'ovirt_storage_vms_facts' module is being renamed 'ovirt_storage_vm_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_tag.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_tag.py
@@ -216,9 +216,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_tags':
-        module.deprecate("The 'ovirt_tags' module is being renamed 'ovirt_tag'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_tag_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_tag_facts.py
@@ -100,9 +100,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_tags_facts':
-        module.deprecate("The 'ovirt_tags_facts' module is being renamed 'ovirt_tag_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_template.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_template.py
@@ -467,9 +467,6 @@ def main():
         required_one_of=[['id', 'name']],
     )
 
-    if module._name == 'ovirt_templates':
-        module.deprecate("The 'ovirt_templates' module is being renamed 'ovirt_template'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_template_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_template_facts.py
@@ -81,9 +81,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_templates_facts':
-        module.deprecate("The 'ovirt_templates_facts' module is being renamed 'ovirt_template_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_user.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_user.py
@@ -138,9 +138,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_users':
-        module.deprecate("The 'ovirt_users' module is being renamed 'ovirt_user'", version=2.8)
-
     check_sdk(module)
     check_params(module)
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_user_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_user_facts.py
@@ -79,9 +79,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_users_facts':
-        module.deprecate("The 'ovirt_users_facts' module is being renamed 'ovirt_user_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -1980,9 +1980,6 @@ def main():
         required_one_of=[['id', 'name']],
     )
 
-    if module._name == 'ovirt_vms':
-        module.deprecate("The 'ovirt_vms' module is being renamed 'ovirt_vm'", version=2.8)
-
     check_sdk(module)
     check_params(module)
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm_facts.py
@@ -97,9 +97,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_vms_facts':
-        module.deprecate("The 'ovirt_vms_facts' module is being renamed 'ovirt_vm_facts'", version=2.8)
-
     check_sdk(module)
 
     try:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vmpool.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vmpool.py
@@ -185,9 +185,6 @@ def main():
         supports_check_mode=True,
     )
 
-    if module._name == 'ovirt_vmpools':
-        module.deprecate("The 'ovirt_vmpools' module is being renamed 'ovirt_vmpool'", version=2.8)
-
     check_sdk(module)
     check_params(module)
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vmpool_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vmpool_facts.py
@@ -79,9 +79,6 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if module._name == 'ovirt_vmpools_facts':
-        module.deprecate("The 'ovirt_vmpools_facts' module is being renamed 'ovirt_vmpool_facts'", version=2.8)
-
     check_sdk(module)
 
     try:


### PR DESCRIPTION
##### SUMMARY
Remove deprecated ovirt module names and the deprecation warnings from the modules.

Fixes #44992, Fixes #44993, Fixes #44994, Fixes #44995, Fixes #44996, Fixes #44997, Fixes #44998, Fixes #44999, Fixes #45000, Fixes #45001, Fixes #45002, Fixes #45003, Fixes #45004, Fixes #45005, Fixes #45006, Fixes #45007, Fixes #45008, Fixes #45009, Fixes #45010, Fixes #45011, Fixes #45012, Fixes #45013, Fixes #45014, Fixes #45015, Fixes #45016, Fixes #45017, Fixes #45018, Fixes #45019, Fixes #45020, Fixes #45021, Fixes #45022, Fixes #45023, Fixes #45024, Fixes #45025, Fixes #45026, Fixes #45027, Fixes #45028, Fixes #45029, Fixes #45030, Fixes #45031, Fixes #45032, Fixes #45033 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ovirt

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
```
