### PR TITLE
Make sure strings are bytes for Py2/3 compatibility in reboot plugin

### DIFF
--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -94,8 +94,8 @@ class ActionModule(ActionBase):
         return reboot_command
 
     def get_system_boot_time(self):
-        stdout = ''
-        stderr = ''
+        stdout = b''
+        stderr = b''
         command_result = self._low_level_execute_command(self.DEFAULT_BOOT_TIME_COMMAND, sudoable=self.DEFAULT_SUDOABLE)
 
         # For single board computers, e.g., Raspberry Pi, that lack a real time clock and are using fake-hwclock


### PR DESCRIPTION
##### SUMMARY

Make sure strings are bytes in `reboot.py`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`reboot.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
2.8
```
