### PR TITLE
Fixes #45983: Add gluster_heal_facts module for Gluster storage.

### DIFF
--- a/lib/ansible/modules/storage/glusterfs/gluster_heal_facts.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_heal_facts.py
@@ -115,7 +115,7 @@ def get_self_heal_status(name):
         elif line.startswith('/') or '\n' in line:
             continue
         else:
-            heal_info.append(br_dict)
+            br_dict and heal_info.append(br_dict)
             br_dict = {}
     return heal_info
 

--- a/lib/ansible/modules/storage/glusterfs/gluster_heal_facts.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_heal_facts.py
@@ -45,12 +45,14 @@ EXAMPLES = '''
   register: self_heal_status
 - debug:
     var: self_heal_status
-# status along with the number of files still in process:
-- gluster_heal_facts:
+
+- name: Gather rebalance facts about all gluster hosts in the cluster
+  gluster_heal_facts:
     name: test_volume
-    status_filter: self-heal
+    status_filter: rebalance
+  register: rebalance_status
 - debug:
-    var: gluster_hosts
+    var: rebalance_status
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/storage/glusterfs/gluster_heal_facts.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_heal_facts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2016 Red Hat, Inc.
+# Copyright: (c) 2016, Red Hat, Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -30,7 +30,9 @@ options:
     default: "self-heal"
     choices: ["self-heal", "rebalance"]
     description:
-      - Determines which facts are to be returned. If the status_filter is
+      - Determines which facts are to be returned.
+      - If the C(status_filter) is C(self-heal), status of self-heal, along with the number of files still in process are returned.
+      - If the C(status_filter) is C(rebalance), rebalance status is returned.
         self-heal, status of self-heal, along with the number of files still
         in process are returned. If status_filter is rebalance,
         rebalance status is returned.
@@ -39,7 +41,13 @@ requirements:
 '''
 
 EXAMPLES = '''
-# Gather facts about all gluster hosts in the cluster and return self-heal
+- name: Gather self-heal facts about all gluster hosts in the cluster
+  gluster_heal_facts:
+    name: test_volume
+    status_filter: self-heal
+  register: self_heal_status
+- debug:
+    var: self_heal_status
 # status along with the number of files still in process:
 - gluster_heal_facts:
     name: test_volume
@@ -93,7 +101,7 @@ def run_gluster(gargs, **kwargs):
 
 
 def get_self_heal_status(name):
-    out = run_gluster(['volume', 'heal', name, 'info'])
+    out = run_gluster(['volume', 'heal', name, 'info'], environ_update=dict(LANG='C', LC_ALL='C', LC_MESSAGES='C'))
     raw_out = out.split("\n")
     heal_info = []
     # return files that still need healing.

--- a/lib/ansible/modules/storage/glusterfs/gluster_heal_facts.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_heal_facts.py
@@ -121,14 +121,18 @@ def get_self_heal_status(name):
 
 
 def get_rebalance_status(name):
-    out = run_gluster(['volume', 'rebalance', name, 'status'])
+    out = run_gluster(['volume', 'rebalance', name, 'status'], environ_update=dict(LANG='C', LC_ALL='C', LC_MESSAGES='C'))
     raw_out = out.split("\n")
     rebalance_status = []
     # return the files that are either still 'in progress' state or 'completed'.
     for line in raw_out:
-        node_dict = {}
         line = " ".join(line.split())
         line_vals = line.split(" ")
+        if line_vals[0].startswith('-') or line_vals[0].startswith('Node'):
+            continue
+        node_dict = {}
+        if len(line_vals) == 1 or len(line_vals) == 4:
+            continue
         node_dict['node'] = line_vals[0]
         node_dict['rebalanced_files'] = line_vals[1]
         node_dict['failures'] = line_vals[4]

--- a/lib/ansible/modules/storage/glusterfs/gluster_heal_facts.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_heal_facts.py
@@ -33,9 +33,6 @@ options:
       - Determines which facts are to be returned.
       - If the C(status_filter) is C(self-heal), status of self-heal, along with the number of files still in process are returned.
       - If the C(status_filter) is C(rebalance), rebalance status is returned.
-        self-heal, status of self-heal, along with the number of files still
-        in process are returned. If status_filter is rebalance,
-        rebalance status is returned.
 requirements:
   - GlusterFS > 3.2
 '''
@@ -113,10 +110,7 @@ def get_self_heal_status(name):
             br_dict['status'] = line.split(":")[1].strip()
         elif 'Number' in line:
             br_dict['no_of_entries'] = line.split(":")[1].strip()
-            if int(br_dict['no_of_entries']) != 0:
-                heal_info.append(br_dict)
-            else:
-                continue
+    heal_info.append(br_dict)
     return heal_info
 
 
@@ -178,8 +172,8 @@ def main():
             heal_info = get_self_heal_status(volume_name)
         elif status_filter == "rebalance":
             rebalance_status = get_rebalance_status(volume_name)
-    except Exception:
-        module.fail_json(msg="Invalid heal status option.")
+    except Exception as e:
+        module.fail_json(msg='Error retrieving status: %s' % e, exception=traceback.format_exc())
 
     facts = {}
     facts['glusterfs'] = {'volume': volume_name, 'status_filter': status_filter, 'heal_info': heal_info, 'rebalance': rebalance_status}

--- a/lib/ansible/modules/storage/glusterfs/gluster_heal_facts.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_heal_facts.py
@@ -112,7 +112,11 @@ def get_self_heal_status(name):
             br_dict['status'] = line.split(":")[1].strip()
         elif 'Number' in line:
             br_dict['no_of_entries'] = line.split(":")[1].strip()
