### PR TITLE
win_nssm: refactor to fix issues, support check mode and add more features

### DIFF
--- a/changelogs/fragments/win_nssm.yaml
+++ b/changelogs/fragments/win_nssm.yaml
@@ -1,0 +1,13 @@
+minor_changes:
+- win_nssm - Add the ``executable`` option to specify the location of the NSSM utility.
+- win_nssm - Add the ``working_directory``, ``display_name`` and ``description`` options.
+- win_nssm - Add support for check and diff modes.
+- win_nssm - Change default value for ``state`` from ``start`` to ``present``.
+
+bugfixes:
+- win_nssm - Fix several escaping and quoting issues of paths and parameters.
+
+deprecated_features:
+- win_nssm - Deprecate ``dependencies``, ``start_mode``, ``user``, and ``password`` options, in favor of using the ``win_service`` module.
+- win_nssm - Deprecate ``start``, ``stop``, and ``restart`` values for ``state`` option, in favor of using the ``win_service`` module.
+- win_nssm - Deprecate ``app_parameters`` option in favor of ``arguments``.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -312,6 +312,24 @@ Noteworthy module changes
 
 * The ``win_psexec`` has deprecated the undocumented ``extra_opts`` module option. This will be removed in Ansible 2.10.
 
+* The ``win_nssm`` module has deprecated the following options in favor of using the ``win_service`` module to configure the service after installing it with ``win_nssm``:
+  * ``dependencies``, use ``dependencies`` of ``win_service`` instead
+  * ``start_mode``, use ``start_mode`` of ``win_service`` instead
+  * ``user``, use ``username`` of ``win_service`` instead
+  * ``password``, use ``password`` of ``win_service`` instead
+  These options will be removed in Ansible 2.12.
+
+* The ``win_nssm`` module has also deprecated the ``start``, ``stop``, and ``restart`` values of the ``status`` option.
+  You should use the ``win_service`` module to control the running state of the service. This will be removed in Ansible 2.12.
+
+* The ``status`` module option for ``win_nssm`` has changed its default value to ``present``. Before, the default was ``start``.
+  Consequently, the service is no longer started by default after creation with ``win_nssm``, and you should use 
+  the ``win_service`` module to start it if needed.
+
+* The ``app_parameters`` module option for ``win_nssm`` has been deprecated; use ``argument`` instead. This will be removed in Ansible 2.12.
+
+* The ``app_parameters_free_form`` module option for ``win_nssm`` has been aliased to the new ``arguments`` option.
+
 * The ``win_dsc`` module will now validate the input options for a DSC resource. In previous versions invalid options
   would be ignored but are now not.
 

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -327,6 +327,10 @@ if ($state -ne 'absent') {
     if($null -eq $appDirectory) {
         $appDirectory = (Get-Item $application).DirectoryName
     }
+
+    if ($user -and -not $password) {
+        Fail-Json -obj $result -message "User without password is informed for service ""$name"""
+    }
 }
 
 
