### PR TITLE
update example to YAML style in documentation

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse_includes.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_includes.rst
@@ -75,7 +75,9 @@ Includes and imports can also be used in the ``handlers:`` section. For instance
 
    # more_handlers.yml
    - name: restart apache
-     service: name=apache state=restarted
+     service:
+       name: apache
+       state: restarted
 
 And in your main playbook file::
 


### PR DESCRIPTION
The example is in a key=value format which is deprecated.

+label: docsite_pr

##### SUMMARY
The example is in a key=value format which is deprecated.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
doc

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.6.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Feb 11 2014, 07:46:25) [GCC 4.8.2 20140120 (Red Hat 4.8.2-13)]
```

##### ADDITIONAL INFORMATION
