### PR TITLE
[aws_ssm_parameter_store] use describe_parameters paginator (#45632)

### DIFF
--- a/changelogs/fragments/aws_parameter_store_pagination.yaml
+++ b/changelogs/fragments/aws_parameter_store_pagination.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - aws_ssm_parameter_store - AWS Systems Manager Parameter store may reach
+    an internal limit before finding the expected parameter, causing misleading
+    results. This is resolved by paginating the describe_parameters call.

--- a/changelogs/fragments/aws_parameter_store_pagination.yaml
+++ b/changelogs/fragments/aws_parameter_store_pagination.yaml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
-  - aws_ssm_parameter_store - AWS Systems Manager Parameter store may reach
+  - aws_ssm_parameter_store - AWS Systems Manager Parameter Store may reach
     an internal limit before finding the expected parameter, causing misleading
     results. This is resolved by paginating the describe_parameters call.

--- a/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
@@ -185,7 +185,10 @@ def create_update_parameter(client, module):
                 # Description field not available from get_parameter function so get it from describe_parameters
                 describe_existing_parameter = None
                 try:
-                    describe_existing_parameter = client.describe_parameters(Filters=[{"Key": "Name", "Values": [args['Name']]}])
+                    describe_existing_parameter_paginator = client.get_paginator('describe_parameters')
+                    describe_existing_parameter = describe_existing_parameter_paginator.paginate(
+                        Filters=[{"Key": "Name", "Values": [args['Name']]}]).build_full_result()
+
                 except ClientError as e:
                     module.fail_json_aws(e, msg="getting description value")
 


### PR DESCRIPTION
##### SUMMARY
Fix the service reaching an internal limit while processing the results and returning unexpected data
(cherry picked from commit 7aaa5da41d802367fe4ed42c623cfc45467f5532)

Backport #45632

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py

##### ANSIBLE VERSION
```
ansible 2.7.0rc2.post0
```
