### PR TITLE
test-module: define ansible_version attribute

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -35,6 +35,7 @@ import sys
 import traceback
 import shutil
 
+from ansible.release import __version__
 import ansible.utils.vars as utils_vars
 from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.utils.jsonify import jsonify
@@ -124,6 +125,7 @@ def boilerplate_module(modfile, args, interpreters, check, destfile):
     complex_args['_ansible_selinux_special_fs'] = C.DEFAULT_SELINUX_SPECIAL_FS
     complex_args['_ansible_tmpdir'] = C.DEFAULT_LOCAL_TMP
     complex_args['_ansible_keep_remote_files'] = C.DEFAULT_KEEP_REMOTE_FILES
+    complex_args['_ansible_version'] = __version__
 
     if args.startswith("@"):
         # Argument is a YAML file (JSON is a subset of YAML)

--- a/test/integration/targets/test_infra/library/test.py
+++ b/test/integration/targets/test_infra/library/test.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(),
+    )
+    result = {
+        'selinux_special_fs': module._selinux_special_fs,
+        'tmpdir': module._tmpdir,
+        'keep_remote_files': module._keep_remote_files,
+        'version': module.ansible_version,
+    }
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/test_infra/runme.sh
+++ b/test/integration/targets/test_infra/runme.sh
@@ -22,9 +22,14 @@ echo "ensure playbook output shows assert/fail works (True)"
 echo "$PB_OUT" | grep -F "fail works (True)" || exit 1
 echo "$PB_OUT" | grep -F "assert works (True)" || exit 1
 
+set -e
+
 # ensure test-module script works well
 PING_MODULE_PATH="$(pwd)/../../../../lib/ansible/modules/system/ping.py"
 ../../../../hacking/test-module -m "$PING_MODULE_PATH" -I ansible_python_interpreter="$(which python)"
+
+# ensure module.ansible_version is defined when using test-module
+../../../../hacking/test-module -m library/test.py -I ansible_python_interpreter="$(which python)" <<< '{"ANSIBLE_MODULE_ARGS": {}}'
 
 # ensure exercising module code locally works
 python -m ansible.modules.files.file  <<< '{"ANSIBLE_MODULE_ARGS": {"path": "/path/to/file", "state": "absent"}}'


### PR DESCRIPTION
##### SUMMARY
`test-module`: fix `AttributeError`

Executed command:

    ./hacking/test-module -m lib/ansible/modules/cloud/scaleway/scaleway_security_group.py -a ...

Fix this exception found while testing scaleway_security_group module:

    Traceback (most recent call last):
      File "~/debug_dir/__main__.py", line 240, in <module>
        main()
      File "~/debug_dir/__main__.py", line 236, in main
        core(module)
      File "~/debug_dir/__main__.py", line 209, in core
        api = Scaleway(module=module)
      File "~/debug_dir/ansible/module_utils/scaleway.py", line 58, in __init__
        'User-Agent': self.get_user_agent_string(module),
      File "~/debug_dir/ansible/module_utils/scaleway.py", line 99, in get_user_agent_string
        return "ansible %s Python %s" % (module.ansible_version, sys.version.split(' ')[0])
    AttributeError: 'AnsibleModule' object has no attribute 'ansible_version'

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hacking/test-module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (devel 66f03827d6) last updated 2018/09/16 17:09:22 (GMT +200)
```