### PR TITLE
iam_role - fix example to remove managed policies

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -87,8 +87,7 @@ EXAMPLES = '''
   iam_role:
     name: mynewrole
     assume_role_policy_document: "{{ lookup('file','policy.json') }}"
-    managed_policy:
-      -
+    managed_policy: []
 
 - name: Delete the role
   iam_role:


### PR DESCRIPTION
##### SUMMARY
```
managed_policy:
  -
```
becomes [None] rather than []. Fix example syntax.

Fixes #45723

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
iam_role

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
```
