### PR TITLE
add docstring for ansible.inventory.helpers.get_group_vars

### DIFF
--- a/lib/ansible/inventory/helpers.py
+++ b/lib/ansible/inventory/helpers.py
@@ -27,7 +27,12 @@ def sort_groups(groups):
 
 
 def get_group_vars(groups):
+    """
+    Combine all the group vars from a list of inventory groups.
 
+    :param groups: list of ansible.inventory.group.Group objects
+    :rtype: dict
+    """
     results = {}
     for group in sort_groups(groups):
         results = combine_vars(results, group.get_vars())


### PR DESCRIPTION
##### SUMMARY

Add a docstring for `ansible.inventory.helpers.get_group_vars()`

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

`ansible.inventory`

##### ANSIBLE VERSION

```
ansible 2.6.4
  config file = /home/kdreyer/.ansible.cfg
  configured module search path = [u'/home/kdreyer/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```

##### ADDITIONAL INFORMATION

I'm working on fixing compatibility problems in ansible-review. Finding this `get_group_vars()` method, it was not immediately obvious that just passing an `InventoryManager`'s `.groups` dict into this method would fail.