### PR TITLE
go back to FreeBSD 11.1 for tests due to 11.2 stability issues

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -47,7 +47,7 @@ matrix:
     - env: T=osx/10.11/1
     - env: T=rhel/7.5/1
     - env: T=freebsd/10.4/1
-    - env: T=freebsd/11.2/1
+    - env: T=freebsd/11.1/1
     - env: T=linux/centos6/1
     - env: T=linux/centos7/1
     - env: T=linux/fedora24/1
@@ -60,7 +60,7 @@ matrix:
     - env: T=osx/10.11/2
     - env: T=rhel/7.5/2
     - env: T=freebsd/10.4/2
-    - env: T=freebsd/11.2/2
+    - env: T=freebsd/11.1/2
     - env: T=linux/centos6/2
     - env: T=linux/centos7/2
     - env: T=linux/fedora24/2
@@ -73,7 +73,7 @@ matrix:
     - env: T=osx/10.11/3
     - env: T=rhel/7.5/3
     - env: T=freebsd/10.4/3
-    - env: T=freebsd/11.2/3
+    - env: T=freebsd/11.1/3
     - env: T=linux/centos6/3
     - env: T=linux/centos7/3
     - env: T=linux/fedora24/3

--- a/test/runner/completion/remote.txt
+++ b/test/runner/completion/remote.txt
@@ -1,4 +1,4 @@
 freebsd/10.4
-freebsd/11.2
+freebsd/11.1
 osx/10.11
 rhel/7.5


### PR DESCRIPTION
##### SUMMARY
FreeBSD has the occasional issue when it doesn't come up in a test, revert back to 11.1 until 11.3 is out or a new AMI with the fix is out.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```paste below
devel
```