### PR TITLE
Add virtualization devices in the inventory of NetBox dynamic inventory plugin

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -89,6 +89,7 @@ import json
 import uuid
 from sys import version as python_version
 from threading import Thread
+from itertools import chain
 
 from ansible.plugins.inventory import BaseInventoryPlugin
 from ansible.module_utils.ansible_release import __version__ as ansible_version
@@ -97,7 +98,6 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib.parse import urljoin, urlencode
 from ansible.module_utils.compat.ipaddress import ip_interface
-
 
 ALLOWED_DEVICE_QUERY_PARAMETERS = (
     "asset_tag",
@@ -174,10 +174,22 @@ class InventoryModule(BaseInventoryPlugin):
             "tenants": self.extract_tenant,
             "racks": self.extract_rack,
             "tags": self.extract_tags,
+            "disk": self.extract_disk,
+            "memory": self.extract_memory,
+            "vcpus": self.extract_vcpus,
             "device_roles": self.extract_device_role,
             "device_types": self.extract_device_type,
             "manufacturers": self.extract_manufacturer
         }
+
+    def extract_disk(self, host):
+        return host.get("disk")
+
+    def extract_vcpus(self, host):
+        return host.get("vcpus")
+
+    def extract_memory(self, host):
+        return host.get("memory")
 
     def extract_device_type(self, host):
         try:
@@ -303,7 +315,8 @@ class InventoryModule(BaseInventoryPlugin):
         v = tuple(x.values())[0]
 
         if not (k in ALLOWED_DEVICE_QUERY_PARAMETERS or k.startswith("cf_")):
-            self.display.warning("Warning: %s not in %s or starting with cf (Custom field)" % (k, ALLOWED_DEVICE_QUERY_PARAMETERS))
+            msg = "Warning: %s not in %s or starting with cf (Custom field)" % (k, ALLOWED_DEVICE_QUERY_PARAMETERS)
+            self.display.warning(msg=msg)
             return
         return k, v
 
@@ -312,9 +325,16 @@ class InventoryModule(BaseInventoryPlugin):
         query_parameters.extend(filter(lambda x: x,
                                        map(self.validate_query_parameters, self.query_filters)))
         self.device_url = self.api_endpoint + "/api/dcim/devices/" + "?" + urlencode(query_parameters)
+        self.virtual_machines_url = "".join([self.api_endpoint,
+                                             "/api/virtualization/virtual-machines/",
+                                             "?",
+                                             urlencode(query_parameters)])
 
     def fetch_hosts(self):
-        return self.get_resource_list(self.device_url)
+        return chain(
+            self.get_resource_list(self.device_url),
+            self.get_resource_list(self.virtual_machines_url),
+        )
 
     def extract_name(self, host):
         # An host in an Ansible inventory requires an hostname.


### PR DESCRIPTION
##### SUMMARY

NetBox virtualized devices were not part of the inventory so far. This PR fixes it.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- netbox dynamic inventory

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (netbox_virtual a47eefad88) last updated 2018/09/17 15:01:38 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```
