### PR TITLE
[2.7] Fix collections.deque import in compat module

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -82,6 +82,7 @@ import pwd
 import platform
 import errno
 import datetime
+from collections import deque
 from itertools import chain, repeat
 
 try:
@@ -148,7 +149,6 @@ except Exception:
         pass
 
 from ansible.module_utils.common._collections_compat import (
-    deque,
     KeysView,
     Mapping, MutableMapping,
     Sequence, MutableSequence,

--- a/lib/ansible/module_utils/common/_collections_compat.py
+++ b/lib/ansible/module_utils/common/_collections_compat.py
@@ -14,7 +14,7 @@ __metaclass__ = type
 try:
     """Python 3.3+ branch."""
     from collections.abc import (
-        deque, KeysView,
+        KeysView,
         Mapping, MutableMapping,
         Sequence, MutableSequence,
         Set, MutableSet,
@@ -22,7 +22,7 @@ try:
 except ImportError:
     """Use old lib location under 2.6-3.2."""
     from collections import (
-        deque, KeysView,
+        KeysView,
         Mapping, MutableMapping,
         Sequence, MutableSequence,
         Set, MutableSet,


### PR DESCRIPTION
`deque` hasn't been moved to `collections.abc`, restoring that.

(cherry picked from commit a978d7f283544e61debfe0e71460d1bbb0fb57e0, PR #45721)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/module_utils/common/_collections_compat.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A