### PR TITLE
BOTMETA: Only notify sivel & gundalow on code changes to validate-modules

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -978,11 +978,17 @@ files:
     maintainers: resmo felixfontein
   test/sanity/validate-modules:
     notified:
-      - gundalow
       - mattclay
-      - sivel
     keywords:
       - validate-modules
+  test/sanity/validate-modules/schema.py:
+    notified:
+      - gundalow
+      - sivel
+  test/sanity/validate-modules/main.py:
+    notified:
+      - gundalow
+      - sivel
   docs/:
     maintainers:
       - acozine


### PR DESCRIPTION
##### SUMMARY
Previously changes to `ignore.txt` were causing @sivel and gundalow to be pinged

##### ISSUE TYPE
- Bugfix Pull Request
