### PR TITLE
Strict file permissions check for private key

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -89,10 +89,9 @@ class ConnectionProcess(object):
         self._ansible_playbook_pid = ansible_playbook_pid
 
     def start(self, variables):
+        messages = list()
+        result = {}
         try:
-            messages = list()
-            result = {}
-
             messages.append('control socket path is %s' % self.socket_path)
 
             # If this is a relative path (~ gets expanded later) then plug the


### PR DESCRIPTION
##### SUMMARY
Check file permissions for private key provided. It should not other
than 600.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bin/ansible-connection
lib/ansible/plugins/connection/ssh.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8-devel
```