### PR TITLE
Account for boolean OVF properties

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
@@ -343,7 +343,7 @@ class VMwareDeployOvf:
             for key, value in self.params['properties'].items():
                 property_mapping = vim.KeyValue()
                 property_mapping.key = key
-                property_mapping.value = value
+                property_mapping.value = str(value) if isinstance(value, bool) else value
                 params['propertyMapping'].append(property_mapping)
 
         if self.params['folder']:


### PR DESCRIPTION
Currently, Ansible interprets variables with a True|False value as
boolean. This causes the vmware_deploy_ovf module to break, because
it can only accept string values as properties.

This fix checks if a value is boolean, and converts it to a string
if it is. Since integers do not seem to be causing the same error, this
is the only check we appear to need.

After completion, OVF properties that are boolean can be specified as
yes|no or true|false.

Closes: #45528

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module: vmware_deply_ovf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jjahns/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/lib/python2.7/site-packages/ansible
  executable location = /opt/ansible/bin/ansible
  python version = 2.7.15 (default, Aug 26 2018, 01:25:53) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Use vmware_deploy_ovf module to deploy an OVF with boolean properties.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
(ansible) jjahns@autobot:~/nsx-ansible$ ansible-playbook install-nsx-manager.yml -vvv
ansible-playbook 2.7.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jjahns/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/lib/python2.7/site-packages/ansible
  executable location = /opt/ansible/bin/ansible-playbook
  python version = 2.7.15 (default, Aug 26 2018, 01:25:53) [GCC 5.4.0 20160609]
Using /etc/ansible/ansible.cfg as config file
Parsed /etc/ansible/hosts inventory source with ini plugin

PLAYBOOK: install-nsx-manager.yml *****************************************************************************************************************************
1 plays in install-nsx-manager.yml

