### PR TITLE
Un-deprecate include in 2.6

### DIFF
--- a/lib/ansible/modules/utilities/logic/include.py
+++ b/lib/ansible/modules/utilities/logic/include.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
-    'status': ['deprecated'],
+    'status': ['preview'],
     'supported_by': 'core'
 }
 


### PR DESCRIPTION
##### SUMMARY

Backport part of #44548

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
`include.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6
```