### PR TITLE
Update base.yml

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -905,18 +905,6 @@ DEFAULT_PRIVATE_KEY_FILE:
   ini:
   - {key: private_key_file, section: defaults}
   type: path
-DEFAULT_PRIVATE_ROLE_VARS:
-  name: Private role variables
-  default: False
-  description:
-    - Makes role variables inaccessible from other roles.
-    - This was introduced as a way to reset role variables to default values if
-      a role is used more than once in a playbook.
-  env: [{name: ANSIBLE_PRIVATE_ROLE_VARS}]
-  ini:
-  - {key: private_role_vars, section: defaults}
-  type: boolean
-  yaml: {key: defaults.private_role_vars}
 DEFAULT_REMOTE_PORT:
   name: Remote port
   default: ~


### PR DESCRIPTION
Removes `private_role_vars` doc

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel 69bbd32264) last updated 2018/09/10 22:57:28 (GMT +200)
  config file = None
  configured module search path = ['/home/nikos/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/nikos/Projects/ansible/lib/ansible
  executable location = /home/nikos/Projects/ansible/bin/ansible
  python version = 3.7.0 (default, Jul 15 2018, 10:44:58) [GCC 8.1.1 20180531]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
According to [this commit](https://github.com/ansible/ansible/commit/0015d4cef3e263bd9a1d7ef45bc277976b890c1a) private vars were never implemented.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
