### PR TITLE
Fix apt module not respecting check mode with certain options

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -1021,7 +1021,11 @@ def update_cache(m, cache, cache_valid_time):
     now = datetime.datetime.now()
     tdelta = datetime.timedelta(seconds=cache_valid_time)
     if not mtimestamp + tdelta >= now:
-        update_cache_run(m, cache)
+        if not m.check_mode:
+            update_cache_run(m, cache)
+        else:
+            # Signal that we would update the cache, but don't.
+            updated_cache = True
         cache.open(progress=None)
         mtimestamp, post_cache_update_time = get_updated_cache_time()
         if updated_cache_time != post_cache_update_time:

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -694,7 +694,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         status = True
         data = dict(changed=False)
 
-    if not build_dep:
+    if not build_dep and not m.check_mode:
         mark_installed_manually(m, package_names)
 
     return (status, data)

--- a/test/integration/targets/apt/tasks/check-mode.yml
+++ b/test/integration/targets/apt/tasks/check-mode.yml
@@ -1,0 +1,15 @@
+# Verify that packages to be installed aren't marked as manual in check mode
+
+- name: Remove hello if installed
+  apt:
+    name: hello
+    state: absent
+
+- name: Check status of hello
+  apt:
+    name: hello
+    state: present
+  check_mode: yes
+
+- name: Ensure hello was not re-marked as manual
+  shell: "! (apt-mark showmanual | grep hello)"

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -24,6 +24,8 @@
 
   - include: 'apt-builddep.yml'
 
+  - include: 'check-mode.yml'
+
   - block:
       - include: 'repo.yml'
     always:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Fix apt-mark marking packages as manually installed in check mode
* Fix apt updating the cache in check mode

There is some minor refactoring taking place to make the cache update code more readable (at least in my opinion). Feedback on that is greatly appreciated.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt module
