### PR TITLE
vultr: fix for unreliable API behavior

### DIFF
--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -169,7 +169,7 @@ class Vultr:
                 timeout=self.api_config['api_timeout'],
             )
 
-            if info.get('status') and info.get('status') == 200:
+            if info.get('status') == 200:
                 break
 
             # Vultr has a rate limiting requests per second, try to be polite

--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -169,8 +169,7 @@ class Vultr:
                 timeout=self.api_config['api_timeout'],
             )
 
-            # Did we hit the rate limit?
-            if info.get('status') and info.get('status') != 503:
+            if info.get('status') and info.get('status') == 200:
                 break
 
             # Vultr has a rate limiting requests per second, try to be polite

--- a/lib/ansible/modules/cloud/vultr/vultr_server.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_server.py
@@ -529,7 +529,6 @@ class AnsibleVultrServer(Vultr):
                             method="POST",
                             data=data
                         )
-                        server = self._wait_for_state(key='server_state', state='ok')
         return server
 
     def _update_ipv6_setting(self, server, start_server):
@@ -554,7 +553,6 @@ class AnsibleVultrServer(Vultr):
                             method="POST",
                             data=data
                         )
-                        server = self._wait_for_state(key='server_state', state='ok')
                         server = self._wait_for_state(key='v6_main_ip')
         return server
 
@@ -579,7 +577,6 @@ class AnsibleVultrServer(Vultr):
                             method="POST",
                             data=data
                         )
-                        server = self._wait_for_state(key='server_state', state='ok')
         return server
 
     def _update_plan_setting(self, server, start_server):
@@ -602,7 +599,6 @@ class AnsibleVultrServer(Vultr):
                         method="POST",
                         data=data
                     )
-                    server = self._wait_for_state(key='server_state', state='ok')
         return server
 
     def _handle_power_status_for_update(self, server, start_server):
@@ -702,7 +698,7 @@ class AnsibleVultrServer(Vultr):
             if self.server_power_state in ['starting', 'running'] and start_server:
                 server = self.start_server(skip_results=True)
 
-        server = self._wait_for_state(key='server_state', state='ok')
+        server = self._wait_for_state(key='status', state='active')
         return server
 
     def absent_server(self):
@@ -720,7 +716,7 @@ class AnsibleVultrServer(Vultr):
                     method="POST",
                     data=data
                 )
-                for s in range(0, 30):
+                for s in range(0, 60):
                     if server is not None:
                         break
                     time.sleep(2)
@@ -764,7 +760,7 @@ class AnsibleVultrServer(Vultr):
     def _wait_for_state(self, key='power_status', state=None):
         time.sleep(1)
         server = self.get_server(refresh=True)
-        for s in range(0, 30):
+        for s in range(0, 60):
             # Check for Truely if wanted state is None
             if state is None and server.get(key):
                 break

--- a/test/legacy/roles/vultr_server/tasks/main.yml
+++ b/test/legacy/roles/vultr_server/tasks/main.yml
@@ -11,6 +11,11 @@
     that:
     - result is success
 
+# Servers can only be destroyed 5 min after creation
+- name: wait for 5 min
+  local_action: wait_for
+  when: result is changed
+
 - name: test fail if missing name
   vultr_server:
   register: result


### PR DESCRIPTION
##### SUMMARY
currently we run to often into a timeout because we wait for state server_state=ok which has been increased dramatically since the development of the module. It can takes 5 or more minutes to get into this state, even when the VM is fully booted.

Another issue is that we should use retry also for all return codes other then HTTP 200, not only for API rate limits or server errors. This increases reliability.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vultr_server

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
should be backported to 2.6, 2.7
```
