### PR TITLE
[2.7] Fixing HTTPError case of fetch_url for Python 3 compatibility.

### DIFF
--- a/changelogs/fragments/45628-fetch_url-error-headers.yaml
+++ b/changelogs/fragments/45628-fetch_url-error-headers.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "fetch_url did not always return lower-case header names in case of HTTP errors (https://github.com/ansible/ansible/pull/45628)."

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1303,7 +1303,8 @@ def fetch_url(module, url, data=None, headers=None, method=None,
 
         # Try to add exception info to the output but don't fail if we can't
         try:
-            info.update(dict(**e.info()))
+            # Lowercase keys, to conform to py2 behavior, so that py3 and py2 are predictable
+            info.update(dict((k.lower(), v) for k, v in e.info().items()))
         except:
             pass
 

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -178,13 +178,14 @@ def test_fetch_url_httperror(open_url_mock, fake_ansible_module):
         'http://ansible.com/',
         500,
         'Internal Server Error',
-        {},
+        {'Content-Type': 'application/json'},
         StringIO('TESTS')
     )
 
     r, info = fetch_url(fake_ansible_module, 'http://ansible.com/')
 
-    assert info == {'msg': 'HTTP Error 500: Internal Server Error', 'body': 'TESTS', 'status': 500, 'url': 'http://ansible.com/'}
+    assert info == {'msg': 'HTTP Error 500: Internal Server Error', 'body': 'TESTS',
+                    'status': 500, 'url': 'http://ansible.com/', 'content-type': 'application/json'}
 
 
 def test_fetch_url_urlerror(open_url_mock, fake_ansible_module):


### PR DESCRIPTION
##### SUMMARY
Backport of #45628 to `stable-2.7`: fixes `fetch_url` to also convert headers to lowercase in error situations.

CC @sivel

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/urls.py

##### ANSIBLE VERSION
```
2.7.0
```
