### PR TITLE
openstack inventory plugin: exit_on_error

### DIFF
--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -78,6 +78,14 @@ DOCUMENTATION = '''
                 inventory script's option fail_on_errors)
             type: bool
             default: 'no'
+        exit_on_errors:
+            description: |
+                Causes ansible to exit if there are any errors retrieving info
+                from openstack clouds from which inventory is built. This can
+                be valuable if you would rather ansible not run if you do not
+                have a complete openstack inventory picture.
+            type: bool
+            default: 'no'
         clouds_yaml_path:
             description: |
                 Override path to clouds.yaml file. If this value is given it
@@ -186,10 +194,20 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 cloud_inventory.clouds = new_clouds
 
             expand_hostvars = self._config_data.get('expand_hostvars', False)
-            fail_on_errors = self._config_data.get('fail_on_errors', False)
+            exit_on_errors = self._config_data.get('exit_on_errors', False)
+            fail_on_errors = exit_on_errors or \
+                    self._config_data.get('fail_on_errors', False)
 
-            source_data = cloud_inventory.list_hosts(
-                expand=expand_hostvars, fail_on_cloud_config=fail_on_errors)
+            try:
+                source_data = cloud_inventory.list_hosts(
+                    expand=expand_hostvars, fail_on_cloud_config=fail_on_errors)
+            except:
+                if exit_on_errors:
+                    sys.exit("Unable to generate complete inventory "
+                             "from openstack clouds")
+                else:
+                    # Use normal ansible error handling
+                    raise
 
             self._cache[cache_key] = source_data
 


### PR DESCRIPTION
##### SUMMARY
This adds an option to the openstack inventory plugin to exit ansible
completely on error talking to the openstack clouds. This is useful to
prevent ansible from running when an incomplete inventory would be
generated. Important when you need to perform steps in an order that may
not be respected if an incomplete inventory is provided.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openstack inventory plugin

##### ANSIBLE VERSION
ansible 2.7.0.dev0
  config file = None
  configured module search path = [u'/home/clark/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/clark/src/ansible/ansible/venv/lib/python2.7/site-packages/ansible
  executable location = venv/bin/ansible
  python version = 2.7.15 (default, May 21 2018, 17:53:03) [GCC]
