### PR TITLE
win_snmp: Initial commit

### DIFF
--- a/lib/ansible/modules/windows/win_snmp.ps1
+++ b/lib/ansible/modules/windows/win_snmp.ps1
@@ -3,7 +3,7 @@
 # Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# POWERSHELL_COMMON
+#Requires -Module Ansible.ModuleUtils.Legacy
 
 $params      = Parse-Args -arguments $args -supports_check_mode $true;
 $check_mode  = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false

--- a/lib/ansible/modules/windows/win_snmp.ps1
+++ b/lib/ansible/modules/windows/win_snmp.ps1
@@ -7,8 +7,8 @@
 
 $params      = Parse-Args -arguments $args -supports_check_mode $true;
 $check_mode  = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
-$managers    = Get-AnsibleParam -obj $params -name "permitted_managers"  -type "list" -failifempty $true
-$communities = Get-AnsibleParam -obj $params -name "community_strings"   -type "list" -failifempty $true
+$managers    = Get-AnsibleParam -obj $params -name "permitted_managers"  -type "list"
+$communities = Get-AnsibleParam -obj $params -name "community_strings"   -type "list"
 $replace     = Get-AnsibleParam -obj $params -name "replace"             -type "bool" -default $false
 
 $result = @{failed = $False; changed = $False;}

--- a/lib/ansible/modules/windows/win_snmp.ps1
+++ b/lib/ansible/modules/windows/win_snmp.ps1
@@ -1,12 +1,15 @@
 #!powershell
 
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 # POWERSHELL_COMMON
 
 $params      = Parse-Args -arguments $args -supports_check_mode $true;
 $check_mode  = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
-$managers    = Get-AnsibleParam -obj $params -name "permitted_managers" -failifempty $true
-$communities = Get-AnsibleParam -obj $params -name "community_strings"  -failifempty $true
-$replace     = Get-AnsibleParam -obj $params -name "replace" -type "bool" -default $false
+$managers    = Get-AnsibleParam -obj $params -name "permitted_managers"  -type "list" -failifempty $true
+$communities = Get-AnsibleParam -obj $params -name "community_strings"   -type "list" -failifempty $true
+$replace     = Get-AnsibleParam -obj $params -name "replace"             -type "bool" -default $false
 
 $result = @{failed = $False; changed = $False;}
 

--- a/lib/ansible/modules/windows/win_snmp.ps1
+++ b/lib/ansible/modules/windows/win_snmp.ps1
@@ -1,0 +1,95 @@
+#!powershell
+
+# POWERSHELL_COMMON
+
+$params      = Parse-Args -arguments $args -supports_check_mode $true;
+$check_mode  = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
+$managers    = Get-AnsibleParam -obj $params -name "permitted_managers" -failifempty $true
+$communities = Get-AnsibleParam -obj $params -name "community_strings"  -failifempty $true
+$replace     = Get-AnsibleParam -obj $params -name "replace" -type "bool" -default $false
+
+$result = @{failed = $False; changed = $False;}
+
+# Make sure lists are modifyable
+[System.Collections.ArrayList]$managers    = $managers
+[System.Collections.ArrayList]$communities = $communities
+
+# Type checking
+If ($managers.Count -gt 0 -And $managers[0].GetType().Name -ne 'String') {
+  Fail-Json $result "Permitted managers must be an array of strings"
+}
+
+If ($communities.Count -gt 0 -And $communities[0].GetType().Name -ne 'String') {
+  Fail-Json $result "SNMP communities must be an array of strings"
+}
+
+$Managers_reg_key    = "HKLM:\System\CurrentControlSet\services\SNMP\Parameters\PermittedManagers"
+$Communities_reg_key = "HKLM:\System\CurrentControlSet\services\SNMP\Parameters\ValidCommunities"
+
+ForEach ($idx in (Get-Item $Managers_reg_key).Property) {
+  $manager = (Get-ItemProperty $Managers_reg_key).$idx
+
+  If ($managers.Contains($manager)) {
+    # Remove manager from list since it already exists
+    $managers.Remove($manager)
+  } Else {
+    If ($replace -And $managers.Count -gt 0) {
+      # Will remove this manager since it is not in the list
+      $result.changed = $True
+
+      If (-Not $check_mode) {
+        # Remove the permitted manager
+        Remove-ItemProperty -Path $Managers_reg_key -Name $idx
+      }
+    }
+  }
+}
+
+ForEach ($community in (Get-Item $Communities_reg_key).Property) {
+  If ($communities.Contains($community)) {
+    # Remove community from list since it already exists
+    $communities.Remove($community)
+  } Else {
+    If ($replace -And $communities.Count -gt 0) {
+      # Will remove this community since it is not in the list
+      $result.changed = $True
+
+      If (-Not $check_mode) {
+        # Remove the community
+        Remove-ItemProperty -Path $Communities_reg_key -Name $community
+      }
+    }
+  }
+}
+
+# Get used manager indexes as integers
+[System.Collections.ArrayList]$indexes=@()
+ForEach ($idx in (Get-Item $Managers_reg_key).Property) {
+  $indexes.Add([int]$idx)
+}
+
+# Add managers that don't already exist
+ForEach ($manager in $managers) {
+  $result.changed = $True
+  If (-Not $check_mode) {
+    $next_index = 1;
+    While($True) {
+      If (-Not $indexes.Contains($next_index)) {
+        New-ItemProperty -Path $Managers_reg_key -Name $next_index -Value "$manager"
+        break
+      }
+
+      $next_index = $next_index + 1
+    }
+  }
+}
+
+# Add communities that don't arleady exist
+ForEach ($community in $communities) {
+  $result.changed = $True
+  If (-Not $check_mode) {
+    New-ItemProperty -Path $Communities_reg_key -Name $community -PropertyType DWord -Value 4
+  }
+}
+
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_snmp.ps1
+++ b/lib/ansible/modules/windows/win_snmp.ps1
@@ -7,8 +7,8 @@
 
 $params      = Parse-Args -arguments $args -supports_check_mode $true;
 $check_mode  = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
