### PR TITLE
Recursive decrypt of vault secrets in lists as well as Mappings

### DIFF
--- a/lib/ansible/parsing/ajson.py
+++ b/lib/ansible/parsing/ajson.py
@@ -36,6 +36,10 @@ class AnsibleJSONDecoder(json.JSONDecoder):
             for k in value:
                 if isinstance(value[k], Mapping):
                     value[k] = self._decode_map(value[k])
+                elif isinstance(value[k], list):
+                    for i in range(len(value[k])):
+                        if isinstance(value[k][i], Mapping):
+                            value[k][i] = self._decode_map(value[k][i])
         return value
 
     def decode(self, obj):


### PR DESCRIPTION
##### SUMMARY
Solves the issue described in https://github.com/ansible/awx/issues/2226

I haven't gotten around to filing a corresponding issue in the Ansible issue queue.

More targeted steps to reproduce can be found in:

https://github.com/AlanCoding/Ansible-inventory-file-examples/tree/master/scripts/vault/bug2226

Implementation of the original feature was by @bcoca in https://github.com/ansible/ansible/pull/38759, it just never did lists, because it never addressed the list type.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
JSON-defined vault decryption

##### ANSIBLE VERSION
```paste below
ansible --version
ansible 2.8.0.dev0
  config file = None
  configured module search path = [u'/Users/alancoding/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible
  executable location = /Users/alancoding/.virtualenvs/ansible/bin/ansible
  python version = 2.7.11 (default, Oct 17 2016, 14:59:40) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```

Also present in 2.6, but I am ambivalent about need for backport.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Output post-fix:

```paste below
 ____________ 
< PLAY [all] >
 ------------ 
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

 ______________ 
< TASK [debug] >
 -------------- 
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

ok: [server1.example.com] => {
    "msg": {
        "ansible_check_mode": false, 
        "ansible_diff_mode": false, 
        "ansible_facts": {}, 
        "ansible_forks": 5, 
        "ansible_inventory_sources": [
            "/Users/alancoding/Documents/repos/ansible-inventory-file-examples/scripts/vault/bug2226/single.py"
        ], 
        "ansible_playbook_python": "/Users/alancoding/.virtualenvs/ansible/bin/python", 
        "ansible_run_tags": [
            "all"
        ], 
        "ansible_skip_tags": [], 
        "ansible_verbosity": 0, 
        "ansible_version": {
            "full": "2.8.0.dev0", 
            "major": 2, 
            "minor": 8, 
            "revision": 0, 
            "string": "2.8.0.dev0"
        }, 
        "baz": [
            "MyPassword"
        ], 
        "group_names": [
            "ungrouped"
        ], 
        "groups": {
            "all": [
                "server1.example.com"
            ], 
            "ungrouped": [
                "server1.example.com"
            ]
        }, 
        "inventory_dir": "/Users/alancoding/Documents/repos/ansible-inventory-file-examples/scripts/vault/bug2226", 
        "inventory_file": "/Users/alancoding/Documents/repos/ansible-inventory-file-examples/scripts/vault/bug2226/single.py", 
        "inventory_hostname": "server1.example.com", 
        "inventory_hostname_short": "server1", 
        "omit": "__omit_place_holder__0046b1b0c58b197e5c71c8a30447e342aee266b7", 
        "playbook_dir": "/Users/alancoding/Documents/repos/ansible-inventory-file-examples/debugging"
    }
}
 ____________ 
< PLAY RECAP >
 ------------ 
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

server1.example.com        : ok=1    changed=0    unreachable=0    failed=0   
```

This shows the value 

```
        "baz": [
            "MyPassword"
        ], 
```

which is what the issue (and examples made for the issue) showed was not being decrypted.
