### PR TITLE
Ignore additional fields in ignore.txt

### DIFF
--- a/test/runner/lib/sanity/validate_modules.py
+++ b/test/runner/lib/sanity/validate_modules.py
@@ -77,7 +77,8 @@ class ValidateModulesTest(SanitySingleVersion):
                     invalid_ignores.append((line, 'Invalid syntax'))
                     continue
 
-                path, code = ignore_entry.split(' ', 1)
+                # Ignore additional comments in ignore.txt
+                path, code = ignore_entry.split(' ')[0:2]
 
                 ignore[path][code] = line
 


### PR DESCRIPTION
##### SUMMARY
This allows to add annotations in the ignore.txt for future reference.
Useful to indicate why certain ignored errors are deliberately being ignored.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
validate_modules sanit tests

##### ANSIBLE VERSION
v2.8