### PR TITLE
VMware: Fix wait_for_task backoff behavior

### DIFF
--- a/changelogs/fragments/vmware_wait_for_task_fix.yaml
+++ b/changelogs/fragments/vmware_wait_for_task_fix.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- Fix timer in exponential backoff algorithm in vmware.py.

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -58,7 +58,7 @@ def wait_for_task(task, max_backoff=64, timeout=3600):
             finally:
                 raise_from(TaskError(error_msg), task.info.error)
         if task.info.state in [vim.TaskInfo.State.running, vim.TaskInfo.State.queued]:
-            sleep_time = min(2 ** failure_counter + randint(1, 1000), max_backoff)
+            sleep_time = min(2 ** failure_counter + randint(1, 1000) / 1000, max_backoff)
             time.sleep(sleep_time)
             failure_counter += 1
 


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Harald Albers <github@albersweb.de>

(cherry picked from commit 796d8b5dc8d36a84afe61b9da30779ef88e2cfcd)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/vmware_wait_for_task_fix.yaml
lib/ansible/module_utils/vmware.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
Stable-2.7
```