### PR TITLE
Cloudstack: Add support for some VPC service capabilities

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_vpc_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vpc_offering.py
@@ -65,8 +65,36 @@ EXAMPLES = '''
     state: enabled
     supported_services: [ Dns, Dhcp ]
     service_providers:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
+      - {service: 'dns', provider: 'VpcVirtualRouter'}
+      - {service: 'dhcp', provider: 'VpcVirtualRouter'}
+
+# Create a vpc offering with redundant router
+- local_action:
+    module: cs_vpc_offering
+    name: "my_vpc_offering"
+    display_text: "vpc offering description"
+    supported_services: [ Dns, Dhcp, SourceNat ]
+    service_providers:
+      - {service: 'dns', provider: 'VpcVirtualRouter'}
+      - {service: 'dhcp', provider: 'VpcVirtualRouter'}
+      - {service: 'SourceNat', provider: 'VpcVirtualRouter'}
+    service_capabilities:
+      - {service: 'SourceNat', capabilitytype: 'RedundantRouter', capabilityvalue: true}
+
+# Create a region level vpc offering with distributed router
+- local_action:
+    module: cs_vpc_offering
+    name: "my_vpc_offering"
+    display_text: "vpc offering description"
+    state: present
+    supported_services: [ Dns, Dhcp, SourceNat ]
+    service_providers:
+      - {service: 'dns', provider: 'VpcVirtualRouter'}
+      - {service: 'dhcp', provider: 'VpcVirtualRouter'}
+      - {service: 'SourceNat', provider: 'VpcVirtualRouter'}
+    service_capabilities:
+      - {service: 'Connectivity', capabilitytype: 'DistributedRouter', capabilityvalue: true}
+      - {service: 'Connectivity', capabilitytype: 'RegionLevelVPC', capabilityvalue: true}
 
 # Remove a vpc offering
 - local_action:
@@ -189,6 +217,7 @@ class AnsibleCloudStackVPCOffering(AnsibleCloudStack):
             'supportedservices': self.module.params.get('supported_services'),
             'serviceproviderlist': self.module.params.get('service_providers'),
             'serviceofferingid': self.get_service_offering_id(),
+            'servicecapabilitylist': self.module.params.get('service_capabilities'),
         }
 
         required_params = [

--- a/test/integration/targets/cs_vpc_offering/tasks/main.yml
+++ b/test/integration/targets/cs_vpc_offering/tasks/main.yml
@@ -380,12 +380,47 @@
     - vpcoffer.state == "Enabled"
     - vpcoffer.display_text == "vpc offering description"
 
+- name: test create enabled region level vpc offer with distrubuted router
+  cs_vpc_offering:
+    name: "{{ cs_resource_prefix }}_vpc_drl"
+    display_text: "vpc offering description"
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, StaticNat, Vpn, Lb ]
+    service_providers:
+      - { service: 'dns', provider: 'virtualrouter' }
+      - { service: 'dhcp', provider: 'virtualrouter' }
+    state: enabled
+    service_capabilities:
+      - {service: 'Connectivity', capabilitytype: 'DistributedRouter', capabilityvalue: true}
+      - {service: 'Connectivity', capabilitytype: 'RegionLevelVPC', capabilityvalue: true}
+  register: vpcoffer
+- name: verify results of create enabled region level vpc offer with distrubuted router
+  assert:
+    that:
+    - vpcoffer is successful
+    - vpcoffer is changed
+    - vpcoffer.name == "{{ cs_resource_prefix }}_vpc_drl"
+    - vpcoffer.state == "Enabled"
+    - vpcoffer.display_text == "vpc offering description"
+    - vpcoffer.distributed == true
+    - vpcoffer.region_level == true
+
 - name: remove vpc offer
   cs_vpc_offering:
     name: "{{ cs_resource_prefix }}_vpc"
     state: absent
   register: vpcoffer
 - name: verify results of remove vpc offer
+  assert:
+    that:
+    - vpcoffer is successful
+    - vpcoffer is changed
+
+- name: remove region level vpc offer with distrubuted router
+  cs_vpc_offering:
+    name: "{{ cs_resource_prefix }}_vpc_drl"
+    state: absent
+  register: vpcoffer
+- name: verify results of remove region level vpc offer with distrubuted router
   assert:
     that:
     - vpcoffer is successful


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The ```service_capabilities``` parameter was not used by the ```cs_vpc_offering``` module when creating a new VPC offer since I didn't find any documentation on how to use it.

I added the parameter to the ```createVPCOffering``` command with some examples.

The support of the following service capabilities can now be enabled on VPC service offers:
* RedundantRouter
* DistributedRouter
* RegionLevelVPC
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #45729

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cs_vpc_offering

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8.0.dev0
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
