### PR TITLE
Improve GitHub templates (step 2)

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,34 +2,34 @@
 <!--- Also test if the latest release and devel branch are affected too -->
 <!--- Complete *all* sections as described, this form is processed automatically -->
 
-##### SUMMARY
+### Summary
 <!--- Explain the problem briefly below -->
 
-##### ISSUE TYPE
+### Issue type
 <!--- Pick one below and delete the rest -->
  - Bug Report
  - Feature Idea
  - Documentation Report
 
-##### COMPONENT NAME
+### Component name
 <!--- Write the short name of the module, plugin, task or feature below, use your best guess if unsure -->
 
-##### ANSIBLE VERSION
+### Ansible version
 <!--- Paste verbatim output from "ansible --version" between quotes -->
 ```paste below
 
 ```
 
-##### CONFIGURATION
+### Configuration
 <!--- Paste verbatim output from "ansible-config dump --only-changed" between quotes -->
 ```paste below
 
 ```
 
-##### OS / ENVIRONMENT
+### OS / Environment
 <!--- Provide all relevant information below, e.g. target OS versions, network device firmware, etc. -->
 
-##### STEPS TO REPRODUCE
+### Steps to reproduce
 <!--- Describe exactly how to reproduce the problem, using a minimal test-case -->
 
 <!--- Paste example playbooks or commands between quotes below -->
@@ -39,10 +39,10 @@
 
 <!--- HINT: You can paste gist.github.com links for larger files -->
 
-##### EXPECTED RESULTS
+### Expected results
 <!--- Describe what you expected to happen when running the steps above -->
 
-##### ACTUAL RESULTS
+### Actual results
 <!--- Describe what actually happened. If possible run with extra verbosity (-vvvv) -->
 
 <!--- Paste verbatim command output between quotes -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,35 +2,33 @@
 name: 🐛 Bug report
 about: Create a report to help us improve
 ---
+## Bug report
 <!--- Verify first that your issue is not already reported on GitHub -->
 <!--- Also test if the latest release and devel branch are affected too -->
 <!--- Complete *all* sections as described, this form is processed automatically -->
 
-##### SUMMARY
+### Summary
 <!--- Explain the problem briefly below -->
 
-##### ISSUE TYPE
-- Bug Report
-
-##### COMPONENT NAME
+### Component name
 <!--- Write the short name of the module, plugin, task or feature below, use your best guess if unsure -->
 
-##### ANSIBLE VERSION
+### Ansible version
 <!--- Paste verbatim output from "ansible --version" between quotes -->
 ```paste below
 
 ```
 
-##### CONFIGURATION
+### Configuration
 <!--- Paste verbatim output from "ansible-config dump --only-changed" between quotes -->
 ```paste below
 
 ```
 
-##### OS / ENVIRONMENT
+### OS / Environment
 <!--- Provide all relevant information below, e.g. target OS versions, network device firmware, etc. -->
 
-##### STEPS TO REPRODUCE
+### Steps to reproduce
 <!--- Describe exactly how to reproduce the problem, using a minimal test-case -->
 
 <!--- Paste example playbooks or commands between quotes below -->
@@ -40,11 +38,11 @@ about: Create a report to help us improve
 
 <!--- HINT: You can paste gist.github.com links for larger files -->
 
-##### EXPECTED RESULTS
+### Expected results
 <!--- Describe what you expected to happen when running the steps above -->
 
 
-##### ACTUAL RESULTS
+### Actual results
 <!--- Describe what actually happened. If possible run with extra verbosity (-vvvv) -->
 
 <!--- Paste verbatim command output between quotes -->

--- a/.github/ISSUE_TEMPLATE/documentation_report.md
+++ b/.github/ISSUE_TEMPLATE/documentation_report.md
@@ -2,37 +2,35 @@
 name: 📝 Documentation Report
 about: Ask us about docs
 ---
+## Documentation report
 <!--- Verify first that your improvement is not already reported on GitHub -->
 <!--- Also test if the latest release and devel branch are affected too -->
 <!--- Complete *all* sections as described, this form is processed automatically -->
 
-##### SUMMARY
+### Summary
 <!--- Explain the problem briefly below, add suggestions to wording or structure -->
 
 <!--- HINT: Did you know the documentation has an "Edit on GitHub" link on every page ? -->
 
