### PR TITLE
avoid empty groups in json output

### DIFF
--- a/changelogs/fragments/no_empty_groups.yml
+++ b/changelogs/fragments/no_empty_groups.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - avoid empty groups in ansbile-inventory JSON output as they will be interpreted as hosts

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -329,6 +329,8 @@ class InventoryCLI(CLI):
                 results[group.name]['vars'] = self._get_group_variables(group)
 
             self._remove_empty(results[group.name])
+            if not results[group.name]:
+                del results[group.name]
 
             return results
 


### PR DESCRIPTION
##### SUMMARY
they get confused as hosts by script plugin

fixes #45601


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-inventory
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2,x
```
