### PR TITLE
Ensure _raw_params retain exact spaces

### DIFF
--- a/lib/ansible/modules/commands/shell.py
+++ b/lib/ansible/modules/commands/shell.py
@@ -68,9 +68,6 @@ notes:
   -  To sanitize any variables passed to the shell module, you should use
      "{{ var | quote }}" instead of just "{{ var }}" to make sure they don't include evil things like semicolons.
   - For Windows targets, use the M(win_shell) module instead.
-  - Rather than using here documents to create multi-line scripts inside playbooks,
-    use the M(script) module instead.
-requirements: [ ]
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/commands/shell.py
+++ b/lib/ansible/modules/commands/shell.py
@@ -67,6 +67,8 @@ notes:
      are not supplied, the task will be skipped.
   -  To sanitize any variables passed to the shell module, you should use
      "{{ var | quote }}" instead of just "{{ var }}" to make sure they don't include evil things like semicolons.
+  - An alternative to using inline shell scripts with this module is to use
+    the M(script) module possibly together with the M(template) module.
   - For Windows targets, use the M(win_shell) module instead.
 author:
     - Ansible Core Team
@@ -121,7 +123,7 @@ EXAMPLES = '''
 - name: Using curl to connect to a host via SOCKS proxy (unsupported in uri). Ordinarily this would throw a warning.
   shell: curl --socks5 localhost:9000 http://www.ansible.com
   args:
-    warn: False
+    warn: no
 '''
 
 RETURN = '''

--- a/lib/ansible/parsing/splitter.py
+++ b/lib/ansible/parsing/splitter.py
@@ -97,7 +97,7 @@ def parse_kv(args, check_raw=False):
         # recombine the free-form params, if any were found, and assign
         # them to a special option for use later by the shell/command module
         if len(raw_params) > 0:
-            options[u'_raw_params'] = ' '.join(raw_params)
+            options[u'_raw_params'] = join_args(raw_params)
 
     return options
 
@@ -137,6 +137,20 @@ def _count_jinja2_blocks(token, cur_depth, open_token, close_token):
     return cur_depth
 
 
+def join_args(s):
+    '''
+    Join the original cmd based on manipulations by split_args().
+    This retains the original newlines and whitespaces.
+    '''
+    result = ''
+    for p in s:
+        if len(result) == 0 or result.endswith('\n'):
+            result += p
+        else:
+            result += ' ' + p
+    return result
+
+
 def split_args(args):
     '''
     Splits args on whitespace, but intelligently reassembles
@@ -157,9 +171,8 @@ def split_args(args):
     # this is going to be the result value when we are done
     params = []
 
-    # Initial split on white space
-    args = args.strip()
-    items = args.strip().split('\n')
+    # Initial split on newlines
+    items = args.split('\n')
 
     # iterate over the tokens, and reassemble any that may have been
     # split on a space inside a jinja2 block.
@@ -182,10 +195,16 @@ def split_args(args):
         # we split on spaces and newlines separately, so that we
         # can tell which character we split on for reassembly
         # inside quotation characters
-        tokens = item.strip().split(' ')
+        tokens = item.split(' ')
 
         line_continuation = False
         for (idx, token) in enumerate(tokens):
+
+            # Empty entries means we have subsequent spaces
+            # We want to hold onto them so we can reconstruct them later
+            if len(token) == 0 and idx != 0:
+                params[-1] += ' '
+                continue
 
             # if we hit a line continuation character, but
             # we're not inside quotes, ignore it and continue

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -1,20 +1,7 @@
 # Test code for the command and shell modules.
-# (c) 2014, Richard Isaacson <richard.c.isaacson@gmail.com>
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2014, Richard Isaacson <richard.c.isaacson@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: use command to execute sudo
   command: sudo -h
@@ -240,16 +227,18 @@
 ## shell
 ##
 
-- name: execute the test.sh script
+- name: Execute the test.sh script
   shell: "{{output_dir_test | expanduser}}/test.sh"
   register: shell_result0
 
-- name: assert that the script executed correctly
+- name: Assert that the script executed correctly
   assert:
     that:
-      - "shell_result0.rc == 0"
-      - "shell_result0.stderr == ''"
-      - "shell_result0.stdout == 'win'"
+    - shell_result0 is changed
+    - shell_result0.cmd == '{{output_dir_test | expanduser}}/test.sh'
+    - shell_result0.rc == 0
+    - shell_result0.stderr == ''
+    - shell_result0.stdout == 'win'
 
 # executable
 
@@ -268,34 +257,36 @@
 
 # chdir
 
-- name: execute the test.sh script with chdir
+- name: Execute the test.sh script with chdir
   shell: ./test.sh chdir="{{output_dir_test | expanduser}}"
   register: shell_result2
 
-- name: assert that the shell executed correctly with chdir
+- name: Assert that the shell executed correctly with chdir
   assert:
     that:
-      - "shell_result2.rc == 0"
-      - "shell_result2.stderr == ''"
-      - "shell_result2.stdout == 'win'"
+    - shell_result2 is changed
+    - shell_result2.cmd == './test.sh'
+    - shell_result2.rc == 0
+    - shell_result2.stderr == ''
+    - shell_result2.stdout == 'win'
 
 # creates
 
