### PR TITLE
Ensure that exercising module code locally works

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -211,7 +211,7 @@ If you module does not need to target a remote host, you can quickly and easily 
    development) activate it: ``$ . venv/bin/activate``
 -  Setup the environment for development: ``$ . hacking/env-setup``
 -  Run your test module locally and directly:
-   ``$ python ./my_new_test_module.py /tmp/args.json``
+   ``$ python -m ansible.modules.cloud.azure.my_new_test_module /tmp/args.json``
 
 This should return output something like this:
 

--- a/test/integration/targets/test_infra/runme.sh
+++ b/test/integration/targets/test_infra/runme.sh
@@ -25,3 +25,6 @@ echo "$PB_OUT" | grep -F "assert works (True)" || exit 1
 # ensure test-module script works well
 PING_MODULE_PATH="$(pwd)/../../../../lib/ansible/modules/system/ping.py"
 ../../../../hacking/test-module -m "$PING_MODULE_PATH" -I ansible_python_interpreter="$(which python)"
+
+# ensure exercising module code locally works
+python -m ansible.modules.files.file  <<< '{"ANSIBLE_MODULE_ARGS": {"path": "/path/to/file", "state": "absent"}}'


### PR DESCRIPTION
##### SUMMARY
doc: fix the command used for exercising module code locally

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
doc

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel 66f03827d6) last updated 2018/09/16 17:09:22 (GMT +200)
```

##### ADDITIONAL INFORMATION

Not sure if backports are allowed for documentation at this point in time, but it would be nice to fix 2.7 documentation too.