### PR TITLE
Backport #45607 and #45746 for 2.7 -  reboot plugin fix variable and support bare Linux

### DIFF
--- a/changelogs/fragments/reboot-unicode-string.yaml
+++ b/changelogs/fragments/reboot-unicode-string.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - reboot - use unicode instead of bytes for stdout and stderr to match the
+    type returned from low_level_execute()

--- a/changelogs/fragments/reboot-var-fix-bare-linux.yaml
+++ b/changelogs/fragments/reboot-var-fix-bare-linux.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - reboot - use correct syntax for fetching a value from a dict and account for bare Linux systems (https://github.com/ansible/ansible/pull/45607#issuecomment-422403177)

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -94,6 +94,8 @@ class ActionModule(ActionBase):
         return reboot_command
 
     def get_system_boot_time(self):
+        stdout = ''
+        stderr = ''
         command_result = self._low_level_execute_command(self.DEFAULT_BOOT_TIME_COMMAND, sudoable=self.DEFAULT_SUDOABLE)
 
         # For single board computers, e.g., Raspberry Pi, that lack a real time clock and are using fake-hwclock
@@ -101,11 +103,22 @@ class ActionModule(ActionBase):
         # Fall back to using uptime -s for those systems.
         # https://github.com/systemd/systemd/issues/6057
         if '1970-01-01 00:00' in command_result['stdout']:
+            stdout += command_result['stdout']
+            stderr += command_result['stderr']
             command_result = self._low_level_execute_command('uptime -s', sudoable=self.DEFAULT_SUDOABLE)
 
+        # This is a last resort for bare Linux systems (e.g. OpenELEC) where 'who -b' or 'uptime -s' are not supported.
+        # Other options like parsing /proc/uptime or default uptime output are less reliable than this
         if command_result['rc'] != 0:
+            stdout += command_result['stdout']
+            stderr += command_result['stderr']
+            command_result = self._low_level_execute_command('cat /proc/sys/kernel/random/boot_id', sudoable=self.DEFAULT_SUDOABLE)
+
+        if command_result['rc'] != 0:
+            stdout += command_result['stdout']
+            stderr += command_result['stderr']
             raise AnsibleError("%s: failed to get host boot time info, rc: %d, stdout: %s, stderr: %s"
-                               % (self._task.action, command_result.rc, to_native(command_result['stdout']), to_native(command_result['stderr'])))
+                               % (self._task.action, command_result['rc'], to_native(stdout), to_native(stderr)))
 
         return command_result['stdout'].strip()
 

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -94,8 +94,8 @@ class ActionModule(ActionBase):
         return reboot_command
 
     def get_system_boot_time(self):
-        stdout = ''
-        stderr = ''
+        stdout = u''
+        stderr = u''
         command_result = self._low_level_execute_command(self.DEFAULT_BOOT_TIME_COMMAND, sudoable=self.DEFAULT_SUDOABLE)
 
         # For single board computers, e.g., Raspberry Pi, that lack a real time clock and are using fake-hwclock


### PR DESCRIPTION
##### SUMMARY
Backport of #45607 and #45746 for Ansible 2.7

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`reboot.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```