### PR TITLE
[2.6] docker_container: don't parse/interpret options if state is 'absent'

### DIFF
--- a/changelogs/fragments/45700-docker_container-dont-parse-absent.yml
+++ b/changelogs/fragments/45700-docker_container-dont-parse-absent.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Don't parse parameters and options when ``state`` is ``absent`` (https://github.com/ansible/ansible/pull/45700)."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -730,6 +730,11 @@ class TaskParameters(DockerBaseClass):
         for key, value in client.module.params.items():
             setattr(self, key, value)
 
+        # If state is 'absent', parameters do not have to be parsed or interpreted.
+        # Only the container's name is needed.
+        if self.state == 'absent':
+            return
+
         for param_name in REQUIRES_CONVERSION_TO_BYTES:
             if client.module.params.get(param_name):
                 try:


### PR DESCRIPTION
##### SUMMARY
Backport of #45700 to `stable-2.6`: don't parse and/or interpret options (ports, networks, IP addresses, ...) when state is 'absent' (fixed #45486).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.6.4
```
