### PR TITLE
vmware_vm_facts: custom attributes support

### DIFF
--- a/test/integration/targets/vmware_vm_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vm_facts/tasks/main.yml
@@ -1,5 +1,6 @@
 # Test code for the vmware_vm_facts module
 # Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
+# Copyright, (c) 2018, Fedor Vompe <f.vompe@comptek.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: store the vcenter container ip
@@ -73,6 +74,7 @@
       - "item.power_state is defined"
       - "item.uuid is defined"
       - "item.vm_network is defined"
+      - "item.attributes is defined"
   with_items:
     - "{{ vm_facts_0001.virtual_machines | json_query(query) }}"
   vars:


### PR DESCRIPTION
##### SUMMARY
Adding support for `attributes` in vmware_vm_facts module.
Attributes are key-value pair assigned for each Virtual Machine.
In vSphere they are present in Custom Attributes section.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cloud/vmware/vmware_vm_facts module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.4
  config file = <SCRUBBED>
  configured module search path = [u'<SCRUBBED>']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Feb 20 2018, 09:19:12) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```