### PR TITLE
VMware: New option destination_resource_pool for vmware_vmotion module.

### DIFF
--- a/changelogs/fragments/vmware_vmotion-destination_resource_pool.yml
+++ b/changelogs/fragments/vmware_vmotion-destination_resource_pool.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - The `vmware_vmotion` module has a new option, `destination_resource_pool`.

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -172,6 +172,17 @@ def find_resource_pool_by_name(content, resource_pool_name):
     return find_object_by_name(content, resource_pool_name, [vim.ResourcePool])
 
 
+def find_resource_pool_by_name_and_host(content, resource_pool_name,
+                                        host_name):
+    for obj in get_all_objs(content, [vim.ResourcePool]):
+        if obj.name == resource_pool_name:
+            for host in obj.owner.host:
+                if host.name == host_name:
+                    return obj
+
+    return None
+
+
 def find_network_by_name(content, network_name):
     return find_object_by_name(content, network_name, [vim.Network])
 

--- a/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -115,7 +115,6 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import (PyVmomi, find_hostsystem_by_name,
                                          find_vm_by_id, find_datastore_by_name,
-                                         find_resource_pool_by_name,
                                          find_resource_pool_by_name_and_host,
                                          vmware_argument_spec, wait_for_task, TaskError)
 


### PR DESCRIPTION
##### SUMMARY
Provide a new option in the `vmware_vmotion` module, `destination_resource_pool`, to specify which resource pool the migrated virtual machine should run in.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`vmware_vmotion`

##### ANSIBLE VERSION
```paste below
ansible 2.8.0.dev0 (vmware_vmotion-destination_resource_pool 455da91a59) last updated 2018/09/20 14:34:10 (GMT +100)
```

##### ADDITIONAL INFORMATION
This provides a workaround for #25133.
