### PR TITLE
no-smart-quotes: Skip files by path in code-smell

### DIFF
--- a/test/sanity/code-smell/no-smart-quotes.py
+++ b/test/sanity/code-smell/no-smart-quotes.py
@@ -15,25 +15,27 @@ def main():
         'test/integration/targets/template/files/encoding_1252_utf-8.expected',
         'test/integration/targets/template/files/encoding_1252_windows-1252.expected',
         'test/integration/targets/template/templates/encoding_1252.j2',
+        'docs/docsite/_build/',
     ])
 
     for path in sys.argv[1:] or sys.stdin.read().splitlines():
-        if path in skip:
-            continue
+        for skip_path in skip:
+            if path.startswith(skip_path):
+                break
+        else:
+            with open(path, 'rb') as path_fd:
+                for line, text in enumerate(path_fd.readlines()):
+                    try:
+                        text = text.decode('utf-8')
+                    except UnicodeDecodeError as ex:
+                        print('%s:%d:%d: UnicodeDecodeError: %s' % (path, line + 1, ex.start + 1, ex))
+                        continue
 
-        with open(path, 'rb') as path_fd:
-            for line, text in enumerate(path_fd.readlines()):
-                try:
-                    text = text.decode('utf-8')
-                except UnicodeDecodeError as ex:
-                    print('%s:%d:%d: UnicodeDecodeError: %s' % (path, line + 1, ex.start + 1, ex))
-                    continue
+                    match = re.search(u'([‘’“”])', text)
 
-                match = re.search(u'([‘’“”])', text)
-
-                if match:
-                    print('%s:%d:%d: use ASCII quotes `\'` and `"` instead of Unicode quotes' % (
-                        path, line + 1, match.start(1) + 1))
+                    if match:
+                        print('%s:%d:%d: use ASCII quotes `\'` and `"` instead of Unicode quotes' % (
+                            path, line + 1, match.start(1) + 1))
 
 
 if __name__ == '__main__':

--- a/test/sanity/code-smell/no-smart-quotes.py
+++ b/test/sanity/code-smell/no-smart-quotes.py
@@ -8,34 +8,39 @@ import sys
 
 def main():
     skip = set([
-        'test/sanity/code-smell/%s' % os.path.basename(__file__),
         'docs/docsite/rst/dev_guide/testing/sanity/no-smart-quotes.rst',
-        'test/integration/targets/unicode/unicode.yml',
         'test/integration/targets/lookup_properties/lookup-8859-15.ini',
         'test/integration/targets/template/files/encoding_1252_utf-8.expected',
         'test/integration/targets/template/files/encoding_1252_windows-1252.expected',
         'test/integration/targets/template/templates/encoding_1252.j2',
+        'test/integration/targets/unicode/unicode.yml',
+        'test/sanity/code-smell/%s' % os.path.basename(__file__),
+    ])
+
+    prune = set([
         'docs/docsite/_build/',
     ])
 
     for path in sys.argv[1:] or sys.stdin.read().splitlines():
-        for skip_path in skip:
-            if path.startswith(skip_path):
-                break
-        else:
-            with open(path, 'rb') as path_fd:
-                for line, text in enumerate(path_fd.readlines()):
-                    try:
-                        text = text.decode('utf-8')
-                    except UnicodeDecodeError as ex:
-                        print('%s:%d:%d: UnicodeDecodeError: %s' % (path, line + 1, ex.start + 1, ex))
-                        continue
+        if path in skip:
+            continue
 
-                    match = re.search(u'([‘’“”])', text)
+        if any(path.startswith(p) for p in prune):
+            continue
 
-                    if match:
-                        print('%s:%d:%d: use ASCII quotes `\'` and `"` instead of Unicode quotes' % (
-                            path, line + 1, match.start(1) + 1))
+        with open(path, 'rb') as path_fd:
+            for line, text in enumerate(path_fd.readlines()):
+                try:
+                    text = text.decode('utf-8')
+                except UnicodeDecodeError as ex:
+                    print('%s:%d:%d: UnicodeDecodeError: %s' % (path, line + 1, ex.start + 1, ex))
+                    continue
+
+                match = re.search(u'([‘’“”])', text)
+
+                if match:
+                    print('%s:%d:%d: use ASCII quotes `\'` and `"` instead of Unicode quotes' % (
+                        path, line + 1, match.start(1) + 1))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
This is to ensure the generated docs do not trigger more than 27000 code-smell issues on contributor systems.

The below endless list:
```
Sanity check using no-smart-quotes
ERROR: Found 27518 no-smart-quotes issue(s) which need to be resolved:
ERROR: docs/docsite/_build/html/api/index.html:592:156: use ASCII quotes `'` and `"` instead of Unicode quotes
ERROR: docs/docsite/_build/html/api/index.html:617:112: use ASCII quotes `'` and `"` instead of Unicode quotes
ERROR: docs/docsite/_build/html/api/index.html:874:148: use ASCII quotes `'` and `"` instead of Unicode quotes
ERROR: docs/docsite/_build/html/api/index.html:989:165: use ASCII quotes `'` and `"` instead of Unicode quotes
ERROR: docs/docsite/_build/html/api/index.html:1161:120: use ASCII quotes `'` and `"` instead of Unicode quotes
ERROR: docs/docsite/_build/html/api/index.html:1653:154: use ASCII quotes `'` and `"` instead of Unicode quotes
ERROR: docs/docsite/_build/html/api/index.html:1654:157: use ASCII quotes `'` and `"` instead of Unicode quotes
ERROR: docs/docsite/_build/html/api/index.html:2082:132: use ASCII quotes `'` and `"` instead of Unicode quotes
ERROR: docs/docsite/_build/html/api/index.html:2084:128: use ASCII quotes `'` and `"` instead of Unicode quotes
ERROR: docs/docsite/_build/html/cli/ansible-config.html:594:156: use ASCII quotes `'` and `"` instead of Unicode quotes
ERROR: docs/docsite/_build/html/cli/ansible-config.html:619:112: use ASCII quotes `'` and `"` instead of Unicode quotes
ERROR: docs/docsite/_build/html/cli/ansible-config.html:874:148: use ASCII quotes `'` and `"` instead of Unicode quotes
ERROR: docs/docsite/_build/html/cli/ansible-config.html:989:165: use ASCII quotes `'` and `"` instead of Unicode quotes
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
no-smart-quotes code-smell

##### ANSIBLE VERSION
v2.8