### PR TITLE
Add a new "contains" jinja2 test

### DIFF
--- a/changelogs/fragments/contains-filter.yaml
+++ b/changelogs/fragments/contains-filter.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-- contains jinja2 filter - Add a contains jinja2 filter designed for use in map and selectattr tests (https://github.com/ansible/ansible/pull/45798)

--- a/changelogs/fragments/contains-filter.yaml
+++ b/changelogs/fragments/contains-filter.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- contains jinja2 filter - Add a contains jinja2 filter designed for use in map and selectattr tests (https://github.com/ansible/ansible/pull/45798)

--- a/changelogs/fragments/contains-test.yaml
+++ b/changelogs/fragments/contains-test.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- '``contains`` jinja2 test - Add a ``contains`` jinja2 test designed for use in ``map`` and ``selectattr`` filters (https://github.com/ansible/ansible/pull/45798)'

--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -109,6 +109,41 @@ To see if a list includes or is included by another list, you can use 'subset' a
             msg: "B is included in A"
           when: b is subset(a)
 
+.. _contains_test:
+
+Test if a list contains a value
+```````````````````````````````
+
+.. versionadded:: 2.8
+
+Ansible includes a ``contains`` test which operates similarly, but in reverse of the Jinja2 provided ``in`` test.
+This is designed with the ability to allow use of ``contains`` with filters such as ``map`` and ``selectattr``::
+
+    vars:
+      lacp_groups:
+        - master: lacp0
+          network: 10.65.100.0/24
+          gateway: 10.65.100.1
+          dns4:
+            - 10.65.100.10
+            - 10.65.100.11
+          interfaces:
+            - em1
+            - em2
+
+        - master: lacp1
+          network: 10.65.120.0/24
+          gateway: 10.65.120.1
+          dns4:
+            - 10.65.100.10
+            - 10.65.100.11
+          interfaces:
+              - em3
+              - em4
+
+    tasks:
+      - debug:
+          msg: "{{ (lacp_groups|selectattr('interfaces', 'contains', 'em1')|first).master }}"
 
 .. _path_tests:
 

--- a/lib/ansible/plugins/test/mathstuff.py
+++ b/lib/ansible/plugins/test/mathstuff.py
@@ -36,6 +36,14 @@ def isnotanumber(x):
         return False
 
 
+def contains(seq, value):
+    '''Opposite of the ``in`` test, allowing use as a test in filters like ``selectattr``
+
+    .. versionadded:: 2.8
+    '''
+    return value in seq
+
+
 class TestModule:
     ''' Ansible math jinja2 tests '''
 
@@ -46,6 +54,9 @@ class TestModule:
             'subset': issubset,
             'issuperset': issuperset,
             'superset': issuperset,
+            'contains': contains,
+
+            # numbers
             'isnan': isnotanumber,
             'nan': isnotanumber,
         }


### PR DESCRIPTION
##### SUMMARY
Add a new `contains` jinja2 test that operates similarly to the jinja2 provided `in` test, but with reversed arguments allowing use in filters such as `map` and `selectattr`.

See changed docs for an example.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/test/mathstuff.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```