-$managers    = Get-AnsibleParam -obj $params -name "permitted_managers"  -type "list"
-$communities = Get-AnsibleParam -obj $params -name "community_strings"   -type "list"
+$managers    = Get-AnsibleParam -obj $params -name "permitted_managers"  -type "list" -default @()
+$communities = Get-AnsibleParam -obj $params -name "community_strings"   -type "list" -default @()
 $replace     = Get-AnsibleParam -obj $params -name "replace"             -type "bool" -default $false
 
 $result = @{failed = $False; changed = $False;}

--- a/lib/ansible/modules/windows/win_snmp.ps1
+++ b/lib/ansible/modules/windows/win_snmp.ps1
@@ -51,7 +51,7 @@ ForEach ($idx in (Get-Item $Managers_reg_key).Property) {
 
   If ($remove) {
     $result.changed = $True
-    Remove-ItemProperty -Path $Managers_reg_key -Name $idx -WhatIf $check_mode
+    Remove-ItemProperty -Path $Managers_reg_key -Name $idx -WhatIf:$check_mode
   }
 }
 
@@ -75,7 +75,7 @@ ForEach ($community in (Get-Item $Communities_reg_key).Property) {
 
   If ($remove) {
     $result.changed = $True
-    Remove-ItemProperty -Path $Communities_reg_key -Name $community -WhatIf $check_mode
+    Remove-ItemProperty -Path $Communities_reg_key -Name $community -WhatIf:$check_mode
   }
 }
 
