### PR TITLE
[stable-2.6] Support empty files with piped transfer_method. Fixes #45426 (#45618)

### DIFF
--- a/changelogs/fragments/piped-transfer-empty-files.yaml
+++ b/changelogs/fragments/piped-transfer-empty-files.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ssh connection - Support empty files with piped transfer_method (https://github.com/ansible/ansible/issues/45426)


### PR DESCRIPTION
(cherry picked from commit e68f895)


Co-authored-by: Matt Martz <matt@sivel.net>