### PR TITLE
Fix unit test parametrize order on Python 3.5.

### DIFF
--- a/test/units/module_utils/basic/test_log.py
+++ b/test/units/module_utils/basic/test_log.py
@@ -55,21 +55,23 @@ class TestAnsibleModuleLogSmokeTest:
 class TestAnsibleModuleLogSyslog:
     """Test the AnsibleModule Log Method"""
 
-    PY2_OUTPUT_DATA = {
-        u'Text string': b'Text string',
-        u'Toshio くらとみ non-ascii test': u'Toshio くらとみ non-ascii test'.encode('utf-8'),
-        b'Byte string': b'Byte string',
-        u'Toshio くらとみ non-ascii test'.encode('utf-8'): u'Toshio くらとみ non-ascii test'.encode('utf-8'),
-        b'non-utf8 :\xff: test': b'non-utf8 :\xff: test'.decode('utf-8', 'replace').encode('utf-8'),
-    }
+    PY2_OUTPUT_DATA = [
+        (u'Text string', b'Text string'),
+        (u'Toshio くらとみ non-ascii test', u'Toshio くらとみ non-ascii test'.encode('utf-8')),
+        (b'Byte string', b'Byte string'),
+        (u'Toshio くらとみ non-ascii test'.encode('utf-8'), u'Toshio くらとみ non-ascii test'.encode('utf-8')),
+        (b'non-utf8 :\xff: test', b'non-utf8 :\xff: test'.decode('utf-8', 'replace').encode('utf-8')),
+    ]
 
-    PY3_OUTPUT_DATA = {
-        u'Text string': u'Text string',
-        u'Toshio くらとみ non-ascii test': u'Toshio くらとみ non-ascii test',
-        b'Byte string': u'Byte string',
-        u'Toshio くらとみ non-ascii test'.encode('utf-8'): u'Toshio くらとみ non-ascii test',
-        b'non-utf8 :\xff: test': b'non-utf8 :\xff: test'.decode('utf-8', 'replace')
-    }
+    PY3_OUTPUT_DATA = [
+        (u'Text string', u'Text string'),
+        (u'Toshio くらとみ non-ascii test', u'Toshio くらとみ non-ascii test'),
+        (b'Byte string', u'Byte string'),
+        (u'Toshio くらとみ non-ascii test'.encode('utf-8'), u'Toshio くらとみ non-ascii test'),
+        (b'non-utf8 :\xff: test', b'non-utf8 :\xff: test'.decode('utf-8', 'replace')),
+    ]
+
+    OUTPUT_DATA = PY3_OUTPUT_DATA if PY3 else PY2_OUTPUT_DATA
 
     @pytest.mark.parametrize('no_log, stdin', (product((True, False), [{}])), indirect=['stdin'])
     def test_no_log(self, am, mocker, no_log):
@@ -85,8 +87,7 @@ class TestAnsibleModuleLogSyslog:
 
     # pylint bug: https://github.com/PyCQA/pylint/issues/511
     @pytest.mark.parametrize('msg, param, stdin',
-                             ((m, p, {}) for m, p in
-                              (PY3_OUTPUT_DATA.items() if PY3 else PY2_OUTPUT_DATA.items())),  # pylint: disable=undefined-variable
+                             ((m, p, {}) for m, p in OUTPUT_DATA),  # pylint: disable=undefined-variable
                              indirect=['stdin'])
     def test_output_matches(self, am, mocker, msg, param):
         """Check that log messages are sent correctly"""
@@ -101,13 +102,13 @@ class TestAnsibleModuleLogSyslog:
 class TestAnsibleModuleLogJournal:
     """Test the AnsibleModule Log Method"""
 
