### PR TITLE
[AWS] profile compatibility with ~/.boto credential file - fixes #44330

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -285,6 +285,7 @@ def get_aws_connection_info(module, boto3=False):
         boto_params['verify'] = validate_certs
 
         if profile_name:
+            boto_params = dict(aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None)
             boto_params['profile_name'] = profile_name
 
     else:


### PR DESCRIPTION
##### SUMMARY
Allow the profile to take precedence to allow better compatibility between ~/.boto and ~/.aws/credential files, since boto3 modules only use the ~/.boto [Credentials] section.
Fixes #44330

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/ec2.py

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
```
