### PR TITLE
Fix incorrect use of subprocess.CalledProcessError

### DIFF
--- a/test/sanity/code-smell/docs-build.py
+++ b/test/sanity/code-smell/docs-build.py
@@ -14,7 +14,10 @@ def main():
     stdout, stderr = sphinx.communicate()
 
     if sphinx.returncode != 0:
-        raise subprocess.CalledProcessError(sphinx.returncode, cmd, output=stdout + stderr)
+        print("Command '%s' failed with status code: %d" % (' '.join(cmd), sphinx.returncode))
+        print(stdout)
+        print(stderr)
+        return
 
     with open('docs/docsite/rst_warnings', 'r') as warnings_fd:
         output = warnings_fd.read().strip()

--- a/test/sanity/code-smell/docs-build.py
+++ b/test/sanity/code-smell/docs-build.py
@@ -14,7 +14,7 @@ def main():
     stdout, stderr = sphinx.communicate()
 
     if sphinx.returncode != 0:
-        raise subprocess.CalledProcessError(sphinx.returncode, cmd, output=stdout, stderr=stderr)
+        raise subprocess.CalledProcessError(sphinx.returncode, cmd, output=stdout + stderr)
 
     with open('docs/docsite/rst_warnings', 'r') as warnings_fd:
         output = warnings_fd.read().strip()


### PR DESCRIPTION
##### SUMMARY
This fixes a secondary traceback on error due to a syntax error.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docs-build sanity

##### ANSIBLE VERSION
v2.8