### PR TITLE
Add a alias from organisation to organization

### DIFF
--- a/lib/ansible/modules/cloud/univention/udm_user.py
+++ b/lib/ansible/modules/cloud/univention/udm_user.py
@@ -125,6 +125,7 @@ options:
     organisation:
         description:
             - Organisation
+        aliases: [ organization ]
     override_pw_history:
         type: bool
         default: 'no'
@@ -330,7 +331,8 @@ def main():
                                          type='list',
                                          aliases=['mobileTelephoneNumber']),
             organisation=dict(default=None,
-                              type='str'),
+                              type='str',
+                              aliases=['organization']),
             overridePWHistory=dict(default=False,
                                    type='bool',
                                    aliases=['override_pw_history']),


### PR DESCRIPTION
##### SUMMARY
Add a alias from organisation to organization

Since 'organization' is the spelling used accross all others modules,
I think it would be better to at least have this one as a alias.

Organisation is the UK/Australia/NZ spelling, while organization is the
US one.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
udm_user

##### ADDITIONAL INFORMATION
Additionally, maybe it would be better to rename and change the parameters, this did seems less controversial for now.