### PR TITLE
[2.7] Remove placeboify from unit tests that are not creating a recording file

### DIFF
--- a/test/units/modules/cloud/amazon/test_cloudformation.py
+++ b/test/units/modules/cloud/amazon/test_cloudformation.py
@@ -120,7 +120,7 @@ def test_get_nonexistent_stack(placeboify):
     assert cfn_module.get_stack_facts(connection, 'ansible-test-nonexist') is None
 
 
-def test_missing_template_body(placeboify):
+def test_missing_template_body():
     m = FakeModule()
     with pytest.raises(Exception, message='Expected module to fail with no template') as exc_info:
         cfn_module.create_stack(

--- a/test/units/modules/cloud/amazon/test_data_pipeline.py
+++ b/test/units/modules/cloud/amazon/test_data_pipeline.py
@@ -180,33 +180,33 @@ def test_delete_pipeline(placeboify, maybe_sleep):
     assert changed is True
 
 
-def test_build_unique_id_different(placeboify, maybe_sleep):
+def test_build_unique_id_different():
     m = FakeModule(**{'name': 'ansible-unittest-1', 'description': 'test-unique-id'})
     m2 = FakeModule(**{'name': 'ansible-unittest-1', 'description': 'test-unique-id-different'})
     assert data_pipeline.build_unique_id(m) != data_pipeline.build_unique_id(m2)
 
 
-def test_build_unique_id_same(placeboify, maybe_sleep):
+def test_build_unique_id_same():
     m = FakeModule(**{'name': 'ansible-unittest-1', 'description': 'test-unique-id', 'tags': {'ansible': 'test'}})
     m2 = FakeModule(**{'name': 'ansible-unittest-1', 'description': 'test-unique-id', 'tags': {'ansible': 'test'}})
     assert data_pipeline.build_unique_id(m) == data_pipeline.build_unique_id(m2)
 
 
-def test_build_unique_id_obj(placeboify, maybe_sleep):
+def test_build_unique_id_obj():
     # check that the object can be different and the unique id should be the same; should be able to modify objects
     m = FakeModule(**{'name': 'ansible-unittest-1', 'objects': [{'first': 'object'}]})
     m2 = FakeModule(**{'name': 'ansible-unittest-1', 'objects': [{'second': 'object'}]})
     assert data_pipeline.build_unique_id(m) == data_pipeline.build_unique_id(m2)
 
 
-def test_format_tags(placeboify, maybe_sleep):
+def test_format_tags():
     unformatted_tags = {'key1': 'val1', 'key2': 'val2', 'key3': 'val3'}
     formatted_tags = data_pipeline.format_tags(unformatted_tags)
     for tag_set in formatted_tags:
         assert unformatted_tags[tag_set['key']] == tag_set['value']
 
 
-def test_format_empty_tags(placeboify, maybe_sleep):
+def test_format_empty_tags():
     unformatted_tags = {}
     formatted_tags = data_pipeline.format_tags(unformatted_tags)
     assert formatted_tags == []


### PR DESCRIPTION
(cherry picked from commit 2167ce6cb6db57bf066dce83a5a03978a13bf1ef)

##### SUMMARY
Backport #45754

Placebo was creating empty directories needlessly for unit tests that don't query AWS. Since empty directories aren't added by git, this led to unexpected permission errors in CI when it tried creating the expected directories.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/units/modules/cloud/amazon

##### ANSIBLE VERSION
```
2.7
```
