### PR TITLE
Changed when condition from checking image version to checking keys b…

### DIFF
--- a/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_http.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_http.yaml
@@ -5,7 +5,7 @@
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port|string is search("80")
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
-  when: major_version is version('9.2', '<')
+  when: result.stdout[0].TABLE_listen_on_port is defined
 
 - name: Assert HTTP configuration changes 9.2 or greater
   assert:
@@ -13,4 +13,4 @@
       - result.stdout[0]['http_port']
       - result.stdout[0]['http_port']|string is search("80")
       - result.stdout[0]['nxapi_status'] == 'nxapi enabled'
-  when: major_version is version('9.2', '>=')
+  when: result.stdout[0].http_port is defined

--- a/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https.yaml
@@ -5,7 +5,7 @@
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port|string is search("9443")
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
-  when: major_version is version('9.2', '<')
+  when: result.stdout[0].TABLE_listen_on_port is defined
 
 - name: Assert HTTPS configuration changes 9.2 or greater
   assert:
@@ -13,4 +13,4 @@
       - result.stdout[0]['https_port']
       - result.stdout[0]['https_port']|string is search("9443")
       - result.stdout[0]['nxapi_status'] == 'nxapi enabled'
-  when: major_version is version('9.2', '>=')
+  when: result.stdout[0].https_port is defined

--- a/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http.yaml
@@ -7,7 +7,7 @@
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][0].l_port
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][0].l_port|string is search("80")
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
-  when: major_version is version('9.2', '<')
+  when: result.stdout[0].TABLE_listen_on_port is defined
 
 - name: Assert HTTPS & HTTP configuration changes 9.2 or greater
   assert:
@@ -17,4 +17,4 @@
       - result.stdout[0]['http_port']
       - result.stdout[0]['http_port']|string is search("80")
       - result.stdout[0]['nxapi_status'] == 'nxapi enabled'
-  when: major_version is version('9.2', '>=')
+  when: result.stdout[0].https_port is defined or result.stdout[0].http_port is defined

--- a/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http_ports.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes_https_http_ports.yaml
@@ -7,7 +7,7 @@
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][0].l_port
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'][0].l_port|string is search("99")
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'
-  when: major_version is version('9.2', '<')
+  when: result.stdout[0].TABLE_listen_on_port is defined
 
 - name: Assert HTTPS & HTTP configuration changes 9.2 or greater
   assert:
@@ -17,4 +17,4 @@
       - result.stdout[0]['http_port']
       - result.stdout[0]['http_port']|string is search("99")
       - result.stdout[0]['nxapi_status'] == 'nxapi enabled'
-  when: major_version is version('9.2', '>=')
+  when: result.stdout[0].https_port is defined or result.stdout[0].http_port is defined


### PR DESCRIPTION
Changed when condition from checking image version to checking keys being defined

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_nxapi
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (nxapi_http aeab6a7837) last updated 2018/09/20 18:55:25 (GMT -400)
  config file = None
  configured module search path = [u'/Users/tmstoner/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/tmstoner/ansible/lib/ansible
  executable location = /Users/tmstoner/ansible/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Checking if keys are defined is a more reliable way of determining which task to use vs. checking for image version.  
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```