### PR TITLE
Do not reset permissions in checkmode of authorized_key

### DIFF
--- a/lib/ansible/modules/system/authorized_key.py
+++ b/lib/ansible/modules/system/authorized_key.py
@@ -328,7 +328,7 @@ def keyfile(module, user, write=False, path=None, manage_dir=True, follow=False)
     if follow:
         keysfile = os.path.realpath(keysfile)
 
-    if not write:
+    if not write or module.check_mode:
         return keysfile
 
     uid = user_entry.pw_uid


### PR DESCRIPTION
##### SUMMARY
Do not reset permissions in checkmode

If using authorized_key on a directory with non standard permissions,
using checkmode will reset the permission silently.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
authorized_key

##### ADDITIONAL INFORMATION
I found it while trying to get a .ssh/authorized_key to be managed by root only, with a sftp account. So silently changing the ownership would open a security hole where a user would have been able to upload new keys (and btpass force command).