### PR TITLE
ec2_group - fix VPC precedence for security group targets

### DIFF
--- a/changelogs/fragments/fix_ec2_group_target_vpc_precedence.yaml
+++ b/changelogs/fragments/fix_ec2_group_target_vpc_precedence.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - ec2_group - There can be multiple security groups with the same name in
+    different VPCs. Prior to 2.6 if a target group name was provided, the group
+    matching the name and VPC had highest precedence. Restore this behavior by
+    updated the dictionary with the groups matching the VPC last.

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -855,6 +855,9 @@ def group_exists(client, module, vpc_id, group_id, name):
     if security_groups:
         groups = dict((group['GroupId'], group) for group in all_groups)
         groups.update(dict((group['GroupName'], group) for group in all_groups))
+        if vpc_id:
+            vpc_wins = dict((group['GroupName'], group) for group in all_groups if group['VpcId'] == vpc_id)
+            groups.update(vpc_wins)
         # maintain backwards compatibility by using the last matching group
         return security_groups[-1], groups
     return None, {}


### PR DESCRIPTION
##### SUMMARY
Update the dictionary with the preferred values last to get the right order of VPC precedence

Fixes #45782

This should be backported to 2.6 and 2.7.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_group

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
```
