### PR TITLE
fix for banner idempotent issue

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_banner.py
+++ b/lib/ansible/modules/network/nxos/nxos_banner.py
@@ -98,7 +98,7 @@ def execute_show_command(module, command):
         'command': command,
         'output': format,
     }]
-    output = run_commands(module, cmds, check_rc='retry_json')
+    output = run_commands(module, cmds)
     return output
 
 

--- a/lib/ansible/modules/network/nxos/nxos_banner.py
+++ b/lib/ansible/modules/network/nxos/nxos_banner.py
@@ -93,7 +93,7 @@ import re
 
 
 def execute_show_command(module, command):
-    format = 'json'
+    format = 'text'
     cmds = [{
         'command': command,
         'output': format,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #46000 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_banner
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel ccb89a8cb8) last updated 2018/09/21 11:58:21 (GMT -400)
  config file = /root/agents-ci/ansible/test/integration/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

```

##### ADDITIONAL INFORMATION
* Fixes #46000 
* As mentioned in the issue, the old versions of platform have no support for structured out for `show banner motd` command. So the current config is returning nil and idempotent tests fail. Use `cli_show_ascii` instead.
* Tested on all platforms and they pass