### PR TITLE
nmcli: Set boolean datatype to hairpin

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -1195,7 +1195,7 @@ def main():
             hellotime=dict(required=False, default="2", type='str'),
             maxage=dict(required=False, default="20", type='str'),
             ageingtime=dict(required=False, default="300", type='str'),
-            hairpin=dict(required=False, default=True, type='str'),
+            hairpin=dict(required=False, default=True, type='bool'),
             path_cost=dict(required=False, default="100", type='str'),
             # vlan specific vars
             vlanid=dict(required=False, default=None, type='str'),


### PR DESCRIPTION
Fix: nmcli module always sets hairpin mode to 1 for bridge slaves.

The bool_to_string always evalutes to true

Closes #42569

Signed-off-by: Susant Sahani<susant@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request #42569 

##### COMPONENT NAME
nmcli

##### ANSIBLE VERSION
ansible 2.8.0.dev0
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
