### PR TITLE
Backport test updates to stable-2.6.

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
@@ -173,7 +173,8 @@ class AzureRMStorageAccount(AzureRMModuleBase):
 
         if HAS_AZURE:
             for key in self.storage_models.SkuName:
-                self.module_arg_spec['account_type']['choices'].append(getattr(key, 'value'))
+                if getattr(key, 'value') not in self.module_arg_spec['account_type']['choices']:
+                    self.module_arg_spec['account_type']['choices'].append(getattr(key, 'value'))
 
         self.results = dict(
             changed=False,

--- a/test/integration/targets/azure_rm_mysqlserver/tasks/main.yml
+++ b/test/integration/targets/azure_rm_mysqlserver/tasks/main.yml
@@ -8,9 +8,9 @@
     resource_group: "{{ resource_group }}"
     name: mysqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     version: 5.6
     enforce_ssl: True
@@ -28,9 +28,9 @@
     resource_group: "{{ resource_group }}"
     name: mysqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     version: 5.6
     enforce_ssl: True
@@ -48,9 +48,9 @@
     resource_group: "{{ resource_group }}"
     name: mysqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     version: 5.6
     enforce_ssl: True

--- a/test/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
+++ b/test/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
@@ -8,9 +8,9 @@
     resource_group: "{{ resource_group }}"
     name: postgresqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     enforce_ssl: True
     admin_username: zimxyz
@@ -27,9 +27,9 @@
     resource_group: "{{ resource_group }}"
     name: postgresqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     enforce_ssl: True
     admin_username: zimxyz
@@ -46,9 +46,9 @@
     resource_group: "{{ resource_group }}"
     name: postgresqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     enforce_ssl: True
     admin_username: zimxyz

--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -1,4 +1,4 @@
-default name=quay.io/ansible/default-test-container:1.0.0
+default name=quay.io/ansible/default-test-container:1.2.0
 centos6 name=quay.io/ansible/centos6-test-container:1.4.0 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.4.0 seccomp=unconfined
 fedora24 name=quay.io/ansible/fedora24-test-container:1.4.0 seccomp=unconfined

--- a/test/units/module_utils/network/aci/test_aci.py
+++ b/test/units/module_utils/network/aci/test_aci.py
@@ -260,8 +260,6 @@ class AciRest(unittest.TestCase):
             error_text = to_native(u"Unable to parse output as XML, see 'raw' output. None (line 0)", errors='surrogate_or_strict')
         elif PY2:
             error_text = "Unable to parse output as XML, see 'raw' output. Document is empty, line 1, column 1 (line 1)"
-        elif sys.version_info >= (3, 7):
-            error_text = to_native(u"Unable to parse output as XML, see 'raw' output. None (line 0)", errors='surrogate_or_strict')
         else:
             error_text = "Unable to parse output as XML, see 'raw' output. Document is empty, line 1, column 1 (<string>, line 1)"
 


### PR DESCRIPTION
##### SUMMARY

Backport test updates to stable-2.6:

- Avoid duplicate Azure storage account types. Required for tests to pass with Azure SDK installed.
- Fix ACI unit test on Python 3.7.0. Required for tests to pass with LXML installed.
- Reduce cost of Azure DB tests.
- Update default container to version 1.2.0.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

various

##### ANSIBLE VERSION

```
ansible 2.6.4.post0 (test-update-2.6 d34b87cb04) last updated 2018/09/11 15:52:56 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
