### PR TITLE
Fix integration test library search path.

### DIFF
--- a/test/runner/lib/ansible_util.py
+++ b/test/runner/lib/ansible_util.py
@@ -41,6 +41,7 @@ def ansible_environment(args, color=True):
         ANSIBLE_DEPRECATION_WARNINGS='false',
         ANSIBLE_HOST_KEY_CHECKING='false',
         ANSIBLE_CONFIG=os.path.abspath(ansible_config),
+        ANSIBLE_LIBRARY='/dev/null',
         PYTHONPATH=os.path.abspath('lib'),
         PAGER='/bin/cat',
         PATH=path,


### PR DESCRIPTION
##### SUMMARY

Fix integration test library search path.

This prevents tests from loading modules outside the source tree, which could result in testing the wrong module if a system-wide install is present, or custom modules exist.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (at-library-fix ec59741404) last updated 2018/09/21 13:00:45 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
