### PR TITLE
Add a default man path in hacking/env-setup

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -20,7 +20,7 @@ prepend_path()
 # Default values for shell variables we use
 PYTHONPATH=${PYTHONPATH-""}
 PATH=${PATH-""}
-MANPATH=${MANPATH-""}
+MANPATH=${MANPATH-$(manpath)}
 PYTHON=$(which python 2>/dev/null || which python3 2>/dev/null)
 PYTHON_BIN=${PYTHON_BIN-$PYTHON}
 


### PR DESCRIPTION
##### SUMMARY
Add a default man path

It seems that on some Linux distribution (Fedora 28, Debian), man will
not fallback on a default path if MANPATH is set. So using the env-setup
script will prevent man from working.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hacking/env-setup
