### PR TITLE
lineinfile note belongs in changelog for 2.6, not 2.7

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.6.rst
@@ -27,8 +27,7 @@ Deprecated
 Modules
 =======
 
-Major changes in popular modules are detailed here
-
+Major changes in popular modules are detailed here:
 
 
 Modules removed
@@ -74,6 +73,10 @@ Noteworthy module changes
 * The ``k8s`` module will not automatically change ``Project`` creation requests into ``ProjectRequest`` creation requests as the ``openshift_raw`` module did. You must now specify the ``ProjectRequest`` kind explicitly.
 * The ``k8s`` module will not automatically remove secrets from the Ansible return values (and by extension the log). In order to prevent secret values in a task from being logged, specify the ``no_log`` parameter on the task block.
 * The ``k8s_scale`` module now supports scalable OpenShift objects, such as ``DeploymentConfig``.
+* The ``lineinfile`` module was changed to show a warning when using an empty string as a regexp.
+  Since an empty regexp matches every line in a file, it will replace the last line in a file rather
+  than inserting. If this is the desired behavior, use ``'^'`` which will match every line and
+  will not trigger the warning.
 * Openstack modules are no longer using ``shade`` library. Instead ``openstacksdk`` is used. Since ``openstacksdk`` should be already present as a dependency to ``shade`` no additional actions are required.
 
 Plugins

--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -145,12 +145,6 @@ Major changes in popular modules are detailed here
   :ref:`DEFAULT_SYSLOG_FACILITY`. If you have :ref:`DEFAULT_SYSLOG_FACILITY` configured, the
   location of remote logs on systems which use journald may change.
 
-* The ``lineinfile`` module was changed to show a warning when using an empty string as a regexp.
-  Since an empty regexp matches every line in a file, it will replace the last line in a file rather
-  than inserting. If this is the desired behavior, use ``'^'`` which will match every line and
-  will not trigger the warning.
-
-
 Modules removed
 ---------------
 


### PR DESCRIPTION
##### SUMMARY
When the `devel` branch was In transition from version 2.6 to version 2.7, this documentation about changes to the `lineinfile` module got mistakenly added to the Porting Guide for 2.7. The code change was made in version 2.6, so the note belongs in the 2.6 Porting Guide. 

On the `stable-2.6` branch, the location is already correct. This PR will fix `devel` and when it's merge I'll backport to `stable-2.7` so the Porting Guide is consistent across branches (and therefore across versions of the docs).

Related to #42013 and #42204.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.8 and 2.7
