### PR TITLE
Add a download_only option to the apt module #23220

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -123,6 +123,7 @@ options:
   download_only:
     description:
       - Only download packages. Do not install them now.
+    type: bool
     default: 'no'
     version_added: "2.8"
 requirements:

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -120,6 +120,11 @@ options:
     type: bool
     default: 'no'
     version_added: "2.4"
+  download_only:
+    description:
+      - Only download packages. Do not install them now.
+    default: 'no'
+    version_added: "2.8"
 requirements:
    - python-apt (python 2)
    - python3-apt (python 3)
@@ -515,7 +520,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
             install_recommends=None, force=False,
             dpkg_options=expand_dpkg_options(DPKG_OPTIONS),
             build_dep=False, autoremove=False, only_upgrade=False,
-            allow_unauthenticated=False):
+            allow_unauthenticated=False, download_only=False):
     pkg_list = []
     packages = ""
     pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache)
@@ -562,10 +567,15 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         else:
             only_upgrade = ''
 
+        if download_only:
+            download_only = '--download-only'
+        else:
+            download_only = ''
+
         if build_dep:
             cmd = "%s -y %s %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, only_upgrade, force_yes, check_arg, packages)
         else:
-            cmd = "%s -y %s %s %s %s %s install %s" % (APT_GET_CMD, dpkg_options, only_upgrade, force_yes, autoremove, check_arg, packages)
+            cmd = "%s -y %s %s %s %s %s %s install %s" % (APT_GET_CMD, dpkg_options, only_upgrade, force_yes, autoremove, check_arg, download_only, packages)
 
         if default_release:
             cmd += " -t '%s'" % (default_release,)
@@ -944,6 +954,7 @@ def main():
             only_upgrade=dict(type='bool', default=False),
             force_apt_get=dict(type='bool', default=False),
             allow_unauthenticated=dict(type='bool', default=False, aliases=['allow-unauthenticated']),
+            download_only=dict(type='bool', default=False),
         ),
         mutually_exclusive=[['deb', 'package', 'upgrade']],
         required_one_of=[['autoremove', 'deb', 'package', 'update_cache', 'upgrade']],
@@ -1102,7 +1113,8 @@ def main():
                 build_dep=state_builddep,
                 autoremove=autoremove,
                 only_upgrade=p['only_upgrade'],
-                allow_unauthenticated=allow_unauthenticated
+                allow_unauthenticated=allow_unauthenticated,
+                download_only=p['download_only']
             )
 
             # Store if the cache has been updated


### PR DESCRIPTION
##### SUMMARY
Added an option in the apt module to allow for downloading packages only, but not installing them right away.  

Fixes #23220

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/packaging/os/apt.py

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.8.0.dev0
  config file = None
  configured module search path = ['/home/treece/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/treece/src/ansible-venv/local/lib/python3.5/site-packages/ansible
  executable location = /home/treece/src/ansible-venv/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
```
$ ansible localhost -m apt -a 'name=sl state=present download_only=yes' -vvv -b

...

localhost | CHANGED => {
    "cache_update_time": 1536699399,
    "cache_updated": false,
    "changed": true,
    "diff": {},
    "invocation": {
        "module_args": {
            "allow_unauthenticated": false,
            "autoclean": false,
            "autoremove": false,
            "cache_valid_time": 0,
            "deb": null,
            "default_release": null,
            "download_only": true,
            "dpkg_options": "force-confdef,force-confold",
            "force": false,
            "force_apt_get": false,
            "install_recommends": null,
            "name": "sl",
            "only_upgrade": false,
            "package": [
                "sl"
            ],
            "purge": false,
            "state": "present",
            "update_cache": null,
            "upgrade": null
        }
    },
    "stderr": "",
    "stderr_lines": [],
    "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following NEW packages will be installed:\n  sl\n0 upgraded, 1 newly installed, 0 to remove and 87 not upgraded.\nNeed to get 0 B/24.4 kB of archives.\nAfter this operation, 86.0 kB of additional disk space will be used.\nDownload complete and in download only mode\n",
    "stdout_lines": [
        "Reading package lists...",
        "Building dependency tree...",
        "Reading state information...",
        "The following NEW packages will be installed:",
        "  sl",
        "0 upgraded, 1 newly installed, 0 to remove and 87 not upgraded.",
        "Need to get 0 B/24.4 kB of archives.",
        "After this operation, 86.0 kB of additional disk space will be used.",
        "Download complete and in download only mode"
    ]
}
```

Note: I recognize #24247 exists, and this is close to identical.  Sadly, there hasn't been any traction on that pull request in almost a year.