### PR TITLE
adds license details to dev guide pages

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_module_utilities.rst
+++ b/docs/docsite/rst/dev_guide/developing_module_utilities.rst
@@ -11,6 +11,8 @@ Ansible provides a number of module utilities that provide helper functions that
 
 The following is a list of ``module_utils`` files and a general description. The module utility source code lives in the ``./lib/ansible/module_utils`` directory under your main Ansible path - for more details on any specific module utility, please see the source code.
 
+.. include:: shared_snippets/Licensing.txt
+
 - api.py - Adds shared support for generic API modules.
 - azure_rm_common.py - Definitions and utilities for Microsoft Azure Resource Manager template deployments.
 - basic.py - General definitions and helper utilities for Ansible modules.

--- a/docs/docsite/rst/dev_guide/developing_module_utilities.rst
+++ b/docs/docsite/rst/dev_guide/developing_module_utilities.rst
@@ -11,7 +11,7 @@ Ansible provides a number of module utilities that provide helper functions that
 
 The following is a list of ``module_utils`` files and a general description. The module utility source code lives in the ``./lib/ansible/module_utils`` directory under your main Ansible path - for more details on any specific module utility, please see the source code.
 
-.. include:: shared_snippets/Licensing.txt
+.. include:: shared_snippets/licensing.txt
 
 - api.py - Adds shared support for generic API modules.
 - azure_rm_common.py - Definitions and utilities for Microsoft Azure Resource Manager template deployments.

--- a/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
@@ -17,7 +17,7 @@ To contribute a module to Ansible, you must:
 * support Python 2.7 and Python 3.5 - if your module cannot support Python 2.7, explain the required minimum Python version and rationale in the requirements section in ``DOCUMENTATION``
 * use proper :ref:`Python 3 syntax <developing_python_3>`
 * follow `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ Python style conventions - see :ref:`testing_pep8` for more information
-* license your module with GPL 3
+* license your module under the GPL license (GPLv3 or later)
 * conform to Ansible's :ref:`formatting and documentation <developing_modules_documenting>` standards
 * include comprehensive :ref:`tests <developing_testing>` for your module
 * minimize module dependencies


### PR DESCRIPTION
##### SUMMARY
Supersedes #44144. Adds license information to the Module Utilities pages and updates the mention of licensing on the checklist page to refer to GPLv3 or later.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.8
