### PR TITLE
Switch RHEL and Windows tests back to Azure

### DIFF
--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
@@ -1,5 +1,6 @@
 # Copyright (c), Michael DeHaan <michael.dehaan@gmail.com>, 2014, and others
 # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+# test to trigger ci
 
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"

--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -70,10 +70,13 @@ class AnsibleCoreCI(object):
                 'junos',
                 'ios',
                 'tower',
-                'rhel',
             ),
             azure=(
                 'azure',
+                'rhel',
+                'windows/2012',
+                'windows/2012-R2',
+                'windows/2016'
             ),
             parallels=(
                 'osx',


### PR DESCRIPTION
##### SUMMARY
Swap the ansible-test instances for RHEL and Windows 2012+ back to Azure. May need to revert if the issues before have not been fixed.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```paste below
devel
```