### PR TITLE
sensu_silence: Set expire to int

### DIFF
--- a/lib/ansible/modules/monitoring/sensu_silence.py
+++ b/lib/ansible/modules/monitoring/sensu_silence.py
@@ -259,7 +259,7 @@ def main():
         argument_spec=dict(
             check=dict(required=False),
             creator=dict(required=False),
-            expire=dict(required=False),
+            expire=dict(type='int', required=False),
             expire_on_resolve=dict(type='bool', required=False),
             reason=dict(required=False),
             state=dict(default='present', choices=['present', 'absent']),


### PR DESCRIPTION


##### SUMMARY
The current state of the module converts the expire value to
a string which the Sensu API does not accept.

This patch fixes that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sensu_silence
