### PR TITLE
Remove unused import iControlUnexpectedHTTPError

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_device_facts.py
+++ b/lib/ansible/modules/network/f5/bigip_device_facts.py
@@ -5735,7 +5735,6 @@ try:
     from library.module_utils.network.f5.common import flatten_boolean
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     try:
-        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from f5.utils.responses.handlers import Stats
     except ImportError:
         HAS_F5SDK = False
@@ -5751,7 +5750,6 @@ except ImportError:
     from ansible.module_utils.network.f5.common import flatten_boolean
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
     try:
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
         from f5.utils.responses.handlers import Stats
     except ImportError:
         HAS_F5SDK = False


### PR DESCRIPTION
##### SUMMARY

Since that's unused in the code, no need to import it.
This got flagged by linters

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bigip_device_facts