PLAY [nsxmanager[1]] ******************************************************************************************************************************************
META: ran handlers
<nsxmgr02> ESTABLISH LOCAL CONNECTION FOR USER: jjahns
<nsxmgr02> EXEC /bin/sh -c 'echo ~jjahns && sleep 0'
<nsxmgr02> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jjahns/.ansible/tmp/ansible-tmp-1536715465.24-50505497465643 `" && echo ansible-tmp-1536715465.24-50505497465643="` echo /home/jjahns/.ansible/tmp/ansible-tmp-1536715465.24-50505497465643 `" ) && sleep 0'
Using module file /etc/ansible/roles/nsx-ovf/library/vmware_deploy_ovf.py
<nsxmgr02> PUT /home/jjahns/.ansible/tmp/ansible-local-25399zjv3Z_/tmpsbmSUN TO /home/jjahns/.ansible/tmp/ansible-tmp-1536715465.24-50505497465643/AnsiballZ_vmware_deploy_ovf.py
<nsxmgr02> EXEC /bin/sh -c 'chmod u+x /home/jjahns/.ansible/tmp/ansible-tmp-1536715465.24-50505497465643/ /home/jjahns/.ansible/tmp/ansible-tmp-1536715465.24-50505497465643/AnsiballZ_vmware_deploy_ovf.py && sleep 0'
<nsxmgr02> EXEC /bin/sh -c '/opt/ansible/bin/python /home/jjahns/.ansible/tmp/ansible-tmp-1536715465.24-50505497465643/AnsiballZ_vmware_deploy_ovf.py && sleep 0'
<nsxmgr02> EXEC /bin/sh -c 'rm -f -r /home/jjahns/.ansible/tmp/ansible-tmp-1536715465.24-50505497465643/ > /dev/null 2>&1 && sleep 0'

TASK [nsx-ovf : deploy nsx appliance] *************************************************************************************************************************
task path: /etc/ansible/roles/nsx-ovf/tasks/main.yml:2
The full traceback is:
Traceback (most recent call last):
  File "/home/jjahns/.ansible/tmp/ansible-tmp-1536715465.24-50505497465643/AnsiballZ_vmware_deploy_ovf.py", line 113, in <module>
    _ansiballz_main()
  File "/home/jjahns/.ansible/tmp/ansible-tmp-1536715465.24-50505497465643/AnsiballZ_vmware_deploy_ovf.py", line 105, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/jjahns/.ansible/tmp/ansible-tmp-1536715465.24-50505497465643/AnsiballZ_vmware_deploy_ovf.py", line 48, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/tmp/ansible_vmware_deploy_ovf_payload_dNLAer/__main__.py", line 605, in <module>
  File "/tmp/ansible_vmware_deploy_ovf_payload_dNLAer/__main__.py", line 597, in main
  File "/tmp/ansible_vmware_deploy_ovf_payload_dNLAer/__main__.py", line 425, in upload
  File "/tmp/ansible_vmware_deploy_ovf_payload_dNLAer/__main__.py", line 347, in get_lease
  File "/opt/python/lib/python2.7/site-packages/pyVmomi/VmomiSupport.py", line 537, in __setattr__
    CheckField(self._GetPropertyInfo(name), val)
  File "/opt/python/lib/python2.7/site-packages/pyVmomi/VmomiSupport.py", line 972, in CheckField
    % (info.name, info.type.__name__, valType.__name__))
TypeError: For "value" expected type str, but got bool

fatal: [nsxmgr02]: FAILED! => {
    "changed": false, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/jjahns/.ansible/tmp/ansible-tmp-1536715465.24-50505497465643/AnsiballZ_vmware_deploy_ovf.py\", line 113, in <module>\n    _ansiballz_main()\n  File \"/home/jjahns/.ansible/tmp/ansible-tmp-1536715465.24-50505497465643/AnsiballZ_vmware_deploy_ovf.py\", line 105, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/jjahns/.ansible/tmp/ansible-tmp-1536715465.24-50505497465643/AnsiballZ_vmware_deploy_ovf.py\", line 48, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/tmp/ansible_vmware_deploy_ovf_payload_dNLAer/__main__.py\", line 605, in <module>\n  File \"/tmp/ansible_vmware_deploy_ovf_payload_dNLAer/__main__.py\", line 597, in main\n  File \"/tmp/ansible_vmware_deploy_ovf_payload_dNLAer/__main__.py\", line 425, in upload\n  File \"/tmp/ansible_vmware_deploy_ovf_payload_dNLAer/__main__.py\", line 347, in get_lease\n  File \"/opt/python/lib/python2.7/site-packages/pyVmomi/VmomiSupport.py\", line 537, in __setattr__\n    CheckField(self._GetPropertyInfo(name), val)\n  File \"/opt/python/lib/python2.7/site-packages/pyVmomi/VmomiSupport.py\", line 972, in CheckField\n    % (info.name, info.type.__name__, valType.__name__))\nTypeError: For \"value\" expected type str, but got bool\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", 
    "rc": 1
}
	to retry, use: --limit @/home/jjahns/nsx-ansible/install-nsx-manager.retry

PLAY RECAP ****************************************************************************************************************************************************


(ansible) jjahns@autobot:~/nsx-ansible$ ansible-playbook install-nsx-manager.yml -vvv
ansible-playbook 2.7.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jjahns/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/lib/python2.7/site-packages/ansible
  executable location = /opt/ansible/bin/ansible-playbook
  python version = 2.7.15 (default, Aug 26 2018, 01:25:53) [GCC 5.4.0 20160609]
Using /etc/ansible/ansible.cfg as config file
Parsed /etc/ansible/hosts inventory source with ini plugin

PLAYBOOK: install-nsx-manager.yml *****************************************************************************************************************************
1 plays in install-nsx-manager.yml

PLAY [nsxmanager[1]] ******************************************************************************************************************************************
META: ran handlers
<nsxmgr02> ESTABLISH LOCAL CONNECTION FOR USER: jjahns
<nsxmgr02> EXEC /bin/sh -c 'echo ~jjahns && sleep 0'
<nsxmgr02> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jjahns/.ansible/tmp/ansible-tmp-1536713197.4-125268665570360 `" && echo ansible-tmp-1536713197.4-125268665570360="` echo /home/jjahns/.ansible/tmp/ansible-tmp-1536713197.4-125268665570360 `" ) && sleep 0'
Using module file /etc/ansible/roles/nsx-ovf/library/vmware_deploy_ovf.py
<nsxmgr02> PUT /home/jjahns/.ansible/tmp/ansible-local-25320VnUAA9/tmpQvQ1YS TO /home/jjahns/.ansible/tmp/ansible-tmp-1536713197.4-125268665570360/AnsiballZ_vmware_deploy_ovf.py
<nsxmgr02> EXEC /bin/sh -c 'chmod u+x /home/jjahns/.ansible/tmp/ansible-tmp-1536713197.4-125268665570360/ /home/jjahns/.ansible/tmp/ansible-tmp-1536713197.4-125268665570360/AnsiballZ_vmware_deploy_ovf.py && sleep 0'
<nsxmgr02> EXEC /bin/sh -c '/opt/ansible/bin/python /home/jjahns/.ansible/tmp/ansible-tmp-1536713197.4-125268665570360/AnsiballZ_vmware_deploy_ovf.py && sleep 0'
<nsxmgr02> EXEC /bin/sh -c 'rm -f -r /home/jjahns/.ansible/tmp/ansible-tmp-1536713197.4-125268665570360/ > /dev/null 2>&1 && sleep 0'

