### PR TITLE
Update RHEL and FreeBSD versions used for tests.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -45,9 +45,9 @@ matrix:
     - env: T=network
 
     - env: T=osx/10.11/1
-    - env: T=rhel/7.4/1
+    - env: T=rhel/7.5/1
     - env: T=freebsd/10.4/1
-    - env: T=freebsd/11.1/1
+    - env: T=freebsd/11.2/1
     - env: T=linux/centos6/1
     - env: T=linux/centos7/1
     - env: T=linux/fedora24/1
@@ -58,9 +58,9 @@ matrix:
     - env: T=linux/ubuntu1604py3/1
 
     - env: T=osx/10.11/2
-    - env: T=rhel/7.4/2
+    - env: T=rhel/7.5/2
     - env: T=freebsd/10.4/2
-    - env: T=freebsd/11.1/2
+    - env: T=freebsd/11.2/2
     - env: T=linux/centos6/2
     - env: T=linux/centos7/2
     - env: T=linux/fedora24/2
@@ -71,9 +71,9 @@ matrix:
     - env: T=linux/ubuntu1604py3/2
 
     - env: T=osx/10.11/3
-    - env: T=rhel/7.4/3
+    - env: T=rhel/7.5/3
     - env: T=freebsd/10.4/3
-    - env: T=freebsd/11.1/3
+    - env: T=freebsd/11.2/3
     - env: T=linux/centos6/3
     - env: T=linux/centos7/3
     - env: T=linux/fedora24/3

--- a/test/runner/completion/remote.txt
+++ b/test/runner/completion/remote.txt
@@ -1,4 +1,4 @@
 freebsd/10.4
-freebsd/11.1
+freebsd/11.2
 osx/10.11
-rhel/7.4
+rhel/7.5


### PR DESCRIPTION
##### SUMMARY

Update RHEL and FreeBSD versions used for tests:

- RHEL 7.4 -> 7.5
- FreeBSD 11.1 -> 11.2

(cherry picked from commit c50d6f19446bb41c74cf9d64e2e3d522629c3241)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0rc1.post0 (vm-update-2.7 34551d7d0e) last updated 2018/09/11 21:47:12 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
