### PR TITLE
Improve get_url code stability is checksum checking

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -461,11 +461,21 @@ def main():
                 checksum_url = checksum
                 # download checksum file to checksum_tmpsrc
                 checksum_tmpsrc, checksum_info = url_get(module, checksum_url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest)
-                lines = [line.rstrip('\n') for line in open(checksum_tmpsrc)]
-                os.remove(checksum_tmpsrc)
+                with open(checksum_tmpsrc) as f:
+                    lines = [line.rstrip('\n') for line in f]
                 lines = dict(s.split(None, 1) for s in lines)
                 filename = url_filename(url)
-                [checksum] = (k for (k, v) in lines.items() if v.strip('./') == filename)
+
+                # Look through each line in the checksum file for a hash corresponding to
+                # the filename in the url, returning the first hash that is found.
+                for cksum in (s for (s, f) in lines.items() if f.strip('./') == filename):
+                    checksum = cksum
+                    break
+                else:
+                    checksum = None
+
+                if checksum is None:
+                    module.fail_json("Unable to find a checksum for file '%s' in '%s'" % (filename, checksum_url))
             # Remove any non-alphanumeric characters, including the infamous
             # Unicode zero-width space
             checksum = re.sub(r'\W+', '', checksum).lower()


### PR DESCRIPTION
##### SUMMARY
Use a context manager to open the downloaded checksum file.

This line is very fragile:

```python
[checksum] = (k for (k, v) in lines.items() if v.strip('./') == filename)
```

It will break if anything other than exactly one item is returned. It's possible for a checksum file to have no matching entries or multiple, even though it should not.

Using a loop with a `break` statement makes the code much more tolerant of variations in the checksum file.

Also add an error message if the checksum is not found in the file.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`get_url.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
2.8
```