### PR TITLE
vcenter_folder - fix error events being generated, incorrect parent folders

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vcenter_folder.py
+++ b/lib/ansible/modules/cloud/vmware/vcenter_folder.py
@@ -169,7 +169,7 @@ class VmwareFolderManager(PyVmomi):
                                                folder_type=folder_type)
 
                 if not p_folder_obj:
-                    self.module.fail_json(msg="Parent folder %s does not exists" % parent_folder)
+                    self.module.fail_json(msg="Parent folder %s does not exist" % parent_folder)
 
                 # Check if folder exists under parent folder
                 child_folder_obj = self.get_folder(folder_name=folder_name,

--- a/lib/ansible/modules/cloud/vmware/vcenter_folder.py
+++ b/lib/ansible/modules/cloud/vmware/vcenter_folder.py
@@ -129,7 +129,7 @@ result:
 
 try:
     from pyVmomi import vim
-except ImportError as e:
+except ImportError as import_err:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
@@ -154,9 +154,7 @@ class VmwareFolderManager(PyVmomi):
 
     def ensure(self):
         """
-        Function to manage internal state management
-        Returns:
-
+        Manage internal state management
         """
         state = self.module.params.get('state')
         folder_type = self.module.params.get('folder_type')
@@ -164,34 +162,39 @@ class VmwareFolderManager(PyVmomi):
         parent_folder = self.module.params.get('parent_folder', None)
         results = dict(changed=False, result=dict())
         if state == 'present':
-            # check if the folder already exists
+            # Check if the folder already exists
             p_folder_obj = None
             if parent_folder:
                 p_folder_obj = self.get_folder(folder_name=parent_folder,
                                                folder_type=folder_type)
 
-            if self.get_folder(folder_name=folder_name,
-                               folder_type=folder_type,
-                               parent_folder=p_folder_obj):
-                results['result'] = "Folder already exists"
-                self.module.exit_json(**results)
+                if not p_folder_obj:
+                    self.module.fail_json(msg="Parent folder %s does not exists" % parent_folder)
+
+                # Check if folder exists under parent folder
+                child_folder_obj = self.get_folder(folder_name=folder_name,
+                                                   folder_type=folder_type,
+                                                   parent_folder=p_folder_obj)
+                if child_folder_obj:
+                    results['result'] = "Folder %s already exists under" \
+                                        " parent folder %s" % (folder_name, parent_folder)
+                    self.module.exit_json(**results)
+            else:
+                folder_obj = self.get_folder(folder_name=folder_name,
+                                             folder_type=folder_type)
+
+                if folder_obj:
+                    results['result'] = "Folder %s already exists" % folder_name
+                    self.module.exit_json(**results)
 
             # Create a new folder
             try:
-                if parent_folder:
-                    folder = self.get_folder(folder_name=parent_folder,
-                                             folder_type=folder_type)
-                    if folder and not self.get_folder(folder_name=folder_name,
-                                                      folder_type=folder_type,
-                                                      parent_folder=folder):
-                        folder.CreateFolder(folder_name)
-                        results['changed'] = True
-                        results['result'] = "Folder '%s' of type '%s' created under %s" \
-                                            " successfully." % (folder_name, folder_type, parent_folder)
-                    elif folder is None:
-                        self.module.fail_json(msg="Failed to find the parent folder %s"
-                                                  " for folder %s" % (parent_folder, folder_name))
-                else:
+                if parent_folder and p_folder_obj:
+                    p_folder_obj.CreateFolder(folder_name)
+                    results['changed'] = True
+                    results['result'] = "Folder '%s' of type '%s' created under %s" \
+                                        " successfully." % (folder_name, folder_type, parent_folder)
+                elif not parent_folder and not p_folder_obj:
                     self.datacenter_folder_type[folder_type].CreateFolder(folder_name)
                     results['changed'] = True
                     results['result'] = "Folder '%s' of type '%s' created successfully" % (folder_name, folder_type)
@@ -221,15 +224,15 @@ class VmwareFolderManager(PyVmomi):
                                               " modified folder before this operation : %s" % to_native(concurrent_access.msg))
                 except vim.fault.InvalidState as invalid_state:
                     self.module.fail_json(msg="Failed to remove folder as folder is in"
-                                              " invalid state" % to_native(invalid_state.msg))
-                except Exception as e:
+                                              " invalid state : %s" % to_native(invalid_state.msg))
+                except Exception as gen_exec:
                     self.module.fail_json(msg="Failed to remove folder due to generic"
-                                              " exception %s " % to_native(e))
+                                              " exception %s " % to_native(gen_exec))
             self.module.exit_json(**results)
 
     def get_folder(self, folder_name, folder_type, parent_folder=None):
         """
-        Function to get managed object of folder by name
+        Get managed object of folder by name
         Returns: Managed object of folder by name
 
         """


### PR DESCRIPTION
##### SUMMARY
Fixes two bugs with vcenter_folder.py, the first being that the error log is spammed when the folders being created already exist, the second being that the wrong parent folder can be identified when two folders with the same name but different type (e.g. vm, network, datacenter) exist.

This PR doesn't change any functionality of the module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloud/vmware/vcenter_folder.py

##### ANSIBLE VERSION
ansible 2.7.dev
vsphere vcenter 6.7

##### ADDITIONAL INFORMATION
For the first bug, the current behaviour when creating a folder is to attempt to create it regardless of whether the folder already exists, and if it does exist to take the "already exists error return message" as proof of the success. This is functionally fine (it works), but it does produce an error message in the vsphere log, which if you are creating a number of folders can spam the log a bit. This PR adds a check for the folder already existing, and will not attempt to create it if it already exists, and this avoids creating an error message in the vsphere console and logs.

The second bug can be highlighted in the following example: the user is attempting to create a new vm  folder with the parent folder being `my_folder`. If the folder structure is as shown below in the tree diagram, it is the case that when iterating over all of the folders the module possibly will identify the network `my_folder` as the correct parent. This will then fail because the new folder to be created will be of type `vm` but the parent folder found will be of type `network`. Whether or not the module will fail is a race-condition based on which order the vsphere api returns the list of folders, and whether or not the network type `my_folder` is presented first.

This PR adds a check for parent type in the `get_folder()` function, and will only succeed if the types match, in addition to the name matching.

    .
    └── datacenter
        ├── network
        │   └── my_folder
        └── vm
            └── my_folder

I'm afraid I haven't investigated the testing infrastructure for the vmware ansible modules, so there aren't any tests included with this PR.
