### PR TITLE
[WIP] Add a 'ansible-role' cli

### DIFF
--- a/bin/ansible-role
+++ b/bin/ansible-role
@@ -1,0 +1,1 @@
+ansible

--- a/docs/docsite/rst/user_guide/command_line_tools.rst
+++ b/docs/docsite/rst/user_guide/command_line_tools.rst
@@ -2,9 +2,9 @@ Working with Command Line Tools
 ===============================
 
 Most users are familiar with `ansible` and `ansible-playbook`, but those are not the only utilities Ansible provides.
-Below is a complete list of Ansible utilities. Each page contains a description of the utility and a listing of supported parameters.	
+Below is a complete list of Ansible utilities. Each page contains a description of the utility and a listing of supported parameters.
 
-.. toctree:: 
+.. toctree::
    :maxdepth: 1
 
    ../cli/ansible.rst
@@ -15,5 +15,6 @@ Below is a complete list of Ansible utilities. Each page contains a description 
    ../cli/ansible-inventory.rst
    ../cli/ansible-playbook.rst
    ../cli/ansible-pull.rst
+   ../cli/ansible-role.rst
    ../cli/ansible-vault.rst
-   
+

--- a/lib/ansible/cli/role.py
+++ b/lib/ansible/cli/role.py
@@ -1,0 +1,164 @@
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import sys
+
+from ansible import constants as C
+from ansible.cli import CLI
+from ansible.errors import AnsibleOptionsError, AnsibleParserError
+from ansible.module_utils._text import to_text
+from ansible.playbook import Playbook
+from ansible.playbook.helpers import load_list_of_roles
+from ansible.playbook.play import Play
+from ansible.plugins.loader import get_all_plugin_loaders
+from ansible.executor.task_queue_manager import TaskQueueManager
+from ansible.parsing.splitter import parse_kv
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+
+def _play_ds(pattern, role_name, role_args_string, extra_vars, async_val, poll):
+    role_args = parse_kv(role_args_string, check_raw=False)
+
+    # TODO: use varman here? probably at least merge_dict
+    role_params = {}
+
+    role_params.update(role_args)
+
+    # TODO: cli flag to set gather_facts ?
+    return {'name': "Ansible Role",
+            'hosts': pattern,
+            # 'gather_facts': 'no',
+            'tasks': [
+                # TODO: is there anything that would be useful to run
+                #       before or after a role? Maybe something to format
+                #       the invocation and/or results (if it could make for
+                #       better uxd that just the default callback handling)
+                {'action': {'module': 'include_role',
+                            'name': role_name,
+                            },
+                 'vars': role_params,
+                 'async_val': async_val,
+                 'poll': poll}
+            ]
+            }
+
+
+class RoleCLI(CLI):
+    def parse(self):
+        ''' create an options parser for bin/ansible '''
+
+        self.parser = CLI.base_parser(
+            usage="usage: %%prog [%s] [--help] [options] ..." % "|".join(self.VALID_ACTIONS),
+            runas_opts=True,
+            inventory_opts=True,
+            async_opts=True,
+            output_opts=True,
+            connect_opts=True,
+            check_opts=True,
+            runtask_opts=True,
+            vault_opts=True,
+            fork_opts=True,
+            module_opts=True,
+            basedir_opts=True,
+            epilog="\nSee '%s <command> --help' for more information on a specific command.\n\n" % os.path.basename(sys.argv[0]),
+            desc="Perform various Role related operations.",
+        )
+
+        # common
+        self.parser.add_option('-a', '--args', dest='role_args_string',
+                               help="role arguments", default=C.DEFAULT_ROLE_ARGS)
+        self.parser.add_option('-A', '--arg-spec-name', dest='arg_spec_name',
+                               help="The name of a argument_spec to use", default='main')
+        self.parser.add_option('-r', '--role', dest='role_name',
+                               help="role name to execute",
+                               default=None)
+
+        super(RoleCLI, self).parse()
+
+        if len(self.args) < 1:
+            raise AnsibleOptionsError("Missing target hosts")
+        elif len(self.args) > 1:
+            raise AnsibleOptionsError("Extraneous options or arguments")
+
+        if not self.options.role_name:
+            raise AnsibleOptionsError("-r/--role requires a role name")
+
+        display.verbosity = self.options.verbosity
+        self.validate_conflicts(runas_opts=True, vault_opts=True, fork_opts=True)
+
+    def run(self):
+        super(RoleCLI, self).run()
+
+        # only thing left should be host pattern
+        pattern = to_text(self.args[0], errors='surrogate_or_strict')
+
+        sshpass = None
+        becomepass = None
+
+        self.normalize_become_options()
+        (sshpass, becomepass) = self.ask_passwords()
+        passwords = {'conn_pass': sshpass, 'become_pass': becomepass}
+
+        # dynamically load any plugins
+        get_all_plugin_loaders()
+
+        loader, inventory, variable_manager = self._play_prereqs(self.options)
+
+        try:
+            role_includes = load_list_of_roles([self.options.role_name], play=None, variable_manager=variable_manager, loader=loader)
+        except AssertionError as e:
+            raise AnsibleParserError("A malformed role declaration was encountered.", obj=self._ds, orig_exc=e)
+
+        for role_include in role_includes:
+            display.debug('cli.role.run loaded role_include: %s' % role_include)
+
+        extra_vars = variable_manager.extra_vars
+
+        play_ds = _play_ds(pattern, self.options.role_name, self.options.role_args_string,
+                           extra_vars, self.options.seconds, self.options.poll_interval)
+
+        play = Play().load(play_ds, variable_manager=variable_manager, loader=loader)
+
+        # used in start callback
+        playbook = Playbook(loader)
+        playbook._entries.append(play)
+        playbook._file_name = '__role_playbook__'
+
+        cb = C.DEFAULT_STDOUT_CALLBACK
+        if self.callback:
+            cb = self.callback
+
+        # now create a task queue manager to execute the play
+        self._tqm = None
+        try:
+            self._tqm = TaskQueueManager(
+                inventory=inventory,
+                variable_manager=variable_manager,
+                loader=loader,
+                options=self.options,
+                passwords=passwords,
+                stdout_callback=cb,
+                run_additional_callbacks=C.DEFAULT_LOAD_CALLBACK_PLUGINS,
+            )
+
+            self._tqm.send_callback('v2_playbook_on_start', playbook)
+
+            result = self._tqm.run(play)
+
+            self._tqm.send_callback('v2_playbook_on_stats', self._tqm._stats)
+        finally:
+            if self._tqm:
+                self._tqm.cleanup()
+            if loader:
+                loader.cleanup_all_tmp_files()
+
+        return result

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -934,6 +934,23 @@ DEFAULT_REMOTE_USER:
   env: [{name: ANSIBLE_REMOTE_USER}]
   ini:
   - {key: remote_user, section: defaults}
