### PR TITLE
incorrect sample eos_config usage

### DIFF
--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -213,11 +213,6 @@ EXAMPLES = """
   eos_config:
     lines: hostname {{ inventory_hostname }}
 
-- name: diff against a provided master config
-  eos_config:
-    diff_against: config
-    config: "{{ lookup('file', 'master.cfg') }}"
-
 - name: load an acl into the device
   eos_config:
     lines:


### PR DESCRIPTION
no such option "config" for diff_against argument.
Further below, there is an example of eos_config using diff_against with a valid option.
+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
