### PR TITLE
Add eigrp as a possible l3protocol in aci_l3out

### DIFF
--- a/lib/ansible/modules/network/aci/aci_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_l3out.py
@@ -62,6 +62,10 @@ options:
     - Routing protocol for the L3Out
     type: list
     choices: [ static, bgp, ospf, eigrp, pim ]
+  asn:
+    description:
+    - The AS number for the L3Out. Only applicable when using 'eigrp' as the l3protocol
+    aliases: [ as_number ]
   description:
     description:
     - Description for the L3Out.

--- a/lib/ansible/modules/network/aci/aci_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_l3out.py
@@ -265,7 +265,7 @@ def main():
     asn = module.params['asn']
     state = module.params['state']
     tenant = module.params['tenant']
-    
+
     if asn and 'eigrp' not in l3protocol:
         module._warnings = ["Parameter 'asn' is only applicable when l3protocol is 'eigrp'. The ASN will be ignored"]
     if not asn and 'eigrp' in l3protocol:

--- a/lib/ansible/modules/network/aci/aci_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_l3out.py
@@ -61,7 +61,7 @@ options:
     description:
     - Routing protocol for the L3Out
     type: list
-    choices: [ static, bgp, eigrp, ospf, pim ]
+    choices: [ bgp, eigrp, ospf, pim, static ]
   asn:
     description:
     - The AS number for the L3Out. Only applicable when using 'eigrp' as the l3protocol
@@ -239,7 +239,7 @@ def main():
                   choices=['AF11', 'AF12', 'AF13', 'AF21', 'AF22', 'AF23', 'AF31', 'AF32', 'AF33', 'AF41', 'AF42',
                            'AF43', 'CS0', 'CS1', 'CS2', 'CS3', 'CS4', 'CS5', 'CS6', 'CS7', 'EF', 'VA', 'unspecified'],
                   aliases=['target']),
-        l3protocol=dict(type='list', choices=['static', 'bgp', 'eigrp', 'ospf', 'pim']),
+        l3protocol=dict(type='list', choices=['bgp', 'eigrp', 'ospf', 'pim', 'static']),
         asn=dict(type='int', aliases=['as_number']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query'])
     )
@@ -266,10 +266,10 @@ def main():
     state = module.params['state']
     tenant = module.params['tenant']
 
-    if asn and 'eigrp' not in l3protocol:
-        module._warnings = ["Parameter 'asn' is only applicable when l3protocol is 'eigrp'. The ASN will be ignored"]
-    if not asn and 'eigrp' in l3protocol:
+    if 'eigrp' in l3protocol and asn is None:
         module.fail_json(msg="Parameter 'asn' is required when l3protocol is 'eigrp'")
+    if 'eigrp' not in l3protocol and asn is not None:
+        module.warn("Parameter 'asn' is only applicable when l3protocol is 'eigrp'. The ASN will be ignored")
 
     enforce_ctrl = ''
     if enforceRtctrl is not None:

--- a/lib/ansible/modules/network/aci/aci_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_l3out.py
@@ -61,7 +61,7 @@ options:
     description:
     - Routing protocol for the L3Out
     type: list
-    choices: [ static, bgp, ospf, pim ]
+    choices: [ static, bgp, ospf, eigrp, pim ]
   description:
     description:
     - Description for the L3Out.
@@ -234,7 +234,8 @@ def main():
                   choices=['AF11', 'AF12', 'AF13', 'AF21', 'AF22', 'AF23', 'AF31', 'AF32', 'AF33', 'AF41', 'AF42',
                            'AF43', 'CS0', 'CS1', 'CS2', 'CS3', 'CS4', 'CS5', 'CS6', 'CS7', 'EF', 'VA', 'unspecified'],
                   aliases=['target']),
-        l3protocol=dict(type='list', choices=['static', 'bgp', 'ospf', 'pim']),
+        l3protocol=dict(type='list', choices=['static', 'bgp', 'ospf', 'eigrp', 'pim']),
+        asn=dict(type='str', aliases=['as_number']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query'])
     )
 
@@ -242,8 +243,8 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ['state', 'absent', ['name', 'tenant']],
-            ['state', 'present', ['name', 'tenant', 'domain', 'vrf']],
+            ['state', 'absent', ['l3out', 'tenant']],
+            ['state', 'present', ['l3out', 'tenant', 'domain', 'vrf']],
         ],
     )
 
@@ -256,6 +257,7 @@ def main():
     enforceRtctrl = module.params['route_control']
     vrf = module.params['vrf']
     l3protocol = module.params['l3protocol']
+    asn = module.params['asn']
     state = module.params['state']
     tenant = module.params['tenant']
 
@@ -301,6 +303,9 @@ def main():
             elif protocol == 'ospf':
                 child_configs.append(
                     dict(ospfExtP=dict(attributes=dict(descr='', nameAlias=''))))
+            elif protocol == 'eigrp':
+                child_configs.append(
+                    dict(eigrpExtP=dict(attributes=dict(descr='', nameAlias='', asn=asn))))
             elif protocol == 'pim':
                 child_configs.append(
                     dict(pimExtP=dict(attributes=dict(descr='', nameAlias=''))))

--- a/lib/ansible/modules/network/aci/aci_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_l3out.py
@@ -66,6 +66,7 @@ options:
     description:
     - The AS number for the L3Out. Only applicable when using 'eigrp' as the l3protocol
     aliases: [ as_number ]
+    version_added: '2.8'
   description:
     description:
     - Description for the L3Out.


### PR DESCRIPTION
##### SUMMARY
This change will add eigrp as a possible l3protocol to the aci_l3out module. Only thing that needed to be added was the as number and allowing the actual 'eigrp' to be accepted as a parameter to l3protocol

This will also fix an error that caused the l3out parameter to not be accepted as a viable parameter (only 'name' was actually working)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
aci_l3out

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jota/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```