-- name: verify that afile.txt is absent
+- name: Verify that afile.txt is absent
   file: path={{output_dir_test}}/afile.txt state=absent
 
-- name: execute the test.sh script with chdir
+- name: Execute the test.sh script with chdir
   shell: "{{output_dir_test | expanduser}}/test.sh > {{output_dir_test | expanduser}}/afile.txt creates={{output_dir_test | expanduser}}/afile.txt"
 
-- name: verify that afile.txt is present
+- name: Verify that afile.txt is present
   file: path={{output_dir_test}}/afile.txt state=file
 
 # multiline
 
-- name: remove test file previously created
+- name: Remove test file previously created
   file: path={{output_dir_test | expanduser}}/afile.txt state=absent
 
-- name: execute a shell command using a literal multiline block
+- name: Execute a shell command using a literal multiline block
   args:
     executable: "{{ bash.stdout }}"
   shell: |
@@ -307,24 +298,45 @@
     echo "this is a second line"
   register: shell_result5
 
-- name: assert the multiline shell command ran as expected
+- name: Assert the multiline shell command ran as expected
   assert:
     that:
-      - "shell_result5.changed"
-      - "shell_result5.stdout == '5575bb6b71c9558db0b6fbbf2f19909eeb4e3b98\nthis is a second line'"
+    - shell_result5 is changed
+    - shell_result5.rc == 0
+    - shell_result5.cmd == 'echo this is a "multiline echo" "with a new line\nin quotes" | ' + ansible_python_interpreter + ' -c \'import hashlib, sys; print(hashlib.sha1((sys.stdin.buffer if hasattr(sys.stdin, "buffer") else sys.stdin).read()).hexdigest())\'\necho "this is a second line"\n'
+    - shell_result5.stdout == '5575bb6b71c9558db0b6fbbf2f19909eeb4e3b98\nthis is a second line'
 
-- name: execute a shell command using a literal multiline block with arguments in it
+- name: Execute a shell command using a literal multiline block with arguments in it
   shell: |
     executable="{{ bash.stdout }}"
     creates={{output_dir_test | expanduser}}/afile.txt
     echo "test"
   register: shell_result6
 
-- name: assert the multiline shell command with arguments in it run as expected
+- name: Assert the multiline shell command with arguments in it run as expected
   assert:
     that:
-      - "shell_result6.changed"
-      - "shell_result6.stdout == 'test'"
+    - shell_result6 is changed
+    - shell_result6.rc == 0
+    - shell_result6.cmd == 'echo "test"\n'
+    - shell_result6.stdout == 'test'
+
+- name: Execute a shell command using a multiline block where whitespaces matter
+  shell: |
+    cat <<EOF
+    One
+      Two
+        Three
+    EOF
+  register: shell_result7
+
+- name: Assert the multiline shell command outputs with whitespaces preserved
+  assert:
+    that:
+    - shell_result7 is changed
+    - shell_result7.rc == 0
+    - shell_result7.cmd == 'cat <<EOF\nOne\n  Two\n    Three\nEOF\n'
+    - shell_result7.stdout == 'One\n  Two\n    Three'
 
 - name: remove the previously created file
   file: path={{output_dir_test}}/afile.txt state=absent

--- a/test/units/parsing/test_splitter.py
+++ b/test/units/parsing/test_splitter.py
@@ -91,6 +91,9 @@ SPLIT_DATA = (
     (u'a={{ foo | some_filter(\' \', " ") }} b=bar',
         [u'a={{ foo | some_filter(\' \', " ") }}', u'b=bar'],
         {u'a': u'{{ foo | some_filter(\' \', " ") }}', u'b': u'bar'}),
+    (u'One\n  Two\n    Three\n',
+        [u'One\n ', u'Two\n   ', u'Three\n'],
+        {u'_raw_params': u'One\n  Two\n    Three\n'}),
 )
 
 SPLIT_ARGS = ((test[0], test[1]) for test in SPLIT_DATA)


### PR DESCRIPTION
##### SUMMARY
This fixes a longstanding bug related to multi-line YAML strings that lack the original whitespaces and gain a few new whitespaces after newlines.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
shell (and others)

##### ANSIBLE VERSION
v2.8 and older

##### ADDITIONAL INFORMATION
This PR fixes issues with input handling. If you would do the following:
```yaml
- hosts: localhost
  tasks:
  - shell: |
      ls
      cd
      echo "Foo"
```
This would translate to: `ls\n cd\n echo "Foo"`

Any indentation would get lost, all prefixed and trailing whitespaces are eaten and everything is joined with whitespaces (so one whitespace was always added after a newline).

This breaks various things link indentation, but most importantly here-documents in the **shell** module.

```yaml
- hosts: localhost
  tasks:
  - shell: |
      cat <<EOF
        One
        Two
          Three
        Four
      EOF
```

This would translate into something that fails to work as designed:
```yaml
cat <<EOF
 One
 Two
 Three
 Four
 EOF
```