### PR TITLE
Simplify PPA installation steps for Ubuntu

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -147,8 +147,7 @@ To configure the PPA on your machine and install ansible run these commands:
 
     $ sudo apt-get update
     $ sudo apt-get install software-properties-common
-    $ sudo apt-add-repository ppa:ansible/ansible
-    $ sudo apt-get update
+    $ sudo apt-add-repository --yes --update ppa:ansible/ansible
     $ sudo apt-get install ansible
 
 .. note:: On older Ubuntu distributions, "software-properties-common" is called "python-software-properties".


### PR DESCRIPTION
<!--- Your description here -->
Adding the `--update` flag automatically updates the cache after adding a repo (no need to run `apt-get update` in a separate step)
Adding the `--yes` flag disable the Ansible repo description and skips the confirmation dialog.
+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is no need to repeat the `apt-get update` after adding a repo with `add-apt-repository`. This
can be done in one step, so one line less to type/paste. `--yes` adds the repo without the `Y/n` question. I think if someone decides to add the PPA and start typing/pasting installation commands the response will always be `yes`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'~/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
