### PR TITLE
[2.7] ec2_group - fix VPC precedence for security group targets (#45787)

### DIFF
--- a/changelogs/fragments/fix_ec2_group_target_vpc_precedence.yaml
+++ b/changelogs/fragments/fix_ec2_group_target_vpc_precedence.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - ec2_group - There can be multiple security groups with the same name in
+    different VPCs. Prior to 2.6 if a target group name was provided, the group
+    matching the name and VPC had highest precedence. Restore this behavior by
+    updated the dictionary with the groups matching the VPC last.

--- a/changelogs/fragments/fix_ec2_group_target_vpc_precedence.yaml
+++ b/changelogs/fragments/fix_ec2_group_target_vpc_precedence.yaml
@@ -4,3 +4,4 @@ bugfixes:
     different VPCs. Prior to 2.6 if a target group name was provided, the group
     matching the name and VPC had highest precedence. Restore this behavior by
     updated the dictionary with the groups matching the VPC last.
+  - ec2_group - support EC2-Classic by not assuming security groups have VPCs.

--- a/changelogs/fragments/fix_ec2_group_vpc_precedence_classic.yaml
+++ b/changelogs/fragments/fix_ec2_group_vpc_precedence_classic.yaml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - The patch fixing the regression of no longer preferring matching security
+    groups in the same VPC https://github.com/ansible/ansible/pull/45787
+    (which was also backported to 2.6) broke EC2-Classic accounts.
+    https://github.com/ansible/ansible/pull/46242 removes the assumption that
+    security groups must be in a VPC.

--- a/changelogs/fragments/fix_ec2_group_vpc_precedence_classic.yaml
+++ b/changelogs/fragments/fix_ec2_group_vpc_precedence_classic.yaml
@@ -1,7 +1,0 @@
----
-bugfixes:
-  - The patch fixing the regression of no longer preferring matching security
-    groups in the same VPC https://github.com/ansible/ansible/pull/45787
-    (which was also backported to 2.6) broke EC2-Classic accounts.
-    https://github.com/ansible/ansible/pull/46242 removes the assumption that
-    security groups must be in a VPC.

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -854,6 +854,9 @@ def group_exists(client, module, vpc_id, group_id, name):
     if security_groups:
         groups = dict((group['GroupId'], group) for group in all_groups)
         groups.update(dict((group['GroupName'], group) for group in all_groups))
+        if vpc_id:
+            vpc_wins = dict((group['GroupName'], group) for group in all_groups if group['VpcId'] == vpc_id)
+            groups.update(vpc_wins)
         # maintain backwards compatibility by using the last matching group
         return security_groups[-1], groups
     return None, {}

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -855,7 +855,7 @@ def group_exists(client, module, vpc_id, group_id, name):
         groups = dict((group['GroupId'], group) for group in all_groups)
         groups.update(dict((group['GroupName'], group) for group in all_groups))
         if vpc_id:
-            vpc_wins = dict((group['GroupName'], group) for group in all_groups if group['VpcId'] == vpc_id)
+            vpc_wins = dict((group['GroupName'], group) for group in all_groups if group.get('VpcId') and group['VpcId'] == vpc_id)
             groups.update(vpc_wins)
         # maintain backwards compatibility by using the last matching group
         return security_groups[-1], groups


### PR DESCRIPTION
##### SUMMARY
Backport #45787

Update the dictionary with the preferred values last to get the right order of VPC precedence
Fixes #45782
(cherry picked from commit 8d2df9be52768d3acb65a45edad87ea7da2dcff2)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_group

##### ANSIBLE VERSION
```
ansible 2.7.0rc2.post0
```