@@ -422,16 +426,10 @@ if ($state -eq 'absent') {
         Update-NssmServiceParameter -parameter "AppRotateBytes" -value 104858 @common_params
 
 
-        if($null -ne $dependencies) {
-            Update-NssmServiceParameter -parameter "DependOnService" -arguments $dependencies @common_params
-        }
+        Update-NssmServiceParameter -parameter "DependOnService" -arguments $dependencies @common_params
 
         if ($user) {
             $fullUser = $user
-            if (!$password) {
-                Fail-Json -obj $result -message "User without password is informed for service ""$name"""
-            }
-
             if (-Not($user.contains("@")) -And ($user.Split("\").count -eq 1)) {
                 $fullUser = ".\" + $user
             }

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -59,7 +59,6 @@ function Invoke-NssmCommand {
     $command = Argv-ToString -arguments (@($executable) + $arguments)
     $result = Run-Command -command $command
 
-    #TODO Add this to CommandUtil.psm1 ?
     $result.arguments = $command
 
     return $result
@@ -321,7 +320,7 @@ if ($null -ne $appParameters) {
 if ($state -in @("started","stopped","restarted")) {
     Add-DeprecationWarning -obj $result -message "The values 'started', 'stopped', and 'restarted' for 'state' will be removed soon, use the win_service module to start or stop the service instead" -version 2.12
 }
-if ($null -ne $startMode) {
+if ($params.ContainsKey('start_mode')) {
     Add-DeprecationWarning -obj $result -message "The parameter 'start_mode' will be removed soon, use the win_service module instead" -version 2.12
 }
 if ($null -ne $dependencies) {

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -338,12 +338,12 @@ if ($state -ne 'absent') {
         Fail-Json -obj $result -message "The application parameter must be defined when the state is not absent."
     }
 
-    if (-not (Test-Path -Path $application -PathType Leaf)) {
+    if (-not (Test-Path -LiteralPath $application -PathType Leaf)) {
         Fail-Json -obj $result -message "The application specified ""$application"" does not exist on the host."
     }
 
     if($null -eq $appDirectory) {
-        $appDirectory = (Get-Item $application).DirectoryName
+        $appDirectory = (Get-Item -LiteralPath $application).DirectoryName
     }
 
     if ($user -and -not $password) {

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -35,6 +35,8 @@ $appArguments = Get-AnsibleParam -obj $params -name "arguments" -aliases "app_pa
 $stdoutFile = Get-AnsibleParam -obj $params -name "stdout_file" -type "path"
 $stderrFile = Get-AnsibleParam -obj $params -name "stderr_file" -type "path"
 
+$executable = Get-AnsibleParam -obj $params -name "executable" -type "path" -default "nssm.exe"
+
 # Deprecated options since 2.8. Remove in 2.12
 $startMode = Get-AnsibleParam -obj $params -name "start_mode" -type "str" -default "auto" -validateset $start_modes_map.Keys -resultobj $result
 $dependencies = Get-AnsibleParam -obj $params -name "dependencies" -type "list"
@@ -52,14 +54,11 @@ function Invoke-NssmCommand {
         [string[]]$arguments
     )
 
-    $executable = "nssm"
-    $argument_string = Argv-ToString -arguments $arguments
-
-    $command = "$executable $argument_string"
+    $command = Argv-ToString -arguments (@($executable) + $arguments)
     $result = Run-Command -command $command
 
     #TODO Add this to CommandUtil.psm1 ?
-    $result.arguments = $argument_string
+    $result.arguments = $command
 
     return $result
 }

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -47,7 +47,7 @@ $password = Get-AnsibleParam -obj $params -name "password" -type "str"
 $result = @{
     changed = $false
 }
-$global:diff_text = $null
+$diff_text = $null
 
 function Invoke-NssmCommand {
     [CmdletBinding()]
@@ -183,7 +183,7 @@ function Update-NssmServiceParameter {
             }
         }
 
-        $global:diff_text += "-$parameter = $($current_values -join ', ')`n+$parameter = $($arguments -join ', ')`n"
+        $script:diff_text += "-$parameter = $($current_values -join ', ')`n+$parameter = $($arguments -join ', ')`n"
         $result.changed_by = $parameter
         $result.changed = $true
     }

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -154,7 +154,7 @@ function Update-NssmServiceParameter {
     )
 
     if($null -eq $arguments) { return }
-    $arguments = @($arguments | where { $_ -ne '' })
+    $arguments = @($arguments | Where-Object { $_ -ne '' })
 
     $nssm_result = Get-NssmServiceParameter -service $service -parameter $parameter
 
@@ -164,7 +164,7 @@ function Update-NssmServiceParameter {
         Fail-Json -obj $result -message "Error retrieving $parameter for service ""$service"""
     }
 
-    $current_values = @($nssm_result.stdout.split("`n`r") | where { $_ -ne '' })
+    $current_values = @($nssm_result.stdout.split("`n`r") | Where-Object { $_ -ne '' })
 
     if (-not $compare.Invoke($current_values,$arguments)) {
         if ($PSCmdlet.ShouldProcess($service, "Update '$parameter' parameter")) {
@@ -194,7 +194,7 @@ function Test-NssmServiceExists {
         [string]$service
     )
 
-    return [bool](Get-Service "$service" -ErrorAction SilentlyContinue)
+    return [bool](Get-Service -Name $service -ErrorAction SilentlyContinue)
 }
 
 function Invoke-NssmStart {
@@ -294,16 +294,16 @@ if (($null -ne $appParameters) -and ($null -ne $appArguments)) {
 if ($null -ne $appParameters) {
     Add-DeprecationWarning -obj $result -message "The parameter 'app_parameters' will be removed soon, use 'arguments' instead." -version 2.12
 
-	if ($appParameters -isnot [string]) {
-	    Fail-Json -obj $result -message "The app_parameters parameter must be a string representing a dictionary."
-	}
+    if ($appParameters -isnot [string]) {
+        Fail-Json -obj $result -message "The app_parameters parameter must be a string representing a dictionary."
+    }
 
     # Convert dict-as-string form to list
     $escapedAppParameters = $appParameters.TrimStart("@").TrimStart("{").TrimEnd("}").Replace("; ","`n").Replace("\","\\")
     $appParametersHash = ConvertFrom-StringData -StringData $escapedAppParameters
 
     $appParamsArray = @()
-    $appParametersHash.GetEnumerator() | foreach {
+    $appParametersHash.GetEnumerator() | Foreach-Object {
         if ($_.Name -ne "_") {
             $appParamsArray += $_.Name
         }
@@ -386,7 +386,7 @@ if ($state -eq 'absent') {
         Update-NssmServiceParameter -parameter "AppDirectory" -value $appDirectory @common_params
 
 
-        if (($null -ne $appArguments)) {
+        if ($null -ne $appArguments) {
             $singleLineParams = ""
             if ($appArguments -is [array]) {
                 $singleLineParams = Argv-ToString -arguments $appArguments

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -28,13 +28,13 @@ $result = @{
 $name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent","started","stopped","restarted" -resultobj $result
 
-$application = Get-AnsibleParam -obj $params -name "application" -type "str"
+$application = Get-AnsibleParam -obj $params -name "application" -type "path"
 $appParameters = Get-AnsibleParam -obj $params -name "app_parameters"
 $appParametersFree  = Get-AnsibleParam -obj $params -name "app_parameters_free_form" -type "str"
 $startMode = Get-AnsibleParam -obj $params -name "start_mode" -type "str" -default "auto" -validateset $start_modes_map.Keys -resultobj $result
 
-$stdoutFile = Get-AnsibleParam -obj $params -name "stdout_file" -type "str"
-$stderrFile = Get-AnsibleParam -obj $params -name "stderr_file" -type "str"
+$stdoutFile = Get-AnsibleParam -obj $params -name "stdout_file" -type "path"
+$stderrFile = Get-AnsibleParam -obj $params -name "stderr_file" -type "path"
 $dependencies = Get-AnsibleParam -obj $params -name "dependencies" -type "list"
 
 $user = Get-AnsibleParam -obj $params -name "user" -type "str"

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -288,7 +288,7 @@ function Stop-NssmService {
 }
 
 if (($null -ne $appParameters) -and ($null -ne $appArguments)) {
-    Fail-Json $result "Use either 'app_parameters' or 'arguments', but not both."
+    Fail-Json $result "'app_parameters' and 'arguments' are mutually exclusive but have both been set."
 }
 
 if ($null -ne $appParameters) {

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -26,6 +26,7 @@ $name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $tru
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent","started","stopped","restarted" -resultobj $result
 
 $application = Get-AnsibleParam -obj $params -name "application" -type "path"
+$appDirectory  = Get-AnsibleParam -obj $params -name "working_directory" -aliases "app_directory","chdir" -type "path"
 $appParameters = Get-AnsibleParam -obj $params -name "app_parameters"
 $appArguments = Get-AnsibleParam -obj $params -name "arguments" -aliases "app_parameters_free_form"
 $startMode = Get-AnsibleParam -obj $params -name "start_mode" -type "str" -default "auto" -validateset $start_modes_map.Keys -resultobj $result
@@ -321,8 +322,9 @@ if ($state -ne 'absent') {
         Fail-Json -obj $result -message "The application specified ""$application"" does not exist on the host."
     }
 
-    #TODO Add module parameter
-    $applicationPath = (Get-Item $application).DirectoryName
+    if($null -eq $appDirectory) {
+        $appDirectory = (Get-Item $application).DirectoryName
+    }
 }
 
 
@@ -373,7 +375,7 @@ if ($state -eq 'absent') {
 
         Update-NssmServiceParameter -parameter "Application" -value $application @common_params
 
-        Update-NssmServiceParameter -parameter "AppDirectory" -value $applicationPath @common_params
+        Update-NssmServiceParameter -parameter "AppDirectory" -value $appDirectory @common_params
 
 
         if (($null -ne $appArguments)) {

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -291,6 +291,7 @@ if (($null -ne $appParameters) -and ($null -ne $appArguments)) {
     Fail-Json $result "'app_parameters' and 'arguments' are mutually exclusive but have both been set."
 }
 
+# Backward compatibility for old parameters style. Remove the block bellow in 2.12
 if ($null -ne $appParameters) {
     Add-DeprecationWarning -obj $result -message "The parameter 'app_parameters' will be removed soon, use 'arguments' instead." -version 2.12
 
@@ -312,7 +313,6 @@ if ($null -ne $appParameters) {
     $appArguments = @($appParamsArray)
 
     # The rest of the code should use only the new $appArguments variable
-    Remove-Variable -name 'appParameters'
 }
 
 if ($state -ne 'absent') {

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -24,6 +24,8 @@ $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "b
 
 $name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent","started","stopped","restarted" -resultobj $result
+$display_name = Get-AnsibleParam -obj $params -name 'display_name' -type 'str'
+$description = Get-AnsibleParam -obj $params -name 'description' -type 'str'
 
 $application = Get-AnsibleParam -obj $params -name "application" -type "path"
 $appDirectory  = Get-AnsibleParam -obj $params -name "working_directory" -aliases "app_directory","chdir" -type "path"
@@ -374,6 +376,8 @@ if ($state -eq 'absent') {
         }
 
         Update-NssmServiceParameter -parameter "Application" -value $application @common_params
+        Update-NssmServiceParameter -parameter "DisplayName" -value $display_name @common_params
+        Update-NssmServiceParameter -parameter "Description" -value $description @common_params
 
         Update-NssmServiceParameter -parameter "AppDirectory" -value $appDirectory @common_params
 

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -83,10 +83,10 @@ function Install-NssmService {
     )
 
     if (!$application) {
-        throw "Error installing service ""$service"". No application was supplied."
+        Fail-Json -obj $result -message "Error installing service ""$service"". No application was supplied."
     }
     if (-Not (Test-Path -Path $application -PathType Leaf)) {
-        throw "$application does not exist on the host"
+        Fail-Json -obj $result -message "$application does not exist on the host"
     }
 
     if (!(Test-NssmServiceExists -service $service)) {
@@ -95,7 +95,7 @@ function Install-NssmService {
         if ($nssm_result.rc -ne 0) {
             $result.nssm_error_cmd = $nssm_result.arguments
             $result.nssm_error_log = $nssm_result.stderr
-            throw "Error installing service ""$service"""
+            Fail-Json -obj $result -message "Error installing service ""$service"""
         }
 
         $result.changed_by = "install_service"
@@ -107,7 +107,7 @@ function Install-NssmService {
         if ($nssm_result.rc -ne 0) {
             $result.nssm_error_cmd = $nssm_result.arguments
             $result.nssm_error_log = $nssm_result.stderr
-            throw "Error installing service ""$service"""
+            Fail-Json -obj $result -message "Error installing service ""$service"""
         }
 
         if ($nssm_result.stdout.split("`n`r")[0] -ne $application) {
@@ -116,7 +116,7 @@ function Install-NssmService {
             if ($nssm_result.rc -ne 0) {
                 $result.nssm_error_cmd = $nssm_result.arguments
                 $result.nssm_error_log = $nssm_result.stderr
-                throw "Error installing service ""$service"""
+                Fail-Json -obj $result -message "Error installing service ""$service"""
             }
             $result.application = "$application"
 
@@ -133,7 +133,7 @@ function Install-NssmService {
         if ($nssm_result.rc -ne 0) {
             $result.nssm_error_cmd = $nssm_result.arguments
             $result.nssm_error_log = $nssm_result.stderr
-            throw "Error installing service ""$service"""
+            Fail-Json -obj $result -message "Error installing service ""$service"""
         }
     }
 }
@@ -155,7 +155,7 @@ function Uninstall-NssmService {
         if ($nssm_result.rc -ne 0) {
             $result.nssm_error_cmd = $nssm_result.arguments
             $result.nssm_error_log = $nssm_result.stderr
-            throw "Error removing service ""$service"""
+            Fail-Json -obj $result -message "Error removing service ""$service"""
         }
 
         $result.changed_by = "remove_service"
@@ -191,7 +191,7 @@ function Update-NssmServiceAppParameters {
     if ($nssm_result.rc -ne 0) {
         $result.nssm_error_cmd = $nssm_result.arguments
         $result.nssm_error_log = $nssm_result.stderr
-        throw "Error updating AppParameters for service ""$service"""
+        Fail-Json -obj $result -message "Error updating AppParameters for service ""$service"""
     }
 
     $appParamKeys = @()
@@ -234,7 +234,7 @@ function Update-NssmServiceAppParameters {
         if ($nssm_result.rc -ne 0) {
             $result.nssm_error_cmd = $nssm_result.arguments
             $result.nssm_error_log = $nssm_result.stderr
-            throw "Error updating AppParameters for service ""$service"""
+            Fail-Json -obj $result -message "Error updating AppParameters for service ""$service"""
         }
 
         $result.changed_by = "update_app_parameters"
@@ -256,7 +256,7 @@ function Update-NssmServiceOutputFiles {
     if ($nssm_result.rc -ne 0) {
         $result.nssm_error_cmd = $nssm_result.arguments
         $result.nssm_error_log = $nssm_result.stderr
-        throw "Error retrieving existing stdout file for service ""$service"""
+        Fail-Json -obj $result -message "Error retrieving existing stdout file for service ""$service"""
     }
 
     if ($nssm_result.stdout.split("`n`r")[0] -ne $stdout) {
@@ -269,7 +269,7 @@ function Update-NssmServiceOutputFiles {
         if ($nssm_result.rc -ne 0) {
             $result.nssm_error_cmd = $nssm_result.arguments
             $result.nssm_error_log = $nssm_result.stderr
-            throw "Error setting stdout file for service ""$service"""
+            Fail-Json -obj $result -message "Error setting stdout file for service ""$service"""
         }
 
         $result.changed_by = "set_stdout"
@@ -281,7 +281,7 @@ function Update-NssmServiceOutputFiles {
     if ($nssm_result.rc -ne 0) {
         $result.nssm_error_cmd = $nssm_result.arguments
         $result.nssm_error_log = $nssm_result.stderr
-        throw "Error retrieving existing stderr file for service ""$service"""
+        Fail-Json -obj $result -message "Error retrieving existing stderr file for service ""$service"""
     }
 
     if ($nssm_result.stdout.split("`n`r")[0] -ne $stderr) {
@@ -291,7 +291,7 @@ function Update-NssmServiceOutputFiles {
             if ($nssm_result.rc -ne 0) {
                 $result.nssm_error_cmd = $nssm_result.arguments
                 $result.nssm_error_log = $nssm_result.stderr
-                throw "Error clearing stderr file setting for service ""$service"""
+                Fail-Json -obj $result -message "Error clearing stderr file setting for service ""$service"""
             }
         } else {
             $nssm_result = Invoke-NssmCommand -arguments @("set", $service, "AppStderr", $stderr)
@@ -299,7 +299,7 @@ function Update-NssmServiceOutputFiles {
             if ($nssm_result.rc -ne 0) {
                 $result.nssm_error_cmd = $nssm_result.arguments
                 $result.nssm_error_log = $nssm_result.stderr
-                throw "Error setting stderr file for service ""$service"""
+                Fail-Json -obj $result -message "Error setting stderr file for service ""$service"""
             }
         }
 
@@ -345,12 +345,12 @@ function Update-NssmServiceCredentials {
     if ($nssm_result.rc -ne 0) {
         $result.nssm_error_cmd = $nssm_result.arguments
         $result.nssm_error_log = $nssm_result.stderr
-        throw "Error updating credentials for service ""$service"""
+        Fail-Json -obj $result -message "Error updating credentials for service ""$service"""
     }
 
     if ($user) {
         if (!$password) {
-            throw "User without password is informed for service ""$service"""
+            Fail-Json -obj $result -message "User without password is informed for service ""$service"""
         }
         else {
             $fullUser = $user
@@ -364,7 +364,7 @@ function Update-NssmServiceCredentials {
                 if ($nssm_result.rc -ne 0) {
                     $result.nssm_error_cmd = $nssm_result.arguments
                     $result.nssm_error_log = $nssm_result.stderr
-                    throw "Error updating credentials for service ""$service"""
+                    Fail-Json -obj $result -message "Error updating credentials for service ""$service"""
                 }
 
                 $result.changed_by = "update_credentials"
@@ -393,7 +393,7 @@ function Update-NssmServiceDependencies {
     if ($nssm_result.rc -ne 0) {
         $result.nssm_error_cmd = $nssm_result.arguments
         $result.nssm_error_log = $nssm_result.stderr
-        throw "Error updating dependencies for service ""$service"""
+        Fail-Json -obj $result -message "Error updating dependencies for service ""$service"""
     }
 
     $current_dependencies = @($nssm_result.stdout.split("`n`r") | where { $_ -ne '' })
@@ -404,7 +404,7 @@ function Update-NssmServiceDependencies {
         if ($nssm_result.rc -ne 0) {
             $result.nssm_error_cmd = $nssm_result.arguments
             $result.nssm_error_log = $nssm_result.stderr
-            throw "Error updating dependencies for service ""$service"""
+            Fail-Json -obj $result -message "Error updating dependencies for service ""$service"""
         }
 
         $result.changed_by = "update-dependencies"
@@ -426,7 +426,7 @@ function Update-NssmServiceStartMode {
     if ($nssm_result.rc -ne 0) {
         $result.nssm_error_cmd = $nssm_result.arguments
         $result.nssm_error_log = $nssm_result.stderr
-        throw "Error updating start mode for service ""$service"""
+        Fail-Json -obj $result -message "Error updating start mode for service ""$service"""
     }
 
     $modes=@{"auto" = "SERVICE_AUTO_START"; "delayed" = "SERVICE_DELAYED_AUTO_START"; "manual" = "SERVICE_DEMAND_START"; "disabled" = "SERVICE_DISABLED"}
@@ -437,7 +437,7 @@ function Update-NssmServiceStartMode {
         if ($nssm_result.rc -ne 0) {
             $result.nssm_error_cmd = $nssm_result.arguments
             $result.nssm_error_log = $nssm_result.stderr
-            throw "Error updating start mode for service ""$service"""
+            Fail-Json -obj $result -message "Error updating start mode for service ""$service"""
         }
 
         $result.changed_by = "start_mode"
@@ -457,7 +457,7 @@ function Invoke-NssmStart {
     if ($nssm_result.rc -ne 0) {
         $result.nssm_error_cmd = $nssm_result.arguments
         $result.nssm_error_log = $nssm_result.stderr
-        throw "Error starting service ""$service"""
+        Fail-Json -obj $result -message "Error starting service ""$service"""
     }
 
     $result.changed_by = "start_service"
@@ -476,7 +476,7 @@ function Invoke-NssmStop {
     if ($nssm_result.rc -ne 0) {
         $result.nssm_error_cmd = $nssm_result.arguments
         $result.nssm_error_log = $nssm_result.stderr
-        throw "Error stopping service ""$service"""
+        Fail-Json -obj $result -message "Error stopping service ""$service"""
     }
 
     $result.changed_by = "stop_service_command"
@@ -495,7 +495,7 @@ function Start-NssmService {
     if ($currentStatus.rc -ne 0) {
         $result.nssm_error_cmd = $currentStatus.arguments
         $result.nssm_error_log = $currentStatus.stderr
-        throw "Error starting service ""$service"""
+        Fail-Json -obj $result -message "Error starting service ""$service"""
     }
 
     switch -wildcard ($currentStatus.stdout) {
@@ -522,7 +522,7 @@ function Stop-NssmService {
     if ($currentStatus.rc -ne 0) {
         $result.nssm_error_cmd = $currentStatus.arguments
         $result.nssm_error_log = $currentStatus.stderr
-        throw "Error stopping service ""$service"""
+        Fail-Json -obj $result -message "Error stopping service ""$service"""
     }
 
     if ($currentStatus.stdout -notlike "*SERVICE_STOPPED*") {
@@ -531,7 +531,7 @@ function Stop-NssmService {
         if ($nssm_result.rc -ne 0) {
             $result.nssm_error_cmd = $nssm_result.arguments
             $result.nssm_error_log = $nssm_result.stderr
-            throw "Error stopping service ""$service"""
+            Fail-Json -obj $result -message "Error stopping service ""$service"""
         }
 
         $result.changed_by = "stop_service"
@@ -574,30 +574,25 @@ if (($appParameters -ne $null) -and ($appParameters -isnot [string])) {
     Fail-Json -obj $result -message "The app_parameters parameter must be a string representing a dictionary."
 }
 
-try
-{
-    switch ($state) {
-        "absent" {
-            Uninstall-NssmService -service $name
-        }
-        "present" {
-            NssmProcedure -service $name
-        }
-        "started" {
-            NssmProcedure -service $name
-            Start-NssmService -service $name
-        }
-        "stopped" {
-            NssmProcedure -service $name
-            Stop-NssmService -service $name
-        }
-        "restarted" {
-            NssmProcedure -service $name
-            Restart-NssmService -service $name
-        }
+switch ($state) {
+    "absent" {
+        Uninstall-NssmService -service $name
     }
-
-    Exit-Json $result
-} catch {
-     Fail-Json $result $_.Exception.Message
+    "present" {
+        NssmProcedure -service $name
+    }
+    "started" {
+        NssmProcedure -service $name
+        Start-NssmService -service $name
+    }
+    "stopped" {
+        NssmProcedure -service $name
+        Stop-NssmService -service $name
+    }
+    "restarted" {
+        NssmProcedure -service $name
+        Restart-NssmService -service $name
+    }
 }
+
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -44,6 +44,11 @@ options:
         See commit 0b386fc1984ab74ee59b7bed14b7e8f57212c22b in the nssm.git project for more info:
         U(https://git.nssm.cc/?p=nssm.git;a=commit;h=0b386fc1984ab74ee59b7bed14b7e8f57212c22b)
     type: path
+  working_directory:
+    version_added: "2.8.0"
+    description:
+      - The working directory to run the service executable from (defaults to the directory containing the application binary)
+    aliases: [ app_directory, chdir ]
   stdout_file:
     description:
       - Path to receive output.
@@ -94,6 +99,7 @@ author:
   - George Frank (@georgefrank)
   - Hans-Joachim Kliemeck (@h0nIg)
   - Michael Wild (@themiwi)
+  - Kevin Subileau (@ksubileau)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -38,11 +38,6 @@ options:
     description:
       - The application binary to run as a service
       - "Specify this whenever the service may need to be installed (state: present, started, stopped, restarted)"
-      - "Note that the application name must look like the following, if the directory includes spaces:"
-      - 'nssm install service "C:\\Program Files\\app.exe\\" "C:\\Path with spaces\\"'
-      - >
-        See commit 0b386fc1984ab74ee59b7bed14b7e8f57212c22b in the nssm.git project for more info:
-        U(https://git.nssm.cc/?p=nssm.git;a=commit;h=0b386fc1984ab74ee59b7bed14b7e8f57212c22b)
     type: path
   description:
     description:

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -34,7 +34,7 @@ options:
         please use the M(win_service) module instead to start, stop or restart the service.
     type: str
     choices: [ absent, present, started, stopped, restarted ]
-    default: started
+    default: present
   application:
     description:
       - The application binary to run as a service
@@ -125,37 +125,38 @@ author:
 '''
 
 EXAMPLES = r'''
-# Install and start the foo service
-- win_nssm:
+- name: Install the foo service
+  win_nssm:
     name: foo
     application: C:\windows\foo.exe
 
-# Install and start the consul service with a list of parameters
 # This will yield the following command: C:\windows\foo.exe bar "true"
-- win_nssm:
-    name: Install the Consul service
+- name: Install the Consul service with a list of parameters
+  win_nssm:
+    name: Consul
     application: C:\consul\consul.exe
     arguments:
       - agent
       - -config-dir=C:\consul\config
 
-# Install and start the consul service with an arbitrary string of parameters
 # This is strictly equivalent to the previous example
-- name: Install the Consul service (alternative)
+- name: Install the Consul service with an arbitrary string of parameters
   win_nssm:
-    name: consul
+    name: Consul
     application: C:\consul\consul.exe
     arguments: agent -config-dir=C:\consul\config
 
-# Install and start the foo service, redirecting stdout and stderr to the same file
-- win_nssm:
+
+# Install the foo service, an then configure and start it with win_service
+- name: Install the foo service, redirecting stdout and stderr to the same file
+  win_nssm:
     name: foo
     application: C:\windows\foo.exe
     stdout_file: C:\windows\foo.log
     stderr_file: C:\windows\foo.log
 
-# Configure the foo service and start it with win_service
-- win_service:
+- name: Configure and start the foo service using win_service
+  win_service:
     name: foo
     dependencies: [ adf, tcpip ]
     user: foouser
@@ -163,8 +164,8 @@ EXAMPLES = r'''
     start_mode: manual
     state: started
 
-# Remove the foo service
-- win_nssm:
+- name: Remove the foo service
+  win_nssm:
     name: foo
     state: absent
 '''

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -55,12 +55,15 @@ options:
   app_parameters:
     description:
       - A string representing a dictionary of parameters to be passed to the application when it starts.
-      - Use either this or C(app_parameters_free_form), not both.
+      - DEPRECATED since v2.8, please use C(arguments) instead.
+      - Use either this or C(arguments), not both.
     type: str
-  app_parameters_free_form:
+  arguments:
     description:
-      - Single string of parameters to be passed to the service.
+      - Parameters to be passed to the application when it starts.
+      - This can be either a simple string or a list.
       - Use either this or C(app_parameters), not both.
+    aliases: [ app_parameters_free_form ]
     type: str
     version_added: "2.3"
   dependencies:
@@ -99,36 +102,22 @@ EXAMPLES = r'''
     name: foo
     application: C:\windows\foo.exe
 
-# Install and start the foo service with a key-value pair argument
-# This will yield the following command: C:\windows\foo.exe -bar true
+# Install and start the consul service with a list of parameters
+# This will yield the following command: C:\windows\foo.exe bar "true"
 - win_nssm:
-    name: foo
-    application: C:\windows\foo.exe
-    app_parameters: -bar=true
+    name: consul
+    application: C:\consul\consul.exe
+    arguments:
+      - agent
+      - -config-dir=C:\consul\config
 
-# Install and start the foo service with a single parameter
-# This will yield the following command: C:\windows\\foo.exe bar
-- win_nssm:
-    name: foo
-    application: C:\windows\foo.exe
-    app_parameters: _=bar
-
-# Install and start the foo service with a mix of single params, and key value pairs
-# This will yield the following command: C:\windows\\foo.exe bar -file output.bat -foo false
-- win_nssm:
-    name: foo
-    application: C:\windows\foo.exe
-    app_parameters: _=bar; -file=output.bat; -foo=false
-
-# Use the single line parameters option to specify an arbitrary string of parameters
-# for the service executable
+# Install and start the consul service with an arbitrary string of parameters
+# This is strictly equivalent to the previous example
 - name: Make sure the Consul service runs
   win_nssm:
     name: consul
     application: C:\consul\consul.exe
-    app_parameters_free_form: agent -config-dir=C:\consul\config
-    stdout_file: C:\consul\log.txt
-    stderr_file: C:\consul\error.txt
+    arguments: agent -config-dir=C:\consul\config
 
 # Install and start the foo service, redirecting stdout and stderr to the same file
 - win_nssm:

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -49,15 +49,18 @@ options:
   description:
     description:
       - The description to set for the service.
+    type: str
     version_added: "2.8.0"
   display_name:
     description:
       - The display name to set for the service.
+    type: str
     version_added: "2.8.0"
   working_directory:
     version_added: "2.8.0"
     description:
       - The working directory to run the service executable from (defaults to the directory containing the application binary)
+    type: path
     aliases: [ app_directory, chdir ]
   stdout_file:
     description:
@@ -130,7 +133,7 @@ EXAMPLES = r'''
 # Install and start the consul service with a list of parameters
 # This will yield the following command: C:\windows\foo.exe bar "true"
 - win_nssm:
-    name: consul
+    name: Install the Consul service
     application: C:\consul\consul.exe
     arguments:
       - agent
@@ -138,7 +141,7 @@ EXAMPLES = r'''
 
 # Install and start the consul service with an arbitrary string of parameters
 # This is strictly equivalent to the previous example
-- name: Make sure the Consul service runs
+- name: Install the Consul service (alternative)
   win_nssm:
     name: consul
     application: C:\consul\consul.exe

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -30,7 +30,8 @@ options:
   state:
     description:
       - State of the service on the system.
-      - Values C(started), C(stopped), and C(restarted) are deprecated since v2.8, please use the M(win_service) module instead to start, stop or restart the service.
+      - Values C(started), C(stopped), and C(restarted) are deprecated since v2.8,
+        please use the M(win_service) module instead to start, stop or restart the service.
     type: str
     choices: [ absent, present, started, stopped, restarted ]
     default: started
@@ -104,7 +105,7 @@ seealso:
   - module: win_service
 notes:
   - The service will NOT be started after its creation when C(state=present).
-  - Once the service is created, you can use the M(win_service) module to start it or configure 
+  - Once the service is created, you can use the M(win_service) module to start it or configure
     some additionals properties, such as its startup type, dependencies, service account, and so on.
 author:
   - Adam Keech (@smadam813)

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -43,14 +43,15 @@ options:
       - >
         See commit 0b386fc1984ab74ee59b7bed14b7e8f57212c22b in the nssm.git project for more info:
         U(https://git.nssm.cc/?p=nssm.git;a=commit;h=0b386fc1984ab74ee59b7bed14b7e8f57212c22b)
+    type: path
   stdout_file:
     description:
       - Path to receive output.
-    type: str
+    type: path
   stderr_file:
     description:
       - Path to receive error output.
-    type: str
+    type: path
   app_parameters:
     description:
       - A string representing a dictionary of parameters to be passed to the application when it starts.

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -40,6 +40,12 @@ options:
       - The application binary to run as a service
       - Required when I(state) is C(present), C(started), C(stopped), or C(restarted).
     type: path
+  executable:
+    description:
+    - The location of the NSSM utility (in case it is not located in your PATH).
+    type: path
+    default: nssm.exe
+    version_added: "2.8.0"
   description:
     description:
       - The description to set for the service.

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -44,6 +44,14 @@ options:
         See commit 0b386fc1984ab74ee59b7bed14b7e8f57212c22b in the nssm.git project for more info:
         U(https://git.nssm.cc/?p=nssm.git;a=commit;h=0b386fc1984ab74ee59b7bed14b7e8f57212c22b)
     type: path
+  description:
+    description:
+      - The description to set for the service.
+    version_added: "2.8.0"
+  display_name:
+    description:
+      - The display name to set for the service.
+    version_added: "2.8.0"
   working_directory:
     version_added: "2.8.0"
     description:

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -63,14 +63,15 @@ options:
   app_parameters:
     description:
       - A string representing a dictionary of parameters to be passed to the application when it starts.
-      - DEPRECATED since v2.8, please use C(arguments) instead.
-      - Use either this or C(arguments), not both.
+      - DEPRECATED since v2.8, please use I(arguments) instead.
+      - This is mutually exclusive with I(arguments).
     type: str
   arguments:
     description:
       - Parameters to be passed to the application when it starts.
       - This can be either a simple string or a list.
-      - Use either this or C(app_parameters), not both.
+      - This parameter was renamed from I(app_parameters_free_form) in 2.8.
+      - This is mutually exclusive with I(app_parameters).
     aliases: [ app_parameters_free_form ]
     type: str
     version_added: "2.3"

--- a/test/integration/targets/win_nssm/tasks/tests.yml
+++ b/test/integration/targets/win_nssm/tasks/tests.yml
@@ -141,60 +141,63 @@
     - '"Tcpip" in (install_service_complex_again_actual.stdout|from_json).Dependencies'
     - '"Dnscache" in (install_service_complex_again_actual.stdout|from_json).Dependencies'
 
-- name: install service with free form parameters
+- name: install service with string form parameters
   win_nssm:
     name: '{{ test_service_name }}'
     application: C:\Windows\System32\cmd.exe
-    app_parameters_free_form: '-v -Dcom.test.string=value "C:\with space\\"'
+    arguments: '-v -Dtest.str=value "C:\with space\\"'
     state: present
-  register: free_params
+  register: str_params
 
-- name: get result of install service with free form parameters
+- name: get result of install service with string form parameters
   win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
-  register: free_params_actual
+  register: str_params_actual
 
-- name: assert results of install service with free form parameters
+- name: assert results of install service with string form parameters
   assert:
     that:
-    - free_params.changed == true
-    - (free_params_actual.stdout|from_json).Exists == true
-    - (free_params_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
-    # Expected value: -v -Dcom.test.string=value "C:\with space\\" (backslashes doubled for jinja)
-    - (free_params_actual.stdout|from_json).Parameters.AppParameters == '-v -Dcom.test.string=value "C:\\with space\\\\"'
+    - str_params.changed == true
+    - (str_params_actual.stdout|from_json).Exists == true
+    - (str_params_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    # Expected value: -v -Dtest.str=value "C:\with space\\" (backslashes doubled for jinja)
+    - (str_params_actual.stdout|from_json).Parameters.AppParameters == '-v -Dtest.str=value "C:\\with space\\\\"'
 
-- name: install service with free form parameters (idempotent)
+- name: install service with string form parameters (idempotent)
   win_nssm:
     name: '{{ test_service_name }}'
     application: C:\Windows\System32\cmd.exe
-    app_parameters_free_form: '-v -Dcom.test.string=value "C:\with space\\"'
+    arguments: '-v -Dtest.str=value "C:\with space\\"'
     state: present
-  register: free_params_again
+  register: str_params_again
 
-- name: get result of install service with free form parameters (idempotent)
+- name: get result of install service with string form parameters (idempotent)
   win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
-  register: free_params_again_actual
+  register: str_params_again_actual
 
-- name: assert results of install service with free form parameters (idempotent)
+- name: assert results of install service with string form parameters (idempotent)
   assert:
     that:
-    - free_params_again.changed == false
-    - (free_params_again_actual.stdout|from_json).Exists == true
-    - (free_params_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
-    # Expected value: -v -Dcom.test.string=value "C:\with space\\" (backslashes doubled for jinja)
-    - (free_params_again_actual.stdout|from_json).Parameters.AppParameters == '-v -Dcom.test.string=value "C:\\with space\\\\"'
+    - str_params_again.changed == false
+    - (str_params_again_actual.stdout|from_json).Exists == true
+    - (str_params_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    # Expected value: -v -Dtest.str=value "C:\with space\\" (backslashes doubled for jinja)
+    - (str_params_again_actual.stdout|from_json).Parameters.AppParameters == '-v -Dtest.str=value "C:\\with space\\\\"'
 
-- name: install service with dict parameters
+# deprecated in 2.12
+- name: install service with dict-as-string parameters
   win_nssm:
     name: '{{ test_service_name }}'
     application: C:\Windows\System32\cmd.exe
     app_parameters: foo=true; -file.out=output.bat; -path=C:\with space\; -str=test"quotes; _=bar
   register: mixed_params
 
-- name: get result of install service with dict parameters
+# deprecated in 2.12
+- name: get result of install service with dict-as-string parameters
   win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
   register: mixed_params_actual
 
-- name: assert results of install service with dict parameters
+# deprecated in 2.12
+- name: assert results of install service with dict-as-string parameters
   assert:
     that:
     - mixed_params.changed == true
@@ -203,18 +206,21 @@
     # Expected value: bar -file.out output.bat -str "test\"quotes" foo true -path "C:\with space\\" (backslashes doubled for jinja)
     - (mixed_params_actual.stdout|from_json).Parameters.AppParameters == 'bar -file.out output.bat -str "test\\"quotes" foo true -path "C:\\with space\\\\"'
 
-- name: install service with dict parameters (idempotent)
+# deprecated in 2.12
+- name: install service with dict-as-string parameters (idempotent)
   win_nssm:
     name: '{{ test_service_name }}'
     application: C:\Windows\System32\cmd.exe
     app_parameters: foo=true; -file.out=output.bat; -path=C:\with space\; -str=test"quotes; _=bar
   register: mixed_params_again
 
-- name: get result of install service with dict parameters (idempotent)
+# deprecated in 2.12
+- name: get result of install service with dict-as-string parameters (idempotent)
   win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
   register: mixed_params_again_actual
 
-- name: assert results of install service with dict parameters (idempotent)
+# deprecated in 2.12
+- name: assert results of install service with dict-as-string parameters (idempotent)
   assert:
     that:
     - mixed_params_again.changed == false
@@ -222,6 +228,64 @@
     - (mixed_params_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
     # Expected value: bar -file.out output.bat -str "test\"quotes" foo true -path "C:\with space\\" (backslashes doubled for jinja)
     - (mixed_params_again_actual.stdout|from_json).Parameters.AppParameters == 'bar -file.out output.bat -str "test\\"quotes" foo true -path "C:\\with space\\\\"'
+
+- name: install service with list of parameters
+  win_nssm:
+    name: '{{ test_service_name }}'
+    application: C:\Windows\System32\cmd.exe
+    arguments:
+      - -foo=bar
+      - -day
+      # Test non-string value
+      - 14
+      # Test if dot is not interpreted as separator (see #44079)
+      - -file.out
+      # Test if spaces are escaped
+      - C:\with space\output.bat
+      - -str
+      # Test if quotes and backslashes are escaped
+      - test"quotes\
+  register: list_params
+
+- name: get result of install service with list of parameters
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: list_params_actual
+
+- name: assert results of install service with list of parameters
+  assert:
+    that:
+    - list_params.changed == true
+    - (list_params_actual.stdout|from_json).Exists == true
+    - (list_params_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    # Expected value: -foo=bar -day 14 -file.out "C:\with space\output.bat" -str "test\"quotes\\" (backslashes doubled for jinja)
+    - (list_params_actual.stdout|from_json).Parameters.AppParameters == '-foo=bar -day 14 -file.out "C:\\with space\\output.bat" -str "test\\"quotes\\\\"'
+
+- name: install service with list of parameters (idempotent)
+  win_nssm:
+    name: '{{ test_service_name }}'
+    application: C:\Windows\System32\cmd.exe
+    arguments:
+      - -foo=bar
+      - -day
+      - 14
+      - -file.out
+      - C:\with space\output.bat
+      - -str
+      - test"quotes\
+  register: list_params_again
+
+- name: get result of install service with list of parameters (idempotent)
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: list_params_again_actual
+
+- name: assert results of install service with list of parameters (idempotent)
+  assert:
+    that:
+    - list_params_again.changed == false
+    - (list_params_again_actual.stdout|from_json).Exists == true
+    - (list_params_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    # Expected value: -foo=bar -day 14 -file.out "C:\with space\output.bat" -str "test\"quotes\\" (backslashes doubled for jinja)
+    - (list_params_again_actual.stdout|from_json).Parameters.AppParameters == '-foo=bar -day 14 -file.out "C:\\with space\\output.bat" -str "test\\"quotes\\\\"'
 
 - name: remove service
   win_nssm:

--- a/test/integration/targets/win_nssm/tasks/tests.yml
+++ b/test/integration/targets/win_nssm/tasks/tests.yml
@@ -7,7 +7,7 @@
       if ($srvobj) {
         $srvobj | Get-Member -MemberType *Property | % { $res.($_.name) = $srvobj.($_.name) }
         $res.Exists = $true
-        $res.Dependencies = Get-WmiObject -Query "Associators of {Win32_Service.Name=""$service""} Where AssocClass=Win32_DependentService" | select -ExpandProperty Name
+        $res.Dependencies = @(Get-WmiObject -Query "Associators of {Win32_Service.Name=""$service""} Where AssocClass=Win32_DependentService" | select -ExpandProperty Name)
         $res.Parameters = @{}
         $srvkey = "HKLM:\SYSTEM\CurrentControlSet\Services\$service\Parameters"
         Get-Item "$srvkey" | Select-Object -ExpandProperty property | % { $res.Parameters.$_ = (Get-ItemProperty -Path "$srvkey" -Name $_).$_}
@@ -15,6 +15,24 @@
         $res.Exists = $false
       }
       ConvertTo-Json -InputObject $res -Compress
+
+- name: install service (check mode)
+  win_nssm:
+    name: '{{ test_service_name }}'
+    application: C:\Windows\System32\cmd.exe
+    state: present
+  register: install_service_check
+  check_mode: yes
+
+- name: get result of install service (check mode)
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: install_service_check_actual
+
+- name: assert results of install service (check mode)
+  assert:
+    that:
+    - install_service_check.changed == true
+    - (install_service_check_actual.stdout|from_json).Exists == false
 
 - name: install service
   win_nssm:
@@ -75,6 +93,38 @@
     - (install_start_service_actual.stdout|from_json).State == 'Running'
     - (install_start_service_actual.stdout|from_json).StartMode == 'Auto'
     - (install_start_service_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+
+- name: install and start service with more parameters (check mode)
+  win_nssm:
+    name: '{{ test_service_name }}'
+    application: C:\Windows\System32\cmd.exe
+    start_mode: manual
+    working_directory: '{{ test_win_nssm_path }}'
+    dependencies: 'tcpip,dnscache'
+    user: '{{ test_win_nssm_username }}'
+    password: '{{ test_win_nssm_password }}'
+    stdout_file: '{{ test_win_nssm_path }}\log.txt'
+    stderr_file: '{{ test_win_nssm_path }}\error.txt'
+    state: started
+  register: install_service_complex_check
+  check_mode: yes
+
+- name: get result of install and start service with more parameters (check mode)
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: install_service_complex_check_actual
+
+- name: assert results of install and start service with more parameters (check mode)
+  assert:
+    that:
+    - install_service_complex_check.changed == true
+    - (install_service_complex_check_actual.stdout|from_json).Exists == true
+    - (install_service_complex_check_actual.stdout|from_json).StartMode != 'Manual'
+    - (install_service_complex_check_actual.stdout|from_json).StartName != '.\\' + test_win_nssm_username
+    - (install_service_complex_check_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    - (install_service_complex_check_actual.stdout|from_json).Parameters.AppDirectory == "C:\Windows\System32"
+    - '"AppStdout" not in (install_service_complex_check_actual.stdout|from_json).Parameters'
+    - '"AppStderr" not in (install_service_complex_check_actual.stdout|from_json).Parameters'
+    - (install_service_complex_check_actual.stdout|from_json).Dependencies|length == 0
 
 - name: install and start service with more parameters
   win_nssm:
@@ -286,6 +336,23 @@
     - (list_params_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
     # Expected value: -foo=bar -day 14 -file.out "C:\with space\output.bat" -str "test\"quotes\\" (backslashes doubled for jinja)
     - (list_params_again_actual.stdout|from_json).Parameters.AppParameters == '-foo=bar -day 14 -file.out "C:\\with space\\output.bat" -str "test\\"quotes\\\\"'
+
+- name: remove service (check mode)
+  win_nssm:
+    name: '{{ test_service_name }}'
+    state: absent
+  register: remove_service_check
+  check_mode: yes
+
+- name: get result of remove service (check mode)
+  win_shell: '$service = ''{{ test_service_name }}''; {{ test_service_cmd }}'
+  register: remove_service_check_actual
+
+- name: assert results of remove service (check mode)
+  assert:
+    that:
+    - remove_service_check.changed == true
+    - (remove_service_check_actual.stdout|from_json).Exists == true
 
 - name: remove service
   win_nssm:

--- a/test/integration/targets/win_nssm/tasks/tests.yml
+++ b/test/integration/targets/win_nssm/tasks/tests.yml
@@ -3,7 +3,7 @@
   set_fact:
     test_service_cmd: |
       $res = @{}
-      $srvobj = Get-WmiObject Win32_Service -Filter "Name=""$service""" | Select Name,PathName,StartMode,StartName,State
+      $srvobj = Get-WmiObject Win32_Service -Filter "Name=""$service""" | Select Name,DisplayName,Description,PathName,StartMode,StartName,State
       if ($srvobj) {
         $srvobj | Get-Member -MemberType *Property | % { $res.($_.name) = $srvobj.($_.name) }
         $res.Exists = $true
@@ -100,6 +100,8 @@
 - name: install and start service with more parameters (check mode)
   win_nssm:
     name: '{{ test_service_name }}'
+    display_name: Ansible testing
+    description: win_nssm test service
     application: C:\Windows\System32\cmd.exe
     start_mode: manual
     working_directory: '{{ test_win_nssm_path }}'
@@ -121,6 +123,8 @@
     that:
     - install_service_complex_check.changed == true
     - (install_service_complex_check_actual.stdout|from_json).Exists == true
+    - (install_service_complex_check_actual.stdout|from_json).DisplayName == '{{ test_service_name }}'
+    - (install_service_complex_check_actual.stdout|from_json).Description is none
     - (install_service_complex_check_actual.stdout|from_json).StartMode != 'Manual'
     - (install_service_complex_check_actual.stdout|from_json).StartName != '.\\' + test_win_nssm_username
     - (install_service_complex_check_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
@@ -132,6 +136,8 @@
 - name: install and start service with more parameters
   win_nssm:
     name: '{{ test_service_name }}'
+    display_name: Ansible testing
+    description: win_nssm test service
     application: C:\Windows\System32\cmd.exe
     start_mode: manual
     working_directory: '{{ test_win_nssm_path }}'
@@ -152,6 +158,8 @@
     that:
     - install_service_complex.changed == true
     - (install_service_complex_actual.stdout|from_json).Exists == true
+    - (install_service_complex_actual.stdout|from_json).DisplayName == 'Ansible testing'
+    - (install_service_complex_actual.stdout|from_json).Description == 'win_nssm test service'
     - (install_service_complex_actual.stdout|from_json).State == 'Running'
     - (install_service_complex_actual.stdout|from_json).StartMode == 'Manual'
     - (install_service_complex_actual.stdout|from_json).StartName == '.\\' + test_win_nssm_username
@@ -166,6 +174,8 @@
 - name: install and start service with more parameters (idempotent)
   win_nssm:
     name: '{{ test_service_name }}'
+    display_name: Ansible testing
+    description: win_nssm test service
     application: C:\Windows\System32\cmd.exe
     start_mode: manual
     working_directory: '{{ test_win_nssm_path }}'
@@ -187,6 +197,8 @@
     that:
     - install_service_complex_again.changed == false
     - (install_service_complex_again_actual.stdout|from_json).Exists == true
+    - (install_service_complex_again_actual.stdout|from_json).DisplayName == 'Ansible testing'
+    - (install_service_complex_again_actual.stdout|from_json).Description == 'win_nssm test service'
     - (install_service_complex_again_actual.stdout|from_json).State == 'Running'
     - (install_service_complex_again_actual.stdout|from_json).StartMode == 'Manual'
     - (install_service_complex_again_actual.stdout|from_json).StartName == '.\\' + test_win_nssm_username

--- a/test/integration/targets/win_nssm/tasks/tests.yml
+++ b/test/integration/targets/win_nssm/tasks/tests.yml
@@ -53,6 +53,7 @@
     - (install_service_actual.stdout|from_json).State == 'Stopped'
     - (install_service_actual.stdout|from_json).StartMode == 'Auto'
     - (install_service_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    - (install_service_actual.stdout|from_json).Parameters.AppDirectory == "C:\Windows\System32"
 
 - name: test install service (idempotent)
   win_nssm:
@@ -73,6 +74,7 @@
     - (install_service_again_actual.stdout|from_json).State == 'Stopped'
     - (install_service_again_actual.stdout|from_json).StartMode == 'Auto'
     - (install_service_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    - (install_service_again_actual.stdout|from_json).Parameters.AppDirectory == "C:\Windows\System32"
 
 - name: install and start service
   win_nssm:
@@ -93,6 +95,7 @@
     - (install_start_service_actual.stdout|from_json).State == 'Running'
     - (install_start_service_actual.stdout|from_json).StartMode == 'Auto'
     - (install_start_service_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    - (install_start_service_actual.stdout|from_json).Parameters.AppDirectory == "C:\Windows\System32"
 
 - name: install and start service with more parameters (check mode)
   win_nssm:
@@ -131,6 +134,7 @@
     name: '{{ test_service_name }}'
     application: C:\Windows\System32\cmd.exe
     start_mode: manual
+    working_directory: '{{ test_win_nssm_path }}'
     dependencies: 'tcpip,dnscache'
     user: '{{ test_win_nssm_username }}'
     password: '{{ test_win_nssm_password }}'
@@ -152,6 +156,7 @@
     - (install_service_complex_actual.stdout|from_json).StartMode == 'Manual'
     - (install_service_complex_actual.stdout|from_json).StartName == '.\\' + test_win_nssm_username
     - (install_service_complex_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    - (install_service_complex_actual.stdout|from_json).Parameters.AppDirectory == test_win_nssm_path
     - (install_service_complex_actual.stdout|from_json).Parameters.AppStdout == test_win_nssm_path + '\\log.txt'
     - (install_service_complex_actual.stdout|from_json).Parameters.AppStderr == test_win_nssm_path + '\\error.txt'
     - (install_service_complex_actual.stdout|from_json).Dependencies|length == 2
@@ -163,6 +168,7 @@
     name: '{{ test_service_name }}'
     application: C:\Windows\System32\cmd.exe
     start_mode: manual
+    working_directory: '{{ test_win_nssm_path }}'
     # Dependencies order should not trigger a change
     dependencies: 'dnscache,tcpip'
     user: '{{ test_win_nssm_username }}'
@@ -185,6 +191,7 @@
     - (install_service_complex_again_actual.stdout|from_json).StartMode == 'Manual'
     - (install_service_complex_again_actual.stdout|from_json).StartName == '.\\' + test_win_nssm_username
     - (install_service_complex_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
+    - (install_service_complex_again_actual.stdout|from_json).Parameters.AppDirectory == test_win_nssm_path
     - (install_service_complex_again_actual.stdout|from_json).Parameters.AppStdout == test_win_nssm_path + '\\log.txt'
     - (install_service_complex_again_actual.stdout|from_json).Parameters.AppStderr == test_win_nssm_path + '\\error.txt'
     - (install_service_complex_again_actual.stdout|from_json).Dependencies|length == 2

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -91,7 +91,6 @@ lib/ansible/modules/windows/win_iis_website.ps1 PSUseDeclaredVarsMoreThanAssignm
 lib/ansible/modules/windows/win_lineinfile.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_mapped_drive.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_msg.ps1 PSAvoidTrailingWhitespace
-lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_package.ps1 PSAvoidTrailingWhitespace
 lib/ansible/modules/windows/win_package.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_package.ps1 PSUseApprovedVerbs

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -92,8 +92,6 @@ lib/ansible/modules/windows/win_lineinfile.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_mapped_drive.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_msg.ps1 PSAvoidTrailingWhitespace
 lib/ansible/modules/windows/win_nssm.ps1 PSAvoidUsingCmdletAliases
-lib/ansible/modules/windows/win_nssm.ps1 PSCustomUseLiteralPath
-lib/ansible/modules/windows/win_nssm.ps1 PSUseApprovedVerbs
 lib/ansible/modules/windows/win_package.ps1 PSAvoidTrailingWhitespace
 lib/ansible/modules/windows/win_package.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_package.ps1 PSUseApprovedVerbs


### PR DESCRIPTION
##### SUMMARY
This is a refactor of the win_nssm module to fix remaining issues, add check mode and more. This PR does the following:

- [x] Add check mode
- [x] Deprecates `app_parameters`, renames `app_parameters_free_form` to arguments, and add support for passing arguments as list
- [x] Deprecates `dependencies`, `start_mode`, `user`, and `password` options, in favor of using the `win_service` module to control these service parameters.
- [x] Deprecates `start`, `stop`, and `restart` values for `state` option, in favor of using the `win_service` module to control the service running state.
- [x] Add `working_directory`, `display_name` and `description` options
- [x] Ensures that all command-line parameters are correctly escaped (fixes errors when service name contains quotes)
- [x] Add `executable` option to specify the location of the NSSM utility
- [x] Add diff support


Supersedes #44964
Supersedes #48761
Fixes #20032
Fixes #33159
Fixes #48728


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_nssm

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
devel
```
