### PR TITLE
Docs: Avoid use of 'default: null'

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+
 # Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -33,8 +34,6 @@ options:
   create_timeout:
     description:
       - The amount of time (in minutes) that can pass before the stack status becomes CREATE_FAILED
-    required: false
-    default: null
     version_added: "2.6"
   template_parameters:
     description:
@@ -82,6 +81,7 @@ options:
         See the AWS Change Sets docs U(http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-changesets.html).
         WARNING: if the stack does not exist, it will be created without changeset. If the state is absent, the stack will be deleted immediately with no
         changeset."
+    type: bool
     default: 'no'
     version_added: "2.4"
   changeset_name:

--- a/lib/ansible/modules/cloud/openstack/os_volume_snapshot.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume_snapshot.py
@@ -2,19 +2,7 @@
 # coding: utf-8 -*-
 
 # Copyright (c) 2016, Mario Santos <mario.rf.santos@gmail.com>
-#
-# This module is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This software is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -42,8 +30,6 @@ options:
    display_description:
      description:
        - String describing the snapshot
-     required: false
-     default: null
      aliases: ['description']
    volume:
      description:
@@ -53,9 +39,8 @@ options:
      description:
        - Allows or disallows snapshot of a volume to be created when the volume
          is attached to an instance.
-     required: false
-     default: False
      type: bool
+     default: 'no'
    state:
      description:
        - Should the resource be present or absent.
@@ -64,7 +49,6 @@ options:
    availability_zone:
      description:
        - Availability zone in which to create the snapshot.
-     required: false
 requirements:
      - "python >= 2.7"
      - "openstacksdk"

--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2015, Sebastian Kornehl <sebastian.kornehl@asideas.de>
+# Copyright: (c) 2015, Sebastian Kornehl <sebastian.kornehl@asideas.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -62,7 +62,6 @@ options:
         description:
             - The number of minutes before a monitor will notify when data stops reporting. Must be at least 2x the monitor timeframe for metric
               alerts or 2 minutes for service checks.
-        required: false
         default: 2x timeframe for metric, 2 minutes for service
     timeout_h:
         description: ["The number of hours of the monitor not reporting data before it will automatically resolve from a triggered state."]
@@ -99,8 +98,6 @@ options:
         version_added: "2.4"
     evaluation_delay:
         description: ["Time to delay evaluation (in seconds). It is effective for sparse values."]
-        required: false
-        default: null
         version_added: "2.7"
     id:
         description: ["The id of the alert. If set, will be used instead of the name to locate the alert."]

--- a/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2017-2018, Keller Fuchs <kellerfuchs@hashbang.sh>
-#
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -39,7 +38,6 @@ requirements:
 options:
   passwd:
     required: true
-    default: null
     description:
       - The (plaintext) password to be set for I(dn).
 extends_documentation_fragment: ldap.documentation

--- a/lib/ansible/modules/network/exos/exos_command.py
+++ b/lib/ansible/modules/network/exos/exos_command.py
@@ -1,20 +1,6 @@
 #!/usr/bin/python
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -57,7 +43,6 @@ options:
         before moving forward. If the conditional is not true
         within the configured number of retries, the task fails.
         See examples.
-    default: null
   match:
     description:
       - The I(match) argument is used in conjunction with the

--- a/lib/ansible/modules/network/exos/exos_config.py
+++ b/lib/ansible/modules/network/exos/exos_config.py
@@ -1,22 +1,8 @@
 #!/usr/bin/python
-#
-# (c) 2018 Extreme Networks Inc.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+
+# Copyright: (c) 2018, Extreme Networks Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import (absolute_import, division, print_function)
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -43,7 +29,6 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
-    default: null
     aliases: ['commands']
   src:
     description:
@@ -52,7 +37,6 @@ options:
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
         exclusive with I(lines).
-    default: null
   before:
     description:
       - The ordered set of commands to push on to the command stack if
@@ -60,14 +44,12 @@ options:
         the opportunity to perform configuration commands prior to pushing
         any changes without affecting how the set of commands are matched
         against the system.
-    default: null
   after:
     description:
       - The ordered set of commands to append to the end of the command
         stack if a change needs to be made.  Just like with I(before) this
         allows the playbook designer to append a set of commands to be
         executed after the command set.
