### PR TITLE
[2.7] eos: Don't error on VLAN missing warning (#45433)

### DIFF
--- a/lib/ansible/plugins/terminal/eos.py
+++ b/lib/ansible/plugins/terminal/eos.py
@@ -42,7 +42,8 @@ class TerminalModule(TerminalBase):
         re.compile(br"invalid input", re.I),
         re.compile(br"(?:incomplete|ambiguous) command", re.I),
         re.compile(br"connection timed out", re.I),
-        re.compile(br"[^\r\n]+ not found", re.I),
+        # Strings like this regarding VLANs are not errors
+        re.compile(br"[^\r\n]+ not found(?! in current VLAN)", re.I),
         re.compile(br"'[^']' +returned error code: ?\d+"),
         re.compile(br"[^\r\n]\/bin\/(?:ba)?sh"),
         re.compile(br"% More than \d+ OSPF instance", re.I),


### PR DESCRIPTION
(cherry picked from commit eaf01d3)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```