### PR TITLE
Change IAM role name parsing to come from the ARN

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
@@ -467,8 +467,8 @@ class Ec2Metadata(object):
         new_fields = {}
         for key, value in fields.items():
             split_fields = key[len(uri):].split('/')
-            if len(split_fields) == 3 and split_fields[0:2] == ['iam', 'security-credentials']:
-                new_fields[self._prefix % "iam-instance-profile-role"] = split_fields[2]
+            if len(split_fields) == 2 and split_fields[0:2] == ['iam', 'info_instanceprofilearn']:
+                new_fields[self._prefix % "iam-instance-profile-role"] = value.split('/')[1]
             if len(split_fields) > 1 and split_fields[1]:
                 new_key = "-".join(split_fields)
                 new_fields[self._prefix % new_key] = value


### PR DESCRIPTION
##### SUMMARY
Fixes #45228

The change in #38664 (removal of the underscore check) actually caused the keys from the IAM role security credentials JSON dictionary to leak out into the parsing of the IAM role from the URL (`169.254.169.254/latest/meta-data/iam/security-credentials/<role name>`). This affects 2.6 and 2.7.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_metadata_facts

##### ANSIBLE VERSION
```
2.6.3
```

##### ADDITIONAL INFORMATION
Before:
```
"ansible_ec2_iam_instance_profile_role": "<role name>_expiration"
```
or any other key in the JSON dictionary (`accesskeyid`, `code`, `lastupdated`, `secretaccesskey`, `tokentype`) after the underscore

After:
```
"ansible_ec2_iam_instance_profile_role": "<role name>"
```
