### PR TITLE
Ovirt_disk fails with "The 'value' parameter must be an integer"

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -604,6 +604,8 @@ def main():
 
         lun = module.params.get('logical_unit')
         if lun:
+            if lun.get("port"):
+                lun["port"] = int(lun.get("port"))
             disk = _search_by_lun(disks_service, lun.get('id'))
 
         ret = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ovirt_disk fails with error:
```
An exception occurred during task execution. To see the full traceback, use
-vvv. The error was: TypeError: The 'value' parameter must be an integer
localhost | FAILED! => {
    "changed": false,
    "msg": "The 'value' parameter must be an integer"
}
```
when specifying a port for iSCSI target for direct LUN creation. This
commit converts the port string into the integer.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_disk
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.3
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This issue can be reproduced by calling. It has to be a new disk with new LUN_ID
```
./hacking/test-module -m ./lib/ansible/modules/cloud/ovirt/ovirt_disk.py -a "name=Disk01 logical_unit=target=iqdn,address=10.10.10.10,id=36001405fb6247061a564688a9baa34db,port=3260"
```

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before:
```
An exception occurred during task execution. To see the full traceback, use
-vvv. The error was: TypeError: The 'value' parameter must be an integer
localhost | FAILED! => {
    "changed": false,
    "msg": "The 'value' parameter must be an integer"
}
```
After:
no error message and disk is created.

