### PR TITLE
[2.7] ec2_group: fix regression for targets that are a list containing strings and lists

### DIFF
--- a/changelogs/fragments/ec2_group_fix_target_containing_list_within_list.yaml
+++ b/changelogs/fragments/ec2_group_fix_target_containing_list_within_list.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - ec2_group - Sanitize the ingress and egress rules before operating on them by flattening any lists
+    within lists describing the target CIDR(s) into a list of strings. Prior to Ansible 2.6 the ec2_group
+    module accepted a list of strings, a list of lists, or a combination of strings and lists within a list.
+    https://github.com/ansible/ansible/pull/45594

--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -54,6 +54,7 @@
     - include: ./rule_group_create.yml
     - include: ./egress_tests.yml
     - include: ./data_validation.yml
+    - include: ./multi_nested_target.yml
 
     # ============================================================
     - name: test state=absent (CHECK MODE)

--- a/test/integration/targets/ec2_group/tasks/multi_nested_target.yml
+++ b/test/integration/targets/ec2_group/tasks/multi_nested_target.yml
@@ -1,0 +1,230 @@
+---
+  - name: set up aws connection info
+    set_fact:
+      aws_connection_info: &aws_connection_info
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        security_token: "{{ security_token }}"
+        region: "{{ aws_region }}"
+    no_log: yes
+
+  # ============================================================
+
+  - name: test state=present for multiple ipv6 and ipv4 targets (expected changed=true) (CHECK MODE)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      description: '{{ ec2_group_description }}'
+      state: present
+      rules:
+      - proto: "tcp"
+        from_port: 8182
+        to_port: 8182
+        cidr_ipv6:
+          - "64:ff9b::/96"
+          - ["2620::/32"]
+      - proto: "tcp"
+        ports: 5665
+        cidr_ip:
+          - 172.16.1.0/24
+          - 172.16.17.0/24
+          - ["10.0.0.0/24", "20.0.0.0/24"]
+      <<: *aws_connection_info
+    check_mode: true
+    register: result
+
+  - name: assert state=present (expected changed=true)
+    assert:
+      that:
+        - 'result.changed'
+
+  - name: test state=present for multiple ipv6 and ipv4 targets (expected changed=true)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      description: '{{ ec2_group_description }}'
+      state: present
+      rules:
+      - proto: "tcp"
+        from_port: 8182
+        to_port: 8182
+        cidr_ipv6:
+          - "64:ff9b::/96"
+          - ["2620::/32"]
+      - proto: "tcp"
+        ports: 5665
+        cidr_ip:
+          - 172.16.1.0/24
+          - 172.16.17.0/24
+          - ["10.0.0.0/24", "20.0.0.0/24"]
+      <<: *aws_connection_info
+    register: result
+
+  - name: assert state=present (expected changed=true)
+    assert:
+      that:
+        - 'result.changed'
+        - 'result.ip_permissions | length == 2'
+        - 'result.ip_permissions[0].ip_ranges | length == 4 or result.ip_permissions[1].ip_ranges | length == 4'
+        - 'result.ip_permissions[0].ipv6_ranges | length == 2 or result.ip_permissions[1].ipv6_ranges | length == 2'
+
+  - name: test state=present for multiple ipv6 and ipv4 targets (expected changed=false) (CHECK MODE)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      description: '{{ ec2_group_description }}'
+      state: present
+      rules:
+      - proto: "tcp"
+        from_port: 8182
+        to_port: 8182
+        cidr_ipv6:
+          - "64:ff9b::/96"
+          - ["2620::/32"]
+      - proto: "tcp"
+        ports: 5665
+        cidr_ip:
+          - 172.16.1.0/24
+          - 172.16.17.0/24
+          - ["10.0.0.0/24", "20.0.0.0/24"]
+      <<: *aws_connection_info
+    check_mode: true
+    register: result
+
+  - name: assert state=present (expected changed=true)
+    assert:
+      that:
+        - 'not result.changed'
+
+  - name: test state=present for multiple ipv6 and ipv4 targets (expected changed=false)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      description: '{{ ec2_group_description }}'
+      state: present
+      rules:
+      - proto: "tcp"
+        from_port: 8182
+        to_port: 8182
+        cidr_ipv6:
+          - "64:ff9b::/96"
+          - ["2620::/32"]
+      - proto: "tcp"
+        ports: 5665
+        cidr_ip:
+          - 172.16.1.0/24
+          - 172.16.17.0/24
+          - ["10.0.0.0/24", "20.0.0.0/24"]
+      <<: *aws_connection_info
+    register: result
+
+  - name: assert state=present (expected changed=true)
+    assert:
+      that:
+        - 'not result.changed'
+
+  - name: test state=present purging a nested ipv4 target (expected changed=true) (CHECK MODE)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      description: '{{ ec2_group_description }}'
+      state: present
+      rules:
+      - proto: "tcp"
+        from_port: 8182
+        to_port: 8182
+        cidr_ipv6:
+          - "64:ff9b::/96"
+          - ["2620::/32"]
+      - proto: "tcp"
+        ports: 5665
+        cidr_ip:
+          - 172.16.1.0/24
+          - 172.16.17.0/24
+          - ["10.0.0.0/24"]
+      <<: *aws_connection_info
+    check_mode: true
+    register: result
+
+  - assert:
+      that:
+        - result.changed
+
+  - name: test state=present purging a nested ipv4 target (expected changed=true)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      description: '{{ ec2_group_description }}'
+      state: present
+      rules:
+      - proto: "tcp"
+        from_port: 8182
+        to_port: 8182
+        cidr_ipv6:
+          - "64:ff9b::/96"
+          - ["2620::/32"]
+      - proto: "tcp"
+        ports: 5665
+        cidr_ip:
+          - 172.16.1.0/24
+          - 172.16.17.0/24
+          - ["10.0.0.0/24"]
+      <<: *aws_connection_info
+    register: result
+
+  - assert:
+      that:
+        - result.changed
+        - 'result.ip_permissions[0].ip_ranges | length == 3 or result.ip_permissions[1].ip_ranges | length == 3'
+        - 'result.ip_permissions[0].ipv6_ranges | length == 2 or result.ip_permissions[1].ipv6_ranges | length == 2'
+
+  - name: test state=present with both associated ipv6 targets nested (expected changed=false)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      description: '{{ ec2_group_description }}'
+      state: present
+      rules:
+      - proto: "tcp"
+        from_port: 8182
+        to_port: 8182
+        cidr_ipv6:
+          - ["2620::/32", "64:ff9b::/96"]
+      - proto: "tcp"
+        ports: 5665
+        cidr_ip:
+          - 172.16.1.0/24
+          - 172.16.17.0/24
+          - ["10.0.0.0/24"]
+      <<: *aws_connection_info
+    register: result
+
+  - assert:
+      that:
+        - not result.changed
+
+  - name: test state=present add another nested ipv6 target (expected changed=true)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      description: '{{ ec2_group_description }}'
+      state: present
+      rules:
+      - proto: "tcp"
+        from_port: 8182
+        to_port: 8182
+        cidr_ipv6:
+          - ["2620::/32", "64:ff9b::/96"]
+          - ["2001:DB8:A0B:12F0::1/64"]
+      - proto: "tcp"
+        ports: 5665
+        cidr_ip:
+          - 172.16.1.0/24
+          - 172.16.17.0/24
+          - ["10.0.0.0/24"]
+      <<: *aws_connection_info
+    register: result
+
+  - assert:
+      that:
+        - result.changed
+        - 'result.ip_permissions[0].ip_ranges | length == 3 or result.ip_permissions[1].ip_ranges | length == 3'
+        - 'result.ip_permissions[0].ipv6_ranges | length == 3 or result.ip_permissions[1].ipv6_ranges | length == 3'
+
+  - name: delete it
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      state: absent
+      <<: *aws_connection_info


### PR DESCRIPTION
##### SUMMARY
Backport #45594

ec2_group: fix regression for targets that are a list containing strings and lists (#45594)

* Fix targets that may be a list containing strings and lists which worked prior to 2.6.

* Add ec2_group integration tests for lists of nested targets

* changelog

* Add diff mode support for lists of targets containing strings and lists.

(cherry picked from commit d7ca3f2bd3f6bbd0877e684fe136a02b7a74cb79)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_group

##### ANSIBLE VERSION
```
2.7
```
