### PR TITLE
Adds **kwargs parameter to password_hash to support more algorithms.

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -848,6 +848,13 @@ Some hash types allow providing a rounds parameter::
 
     {{ 'secretpassword' | password_hash('sha256', 'mysecretsalt', rounds=10000) }}
 
+When`Passlib <https://passlib.readthedocs.io/en/stable/>`_ is installed
+`password_hash` supports more crypt schematas::
+
+    {{ 'secretpassword' | password_hash('sha256_crypt', 'mysecretsalt', rounds=5000) }}
+    {{ 'secretpassword' | password_hash('bcrypt', ident='2b', rounds=14) }}
+    {{ 'secretpassword' | password_hash('msdcc', user='SomeUser') }}
+
 .. _combine_filter:
 
 Combining hashes/dictionaries

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -261,7 +261,7 @@ def get_hash(data, hashtype='sha1'):
     return h.hexdigest()
 
 
-def get_encrypted_password(password, hashtype='sha512', salt=None, salt_size=None, rounds=None):
+def get_encrypted_password(password, hashtype='sha512', salt=None, salt_size=None, rounds=None, ident=None):
     passlib_mapping = {
         'md5': 'md5_crypt',
         'blowfish': 'bcrypt',
@@ -271,7 +271,7 @@ def get_encrypted_password(password, hashtype='sha512', salt=None, salt_size=Non
 
     hashtype = passlib_mapping.get(hashtype, hashtype)
     try:
-        return passlib_or_crypt(password, hashtype, salt=salt, salt_size=salt_size, rounds=rounds)
+        return passlib_or_crypt(password, hashtype, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
     except AnsibleError as e:
         reraise(AnsibleFilterError, AnsibleFilterError(to_native(e), orig_exc=e), sys.exc_info()[2])
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -261,7 +261,7 @@ def get_hash(data, hashtype='sha1'):
     return h.hexdigest()
 
 
-def get_encrypted_password(password, hashtype='sha512', salt=None, salt_size=None, rounds=None, ident=None):
+def get_encrypted_password(password, hashtype='sha512', salt=None, salt_size=None, rounds=None, ident=None, user=None):
     passlib_mapping = {
         'md5': 'md5_crypt',
         'blowfish': 'bcrypt',
@@ -271,7 +271,7 @@ def get_encrypted_password(password, hashtype='sha512', salt=None, salt_size=Non
 
     hashtype = passlib_mapping.get(hashtype, hashtype)
     try:
-        return passlib_or_crypt(password, hashtype, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
+        return passlib_or_crypt(password, hashtype, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident, user=user)
     except AnsibleError as e:
         reraise(AnsibleFilterError, AnsibleFilterError(to_native(e), orig_exc=e), sys.exc_info()[2])
 

--- a/test/units/utils/test_encrypt.py
+++ b/test/units/utils/test_encrypt.py
@@ -100,6 +100,12 @@ def test_password_hash_filter_passlib():
     # Try algorithm that uses a raw salt
     assert get_encrypted_password("123", "pbkdf2_sha256")
 
+    assert get_encrypted_password("123", "bcrypt", rounds=14).startswith("$2")
+    assert get_encrypted_password("123", "bcrypt", ident="2", rounds=14).startswith("$2$14$")
+    assert get_encrypted_password("123", "bcrypt", ident="2a", rounds=14).startswith("$2a$14$")
+    assert get_encrypted_password("123", "bcrypt", ident="2b", rounds=14).startswith("$2b$14$")
+    assert get_encrypted_password("123", "bcrypt", ident="2y", rounds=14).startswith("$2y$14$")
+
 
 def test_do_encrypt_no_passlib():
     with passlib_off():

--- a/test/units/utils/test_encrypt.py
+++ b/test/units/utils/test_encrypt.py
@@ -137,3 +137,11 @@ def test_random_salt():
     assert len(res) == 8
     for res_char in res:
         assert res_char in expected_salt_candidate_chars
+
+
+def test_msdcc():
+    if not encrypt.PASSLIB_AVAILABLE:
+        pytest.skip("passlib not available")
+
+    assert encrypt.do_encrypt("123", "msdcc", user="SomeUser") == "58900987b4bdbe152a61a7f133847faa"
+    assert encrypt.do_encrypt("123", "msdcc2", user="SomeUser") == "0d96b1069d61c901f21c1dadff724725"


### PR DESCRIPTION
##### SUMMARY
Adds **kwargs parameter to password_hash to support more algorithms.
    
This adds support for the bcrypt algorithm as described in the documentation.
The msdcc and msdcc2 algorithm are also supported now.

Fixes #45392

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
utils/encrypt

##### ANSIBLE VERSION
```paste below
ansible 2.7.0rc2.post0
```