### PR TITLE
Add 'host' and 'all_tenant' options for os_server_facts

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_facts.py
@@ -27,29 +27,30 @@ requirements:
     - "python >= 2.7"
     - "openstacksdk"
 options:
-   server:
-     description:
-       - restrict results to servers with names or UUID matching
-         this glob expression (e.g., <web*>).
-   host:
-     description:
-       - restrict results to servers host on a specific host.
-   detailed:
-    version_added: "2.8"
-     description:
-        - when true, return additional detail about servers at the expense
-          of additional API calls.
-     type: bool
-     default: 'no'
-   all_tenants:
-     version_added: "2.8"
-     description:
-        - when true, return VMs from all projects
-     type: bool
-     default: 'no'
-   availability_zone:
-     description:
-       - Ignored. Present for backwards compatibility
+    server:
+        description:
+            - restrict results to servers with names or UUID matching
+              this glob expression (e.g., <web*>).
+    host:
+        description:
+            - restrict results to servers host on a specific host.
+    detailed:
+        version_added: "2.8"
+        description:
+            - when true, return additional detail about servers at the expense
+                of additional API calls.
+        type: bool
+        default: 'no'
+    all_tenants:
+        version_added: "2.8"
+        description:
+            - when true, return VMs from all projects
+        type: bool
+        default: 'no'
+    availability_zone:
+        description:
+            - Ignored. Present for backwards compatibility
+            
 extends_documentation_fragment: openstack
 '''
 


### PR DESCRIPTION
##### SUMMARY
This patch adds filtering for both the host and all_tenants
options which should allow generating more information out
of this module.

It also moves it to use the generator as part of the new
OpenStack SDK API.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
os_server_facts