### PR TITLE
Add tags grouping in NetBox dynamic inventory plugin

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -42,6 +42,7 @@ DOCUMENTATION = '''
                 - sites
                 - tenants
                 - racks
+                - tags
                 - device_roles
                 - device_types
                 - manufacturers
@@ -162,6 +163,7 @@ class InventoryModule(BaseInventoryPlugin):
             "sites": self.extract_site,
             "tenants": self.extract_tenant,
             "racks": self.extract_rack,
+            "tags": self.extract_tags,
             "device_roles": self.extract_device_role,
             "device_types": self.extract_device_type,
             "manufacturers": self.extract_manufacturer
@@ -169,37 +171,37 @@ class InventoryModule(BaseInventoryPlugin):
 
     def extract_device_type(self, host):
         try:
-            return self.device_types_lookup[host["device_type"]["id"]]
+            return [self.device_types_lookup[host["device_type"]["id"]]]
         except Exception:
             return
 
     def extract_rack(self, host):
         try:
-            return self.racks_lookup[host["rack"]["id"]]
+            return [self.racks_lookup[host["rack"]["id"]]]
         except Exception:
             return
 
     def extract_site(self, host):
         try:
-            return self.sites_lookup[host["site"]["id"]]
+            return [self.sites_lookup[host["site"]["id"]]]
         except Exception:
             return
 
     def extract_tenant(self, host):
         try:
-            return self.tenants_lookup[host["tenant"]["id"]]
+            return [self.tenants_lookup[host["tenant"]["id"]]]
         except Exception:
             return
 
     def extract_device_role(self, host):
         try:
-            return self.device_roles_lookup[host["device_role"]["id"]]
+            return [self.device_roles_lookup[host["device_role"]["id"]]]
         except Exception:
             return
 
     def extract_manufacturer(self, host):
         try:
-            return self.manufacturers_lookup[host["device_type"]["manufacturer"]["id"]]
+            return [self.manufacturers_lookup[host["device_type"]["manufacturer"]["id"]]]
         except Exception:
             return
 
@@ -223,6 +225,9 @@ class InventoryModule(BaseInventoryPlugin):
             return str(ip_interface(address).ip)
         except Exception:
             return
+
+    def extract_tags(self, host):
+        return host["tags"]
 
     def refresh_sites_lookup(self):
         url = urljoin(self.api_endpoint, "/api/dcim/sites/?limit=0")
@@ -297,15 +302,16 @@ class InventoryModule(BaseInventoryPlugin):
         return host["name"] or str(uuid.uuid4())
 
     def add_host_to_groups(self, host, hostname):
-        for g in self.group_by:
-            group = self.group_extractors[g](host)
+        for group in self.group_by:
+            sub_groups = self.group_extractors[group](host)
 
-            if not group:
+            if not sub_groups:
                 continue
 
-            group_name = "_".join([g, group])
-            self.inventory.add_group(group=group_name)
-            self.inventory.add_host(group=group_name, host=hostname)
+            for sub_group in sub_groups:
+                group_name = "_".join([group, sub_group])
+                self.inventory.add_group(group=group_name)
+                self.inventory.add_host(group=group_name, host=hostname)
 
     def _fill_host_variables(self, host, hostname):
         for attribute, extractor in self.group_extractors.items():


### PR DESCRIPTION
##### SUMMARY

Add tags grouping for NetBox

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- lib/ansible/plugins/inventory/netbox.py

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (netbox_tag_grouping d7c57941bf) last updated 2018/09/17 18:04:31 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION

Now all group extractor returns a list of subgroups. Existing extractors return a list with a single element.