### PR TITLE
Symlink ansible-test into bin/

### DIFF
--- a/bin/ansible-test
+++ b/bin/ansible-test
@@ -1,0 +1,1 @@
+../test/runner/test.py

--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -47,7 +47,7 @@ FULL_PATH=$($PYTHON_BIN -c "import os; print(os.path.realpath('$HACKING_DIR'))")
 export ANSIBLE_HOME="$(dirname "$FULL_PATH")"
 
 PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib"
-PREFIX_PATH="$ANSIBLE_HOME/bin:$ANSIBLE_HOME/test/runner"
+PREFIX_PATH="$ANSIBLE_HOME/bin"
 PREFIX_MANPATH="$ANSIBLE_HOME/docs/man"
 
 expr "$PYTHONPATH" : "${PREFIX_PYTHONPATH}.*" > /dev/null || prepend_path PYTHONPATH "$PREFIX_PYTHONPATH"

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -6,7 +6,25 @@ from __future__ import absolute_import, print_function
 
 import errno
 import os
+import os.path
 import sys
+
+libdir = None
+if os.path.islink(__file__):
+    libdir = os.path.dirname(os.path.realpath(__file__))
+else:
+    scriptdir = os.path.dirname(__file__)
+    if scriptdir.endswith('bin'):
+        libdir = os.path.abspath(os.path.join(scriptdir, '..', 'test', 'runner'))
+
+if libdir is None:
+    print('Error: unable to detect the test/runner directory.  Maybe an invalid git checkout?')
+    sys.exit(1)
+elif os.path.exists(libdir):
+    # Success
+    sys.path.insert(0, libdir)
+else:
+    print('Warning: Unable to detect a test/runner directory that exists.  Imports may fail')
 
 from lib.util import (
     ApplicationError,
@@ -72,7 +90,7 @@ import lib.cover
 def main():
     """Main program function."""
     try:
-        git_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+        git_root = os.path.abspath(os.path.join(libdir, '..', '..'))
         os.chdir(git_root)
         initialize_cloud_plugins()
         sanity_init()

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -72,7 +72,7 @@ import lib.cover
 def main():
     """Main program function."""
     try:
-        git_root = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
+        git_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
         os.chdir(git_root)
         initialize_cloud_plugins()
         sanity_init()


### PR DESCRIPTION
##### SUMMARY
By placing the ansible-test tool in the bin/ directory, we don't need to
expose the test/runner directory in the path.

This avoids confusing for those contributors that are not using
env-setup (and e.g. install ansible-test from pip).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
v2.8