### PR TITLE
[stable-2.7] Added documentation for collectstatic --clear. (#42007)

### DIFF
--- a/lib/ansible/modules/web_infrastructure/django_manage.py
+++ b/lib/ansible/modules/web_infrastructure/django_manage.py
@@ -54,6 +54,13 @@ options:
     description:
       - The name of the table used for database-backed caching. Used by the 'createcachetable' command.
     required: false
+  clear:
+    description:
+      - Clear the existing files before trying to copy or link the original file.
+      - Used only with the 'collectstatic' command. The C(--noinput) argument will be added automatically.
+    required: false
+    default: no
+    type: bool
   database:
     description:
       - The database to target. Used by the 'createcachetable', 'flush', 'loaddata', and 'syncdb' commands.


### PR DESCRIPTION
##### SUMMARY

* Added documentation for collectstatic --clear.

Added a description of the --clear argument used with the Django management
command, collectstatic. (When #1810 added this feature the documentation
was not updated).
(cherry picked from commit f96427762817d14b6e858ecdbe0f2c546a3007ed)



##### ISSUE TYPE
- Docs Pull Request
