### PR TITLE
[aws] cloudfront_distribution - fix method name, backport/2.7/45498

### DIFF
--- a/changelogs/fragments/aws_cloudfront_distribution_fix_nonexistent_method_name.yaml
+++ b/changelogs/fragments/aws_cloudfront_distribution_fix_nonexistent_method_name.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - cloudfront_distribution - replace call to nonexistent method 'validate_distribution_id_from_caller_reference'
+    with 'validate_distribution_from_caller_reference' and set the distribution_id variable to the distribution's
+    'Id' key.

--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -1813,7 +1813,7 @@ class CloudFrontValidationManager(object):
 
     def wait_until_processed(self, client, wait_timeout, distribution_id, caller_reference):
         if distribution_id is None:
-            distribution_id = self.validate_distribution_id_from_caller_reference(caller_reference=caller_reference)
+            distribution_id = self.validate_distribution_from_caller_reference(caller_reference=caller_reference)['Id']
 
         try:
             waiter = client.get_waiter('distribution_deployed')


### PR DESCRIPTION
##### SUMMARY
Backport #45498 

Correct method name and set distribution_id to the correct value.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudfront_distribution

##### ANSIBLE VERSION
```
ansible 2.7.0rc1.post0
```
