### PR TITLE
plugins/terminal/eos: Invoke Cli tool before running commands

### DIFF
--- a/lib/ansible/plugins/terminal/eos.py
+++ b/lib/ansible/plugins/terminal/eos.py
@@ -52,6 +52,8 @@ class TerminalModule(TerminalBase):
     ]
 
     def on_open_shell(self):
+        if 'bash' in self._get_prompt():
+            self._exec_cli_command('FastCli')
         try:
             for cmd in (b'terminal length 0', b'terminal width 512'):
                 self._exec_cli_command(cmd)


### PR DESCRIPTION
This fixes #45627