### PR TITLE
botmeta support: core

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -37,6 +37,8 @@ automerge: True
 files:
   .github/BOTMETA.yml:
     labels: botmeta
+    # Changes to BOTMETA MUST always be reviewed by Core Team
+    support: core
   $modules/cloud/amazon/:
     ignored: erydo seiffert simplesteph
   $modules/cloud/amazon/aws_api_gateway.py: willthames

--- a/test/sanity/code-smell/botmeta.py
+++ b/test/sanity/code-smell/botmeta.py
@@ -60,7 +60,7 @@ def main():
             print('%s:%d:%d: %s' % (path, 0, 0, humanize_error(botmeta, error)))
 
     # Ensure botmeta is always support:core
-    botmeta_support = botmeta.get('files', {}).get('.github/BOTMETA.yml', '').get('support', '')
+    botmeta_support = botmeta.get('files', {}).get('.github/BOTMETA.yml', {}).get('support', '')
     if botmeta_support != 'core':
         print('%s:%d:%d: .github/BOTMETA.yml MUST be support: core' % (path, 0, 0))
 

--- a/test/sanity/code-smell/botmeta.py
+++ b/test/sanity/code-smell/botmeta.py
@@ -59,6 +59,11 @@ def main():
             # No way to get line numbers
             print('%s:%d:%d: %s' % (path, 0, 0, humanize_error(botmeta, error)))
 
+    # Ensure botmeta is always support:core
+    botmeta_support = botmeta.get('files', {}).get('.github/BOTMETA.yml', '').get('support', '')
+    if botmeta_support != 'core':
+        print('%s:%d:%d: .github/BOTMETA.yml MUST be support: core' % (path, 0, 0))
+
     # We have two macros to define locations, ensure they haven't been removed
     module_utils_path = botmeta.get('macros', {}).get('module_utils', '')
     modules_path = botmeta.get('macros', {}).get('modules', '')


### PR DESCRIPTION
##### SUMMARY
Lets protect against accidental/deliberate changes to BOTMETA

Not set to `core`
```
Command exited with status 0 after 0.368102073669 seconds.
ERROR: Found 1 botmeta issue(s) which need to be resolved:
ERROR: .github/BOTMETA.yml:0:0: .github/BOTMETA.yml MUST be support: core
ERROR: The 1 sanity test(s) listed below (out of 1) failed. See error output above for details.
botmeta
```

or if not set at all

```
ERROR: Found 2 botmeta issue(s) which need to be resolved:
ERROR: .github/BOTMETA.yml:0:0: .github/BOTMETA.yml MUST be support: core
ERROR: .github/BOTMETA.yml:0:0: Can't find '.github:# /BOTMETA.yml.*' in this branch
ERROR: The 1 sanity test(s) listed below (out of 1) failed. See error output above for details.
botmeta
```

##### ISSUE TYPE
- Bugfix Pull Request
