### PR TITLE
Test host in inventory by name in remove_host

### DIFF
--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -224,8 +224,8 @@ class InventoryData(object):
 
     def remove_host(self, host):
 
-        if host in self.hosts:
-            del self.hosts[host]
+        if host.name in self.hosts:
+            del self.hosts[host.name]
 
         for group in self.groups:
             g = self.groups[group]


### PR DESCRIPTION


##### SUMMARY
The host argument is a Host object, and is used as such by
group.remove_host. However, self.hosts is a dictionary of host name to
Host object. Thus, the existing code is checking to see if the Host
object is one of the keys.

Use host.name to interact with the keys of the dictionary.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Inventory
