### PR TITLE
Improve ansible-test match error handling.

### DIFF
--- a/test/runner/lib/sanity/__init__.py
+++ b/test/runner/lib/sanity/__init__.py
@@ -15,7 +15,7 @@ from lib.util import (
     run_command,
     import_plugins,
     load_plugins,
-    parse_to_dict,
+    parse_to_list_of_dict,
     ABC,
     is_binary_file,
     read_lines_without_comments,
@@ -305,7 +305,7 @@ class SanityCodeSmellTest(SanityTest):
 
         if stdout and not stderr:
             if pattern:
-                matches = [parse_to_dict(pattern, line) for line in stdout.splitlines()]
+                matches = parse_to_list_of_dict(pattern, stdout)
 
                 messages = [SanityMessage(
                     message=m['message'],

--- a/test/runner/lib/sanity/compile.py
+++ b/test/runner/lib/sanity/compile.py
@@ -18,6 +18,7 @@ from lib.util import (
     display,
     find_python,
     read_lines_without_comments,
+    parse_to_list_of_dict,
 )
 
 from lib.config import (
@@ -72,7 +73,7 @@ class CompileTest(SanityMultipleVersion):
 
         pattern = r'^(?P<path>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+): (?P<message>.*)$'
 
-        results = [re.search(pattern, line).groupdict() for line in stdout.splitlines()]
+        results = parse_to_list_of_dict(pattern, stdout)
 
         results = [SanityMessage(
             message=r['message'],

--- a/test/runner/lib/sanity/import.py
+++ b/test/runner/lib/sanity/import.py
@@ -20,6 +20,7 @@ from lib.util import (
     display,
     find_python,
     read_lines_without_comments,
+    parse_to_list_of_dict,
 )
 
 from lib.ansible_util import (
@@ -112,7 +113,7 @@ class ImportTest(SanityMultipleVersion):
 
             pattern = r'^(?P<path>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+): (?P<message>.*)$'
 
-            results = [re.search(pattern, line).groupdict() for line in ex.stdout.splitlines()]
+            results = parse_to_list_of_dict(pattern, ex.stdout)
 
             results = [SanityMessage(
                 message=r['message'],

--- a/test/runner/lib/sanity/pep8.py
+++ b/test/runner/lib/sanity/pep8.py
@@ -16,6 +16,7 @@ from lib.util import (
     display,
     run_command,
     read_lines_without_comments,
+    parse_to_list_of_dict,
 )
 
 from lib.config import (
@@ -80,7 +81,7 @@ class Pep8Test(SanitySingleVersion):
         if stdout:
             pattern = '^(?P<path>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+): (?P<code>[WE][0-9]{3}) (?P<message>.*)$'
 
-            results = [re.search(pattern, line).groupdict() for line in stdout.splitlines()]
+            results = parse_to_list_of_dict(pattern, stdout)
         else:
             results = []
 

--- a/test/runner/lib/sanity/rstcheck.py
+++ b/test/runner/lib/sanity/rstcheck.py
@@ -14,7 +14,7 @@ from lib.sanity import (
 from lib.util import (
     SubprocessError,
     run_command,
-    parse_to_dict,
+    parse_to_list_of_dict,
     display,
     find_executable,
     read_lines_without_comments,
@@ -72,7 +72,7 @@ class RstcheckTest(SanitySingleVersion):
 
         pattern = r'^(?P<path>[^:]*):(?P<line>[0-9]+): \((?P<level>INFO|WARNING|ERROR|SEVERE)/[0-4]\) (?P<message>.*)$'
 
-        results = [parse_to_dict(pattern, line) for line in stderr.splitlines()]
+        results = parse_to_list_of_dict(pattern, stderr)
 
         results = [SanityMessage(
             message=r['message'],

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -741,18 +741,27 @@ def docker_qualify_image(name):
     return config.get('name', name)
 
 
-def parse_to_dict(pattern, value):
+def parse_to_list_of_dict(pattern, value):
     """
     :type pattern: str
     :type value: str
-    :return: dict[str, str]
+    :return: list[dict[str, str]]
     """
-    match = re.search(pattern, value)
+    matched = []
+    unmatched = []
 
-    if match is None:
-        raise Exception('Pattern "%s" did not match value: %s' % (pattern, value))
+    for line in value.splitlines():
+        match = re.search(pattern, line)
 
-    return match.groupdict()
+        if match:
+            matched.append(match.groupdict())
+        else:
+            unmatched.append(line)
+
+    if unmatched:
+        raise Exception('Pattern "%s" did not match values:\n%s' % (pattern, '\n'.join(unmatched)))
+
+    return matched
 
 
 def get_available_port():


### PR DESCRIPTION
##### SUMMARY

Improve ansible-test match error handling.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (at-parse-error-handling 0086039e2d) last updated 2018/09/20 22:45:47 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
