### PR TITLE
Changed hash_merge to link for ANSIBLE_HASH_BEHAVIOUR

### DIFF
--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -304,7 +304,7 @@ is an excellent way to track changes to your inventory and host variables.
 How Variables Are Merged
 ++++++++++++++++++++++++
 
-By default variables are merged/flattened to the specific host before a play is run. This keeps Ansible focused on the Host and Task, so groups don't really survive outside of inventory and host matching. By default, Ansible overwrites variables including the ones defined for a group and/or host (see the `hash_merge` setting to change this) . The order/precedence is (from lowest to highest):
+By default variables are merged/flattened to the specific host before a play is run. This keeps Ansible focused on the Host and Task, so groups don't really survive outside of inventory and host matching. By default, Ansible overwrites variables including the ones defined for a group and/or host (see :ref:`ANSIBLE_HASH_BEHAVIOUR<envvar-ANSIBLE_HASH_BEHAVIOUR>`). The order/precedence is (from lowest to highest):
 
 - all group (because it is the 'parent' of all other groups)
 - parent group

--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -304,7 +304,7 @@ is an excellent way to track changes to your inventory and host variables.
 How Variables Are Merged
 ++++++++++++++++++++++++
 
-By default variables are merged/flattened to the specific host before a play is run. This keeps Ansible focused on the Host and Task, so groups don't really survive outside of inventory and host matching. By default, Ansible overwrites variables including the ones defined for a group and/or host (see :ref:`ANSIBLE_HASH_BEHAVIOUR<envvar-ANSIBLE_HASH_BEHAVIOUR>`). The order/precedence is (from lowest to highest):
+By default variables are merged/flattened to the specific host before a play is run. This keeps Ansible focused on the Host and Task, so groups don't really survive outside of inventory and host matching. By default, Ansible overwrites variables including the ones defined for a group and/or host (see :ref:`DEFAULT_HASH_BEHAVIOUR<DEFAULT_HASH_BEHAVIOUR>`). The order/precedence is (from lowest to highest):
 
 - all group (because it is the 'parent' of all other groups)
 - parent group


### PR DESCRIPTION
##### SUMMARY

There's a reference to `hash_merge` in the inventory page, but it means nothing and goes nowhere. I suspect it means merging (`merge` setting) in ANSIBLE_HASH_BEHAVIOUR.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

Inventory docs.

##### ANSIBLE VERSION
```
ansible 2.6.4
  config file = /home/vagrant/src/vntx/cm/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION

I *think* I've got the link/ref syntax right - but I've not tested it by building the docs, so it could be wrong. Please double check my work :)
