### PR TITLE
[2.6] sysvinit: Fix referenced before assignment in sysvinit module 

### DIFF
--- a/changelogs/fragments/42695-sysvinit_reference-assignment.yml
+++ b/changelogs/fragments/42695-sysvinit_reference-assignment.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sysvinit - fixed an UnboundLocalError. The local variable 'worked' was referenced before assignment (https://github.com/ansible/ansible/pull/42695)

--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -175,12 +175,12 @@ def main():
 
     # figure out started status, everyone does it different!
     is_started = False
+    worked = False
 
     # user knows other methods fail and supplied pattern
     if pattern:
-        is_started = get_ps(module, pattern)
+        worked = is_started = get_ps(module, pattern)
     else:
-        worked = False
         if location.get('service'):
             # standard tool that has been 'destandarized' by reimplementation in other OS/distros
             cmd = '%s %s status' % (location['service'], name)


### PR DESCRIPTION
##### SUMMARY
Backport of #42695

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sysvinit

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
