### PR TITLE
Improve the local toctree (and title)

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
@@ -1,8 +1,8 @@
 .. _developing_modules_general_windows:
 
-**********************************************
-Windows Ansible module development walkthrough
-**********************************************
+**************************************
+Windows module development walkthrough
+**************************************
 
 In this section, we will walk through developing, testing, and debugging an
 Ansible Windows module.
@@ -12,7 +12,8 @@ Windows host, this guide differs from the usual development walkthrough guide.
 
 What's covered in this section:
 
-.. contents:: Topics
+.. contents::
+   :local:
 
 
 Windows environment setup


### PR DESCRIPTION
##### SUMMARY
The local toctree doesn't need to repeat the document title.
And we also don't need to explicitly state 'Ansible' in the title, since
this documentation is about Ansible.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Windows dev_guide

##### ANSIBLE VERSION
v2.8

##### ADDITIONAL INFORMATION
**Before**
--------
![screenshot from 2018-09-13 05-50-11](https://user-images.githubusercontent.com/388198/45466240-f312e500-b718-11e8-98e1-77ce35b1539a.png)
--------

**After**
--------
![screenshot from 2018-09-13 05-47-49](https://user-images.githubusercontent.com/388198/45466175-b7781b00-b718-11e8-8662-fc944895e346.png)
--------