### PR TITLE
Add python.py coverage injector for ansible-test.

### DIFF
--- a/test/runner/injector/injector.py
+++ b/test/runner/injector/injector.py
@@ -105,6 +105,8 @@ def main():
 
         if os.path.basename(__file__) == 'injector.py':
             args, env = runner()  # code coverage collection is baked into the AnsiballZ wrapper when needed
+        elif os.path.basename(__file__) == 'python.py':
+            args, env = python()  # run arbitrary python commands using the correct python and with optional code coverage
         else:
             args, env = injector()
 
@@ -117,6 +119,20 @@ def main():
     except Exception as ex:
         logger.fatal(ex)
         raise
+
+
+def python():
+    """
+    :rtype: list[str], dict[str, str]
+    """
+    if config.coverage_file:
+        args, env = coverage_command()
+    else:
+        args, env = [config.python_interpreter], os.environ.copy()
+
+    args += config.arguments[1:]
+
+    return args, env
 
 
 def injector():

--- a/test/runner/injector/python.py
+++ b/test/runner/injector/python.py
@@ -1,0 +1,1 @@
+injector.py


### PR DESCRIPTION
##### SUMMARY

Add python.py coverage injector for ansible-test.

This can be used to run Python scripts from the repository with the correct interpreter and allow collection of code coverage.

Useful for testing contrib inventory scripts.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (at-coverage 16e09f9714) last updated 2018/09/21 10:37:10 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