@@ -110,7 +110,7 @@ ForEach ($manager in $managers) {
 # Add communities that don't already exist
 ForEach ($community in $communities) {
   $result.changed = $True
-  New-ItemProperty -Path $Communities_reg_key -Name $community -PropertyType DWord -Value 4 -WhatIf $check_mode
+  New-ItemProperty -Path $Communities_reg_key -Name $community -PropertyType DWord -Value 4 -WhatIf:$check_mode
 }
 
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_snmp.ps1
+++ b/lib/ansible/modules/windows/win_snmp.ps1
@@ -18,11 +18,11 @@ $result = @{failed = $False; changed = $False;}
 [System.Collections.ArrayList]$communities = $communities
 
 # Type checking
-If ($managers.Count -gt 0 -And $managers[0].GetType().Name -ne 'String') {
+If ($managers.Count -gt 0 -And $managers[0] -IsNot [String]) {
   Fail-Json $result "Permitted managers must be an array of strings"
 }
 
-If ($communities.Count -gt 0 -And $communities[0].GetType().Name -ne 'String') {
+If ($communities.Count -gt 0 -And $communities[0] -IsNot [String]) {
   Fail-Json $result "SNMP communities must be an array of strings"
 }
 
@@ -68,7 +68,7 @@ ForEach ($community in (Get-Item $Communities_reg_key).Property) {
 # Get used manager indexes as integers
 [System.Collections.ArrayList]$indexes=@()
 ForEach ($idx in (Get-Item $Managers_reg_key).Property) {
-  $indexes.Add([int]$idx)
+  $indexes.Add([int]$idx) | Out-Null
 }
 
 # Add managers that don't already exist

--- a/lib/ansible/modules/windows/win_snmp.ps1
+++ b/lib/ansible/modules/windows/win_snmp.ps1
@@ -9,7 +9,7 @@ $params      = Parse-Args -arguments $args -supports_check_mode $true;
 $check_mode  = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 $managers    = Get-AnsibleParam -obj $params -name "permitted_managers"  -type "list" -default @()
 $communities = Get-AnsibleParam -obj $params -name "community_strings"   -type "list" -default @()
-$action_in   = Get-AnsibleParam -obj $params -name "replace"             -type "str"  -default "set" -ValidateSet @("set", "add", "remove")
+$action_in   = Get-AnsibleParam -obj $params -name "action"              -type "str"  -default "set" -ValidateSet @("set", "add", "remove")
 $action      = $action_in.ToLower()
 
 $result = @{failed = $False; changed = $False;}
@@ -44,7 +44,7 @@ ForEach ($idx in (Get-Item $Managers_reg_key).Property) {
       # Remove manager from list to add since it already exists
       $managers.Remove($manager)
     }
-  } ElseIf ($action -eq "set" -And $managers.Count -gt 0) {
+  } ElseIf ($action -eq "set") {
     # Will remove this manager since it is not in the set list
     $remove = $True
   }
@@ -68,7 +68,7 @@ ForEach ($community in (Get-Item $Communities_reg_key).Property) {
       # Remove community from list to add since it already exists
       $communities.Remove($community)
     }
-  } ElseIf ($action -eq "set" -And $communities.Count -gt 0) {
+  } ElseIf ($action -eq "set") {
     # Will remove this community since it is not in the set list
     $remove = $True
   }

--- a/lib/ansible/modules/windows/win_snmp.ps1
+++ b/lib/ansible/modules/windows/win_snmp.ps1
@@ -31,6 +31,9 @@ $Communities_reg_key = "HKLM:\System\CurrentControlSet\services\SNMP\Parameters\
 
 ForEach ($idx in (Get-Item $Managers_reg_key).Property) {
   $manager = (Get-ItemProperty $Managers_reg_key).$idx
+  If ($idx.ToLower() -eq '(default)') {
+    continue
+  }
 
   If ($managers.Contains($manager)) {
     # Remove manager from list since it already exists
@@ -49,6 +52,10 @@ ForEach ($idx in (Get-Item $Managers_reg_key).Property) {
 }
 
 ForEach ($community in (Get-Item $Communities_reg_key).Property) {
+  If ($community.ToLower() -eq '(default)') {
+    continue
+  }
+
   If ($communities.Contains($community)) {
     # Remove community from list since it already exists
     $communities.Remove($community)
@@ -68,7 +75,9 @@ ForEach ($community in (Get-Item $Communities_reg_key).Property) {
 # Get used manager indexes as integers
 [System.Collections.ArrayList]$indexes=@()
 ForEach ($idx in (Get-Item $Managers_reg_key).Property) {
-  $indexes.Add([int]$idx) | Out-Null
+  If ($idx.ToLower() -ne '(default)') {
+    $indexes.Add([int]$idx) | Out-Null
+  }
 }
 
 # Add managers that don't already exist

--- a/lib/ansible/modules/windows/win_snmp.py
+++ b/lib/ansible/modules/windows/win_snmp.py
@@ -20,12 +20,12 @@ author:
 description:
     - This module configures the Windows SNMP service.
 options:
-    managers:
+    permitted_managers:
         description:
         - The list of permitted SNMP managers
         required: false
         type: list
-    communities:
+    community_strings:
         description:
         - The list of read-only SNMP community strings
         required: false

--- a/lib/ansible/modules/windows/win_snmp.py
+++ b/lib/ansible/modules/windows/win_snmp.py
@@ -1,7 +1,13 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Ansible, inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
     'status': ['preview'],
-    'supported_by': 'michael@cassaniti.id.au'
+    'supported_by': 'community'
 }
 
 DOCUMENTATION = '''
@@ -9,6 +15,8 @@ DOCUMENTATION = '''
 module: win_snmp
 version_added: '2.8'
 short_description: Configures the Windows SNMP service
+author:
+    - Michael Cassaniti (@mcassaniti)
 description:
     - This module configures the Windows SNMP service.
 options:
@@ -27,7 +35,7 @@ options:
         - Whether this module should replace all existing values. The list of
           managers and communities will be maintained if C(replace=true) but no
           list is provided to replace the existing managers or communities.
-        type: boolean
+        type: bool
         default: false
 '''
 
@@ -42,4 +50,7 @@ EXAMPLES = '''
           managers:
             - 192.168.1.2
           replace: True
+'''
+
+RETURN = r'''
 '''

--- a/lib/ansible/modules/windows/win_snmp.py
+++ b/lib/ansible/modules/windows/win_snmp.py
@@ -1,0 +1,45 @@
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'michael@cassaniti.id.au'
+}
+
+DOCUMENTATION = '''
+---
+module: win_snmp
+version_added: '2.8'
+short_description: Configures the Windows SNMP service
+description:
+    - This module configures the Windows SNMP service.
+options:
+    managers:
+        description:
+        - The list of permitted SNMP managers
+        required: false
+        type: list
+    communities:
+        description:
+        - The list of read-only SNMP community strings
+        required: false
+        type: list
+    replace:
+        description:
+        - Whether this module should replace all existing values. The list of
+          managers and communities will be maintained if C(replace=true) but no
+          list is provided to replace the existing managers or communities.
+        type: boolean
+        default: false
+'''
+
+EXAMPLES = '''
+---
+  - hosts: Windows
+    tasks:
+      - name: Replace SNMP communities and managers
+        win_snmp:
+          communities:
+            - public
+          managers:
+            - 192.168.1.2
+          replace: True
+'''

--- a/lib/ansible/modules/windows/win_snmp.py
+++ b/lib/ansible/modules/windows/win_snmp.py
@@ -23,18 +23,16 @@ options:
     permitted_managers:
         description:
         - The list of permitted SNMP managers.
-        required: false
         type: list
     community_strings:
         description:
         - The list of read-only SNMP community strings.
-        required: false
         type: list
     action:
         description:
         - C(add) will add new SNMP community strings and/or SNMP managers
         - C(set) will replace SNMP community strings and/or SNMP managers. An
-          empty value for either C(community_strings) or C(permitted_managers)
+          empty list for either C(community_strings) or C(permitted_managers)
           will result in the respective lists being removed entirely.
         - C(remove) will remove SNMP community strings and/or SNMP managers
         default: set
@@ -51,6 +49,15 @@ EXAMPLES = '''
             - public
           managers:
             - 192.168.1.2
+          action: set
+
+  - hosts: Windows
+    tasks:
+      - name: Replace SNMP communities and clear managers
+        win_snmp:
+          communities:
+            - public
+          managers: []
           action: set
 '''
 

--- a/lib/ansible/modules/windows/win_snmp.py
+++ b/lib/ansible/modules/windows/win_snmp.py
@@ -33,7 +33,9 @@ options:
     action:
         description:
         - C(add) will add new SNMP community strings and/or SNMP managers
-        - C(set) will replace SNMP community strings and/or SNMP managers
+        - C(set) will replace SNMP community strings and/or SNMP managers. An
+          empty value for either C(community_strings) or C(permitted_managers)
+          will result in the respective lists being removed entirely.
         - C(remove) will remove SNMP community strings and/or SNMP managers
         default: set
         choices: [ add, set, remove ]

--- a/lib/ansible/modules/windows/win_snmp.py
+++ b/lib/ansible/modules/windows/win_snmp.py
@@ -30,13 +30,13 @@ options:
         - The list of read-only SNMP community strings.
         required: false
         type: list
-    replace:
+    action:
         description:
-        - Whether this module should replace all existing values. The list of
-          managers and communities will be maintained if C(replace=true) but no
-          list is provided to replace the existing managers or communities.
-        type: bool
-        default: false
+        - C(add) will add new SNMP community strings and/or SNMP managers
+        - C(set) will replace SNMP community strings and/or SNMP managers
+        - C(remove) will remove SNMP community strings and/or SNMP managers
+        default: set
+        choices: [ add, set, remove ]
 '''
 
 EXAMPLES = '''
@@ -49,7 +49,7 @@ EXAMPLES = '''
             - public
           managers:
             - 192.168.1.2
-          replace: True
+          action: set
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/windows/win_snmp.py
+++ b/lib/ansible/modules/windows/win_snmp.py
@@ -61,5 +61,19 @@ EXAMPLES = '''
           action: set
 '''
 
-RETURN = r'''
+RETURN = '''
+community_strings:
+    description: The list of community strings for this machine
+    type: list of strings
+    returned: always
+    sample:
+      - public
+      - snmp-ro
+permitted_managers:
+    description: The list of permitted managers for this machine
+    type: list of strings
+    returned: always
+    sample:
+      - 192.168.1.1
+      - 192.168.1.2
 '''

--- a/lib/ansible/modules/windows/win_snmp.py
+++ b/lib/ansible/modules/windows/win_snmp.py
@@ -22,12 +22,12 @@ description:
 options:
     permitted_managers:
         description:
-        - The list of permitted SNMP managers
+        - The list of permitted SNMP managers.
         required: false
         type: list
     community_strings:
         description:
-        - The list of read-only SNMP community strings
+        - The list of read-only SNMP community strings.
         required: false
         type: list
     replace:

--- a/lib/ansible/modules/windows/win_snmp.py
+++ b/lib/ansible/modules/windows/win_snmp.py
@@ -64,14 +64,14 @@ EXAMPLES = '''
 RETURN = '''
 community_strings:
     description: The list of community strings for this machine
-    type: list of strings
+    type: list
     returned: always
     sample:
       - public
       - snmp-ro
 permitted_managers:
     description: The list of permitted managers for this machine
-    type: list of strings
+    type: list
     returned: always
     sample:
       - 192.168.1.1

--- a/test/integration/targets/win_snmp/aliases
+++ b/test/integration/targets/win_snmp/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group2

--- a/test/integration/targets/win_snmp/tasks/cleanup.yml
+++ b/test/integration/targets/win_snmp/tasks/cleanup.yml
@@ -1,0 +1,16 @@
+---
+  - name: Make sure there are no existing SNMP configuration settings
+    win_regedit:
+      path: "{{ item }}"
+      state: absent
+    loop:
+      - "{{ permitted_managers_key }}"
+      - "{{ valid_communities_key }}"
+
+  - name: Create skeleton registry keys for SNMP
+    win_regedit:
+      path: "{{ item }}"
+      state: present
+    loop:
+      - "{{ permitted_managers_key }}"
+      - "{{ valid_communities_key }}"

--- a/test/integration/targets/win_snmp/tasks/cleanup_using_module.yml
+++ b/test/integration/targets/win_snmp/tasks/cleanup_using_module.yml
@@ -1,22 +1,4 @@
 ---
-  # Already tested
-  - name: Add an SNMP manager and an SNMP community
-    win_snmp:
-      action: add
-      community_strings:
-        - snmp-cleanup
-      permitted_managers:
-        - 192.168.1.1
-
-  - name: Run without options to confirm no changes
-    register: snmp_no_change
-    win_snmp:
-
-  - name: Assert no changes occurred when no options provided
-    assert:
-      that:
-        - not snmp_no_change.changed
-
   - name: Set no SNMP community or SNMP manager
     register: snmp_cleanup
     win_snmp:

--- a/test/integration/targets/win_snmp/tasks/cleanup_using_module.yml
+++ b/test/integration/targets/win_snmp/tasks/cleanup_using_module.yml
@@ -8,10 +8,21 @@
       permitted_managers:
         - 192.168.1.1
 
+  - name: Run without options to confirm no changes
+    register: snmp_no_change
+    win_snmp:
+
+  - name: Assert no changes occurred when no options provided
+    assert:
+      that:
+        - not snmp_no_change.changed
+
   - name: Set no SNMP community or SNMP manager
     register: snmp_cleanup
     win_snmp:
       action: set
+      community_strings: []
+      permitted_managers: []
 
   - name: Check registry for no SNMP community
     register: snmp_cleanup_reg_community

--- a/test/integration/targets/win_snmp/tasks/cleanup_using_module.yml
+++ b/test/integration/targets/win_snmp/tasks/cleanup_using_module.yml
@@ -1,0 +1,33 @@
+---
+  # Already tested
+  - name: Add an SNMP manager and an SNMP community
+    win_snmp:
+      action: add
+      community_strings:
+        - snmp-cleanup
+      permitted_managers:
+        - 192.168.1.1
+
+  - name: Set no SNMP community or SNMP manager
+    register: snmp_cleanup
+    win_snmp:
+      action: set
+
+  - name: Check registry for no SNMP community
+    register: snmp_cleanup_reg_community
+    win_reg_stat:
+      path: "{{ valid_communities_key }}"
+      name: snmp-cleanup
+
+  - name: Check registry for no SNMP manager
+    register: snmp_cleanup_reg_manager
+    win_reg_stat:
+      path: "{{ permitted_managers_key }}"
+      name: 1
+
+  - name: Asset SNMP set operation results in no remaining SNMP details
+    assert:
+      that:
+        - snmp_cleanup.changed
+        - snmp_cleanup_reg_community.exists == false
+        - snmp_cleanup_reg_manager.exists == false

--- a/test/integration/targets/win_snmp/tasks/main.yml
+++ b/test/integration/targets/win_snmp/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+  - include_tasks: cleanup.yml
+  - include_tasks: snmp_community.yml
+  - include_tasks: snmp_managers.yml
+  - include_tasks: cleanup.yml

--- a/test/integration/targets/win_snmp/tasks/main.yml
+++ b/test/integration/targets/win_snmp/tasks/main.yml
@@ -3,5 +3,6 @@
   - include_tasks: snmp_community.yml
   - include_tasks: cleanup.yml
   - include_tasks: snmp_managers.yml
+  - include_tasks: output_only.yml
   - include_tasks: cleanup_using_module.yml
   - include_tasks: cleanup.yml

--- a/test/integration/targets/win_snmp/tasks/main.yml
+++ b/test/integration/targets/win_snmp/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
   - include_tasks: cleanup.yml
   - include_tasks: snmp_community.yml
+  - include_tasks: cleanup.yml
   - include_tasks: snmp_managers.yml
+  - include_tasks: cleanup_using_module.yml
   - include_tasks: cleanup.yml

--- a/test/integration/targets/win_snmp/tasks/output_only.yml
+++ b/test/integration/targets/win_snmp/tasks/output_only.yml
@@ -1,0 +1,24 @@
+---
+  # Already tested
+  - name: Add an SNMP manager and an SNMP community
+    win_snmp:
+      action: add
+      community_strings:
+        - snmp-cleanup
+      permitted_managers:
+        - 192.168.1.1
+
+  - name: Run without options
+    register: snmp_no_options
+    win_snmp:
+
+  - name: Assert no changes occurred when no options provided
+    assert:
+      that:
+        - not snmp_no_options.changed
+
+  - name: Assert community strings and permitted managers are correctly returned
+    assert:
+      that:
+        - "'snmp-cleanup' in snmp_no_options.community_strings"
+        - "'192.168.1.1' in snmp_no_options.permitted_managers"

--- a/test/integration/targets/win_snmp/tasks/snmp_community.yml
+++ b/test/integration/targets/win_snmp/tasks/snmp_community.yml
@@ -1,0 +1,99 @@
+---
+  - name: Add initial SNMP community
+    register: snmp_community
+    win_snmp:
+      community_strings:
+        - ansible-ro-test
+
+  - name: Check initial SNMP community exists in registry
+    register: snmp_community_reg
+    win_reg_stat:
+      path: "{{ valid_communities_key }}"
+      name: ansible-ro-test
+
+  - name: Assert initial SNMP community is correct
+    assert:
+      that:
+        - snmp_community is changed
+        - snmp_community_reg.exists
+        - snmp_community_reg.type == 'REG_DWORD'
+        - snmp_community_reg.value == 4
+
+  - name: Add initial SNMP community again
+    register: snmp_community_again
+    win_snmp:
+      community_strings:
+        - ansible-ro-test
+
+  - name: Check no change occurred when adding SNMP community again
+    assert:
+      that:
+        - snmp_community_again is not changed
+
+  - name: Add next SNMP community
+    register: snmp_community_next
+    win_snmp:
+      community_strings:
+        - ansible-ro-test-next
+
+  - name: Check initial SNMP community still exists in registry
+    register: snmp_community_reg_orig
+    win_reg_stat:
+      path: "{{ valid_communities_key }}"
+      name: ansible-ro-test
+
+  - name: Check next SNMP community exists in registry
+    register: snmp_community_reg_next
+    win_reg_stat:
+      path: "{{ valid_communities_key }}"
+      name: ansible-ro-test-next
+
+  - name: Assert initial SNMP community still exists
+    assert:
+      that:
+        - snmp_community_reg_orig.exists
+        - snmp_community_reg_orig.type == 'REG_DWORD'
+        - snmp_community_reg_orig.value == 4
+
+  - name: Assert next SNMP community exists
+    assert:
+      that:
+        - snmp_community_next is changed
+        - snmp_community_reg_next.exists
+        - snmp_community_reg_next.type == 'REG_DWORD'
+        - snmp_community_reg_next.value == 4
+
+  - name: Replace SNMP community
+    register: snmp_community_replace
+    win_snmp:
+      replace: yes
+      community_strings:
+        - ansible-ro-test-replace
+
+  - name: Check initial SNMP community does not exist in registry
+    register: snmp_community_reg_orig_replace
+    win_reg_stat:
+      path: "{{ valid_communities_key }}"
+      name: ansible-ro-test
+
+  - name: Check next SNMP community does not exist in registry
+    register: snmp_community_reg_next_replace
+    win_reg_stat:
+      path: "{{ valid_communities_key }}"
+      name: ansible-ro-test-next
+
+  - name: Check replace SNMP community exists in registry
+    register: snmp_community_reg_replace
+    win_reg_stat:
+      path: "{{ valid_communities_key }}"
+      name: ansible-ro-test-replace
+
+  - name: Assert replace SNMP community exists and others are replaced
+    assert:
+      that:
+        - snmp_community_replace is changed
+        - snmp_community_reg_orig_replace.exists == false
+        - snmp_community_reg_next_replace.exists == false
+        - snmp_community_reg_replace.exists
+        - snmp_community_reg_replace.type == 'REG_DWORD'
+        - snmp_community_reg_replace.value == 4

--- a/test/integration/targets/win_snmp/tasks/snmp_community.yml
+++ b/test/integration/targets/win_snmp/tasks/snmp_community.yml
@@ -135,3 +135,31 @@
         - snmp_community_reg_remove_add.exists
         - snmp_community_reg_remove_add.type == 'REG_DWORD'
         - snmp_community_reg_remove_add.value == 4
+
+  - name: Remove the replaced SNMP community (again)
+    register: snmp_community_remove
+    win_snmp:
+      action: remove
+      community_strings:
+        - ansible-ro-test-replace
+
+  - name: Check replace SNMP community is removed in registry (again)
+    register: snmp_community_reg_remove
+    win_reg_stat:
+      path: "{{ valid_communities_key }}"
+      name: ansible-ro-test-replace
+
+  - name: Check SNMP community that was added for testing removal exists in registry (again)
+    register: snmp_community_reg_remove_add
+    win_reg_stat:
+      path: "{{ valid_communities_key }}"
+      name: ansible-ro-remove-add
+
+  - name: Assert removal of SNMP community succeeded and next SNMP community remains (again)
+    assert:
+      that:
+        - snmp_community_remove is not changed
+        - snmp_community_reg_remove.exists == false
+        - snmp_community_reg_remove_add.exists
+        - snmp_community_reg_remove_add.type == 'REG_DWORD'
+        - snmp_community_reg_remove_add.value == 4

--- a/test/integration/targets/win_snmp/tasks/snmp_community.yml
+++ b/test/integration/targets/win_snmp/tasks/snmp_community.yml
@@ -2,6 +2,7 @@
   - name: Add initial SNMP community
     register: snmp_community
     win_snmp:
+      action: add
       community_strings:
         - ansible-ro-test
 
@@ -22,6 +23,7 @@
   - name: Add initial SNMP community again
     register: snmp_community_again
     win_snmp:
+      action: add
       community_strings:
         - ansible-ro-test
 
@@ -33,6 +35,7 @@
   - name: Add next SNMP community
     register: snmp_community_next
     win_snmp:
+      action: add
       community_strings:
         - ansible-ro-test-next
 
@@ -66,7 +69,7 @@
   - name: Replace SNMP community
     register: snmp_community_replace
     win_snmp:
-      replace: yes
+      action: set
       community_strings:
         - ansible-ro-test-replace
 
@@ -97,3 +100,38 @@
         - snmp_community_reg_replace.exists
         - snmp_community_reg_replace.type == 'REG_DWORD'
         - snmp_community_reg_replace.value == 4
+
+  # This task has already been tested
+  - name: Add another SNMP community before testing removal
+    win_snmp:
+      action: add
+      community_strings:
+        - ansible-ro-remove-add
+
+  - name: Remove the replaced SNMP community
+    register: snmp_community_remove
+    win_snmp:
+      action: remove
+      community_strings:
+        - ansible-ro-test-replace
+
+  - name: Check replace SNMP community is removed in registry
+    register: snmp_community_reg_remove
+    win_reg_stat:
+      path: "{{ valid_communities_key }}"
+      name: ansible-ro-test-replace
+
+  - name: Check SNMP community that was added for testing removal exists in registry
+    register: snmp_community_reg_remove_add
+    win_reg_stat:
+      path: "{{ valid_communities_key }}"
+      name: ansible-ro-remove-add
+
+  - name: Assert removal of SNMP community succeeded and next SNMP community remains
+    assert:
+      that:
+        - snmp_community_remove is changed
+        - snmp_community_reg_remove.exists == false
+        - snmp_community_reg_remove_add.exists
+        - snmp_community_reg_remove_add.type == 'REG_DWORD'
+        - snmp_community_reg_remove_add.value == 4

--- a/test/integration/targets/win_snmp/tasks/snmp_managers.yml
+++ b/test/integration/targets/win_snmp/tasks/snmp_managers.yml
@@ -1,0 +1,92 @@
+---
+  - name: Add initial SNMP manager
+    register: snmp_manager
+    win_snmp:
+      permitted_managers:
+        - 192.168.1.1
+
+  - name: Check initial SNMP manager exists in registry
+    register: snmp_manager_reg
+    win_reg_stat:
+      path: "{{ permitted_managers_key }}"
+      name: 1
+
+  - name: Assert initial SNMP manager is correct
+    assert:
+      that:
+        - snmp_manager is changed
+        - snmp_manager_reg.exists
+        - snmp_manager_reg.type == 'REG_SZ'
+        - snmp_manager_reg.value == '192.168.1.1'
+
+  - name: Add initial SNMP manager again
+    register: snmp_manager_again
+    win_snmp:
+      permitted_managers:
+        - 192.168.1.1
+
+  - name: Check no change occurred when adding SNMP manager again
+    assert:
+      that:
+        - snmp_manager_again is not changed
+
+  - name: Add next SNMP manager
+    register: snmp_manager_next
+    win_snmp:
+      permitted_managers:
+        - 192.168.1.2
+
+  - name: Check initial SNMP manager still exists in registry
+    register: snmp_manager_reg_orig
+    win_reg_stat:
+      path: "{{ permitted_managers_key }}"
+      name: 1
+
+  - name: Check next SNMP manager exists in registry
+    register: snmp_manager_reg_next
+    win_reg_stat:
+      path: "{{ permitted_managers_key }}"
+      name: 2
+
+  - name: Assert initial SNMP manager still exists
+    assert:
+      that:
+        - snmp_manager_reg_orig.exists
+        - snmp_manager_reg_orig.type == 'REG_SZ'
+        - snmp_manager_reg_orig.value == '192.168.1.1'
+
+  - name: Assert next SNMP manager exists
+    assert:
+      that:
+        - snmp_manager_next is changed
+        - snmp_manager_reg_next.exists
+        - snmp_manager_reg_next.type == 'REG_SZ'
+        - snmp_manager_reg_next.value == '192.168.1.2'
+
+  - name: Replace SNMP manager
+    register: snmp_manager_replace
+    win_snmp:
+      replace: yes
+      permitted_managers:
+        - 192.168.1.10
+
+  - name: Check next SNMP manager does not exist in registry
+    register: snmp_manager_reg_next_replace
+    win_reg_stat:
+      path: "{{ permitted_managers_key }}"
+      name: 2
+
+  - name: Check replace SNMP manager exists in registry (overrides original slot)
+    register: snmp_manager_reg_replace
+    win_reg_stat:
+      path: "{{ permitted_managers_key }}"
+      name: 1
+
+  - name: Assert replace SNMP manager exists and others are replaced
+    assert:
+      that:
+        - snmp_manager_replace is changed
+        - snmp_manager_reg_next_replace.exists == false
+        - snmp_manager_reg_replace.exists
+        - snmp_manager_reg_replace.type == 'REG_SZ`'
+        - snmp_manager_reg_replace.value == '192.168.1.10'

--- a/test/integration/targets/win_snmp/tasks/snmp_managers.yml
+++ b/test/integration/targets/win_snmp/tasks/snmp_managers.yml
@@ -88,5 +88,5 @@
         - snmp_manager_replace is changed
         - snmp_manager_reg_next_replace.exists == false
         - snmp_manager_reg_replace.exists
-        - snmp_manager_reg_replace.type == 'REG_SZ`'
+        - snmp_manager_reg_replace.type == 'REG_SZ'
         - snmp_manager_reg_replace.value == '192.168.1.10'

--- a/test/integration/targets/win_snmp/tasks/snmp_managers.yml
+++ b/test/integration/targets/win_snmp/tasks/snmp_managers.yml
@@ -2,6 +2,7 @@
   - name: Add initial SNMP manager
     register: snmp_manager
     win_snmp:
+      action: add
       permitted_managers:
         - 192.168.1.1
 
@@ -22,6 +23,7 @@
   - name: Add initial SNMP manager again
     register: snmp_manager_again
     win_snmp:
+      action: add
       permitted_managers:
         - 192.168.1.1
 
@@ -33,6 +35,7 @@
   - name: Add next SNMP manager
     register: snmp_manager_next
     win_snmp:
+      action: add
       permitted_managers:
         - 192.168.1.2
 
@@ -66,7 +69,7 @@
   - name: Replace SNMP manager
     register: snmp_manager_replace
     win_snmp:
-      replace: yes
+      action: set
       permitted_managers:
         - 192.168.1.10
 
@@ -90,3 +93,38 @@
         - snmp_manager_reg_replace.exists
         - snmp_manager_reg_replace.type == 'REG_SZ'
         - snmp_manager_reg_replace.value == '192.168.1.10'
+
+  # This task has already been tested
+  - name: Add another SNMP manager before testing removal
+    win_snmp:
+      action: add
+      permitted_managers:
+        - 192.168.1.20
+
+  - name: Remove the replaced SNMP manager
+    register: snmp_manager_remove
+    win_snmp:
+      action: remove
+      permitted_managers:
+        - 192.168.1.10
+
+  - name: Check replace SNMP manager is removed in registry
+    register: snmp_manager_reg_remove
+    win_reg_stat:
+      path: "{{ permitted_managers_key }}"
+      name: 1
+
+  - name: Check SNMP manager that was added for testing removal exists in registry
+    register: snmp_manager_reg_remove_add
+    win_reg_stat:
+      path: "{{ permitted_managers_key }}"
+      name: 2
+
+  - name: Assert removal of SNMP manager succeeded and next SNMP manager remains
+    assert:
+      that:
+        - snmp_manager_remove is changed
+        - snmp_manager_reg_remove.exists == false
+        - snmp_manager_reg_remove_add.exists
+        - snmp_manager_reg_remove_add.type == 'REG_SZ'
+        - snmp_manager_reg_remove_add.value == '192.168.1.20'

--- a/test/integration/targets/win_snmp/tasks/snmp_managers.yml
+++ b/test/integration/targets/win_snmp/tasks/snmp_managers.yml
@@ -128,3 +128,31 @@
         - snmp_manager_reg_remove_add.exists
         - snmp_manager_reg_remove_add.type == 'REG_SZ'
         - snmp_manager_reg_remove_add.value == '192.168.1.20'
+
+  - name: Remove the replaced SNMP manager (again)
+    register: snmp_manager_remove
+    win_snmp:
+      action: remove
+      permitted_managers:
+        - 192.168.1.10
+
+  - name: Check replace SNMP manager is removed in registry (again)
+    register: snmp_manager_reg_remove
+    win_reg_stat:
+      path: "{{ permitted_managers_key }}"
+      name: 1
+
+  - name: Check SNMP manager that was added for testing removal exists in registry (again)
+    register: snmp_manager_reg_remove_add
+    win_reg_stat:
+      path: "{{ permitted_managers_key }}"
+      name: 2
+
+  - name: Assert removal of SNMP manager succeeded and next SNMP manager remains (again)
+    assert:
+      that:
+        - snmp_manager_remove is not changed
+        - snmp_manager_reg_remove.exists == false
+        - snmp_manager_reg_remove_add.exists
+        - snmp_manager_reg_remove_add.type == 'REG_SZ'
+        - snmp_manager_reg_remove_add.value == '192.168.1.20'

--- a/test/integration/targets/win_snmp/vars/main.yml
+++ b/test/integration/targets/win_snmp/vars/main.yml
@@ -1,0 +1,3 @@
+---
+  permitted_managers_key: 'HKLM:\System\CurrentControlSet\services\SNMP\Parameters\PermittedManagers'
+  valid_communities_key: 'HKLM:\System\CurrentControlSet\services\SNMP\Parameters\ValidCommunities'


### PR DESCRIPTION
##### SUMMARY
Adds support for configuring the SNMP permitted managers and the list of read-only SNMP communities for a Windows host.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
win_snmp

##### ANSIBLE VERSION
```ansible 2.8.0.dev0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, Aug 16 2018, 14:17:09) [GCC 6.4.0]
```