### PR TITLE
Force PEM SSH keys for paramiko

### DIFF
--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -541,7 +541,7 @@ class SshKey(object):
                 make_dirs(base_dir)
 
             if not os.path.isfile(key) or not os.path.isfile(pub):
-                run_command(args, ['ssh-keygen', '-q', '-t', 'rsa', '-N', '', '-f', key])
+                run_command(args, ['ssh-keygen', '-m', 'PEM', '-q', '-t', 'rsa', '-N', '', '-f', key])
 
             if not args.explain:
                 shutil.copy2(key, self.key)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix ansible-test for fedora-28. This is because RFC4716 keys don't currently seem to be supported by paramiko.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-test