### PR TITLE
add skip/docker alias to skip tests when running on Docker (#45955)

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
@@ -42,6 +42,7 @@ Aliases can be used to skip platforms using one of the following:
 - ``skip/freebsd`` - Skip tests on FreeBSD.
 - ``skip/osx`` - Skip tests on macOS / OS X.
 - ``skip/rhel`` - Skip tests on RHEL.
+- ``skip/docker`` - Skip tests when running on a Docker container
 
 Aliases can be used to skip Python major versions using one of the following:
 

--- a/test/integration/targets/xattr/aliases
+++ b/test/integration/targets/xattr/aliases
@@ -1,4 +1,5 @@
 shippable/posix/group2
+skip/docker
 skip/freebsd
 skip/osx
 destructive

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1429,6 +1429,13 @@ def get_integration_docker_filter(args, targets):
 
     common_integration_filter(args, targets, exclude)
 
+    skip = 'skip/docker/'
+    skipped = [target.name for target in targets if skip in target.aliases]
+    if skipped:
+        exclude.append(skip)
+        display.warning('Excluding tests marked "%s" which cannot run under docker: %s'
+                        % (skip.rstrip('/'), ', '.join(skipped)))
+
     if not args.docker_privileged:
         skip = 'needs/privileged/'
         skipped = [target.name for target in targets if skip in target.aliases]


### PR DESCRIPTION
* add skip/docker alias to skip tests when running on Docker

* changed warning message wording

(cherry picked from commit 27c10fa502ca5ba95ffd80ac602ca49965a1936b)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/45955

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```paste below
2.5
```