-    OUTPUT_DATA = {
-        u'Text string': u'Text string',
-        u'Toshio くらとみ non-ascii test': u'Toshio くらとみ non-ascii test',
-        b'Byte string': u'Byte string',
-        u'Toshio くらとみ non-ascii test'.encode('utf-8'): u'Toshio くらとみ non-ascii test',
-        b'non-utf8 :\xff: test': b'non-utf8 :\xff: test'.decode('utf-8', 'replace')
-    }
+    OUTPUT_DATA = [
+        (u'Text string', u'Text string'),
+        (u'Toshio くらとみ non-ascii test', u'Toshio くらとみ non-ascii test'),
+        (b'Byte string', u'Byte string'),
+        (u'Toshio くらとみ non-ascii test'.encode('utf-8'), u'Toshio くらとみ non-ascii test'),
+        (b'non-utf8 :\xff: test', b'non-utf8 :\xff: test'.decode('utf-8', 'replace')),
+    ]
 
     @pytest.mark.parametrize('no_log, stdin', (product((True, False), [{}])), indirect=['stdin'])
     def test_no_log(self, am, mocker, no_log):
@@ -127,7 +128,7 @@ class TestAnsibleModuleLogJournal:
 
     # pylint bug: https://github.com/PyCQA/pylint/issues/511
     @pytest.mark.parametrize('msg, param, stdin',
-                             ((m, p, {}) for m, p in OUTPUT_DATA.items()),  # pylint: disable=undefined-variable
+                             ((m, p, {}) for m, p in OUTPUT_DATA),  # pylint: disable=undefined-variable
                              indirect=['stdin'])
     def test_output_matches(self, am, mocker, msg, param):
         journal_send = mocker.patch('systemd.journal.send')

--- a/test/units/module_utils/test_database.py
+++ b/test/units/module_utils/test_database.py
@@ -73,8 +73,8 @@ HOW_MANY_DOTS = (
      'PostgreSQL does not support column with more than 4 dots'),
 )
 
-VALID_QUOTES = ((test, VALID[test]) for test in VALID)
-INVALID_QUOTES = ((test[0], test[1], INVALID[test]) for test in INVALID)
+VALID_QUOTES = ((test, VALID[test]) for test in sorted(VALID))
+INVALID_QUOTES = ((test[0], test[1], INVALID[test]) for test in sorted(INVALID))
 
 
 @pytest.mark.parametrize("identifier, quoted_identifier", VALID_QUOTES)

--- a/test/units/module_utils/test_known_hosts.py
+++ b/test/units/module_utils/test_known_hosts.py
@@ -85,19 +85,19 @@ URLS = {
 }
 
 
-@pytest.mark.parametrize('url, is_ssh_url', ((k, v['is_ssh_url']) for k, v in URLS.items()))
+@pytest.mark.parametrize('url, is_ssh_url', ((k, URLS[k]['is_ssh_url']) for k in sorted(URLS)))
 def test_is_ssh_url(url, is_ssh_url):
     assert known_hosts.is_ssh_url(url) == is_ssh_url
 
 
-@pytest.mark.parametrize('url, fqdn, port', ((k, v['get_fqdn'], v['port']) for k, v in URLS.items()))
+@pytest.mark.parametrize('url, fqdn, port', ((k, URLS[k]['get_fqdn'], URLS[k]['port']) for k in sorted(URLS)))
 def test_get_fqdn_and_port(url, fqdn, port):
     assert known_hosts.get_fqdn_and_port(url) == (fqdn, port)
 
 
 @pytest.mark.parametrize('fqdn, port, add_host_key_cmd, stdin',
-                         ((v['get_fqdn'], v['port'], v['add_host_key_cmd'], {})
-                          for v in URLS.values() if v['is_ssh_url']),
+                         ((URLS[k]['get_fqdn'], URLS[k]['port'], URLS[k]['add_host_key_cmd'], {})
+                          for k in sorted(URLS) if URLS[k]['is_ssh_url']),
                          indirect=['stdin'])
 def test_add_host_key(am, mocker, fqdn, port, add_host_key_cmd):
     get_bin_path = mocker.MagicMock()


### PR DESCRIPTION
##### SUMMARY

Fix unit test parametrize order on Python 3.5.

This provides deterministic ordering of parametrized tests.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

unit tests

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (units-order-fix 34c91ab796) last updated 2018/09/17 22:18:35 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