-    heal_info.append(br_dict)
+        elif line.startswith('/') or '\n' in line:
+            continue
+        else:
+            heal_info.append(br_dict)
+            br_dict = {}
     return heal_info
 
 

--- a/lib/ansible/modules/storage/glusterfs/gluster_heal_facts.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_heal_facts.py
@@ -1,0 +1,167 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: gluster_heal_facts
+short_description: Gather facts about self-heal or rebalance status
+author: "Devyani Kota (@devyanikota)"
+version_added: "2.8"
+description:
+  - Gather facts about either self-heal or rebalance status.
+options:
+  name:
+    description:
+      - The volume name.
+    required: true
+    aliases: ['volume']
+  status_filter:
+    default: "self-heal"
+    choices: ["self-heal", "rebalance"]
+    description:
+      - Determines which facts are to be returned. If the status_filter is
+        self-heal, status of self-heal, along with the number of files still
+        in process are returned. If status_filter is rebalance,
+        rebalance status is returned.
+requirements:
+  - GlusterFS > 3.2
+'''
+
+EXAMPLES = '''
+# Gather facts about all gluster hosts in the cluster and return self-heal
+# status along with the number of files still in process:
+- gluster_heal_facts:
+    name: test_volume
+    status_filter: self-heal
+- debug:
+    var: gluster_hosts
+'''
+
+RETURN = '''
+name:
+    description: GlusterFS volume name
+    returned: always
+    type: string
+status_filter:
+    description: Whether self-heal or rebalance status is to be returned
+    returned: always
+    type: string
+heal_info:
+    description: List of files that still need healing process
+    returned: On success
+    type: string
+rebalance_status:
+    description: Status of rebalance operation
+    returned: On success
+    type: string
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from distutils.version import LooseVersion
+
+glusterbin = ''
+
+
+def run_gluster(gargs, **kwargs):
+    global glusterbin
+    global module
+    args = [glusterbin, '--mode=script']
+    args.extend(gargs)
+    try:
+        rc, out, err = module.run_command(args, **kwargs)
+        if rc != 0:
+            module.fail_json(msg='error running gluster (%s) command (rc=%d): %s' %
+                             (' '.join(args), rc, out or err), exception=traceback.format_exc())
+    except Exception as e:
+        module.fail_json(msg='error running gluster (%s) command: %s' % (' '.join(args),
+                                                                         to_native(e)), exception=traceback.format_exc())
+    return out
+
+
+def get_self_heal_status(name):
+    out = run_gluster(['volume', 'heal', name, 'info'])
+    raw_out = out.split("\n")
+    heal_info = []
+    # return files that still need healing.
+    for line in raw_out:
+        if 'Brick' in line:
+            br_dict = {}
+            br_dict['brick'] = line.strip().strip("Brick")
+        elif 'Status' in line:
+            br_dict['status'] = line.split(":")[1].strip()
+        elif 'Number' in line:
+            br_dict['no_of_entries'] = line.split(":")[1].strip()
+            if int(br_dict['no_of_entries']) != 0:
+                heal_info.append(br_dict)
+            else:
+                continue
+    return heal_info
+
+
+def get_rebalance_status(name):
+    out = run_gluster(['volume', 'rebalance', name, 'status'])
+    return out
+
+
+def is_invalid_gluster_version(module, required_version):
+    cmd = module.get_bin_path('gluster', True) + ' --version'
+    result = module.run_command(cmd)
+    ver_line = result[1].split('\n')[0]
+    version = ver_line.split(' ')[1]
+    # If the installed version is less than 3.2, it is an invalid version
+    # return True
+    return LooseVersion(version) < LooseVersion(required_version)
+
+
+def main():
+    global module
+    global glusterbin
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(type='str', required=True, aliases=['volume']),
+            status_filter=dict(default='self-heal', choices=['self-heal', 'rebalance']),
+        ),
+    )
+
+    glusterbin = module.get_bin_path('gluster', True)
+    required_version = "3.2"
+    status_filter = module.params['status_filter']
+    volume_name = module.params['name']
+    heal_info = ''
+    rebalance_status = ''
+
+    # Verify if required GlusterFS version is installed
+    if is_invalid_gluster_version(module, required_version):
+        module.fail_json(msg="GlusterFS version > %s is required" %
+                         required_version)
+
+    try:
+        if status_filter == "self-heal":
+            heal_info = get_self_heal_status(volume_name)
+        elif status_filter == "rebalance":
+            rebalance_status = get_rebalance_status(volume_name)
+    except Exception:
+        module.fail_json(msg="Invalid heal status option.")
+
+    facts = {}
+    facts['glusterfs'] = {'volume': volume_name, 'status_filter': status_filter, 'heal_info': heal_info, 'rebalance': rebalance_status}
+
+    module.exit_json(ansible_facts=facts)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This module will add support to extract self-heal status of a cluster
and return the number of files that are still in progress for the
healing process to complete.

Signed-off-by: Devyani Kota <dkota@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #45983 : Adds gluster_heal_facts module
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
storage/glusterfs/gluster_heal_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/devyani/work/gdeploy/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.13 (default, Dec  1 2017, 09:21:53) [GCC 6.4.1 20170727 (Red Hat 6.4.1-1)]

```

##### ADDITIONAL INFORMATION
In a cluster, when a brick goes offline and comes back online, self-heal needs to be
triggered to bring all the replicas in sync.
This module will help list the files that still need to be healed, and the ones that have healed.
gluster volume heal test-volume info
```
Brick server1:/glusterfs/test-volume_0
Number of entries: 0
 
Brick server2:/glusterfs/test-volume_1
Number of entries: 101 
/95.txt
/32.txt
/66.txt
/35.txt
```
