### PR TITLE
added note about cli execution of include_x (#45227)

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -198,6 +198,10 @@ Noteworthy module changes
 * The ``win_disk_image`` module has deprecated the return value ``mount_path``, use ``mount_paths[0]`` instead. This will
   be removed in Ansible 2.11.
 
+* ``include_role`` and ``include_tasks`` can now be used directly from ``ansible`` (adhoc) and ``ansible-console``::
+
+    #> ansible -m include_role -a 'name=myrole' all
+
 Plugins
 =======
 


### PR DESCRIPTION
(cherry picked from commit 03d8b6854951d1c551a52c941c64bd32bfcd666e)

##### SUMMARY
Adds a note to the 2.7 porting guide about using `include_x` at the command line with `ansible -m`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.7
