### PR TITLE
Add new expand_shell argument for run_command, to disable expanding shellisms

### DIFF
--- a/changelogs/fragments/run-command-expand-shell.yaml
+++ b/changelogs/fragments/run-command-expand-shell.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+- run_command - Add a new keyword argument expand_shell, which defaults to True,
+  allowing the module author to decide whether or not shellisms such as paths and variables
+  are expanded before running the command when use_unsafe_shell=False
+  (https://github.com/ansible/ansible/issues/45418)

--- a/changelogs/fragments/run-command-expand-shell.yaml
+++ b/changelogs/fragments/run-command-expand-shell.yaml
@@ -1,5 +1,5 @@
 minor_changes:
-- run_command - Add a new keyword argument expand_shell, which defaults to True,
-  allowing the module author to decide whether or not shellisms such as paths and variables
+- run_command - Add a new keyword argument expand_user_and_vars, which defaults to True,
+  allowing the module author to decide whether or paths and variables
   are expanded before running the command when use_unsafe_shell=False
   (https://github.com/ansible/ansible/issues/45418)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2681,7 +2681,7 @@ class AnsibleModule(object):
 
     def run_command(self, args, check_rc=False, close_fds=True, executable=None, data=None, binary_data=False, path_prefix=None, cwd=None,
                     use_unsafe_shell=False, prompt_regex=None, environ_update=None, umask=None, encoding='utf-8', errors='surrogate_or_strict',
-                    expand_shell=True):
+                    expand_user_and_vars=True):
         '''
         Execute a command, returns rc, stdout, and stderr.
 
@@ -2719,8 +2719,8 @@ class AnsibleModule(object):
             python3 versions we support) otherwise a UnicodeError traceback
             will be raised.  This does not affect transformations of strings
             given as args.
-        :kw expand_shell: When ``use_unsafe_shell=False`` this argument
-            dictates whether shellisms such as environment variables and paths
+        :kw expand_user_and_vars: When ``use_unsafe_shell=False`` this argument
+            dictates whether ``~`` is expanded in paths and environment variables
             are expanded before running the command. When ``True`` a string such as
             ``$SHELL`` will be expanded regardless of escaping. When ``False`` and
             ``use_unsafe_shell=False`` no path or variable expansion will be done.
@@ -2762,8 +2762,8 @@ class AnsibleModule(object):
                     args = to_text(args, errors='surrogateescape')
                 args = shlex.split(args)
 
-            # expand shellisms
-            if expand_shell:
+            # expand ``~`` in paths, and all environment vars
+            if expand_user_and_vars:
                 args = [os.path.expanduser(os.path.expandvars(x)) for x in args if x is not None]
             else:
                 args = [x for x in args if x is not None]

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2680,7 +2680,8 @@ class AnsibleModule(object):
         return self._clean
 
     def run_command(self, args, check_rc=False, close_fds=True, executable=None, data=None, binary_data=False, path_prefix=None, cwd=None,
-                    use_unsafe_shell=False, prompt_regex=None, environ_update=None, umask=None, encoding='utf-8', errors='surrogate_or_strict'):
+                    use_unsafe_shell=False, prompt_regex=None, environ_update=None, umask=None, encoding='utf-8', errors='surrogate_or_strict',
+                    expand_shell=True):
         '''
         Execute a command, returns rc, stdout, and stderr.
 
@@ -2718,6 +2719,11 @@ class AnsibleModule(object):
             python3 versions we support) otherwise a UnicodeError traceback
             will be raised.  This does not affect transformations of strings
             given as args.
+        :kw expand_shell: When ``use_unsafe_shell=False`` this argument
+            dictates whether shellisms such as environment variables and paths
+            are expanded before running the command. When ``True`` a string such as
+            ``$SHELL`` will be expanded regardless of escaping. When ``False`` and
+            ``use_unsafe_shell=False`` no path or variable expansion will be done.
         :returns: A 3-tuple of return code (integer), stdout (native string),
             and stderr (native string).  On python2, stdout and stderr are both
             byte strings.  On python3, stdout and stderr are text strings converted
@@ -2757,7 +2763,10 @@ class AnsibleModule(object):
                 args = shlex.split(args)
 
             # expand shellisms
-            args = [os.path.expanduser(os.path.expandvars(x)) for x in args if x is not None]
+            if expand_shell:
+                args = [os.path.expanduser(os.path.expandvars(x)) for x in args if x is not None]
+            else:
+                args = [x for x in args if x is not None]
 
         prompt_re = None
         if prompt_regex:


### PR DESCRIPTION
##### SUMMARY
Add new expand_shell argument for run_command, to disable expanding shellisms. Fixes #45418

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```