### PR TITLE
[2.6] fix nxos_facts indefinite hang for text based output

### DIFF
--- a/changelogs/fragments/nxos_facts_26.yaml
+++ b/changelogs/fragments/nxos_facts_26.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- fix nxos_facts indefinite hang for text based output (https://github.com/ansible/ansible/pull/45845).

--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -630,7 +630,7 @@ class Interfaces(FactsBase):
             fact = dict()
             fact['port'] = self.parse_lldp_port(item)
             fact['sysname'] = self.parse_lldp_sysname(item)
-            facts[local_intf].append(facts)
+            facts[local_intf].append(fact)
 
         return facts
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

