### PR TITLE
Makefile: build rpm git parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,13 @@ CODENAME := $(shell $(PYTHON) packaging/release/versionhelper/version_helper.py 
 RELEASE ?= 1
 
 # Get the branch information from git
-ifneq ($(shell which git),)
+ifneq ($(shell git log),)
 GIT_DATE := $(shell git log -n 1 --format="%ai")
 GIT_HASH := $(shell git log -n 1 --format="%h")
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD | sed 's/[-_.\/]//g')
 GITINFO = .$(GIT_HASH).$(GIT_BRANCH)
 else
-GITINFO = ""
+GITINFO =
 endif
 
 ifeq ($(shell echo $(OS) | egrep -c 'Darwin|FreeBSD|OpenBSD|DragonFly'),1)


### PR DESCRIPTION
##### SUMMARY
In some cases the system can have git, but there are no any ansible repo, just a source. For example from https://releases.ansible.com/ansible/ .
In such case it is impossible to detect no hash, no branch.

in Makefile to empty parameter we don't need quotes.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Makefile

##### ANSIBLE VERSION
```
current
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
before changes - impossible to build rpm from tarball if git installed
after - ok
```
