### PR TITLE
Backport 2.6: Return correct version on installed VyOS (#39115)

### DIFF
--- a/changelogs/fragments/fix_vyos_facts.yaml
+++ b/changelogs/fragments/fix_vyos_facts.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - vyos_facts - fix vyos_facts not returning version number issue (https://github.com/ansible/ansible/pull/39115)

--- a/lib/ansible/modules/network/vyos/vyos_facts.py
+++ b/lib/ansible/modules/network/vyos/vyos_facts.py
@@ -135,7 +135,7 @@ class Default(FactsBase):
         self.facts['hostname'] = self.responses[1]
 
     def parse_version(self, data):
-        match = re.search(r'Version:\s*(\S+)', data)
+        match = re.search(r'Version:\s*(.*)', data)
         if match:
             return match.group(1)
 

--- a/test/units/modules/network/vyos/test_vyos_facts.py
+++ b/test/units/modules/network/vyos/test_vyos_facts.py
@@ -63,7 +63,7 @@ class TestVyosFactsModule(TestVyosModule):
         facts = result.get('ansible_facts')
         self.assertEqual(len(facts), 5)
         self.assertEqual(facts['ansible_net_hostname'].strip(), 'vyos01')
-        self.assertEqual(facts['ansible_net_version'], 'VyOS')
+        self.assertEqual(facts['ansible_net_version'], 'VyOS 1.1.7')
 
     def test_vyos_facts_not_all(self):
         set_module_args(dict(gather_subset='!all'))
@@ -71,7 +71,7 @@ class TestVyosFactsModule(TestVyosModule):
         facts = result.get('ansible_facts')
         self.assertEqual(len(facts), 5)
         self.assertEqual(facts['ansible_net_hostname'].strip(), 'vyos01')
-        self.assertEqual(facts['ansible_net_version'], 'VyOS')
+        self.assertEqual(facts['ansible_net_version'], 'VyOS 1.1.7')
 
     def test_vyos_facts_exclude_most(self):
         set_module_args(dict(gather_subset=['!neighbors', '!config']))
@@ -79,7 +79,7 @@ class TestVyosFactsModule(TestVyosModule):
         facts = result.get('ansible_facts')
         self.assertEqual(len(facts), 5)
         self.assertEqual(facts['ansible_net_hostname'].strip(), 'vyos01')
-        self.assertEqual(facts['ansible_net_version'], 'VyOS')
+        self.assertEqual(facts['ansible_net_version'], 'VyOS 1.1.7')
 
     def test_vyos_facts_invalid_subset(self):
         set_module_args(dict(gather_subset='cereal'))


### PR DESCRIPTION
##### SUMMARY
* Return correct version on installed VyOS

Previously existing regexp will shows only "VyOS" without numeric output of router version.
For example: from  "Version:      VyOS 1.1.6" only VyOS will be written in ansible_net_version variable
For more informative output numeric value should be returned as well

* Fixed unittests

(cherry picked from commit 235b11f681558c614b8b44e05d6679d48784a34c)
##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
vyos_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
stable-2.6
```