### PR TITLE
Extend java_cert module to handle common files properties.

### DIFF
--- a/lib/ansible/modules/system/java_cert.py
+++ b/lib/ansible/modules/system/java_cert.py
@@ -24,7 +24,7 @@ options:
       - Basic URL to fetch SSL certificate from. One of cert_url or cert_path is required to load certificate.
   cert_port:
     description:
-      - Port to connect to URL. This will be used to create server URL:PORT
+      - Port to connect to URL. This will be used to create server C(URL:PORT)
     default: 443
   cert_path:
     description:
@@ -59,7 +59,7 @@ options:
       - Create keystore if it doesn't exist
   executable:
     description:
-      - Path to keytool binary if not used we search in PATH for it.
+      - Path to keytool binary if not used we search in C(PATH) for it.
     default: keytool
   state:
     description:

--- a/lib/ansible/modules/system/java_cert.py
+++ b/lib/ansible/modules/system/java_cert.py
@@ -319,16 +319,14 @@ def main():
     cert_present = check_cert_present(module, executable, keystore_path,
                                       keystore_pass, cert_alias)
 
-    if state == 'absent':
-        if cert_present:
+    if state == 'absent' and cert_present:
 
             if module.check_mode:
                 module.exit_json(changed=True)
 
             delete_cert(module, executable, keystore_path, keystore_pass, cert_alias)
 
-    elif state == 'present':
-        if not cert_present:
+    elif state == 'present' and not cert_present:
 
             if module.check_mode:
                 module.exit_json(changed=True)

--- a/lib/ansible/modules/system/java_cert.py
+++ b/lib/ansible/modules/system/java_cert.py
@@ -171,9 +171,6 @@ def import_cert_url(module, executable, url, port, keystore_path, keystore_pass,
                   "-storepass '%s' -alias '%s'") % (executable, keystore_path,
                                                     keystore_pass, alias)
 
-    if module.check_mode:
-        module.exit_json(changed=True)
-
     # Fetch SSL certificate from remote host.
     (_, fetch_out, _) = module.run_command(fetch_cmd, check_rc=True)
 
@@ -200,9 +197,6 @@ def import_cert_path(module, executable, path, keystore_path, keystore_pass, ali
                                                                keystore_pass,
                                                                path, alias)
 
-    if module.check_mode:
-        module.exit_json(changed=True)
-
     # Use local certificate from local path and import it to a java keystore
     (import_rc, import_out, import_err) = module.run_command(import_cmd,
                                                              check_rc=False)
@@ -224,9 +218,6 @@ def import_pkcs12_path(module, executable, path, keystore_path, keystore_pass, p
                   "-srcalias '%s' -destalias '%s'") % (executable, keystore_path, keystore_pass,
                                                        keystore_pass, path, pkcs12_pass, pkcs12_alias, alias)
 
-    if module.check_mode:
-        module.exit_json(changed=True)
-
     # Use local certificate from local path and import it to a java keystore
     (import_rc, import_out, import_err) = module.run_command(import_cmd,
                                                              check_rc=False)
@@ -244,9 +235,6 @@ def delete_cert(module, executable, keystore_path, keystore_pass, alias):
     ''' Delete certificate identified with alias from keystore on keystore_path '''
     del_cmd = ("%s -delete -keystore '%s' -storepass '%s' "
                "-alias '%s'") % (executable, keystore_path, keystore_pass, alias)
-
-    if module.check_mode:
-        module.exit_json(changed=True)
 
     # Delete SSL certificate from keystore
     (del_rc, del_out, del_err) = module.run_command(del_cmd, check_rc=True)
@@ -333,10 +321,18 @@ def main():
 
     if state == 'absent':
         if cert_present:
+
+            if module.check_mode:
+                module.exit_json(changed=True)
+
             delete_cert(module, executable, keystore_path, keystore_pass, cert_alias)
 
     elif state == 'present':
         if not cert_present:
+
+            if module.check_mode:
+                module.exit_json(changed=True)
+
             if pkcs12_path:
                 import_pkcs12_path(module, executable, pkcs12_path, keystore_path,
                                    keystore_pass, pkcs12_pass, pkcs12_alias, cert_alias)

--- a/lib/ansible/modules/system/java_cert.py
+++ b/lib/ansible/modules/system/java_cert.py
@@ -183,12 +183,12 @@ def import_cert_url(module, executable, url, port, keystore_path, keystore_pass,
                                                              check_rc=False)
     diff = {'before': '\n', 'after': '%s\n' % alias}
     if import_rc == 0:
