### PR TITLE
Fix link and toctree

### DIFF
--- a/docs/docsite/rst/user_guide/windows_dsc.rst
+++ b/docs/docsite/rst/user_guide/windows_dsc.rst
@@ -2,6 +2,7 @@ Desired State Configuration
 ===========================
 
 .. contents:: Topics
+   :local:
 
 What is Desired State Configuration?
 ````````````````````````````````````
@@ -387,7 +388,7 @@ Setup IIS Website
        An introduction to playbooks
    :doc:`playbooks_best_practices`
        Best practices advice
-   `List of Windows Modules :ref:`<windows_modules>`
+   :ref:`List of Windows Modules <windows_modules>`
        Windows specific module list, all implemented in PowerShell
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -3,6 +3,7 @@ Setting up a Windows Host
 This document discusses the setup that is required before Ansible can communicate with a Microsoft Windows host.
 
 .. contents:: Topics
+   :local:
 
 Host Requirements
 `````````````````

--- a/docs/docsite/rst/user_guide/windows_usage.rst
+++ b/docs/docsite/rst/user_guide/windows_usage.rst
@@ -6,6 +6,7 @@ when it comes to components like path separators and OS-specific tasks.
 This document covers details specific to using Ansible for Windows.
 
 .. contents:: Topics
+   :local:
 
 Use Cases
 `````````

--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -4,6 +4,7 @@ Unlike Linux/Unix hosts, which use SSH by default, Windows hosts are
 configured with WinRM. This topic covers how to configure and use WinRM with Ansible.
 
 .. contents:: Topics
+   :local:
 
 What is WinRM?
 ``````````````


### PR DESCRIPTION
##### SUMMARY
This PR fixes an issue with a link in: 
- https://docs.ansible.com/ansible/devel/user_guide/windows_dsc.html#examples
- https://docs.ansible.com/ansible/2.6/user_guide/windows_dsc.html#examples
- https://docs.ansible.com/ansible/2.5/user_guide/windows_dsc.html#examples

This could be backport to v2.5, v2.6 and v2.7

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Windows DSC user_guide

##### ANSIBLE VERSION
v2.8 and earlier

##### ADDITIONAL INFORMATION
**Before**
-----------
![screenshot from 2018-09-13 13-22-22](https://user-images.githubusercontent.com/388198/45485492-2032b800-b758-11e8-8013-2852aaf6746f.png)
-----------

**After**
-----------
![screenshot from 2018-09-13 13-26-51](https://user-images.githubusercontent.com/388198/45485682-cb437180-b758-11e8-8d10-3e6c07b7a0a9.png)
-----------