### PR TITLE
Support list of dicts with omit. Fixes #45907

### DIFF
--- a/changelogs/fragments/omit-list-of-dicts.yaml
+++ b/changelogs/fragments/omit-list-of-dicts.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- omit - support list types containing dicts (https://github.com/ansible/ansible/issues/45907)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -42,13 +42,18 @@ def remove_omit(task_args, omit_token):
     Remove args with a value equal to the ``omit_token`` recursively
     to align with now having suboptions in the argument_spec
     '''
-    new_args = {}
 
+    if not isinstance(task_args, dict):
+        return task_args
+
+    new_args = {}
     for i in iteritems(task_args):
         if i[1] == omit_token:
             continue
         elif isinstance(i[1], dict):
             new_args[i[0]] = remove_omit(i[1], omit_token)
+        elif isinstance(i[1], list):
+            new_args[i[0]] = [remove_omit(v, omit_token) for v in i[1]]
         else:
             new_args[i[0]] = i[1]
 

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -502,6 +502,14 @@ class TestTaskExecutor(unittest.TestCase):
                 'a_list': ['POPCORN'],
             },
             'a_list': ['POPCORN'],
+            'list_of_lists': [
+                ['some', 'thing'],
+            ],
+            'list_of_dicts': [
+                {
+                    'remove': 'POPCORN',
+                }
+            ],
         }
 
         expected = {
@@ -516,6 +524,10 @@ class TestTaskExecutor(unittest.TestCase):
                 'a_list': ['POPCORN'],
             },
             'a_list': ['POPCORN'],
+            'list_of_lists': [
+                ['some', 'thing'],
+            ],
+            'list_of_dicts': [{}],
         }
 
         self.assertEqual(remove_omit(data, omit_token), expected)


### PR DESCRIPTION
##### SUMMARY
Support list of dicts with omit. Fixes #45907

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_executor.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.5
2.6
2.7
2.8
```

##### ADDITIONAL INFORMATION
```yaml
- hosts: localhost             
  gather_facts: no             
  tasks:                       
    - demo:                    
        name: sdfsf            
        qqq: "{{ omit }}"      
        ggg:                   
          - key1: "{{ omit }}" 
            key2:              
              subkey: 111 
```