### PR TITLE
swupd: fail in case of an incorrect bundle

### DIFF
--- a/lib/ansible/modules/packaging/os/swupd.py
+++ b/lib/ansible/modules/packaging/os/swupd.py
@@ -197,10 +197,6 @@ class Swupd(object):
             self.msg = "Bundle %s installed" % bundle
             return
 
-        if self.rc == 18:
-            self.msg = "Bundle name %s is invalid" % bundle
-            return
-
         self.failed = True
         self.msg = "Failed to install bundle %s" % bundle
 


### PR DESCRIPTION
##### SUMMARY
The ClearLinux OS uses 'swupd' package manager, which is supported by ansible's 'swupd' module.
Unlike other package modules like 'yum' and 'dnf', the 'swupd' module does not fail when an non-existing module is specified.

For example:

package:
  state: latest
  name: xxxx

Will fail for Fedora or CentOS, but will succeed for ClearLinux. This is inconsistent.

This pull request changes swupd behaviour and makes it fail when the bundle does not exist.

##### ISSUE TYPE
- Bugfix Pull Request

In my opinion this a bug.

##### COMPONENT NAME
swupd

##### ANSIBLE VERSION
All versions. I verified 2.4, 2.7, and 2.8dev (tip of devel).