### PR TITLE
Do not reset permissions in checkmode

### DIFF
--- a/lib/ansible/modules/system/authorized_key.py
+++ b/lib/ansible/modules/system/authorized_key.py
@@ -328,7 +328,7 @@ def keyfile(module, user, write=False, path=None, manage_dir=True, follow=False)
     if follow:
         keysfile = os.path.realpath(keysfile)
 
-    if not write:
+    if not write or module.check_mode:
         return keysfile
 
     uid = user_entry.pw_uid


### PR DESCRIPTION
##### SUMMARY
Do not reset permissions in checkmode

If using authorized_key on a directory with non standard permissions,
using checkmode will reset the permission silently.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
authorized_keys
