### PR TITLE
Flip default for AGNOSTIC_BECOME_PROMPT

### DIFF
--- a/changelogs/fragments/agnostic-become-prompt.yaml
+++ b/changelogs/fragments/agnostic-become-prompt.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- become - Change the default value for AGNOSTIC_BECOME_PROMPT so that become prompts are agnostic of the become method ()

--- a/changelogs/fragments/agnostic-become-prompt.yaml
+++ b/changelogs/fragments/agnostic-become-prompt.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-- become - Change the default value for AGNOSTIC_BECOME_PROMPT so that become prompts are agnostic of the become method ()
+- become - Change the default value for `AGNOSTIC_BECOME_PROMPT` to `True` so become prompts display `BECOME password:` regardless of the become method used. To display the become method in the prompt (for example, `SUDO password:`), set this config option to `False`.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -26,21 +26,19 @@ Command Line
 Become Prompting
 ----------------
 
-In Ansible 2.5 a config value was introduced to change the become password prompts to not include the become method. When this was introduced, the default was set to ``False``.
+Beginning in version 2.8, by default Ansible will use the word ``BECOME`` to prompt you for a password for elevated privileges (``sudo`` privileges in *nix or ``enable mode`` in many network OSs):
 
-In the Ansible 2.8 release, this configuration value has been changed to ``True`` to no longer display the become method in the prompt by default.
-
-**OLD** In Ansible 2.7::
-
-    ansible-playbook --become --ask-become-pass site.yml
-    SUDO password:
-
-**NEW** In Ansible 2.8::
+By default in Ansible 2.8::
 
     ansible-playbook --become --ask-become-pass site.yml
     BECOME password:
 
-For more information about this configuration please see :ref:`AGNOSTIC_BECOME_PROMPT`
+If you want the prompt to display the specific ``become_method`` you're using, instead of the agnostic value ``BECOME``, set :ref:`AGNOSTIC_BECOME_PROMPT` to ``False`` in your Ansible configuration.
+
+By default in Ansible 2.7, or with ``AGNOSTIC_BECOME_PROMPT=False`` in Ansible 2.7::
+
+    ansible-playbook --become --ask-become-pass site.yml
+    SUDO password:
 
 Deprecated
 ==========

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -26,7 +26,7 @@ Command Line
 Become Prompting
 ----------------
 
-Beginning in version 2.8, by default Ansible will use the word ``BECOME`` to prompt you for a password for elevated privileges (``sudo`` privileges in *nix or ``enable mode`` in many network OSs):
+Beginning in version 2.8, by default Ansible will use the word ``BECOME`` to prompt you for a password for elevated privileges (``sudo`` privileges on unix systems or ``enable`` mode on network devices):
 
 By default in Ansible 2.8::
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -35,7 +35,7 @@ By default in Ansible 2.8::
 
 If you want the prompt to display the specific ``become_method`` you're using, instead of the agnostic value ``BECOME``, set :ref:`AGNOSTIC_BECOME_PROMPT` to ``False`` in your Ansible configuration.
 
-By default in Ansible 2.7, or with ``AGNOSTIC_BECOME_PROMPT=False`` in Ansible 2.7::
+By default in Ansible 2.7, or with ``AGNOSTIC_BECOME_PROMPT=False`` in Ansible 2.8::
 
     ansible-playbook --become --ask-become-pass site.yml
     SUDO password:

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -20,6 +20,28 @@ Playbook
 No notable changes.
 
 
+Command Line
+============
+
+Become Prompting
+----------------
+
+In Ansible 2.5 a config value was introduced to change the become password prompts to not include the become method. When this was introduced, the default was set to ``False``.
+
+In the Ansible 2.8 release, this configuration value has been changed to ``True`` to no longer display the become method in the prompt by default.
+
+**OLD** In Ansible 2.7::
+
+    ansible-playbook --become --ask-become-pass site.yml
+    SUDO password:
+
+**NEW** In Ansible 2.8::
+
+    ansible-playbook --become --ask-become-pass site.yml
+    BECOME password:
+
+For more information about this configuration please see :ref:`AGNOSTIC_BECOME_PROMPT`
+
 Deprecated
 ==========
 

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -160,9 +160,8 @@ BECOME_ALLOW_SAME_USER:
   type: boolean
   yaml: {key: privilege_escalation.become_allow_same_user}
 AGNOSTIC_BECOME_PROMPT:
-  # TODO: Switch the default to True in either the Ansible 2.6 release or the 2.7 release, whichever happens after the Tower 3.3 release
   name: Display an agnostic become prompt
-  default: False
+  default: True
   type: boolean
   description: Display an agnostic become prompt instead of displaying a prompt containing the command line supplied become method
   env: [{name: ANSIBLE_AGNOSTIC_BECOME_PROMPT}]


### PR DESCRIPTION
##### SUMMARY

In 2.5 we made a change to make the become prompt agnostic of the become method.  This caused an issue with Ansible Tower, so we added a config toggle and defaulted the new behavior to False.

The plan was to swap the default to `True` after the Ansible Tower 3.3 release.  With the 3.3 release announced today, I'm flipping the default.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/config/base.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```