+DEFAULT_ROLE_ARGS:
+  name: ansible-role default role arguments
+  default: ''
+  description:
+    - This sets the default arguments to pass to the ``ansible-role`` binary if no ``-a`` is specified.
+  env: [{name: ANSIBLE_ROLE_ARGS}]
+  ini:
+  - {key: role_args, section: defaults}
+DEFAULT_ARG_SPEC_NAME:
+  name: Default argument spec name
+  default: "default"
+  description:
+    - The arg spec name to use if one isnt specified.
+    - The default value is "default"
+  env: [{name: ANSIBLE_ARG_SPEC_NAME}]
+  ini:
+  - {key: default_arg_spec_name, sections: defaults}
 DEFAULT_ROLES_PATH:
   name: Roles path
   default: ~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles

--- a/test/units/cli/test_role.py
+++ b/test/units/cli/test_role.py
@@ -1,0 +1,69 @@
+# Copyright: (c) 2017, 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import logging
+
+import pytest
+
+from ansible.cli.role import RoleCLI
+
+from ansible.errors import AnsibleOptionsError
+
+log = logging.getLogger(__name__)
+
+
+def test_role_cli_no_args():
+    with pytest.raises(TypeError):
+        RoleCLI()
+
+
+def test_role_cli_empty_args():
+    cli = RoleCLI(args=[])
+    assert isinstance(cli, RoleCLI)
+    log.debug('cli: %s', cli)
+
+
+def test_parse_empty_args():
+    args = []
+    cli = RoleCLI(args=args)
+    with pytest.raises(AnsibleOptionsError):
+        cli.parse()
+
+    log.debug('cli.parser: %s', cli.parser)
+
+    assert cli.parser is not None
+
+
+def test_parse():
+    args = ['ansible-role', 'localhost', '-r', 'somenamespace.somerepo', '-a', 'some_arg=some_value']
+    cli = RoleCLI(args=args)
+    cli.parse()
+
+    log.debug('cli.parser: %s', cli.parser)
+
+    assert cli.parser is not None
+
+    log.debug('cli.options: %s', cli.options)
+    log.debug('cli.options.role_name: %s', cli.options.role_name)
+    log.debug('cli.options.role_args_string: %s', cli.options.role_args_string)
+    assert cli.options.role_args_string == 'some_arg=some_value'
+
+
+def test_run(mocker):
+
+    mocker.patch('ansible.playbook.role.include.RoleInclude._load_role_path',
+                 return_value=('somenamespace.somerepo', '/dev/null/not/a/path'))
+    args = ['ansible-role', 'localhost', '-r', 'somenamespace.somerepo']
+    cli = RoleCLI(args=args)
+    cli.parse()
+
+    rc = cli.run()
+
+    log.debug('rc: %s', rc)
+
+    assert rc == 0


### PR DESCRIPTION
##### SUMMARY
Add a 'ansible-role' cli

This is split off from the https://github.com/ansible/ansible/pull/44983 role arg spec pr.

Apply a role to a host list, similar to 'ansible localhost -m ping'


For example using  test1 role in test/integration/targets/validate_arg_spec
 $ cd test/integration/targets/validate_arg_spec

 # will use the 'default' role arg specs from meta/arg_specs.yml
 $ ansible-role localhost -r test1


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/cli/role.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (ansible_role_ier 31618fb8ea) last updated 2018/09/19 14:26:36 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = ['/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```

