### PR TITLE
BOTMETA Changelog fragments are community

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -356,6 +356,8 @@ files:
     keywords:
       - persistent connection
     labels: networking
+  changelogs/fragments/:
+    support: community
   contrib/:
     support: community
   contrib/inventory:


### PR DESCRIPTION
##### SUMMARY
Currently any PR which adds a changelog fragment is marked as `support:core` which isn't useful

##### ISSUE TYPE
- Feature Pull Request
