### PR TITLE
[2.7] only create a recordings directory when the env var is set

### DIFF
--- a/test/units/utils/amazon_placebo_fixtures.py
+++ b/test/units/utils/amazon_placebo_fixtures.py
@@ -61,12 +61,16 @@ def placeboify(request, monkeypatch):
         # remove the test_ prefix from the function & file name
     ).replace('test_', '')
 
-    try:
-        # make sure the directory for placebo test recordings is available
-        os.makedirs(recordings_path)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
+    if not os.getenv('PLACEBO_RECORD'):
+        if not os.path.isdir(recordings_path):
+            raise NotImplementedError('Missing Placebo recordings in directory: %s' % recordings_path)
+    else:
+        try:
+            # make sure the directory for placebo test recordings is available
+            os.makedirs(recordings_path)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
 
     pill = placebo.attach(session, data_path=recordings_path)
     if os.getenv('PLACEBO_RECORD'):


### PR DESCRIPTION
* Only create placebo recording test directories when the environment variable PLACEBO_RECORD is set
(cherry picked from commit 5467ac3454d684470917ddf399b3a9bbd430488d)

##### SUMMARY
Backport #45752

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
test/units/utils/amazon_placebo_fixtures.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
2.7
```
