### PR TITLE
Add number of skipped tasks to play recap in 'default' callback

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -327,21 +327,23 @@ class CallbackModule(CallbackBase):
         for h in hosts:
             t = stats.summarize(h)
 
-            self._display.display(u"%s : %s %s %s %s" % (
+            self._display.display(u"%s : %s %s %s %s %s" % (
                 hostcolor(h, t),
                 colorize(u'ok', t['ok'], C.COLOR_OK),
                 colorize(u'changed', t['changed'], C.COLOR_CHANGED),
                 colorize(u'unreachable', t['unreachable'], C.COLOR_UNREACHABLE),
-                colorize(u'failed', t['failures'], C.COLOR_ERROR)),
+                colorize(u'failed', t['failures'], C.COLOR_ERROR),
+                colorize(u'skipped', t['skipped'], C.COLOR_SKIP)),
                 screen_only=True
             )
 
-            self._display.display(u"%s : %s %s %s %s" % (
+            self._display.display(u"%s : %s %s %s %s %s" % (
                 hostcolor(h, t, False),
                 colorize(u'ok', t['ok'], None),
                 colorize(u'changed', t['changed'], None),
                 colorize(u'unreachable', t['unreachable'], None),
-                colorize(u'failed', t['failures'], None)),
+                colorize(u'failed', t['failures'], None),
+                colorize(u'skipped', t['skipped'], None)),
                 log_only=True
             )
 

--- a/test/integration/targets/callback_default/callback_default.out.default.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.default.stdout
@@ -40,5 +40,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=10   changed=7    unreachable=0    failed=0   
+testhost                   : ok=10   changed=7    unreachable=0    failed=0    skipped=1   
 

--- a/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
@@ -39,5 +39,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=10   changed=7    unreachable=0    failed=0   
+testhost                   : ok=10   changed=7    unreachable=0    failed=0    skipped=1   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
@@ -34,5 +34,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=10   changed=7    unreachable=0    failed=0   
+testhost                   : ok=10   changed=7    unreachable=0    failed=0    skipped=1   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
@@ -37,5 +37,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=10   changed=7    unreachable=0    failed=0   
+testhost                   : ok=10   changed=7    unreachable=0    failed=0    skipped=1   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
@@ -31,5 +31,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=10   changed=7    unreachable=0    failed=0   
+testhost                   : ok=10   changed=7    unreachable=0    failed=0    skipped=1   
 


### PR DESCRIPTION
##### SUMMARY
Display the number of skipped tasks in the play recap in the `default` callback plugin.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`default` callback plugin

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (default_callback_stats_skipped db957c28cb) last updated 2018/09/18 10:10:10 (GMT -500)
```

##### ADDITIONAL INFORMATION
N/A