TASK [nsx-ovf : deploy nsx appliance] *************************************************************************************************************************
task path: /etc/ansible/roles/nsx-ovf/tasks/main.yml:2
changed: [nsxmgr02] => {
    "changed": true, 
    "instance": {
        "annotation": "", 
        "current_snapshot": null, 
        "customvalues": {}, 
        "guest_consolidation_needed": false, 
        "guest_question": null, 
        "guest_tools_status": "guestToolsRunning", 
        "guest_tools_version": "10247", 
        "hw_cores_per_socket": 1, 
        "hw_datastores": [
            "mgmt01-vsan"
        ], 
        "hw_esxi_host": "r23-svr02.mhos.eng.vmware.com", 
        "hw_eth0": {
            "addresstype": "assigned", 
            "ipaddresses": [
                "10.38.201.34"
            ], 
            "label": "Network adapter 1", 
            "macaddress": "00:50:56:9a:a8:91", 
            "macaddress_dash": "00-50-56-9a-a8-91", 
            "portgroup_key": "dvportgroup-2186", 
            "portgroup_portkey": "13", 
            "summary": "DVSwitch: 50 2b bd bb 5f 64 0b d5-b0 0e 7a bc 8e 8f 31 8c"
        }, 
        "hw_files": [
            "[mgmt01-vsan] ef61985b-6023-ffb8-74cc-f8bc120497d0/nsxmgr02.vmx", 
            "[mgmt01-vsan] ef61985b-6023-ffb8-74cc-f8bc120497d0/nsxmgr02.vmsd", 
            "[mgmt01-vsan] ef61985b-6023-ffb8-74cc-f8bc120497d0/nsxmgr02.nvram", 
            "[mgmt01-vsan] ef61985b-6023-ffb8-74cc-f8bc120497d0/nsxmgr02.vmdk"
        ], 
        "hw_folder": "/SCDC2/vm", 
        "hw_guest_full_name": "Ubuntu Linux (64-bit)", 
        "hw_guest_ha_state": true, 
        "hw_guest_id": "ubuntu64Guest", 
        "hw_interfaces": [
            "eth0"
        ], 
        "hw_is_template": false, 
        "hw_memtotal_mb": 16384, 
        "hw_name": "nsxmgr02", 
        "hw_power_status": "poweredOn", 
        "hw_processor_count": 4, 
        "hw_product_uuid": "421ae0fa-2413-fe3e-58b4-43d2a2be8d84", 
        "hw_version": "vmx-13", 
        "instance_uuid": "501a503d-4482-cc82-5225-ca7f7931a18b", 
        "ipv4": "10.38.201.34", 
        "ipv6": null, 
        "module_hw": true, 
        "snapshots": []
    }, 
    "invocation": {
        "module_args": {
            "allow_duplicates": false, 
            "cluster": "mgmt01", 
            "datacenter": "SCDC2", 
            "datastore": "mgmt01-vsan", 
            "deployment_option": "medium", 
            "disk_provisioning": "thin", 
            "fail_on_spec_warnings": true, 
            "folder": null, 
            "hostname": "vcenter001.mhos.eng.vmware.com", 
            "name": "nsxmgr02", 
            "networks": {
                "Network 1": "nsx-vlan3000-mgmt"
            }, 
            "ovf": "/tmp/nsx-unified-appliance-2.3.0.0.0.9597332.ova", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "power_on": true, 
            "properties": {
                "nsx_allowSSHRootLogin": true, 
                "nsx_cli_passwd_0": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "nsx_dns1_0": "10.34.35.11 10.34.45.11", 
                "nsx_domain_0": "mhos.eng.vmware.com", 
                "nsx_gateway_0": "10.38.201.1", 
                "nsx_hostname": "nsxmgr02", 
                "nsx_ip_0": "10.38.201.34", 
                "nsx_isSSHEnabled": true, 
                "nsx_netmask_0": "255.255.255.0", 
                "nsx_ntp_0": "10.166.17.90 10.166.17.91", 
                "nsx_passwd_0": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "nsx_role": "nsx-manager"
            }, 
            "resource_pool": "Resources", 
            "username": "administrator@vsphere.local", 
            "validate_certs": false, 
            "wait": true, 
            "wait_for_ip_address": true
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP ****************************************************************************************************************************************************
nsxmgr02                   : ok=1    changed=1    unreachable=0    failed=0 
```
