### PR TITLE
Update eos_config.py

### DIFF
--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -221,10 +221,10 @@ EXAMPLES = """
 - name: load an acl into the device
   eos_config:
     lines:
-      - 10 permit ip 192.0.2.1/32 any log
-      - 20 permit ip 192.0.2.2/32 any log
-      - 30 permit ip 192.0.2.3/32 any log
-      - 40 permit ip 192.0.2.4/32 any log
+      - 10 permit ip host 192.0.2.1 any log
+      - 20 permit ip host 192.0.2.2 any log
+      - 30 permit ip host 192.0.2.3 any log
+      - 40 permit ip host 192.0.2.4 any log
     parents: ip access-list test
     before: no ip access-list test
     replace: block


### PR DESCRIPTION
Switches will accept the previously used syntax for /32 ACL entries, but they get changed to host ipaddress in the config file.
This results in the config check failing every time (permit ip 1.1.1.1/32 any log != permit ip host 1.1.1.1 any log), resulting in the ACL getting re-created on every single run of the Playbook.
Making this proposed change to the example will make it work in an idempotent manner.
+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
