### PR TITLE
vmware_vm_shell - fix to return a tuple instead of a bool

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
@@ -291,7 +291,7 @@ class VMwareShellManager(PyVmomi):
     def process_exists_in_guest(self, vm, pid, creds):
         res = self.pm.ListProcessesInGuest(vm, creds, pids=[pid])
         if not res:
-            return False
+            return False, ''
         res = res[0]
         if res.exitCode is None:
             return True, ''


### PR DESCRIPTION
##### SUMMARY
Fixes "'bool' object is not iterable" exception when `self.pm.ListProcessesInGuest` returns falsey.

Currently if res does not exist (or is falsey) in `process_exists_in_guest`, the function returns a single Boolean rather than a tuple, which causes `wait_for_process` to raise "'bool' object is not iterable.

This PR just adds an empty string so that the return fits the expected usage in wait_for_process.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloud/vmware/vmware_vm_shell.py

##### ANSIBLE VERSION
2.7.0.dev0

##### ADDITIONAL INFORMATION

