### PR TITLE
explains what happens when gpgcheck is not set in yum

### DIFF
--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -108,6 +108,8 @@ options:
     description:
       - Tells yum whether or not it should perform a GPG signature check on
         packages.
+      - No default setting. If the value is not set, falls back on the global
+        default setting in C(/etc/yum.conf).
     type: bool
   gpgkey:
     description:

--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -108,8 +108,8 @@ options:
     description:
       - Tells yum whether or not it should perform a GPG signature check on
         packages.
-      - No default setting. If the value is not set, falls back on the global
-        default setting in C(/etc/yum.conf).
+      - No default setting. If the value is not set, the system setting from
+        C(/etc/yum.conf) or system default of C(no) will be used.
     type: bool
   gpgkey:
     description:


### PR DESCRIPTION
##### SUMMARY
Related to #39485.
Related to #36267.

We've gone back and forth a few times on how to describe the way the `gpgcheck` parameter works. It has no default value, but functionally it defaults to the setting in `/etc/yum.conf`, which defaults to `no`. This PR is an attempt to clarify how the `gpgcheck` parameter interacts with the settings on the target machine.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.8
