### PR TITLE
Fixes HTTP redirect issue (#45513)

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -27,7 +27,8 @@ class RedfishUtils(object):
                             url_username=self.creds['user'],
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
-                            timeout=10, use_proxy=False)
+                            follow_redirects='all',
+                            use_proxy=False)
             data = json.loads(resp.read())
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
@@ -45,6 +46,7 @@ class RedfishUtils(object):
                             url_username=self.creds['user'],
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
+                            follow_redirects='all',
                             use_proxy=False)
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
@@ -62,6 +64,7 @@ class RedfishUtils(object):
                             url_username=self.creds['user'],
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
+                            follow_redirects='all',
                             use_proxy=False)
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
@@ -79,6 +82,7 @@ class RedfishUtils(object):
                             url_username=self.creds['user'],
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
+                            follow_redirects='all',
                             use_proxy=False)
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change parameter follow_redirects to 'all' to use HTTP redirect code directly from module_utils/urls.py instead of the urlib2 version.

Fixes HTTP redirect issue (#45513)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (fix-http-redirect 8a94ca8349) last updated 2018/09/13 22:14:21 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /share1/git/ansible/lib/ansible
  executable location = /share1/git/ansible/bin/ansible
  python version = 2.7.5 (default, May 31 2018, 09:41:32) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Thanks @billdodd for suggested fix.

