### PR TITLE
Make snow_record support unique service-now urls

### DIFF
--- a/lib/ansible/modules/notification/snow_record.py
+++ b/lib/ansible/modules/notification/snow_record.py
@@ -33,12 +33,14 @@ options:
         required: false
         default: false
         type: bool
+        version_added: "2.8"
     validate_certs:
         description:
             - If True we validate certificates when using a unique service now address
         required: false
         default: true
         type: bool
+        version_added: "2.8"
     username:
         description:
             - User to connect to ServiceNow as
@@ -59,7 +61,7 @@ options:
               the supplied data.  If no such record exists, a new one will
               be created.  C(absent) will delete a record.
         choices: [ present, absent ]
-        required: false
+        required: True
     data:
         description:
             - key, value pairs of data to load into the record.
@@ -193,6 +195,7 @@ try:
 except ImportError:
     pass
 
+
 def run_module():
     # define the available arguments/parameters that a user can pass to
     # the module
@@ -204,7 +207,7 @@ def run_module():
         validate_certs=dict(type='bool', required=False, default=True),
         table=dict(type='str', required=False, default='incident'),
         state=dict(choices=['present', 'absent'],
-                   type='str', required=False, default=None),
+                   type='str', required=True),
         number=dict(default=None, required=False, type='str'),
         data=dict(default=None, required=False, type='dict'),
         lookup_field=dict(default='number', required=False, type='str'),

--- a/lib/ansible/modules/notification/snow_record.py
+++ b/lib/ansible/modules/notification/snow_record.py
@@ -29,9 +29,16 @@ options:
         required: true
     host:
         description:
-            - The instance is an address to the on premise endpoint
+            - Instance parameter is now assumed to be an address to the on premise endpoint
         required: false
-	default: false
+        default: false
+        type: bool
+    validate_certs:
+        description:
+            - If True we validate certificates when using a unique service now address
+        required: false
+        default: true
+        type: bool
     username:
         description:
             - User to connect to ServiceNow as
@@ -44,7 +51,7 @@ options:
         description:
             - Table to query for records
         required: false
-        default: incident
+        default: "incident"
     state:
         description:
             - If C(present) is supplied with a C(number)
@@ -65,7 +72,7 @@ options:
         description:
             - Changes the field that C(number) uses to find records
         required: false
-        default: number
+        default: 'number'
     attachment:
         description:
             - Attach a file to the record
@@ -194,7 +201,7 @@ def run_module():
         username=dict(default=None, type='str', required=True, no_log=True),
         password=dict(default=None, type='str', required=True, no_log=True),
         host=dict(type='bool', required=False, default=False),
-        validate_certs=dict(type='bool', required=False, default=False),
+        validate_certs=dict(type='bool', required=False, default=True),
         table=dict(type='str', required=False, default='incident'),
         state=dict(choices=['present', 'absent'],
                    type='str', required=False, default=None),

--- a/lib/ansible/modules/notification/snow_record.py
+++ b/lib/ansible/modules/notification/snow_record.py
@@ -61,7 +61,7 @@ options:
               the supplied data.  If no such record exists, a new one will
               be created.  C(absent) will delete a record.
         choices: [ present, absent ]
-        required: True
+        required: true
     data:
         description:
             - key, value pairs of data to load into the record.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Allow not validating SSL certificates

Two new parameters:
 - host (bool)
 - validate_certs (bool)

host)
 - if True then instance is treated as a URL (like snow.example.org)

validate_certs)
 - if True then we use the requests library to not validate SSL when
   connecting to the unique URL

Fixes #41320

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
snow_record

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
 ansible --version
ansible 2.8.0.dev0 (41320/snow_record/only-host-parameter ec6996d833) last updated 2018/09/12 14:11:06 (GMT +300)
  config file = None
  configured module search path = [u'/home/myuser/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/myuser/Git/ansible/lib/ansible
  executable location = /home/myuser/Git/ansible/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

I don't have access to a SNOW with incidents. Only a on-premise one with cmdb_ci which I can't get working like I want it to with this module (but I just want to query it which is complicated and this module is using deprecated (but not removed) APIs of pysnow). 

With this code one should be able to connect to one, but would be nice to get some help with testing this.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->