### PR TITLE
Remove uneeded global declaration of variable warnings

### DIFF
--- a/lib/ansible/modules/network/voss/voss_facts.py
+++ b/lib/ansible/modules/network/voss/voss_facts.py
@@ -441,9 +441,6 @@ FACT_SUBSETS = dict(
 
 VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())
 
-global warnings
-warnings = list()
-
 
 def main():
     """main entry point for module execution
@@ -504,6 +501,7 @@ def main():
         key = 'ansible_net_%s' % key
         ansible_facts[key] = value
 
+    warnings = list()
     check_args(module, warnings)
 
     module.exit_json(ansible_facts=ansible_facts, warnings=warnings)


### PR DESCRIPTION
##### SUMMARY
Remove uneeded global declaration of variable warnings

Since the variable is used only once, no need to declare it global.
Remove a warning from linter (lgtm.com)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
voss_facts