### PR TITLE
[2.7] Exclude the whole ansible_failed_task block from ansible-connection (#45587)

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -843,7 +843,10 @@ class TaskExecutor:
             display.vvvv('attempting to start connection', host=self._play_context.remote_addr)
             display.vvvv('using connection plugin %s' % connection.transport, host=self._play_context.remote_addr)
             # We don't need to send the entire contents of variables to ansible-connection
-            filtered_vars = dict((key, value) for key, value in variables.items() if key.startswith('ansible'))
+            filtered_vars = dict(
+                (key, value) for key, value in variables.items()
+                if key.startswith('ansible') and key != 'ansible_failed_task'
+            )
             socket_path = self._start_connection(filtered_vars)
             display.vvvv('local domain socket path is %s' % socket_path, host=self._play_context.remote_addr)
             setattr(connection, '_socket_path', socket_path)


### PR DESCRIPTION
##### SUMMARY
It has lots of FieldAttributes that won't serialize.
Also the connection doesn't care.
(cherry picked from commit 3d0f19d)
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```
