### PR TITLE
Fix missing exceptions

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_quota.py
+++ b/lib/ansible/modules/cloud/openstack/os_quota.py
@@ -249,12 +249,12 @@ def _get_quotas(sdk, module, cloud, project):
     quota = {}
     try:
         quota['volume'] = _get_volume_quotas(cloud, project)
-    except sdk.exceptions.OpenStackCloudURINotFound:
+    except sdk.exceptions.NotFoundException:
         module.warn("No public endpoint for volumev2 service was found. Ignoring volume quotas.")
 
     try:
         quota['network'] = _get_network_quotas(cloud, project)
-    except sdk.exceptions.OpenStackCloudURINotFound:
+    except sdk.exceptions.NotFoundException:
         module.warn("No public endpoint for network service was found. Ignoring network quotas.")
 
     quota['compute'] = _get_compute_quotas(cloud, project)

--- a/lib/ansible/modules/cloud/openstack/os_server_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_volume.py
@@ -139,7 +139,7 @@ def main():
                 result='Detached volume from server'
             )
 
-    except (sdk.exceptions.OpenStackCloudException, sdk.exceptions.OpenStackCloudTimeout) as e:
+    except (sdk.exceptions.OpenStackCloudException, sdk.exceptions.ResourceTimeout) as e:
         module.fail_json(msg=str(e))
 
 

--- a/lib/ansible/modules/cloud/openstack/os_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume.py
@@ -124,7 +124,7 @@ def _absent_volume(module, cloud, sdk):
             changed = cloud.delete_volume(name_or_id=module.params['display_name'],
                                           wait=module.params['wait'],
                                           timeout=module.params['timeout'])
-        except sdk.exceptions.OpenStackCloudTimeout:
+        except sdk.exceptions.ResourceTimeout:
             module.exit_json(changed=changed)
 
     module.exit_json(changed=changed)

--- a/lib/ansible/modules/cloud/openstack/os_volume_snapshot.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume_snapshot.py
@@ -186,7 +186,7 @@ def main():
             module.fail_json(
                 msg="No volume with name or id '{0}' was found.".format(
                     module.params['volume']))
-    except (sdk.exceptions.OpenStackCloudException, sdk.exceptions.OpenStackCloudTimeout) as e:
+    except (sdk.exceptions.OpenStackCloudException, sdk.exceptions.ResourceTimeout) as e:
         module.fail_json(msg=e.message)
 
 


### PR DESCRIPTION
##### SUMMARY
Replace non-existing OpenStackCloudTimeout exception. Fixes: #45151
Replace OpenStackCloudURINotFound that doesn't exist in the 'exceptions' module

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
os_volume
os_volume_snapshot
os_quota
os_server_volume

##### ANSIBLE VERSION
```
ansible-playbook 2.6.3
  config file = /Users/nowaka/git/nk2/nk2-ci-ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
Several modules refer to exceptions that don't exist in the openstacksdk exceptions module. 
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
