### PR TITLE
Make ansible-test available in the bin directory.

### DIFF
--- a/bin/ansible-test
+++ b/bin/ansible-test
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# PYTHON_ARGCOMPLETE_OK
+"""Primary entry point for ansible-test."""
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import os
+import sys
+
+if __name__ == '__main__':
+    sys.path.insert(0, os.path.abspath(os.path.join(__file__, '..', '..', 'test', 'runner')))
+    import lib.cli
+    lib.cli.main()

--- a/bin/ansible-test
+++ b/bin/ansible-test
@@ -10,6 +10,6 @@ import os
 import sys
 
 if __name__ == '__main__':
-    sys.path.insert(0, os.path.abspath(os.path.join(__file__, '..', '..', 'test', 'runner')))
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'test', 'runner')))
     import lib.cli
     lib.cli.main()

--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -47,7 +47,7 @@ FULL_PATH=$($PYTHON_BIN -c "import os; print(os.path.realpath('$HACKING_DIR'))")
 export ANSIBLE_HOME="$(dirname "$FULL_PATH")"
 
 PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib"
-PREFIX_PATH="$ANSIBLE_HOME/bin:$ANSIBLE_HOME/test/runner"
+PREFIX_PATH="$ANSIBLE_HOME/bin"
 PREFIX_MANPATH="$ANSIBLE_HOME/docs/man"
 
 expr "$PYTHONPATH" : "${PREFIX_PYTHONPATH}.*" > /dev/null || prepend_path PYTHONPATH "$PREFIX_PYTHONPATH"

--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -5,7 +5,7 @@ set HACKING_DIR (dirname (status -f))
 set FULL_PATH (python -c "import os; print(os.path.realpath('$HACKING_DIR'))")
 set ANSIBLE_HOME (dirname $FULL_PATH)
 set PREFIX_PYTHONPATH $ANSIBLE_HOME/lib
-set PREFIX_PATH $ANSIBLE_HOME/bin $ANSIBLE_HOME/test/runner
+set PREFIX_PATH $ANSIBLE_HOME/bin
 set PREFIX_MANPATH $ANSIBLE_HOME/docs/man
 
 # set quiet flag

--- a/test/runner/ansible-test
+++ b/test/runner/ansible-test
@@ -1,1 +1,8 @@
-test.py
+#!/usr/bin/env python
+# PYTHON_ARGCOMPLETE_OK
+"""Legacy entry point for ansible-test. The preferred version is in the bin directory."""
+
+import lib.cli
+
+if __name__ == '__main__':
+    lib.cli.main()

--- a/test/runner/lib/cli.py
+++ b/test/runner/lib/cli.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# PYTHON_ARGCOMPLETE_OK
 """Test runner for all Ansible tests."""
 
 from __future__ import absolute_import, print_function
@@ -72,7 +70,7 @@ import lib.cover
 def main():
     """Main program function."""
     try:
-        git_root = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
+        git_root = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..'))
         os.chdir(git_root)
         initialize_cloud_plugins()
         sanity_init()
@@ -786,7 +784,3 @@ def complete_sanity_test(prefix, parsed_args, **_):
     tests = sorted(t.name for t in sanity_get_tests())
 
     return [i for i in tests if i.startswith(prefix)]
-
-
-if __name__ == '__main__':
-    main()

--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -143,7 +143,7 @@ def delegate_tox(args, exclude, require, integration_targets):
 
         tox.append('--')
 
-        cmd = generate_command(args, os.path.abspath('test/runner/test.py'), options, exclude, require)
+        cmd = generate_command(args, os.path.abspath('bin/ansible-test'), options, exclude, require)
 
         if not args.python:
             cmd += ['--python', version]
@@ -195,7 +195,7 @@ def delegate_docker(args, exclude, require, integration_targets):
         '--docker-util': 1,
     }
 
-    cmd = generate_command(args, '/root/ansible/test/runner/test.py', options, exclude, require)
+    cmd = generate_command(args, '/root/ansible/bin/ansible-test', options, exclude, require)
 
     if isinstance(args, TestConfig):
         if args.coverage and not args.coverage_label:
@@ -364,7 +364,7 @@ def delegate_remote(args, exclude, require, integration_targets):
                 '--remote': 1,
             }
 
-            cmd = generate_command(args, 'ansible/test/runner/test.py', options, exclude, require)
+            cmd = generate_command(args, 'ansible/bin/ansible-test', options, exclude, require)
 
             if httptester_id:
                 cmd += ['--inject-httptester']

--- a/test/sanity/pylint/ignore.txt
+++ b/test/sanity/pylint/ignore.txt
@@ -106,6 +106,5 @@ test/runner/lib/thread.py missing-docstring 3.7
 test/runner/lib/util.py missing-docstring 3.7
 test/runner/retry.py missing-docstring 3.7
 test/runner/shippable.py missing-docstring 3.7
-test/runner/test.py missing-docstring 3.7
 test/runner/units/test_diff.py missing-docstring 3.7
 test/sanity/import/importer.py missing-docstring 3.7


### PR DESCRIPTION
##### SUMMARY

Make `ansible-test` available in the bin directory.

Thanks to @dagwieers for https://github.com/ansible/ansible/pull/45857 which inspired this.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (at-entry-point c6adf25471) last updated 2018/09/19 16:30:23 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
