### PR TITLE
Add ospf net type

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -141,6 +141,7 @@ PARAM_TO_COMMAND_KEYMAP = {
     'message_digest_algorithm_type': 'ip ospf message-digest-key',
     'message_digest_encryption_type': 'ip ospf message-digest-key',
     'message_digest_password': 'ip ospf message-digest-key',
+    'network': 'ip ospf network',
 }
 
 
@@ -249,6 +250,12 @@ def get_custom_command(existing_cmd, proposed, key, module):
         if command not in existing_cmd:
             commands.append(command)
 
+    if key == 'ip ospf network':
+        command = '{0} {1}'.format(key, proposed['network'])
+
+        if command not in existing_cmd:
+            commands.append(command)
+
     elif key.startswith('ip ospf message-digest-key'):
         if (proposed['message_digest_key_id'] != 'default' and
                 'options' not in key):
@@ -281,6 +288,8 @@ def state_present(module, existing, proposed, candidate):
 
         if key == 'ip ospf passive-interface' and module.params.get('interface').upper().startswith('LO'):
             module.fail_json(msg='loopback interface does not support passive_interface')
+        if key == 'ip ospf network' and value == 'broadcast' and module.params.get('interface').upper().startswith('LO'):
+            module.fail_json(msg='loopback interface does not support ospf network type broadcast')
         if value is True:
             commands.append(key)
         elif value is False:
@@ -325,7 +334,7 @@ def state_absent(module, existing, proposed, candidate):
                         existing['message_digest_password'])
                     commands.append(command)
             elif key in ['ip ospf authentication message-digest',
-                         'ip ospf passive-interface']:
+                         'ip ospf passive-interface', 'ip ospf network']:
                 if value:
                     commands.append('no {0}'.format(key))
             elif key == 'ip router ospf':
@@ -359,6 +368,7 @@ def main():
         hello_interval=dict(required=False, type='str'),
         dead_interval=dict(required=False, type='str'),
         passive_interface=dict(required=False, type='bool'),
+        network=dict(required=False, type='str', choices=['broadcast', 'point-to-point']),
         message_digest=dict(required=False, type='bool'),
         message_digest_key_id=dict(required=False, type='str'),
         message_digest_algorithm_type=dict(required=False, type='str', choices=['md5', 'default']),

--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -74,6 +74,7 @@ options:
     description:
       - Specifies interface ospf network type. Valid values are 'point-to-point' or 'broadcast'.
     choices: ['point-to-point', 'broadcast']
+    version_added: "2.8"
   message_digest:
     description:
       - Enables or disables the usage of message digest authentication.

--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -36,6 +36,7 @@ notes:
   - To remove an existing authentication configuration you should use
     C(message_digest_key_id=default) plus all other options matching their
     existing values.
+  - Loopback interfaces only support ospf network type 'point-to-point'.
   - C(state=absent) removes the whole OSPF interface configuration.
 options:
   interface:
@@ -69,6 +70,10 @@ options:
       - Setting to true will prevent this interface from receiving
         HELLO packets.
     type: bool
+  network:
+    description:
+      - Specifies interface ospf network type. Valid values are 'point-to-point' or 'broadcast'.
+    choices: ['point-to-point', 'broadcast']
   message_digest:
     description:
       - Enables or disables the usage of message digest authentication.
@@ -105,6 +110,13 @@ EXAMPLES = '''
     ospf: 1
     area: 1
     cost: default
+
+- nxos_interface_ospf:
+    interface: loopback0
+    ospf: prod
+    area: 0.0.0.0
+    network: point-to-point
+    state: present
 '''
 
 RETURN = '''

--- a/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
@@ -55,6 +55,7 @@
       passive_interface: true
       hello_interval: 15
       dead_interval: 75
+      network: point-to-point
       provider: "{{ connection }}"
       state: present
     register: result
@@ -80,6 +81,7 @@
       passive_interface: false
       hello_interval: 17
       dead_interval: 70
+      network: broadcast
       provider: "{{ connection }}"
       state: present
     register: result

--- a/test/units/modules/network/nxos/test_nxos_interface_ospf.py
+++ b/test/units/modules/network/nxos/test_nxos_interface_ospf.py
@@ -54,3 +54,5 @@ class TestNxosInterfaceOspfModule(TestNxosModule):
     def test_loopback_interface_failed(self):
         set_module_args(dict(interface='loopback0', ospf=1, area=0, passive_interface=True))
         self.execute_module(failed=True, changed=False)
+        set_module_args(dict(interface='loopback0', ospf=1, area=0, network='broadcast'))
+        self.execute_module(failed=True, changed=False)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding option to configure interface network type using nxos_interface_ospf module
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #45901 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_interface_ospf
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel 6e04a1dbdc) last updated 2018/09/19 11:40:47 (GMT +000)
  config file = None
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This PR adds extra network parameter mentioned in #45901 
Tested on 93180YC-EX running NXOS: version 7.0(3)I6(1)
Added documentation and test cases as well.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
