### PR TITLE
Fixed implementation of muting/unmuting a monitor on a scope and end …

### DIFF
--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -104,10 +104,10 @@ options:
         version_added: "2.3"
     scope:
         description: ["String of monitor's scope. The defined scope will be muted, or, if not defined, or defined as '*', all scopes will be muted."]
-        version_added: "2.7"
+        version_added: "2.8"
     end:
         description: ["String of POSIX timestamp. The defined scope/all scopes will be muted until the given POSIX, or forever if the value is not defined."]
-        version_added: "2.7"
+        version_added: "2.8"
 
 '''
 


### PR DESCRIPTION
Fixed implementation of muting/unmuting a monitor on a scope and end date.

To mute on a scope, API expects body containing ```'scope': 'foo:bar', 'end': 'POSIX_timestamp'```.
This fix implements that by defining separate scope and end module parameters.
It also makes default scope of '*', as the scope is optional.
https://docs.datadoghq.com/api/?lang=python#mute-a-monitor

Fixes#43918

##### SUMMARY
Fixes#43918
The current (without this fix) implementation of mute is sending invalid body to DD API, which results in muting on all scopes and with no end period. This is because DD API interprets invalid body in a way that it applies the mute to all scopes and with no end timestamp. Example of such invalid body sent without this fix:
```'silenced': "{'healthcheckid:1aaf9740-aff8-4565-9980-703c8602e60c': 1539507717}"```.
Note that we call `silenced` parameter which is not defined in API.
According to the API doc: https://docs.datadoghq.com/api/?lang=python#mute-a-monitor
you can mute a monitor on a scope using body like this:
```'scope': 'healthcheckid:1aaf9740-aff8-4565-9980-703c8602e60c', 'end': '1539507717'```
To implement that, I have removed `silenced` parameter, added `scope` and `end` and defined defaults, so scope defaults to `*` if not specified, just like specified on API's page.
I have also fixed the unmute call, to generate valid body, and to unmute on either all scopes or a single scope, depending on what is requested. Now it mutes and unmutes whatever it is asked for.

I have run test cases and monitor behaves as expected. 
Test cases passed:

mute:
Scope defined,     end defined     - muted on a scope until end
Scope not defined, end defined     - muted on all scopes until end
Scope defined,     end not defined - muted on a scope forever
Scope not defined, end not defined - muted on all scopes forever

unmute:
Scope defined      - unmutes a scope if the monitor was only muted on that scope
Scope undefined    - unmutes all scopes if the monitor was muted on all the scopes
Any other case will not result in any action taken.
 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
/lib/ansible/modules/monitoring/datadog_monitor.py

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = /Users/tczajka/git/ansible-tenable-cloud/ansible-core/ansible.cfg
  configured module search path = ['/Users/tczajka/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/tczajka/ansible2.6/lib/python3.6/site-packages/ansible
  executable location = /Users/tczajka/ansible2.6/bin/ansible
  python version = 3.6.4 (default, Mar  1 2018, 18:36:50) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION
My repro steps before fixing the problem:
```
---
- hosts: localhost
  connection: local
  gather_facts: false
  vars_files:
    - vars/creds.yml
  vars:
  tasks:
    - name: "Muting Datadog"
      datadog_monitor:
        id: "6090000"
        name: "route 53 monitor tomek"
        state: "mute"
        silenced: '{"healthcheckid:1aaf9740-aff8-4565-9980-703c8602e60c":"1539762498"}
        api_key: "{{ datadog_api_key }}"
        app_key: "{{ datadog_app_key }}"
```

Result: The monitor was muted on all the scopes.

My repro steps after fixing the problem:
```
---
- hosts: localhost
  connection: local
  gather_facts: false
  vars_files:
    - vars/creds.yml
  vars:
  tasks:
    - name: "Muting Datadog"
      datadog_monitor:
        id: "6090000"
        name: "route 53 monitor tomek"
        state: "mute"
        scope: 'healthcheckid:1aaf9740-aff8-4565-9980-703c8602e60c'
        end: '1539762498'
        api_key: "{{ datadog_api_key }}"
        app_key: "{{ datadog_app_key }}"
```

Result: The monitor was muted on the correct scope and with valid end.