### PR TITLE
[2.6] These won't get upgraded to bool if ansible doesn't know they are

### DIFF
--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -61,6 +61,7 @@ options:
       - name: ansible_password
       - name: ansible_httpapi_pass
   use_ssl:
+    type: boolean
     description:
       - Whether to connect using SSL (HTTPS) or not (HTTP)
     default: False


### PR DESCRIPTION
##### SUMMARY
Inspired by #45736, but that var doesn't exist yet, so label the one
that does exist.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
httpapi

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6
```