### PR TITLE
fix nxos_facts indefinite hang for text based output

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -630,7 +630,7 @@ class Interfaces(FactsBase):
             fact = dict()
             fact['port'] = self.parse_lldp_port(item)
             fact['sysname'] = self.parse_lldp_sysname(item)
-            facts[local_intf].append(facts)
+            facts[local_intf].append(fact)
 
         return facts
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/45814
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/network/nxos/nxos_facts.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
devel
```