### PR TITLE
docker_container: don't parse/interpret options if state is 'absent'

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -753,6 +753,11 @@ class TaskParameters(DockerBaseClass):
         for key, value in client.module.params.items():
             setattr(self, key, value)
 
+        # If state is 'absent', parameters do not have to be parsed or interpreted.
+        # Only the container's name is needed.
+        if self.state == 'absent':
+            return
+
         for param_name in REQUIRES_CONVERSION_TO_BYTES:
             if client.module.params.get(param_name):
                 try:


### PR DESCRIPTION
##### SUMMARY
Don't parse and/or interpret options (ports, networks, IP addresses, ...) when `state` is `'absent'`. Fixes #45486.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.7.0
```
