### PR TITLE
[WIP] Add platform and distribution to reboot plugin

### DIFF
--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -105,7 +105,7 @@ class ActionModule(ActionBase):
 
         if command_result['rc'] != 0:
             raise AnsibleError("%s: failed to get host boot time info, rc: %d, stdout: %s, stderr: %s"
-                               % (self._task.action, command_result.rc, to_native(command_result['stdout']), to_native(command_result['stderr'])))
+                               % (self._task.action, command_result['rc'], to_native(command_result['stdout']), to_native(command_result['stderr'])))
 
         return command_result['stdout'].strip()
 

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -40,6 +40,17 @@ class ActionModule(RebootActionModule, ActionBase):
         'shutdown_timeout_sec': '2.5',
     }
 
+    BOOT_TIME_COMMANDS = {
+        'windows': DEFAULT_BOOT_TIME_COMMAND
+    }
+
+    def _get_platform(self):
+        return 'windows'
+
+    def _get_distribution(self):
+        version = self._low_level_execute_command('[System.Environment]::OSVersion.Version.Major')['stdout_lines'][0]
+        return version
+
     def construct_command(self):
         shutdown_command = self.DEFAULT_SHUTDOWN_COMMAND
         pre_reboot_delay = int(self._task.args.get('pre_reboot_delay', self._task.args.get('pre_reboot_delay_sec', self.DEFAULT_PRE_REBOOT_DELAY)))


### PR DESCRIPTION
##### SUMMARY

Add platfrom and distribution gathering to `reboot` action plugin to allow for choosing commands and/or parameters based on that information. There is no "universal" set of commands, so this will be necessary to account for these differences and function reliably.

This is just a first attempt. It most likely has some glaring architectural issues. Open to feedback on how to improve this.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`reboot.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
2.7
```

##### ADDITIONAL INFORMATION

I originally wanted to avoid running the `setup` module on the managed node, but that may indeed be the best way forward rather than reinventing several wheels to gather the necessary data (platform, distribution, and version).