### PR TITLE
Fix issues with PLUGIN_FILTERS_CFG config handling

### DIFF
--- a/changelogs/fragments/plugin-filters-cfg.yaml
+++ b/changelogs/fragments/plugin-filters-cfg.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- PLUGIN_FILTERS_CFG - Ensure that the value is treated as type=path, and that we use the standard section of ``defaults`` instead of ``default`` (https://github.com/ansible/ansible/pull/45994)

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1549,8 +1549,13 @@ PLUGIN_FILTERS_CFG:
   ini:
   - key: plugin_filters_cfg
     section: default
+    deprecated:
+      why: Specifying "plugin_filters_cfg" under the "default" section is deprecated
+      version: "2.12"
+      alternatives: the "defaults" section instead
   - key: plugin_filters_cfg
     section: defaults
+    version_added: "2.8"
   type: path
 RETRY_FILES_ENABLED:
   name: Retry files

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1555,7 +1555,6 @@ PLUGIN_FILTERS_CFG:
       alternatives: the "defaults" section instead
   - key: plugin_filters_cfg
     section: defaults
-    version_added: "2.8"
   type: path
 RETRY_FILES_ENABLED:
   name: Retry files

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1549,6 +1549,9 @@ PLUGIN_FILTERS_CFG:
   ini:
   - key: plugin_filters_cfg
     section: default
+  - key: plugin_filters_cfg
+    section: defaults
+  type: path
 RETRY_FILES_ENABLED:
   name: Retry files
   default: True


### PR DESCRIPTION
##### SUMMARY

Ensure that the value is treated as type=path, and that we use the standard section of `defaults` instead of `default`

I didn't remove the ability to use `default` as the section, as removing it could have bad consequences for users who figured out that they needed to use `default` instead of `defaults`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/config/base.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.5
2.6
2.7
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
