### PR TITLE
Use recursive_diff for kubernetes

### DIFF
--- a/lib/ansible/module_utils/common/dict_transformations.py
+++ b/lib/ansible/module_utils/common/dict_transformations.py
@@ -121,3 +121,21 @@ def dict_merge(a, b):
         else:
             result[k] = deepcopy(v)
     return result
+
+
+def recursive_diff(dict1, dict2):
+    left = dict((k, v) for (k, v) in dict1.items() if k not in dict2)
+    right = dict((k, v) for (k, v) in dict2.items() if k not in dict1)
+    for k in (set(dict1.keys()) & set(dict2.keys())):
+        if isinstance(dict1[k], dict) and isinstance(dict2[k], dict):
+            result = recursive_diff(dict1[k], dict2[k])
+            if result:
+                left[k] = result[0]
+                right[k] = result[1]
+        elif dict1[k] != dict2[k]:
+            left[k] = dict1[k]
+            right[k] = dict2[k]
+    if left or right:
+        return left, right
+    else:
+        return None

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -22,6 +22,7 @@ import copy
 
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.dict_transformations import recursive_diff
 from ansible.module_utils.six import iteritems, string_types
 
 try:
@@ -38,12 +39,6 @@ try:
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False
-
-try:
-    import dictdiffer
-    HAS_DICTDIFFER = True
-except ImportError:
-    HAS_DICTDIFFER = False
 
 try:
     import urllib3
@@ -225,12 +220,12 @@ class K8sAnsibleMixin(object):
 
     @staticmethod
     def diff_objects(existing, new):
-        if not HAS_DICTDIFFER:
-            return False, []
-
-        diffs = list(dictdiffer.diff(new, existing))
-        match = len(diffs) == 0
-        return match, diffs
+        result = dict()
+        diff = recursive_diff(existing, new)
+        if diff:
+            result['before'] = diff[0]
+            result['after'] = diff[1]
+        return not diff, result
 
 
 class KubernetesAnsibleModule(AnsibleModule, K8sAnsibleMixin):

--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -1092,6 +1092,7 @@ web_acl_id:
 from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.aws.cloudfront_facts import CloudFrontFactsServiceManager
+from ansible.module_utils.common.dict_transformations import recursive_diff
 from ansible.module_utils.ec2 import get_aws_connection_info
 from ansible.module_utils.ec2 import ec2_argument_spec, boto3_conn, compare_aws_tags
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
@@ -1144,24 +1145,6 @@ def ansible_list_to_cloudfront_list(list_items=None, include_quantity=True):
     if len(list_items) > 0:
         result['items'] = list_items
     return result
-
-
-def recursive_diff(dict1, dict2):
-    left = dict((k, v) for (k, v) in dict1.items() if k not in dict2)
-    right = dict((k, v) for (k, v) in dict2.items() if k not in dict1)
-    for k in (set(dict1.keys()) & set(dict2.keys())):
-        if isinstance(dict1[k], dict) and isinstance(dict2[k], dict):
-            result = recursive_diff(dict1[k], dict2[k])
-            if result:
-                left[k] = result[0]
-                right[k] = result[1]
-        elif dict1[k] != dict2[k]:
-            left[k] = dict1[k]
-            right[k] = dict2[k]
-    if left or right:
-        return left, right
-    else:
-        return None
 
 
 def create_distribution(client, module, config, tags):


### PR DESCRIPTION
##### SUMMARY
Move recursive_diff from cloudfront_distribution to
common.dict_transformations and reuse it in k8s modules

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
k8s

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel e038338e9f) last updated 2018/09/14 20:28:45 (GMT +1000)
  config file = None
  configured module search path = ['/Users/will/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 3.6.4 (default, Mar  9 2018, 23:15:03) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION

recursive_diff can likely be widely used for diffs in module results