### PR TITLE
Explain disk size in mount and add example (#41681)

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -216,7 +216,7 @@ EXAMPLES = '''
     ostemplate: 'local:vztmpl/ubuntu-14.04-x86_64.tar.gz'
     netif: '{"net0":"name=eth0,gw=192.168.0.1,ip=192.168.0.2/24,bridge=vmbr0"}'
 
-# Create new container with minimal options defining a mount
+# Create new container with minimal options defining a mount with 8GB
 - proxmox:
     vmid: 100
     node: uk-mc02
@@ -247,6 +247,15 @@ EXAMPLES = '''
     api_password: 1q2w3e
     api_host: node1
     state: started
+
+# Start container with mount. You should enter a 90-second timeout because servers with additional disks take longer to boot.
+- proxmox:
+    vmid: 100
+    api_user: root@pam
+    api_password: 1q2w3e
+    api_host: node1
+    state: started
+    timeout: 90
 
 # Stop container
 - proxmox:


### PR DESCRIPTION
##### SUMMARY


* Explain disk size in mount and add example

- Explain mount with 8GB
- Add new example to start container with mount

* Removed trailing whitespace

(cherry picked from commit f85065dabf7e995d8d4789443fbb293409e7b0fc)

##### ISSUE TYPE
- Docs Pull Request
