### PR TITLE
Fix useless comparaison between 2 constants

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_device_facts.py
+++ b/lib/ansible/modules/network/f5/bigip_device_facts.py
@@ -12438,9 +12438,9 @@ class VirtualServersParameters(BaseParameters):
         result = []
         for item in self._values['profiles']['items']:
             context = item['context']
-            if 'context' == 'serverside':
+            if context == 'serverside':
                 context = 'server-side'
-            elif 'context' == 'clientside':
+            elif context == 'clientside':
                 context = 'client-side'
             name = item['name']
             if context in ['all', 'server-side', 'client-side']:


### PR DESCRIPTION
##### SUMMARY
Fix useless comparaison between 2 constants

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bigip_device_facts
