### PR TITLE
powershell - fix for ANSIBLE_KEEP_REMOTE_FILES on older Pythons

### DIFF
--- a/changelogs/fragments/win_keep_remote_file_python26.yaml
+++ b/changelogs/fragments/win_keep_remote_file_python26.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- powershell - Fix issue where setting ANSIBLE_KEEP_REMOTE_FILES fails when using Python 2.6 - https://github.com/ansible/ansible/issues/45490

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -57,7 +57,7 @@ import re
 import shlex
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_native, to_text
 from ansible.plugins.shell import ShellBase
 
 
@@ -1605,7 +1605,7 @@ class ShellModule(ShellBase):
 
         # non-pipelining
 
-        cmd_parts = shlex.split(cmd, posix=False)
+        cmd_parts = shlex.split(to_native(cmd), posix=False)
         cmd_parts = list(map(to_text, cmd_parts))
         if shebang and shebang.lower() == '#!powershell':
             if not self._unquote(cmd_parts[0]).lower().endswith('.ps1'):


### PR DESCRIPTION
##### SUMMARY
As stated by https://docs.python.org/2/library/shlex.html

> Prior to Python 2.7.3, this module did not support Unicode input.

This change makes sure the command passed into the PowerShell command builder is a native (byte string) on Python 2.x and a unicode string on Python 3.x. This fits the support statement for shlex and ensures the output command is valid.

Fixes https://github.com/ansible/ansible/issues/45490

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
powershell

##### ANSIBLE VERSION
```paste below
devel
```