### PR TITLE
Fixed bug preventing repository from being deleted

### DIFF
--- a/lib/ansible/modules/windows/win_psmodule.ps1
+++ b/lib/ansible/modules/windows/win_psmodule.ps1
@@ -72,7 +72,7 @@ Function Remove-Repository{
     [bool]$CheckMode
     )
 
-    $Repo = (Get-PSRepository).SourceLocation
+    $Repo = (Get-PSRepository).Name
 
     # Try to remove the repository
     if ($Repo -contains $Name){


### PR DESCRIPTION
Because the code was pulling in the list of repository urls instead of repository names it would never remove the repository.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_psmodule

##### ANSIBLE VERSION
```paste below
ansible 2.5.5
  config file = None
  configured module search path = [u'/home/cvx_admin_user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/cvx_admin_user/.ansible-virtualenv/lib/python2.7/site-packages/ansible
  executable location = /home/cvx_admin_user/.ansible-virtualenv/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
If you try to delete repository it will never get deleted because the logic used will try to evaluate if the url matches the name. This if statement will always be false. Instead it needs to pull the name of the repositories so that if statement will work.
