### PR TITLE
Update vmware_vmkernel to support Distributed Virtual Switches

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
@@ -48,6 +48,7 @@ options:
       - Whether or not C(switch_name) is a DVS.
       version_added: 2.8
       default: False
+      type: bool
     device_name:
       description:
       - The name of the vmkernel device.
@@ -250,7 +251,6 @@ class PyVmomiHelper(PyVmomi):
         if not self.port_group_obj:
             module.fail_json(msg="Portgroup name %s not found on %s" % (self.port_group_name, self.switch_name))
 
-
         if self.network_type == 'static':
             if not self.ip_address:
                 module.fail_json(msg="network.ip_address is required parameter when network is set to 'static'.")
@@ -314,7 +314,7 @@ class PyVmomiHelper(PyVmomi):
 
         """
         ret = False
-        vnics = [ vnic for vnic in self.esxi_host_obj.config.network.vnic if vnic.device == device_name]
+        vnics = [vnic for vnic in self.esxi_host_obj.config.network.vnic if vnic.device == device_name]
 
         if vnics:
             ret = vnics[0]
@@ -333,7 +333,6 @@ class PyVmomiHelper(PyVmomi):
             if not self.is_dvs_switch and self.vnic.portgroup != self.port_group_obj.spec.name:
                 state = 'update'
             if self.is_dvs_switch and self.vnic.spec.distributedVirtualPort.switchUuid != self.dv_switch.uuid:
-                #self.module.fail_json(msg="on wrong dvs") # name %s not found on %s" % (self.port_group_name, self.switch_name))
                 state = 'update'
             if self.vnic.spec.mtu != self.mtu:
                 state = 'update'
@@ -694,7 +693,7 @@ def main():
         enable_provisioning=dict(type='bool'),
         enable_replication=dict(type='bool'),
         enable_replication_nfc=dict(type='bool'),
-        vswitch_name=dict(required=False, type='str',  aliases=['switch_name']),
+        vswitch_name=dict(required=False, type='str', aliases=['switch_name']),
         state=dict(type='str',
                    choices=['present', 'absent'],
                    default='present'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Update vmware_vmkernel to support Distributed Virtual Switches.

- I aliased `vswitch_name` to a more generic `switch_name` which matches other vmware ansible modules.
- Add new required parameter `device_name` so that devices can be looked up by name instead of assuming it is the only device on a portgroup.
- Added new optional parameter `is_dvs_switch` which will determine whether vmkernel device is being added to a VSS or DVS.
- Removed parameter `vlan_id` which was not used

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
- vmware_vmkernel

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/opt/lib/ansible/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

# Add new vmk3
```
changed: [10.193.0.223 -> localhost] => (item={u'ft': False, u'name': u'vmk3', u'portgroup': u'vmotion', u'network': {u'type': u'dhcp', u'netmask': None, u'ip_address': None}, u'state': u'present', u'mgmt': False, u'mtu': 9000, u'vsan': True, u'switch_name': u'nova_dvs', u'dvs': True, u'vmotion': False}) => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "device_name": "vmk3", 
            "enable_ft": false, 
            "enable_mgmt": false, 
            "enable_vmotion": false, 
            "enable_vsan": true, 
            "esxi_hostname": "10.193.0.223", 
            "hostname": "10.193.18.128", 
            "ip_address": null, 
            "is_dvs_switch": true, 
            "mtu": 9000, 
            "network": {
                "ip_address": "", 
                "subnet_mask": "", 
                "type": "dhcp"
            }, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "portgroup_name": "vmotion", 
            "state": "present", 
            "subnet_mask": null, 
            "switch_name": "nova_dvs", 
            "username": "administrator@vsphere.local", 
            "validate_certs": false, 
            "vswitch_name": "nova_dvs"
        }
    }, 
    "item": {
        "dvs": true, 
        "ft": false, 
        "mgmt": false, 
        "mtu": 9000, 
        "name": "vmk3", 
        "network": {
            "ip_address": null, 
            "netmask": null, 
            "type": "dhcp"
        }, 
        "portgroup": "vmotion", 
        "state": "present", 
        "switch_name": "nova_dvs", 
        "vmotion": false, 
        "vsan": true
    }, 
    "result": null
}
```

# device on wrong dvs
```
changed: [10.193.2.215 -> localhost] => (item={u'ft': False, u'name': u'vmk3', u'portgroup': u'vmotion2', u'network': {u'type': u'dhcp', u'netmask': None, u'ip_address': None}, u'state': u'present', u'mgmt': False, u'mtu': 9000, u'vsan': False, u'switch_name': u'test_dvs', u'dvs': True, u'vmotion': True}) => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "device_name": "vmk3", 
            "enable_ft": false, 
            "enable_mgmt": false, 
            "enable_vmotion": true, 
            "enable_vsan": false, 
            "esxi_hostname": "10.193.2.215", 
            "hostname": "10.193.18.128", 
            "ip_address": null, 
            "is_dvs_switch": true, 
            "mtu": 9000, 
            "network": {
                "ip_address": "", 
                "subnet_mask": "", 
                "type": "dhcp"
            }, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "portgroup_name": "vmotion2", 
            "state": "present", 
            "subnet_mask": null, 
            "switch_name": "test_dvs", 
            "username": "administrator@vsphere.local", 
            "validate_certs": false, 
            "vswitch_name": "test_dvs"
        }
    }, 
    "item": {
        "dvs": true, 
        "ft": false, 
        "mgmt": false, 
        "mtu": 9000, 
        "name": "vmk3", 
        "network": {
            "ip_address": null, 
            "netmask": null, 
            "type": "dhcp"
        }, 
        "portgroup": "vmotion2", 
        "state": "present", 
        "switch_name": "test_dvs", 
        "vmotion": true, 
        "vsan": false
    }, 
    "result": "vmk3"
}
```


# device on wrong vswitch
```
changed: [10.193.2.215 -> localhost] => (item={u'ft': True, u'name': u'vmk4', u'portgroup': u'test_network2', u'network': {u'type': u'dhcp', u'netmask': None, u'ip_address': None}, u'state': u'present', u'mgmt': False, u'mtu': 9000, u'vsan': False, u'switch_name': u'vSwitch0', u'dvs': False, u'vmotion': False}) => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "device_name": "vmk4", 
            "enable_ft": true, 
            "enable_mgmt": false, 
            "enable_vmotion": false, 
            "enable_vsan": false, 
            "esxi_hostname": "10.193.2.215", 
            "hostname": "10.193.18.128", 
            "ip_address": null, 
            "is_dvs_switch": false, 
            "mtu": 9000, 
            "network": {
                "ip_address": "", 
                "subnet_mask": "", 
                "type": "dhcp"
            }, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "portgroup_name": "test_network2", 
            "state": "present", 
            "subnet_mask": null, 
            "switch_name": "vSwitch0", 
            "username": "administrator@vsphere.local", 
            "validate_certs": false, 
            "vswitch_name": "vSwitch0"
        }
    }, 
    "item": {
        "dvs": false, 
        "ft": true, 
        "mgmt": false, 
        "mtu": 9000, 
        "name": "vmk4", 
        "network": {
            "ip_address": null, 
            "netmask": null, 
            "type": "dhcp"
        }, 
        "portgroup": "test_network2", 
        "state": "present", 
        "switch_name": "vSwitch0", 
        "vmotion": false, 
        "vsan": false
    }, 
    "result": "vmk4"
}
```


# port group not found on vSwitch 
```
failed: [10.193.2.215 -> localhost] (item={u'ft': True, u'name': u'vmk4', u'portgroup': u'test_network', u'network': {u'type': u'dhcp', u'netmask': None, u'ip_address': None}, u'state': u'present', u'mgmt': False, u'mtu': 9000, u'vsan': False, u'switch_name': u'vSwitch0', u'dvs': False, u'vmotion': False}) => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "device_name": "vmk4", 
            "enable_ft": true, 
            "enable_mgmt": false, 
            "enable_vmotion": false, 
            "enable_vsan": false, 
            "esxi_hostname": "10.193.2.215", 
            "hostname": "10.193.18.128", 
            "ip_address": null, 
            "is_dvs_switch": false, 
            "mtu": 9000, 
            "network": {
                "ip_address": "", 
                "subnet_mask": "", 
                "type": "dhcp"
            }, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "portgroup_name": "test_network", 
            "state": "present", 
            "subnet_mask": null, 
            "switch_name": "vSwitch0", 
            "username": "administrator@vsphere.local", 
            "validate_certs": false, 
            "vswitch_name": "vSwitch0"
        }
    }, 
    "item": {
        "dvs": false, 
        "ft": true, 
        "mgmt": false, 
        "mtu": 9000, 
        "name": "vmk4", 
        "network": {
            "ip_address": null, 
            "netmask": null, 
            "type": "dhcp"
        }, 
        "portgroup": "test_network", 
        "state": "present", 
        "switch_name": "vSwitch0", 
        "vmotion": false, 
        "vsan": false
    }, 
    "msg": "Portgroup name test_network not found on vSwitch0"
}
```


# Remove vmk4 (vswitch)
```
changed: [10.193.2.215 -> localhost] => (item={u'ft': True, u'name': u'vmk4', u'portgroup': u'test_network2', u'network': {u'type': u'dhcp', u'netmask': None, u'ip_address': None}, u'state': u'absent', u'mgmt': False, u'mtu': 9000, u'vsan': False, u'switch_name': u'vSwitch0', u'dvs': False, u'vmotion': False}) => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "device_name": "vmk4", 
            "enable_ft": true, 
            "enable_mgmt": false, 
            "enable_vmotion": false, 
            "enable_vsan": false, 
            "esxi_hostname": "10.193.2.215", 
            "hostname": "10.193.18.128", 
            "ip_address": null, 
            "is_dvs_switch": false, 
            "mtu": 9000, 
            "network": {
                "ip_address": "", 
                "subnet_mask": "", 
                "type": "dhcp"
            }, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "portgroup_name": "test_network2", 
            "state": "absent", 
            "subnet_mask": null, 
            "switch_name": "vSwitch0", 
            "username": "administrator@vsphere.local", 
            "validate_certs": false, 
            "vswitch_name": "vSwitch0"
        }
    }, 
    "item": {
        "dvs": false, 
        "ft": true, 
        "mgmt": false, 
        "mtu": 9000, 
        "name": "vmk4", 
        "network": {
            "ip_address": null, 
            "netmask": null, 
            "type": "dhcp"
        }, 
        "portgroup": "test_network2", 
        "state": "absent", 
        "switch_name": "vSwitch0", 
        "vmotion": false, 
        "vsan": false
    }, 
    "result": "vmk4"
}
```

# Remove vmk3 (DVS)
```
changed: [10.193.2.215 -> localhost] => (item={u'ft': False, u'name': u'vmk3', u'portgroup': u'vmotion2', u'network': {u'type': u'dhcp', u'netmask': None, u'ip_address': None}, u'state': u'absent', u'mgmt': False, u'mtu': 9000, u'vsan': False, u'switch_name': u'test_dvs', u'dvs': True, u'vmotion': True}) => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "device_name": "vmk3", 
            "enable_ft": false, 
            "enable_mgmt": false, 
            "enable_vmotion": true, 
            "enable_vsan": false, 
            "esxi_hostname": "10.193.2.215", 
            "hostname": "10.193.18.128", 
            "ip_address": null, 
            "is_dvs_switch": true, 
            "mtu": 9000, 
            "network": {
                "ip_address": "", 
                "subnet_mask": "", 
                "type": "dhcp"
            }, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "portgroup_name": "vmotion2", 
            "state": "absent", 
            "subnet_mask": null, 
            "switch_name": "test_dvs", 
            "username": "administrator@vsphere.local", 
            "validate_certs": false, 
            "vswitch_name": "test_dvs"
        }
    }, 
    "item": {
        "dvs": true, 
        "ft": false, 
        "mgmt": false, 
        "mtu": 9000, 
        "name": "vmk3", 
        "network": {
            "ip_address": null, 
            "netmask": null, 
            "type": "dhcp"
        }, 
        "portgroup": "vmotion2", 
        "state": "absent", 
        "switch_name": "test_dvs", 
        "vmotion": true, 
        "vsan": false
    }, 
    "result": "vmk3"
}
```