### PR TITLE
[2.6] Clean up after ansible-connection if failure occurred in start()

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -263,6 +263,8 @@ def main():
 
                     if rc == 0:
                         process.run()
+                    else:
+                        process.shutdown()
 
                     sys.exit(rc)
 


### PR DESCRIPTION
(#45929)

(cherry picked from commit 0d143ed)

Co-authored-by: Nathaniel Case <this.is@nathanielca.se>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6
```