### PR TITLE
escape regular expressions when prompt matching in network_cli

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -426,7 +426,7 @@ class Connection(NetworkConnectionBase):
             single_prompt = True
         if not isinstance(answer, list):
             answer = [answer]
-        prompts_regex = [re.compile(r, re.I) for r in prompts]
+        prompts_regex = [re.compile(re.escape(r), re.I) for r in prompts]
         for index, regex in enumerate(prompts_regex):
             match = regex.search(resp)
             if match:


### PR DESCRIPTION
This minor change will now cause prompts to be escaped before compiling
them as regular expressions.  This will allow prompt matching that uses
regular expression characters.

