### PR TITLE
meraki - Remove YAML formatting on JSON code block

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_meraki.rst
+++ b/docs/docsite/rst/scenario_guides/guide_meraki.rst
@@ -102,16 +102,16 @@ Returned Data Structures
 
 Meraki and its related Ansible modules return most information in the form of a list. For example, this is returned information by ``meraki_admin`` querying administrators. It returns a list even though there's only one.
 
-.. code-block::
+.. code-block:: json
 
 	[
 		{
-			'orgAccess': 'full', 
-			'name': 'John Doe',
-			'tags': [],
-			'networks': [],
-			'email': 'john@doe.com',
-			'id': '12345677890'
+			"orgAccess": "full", 
+			"name": "John Doe",
+			"tags": [],
+			"networks": [],
+			"email": "john@doe.com",
+			"id": "12345677890"
 		}
 	]
 

--- a/docs/docsite/rst/scenario_guides/guide_meraki.rst
+++ b/docs/docsite/rst/scenario_guides/guide_meraki.rst
@@ -102,7 +102,7 @@ Returned Data Structures
 
 Meraki and its related Ansible modules return most information in the form of a list. For example, this is returned information by ``meraki_admin`` querying administrators. It returns a list even though there's only one.
 
-.. code-block:: yaml
+.. code-block::
 
 	[
 		{


### PR DESCRIPTION
##### SUMMARY
Code block used to use YAML formatting but I removed as it's JSON in arrays and not valid. Simple code block now.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
meraki

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```﻿
ansible 2.8.0.dev0 (meraki/scenario-code-block-fix a53366f7f0) last updated 2018/09/11 19:08:45 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]

```
