### PR TITLE
powershell: do not quote join_path result to reflect ShellBase join_path (#45944)

### DIFF
--- a/changelogs/fragments/win_copy-dest-quote.yaml
+++ b/changelogs/fragments/win_copy-dest-quote.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_copy - Fix issue where the dest return value would be enclosed in single quote when dest is a folder - https://github.com/ansible/ansible/issues/45281

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -1488,7 +1488,7 @@ class ShellModule(ShellBase):
         path = '\\'.join(parts)
         if path.startswith('~'):
             return path
-        return '\'%s\'' % path
+        return path
 
     def get_remote_filename(self, pathname):
         # powershell requires that script files end with .ps1

--- a/test/integration/targets/win_copy/tasks/tests.yml
+++ b/test/integration/targets/win_copy/tasks/tests.yml
@@ -134,6 +134,7 @@
     that:
     - copy_file_check is changed
     - copy_file_check.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+    - copy_file_check.dest == test_win_copy_path + '\\foo-target.txt'
     - copy_file_check.operation == 'file_copy'
     - copy_file_check.size == 8
     - copy_file_actual_check.stat.exists == False
@@ -154,6 +155,7 @@
     that:
     - copy_file is changed
     - copy_file.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+    - copy_file.dest == test_win_copy_path + '\\foo-target.txt'
     - copy_file.operation == 'file_copy'
     - copy_file.size == 8
     - copy_file_actual.stat.exists == True
@@ -187,6 +189,7 @@
     that:
     - copy_file_to_folder_check is changed
     - copy_file_to_folder_check.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+    - copy_file_to_folder_check.dest == test_win_copy_path + '\\foo.txt'
     - copy_file_to_folder_check.operation == 'file_copy'
     - copy_file_to_folder_check.size == 8
     - copy_file_to_folder_actual_check.stat.exists == False
@@ -207,6 +210,7 @@
     that:
     - copy_file_to_folder is changed
     - copy_file_to_folder.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+    - copy_file_to_folder.dest == test_win_copy_path + '\\foo.txt'
     - copy_file_to_folder.operation == 'file_copy'
     - copy_file_to_folder.size == 8
     - copy_file_to_folder_actual.stat.exists == True


### PR DESCRIPTION
(cherry picked from commit 198423d6fbe82110b897a088744f099f783cd452)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/45944

This doesn't need to block the 2.7.0 release, can wait until 2.7.1.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
powershell.py

##### ANSIBLE VERSION
```paste below
2.7
```