### PR TITLE
Fortinet FortiManager Device Add Module

### DIFF
--- a/lib/ansible/modules/network/fortimanager/fmgr_device.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_device.py
@@ -1,0 +1,289 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community"
+}
+
+DOCUMENTATION = '''
+---
+module: fmgr_device
+version_added: "2.6"
+author: Andrew Welsh, Luke Weighall
+short_description: Add or remove device
+description:
+  - Add or remove a device or list of devices from FortiManager Device Manager using jsonrpc API
+
+options:
+  adom:
+    description:
+      - The ADOM the configuration should belong to.
+    required: true
+  host:
+    description:
+      - The FortiManager's Address.
+    required: true
+  username:
+    description:
+      - The username used to authenticate with the FortiManager.
+    required: false
+  password:
+    description:
+      - The password associated with the username account.
+    required: false
+  state:
+    description:
+      - The desired state of the specified object.
+      - absent will delete the object if it exists.
+      - present will create the configuration if needed.
+    required: false
+    default: present
+    choices: ["absent", "present"]
+
+  device_username:
+    description:
+      - The username of the device being added to FortiManager.
+    required: false
+  device_password:
+    description:
+      - The password of the device being added to FortiManager.
+    required: false
+  device_ip:
+    description:
+      - The IP of the device being added to FortiManager.
+    required: false
+  device_unique_name:
+    description:
+      - The desired "friendly" name of the device being added to FortiManager.
+    required: false
+  device_serial:
+    description:
+      - The serial number of the device being added to FortiManager.
+    required: false
+'''
+
+
+EXAMPLES = '''
+- name: DISCOVER AND ADD DEVICE FGT1
+  fmgr_device:
+    host: "{{inventory_hostname}}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    adom: "root"
+    device_username: "admin"
+    device_password: "admin"
+    device_ip: "10.10.24.201"
+    device_unique_name: "FGT1"
+    device_serial: "FGVM000000117994"
+    state: "present"
+
+- name: DISCOVER AND ADD DEVICE FGT2
+  fmgr_device:
+    host: "{{inventory_hostname}}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    adom: "root"
+    device_username: "admin"
+    device_password: "admin"
+    device_ip: "10.10.24.202"
+    device_unique_name: "FGT2"
+    device_serial: "FGVM000000117992"
+    state: "absent"
+'''
+
+RETURN = """
+api_result:
+  description: full API response, includes status code and message
+  returned: always
+  type: string
+"""
+
+from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils.network.fortimanager.fortimanager import AnsibleFortiManager
+
+# check for pyFMG lib
+try:
+    from pyFMG.fortimgr import FortiManager
+    HAS_PYFMGR = True
+except ImportError:
+    HAS_PYFMGR = False
+
+
+def discover_device(fmg, paramgram):
+    """
+    This method is used to discover devices before adding them to FMGR
+    """
+
+    datagram = {
+        "odd_request_form": "True",
+        "device": {"adm_usr": paramgram["device_username"],
+                   "adm_pass": paramgram["device_password"],
+                   "ip": paramgram["device_ip"]}
+    }
+
+    url = '/dvm/cmd/discover/device/'
+    response = fmg.execute(url, datagram)
+    return response
+
+
+def add_device(fmg, paramgram):
+    """
+    This method is used to add devices to the FMGR
+    """
+
+    datagram = {
+        "adom": paramgram["adom"],
+        "flags": ["create_task", "nonblocking"],
+        "odd_request_form": "True",
+        "device": {"adm_usr": paramgram["device_username"], "adm_pass": paramgram["device_password"],
+                   "ip": paramgram["device_ip"], "name": paramgram["device_unique_name"],
+                   "sn": paramgram["device_serial"], "mgmt_mode": "fmgfaz", "flags": 24}
+    }
+
+    url = '/dvm/cmd/add/device/'
+    response = fmg.execute(url, datagram)
+    return response
+
+
+def delete_device(fmg, paramgram):
+    """
+    This method deletes a device from the FMGR
+    """
+    datagram = {
+        "adom": paramgram["adom"],
+        "flags": ["create_task", "nonblocking"],
+        "odd_request_form": "True",
+        "device": paramgram["device_unique_name"],
+    }
+
+    url = '/dvm/cmd/del/device/'
+    response = fmg.execute(url, datagram)
+    return response
+
+
+# FUNCTION/METHOD FOR LOGGING OUT AND ANALYZING ERROR CODES
+def fmgr_logout(fmg, module, msg="NULL", results=list(), good_codes=[0], logout_on_fail=True, logout_on_success=False):
+    """
+    THIS METHOD CONTROLS THE LOGOUT AND ERROR REPORTING AFTER AN METHOD OR FUNCTION RUNS
+    """
+
+    # VALIDATION ERROR (NO RESULTS, JUST AN EXIT)
+    if msg != "NULL" and len(results) == 0:
+        try:
+            fmg.logout()
+        except:
+            pass
+        module.fail_json(msg=msg)
+
+    # SUBMISSION ERROR
+    if len(results) > 0:
+        if msg == "NULL":
+            try:
+                msg = results[1]['status']['message']
+            except:
+                msg = "No status message returned from pyFMG. Possible that this was a GET with a tuple result."
+
+            if results[0] not in good_codes:
+                if logout_on_fail:
+                    fmg.logout()
+                    module.fail_json(msg=msg, **results[1])
+                else:
+                    return_msg = msg + " -- LOGOUT ON FAIL IS OFF, MOVING ON"
+                    return return_msg
+            else:
+                if logout_on_success:
+                    fmg.logout()
+                    module.exit_json(msg=msg, **results[1])
+                else:
+                    return_msg = msg + " -- LOGOUT ON SUCCESS IS OFF, MOVING ON TO REST OF CODE"
+                    return return_msg
+
+
+def main():
+    argument_spec = dict(
+        adom=dict(required=False, type="str", default="root"),
+        host=dict(required=True, type="str"),
+        username=dict(fallback=(env_fallback, ["ANSIBLE_NET_USERNAME"])),
+        password=dict(fallback=(env_fallback, ["ANSIBLE_NET_PASSWORD"]), no_log=True),
+        state=dict(choices=["absent", "present"], type="str", default="present"),
+
+        device_ip=dict(required=False, type="str"),
+        device_username=dict(required=False, type="str"),
+        device_password=dict(required=False, type="str", no_log=True),
+        device_unique_name=dict(required=True, type="str"),
+        device_serial=dict(required=False, type="str")
+    )
+
+    module = AnsibleModule(argument_spec, supports_check_mode=True,)
+
+    # handle params passed via provider and insure they are represented as the data type expected by fortimanagerd
+    paramgram = {
+        "device_ip": module.params["device_ip"],
+        "device_username": module.params["device_username"],
+        "device_password": module.params["device_password"],
+        "device_unique_name": module.params["device_unique_name"],
+        "device_serial": module.params["device_serial"],
+        "adom": module.params["adom"],
+        "state": module.params["state"]
+    }
+
+    # validate required arguments are passed; not used in argument_spec to allow params to be called from provider
+    # check if params are set
+    if module.params["host"] is None or module.params["username"] is None or module.params["password"] is None:
+        module.fail_json(msg="Host and username are required for connection")
+
+    # CHECK IF LOGIN FAILED
+    fmg = AnsibleFortiManager(module, module.params["host"], module.params["username"], module.params["password"])
+    response = fmg.login()
+
+    if response[1]['status']['code'] != 0:
+        module.fail_json(msg="Connection to FortiManager Failed")
+    else:
+        # START SESSION LOGIC
+
+        if paramgram["state"] == "present":
+            # add device
+            results = discover_device(fmg, paramgram)
+            if not results[0] == 0:
+                if results[0] == -20042:
+                    fmgr_logout(fmg, module, msg="Couldn't contact device on network", results=results, good_codes=[0])
+                else:
+                    fmgr_logout(fmg, module, msg="Discovering Device Failed", results=results, good_codes=[0])
+
+            if results[0] == 0:
+                results = add_device(fmg, paramgram)
+                if not results[0] == 0 and not results[0] == -20010:
+                    fmgr_logout(fmg, module, msg="Adding Device Failed", results=results, good_codes=[0])
+
+        if paramgram["state"] == "absent":
+            # remove device
+            results = delete_device(fmg, paramgram)
+            if not results[0] == 0:
+                fmgr_logout(fmg, module, msg="Deleting Device Failed", results=results, good_codes=[0])
+
+    fmg.logout()
+    return module.exit_json(**results[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ansible/modules/network/fortimanager/fmgr_device.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_device.py
@@ -28,7 +28,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: fmgr_device
-version_added: "2.6"
+version_added: "2.8"
 author: Andrew Welsh, Luke Weighall
 short_description: Add or remove device
 description:
@@ -39,6 +39,7 @@ options:
     description:
       - The ADOM the configuration should belong to.
     required: true
+    default: root
   host:
     description:
       - The FortiManager's Address.

--- a/lib/ansible/modules/network/fortimanager/fmgr_device.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_device.py
@@ -182,7 +182,7 @@ def delete_device(fmg, paramgram):
 
 
 # FUNCTION/METHOD FOR LOGGING OUT AND ANALYZING ERROR CODES
-def fmgr_logout(fmg, module, msg="NULL", results=list(), good_codes=[0], logout_on_fail=True, logout_on_success=False):
+def fmgr_logout(fmg, module, msg="NULL", results=(), good_codes=(0,), logout_on_fail=True, logout_on_success=False):
     """
     THIS METHOD CONTROLS THE LOGOUT AND ERROR REPORTING AFTER AN METHOD OR FUNCTION RUNS
     """
@@ -260,7 +260,7 @@ def main():
         module.fail_json(msg="Connection to FortiManager Failed")
     else:
         # START SESSION LOGIC
-
+        results = (-100000, {"msg": "Nothing Happened."})
         if paramgram["state"] == "present":
             # add device
             results = discover_device(fmg, paramgram)

--- a/lib/ansible/modules/network/fortimanager/fmgr_device.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_device.py
@@ -265,7 +265,7 @@ def main():
         if paramgram["state"] == "present":
             # add device
             results = discover_device(fmg, paramgram)
-            if not results[0] == 0:
+            if results[0] != 0:
                 if results[0] == -20042:
                     fmgr_logout(fmg, module, msg="Couldn't contact device on network", results=results, good_codes=[0])
                 else:
@@ -273,13 +273,13 @@ def main():
 
             if results[0] == 0:
                 results = add_device(fmg, paramgram)
-                if not results[0] == 0 and not results[0] == -20010:
+                if results[0] != 0 and results[0] != -20010:
                     fmgr_logout(fmg, module, msg="Adding Device Failed", results=results, good_codes=[0])
 
         if paramgram["state"] == "absent":
             # remove device
             results = delete_device(fmg, paramgram)
-            if not results[0] == 0:
+            if results[0] != 0:
                 fmgr_logout(fmg, module, msg="Deleting Device Failed", results=results, good_codes=[0])
 
     fmg.logout()

--- a/lib/ansible/modules/network/fortimanager/fmgr_device.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_device.py
@@ -71,7 +71,7 @@ options:
     required: false
   device_ip:
     description:
-      - The IP of the device being added to FortiManager.
+      - The IP of the device being added to FortiManager. Supports both IPv4 and IPv6.
     required: false
   device_unique_name:
     description:

--- a/lib/ansible/modules/network/fortimanager/fmgr_device.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_device.py
@@ -29,7 +29,10 @@ DOCUMENTATION = '''
 ---
 module: fmgr_device
 version_added: "2.8"
-author: Andrew Welsh, Luke Weighall
+author:
+    - Luke Weighall (@lweighall)
+    - Andrew Welsh (@Ghilli3)
+    - Jim Huber (@p4r4n0y1ng)
 short_description: Add or remove device
 description:
   - Add or remove a device or list of devices from FortiManager Device Manager using JSON RPC API.

--- a/lib/ansible/modules/network/fortimanager/fmgr_device.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_device.py
@@ -32,7 +32,7 @@ version_added: "2.8"
 author: Andrew Welsh, Luke Weighall
 short_description: Add or remove device
 description:
-  - Add or remove a device or list of devices from FortiManager Device Manager using jsonrpc API
+  - Add or remove a device or list of devices from FortiManager Device Manager using JSON RPC API.
 
 options:
   adom:
@@ -42,7 +42,7 @@ options:
     default: root
   host:
     description:
-      - The FortiManager's Address.
+      - The FortiManager's address.
     required: true
   username:
     description:

--- a/test/units/modules/network/fortimanager/fixtures/test_fmgr_device.json
+++ b/test/units/modules/network/fortimanager/fixtures/test_fmgr_device.json
@@ -1,0 +1,526 @@
+{
+   "add_device": [
+      {
+         "url": "/dvm/cmd/add/device/", 
+         "raw_response": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "ip": "10.7.220.151", 
+               "mgmt.__data[6]": 1, 
+               "vm_mem": 2005, 
+               "maxvdom": 10, 
+               "conn_mode": 1, 
+               "vm_cpu_limit": 1, 
+               "vm_cpu": 1, 
+               "branch_pt": 163, 
+               "hostname": "FGVM010000122995", 
+               "source": 1, 
+               "mgmt_id": 312304802, 
+               "version": 600, 
+               "build": 163, 
+               "mgmt_mode": 3, 
+               "adm_usr": "admin", 
+               "av_ver": "61.00026(2018-07-27 11:28)", 
+               "oid": 378, 
+               "conn_status": 1, 
+               "beta": -1, 
+               "dev_status": 1, 
+               "platform_str": "FortiGate-VM64", 
+               "last_checked": 1537410598, 
+               "patch": 2, 
+               "vm_mem_limit": 2048, 
+               "mgmt.__data[0]": 3870643, 
+               "name": "FGT1", 
+               "tab_status": "<unknown>", 
+               "mgmt.__data[4]": 2103046144, 
+               "platform_id": 111, 
+               "vm_status": 3, 
+               "ips_ver": "6.00741(2015-12-01 02:30)", 
+               "flags": 2097169, 
+               "sn": "FGVM010000122995", 
+               "mr": 0, 
+               "os_type": 0, 
+               "os_ver": 6
+            }
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.151", 
+            "state": "present", 
+            "device_unique_name": "FGT1", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "execute"
+      }, 
+      {
+         "url": "/dvm/cmd/add/device/", 
+         "raw_response": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "ip": "10.7.220.152", 
+               "mgmt.__data[6]": 1, 
+               "vm_mem": 2005, 
+               "maxvdom": 10, 
+               "conn_mode": 1, 
+               "vm_cpu_limit": 1, 
+               "vm_cpu": 1, 
+               "branch_pt": 163, 
+               "hostname": "FGVM010000123005", 
+               "source": 1, 
+               "mgmt_id": 2084190718, 
+               "version": 600, 
+               "build": 163, 
+               "mgmt_mode": 3, 
+               "adm_usr": "admin", 
+               "av_ver": "61.00026(2018-07-27 11:28)", 
+               "oid": 390, 
+               "conn_status": 1, 
+               "beta": -1, 
+               "dev_status": 1, 
+               "platform_str": "FortiGate-VM64", 
+               "last_checked": 1537410631, 
+               "patch": 2, 
+               "vm_mem_limit": 2048, 
+               "mgmt.__data[0]": 3870643, 
+               "name": "FGT2", 
+               "tab_status": "<unknown>", 
+               "mgmt.__data[4]": 2103046144, 
+               "platform_id": 111, 
+               "vm_status": 3, 
+               "ips_ver": "6.00741(2015-12-01 02:30)", 
+               "flags": 2097169, 
+               "sn": "FGVM010000123005", 
+               "mr": 0, 
+               "os_type": 0, 
+               "os_ver": 6
+            }
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.152", 
+            "state": "present", 
+            "device_unique_name": "FGT2", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "execute"
+      }, 
+      {
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.151", 
+            "state": "present", 
+            "device_unique_name": "FGT1", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "raw_response": {
+            "status": {
+               "message": "Serial number already in use", 
+               "code": -20010
+            }, 
+            "url": "/dvm/cmd/add/device/"
+         }, 
+         "post_method": "execute"
+      }, 
+      {
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.152", 
+            "state": "present", 
+            "device_unique_name": "FGT2", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "raw_response": {
+            "status": {
+               "message": "Serial number already in use", 
+               "code": -20010
+            }, 
+            "url": "/dvm/cmd/add/device/"
+         }, 
+         "post_method": "execute"
+      }, 
+      {
+         "url": "/dvm/cmd/add/device/", 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.153", 
+            "state": "present", 
+            "device_unique_name": "FGT3", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "raw_response": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "os_ver": 6, 
+               "ip": "10.7.220.153", 
+               "mgmt.__data[6]": 1, 
+               "vm_mem": 2005, 
+               "maxvdom": 10, 
+               "conn_mode": 1, 
+               "platform_id": 111, 
+               "branch_pt": 163, 
+               "hostname": "FGVM010000123017", 
+               "source": 1, 
+               "mgmt_id": 501253209, 
+               "version": 600, 
+               "build": 163, 
+               "mgmt_mode": 3, 
+               "adm_usr": "admin", 
+               "av_ver": "62.00278(2018-09-17 13:28)", 
+               "mgmt.__data[4]": 2103046144, 
+               "oid": 402, 
+               "conn_status": 1, 
+               "beta": -1, 
+               "dev_status": 1, 
+               "platform_str": "FortiGate-VM64", 
+               "last_checked": 1537410728, 
+               "vm_mem_limit": 2048, 
+               "mgmt.__data[0]": 3870643, 
+               "name": "FGT3", 
+               "tab_status": "<unknown>", 
+               "patch": 2, 
+               "vm_cpu_limit": 1, 
+               "vm_status": 3, 
+               "ips_ver": "6.00741(2015-12-01 02:30)", 
+               "flags": 2097169, 
+               "sn": "FGVM010000123017", 
+               "mr": 0, 
+               "os_type": 0, 
+               "vm_cpu": 1
+            }
+         }, 
+         "post_method": "execute"
+      }
+   ], 
+   "discover_device": [
+      {
+         "url": "/dvm/cmd/discover/device/", 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.151", 
+            "state": "present", 
+            "device_unique_name": "FGT1", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "raw_response": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "os_ver": 6, 
+               "ip": "10.7.220.151", 
+               "vm_mem": 2005, 
+               "maxvdom": 10, 
+               "conn_mode": 1, 
+               "platform_id": 111, 
+               "branch_pt": 163, 
+               "hostname": "FGVM010000122995", 
+               "source": 1, 
+               "version": 600, 
+               "build": 163, 
+               "adm_usr": "admin", 
+               "av_ver": "61.00026(2018-07-27 11:28)", 
+               "conn_status": 1, 
+               "beta": -1, 
+               "dev_status": 1, 
+               "platform_str": "FortiGate-VM64", 
+               "last_checked": 1537410595, 
+               "vm_mem_limit": 2048, 
+               "name": "FGVM010000122995", 
+               "tab_status": "<unknown>", 
+               "patch": 2, 
+               "vm_cpu_limit": 1, 
+               "vm_status": 3, 
+               "ips_ver": "6.00741(2015-12-01 02:30)", 
+               "flags": 2097153, 
+               "sn": "FGVM010000122995", 
+               "mr": 0, 
+               "os_type": 0, 
+               "vm_cpu": 1
+            }
+         }, 
+         "post_method": "execute"
+      }, 
+      {
+         "url": "/dvm/cmd/discover/device/", 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.152", 
+            "state": "present", 
+            "device_unique_name": "FGT2", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "raw_response": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "os_ver": 6, 
+               "ip": "10.7.220.152", 
+               "vm_mem": 2005, 
+               "maxvdom": 10, 
+               "conn_mode": 1, 
+               "platform_id": 111, 
+               "branch_pt": 163, 
+               "hostname": "FGVM010000123005", 
+               "source": 1, 
+               "version": 600, 
+               "build": 163, 
+               "adm_usr": "admin", 
+               "av_ver": "61.00026(2018-07-27 11:28)", 
+               "conn_status": 1, 
+               "beta": -1, 
+               "dev_status": 1, 
+               "platform_str": "FortiGate-VM64", 
+               "last_checked": 1537410627, 
+               "vm_mem_limit": 2048, 
+               "name": "FGVM010000123005", 
+               "tab_status": "<unknown>", 
+               "patch": 2, 
+               "vm_cpu_limit": 1, 
+               "vm_status": 3, 
+               "ips_ver": "6.00741(2015-12-01 02:30)", 
+               "flags": 2097153, 
+               "sn": "FGVM010000123005", 
+               "mr": 0, 
+               "os_type": 0, 
+               "vm_cpu": 1
+            }
+         }, 
+         "post_method": "execute"
+      }, 
+      {
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.153", 
+            "state": "present", 
+            "device_unique_name": "FGT3", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "raw_response": {
+            "status": {
+               "message": "Probe failed: network", 
+               "code": -20042
+            }, 
+            "url": "/dvm/cmd/discover/device/"
+         }, 
+         "post_method": "execute"
+      }, 
+      {
+         "url": "/dvm/cmd/discover/device/", 
+         "raw_response": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "ip": "10.7.220.151", 
+               "vm_mem": 2005, 
+               "maxvdom": 10, 
+               "conn_mode": 1, 
+               "vm_cpu_limit": 1, 
+               "vm_cpu": 1, 
+               "branch_pt": 163, 
+               "hostname": "FGVM010000122995", 
+               "source": 1, 
+               "version": 600, 
+               "build": 163, 
+               "managed_sn": "FMG-VM0A17004505", 
+               "adm_usr": "admin", 
+               "av_ver": "61.00026(2018-07-27 11:28)", 
+               "conn_status": 1, 
+               "beta": -1, 
+               "dev_status": 1, 
+               "platform_str": "FortiGate-VM64", 
+               "last_checked": 1537410707, 
+               "vm_mem_limit": 2048, 
+               "name": "FGVM010000122995", 
+               "tab_status": "<unknown>", 
+               "patch": 2, 
+               "platform_id": 111, 
+               "vm_status": 3, 
+               "ips_ver": "6.00741(2015-12-01 02:30)", 
+               "flags": 2097153, 
+               "sn": "FGVM010000122995", 
+               "mr": 0, 
+               "os_type": 0, 
+               "os_ver": 6
+            }
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.151", 
+            "state": "present", 
+            "device_unique_name": "FGT1", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "execute"
+      }, 
+      {
+         "url": "/dvm/cmd/discover/device/", 
+         "raw_response": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "ip": "10.7.220.152", 
+               "vm_mem": 2005, 
+               "maxvdom": 10, 
+               "conn_mode": 1, 
+               "vm_cpu_limit": 1, 
+               "vm_cpu": 1, 
+               "branch_pt": 163, 
+               "hostname": "FGVM010000123005", 
+               "source": 1, 
+               "version": 600, 
+               "build": 163, 
+               "managed_sn": "FMG-VM0A17004505", 
+               "adm_usr": "admin", 
+               "av_ver": "61.00026(2018-07-27 11:28)", 
+               "conn_status": 1, 
+               "beta": -1, 
+               "dev_status": 1, 
+               "platform_str": "FortiGate-VM64", 
+               "last_checked": 1537410713, 
+               "vm_mem_limit": 2048, 
+               "name": "FGVM010000123005", 
+               "tab_status": "<unknown>", 
+               "patch": 2, 
+               "platform_id": 111, 
+               "vm_status": 3, 
+               "ips_ver": "6.00741(2015-12-01 02:30)", 
+               "flags": 2097153, 
+               "sn": "FGVM010000123005", 
+               "mr": 0, 
+               "os_type": 0, 
+               "os_ver": 6
+            }
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.152", 
+            "state": "present", 
+            "device_unique_name": "FGT2", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "execute"
+      }, 
+      {
+         "url": "/dvm/cmd/discover/device/", 
+         "raw_response": {
+            "device": {
+               "adm_pass": "fortinet", 
+               "ip": "10.7.220.153", 
+               "vm_mem": 2005, 
+               "maxvdom": 10, 
+               "conn_mode": 1, 
+               "vm_cpu_limit": 1, 
+               "vm_cpu": 1, 
+               "branch_pt": 163, 
+               "hostname": "FGVM010000123017", 
+               "source": 1, 
+               "version": 600, 
+               "build": 163, 
+               "adm_usr": "admin", 
+               "av_ver": "62.00278(2018-09-17 13:28)", 
+               "conn_status": 1, 
+               "beta": -1, 
+               "dev_status": 1, 
+               "platform_str": "FortiGate-VM64", 
+               "last_checked": 1537410723, 
+               "vm_mem_limit": 2048, 
+               "name": "FGVM010000123017", 
+               "tab_status": "<unknown>", 
+               "patch": 2, 
+               "platform_id": 111, 
+               "vm_status": 3, 
+               "ips_ver": "6.00741(2015-12-01 02:30)", 
+               "flags": 2097153, 
+               "sn": "FGVM010000123017", 
+               "mr": 0, 
+               "os_type": 0, 
+               "os_ver": 6
+            }
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.153", 
+            "state": "present", 
+            "device_unique_name": "FGT3", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "execute"
+      }
+   ], 
+   "delete_device": [
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvm/cmd/del/device/"
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.151", 
+            "state": "absent", 
+            "device_unique_name": "FGT1", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "execute"
+      }, 
+      {
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.152", 
+            "state": "absent", 
+            "device_unique_name": "FGT2", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvm/cmd/del/device/"
+         }, 
+         "post_method": "execute"
+      }, 
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvm/cmd/del/device/"
+         }, 
+         "paramgram_used": {
+            "device_username": "admin", 
+            "adom": "ansible", 
+            "device_ip": "10.7.220.153", 
+            "state": "absent", 
+            "device_unique_name": "FGT3", 
+            "device_serial": null, 
+            "device_password": "fortinet"
+         }, 
+         "post_method": "execute"
+      }
+   ]
+}

--- a/test/units/modules/network/fortimanager/test_fmgr_device.py
+++ b/test/units/modules/network/fortimanager/test_fmgr_device.py
@@ -19,10 +19,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import pytest
 import os
 import json
 from pyFMG.fortimgr import FortiManager
+import pytest
 
 try:
     from ansible.modules.network.fortimanager import fmgr_device
@@ -33,7 +33,8 @@ fmg_instance = FortiManager("1.1.1.1", "admin", "")
 
 
 def load_fixtures():
-    fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures') + "/{}.json".format(os.path.splitext(os.path.basename(__file__))[0])
+    fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures') + "/{filename}.json".format(
+        filename=os.path.splitext(os.path.basename(__file__))[0])
     try:
         with open(fixture_path, "r") as fixture_file:
             fixture_data = json.load(fixture_file)
@@ -46,6 +47,7 @@ def load_fixtures():
 def fixture_data(request):
     func_name = request.function.__name__.replace("test_", "")
     return request.param.get(func_name, None)
+
 
 
 def test_discover_device(fixture_data, mocker):
@@ -65,7 +67,6 @@ def test_discover_device(fixture_data, mocker):
     # mode: execute
     ##################################################
     assert isinstance(output['raw_response'], dict) is True
-
     paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'present',
                       'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
                       'mode': 'execute'}
@@ -81,7 +82,6 @@ def test_discover_device(fixture_data, mocker):
     # mode: execute
     ##################################################
     assert isinstance(output['raw_response'], dict) is True
-
     paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.153', 'state': 'present',
                       'device_unique_name': 'FGT3', 'device_serial': None, 'device_password': 'fortinet',
                       'mode': 'execute'}
@@ -97,7 +97,6 @@ def test_discover_device(fixture_data, mocker):
     # mode: execute
     ##################################################
     assert output['raw_response']['status']['code'] == -20042
-
     paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.151', 'state': 'present',
                       'device_unique_name': 'FGT1', 'device_serial': None, 'device_password': 'fortinet',
                       'mode': 'execute'}
@@ -113,7 +112,6 @@ def test_discover_device(fixture_data, mocker):
     # mode: execute
     ##################################################
     assert isinstance(output['raw_response'], dict) is True
-
     paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'present',
                       'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
                       'mode': 'execute'}
@@ -129,7 +127,6 @@ def test_discover_device(fixture_data, mocker):
     # mode: execute
     ##################################################
     assert isinstance(output['raw_response'], dict) is True
-
     paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.153', 'state': 'present',
                       'device_unique_name': 'FGT3', 'device_serial': None, 'device_password': 'fortinet',
                       'mode': 'execute'}
@@ -164,7 +161,6 @@ def test_add_device(fixture_data, mocker):
     # mode: execute
     ##################################################
     assert isinstance(output['raw_response'], dict) is True
-
     paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'present',
                       'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
                       'mode': 'execute'}
@@ -180,7 +176,6 @@ def test_add_device(fixture_data, mocker):
     # mode: execute
     ##################################################
     assert isinstance(output['raw_response'], dict) is True
-
     paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.151', 'state': 'present',
                       'device_unique_name': 'FGT1', 'device_serial': None, 'device_password': 'fortinet',
                       'mode': 'execute'}
@@ -196,7 +191,6 @@ def test_add_device(fixture_data, mocker):
     # mode: execute
     ##################################################
     assert output['raw_response']['status']['code'] == -20010
-
     paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'present',
                       'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
                       'mode': 'execute'}
@@ -212,7 +206,6 @@ def test_add_device(fixture_data, mocker):
     # mode: execute
     ##################################################
     assert output['raw_response']['status']['code'] == -20010
-
     paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.153', 'state': 'present',
                       'device_unique_name': 'FGT3', 'device_serial': None, 'device_password': 'fortinet',
                       'mode': 'execute'}
@@ -247,7 +240,6 @@ def test_delete_device(fixture_data, mocker):
     # mode: execute
     ##################################################
     assert output['raw_response']['status']['code'] == 0
-
     paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'absent',
                       'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
                       'mode': 'execute'}
@@ -263,7 +255,6 @@ def test_delete_device(fixture_data, mocker):
     # mode: execute
     ##################################################
     assert output['raw_response']['status']['code'] == 0
-
     paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.153', 'state': 'absent',
                       'device_unique_name': 'FGT3', 'device_serial': None, 'device_password': 'fortinet',
                       'mode': 'execute'}

--- a/test/units/modules/network/fortimanager/test_fmgr_device.py
+++ b/test/units/modules/network/fortimanager/test_fmgr_device.py
@@ -33,8 +33,7 @@ fmg_instance = FortiManager("1.1.1.1", "admin", "")
 
 
 def load_fixtures():
-    fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures') + "/{}.json".format(
-        os.path.splitext(os.path.basename(__file__))[0])
+    fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures') + "/{}.json".format(os.path.splitext(os.path.basename(__file__))[0])
     try:
         with open(fixture_path, "r") as fixture_file:
             fixture_data = json.load(fixture_file)

--- a/test/units/modules/network/fortimanager/test_fmgr_device.py
+++ b/test/units/modules/network/fortimanager/test_fmgr_device.py
@@ -49,7 +49,6 @@ def fixture_data(request):
     return request.param.get(func_name, None)
 
 
-
 def test_discover_device(fixture_data, mocker):
     mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
     paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.151', 'state': 'present',

--- a/test/units/modules/network/fortimanager/test_fmgr_device.py
+++ b/test/units/modules/network/fortimanager/test_fmgr_device.py
@@ -1,0 +1,282 @@
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+import os
+import json
+from pyFMG.fortimgr import FortiManager
+
+try:
+    from ansible.modules.network.fortimanager import fmgr_device
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+fmg_instance = FortiManager("1.1.1.1", "admin", "")
+
+
+def load_fixtures():
+    fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures') + "/{}.json".format(
+        os.path.splitext(os.path.basename(__file__))[0])
+    try:
+        with open(fixture_path, "r") as fixture_file:
+            fixture_data = json.load(fixture_file)
+    except IOError:
+        return []
+    return [fixture_data]
+
+
+@pytest.fixture(scope="function", params=load_fixtures())
+def fixture_data(request):
+    func_name = request.function.__name__.replace("test_", "")
+    return request.param.get(func_name, None)
+
+
+def test_discover_device(fixture_data, mocker):
+    mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
+    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.151', 'state': 'present',
+                      'device_unique_name': 'FGT1', 'device_serial': None, 'device_password': 'fortinet',
+                      'mode': 'execute'}
+    output = fmgr_device.discover_device(fmg_instance, paramgram_used)
+    ##################################################
+    # device_username: admin
+    # adom: ansible
+    # device_ip: 10.7.220.151
+    # state: present
+    # device_unique_name: FGT1
+    # device_serial: None
+    # device_password: fortinet
+    # mode: execute
+    ##################################################
+    assert isinstance(output['raw_response'], dict) is True
+
+    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'present',
+                      'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
+                      'mode': 'execute'}
+    output = fmgr_device.discover_device(fmg_instance, paramgram_used)
+    ##################################################
+    # device_username: admin
+    # adom: ansible
+    # device_ip: 10.7.220.152
+    # state: present
+    # device_unique_name: FGT2
+    # device_serial: None
+    # device_password: fortinet
+    # mode: execute
+    ##################################################
+    assert isinstance(output['raw_response'], dict) is True
+
+    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.153', 'state': 'present',
+                      'device_unique_name': 'FGT3', 'device_serial': None, 'device_password': 'fortinet',
+                      'mode': 'execute'}
+    output = fmgr_device.discover_device(fmg_instance, paramgram_used)
+    ##################################################
+    # device_username: admin
+    # adom: ansible
+    # device_ip: 10.7.220.153
+    # state: present
+    # device_unique_name: FGT3
+    # device_serial: None
+    # device_password: fortinet
+    # mode: execute
+    ##################################################
+    assert output['raw_response']['status']['code'] == -20042
+
+    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.151', 'state': 'present',
+                      'device_unique_name': 'FGT1', 'device_serial': None, 'device_password': 'fortinet',
+                      'mode': 'execute'}
+    output = fmgr_device.discover_device(fmg_instance, paramgram_used)
+    ##################################################
+    # device_username: admin
+    # adom: ansible
+    # device_ip: 10.7.220.151
+    # state: present
+    # device_unique_name: FGT1
+    # device_serial: None
+    # device_password: fortinet
+    # mode: execute
+    ##################################################
+    assert isinstance(output['raw_response'], dict) is True
+
+    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'present',
+                      'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
+                      'mode': 'execute'}
+    output = fmgr_device.discover_device(fmg_instance, paramgram_used)
+    ##################################################
+    # device_username: admin
+    # adom: ansible
+    # device_ip: 10.7.220.152
+    # state: present
+    # device_unique_name: FGT2
+    # device_serial: None
+    # device_password: fortinet
+    # mode: execute
+    ##################################################
+    assert isinstance(output['raw_response'], dict) is True
+
+    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.153', 'state': 'present',
+                      'device_unique_name': 'FGT3', 'device_serial': None, 'device_password': 'fortinet',
+                      'mode': 'execute'}
+    output = fmgr_device.discover_device(fmg_instance, paramgram_used)
+    ##################################################
+    # device_username: admin
+    # adom: ansible
+    # device_ip: 10.7.220.153
+    # state: present
+    # device_unique_name: FGT3
+    # device_serial: None
+    # device_password: fortinet
+    # mode: execute
+    ##################################################
+    assert isinstance(output['raw_response'], dict) is True
+
+
+def test_add_device(fixture_data, mocker):
+    mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
+    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.151', 'state': 'present',
+                      'device_unique_name': 'FGT1', 'device_serial': None, 'device_password': 'fortinet',
+                      'mode': 'execute'}
+    output = fmgr_device.add_device(fmg_instance, paramgram_used)
+    ##################################################
+    # device_username: admin
+    # adom: ansible
+    # device_ip: 10.7.220.151
+    # state: present
+    # device_unique_name: FGT1
+    # device_serial: None
+    # device_password: fortinet
+    # mode: execute
+    ##################################################
+    assert isinstance(output['raw_response'], dict) is True
+
+    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'present',
+                      'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
+                      'mode': 'execute'}
+    output = fmgr_device.add_device(fmg_instance, paramgram_used)
+    ##################################################
+    # device_username: admin
+    # adom: ansible
+    # device_ip: 10.7.220.152
+    # state: present
+    # device_unique_name: FGT2
+    # device_serial: None
+    # device_password: fortinet
+    # mode: execute
+    ##################################################
+    assert isinstance(output['raw_response'], dict) is True
+
+    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.151', 'state': 'present',
+                      'device_unique_name': 'FGT1', 'device_serial': None, 'device_password': 'fortinet',
+                      'mode': 'execute'}
+    output = fmgr_device.add_device(fmg_instance, paramgram_used)
+    ##################################################
+    # device_username: admin
+    # adom: ansible
+    # device_ip: 10.7.220.151
+    # state: present
+    # device_unique_name: FGT1
+    # device_serial: None
+    # device_password: fortinet
+    # mode: execute
+    ##################################################
+    assert output['raw_response']['status']['code'] == -20010
+
+    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'present',
+                      'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
+                      'mode': 'execute'}
+    output = fmgr_device.add_device(fmg_instance, paramgram_used)
+    ##################################################
+    # device_username: admin
+    # adom: ansible
+    # device_ip: 10.7.220.152
+    # state: present
+    # device_unique_name: FGT2
+    # device_serial: None
+    # device_password: fortinet
+    # mode: execute
+    ##################################################
+    assert output['raw_response']['status']['code'] == -20010
+
+    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.153', 'state': 'present',
+                      'device_unique_name': 'FGT3', 'device_serial': None, 'device_password': 'fortinet',
+                      'mode': 'execute'}
+    output = fmgr_device.add_device(fmg_instance, paramgram_used)
+    ##################################################
+    # device_username: admin
+    # adom: ansible
+    # device_ip: 10.7.220.153
+    # state: present
+    # device_unique_name: FGT3
+    # device_serial: None
+    # device_password: fortinet
+    # mode: execute
+    ##################################################
+    assert isinstance(output['raw_response'], dict) is True
+
+
+def test_delete_device(fixture_data, mocker):
+    mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
+    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.151', 'state': 'absent',
+                      'device_unique_name': 'FGT1', 'device_serial': None, 'device_password': 'fortinet',
+                      'mode': 'execute'}
+    output = fmgr_device.delete_device(fmg_instance, paramgram_used)
+    ##################################################
+    # device_username: admin
+    # adom: ansible
+    # device_ip: 10.7.220.151
+    # state: absent
+    # device_unique_name: FGT1
+    # device_serial: None
+    # device_password: fortinet
+    # mode: execute
+    ##################################################
+    assert output['raw_response']['status']['code'] == 0
+
+    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'absent',
+                      'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
+                      'mode': 'execute'}
+    output = fmgr_device.delete_device(fmg_instance, paramgram_used)
+    ##################################################
+    # device_username: admin
+    # adom: ansible
+    # device_ip: 10.7.220.152
+    # state: absent
+    # device_unique_name: FGT2
+    # device_serial: None
+    # device_password: fortinet
+    # mode: execute
+    ##################################################
+    assert output['raw_response']['status']['code'] == 0
+
+    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.153', 'state': 'absent',
+                      'device_unique_name': 'FGT3', 'device_serial': None, 'device_password': 'fortinet',
+                      'mode': 'execute'}
+    output = fmgr_device.delete_device(fmg_instance, paramgram_used)
+    ##################################################
+    # device_username: admin
+    # adom: ansible
+    # device_ip: 10.7.220.153
+    # state: absent
+    # device_unique_name: FGT3
+    # device_serial: None
+    # device_password: fortinet
+    # mode: execute
+    ##################################################
+    assert output['raw_response']['status']['code'] == 0

--- a/test/units/modules/network/fortimanager/test_fmgr_device.py
+++ b/test/units/modules/network/fortimanager/test_fmgr_device.py
@@ -27,7 +27,9 @@ import pytest
 try:
     from ansible.modules.network.fortimanager import fmgr_device
 except ImportError:
-    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+    pytest.skip(
+        "Could not load required modules for testing",
+        allow_module_level=True)
 
 fmg_instance = FortiManager("1.1.1.1", "admin", "")
 
@@ -50,12 +52,17 @@ def fixture_data(request):
 
 
 def test_discover_device(fixture_data, mocker):
-    mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
-    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.151', 'state': 'present',
-                      'device_unique_name': 'FGT1', 'device_serial': None, 'device_password': 'fortinet',
-                      'mode': 'execute'}
+    mocker.patch(
+        "pyFMG.fortimgr.FortiManager._post_request",
+        side_effect=fixture_data)
+    paramgram_used = {
+        'device_username': 'admin', 'adom': 'ansible',
+        'device_ip': '10.7.220.151', 'state': 'present',
+        'device_unique_name': 'FGT1', 'device_serial':
+        None, 'device_password': 'fortinet',
+        'mode': 'execute'}
     output = fmgr_device.discover_device(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # device_username: admin
     # adom: ansible
     # device_ip: 10.7.220.151
@@ -64,13 +71,16 @@ def test_discover_device(fixture_data, mocker):
     # device_serial: None
     # device_password: fortinet
     # mode: execute
-    ##################################################
+    #
     assert isinstance(output['raw_response'], dict) is True
-    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'present',
-                      'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
-                      'mode': 'execute'}
+    paramgram_used = {
+        'device_username': 'admin', 'adom': 'ansible',
+        'device_ip': '10.7.220.152', 'state': 'present',
+        'device_unique_name': 'FGT2', 'device_serial':
+        None, 'device_password': 'fortinet',
+        'mode': 'execute'}
     output = fmgr_device.discover_device(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # device_username: admin
     # adom: ansible
     # device_ip: 10.7.220.152
@@ -79,13 +89,16 @@ def test_discover_device(fixture_data, mocker):
     # device_serial: None
     # device_password: fortinet
     # mode: execute
-    ##################################################
+    #
     assert isinstance(output['raw_response'], dict) is True
-    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.153', 'state': 'present',
-                      'device_unique_name': 'FGT3', 'device_serial': None, 'device_password': 'fortinet',
-                      'mode': 'execute'}
+    paramgram_used = {
+        'device_username': 'admin', 'adom': 'ansible',
+        'device_ip': '10.7.220.153', 'state': 'present',
+        'device_unique_name': 'FGT3', 'device_serial':
+        None, 'device_password': 'fortinet',
+        'mode': 'execute'}
     output = fmgr_device.discover_device(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # device_username: admin
     # adom: ansible
     # device_ip: 10.7.220.153
@@ -94,13 +107,16 @@ def test_discover_device(fixture_data, mocker):
     # device_serial: None
     # device_password: fortinet
     # mode: execute
-    ##################################################
+    #
     assert output['raw_response']['status']['code'] == -20042
-    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.151', 'state': 'present',
-                      'device_unique_name': 'FGT1', 'device_serial': None, 'device_password': 'fortinet',
-                      'mode': 'execute'}
+    paramgram_used = {
+        'device_username': 'admin', 'adom': 'ansible',
+        'device_ip': '10.7.220.151', 'state': 'present',
+        'device_unique_name': 'FGT1', 'device_serial':
+        None, 'device_password': 'fortinet',
+        'mode': 'execute'}
     output = fmgr_device.discover_device(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # device_username: admin
     # adom: ansible
     # device_ip: 10.7.220.151
@@ -109,13 +125,16 @@ def test_discover_device(fixture_data, mocker):
     # device_serial: None
     # device_password: fortinet
     # mode: execute
-    ##################################################
+    #
     assert isinstance(output['raw_response'], dict) is True
-    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'present',
-                      'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
-                      'mode': 'execute'}
+    paramgram_used = {
+        'device_username': 'admin', 'adom': 'ansible',
+        'device_ip': '10.7.220.152', 'state': 'present',
+        'device_unique_name': 'FGT2', 'device_serial':
+        None, 'device_password': 'fortinet',
+        'mode': 'execute'}
     output = fmgr_device.discover_device(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # device_username: admin
     # adom: ansible
     # device_ip: 10.7.220.152
@@ -124,13 +143,16 @@ def test_discover_device(fixture_data, mocker):
     # device_serial: None
     # device_password: fortinet
     # mode: execute
-    ##################################################
+    #
     assert isinstance(output['raw_response'], dict) is True
-    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.153', 'state': 'present',
-                      'device_unique_name': 'FGT3', 'device_serial': None, 'device_password': 'fortinet',
-                      'mode': 'execute'}
+    paramgram_used = {
+        'device_username': 'admin', 'adom': 'ansible',
+        'device_ip': '10.7.220.153', 'state': 'present',
+        'device_unique_name': 'FGT3', 'device_serial':
+        None, 'device_password': 'fortinet',
+        'mode': 'execute'}
     output = fmgr_device.discover_device(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # device_username: admin
     # adom: ansible
     # device_ip: 10.7.220.153
@@ -139,17 +161,22 @@ def test_discover_device(fixture_data, mocker):
     # device_serial: None
     # device_password: fortinet
     # mode: execute
-    ##################################################
+    #
     assert isinstance(output['raw_response'], dict) is True
 
 
 def test_add_device(fixture_data, mocker):
-    mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
-    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.151', 'state': 'present',
-                      'device_unique_name': 'FGT1', 'device_serial': None, 'device_password': 'fortinet',
-                      'mode': 'execute'}
+    mocker.patch(
+        "pyFMG.fortimgr.FortiManager._post_request",
+        side_effect=fixture_data)
+    paramgram_used = {
+        'device_username': 'admin', 'adom': 'ansible',
+        'device_ip': '10.7.220.151', 'state': 'present',
+        'device_unique_name': 'FGT1', 'device_serial':
+        None, 'device_password': 'fortinet',
+        'mode': 'execute'}
     output = fmgr_device.add_device(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # device_username: admin
     # adom: ansible
     # device_ip: 10.7.220.151
@@ -158,13 +185,16 @@ def test_add_device(fixture_data, mocker):
     # device_serial: None
     # device_password: fortinet
     # mode: execute
-    ##################################################
+    #
     assert isinstance(output['raw_response'], dict) is True
-    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'present',
-                      'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
-                      'mode': 'execute'}
+    paramgram_used = {
+        'device_username': 'admin', 'adom': 'ansible',
+        'device_ip': '10.7.220.152', 'state': 'present',
+        'device_unique_name': 'FGT2', 'device_serial':
+        None, 'device_password': 'fortinet',
+        'mode': 'execute'}
     output = fmgr_device.add_device(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # device_username: admin
     # adom: ansible
     # device_ip: 10.7.220.152
@@ -173,13 +203,16 @@ def test_add_device(fixture_data, mocker):
     # device_serial: None
     # device_password: fortinet
     # mode: execute
-    ##################################################
+    #
     assert isinstance(output['raw_response'], dict) is True
-    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.151', 'state': 'present',
-                      'device_unique_name': 'FGT1', 'device_serial': None, 'device_password': 'fortinet',
-                      'mode': 'execute'}
+    paramgram_used = {
+        'device_username': 'admin', 'adom': 'ansible',
+        'device_ip': '10.7.220.151', 'state': 'present',
+        'device_unique_name': 'FGT1', 'device_serial':
+        None, 'device_password': 'fortinet',
+        'mode': 'execute'}
     output = fmgr_device.add_device(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # device_username: admin
     # adom: ansible
     # device_ip: 10.7.220.151
@@ -188,13 +221,16 @@ def test_add_device(fixture_data, mocker):
     # device_serial: None
     # device_password: fortinet
     # mode: execute
-    ##################################################
+    #
     assert output['raw_response']['status']['code'] == -20010
-    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'present',
-                      'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
-                      'mode': 'execute'}
+    paramgram_used = {
+        'device_username': 'admin', 'adom': 'ansible',
+        'device_ip': '10.7.220.152', 'state': 'present',
+        'device_unique_name': 'FGT2', 'device_serial':
+        None, 'device_password': 'fortinet',
+        'mode': 'execute'}
     output = fmgr_device.add_device(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # device_username: admin
     # adom: ansible
     # device_ip: 10.7.220.152
@@ -203,13 +239,16 @@ def test_add_device(fixture_data, mocker):
     # device_serial: None
     # device_password: fortinet
     # mode: execute
-    ##################################################
+    #
     assert output['raw_response']['status']['code'] == -20010
-    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.153', 'state': 'present',
-                      'device_unique_name': 'FGT3', 'device_serial': None, 'device_password': 'fortinet',
-                      'mode': 'execute'}
+    paramgram_used = {
+        'device_username': 'admin', 'adom': 'ansible',
+        'device_ip': '10.7.220.153', 'state': 'present',
+        'device_unique_name': 'FGT3', 'device_serial':
+        None, 'device_password': 'fortinet',
+        'mode': 'execute'}
     output = fmgr_device.add_device(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # device_username: admin
     # adom: ansible
     # device_ip: 10.7.220.153
@@ -218,17 +257,22 @@ def test_add_device(fixture_data, mocker):
     # device_serial: None
     # device_password: fortinet
     # mode: execute
-    ##################################################
+    #
     assert isinstance(output['raw_response'], dict) is True
 
 
 def test_delete_device(fixture_data, mocker):
-    mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
-    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.151', 'state': 'absent',
-                      'device_unique_name': 'FGT1', 'device_serial': None, 'device_password': 'fortinet',
-                      'mode': 'execute'}
+    mocker.patch(
+        "pyFMG.fortimgr.FortiManager._post_request",
+        side_effect=fixture_data)
+    paramgram_used = {
+        'device_username': 'admin', 'adom': 'ansible',
+        'device_ip': '10.7.220.151', 'state': 'absent',
+        'device_unique_name': 'FGT1', 'device_serial':
+        None, 'device_password': 'fortinet',
+        'mode': 'execute'}
     output = fmgr_device.delete_device(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # device_username: admin
     # adom: ansible
     # device_ip: 10.7.220.151
@@ -237,13 +281,16 @@ def test_delete_device(fixture_data, mocker):
     # device_serial: None
     # device_password: fortinet
     # mode: execute
-    ##################################################
+    #
     assert output['raw_response']['status']['code'] == 0
-    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.152', 'state': 'absent',
-                      'device_unique_name': 'FGT2', 'device_serial': None, 'device_password': 'fortinet',
-                      'mode': 'execute'}
+    paramgram_used = {
+        'device_username': 'admin', 'adom': 'ansible',
+        'device_ip': '10.7.220.152', 'state': 'absent',
+        'device_unique_name': 'FGT2', 'device_serial':
+        None, 'device_password': 'fortinet',
+        'mode': 'execute'}
     output = fmgr_device.delete_device(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # device_username: admin
     # adom: ansible
     # device_ip: 10.7.220.152
@@ -252,13 +299,16 @@ def test_delete_device(fixture_data, mocker):
     # device_serial: None
     # device_password: fortinet
     # mode: execute
-    ##################################################
+    #
     assert output['raw_response']['status']['code'] == 0
-    paramgram_used = {'device_username': 'admin', 'adom': 'ansible', 'device_ip': '10.7.220.153', 'state': 'absent',
-                      'device_unique_name': 'FGT3', 'device_serial': None, 'device_password': 'fortinet',
-                      'mode': 'execute'}
+    paramgram_used = {
+        'device_username': 'admin', 'adom': 'ansible',
+        'device_ip': '10.7.220.153', 'state': 'absent',
+        'device_unique_name': 'FGT3', 'device_serial':
+        None, 'device_password': 'fortinet',
+        'mode': 'execute'}
     output = fmgr_device.delete_device(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # device_username: admin
     # adom: ansible
     # device_ip: 10.7.220.153
@@ -267,5 +317,5 @@ def test_delete_device(fixture_data, mocker):
     # device_serial: None
     # device_password: fortinet
     # mode: execute
-    ##################################################
+    #
     assert output['raw_response']['status']['code'] == 0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This module adds/discovers devices to a Fortinet FortiManager via API/Ansible.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
This module adds/discovers devices to a Fortinet FortiManager via API. 

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel 4b121ea2ad) last updated 2018/09/20 13:34:55 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/ansible_ftnt/library']
  ansible python module location = /root/ansibleSource/ansible/lib/ansible
  executable location = /root/ansibleSource/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
