### PR TITLE
Port the aix_inittab to python 3

### DIFF
--- a/lib/ansible/modules/system/aix_inittab.py
+++ b/lib/ansible/modules/system/aix_inittab.py
@@ -118,7 +118,12 @@ changed:
 '''
 
 # Import necessary libraries
-import itertools
+try:
+    # python 2
+    from itertools import izip
+except ImportError:
+    izip = zip
+
 from ansible.module_utils.basic import AnsibleModule
 
 # end import modules
@@ -136,7 +141,7 @@ def check_current_entry(module):
         values = out.split(":")
         # strip non readable characters as \n
         values = map(lambda s: s.strip(), values)
-        existsdict = dict(itertools.izip(keys, values))
+        existsdict = dict(izip(keys, values))
         existsdict.update({'exist': True})
     return existsdict
 


### PR DESCRIPTION
##### SUMMARY
Port the aix_inittab to python 3

Since izip no longer exist on python 3, we need to use zip
Fix #45220

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aix_inittab

##### ADDITIONAL INFORMATION
I couldn't test