### PR TITLE
Minor fixes for unit test delegation.

### DIFF
--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -278,7 +278,6 @@ def delegate_docker(args, exclude, require, integration_targets):
             # run unit tests unprivileged to prevent stray writes to the source tree
             if isinstance(args, UnitsConfig):
                 writable_dirs = [
-                    '/root/ansible/lib/ansible.egg-info',
                     '/root/ansible/.pytest_cache',
                 ]
 

--- a/test/runner/lib/pytar.py
+++ b/test/runner/lib/pytar.py
@@ -37,6 +37,7 @@ class DefaultTarFilter(TarFilter):
             '.tox',
             '.git',
             '.idea',
+            '.pytest_cache',
             '__pycache__',
             'ansible.egg-info',
         )


### PR DESCRIPTION
##### SUMMARY

Minor fixes for unit test delegation.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (delegate-fix db5ba1cc4b) last updated 2018/09/18 14:13:36 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
