### PR TITLE
Backport a change on doc for lvol module

### DIFF
--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -80,7 +80,7 @@ options:
     description:
     - Resize the underlying filesystem together with the logical volume.
     type: bool
-    default: 'yes'
+    default: 'no'
     version_added: "2.5"
 notes:
   - You must specify lv (when managing the state of logical volumes) or thinpool (when managing a thin provisioned volume).
@@ -138,7 +138,7 @@ EXAMPLES = '''
     lv: test
     size: +100%FREE
 
-- name: Extend the logical volume to take all remaining space of the PVs
+- name: Extend the logical volume to take all remaining space of the PVs and resize the underlying filesystem
   lvol:
     vg: firefly
     lv: test

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -2177,7 +2177,6 @@ lib/ansible/modules/system/iptables.py E326
 lib/ansible/modules/system/java_cert.py E324
 lib/ansible/modules/system/java_cert.py E325
 lib/ansible/modules/system/known_hosts.py E324
-lib/ansible/modules/system/known_hosts.py E325
 lib/ansible/modules/system/lvol.py E324
 lib/ansible/modules/system/make.py E317
 lib/ansible/modules/system/make.py E324

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -2177,7 +2177,7 @@ lib/ansible/modules/system/iptables.py E326
 lib/ansible/modules/system/java_cert.py E324
 lib/ansible/modules/system/java_cert.py E325
 lib/ansible/modules/system/known_hosts.py E324
-lib/ansible/modules/system/lvol.py E324
+lib/ansible/modules/system/known_hosts.py E325
 lib/ansible/modules/system/make.py E317
 lib/ansible/modules/system/make.py E324
 lib/ansible/modules/system/make.py E327


### PR DESCRIPTION
##### SUMMARY
Backport a change on doc for lvol module. The resizefs option of lvol is said to be enabled  by default in the doc of 2.5, but the code has `default=False` as argument. This is fixed in devel, but not in the 2.5/2.6 documentation

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
lvol module

##### ANSIBLE VERSION
```
ansible 2.6.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/<redacted_username>/.ansible/plugins/modules', '/usr/share/ansible/plugins/m
odules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible                             
  executable location = /usr/bin/ansible
  python version = 3.7.0 (default, Sep 15 2018, 19:13:07) [GCC 8.2.1 20180831]                          

```

##### ADDITIONAL INFORMATION
Similar PR has to be done on stable-2.6. Could also do a separated commit for only the default change