-    default: null
   match:
     description:
       - Instructs the module on the way to perform the matching of
@@ -97,8 +79,8 @@ options:
         changes are made.  The backup file is written to the C(backup)
         folder in the playbook root directory.  If the directory does not
         exist, it is created.
-    default: no
     type: bool
+    default: 'no'
   running_config:
     description:
       - The module, by default, will connect to the remote device and
@@ -108,7 +90,6 @@ options:
         every task in a playbook.  The I(running_config) argument allows the
         implementer to pass in the configuration to use as the base
         config for comparison.
-    default: null
     aliases: ['config']
   defaults:
     description:

--- a/lib/ansible/modules/network/fortios/fortios_webfilter.py
+++ b/lib/ansible/modules/network/fortios/fortios_webfilter.py
@@ -1,21 +1,7 @@
 #!/usr/bin/python
-# Copyright 2018 Fortinet, Inc.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-# the lib use python logging can get it if the following is set in your
-# Ansible config.
+
+# Copyright: (c) 2018, Fortinet, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -67,7 +53,6 @@ options:
         description:
             - Container for a group of url entries that the FortiGate
               must act upon
-        default: null
         suboptions:
             id:
                 description:
@@ -80,7 +65,6 @@ options:
             comment:
                 description:
                     - Optional comments.
-                default: null
             one-arm-ips-urlfilter:
                 description:
                     - Enable/disable DNS resolver for one-arm IPS URL filter operation.
@@ -169,7 +153,6 @@ options:
         description:
             - Container for a group of content-filtering entries that
               the FortiGate must act upon
-        default: null
         suboptions:
             id:
                 description:
@@ -181,7 +164,6 @@ options:
             comment:
                 description:
                     - Optional comments.
-                default: null
             entries:
                 description:
                     - Content filter entries.

--- a/lib/ansible/modules/network/nos/nos_command.py
+++ b/lib/ansible/modules/network/nos/nos_command.py
@@ -1,22 +1,8 @@
 #!/usr/bin/python
-#
-# (c) 2018 Extreme Networks Inc.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+
+# Copyright: (c) 2018, Extreme Networks Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import (absolute_import, division, print_function)
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -56,7 +42,6 @@ options:
         before moving forward. If the conditional is not true
         within the configured number of retries, the task fails.
         See examples.
-    default: null
   match:
     description:
       - The I(match) argument is used in conjunction with the
@@ -65,7 +50,6 @@ options:
         then all conditionals in the wait_for must be satisfied. If
         the value is set to C(any) then only one of the values must be
         satisfied.
-    required: false
     default: all
     choices: ['any', 'all']
   retries:
@@ -74,7 +58,6 @@ options:
         before it is considered failed. The command is run on the
         target device every retry and evaluated against the
         I(wait_for) conditions.
-    required: false
     default: 10
   interval:
     description:
@@ -82,7 +65,6 @@ options:
         of the command. If the command does not pass the specified
         conditions, the interval indicates how long to wait before
         trying the command again.
