### PR TITLE
Wrong parameter in scaleway sshkey module example

### DIFF
--- a/lib/ansible/modules/cloud/scaleway/scaleway_sshkey.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_sshkey.py
@@ -61,7 +61,7 @@ EXAMPLES = '''
 - name: "Add SSH key with explicit token"
   scaleway_sshkey:
     ssh_pub_key: "ssh-rsa AAAA..."
-    state: "Present"
+    state: "present"
     oauth_token: "6ecd2c9b-6f4f-44d4-a187-61a92078d08c"
 '''
 

--- a/lib/ansible/modules/cloud/scaleway/scaleway_sshkey.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_sshkey.py
@@ -51,7 +51,7 @@ EXAMPLES = '''
 - name: "Add SSH key"
   scaleway_sshkey:
     ssh_pub_key: "ssh-rsa AAAA..."
-    state: "Present"
+    state: "present"
 
 - name: "Delete SSH key"
   scaleway_sshkey:


### PR DESCRIPTION
##### SUMMARY
Documentation states that you have to add a SSH key with "Present", but the module is case sensitive

```
- name: "Add SSH key with explicit token"
  scaleway_sshkey:
    ssh_pub_key: "ssh-rsa AAAA..."
    state: "Present"
```

```
TASK [Add SSH key] **************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "value of state must be one of: present, absent, got: Present"}
        to retry, use: --limit @/root/Sources/ansible-bdx.io/scaleway/create_vms.retry
```
##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
scaleway_sshkey

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```ansible 2.7.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.7.0.dev0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]

```

##### ADDITIONAL INFORMATION

