### PR TITLE
 Add the key_name/value_name options to the dict2items filter

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -200,9 +200,11 @@ into::
     - key: Environment
       value: dev
 
+.. versionadded:: 2.8
+
 ``dict2items`` accepts 2 keyword arguments, ``key_name`` and ``value_name`` that allow configuration of the names of the keys to use for the transformation::
 
-    {{ tags | dict2items(key_name='key', value_name='value') }}
+    {{ files | dict2items(key_name='file', value_name='path') }}
 
 items2dict filter
 `````````````````

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -206,6 +206,19 @@ into::
 
     {{ files | dict2items(key_name='file', value_name='path') }}
 
+Which turns::
+
+    files:
+      users: /etc/passwd
+      groups: /etc/group
+
+into::
+
+    - file: users
+      path: /etc/passwd
+    - file: groups
+      path: /etc/group
+
 items2dict filter
 `````````````````
 

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -200,6 +200,10 @@ into::
     - key: Environment
       value: dev
 
+``dict2items`` accepts 2 keyword arguments, ``key_name`` and ``value_name`` that allow configuration of the names of the keys to use for the transformation::
+
+    {{ tags | dict2items(key_name='key', value_name='value') }}
+
 items2dict filter
 `````````````````
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -494,7 +494,7 @@ def subelements(obj, subelements, skip_missing=False):
     return results
 
 
-def dict_to_list_of_dict_key_value_elements(mydict):
+def dict_to_list_of_dict_key_value_elements(mydict, key_name='key', value_name='value'):
     ''' takes a dictionary and transforms it into a list of dictionaries,
         with each having a 'key' and 'value' keys that correspond to the keys and values of the original '''
 
@@ -503,7 +503,7 @@ def dict_to_list_of_dict_key_value_elements(mydict):
 
     ret = []
     for key in mydict:
-        ret.append({'key': key, 'value': mydict[key]})
+        ret.append({key_name: key, value_name: mydict[key]})
     return ret
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

As with the `items2dict` filter, allow users to configure the key/value name for `dict2items`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

`dict2items`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.2
  config file = <redacted>
  configured module search path = ['<redacted>', '/usr/share/ansible/plugins/modules']
  ansible python module location = <redacted>
  executable location = <redacted>
  python version = 3.7.0 (default, Aug  1 2018, 17:14:57) [Clang 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
N/A
```