-    required: false
     default: 1
 """
 

--- a/lib/ansible/modules/network/nos/nos_config.py
+++ b/lib/ansible/modules/network/nos/nos_config.py
@@ -1,22 +1,8 @@
 #!/usr/bin/python
-#
-# (c) 2018 Extreme Networks Inc.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+
+# Copyright: (c) 2018, Extreme Networks Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import (absolute_import, division, print_function)
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -44,7 +30,6 @@ options:
         in the device running-config. Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
-    default: null
     aliases: ['commands']
   parents:
     description:
@@ -52,7 +37,6 @@ options:
         the commands should be checked against. If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.
-    default: null
   src:
     description:
       - Specifies the source path to the file that contains the configuration
@@ -60,7 +44,6 @@ options:
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory. This argument is mutually
         exclusive with I(lines), I(parents).
-    default: null
   before:
     description:
       - The ordered set of commands to push on to the command stack if
@@ -68,14 +51,12 @@ options:
         the opportunity to perform configuration commands prior to pushing
         any changes without affecting how the set of commands are matched
         against the system.
-    default: null
   after:
     description:
       - The ordered set of commands to append to the end of the command
         stack if a change needs to be made. Just like with I(before) this
         allows the playbook designer to append a set of commands to be
         executed after the command set.
-    default: null
   match:
     description:
       - Instructs the module on the way to perform the matching of
@@ -112,8 +93,8 @@ options:
         changes are made. The backup file is written to the C(backup)
         folder in the playbook root directory. If the directory does not
         exist, it is created.
-    default: no
     type: bool
+    default: 'no'
   running_config:
     description:
       - The module, by default, will connect to the remote device and
@@ -123,7 +104,6 @@ options:
         every task in a playbook. The I(running_config) argument allows the
         implementer to pass in the configuration to use as the base
         config for comparison.
-    default: null
     aliases: ['config']
   diff_against:
     description:

--- a/lib/ansible/modules/network/routeros/routeros_command.py
+++ b/lib/ansible/modules/network/routeros/routeros_command.py
@@ -1,20 +1,7 @@
 #!/usr/bin/python
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
@@ -50,8 +37,6 @@ options:
         before moving forward. If the conditional is not true
         within the configured number of retries, the task fails.
         See examples.
-    required: false
-    default: null
   match:
     description:
       - The I(match) argument is used in conjunction with the
@@ -60,7 +45,6 @@ options:
         then all conditionals in the wait_for must be satisfied.  If
         the value is set to C(any) then only one of the values must be
         satisfied.
-    required: false
     default: all
     choices: ['any', 'all']
   retries:
@@ -69,7 +53,6 @@ options:
         before it is considered failed. The command is run on the
         target device every retry and evaluated against the
         I(wait_for) conditions.
-    required: false
     default: 10
   interval:
     description:
@@ -77,7 +60,6 @@ options:
         of the command. If the command does not pass the specified
         conditions, the interval indicates how long to wait before
         trying the command again.
-    required: false
     default: 1
 """
 

--- a/lib/ansible/modules/network/slxos/slxos_command.py
+++ b/lib/ansible/modules/network/slxos/slxos_command.py
@@ -1,22 +1,8 @@
 #!/usr/bin/python
-#
-# (c) 2018 Extreme Networks Inc.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+
+# Copyright: (c) 2018, Extreme Networks Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import (absolute_import, division, print_function)
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -56,7 +42,6 @@ options:
         before moving forward. If the conditional is not true
         within the configured number of retries, the task fails.
         See examples.
-    default: null
   match:
     description:
       - The I(match) argument is used in conjunction with the
@@ -65,7 +50,6 @@ options:
         then all conditionals in the wait_for must be satisfied.  If
         the value is set to C(any) then only one of the values must be
         satisfied.
-    required: false
     default: all
     choices: ['any', 'all']
   retries:
@@ -74,7 +58,6 @@ options:
         before it is considered failed. The command is run on the
         target device every retry and evaluated against the
         I(wait_for) conditions.
-    required: false
     default: 10
   interval:
     description:
@@ -82,7 +65,6 @@ options:
         of the command. If the command does not pass the specified
         conditions, the interval indicates how long to wait before
         trying the command again.