-##### ISSUE TYPE
-- Documentation Report
-
-##### COMPONENT NAME
+### Component name
 <!--- Write the short name of the rst file, module, plugin, task or feature below, use your best guess if unsure -->
 
-##### ANSIBLE VERSION
+### Ansible version
 <!--- Paste verbatim output from "ansible --version" between quotes -->
 ```paste below
 
 ```
 
-##### CONFIGURATION
+### Configuration
 <!--- Paste verbatim output from "ansible-config dump --only-changed" between quotes -->
 ```paste below
 
 ```
 
-##### OS / ENVIRONMENT
+### OS / Environment
 <!--- Provide all relevant information below, e.g. OS version, browser, etc. -->
 
-##### ADDITIONAL INFORMATION
+### Additional information
 <!--- Describe how this improves the documentation, e.g. before/after situation or screenshots -->
 
 <!--- HINT: You can paste gist.github.com links for larger files -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,19 +2,17 @@
 name: ✨ Feature request
 about: Suggest an idea for this project
 ---
+## Feature request
 <!--- Verify first that your feature was not already discussed on GitHub -->
 <!--- Complete *all* sections as described, this form is processed automatically -->
 
-##### SUMMARY
+### Summary
 <!--- Describe the new feature/improvement briefly below -->
 
-##### ISSUE TYPE
-- Feature Idea
-
-##### COMPONENT NAME
+### Component name
 <!--- Write the short name of the module, plugin, task or feature below, use your best guess if unsure -->
 
-##### ADDITIONAL INFORMATION
+### Additional information
 <!--- Describe how the feature would be used, why it is needed and what it would solve -->
 
 <!--- Paste example playbooks or commands between quotes below -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,18 @@
-##### SUMMARY
 <!--- Describe the change below, including rationale and design decisions -->
 
 <!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
 
-##### ISSUE TYPE
+### Type of pull request
 <!--- Pick one below and delete the rest -->
-- Bugfix Pull Request
-- Docs Pull Request
-- Feature Pull Request
-- New Module Pull Request
+- Bugfix
+- Documentation
+- Feature
+- New Module
 
-##### COMPONENT NAME
+### Component name
 <!--- Write the short name of the module, plugin, task or feature below -->
 
-##### ADDITIONAL INFORMATION
+### Additional information
 <!--- Include additional information to help people understand the change here -->
 <!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
-<!--- Describe the change below, including rationale and design decisions -->
 
+<!--- Describe the change above, including rationale and design decisions -->
 <!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
 
 ### Type of pull request
@@ -8,9 +8,6 @@
 - Documentation
 - Feature
 - New Module
-
-### Component name
-<!--- Write the short name of the module, plugin, task or feature below -->
 
 ### Additional information
 <!--- Include additional information to help people understand the change here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,6 @@
 
 <!--- Describe the change above, including rationale and design decisions -->
+
 <!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
 
 ### Type of pull request
@@ -10,8 +11,9 @@
 - New Module
 
 ### Additional information
-<!--- Include additional information to help people understand the change here -->
 <!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
+
+<!--- HINT: Include the lowest supported Ansible version that is affected by this issue -->
 
 <!--- Paste verbatim command output below, e.g. before and after your change -->
 ```paste below


### PR DESCRIPTION
This is a continuation of #44455. It includes the more controversial changes.

This PR includes:
- NO NEED FOR FRUSTRATION CAPS IN TITLES!
- Better headings/titles
- No 'Summary' title for PRs (so commit information is placed correctly)
- No 'Component name' section for PRs (modified files is clearer)
- No 'Ansible version' section for PRs (but add a hint to ask for lowest version affected)

This PR would require some improvements to Ansibot.
<!--- Describe the change above, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

### Type of pull request
<!--- Pick one below and delete the rest -->
- Feature

### Additional information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This description shows what the change would look like.

Remarks ?
- ~Is there still a reason to ask for the "Component name" when doing a PR ?~
  - ~Is the  list of modified files not the best indicator ?~
  - ~@gundalow agrees, so gone is that section now...~
- I prefer level-2 headings (because it includes a wide line) but the font might be considered too big.
- The removal of a SUMMARY title for pull-requests is definitely something to get used to.
  - It would have been nice if the PR template supported a placeholder for the commit message.

<!--- Paste verbatim command output below, e.g. before and after your change -->