### PR TITLE
Improve iam_group exception handling

### DIFF
--- a/hacking/aws_config/testing_policies/security-policy.json
+++ b/hacking/aws_config/testing_policies/security-policy.json
@@ -3,12 +3,16 @@
     "Statement": [
         {
             "Action": [
+                "iam:GetGroup",
                 "iam:GetInstanceProfile",
                 "iam:GetPolicy",
                 "iam:GetPolicyVersion",
                 "iam:GetRole",
                 "iam:GetRolePolicy",
+                "iam:GetUser",
+                "iam:ListAttachedGroupPolicies",
                 "iam:ListAttachedRolePolicies",
+                "iam:ListAttachedUserPolicies",
                 "iam:ListGroups",
                 "iam:ListInstanceProfiles",
                 "iam:ListInstanceProfilesForRole",

--- a/test/integration/targets/iam_group/aliases
+++ b/test/integration/targets/iam_group/aliases
@@ -1,0 +1,2 @@
+unsupported
+cloud/aws

--- a/test/integration/targets/iam_group/tasks/main.yml
+++ b/test/integration/targets/iam_group/tasks/main.yml
@@ -20,6 +20,11 @@
       - AnsibleTestUser
     state: present
     <<: *aws_connection_info
+  register: iam_group
+
+- assert:
+    that:
+      - iam_group.users
 
 - name: add non existent user to group
   iam_group:
@@ -37,3 +42,29 @@
     that:
       - iam_group is failed
       - iam_group.msg.startswith("Couldn't add user NonExistentUser to group ansible_test")
+
+- name: remove a user
+  iam_group:
+    name: ansible_test
+    purge_users: True
+    users: []
+    state: present
+    <<: *aws_connection_info
+  register: iam_group
+
+- assert:
+    that:
+      - iam_group.changed
+      - not iam_group.users
+
+- name: remove group
+  iam_group:
+    name: ansible_test
+    state: absent
+    <<: *aws_connection_info
+
+- name: remove ansible user
+  iam_user:
+    name: AnsibleTestUser
+    state: absent
+    <<: *aws_connection_info

--- a/test/integration/targets/iam_group/tasks/main.yml
+++ b/test/integration/targets/iam_group/tasks/main.yml
@@ -1,0 +1,39 @@
+- name: set up aws connection info
+  set_fact:
+    aws_connection_info: &aws_connection_info
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token }}"
+      region: "{{ aws_region }}"
+  no_log: yes
+
+- name: ensure ansible user exists
+  iam_user:
+    name: AnsibleTestUser
+    state: present
+    <<: *aws_connection_info
+
+- name: ensure group exists
+  iam_group:
+    name: ansible_test
+    users:
+      - AnsibleTestUser
+    state: present
+    <<: *aws_connection_info
+
+- name: add non existent user to group
+  iam_group:
+    name: ansible_test
+    users:
+      - AnsibleTestUser
+      - NonExistentUser
+    state: present
+    <<: *aws_connection_info
+  ignore_errors: yes
+  register: iam_group
+
+- name: assert that adding non existent user to group fails with helpful message
+  assert:
+    that:
+      - iam_group is failed
+      - iam_group.msg.startswith("Couldn't add user NonExistentUser to group ansible_test")


### PR DESCRIPTION
##### SUMMARY
Use AnsibleAWSModule for iam_group and handle BotoCoreErrors
as well as ClientErrors. Use fail_json_aws to improve error messages

Fixes #45593
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
iam_group

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel 1463c2e4a8) last updated 2018/09/08 10:08:47 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION
Candidate for backport to all supported versions of ansible