### PR TITLE
Improve error handling for docs-build test.

### DIFF
--- a/test/sanity/code-smell/docs-build.py
+++ b/test/sanity/code-smell/docs-build.py
@@ -3,21 +3,32 @@
 import os
 import re
 import subprocess
+import sys
 
 
 def main():
-    base_dir = os.getcwd() + os.sep
+    base_dir = os.getcwd() + os.path.sep
     docs_dir = os.path.abspath('docs/docsite')
     cmd = ['make', 'singlehtmldocs']
 
     sphinx = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=docs_dir)
     stdout, stderr = sphinx.communicate()
 
+    stdout = stdout.decode('utf-8')
+    stderr = stderr.decode('utf-8')
+
     if sphinx.returncode != 0:
-        print("Command '%s' failed with status code: %d" % (' '.join(cmd), sphinx.returncode))
-        print(stdout)
-        print(stderr)
-        return
+        sys.stderr.write("Command '%s' failed with status code: %d\n" % (' '.join(cmd), sphinx.returncode))
+
+        if stdout.strip():
+            sys.stderr.write("--> Standard Output\n")
+            sys.stderr.write("%s\n" % stdout.strip())
+
+        if stderr.strip():
+            sys.stderr.write("--> Standard Error\n")
+            sys.stderr.write("%s\n" % stderr.strip())
+
+        sys.exit(1)
 
     with open('docs/docsite/rst_warnings', 'r') as warnings_fd:
         output = warnings_fd.read().strip()


### PR DESCRIPTION
##### SUMMARY

Improve error handling for docs-build test. Errors will now be properly processed by ansible-test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

docs-build sanity test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (docs-build-errors fea06a35e5) last updated 2018/09/21 00:24:06 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
