### PR TITLE
Backport: fix the autoscale resource id #45477

### DIFF
--- a/changelogs/fragments/azure_autoscale.yaml
+++ b/changelogs/fragments/azure_autoscale.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- fix azure_rm_autoscale module can use dict to identify target (https://github.com/ansible/ansible/pull/45477)

--- a/lib/ansible/modules/cloud/azure/azure_rm_autoscale.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_autoscale.py
@@ -521,11 +521,11 @@ class AzureRMAutoScale(AzureRMModuleBase):
 
             resource_id = self.target
             if isinstance(self.target, dict):
-                resource_id = format_resource_id(val=self.target.name,
-                                                 subscription_id=self.target.subscription_id or self.subscription_id,
-                                                 namespace=self.target.namespace,
-                                                 types=self.target.types,
-                                                 resource_group=self.target.resource_group or self.resource_group)
+                resource_id = format_resource_id(val=self.target['name'],
+                                                 subscription_id=self.target.get('subscription_id') or self.subscription_id,
+                                                 namespace=self.target['namespace'],
+                                                 types=self.target['types'],
+                                                 resource_group=self.target.get('resource_group') or self.resource_group)
             self.target = resource_id
             resource_name = self.name
 

--- a/test/integration/targets/azure_rm_autoscale/tasks/main.yml
+++ b/test/integration/targets/azure_rm_autoscale/tasks/main.yml
@@ -74,7 +74,10 @@
   azure_rm_autoscale:
     resource_group: "{{ resource_group }}"
     name: "{{ name }}"
-    target: "{{ vmss.ansible_facts.azure_vmss.id }}"
+    target:
+      name: "testVMSS{{ rpfx }}"
+      types: "virtualMachineScaleSets"
+      namespace: "Microsoft.Compute"
     enabled: true
     profiles:
     - count: '1'


### PR DESCRIPTION
* fix the autoscale resource id

* Update main.yml

(cherry picked from commit fa04387550de60921373f9d225745d7ca1f80712)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_autoscale

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7.0rc1
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