-        return module.exit_json(changed=True, msg=import_out,
-                                rc=import_rc, cmd=import_cmd, stdout=import_out,
-                                diff=diff)
+        module.exit_json(changed=True, msg=import_out,
+                         rc=import_rc, cmd=import_cmd, stdout=import_out,
+                         diff=diff)
     else:
-        return module.fail_json(msg=import_out, rc=import_rc, cmd=import_cmd,
-                                error=import_err)
+        module.fail_json(msg=import_out, rc=import_rc, cmd=import_cmd,
+                         error=import_err)
 
 
 def import_cert_path(module, executable, path, keystore_path, keystore_pass, alias):
@@ -209,11 +209,11 @@ def import_cert_path(module, executable, path, keystore_path, keystore_pass, ali
 
     diff = {'before': '\n', 'after': '%s\n' % alias}
     if import_rc == 0:
-        return module.exit_json(changed=True, msg=import_out,
-                                rc=import_rc, cmd=import_cmd, stdout=import_out,
-                                error=import_err, diff=diff)
+        module.exit_json(changed=True, msg=import_out,
+                         rc=import_rc, cmd=import_cmd, stdout=import_out,
+                         error=import_err, diff=diff)
     else:
-        return module.fail_json(msg=import_out, rc=import_rc, cmd=import_cmd)
+        module.fail_json(msg=import_out, rc=import_rc, cmd=import_cmd)
 
 
 def import_pkcs12_path(module, executable, path, keystore_path, keystore_pass, pkcs12_pass, pkcs12_alias, alias):
@@ -233,11 +233,11 @@ def import_pkcs12_path(module, executable, path, keystore_path, keystore_pass, p
 
     diff = {'before': '\n', 'after': '%s\n' % alias}
     if import_rc == 0:
-        return module.exit_json(changed=True, msg=import_out,
-                                rc=import_rc, cmd=import_cmd, stdout=import_out,
-                                error=import_err, diff=diff)
+        module.exit_json(changed=True, msg=import_out,
+                         rc=import_rc, cmd=import_cmd, stdout=import_out,
+                         error=import_err, diff=diff)
     else:
-        return module.fail_json(msg=import_out, rc=import_rc, cmd=import_cmd)
+        module.fail_json(msg=import_out, rc=import_rc, cmd=import_cmd)
 
 
 def delete_cert(module, executable, keystore_path, keystore_pass, alias):
@@ -253,9 +253,9 @@ def delete_cert(module, executable, keystore_path, keystore_pass, alias):
 
     diff = {'before': '%s\n' % alias, 'after': None}
 
-    return module.exit_json(changed=True, msg=del_out,
-                            rc=del_rc, cmd=del_cmd, stdout=del_out,
-                            error=del_err, diff=diff)
+    module.exit_json(changed=True, msg=del_out,
+                     rc=del_rc, cmd=del_cmd, stdout=del_out,
+                     error=del_err, diff=diff)
 
 
 def test_keytool(module, executable):
@@ -272,9 +272,8 @@ def test_keystore(module, keystore_path):
 
     if not os.path.exists(keystore_path) and not os.path.isfile(keystore_path):
         # Keystore doesn't exist we want to create it
-        return module.fail_json(changed=False,
-                                msg="Module require existing keystore at keystore_path '%s'"
-                                    % (keystore_path))
+        module.fail_json(changed=False,
+                         msg="Module require existing keystore at keystore_path '%s'" % (keystore_path))
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY

Code contribution against java_cert.

This commit handle common files properties (mode, owner group). I also added the possibility to import a certificate using a new field cert_content. This way, you don't need to transfert certificate on remote host.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

java_cert

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (java_cert d59f2c494f) last updated 2018/09/18 14:43:24 (GMT +200)
  config file = /home/yannig/.ansible.cfg
  configured module search path = [u'/home/yannig/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/yannig/dev/ansible/lib/ansible
  executable location = /home/yannig/dev/ansible/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION

Here an example of this new field (cert_content):

```
- name: Import SSL certificate from local file to a given cacerts keystore
  java_cert:
    cert_content: "{{q('file', inventory_dir+'/certs/cert.pem')}}"
    cert_port: 443
    keystore_path: /etc/ssl/certs/java/cacerts
    keystore_pass: changeit
    state: present
```