-    required: false
     default: 1
 """
 

--- a/lib/ansible/modules/network/slxos/slxos_config.py
+++ b/lib/ansible/modules/network/slxos/slxos_config.py
@@ -1,22 +1,8 @@
 #!/usr/bin/python
-#
-# (c) 2018 Extreme Networks Inc.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+
+# Copyright: (c) 2018, Extreme Networks Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import (absolute_import, division, print_function)
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -44,7 +30,6 @@ options:
         in the device running-config.  Be sure to note the configuration
         command syntax as some commands are automatically modified by the
         device config parser.
-    default: null
     aliases: ['commands']
   parents:
     description:
@@ -52,7 +37,6 @@ options:
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.
-    default: null
   src:
     description:
       - Specifies the source path to the file that contains the configuration
@@ -60,7 +44,6 @@ options:
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
         exclusive with I(lines), I(parents).
-    default: null
   before:
     description:
       - The ordered set of commands to push on to the command stack if
@@ -68,14 +51,12 @@ options:
         the opportunity to perform configuration commands prior to pushing
         any changes without affecting how the set of commands are matched
         against the system.
-    default: null
   after:
     description:
       - The ordered set of commands to append to the end of the command
         stack if a change needs to be made.  Just like with I(before) this
         allows the playbook designer to append a set of commands to be
         executed after the command set.
-    default: null
   match:
     description:
       - Instructs the module on the way to perform the matching of
@@ -112,8 +93,8 @@ options:
         changes are made.  The backup file is written to the C(backup)
         folder in the playbook root directory.  If the directory does not
         exist, it is created.
-    default: no
     type: bool
+    default: 'no'
   running_config:
     description:
       - The module, by default, will connect to the remote device and
@@ -123,7 +104,6 @@ options:
         every task in a playbook.  The I(running_config) argument allows the
         implementer to pass in the configuration to use as the base
         config for comparison.
-    default: null
     aliases: ['config']
   defaults:
     description:

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -77,9 +77,7 @@ options:
     description:
       - Specifies an alternative release from which all packages will be
         installed.
-    required: false
     version_added: "2.6"
-    default: null
 
   autoremove:
     description:
@@ -87,7 +85,7 @@ options:
         installed as dependencies of user-installed packages but which are no longer
         required by any such package. Should be used alone or when state is I(absent)
     type: bool
-    default: false
+    default: "no"
     version_added: "2.4"
   exclude:
     description:
@@ -112,7 +110,6 @@ options:
     description:
       - When using latest, only update installed packages. Do not install packages.
       - Has an effect only if state is I(latest)
-    required: false
     default: "no"
     type: bool
     version_added: "2.7"
@@ -125,7 +122,6 @@ options:
   bugfix:
     description:
       - If set to C(yes), and C(state=latest) then only installs updates that have been marked bugfix related.
-    required: false
     default: "no"
     type: bool
     version_added: "2.7"
@@ -133,13 +129,11 @@ options:
     description:
       - I(Plugin) name to enable for the install/update operation.
         The enabled plugin will not persist beyond the transaction.
-    required: false
     version_added: "2.7"
   disable_plugin:
     description:
       - I(Plugin) name to disable for the install/update operation.
         The disabled plugins will not persist beyond the transaction.
-    required: false
     version_added: "2.7"
   disable_excludes:
     description:
@@ -147,7 +141,6 @@ options:
       - If set to C(all), disables all excludes.
       - If set to C(main), disable excludes defined in [main] in yum.conf.
       - If set to C(repoid), disable excludes defined for given repo id.
-    required: false
     choices: [ all, main, repoid ]
     version_added: "2.7"
   validate_certs:
@@ -168,19 +161,18 @@ options:
         package and others can cause changes to the packages which were
         in the earlier transaction).
     type: bool
-    default: False
+    default: "no"
     version_added: "2.7"
   install_repoquery:
     description:
       - This is effectively a no-op in DNF as it is not needed with DNF, but is an accepted parameter for feature
         parity/compatibility with the I(yum) module.
     type: bool
-    default: True
+    default: "yes"
     version_added: "2.7"
   download_only:
     description:
       - Only download the packages, do not install them.
-    required: false
     default: "no"
     type: bool
     version_added: "2.7"

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -29,7 +29,6 @@ options:
         upstream yum developers. As of Ansible 2.7+, this module also supports C(YUM4), which is the
         "new yum" and it has an C(dnf) backend.
       - By default, this module will select the backend based on the C(ansible_pkg_mgr) fact.
-    required: false
     default: "auto"
     choices: [ auto, yum, yum4, dnf ]
     version_added: "2.7"
@@ -112,7 +111,6 @@ options:
     description:
       - When using latest, only update installed packages. Do not install packages.
       - Has an effect only if state is I(latest)
-    required: false
     default: "no"
     type: bool
     version_added: "2.5"
@@ -132,7 +130,6 @@ options:
   bugfix:
     description:
       - If set to C(yes), and C(state=latest) then only installs updates that have been marked bugfix related.
-    required: false
     default: "no"
     version_added: "2.6"
   allow_downgrade:
@@ -152,21 +149,17 @@ options:
     description:
       - I(Plugin) name to enable for the install/update operation.
         The enabled plugin will not persist beyond the transaction.
-    required: false
     version_added: "2.5"
   disable_plugin:
     description:
       - I(Plugin) name to disable for the install/update operation.
         The disabled plugins will not persist beyond the transaction.
-    required: false
     version_added: "2.5"
   releasever:
     description:
       - Specifies an alternative release from which all packages will be
         installed.
-    required: false
     version_added: "2.7"
-    default: null
   autoremove:
     description:
       - If C(yes), removes all "leaf" packages from the system that were originally
@@ -174,7 +167,7 @@ options:
         required by any such package. Should be used alone or when state is I(absent)
       - "NOTE: This feature requires yum >= 3.4.3 (RHEL/CentOS 7+)"
     type: bool
-    default: false
+    default: "no"
     version_added: "2.7"
   disable_excludes:
     description:
@@ -182,13 +175,11 @@ options:
       - If set to C(all), disables all excludes.
       - If set to C(main), disable excludes defined in [main] in yum.conf.
       - If set to C(repoid), disable excludes defined for given repo id.
-    required: false
     choices: [ all, main, repoid ]
     version_added: "2.7"
   download_only:
     description:
       - Only download the packages, do not install them.
-    required: false
     default: "no"
     type: bool
     version_added: "2.7"

--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
-# (c) 2015, Werner Dijkerman (ikben@werner-dijkerman.nl)
+
+# Copyright: (c) 2015, Werner Dijkerman (ikben@werner-dijkerman.nl)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -29,25 +30,19 @@ options:
     validate_certs:
         description:
             - When using https if SSL certificate needs to be verified.
-        required: false
-        default: true
+        type: bool
+        default: 'yes'
         aliases:
             - verify_ssl
     login_user:
         description:
             - Gitlab user name.
-        required: false
-        default: null
     login_password:
         description:
             - Gitlab password for login_user
-        required: false
-        default: null
     login_token:
         description:
             - Gitlab token for logging in.
-        required: false
-        default: null
     name:
         description:
             - Name of the group you want to create.
@@ -56,19 +51,14 @@ options:
         description:
             - The path of the group you want to create, this will be server_url/group_path
             - If not supplied, the group_name will be used.
-        required: false
-        default: null
     description:
         description:
             - A description for the group.
-        required: false
-        default: null
         version_added: "2.7"
     state:
         description:
             - create or delete group.
             - Possible values are present and absent.
-        required: false
         default: "present"
         choices: ["present", "absent"]
 '''

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # coding: utf-8 -*-
 
-# (c) 2017, Wayne Witzel III <wayne@riotousliving.com>
+# Copyright: (c) 2017, Wayne Witzel III <wayne@riotousliving.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -74,13 +74,9 @@ options:
     client:
       description:
         - Client or application ID for azure_rm type.
-      required: False
-      default: null
     security_token:
       description:
         - STS token for aws type.
-      required: False
-      default: null
       version_added: "2.6"
     secret:
       description:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory_source.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory_source.py
@@ -1,9 +1,8 @@
 #!/usr/bin/python
 # coding: utf-8 -*-
-#
-# (c) 2018, Adrien Fleury <fleu42@gmail.com>
-# GNU General Public License v3.0+
-# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Copyright: (c) 2018, Adrien Fleury <fleu42@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -31,8 +30,6 @@ options:
     description:
       description:
         - The description to use for the inventory source.
-      required: False
-      default: null
     inventory:
       description:
         - The inventory the source is linked to.
@@ -58,7 +55,6 @@ options:
     credential:
       description:
         - Credential to use to retrieve the inventory from.
-      required: False
     source_vars:
       description:
         - >-
@@ -66,24 +62,20 @@ options:
           file. For example with Openstack, specifying *private: false* would
           change the output of the openstack.py script. It has to be YAML or
           JSON.
-      required: False
     timeout:
       description:
         - Number in seconds after which the Tower API methods will time out.
     source_project:
       description:
         - Use a *project* as a source for the *inventory*.
-      required: False
     source_path:
       description:
         - Path to the file to use as a source in the selected *project*.
-      required: False
     update_on_project_update:
       description:
         - >-
           That parameter will sync the inventory when the project is synced. It
           can only be used with a SCM source.
-      required: False
       type: bool
     source_regions:
       description:
@@ -91,27 +83,23 @@ options:
           List of regions for your cloud provider. You can include multiple all
           regions. Only Hosts associated with the selected regions will be
           updated. Refer to Ansible Tower documentation for more detail.
-      required: False
     instance_filters:
       description:
         - >-
           Provide a comma-separated list of filter expressions. Hosts are
           imported when all of the filters match. Refer to Ansible Tower
           documentation for more detail.
-      required: False
     group_by:
       description:
         - >-
           Specify which groups to create automatically. Group names will be
           created similar to the options selected. If blank, all groups above
           are created. Refer to Ansible Tower documentation for more detail.
-      required: False
     source_script:
       description:
         - >-
           The source custom script to use to build the inventory. It needs to
           exist.
-      required: False
     overwrite:
       description:
         - >-
@@ -123,7 +111,6 @@ options:
           left in the "all" default group for the inventory. When not checked,
           local child hosts and groups not found on the external source will
           remain untouched by the inventory update process.
-      required: False
       type: bool
     overwrite_vars:
       description:
@@ -132,14 +119,12 @@ options:
           and replaced by those found on the external source. When not checked,
           a merge will be performed, combining local variables with those found
           on the external source.
-      required: False
       type: bool
     update_on_launch:
       description:
         - >-
           Each time a job runs using this inventory, refresh the inventory from
           the selected source before executing job tasks.
-      required: False
       type: bool
     update_cache_timeout:
       description:
@@ -148,17 +133,14 @@ options:
           job runs and callbacks the task system will evaluate the timestamp of
           the latest sync. If it is older than Cache Timeout, it is not
           considered current, and a new inventory sync will be performed.
-      required: False
     state:
       description:
         - Desired state of the resource.
-      required: False
       default: "present"
       choices: ["present", "absent"]
     tower_verify_ssl:
       description:
         - Tower option to avoid certificates check.
-      required: False
       type: bool
 extends_documentation_fragment: tower
 '''

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_workflow_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_workflow_template.py
@@ -1,9 +1,8 @@
 #!/usr/bin/python
 # coding: utf-8 -*-
-#
-# (c) 2018, Adrien Fleury <fleu42@gmail.com>
-# GNU General Public License v3.0+
-# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Copyright: (c) 2018, Adrien Fleury <fleu42@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -27,18 +26,13 @@ options:
     allow_simultaneous:
       description:
         - If enabled, simultaneous runs of this job template will be allowed.
-      required: False
       type: bool
     description:
       description:
         - The description to use for the workflow.
-      required: False
-      default: null
     extra_vars:
       description:
-        - >
-          Extra variables used by Ansible in YAML or key=value format.
-      required: False
+        - Extra variables used by Ansible in YAML or key=value format.
     name:
       description:
         - The name to use for the workflow.
@@ -46,28 +40,23 @@ options:
     organization:
       description:
         - The organization the workflow is linked to.
-      required: False
     schema:
       description:
         - >
           The schema is a JSON- or YAML-formatted string defining the
           hierarchy structure that connects the nodes. Refer to Tower
           documentation for more information.
-      required: False
     survey_enabled:
       description:
         - Setting that variable will prompt the user for job type on the
           workflow launch.
-      required: False
       type: bool
     survey:
       description:
         - The definition of the survey associated to the workflow.
-      required: False
     state:
       description:
         - Desired state of the resource.
-      required: False
       default: "present"
       choices: ["present", "absent"]
 extends_documentation_fragment: tower

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -1042,7 +1042,6 @@ lib/ansible/modules/remote_management/ucs/ucs_wwn_pool.py E322
 lib/ansible/modules/remote_management/ucs/ucs_wwn_pool.py E323
 lib/ansible/modules/source_control/github_issue.py E324
 lib/ansible/modules/source_control/github_issue.py E326
-lib/ansible/modules/source_control/gitlab_group.py E325
 lib/ansible/modules/source_control/gitlab_project.py E324
 lib/ansible/modules/source_control/gitlab_project.py E326
 lib/ansible/modules/source_control/gitlab_user.py E326


### PR DESCRIPTION
##### SUMMARY
Various modules document the default 'null' value, but it causes None to be shown in the documentation explicitly.

For the modified files, this PR also includes:
- Removal of `required: false`
- Copyright/License improvements

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Module docs

##### ANSIBLE VERSION
v2.8 and earlier

##### ADDITIONAL INFORMATION
So we want to avoid the ambiguity between parameters that have this set, and not have this set.

![screenshot from 2018-09-18 17-00-37](https://user-images.githubusercontent.com/388198/45696807-a722ce80-bb64-11e8-9142-b269b9390463.png)