### PR TITLE
Add test suite for ec2_vpc_igw before boto3 upgrade

### DIFF
--- a/test/integration/targets/ec2_vpc_igw/aliases
+++ b/test/integration/targets/ec2_vpc_igw/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+shippable/aws/group2

--- a/test/integration/targets/ec2_vpc_igw/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_igw/tasks/main.yml
@@ -1,0 +1,84 @@
+---
+- block:
+  - name: set up aws connection info
+    set_fact:
+      aws_connection_info: &aws_connection_info
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        security_token: "{{ security_token }}"
+        region: "{{ aws_region }}"
+    no_log: yes
+
+  # ============================================================
+  - name: create a VPC
+    ec2_vpc_net:
+      name: "{{ resource_prefix }}-vpc"
+      state: present
+      cidr_block: "10.232.232.128/26"
+      <<: *aws_connection_info
+      tags:
+        Name: "{{ resource_prefix }}-vpc"
+        Description: "Created by ansible-test"
+    register: vpc_result
+
+  # ============================================================
+  - name: create internet gateway (expected changed=true)
+    ec2_vpc_igw:
+      state: present
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      <<: *aws_connection_info
+    register: vpc_igw_create
+
+  - name: assert creation happened (expected changed=true)
+    assert:
+      that:
+          - 'vpc_igw_create'
+          - 'vpc_igw_create.gateway_id.startswith("igw-")'
+          - 'vpc_igw_create.vpc_id == vpc_result.vpc.id'
+          - '"tags" in vpc_igw_create'
+          - '"gateway_id" in vpc_igw_create'
+
+  # ============================================================
+  - name: attempt to recreate internet gateway on VPC (expected changed=false)
+    ec2_vpc_igw:
+      state: present
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      <<: *aws_connection_info
+    register: vpc_igw_recreate
+
+  - name: assert recreation did nothing (expected changed=false)
+    assert:
+      that:
+          - 'vpc_igw_recreate.changed == False'
+          - 'vpc_igw_recreate.gateway_id == vpc_igw_create.gateway_id'
+          - 'vpc_igw_recreate.vpc_id == vpc_igw_create.vpc_id'
+
+  # ============================================================
+  - name: test state=absent (expected changed=true)
+    ec2_vpc_igw:
+      state: absent
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      <<: *aws_connection_info
+    register: vpc_igw_delete
+
+  - name: assert state=absent (expected changed=true)
+    assert:
+      that:
+          - 'vpc_igw_delete.changed'
+
+  always:
+    # ============================================================
+    - name: tidy up IGW
+      ec2_vpc_igw:
+        state: absent
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        <<: *aws_connection_info
+      ignore_errors: true
+
+    - name: tidy up VPC
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        state: absent
+        cidr_block: "10.232.232.128/26"
+        <<: *aws_connection_info
+      ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
Checks results of ec2_vpc_igw is same before and after boto3 upgrade

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2_vpc_igw
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel 5c73d4f4bd) last updated 2018/09/20 19:53:36 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Mar  9 2018, 23:57:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
