### PR TITLE
Add scope parameter for docker networks

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -78,6 +78,7 @@ options:
       - local
       - swarm
       - global
+    version_added: "2.8"
 
   state:
     description:


### PR DESCRIPTION
##### SUMMARY
`docker network create` accepts an extra parameter `scope` that sets the network scope, the allowed values are `local`, `swarm` and `global`. The `docker_network` module doesn't implement this option, thus any new network will be created within `local` scope.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`docker_network`

##### ANSIBLE VERSION
```ansible 2.7.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/dfarher/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```
