### PR TITLE
powershell - fix for ANSIBLE_KEEP_REMOTE_FILES on older Pythons (#45942)

### DIFF
--- a/changelogs/fragments/win_keep_remote_file_python26.yaml
+++ b/changelogs/fragments/win_keep_remote_file_python26.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- powershell - Fix issue where setting ANSIBLE_KEEP_REMOTE_FILES fails when using Python 2.6 - https://github.com/ansible/ansible/issues/45490

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -46,7 +46,7 @@ import re
 import shlex
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_native, to_text
 from ansible.plugins.shell import ShellBase
 
 
@@ -2028,7 +2028,7 @@ class ShellModule(ShellBase):
 
         # non-pipelining
 
-        cmd_parts = shlex.split(cmd, posix=False)
+        cmd_parts = shlex.split(to_native(cmd), posix=False)
         cmd_parts = list(map(to_text, cmd_parts))
         if shebang and shebang.lower() == '#!powershell':
             if not self._unquote(cmd_parts[0]).lower().endswith('.ps1'):


### PR DESCRIPTION
(cherry picked from commit ce515a626c5d31fec55ab7b0304575d2bf7b9eb0)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/45942

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
powershell.py

##### ANSIBLE VERSION
```paste below
2.6
```