### PR TITLE
Fix formatting for the error on azure_rm_appserviceplan_facts

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_appserviceplan_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_appserviceplan_facts.py
@@ -203,7 +203,7 @@ class AzureRMAppServicePlanFacts(AzureRMModuleBase):
         try:
             response = list(self.web_client.app_service_plans.list())
         except CloudError as exc:
-            self.fail("Error listing app service plans: {1}".format(str(exc)))
+            self.fail("Error listing app service plans: {0}".format(str(exc)))
 
         results = []
         for item in response:


### PR DESCRIPTION
##### SUMMARY
Fix formatting for the error on azure_rm_appserviceplan_facts

Since there is only 1 argument, {1} can't work since that's the
2nd argument for format. Flagged by lgmt.com

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_appserviceplan_facts

