### PR TITLE
VMware: vm_guest - allow existing vmdk files to be attached to guest

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -1186,3 +1186,55 @@ class PyVmomi(object):
             return datastore_name, vmdk_fullpath, vmdk_filename, vmdk_folder
         except (IndexError, AttributeError) as e:
             self.module.fail_json(msg="Bad path '%s' for filename disk vmdk image: %s" % (vmdk_path, to_native(e)))
+
+    def find_vmdk_file(self, datastore_obj, vmdk_fullpath, vmdk_filename, vmdk_folder):
+        """
+        Return vSphere file object or fail_json
+        Args:
+            datastore_obj: Managed object of datastore
+            vmdk_fullpath: Path of VMDK file e.g., path/to/vm/vmdk_filename.vmdk
+            vmdk_filename: Name of vmdk e.g., VM0001_1.vmdk
+            vmdk_folder: Base dir of VMDK e.g, path/to/vm
+
+        """
+
+        browser = datastore_obj.browser
+        datastore_name = datastore_obj.name
+        datastore_name_sq = "[" + datastore_name + "]"
+        if browser is None:
+            self.module.fail_json(msg="Unable to access browser for datastore %s" % datastore_name)
+
+        detail_query = vim.host.DatastoreBrowser.FileInfo.Details(
+            fileOwner=True,
+            fileSize=True,
+            fileType=True,
+            modification=True
+        )
+        search_spec = vim.host.DatastoreBrowser.SearchSpec(
+            details=detail_query,
+            matchPattern=[vmdk_filename],
+            searchCaseInsensitive=True,
+        )
+        search_res = browser.SearchSubFolders(
+            datastorePath=datastore_name_sq,
+            searchSpec=search_spec
+        )
+
+        changed = False
+        vmdk_path = datastore_name_sq + " " + vmdk_fullpath
+        try:
+            changed, result = wait_for_task(search_res)
+        except TaskError as task_e:
+            self.module.fail_json(msg=to_native(task_e))
+
+        if not changed:
+            self.module.fail_json(msg="No valid disk vmdk image found for path %s" % vmdk_path)
+
+        target_folder_path = datastore_name_sq + " " + vmdk_folder + '/'
+
+        for file_result in search_res.info.result:
+            for f in getattr(file_result, 'file'):
+                if f.path == vmdk_filename and file_result.folderPath == target_folder_path:
+                    return f
+
+        self.module.fail_json(msg="No vmdk file found for path specified [%s]" % vmdk_path)

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1830,6 +1830,12 @@ class PyVmomiHelper(PyVmomi):
                 diskspec = self.device_helper.create_scsi_disk(scsi_ctl, disk_index)
                 disk_modified = True
 
+            # increment index for next disk search
+            disk_index += 1
+            # index 7 is reserved to SCSI controller
+            if disk_index == 7:
+                disk_index += 1
+
             if 'disk_mode' in expected_disk_spec:
                 disk_mode = expected_disk_spec.get('disk_mode', 'persistent').lower()
                 valid_disk_mode = ['persistent', 'independent_persistent', 'independent_nonpersistent']
@@ -1863,12 +1869,6 @@ class PyVmomiHelper(PyVmomi):
                 # but it needs to eventually be handled for all the
                 # other disks defined
                 pass
-
-            # increment index for next disk search
-            disk_index += 1
-            # index 7 is reserved to SCSI controller
-            if disk_index == 7:
-                disk_index += 1
 
             kb = self.get_configured_disk_size(expected_disk_spec)
             # VMWare doesn't allow to reduce disk sizes

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -178,7 +178,7 @@ options:
     - '     - C(eagerzeroedthick) eagerzeroedthick disk, added in version 2.5'
     - '     Default: C(None) thick disk, no eagerzero.'
     - ' - C(datastore) (string): Datastore to use for the disk. If C(autoselect_datastore) is enabled, filter datastore selection.'
-    - ' - C(filename) (string): Existing disk image to use. Must already exist on the datastore. String is in [datastore_name] path/to/file.vmdk format
+    - ' - C(filename) (string): Existing disk image to use. Must already exist on the datastore. String is in C([datastore_name] path/to/file.vmdk) format'
     - ' - C(autoselect_datastore) (bool): select the less used datastore. Specify only if C(datastore) is not specified.'
     - ' - C(disk_mode) (string): Type of disk mode. Added in version 2.6'
     - '     - Available options are :'


### PR DESCRIPTION
##### SUMMARY
Allows existing vmdk files to be attached to a new guest vm. Adds the `filename` parameter to the `disk` dictionary. Still requires the the datastore to be separately specified as there are many dependencies on this value through the code.

Fixes #30041 , although that issue is for the deprecated vsphere_guest.py module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
2.7.0dev
vsphere vcenter 6.7

##### ADDITIONAL INFORMATION
Currently there is no method of attaching existing vmdk disks to a new guest vm (as far as I'm aware...). This PR will search for the specified vmdk file, get its size, and create the spec for attaching the existing disk to this vm. The guest vm also seems to be happy booting off a vmdk file attached like this. 

A working yml disk definition to add a vmdk file looks like:

     ...
     disk:
       - filename: [datastore_name] path/to/my_disk.vmdk
          datastore: datastore_name

This will need some testing as I don't have a clustered vsphere setup to test on, and that might have some different behaviour that I don't know about.

I also note that there is a separate module being introduced at #36165 which this (should it work properly) might be appropriate to be merged into.
