### PR TITLE
Block network access for unit tests in docker.

### DIFF
--- a/test/runner/lib/docker_util.py
+++ b/test/runner/lib/docker_util.py
@@ -67,6 +67,17 @@ def get_docker_container_ip(args, container_id):
     return ipaddress
 
 
+def get_docker_networks(args, container_id):
+    """
+    :param args: EnvironmentConfig
+    :param container_id: str
+    :rtype: list[str]
+    """
+    results = docker_inspect(args, container_id)
+    networks = sorted(results[0]['NetworkSettings']['Networks'])
+    return networks
+
+
 def docker_pull(args, image):
     """
     :type args: EnvironmentConfig
@@ -163,6 +174,15 @@ def docker_inspect(args, container_id):
             return json.loads(ex.stdout)
         except:
             raise ex  # pylint: disable=locally-disabled, raising-bad-type
+
+
+def docker_network_disconnect(args, container_id, network):
+    """
+    :param args: EnvironmentConfig
+    :param container_id: str
+    :param network: str
+    """
+    docker_command(args, ['network', 'disconnect', network, container_id], capture=True)
 
 
 def docker_network_inspect(args, network):


### PR DESCRIPTION
##### SUMMARY

Block network access for unit tests in docker.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (units-no-network af6dc63cee) last updated 2018/09/18 16:49:10 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
