### PR TITLE
Allow NSGs to be added onto NICs at creation and update

### DIFF
--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -546,7 +546,7 @@
     that:
       - output.changed
 
-- name: create a NIC to add an existing NSG to
+- name: add an existing NSG to an existing NIC
   azure_rm_networkinterface:
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}nsgadd"
@@ -562,7 +562,7 @@
       - output.changed
       - output.state.network_security_group.name == 'nsg{{ rpfx }}'
 
-- name: create a NIC to add an existing NSG to (idempotent)
+- name: add an existing NSG to an existing NIC (idempotent)
   azure_rm_networkinterface:
     resource_group: "{{ resource_group }}"
     name: "tn{{ rpfx }}nsgadd"
@@ -577,6 +577,32 @@
     that:
       - not output.changed
       - output.state.network_security_group.name == 'nsg{{ rpfx }}'
+
+- name: disassociate an NSG from a NIC
+  azure_rm_networkinterface:
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}nsg"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+  register: output
+
+- assert:
+    that:
+      - output.changed
+      - not output.state.network_security_group
+
+- name: disassociate an NSG from a NIC (idempotent)
+  azure_rm_networkinterface:
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}nsg"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+  register: output
+
+- assert:
+    that:
+      - not output.changed
+      - not output.state.network_security_group
 
 - name: Delete the NICs
   azure_rm_networkinterface:

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -495,3 +495,105 @@
     name: "pip{{ rpfx }}"
     resource_group: '{{ resource_group }}'
     state: absent
+
+- name: create a network security group
+  azure_rm_securitygroup:
+    name: "nsg{{ rpx }}"
+    resource_group: '{{ resource_group }}'
+
+- name: create a NIC with an existing NSG
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}nsg"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      security_group:
+        name: "nsg{{ rpx }}"
+        resource_group: "{{ resource_group }}"
+  register: output
+
+- assert:
+    that:
+      - output.changed
+      - output.state.network_security_group.name == 'nsg{{ rpx }}'
+      
+
+- name: create a NIC with an existing NSG (idempotent)
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}nsg"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      security_group:
+        name: "nsg{{ rpx }}"
+        resource_group: "{{ resource_group }}"
+  register: output
+
+- assert:
+    that:
+      - not output.changed
+      - output.state.network_security_group.name == 'nsg{{ rpx }}'
+
+- name: create a NIC to add an existing NSG to
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}nsgadd"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+  register: output
+
+- assert:
+    that:
+      - output.changed
+
+- name: create a NIC to add an existing NSG to
+  azure_rm_networkinterface:
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}nsgadd"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    security_group:
+      name: "nsg{{ rpx }}"
+      resource_group: "{{ resource_group }}"
+  register: output
+
+- assert:
+    that:
+      - output.changed
+      - output.state.network_security_group.name == 'nsg{{ rpx }}'
+
+- name: create a NIC to add an existing NSG to (idempotent)
+  azure_rm_networkinterface:
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}nsgadd"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    security_group:
+      name: "nsg{{ rpx }}"
+      resource_group: "{{ resource_group }}"
+  register: output
+
+- assert:
+    that:
+      - not output.changed
+      - output.state.network_security_group.name == 'nsg{{ rpx }}'
+
+- name: Delete the NICs
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "{{ item }}"
+      state: absent
+  with_items:
+    - "tn{{ rpfx }}nsgadd"
+    - "tn{{ rpfx }}nsg"
+  register: output
+
+- assert:
+    that:
+      - output.changed
+
+- name: Delete the NSG
+  azure_rm_securitygroup:
+    name: "nsg{{ rpx }}"
+    resource_group: '{{ resource_group }}'
+    state: absent

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -498,7 +498,7 @@
 
 - name: create a network security group
   azure_rm_securitygroup:
-    name: "nsg{{ rpx }}"
+    name: "nsg{{ rpfx }}"
     resource_group: '{{ resource_group }}'
 
 - name: create a NIC with an existing NSG
@@ -508,14 +508,14 @@
       virtual_network: "{{ vn.state.id }}"
       subnet: "tn{{ rpfx }}"
       security_group:
-        name: "nsg{{ rpx }}"
+        name: "nsg{{ rpfx }}"
         resource_group: "{{ resource_group }}"
   register: output
 
 - assert:
     that:
       - output.changed
-      - output.state.network_security_group.name == 'nsg{{ rpx }}'
+      - output.state.network_security_group.name == 'nsg{{ rpfx }}'
       
 
 - name: create a NIC with an existing NSG (idempotent)
@@ -525,14 +525,14 @@
       virtual_network: "{{ vn.state.id }}"
       subnet: "tn{{ rpfx }}"
       security_group:
-        name: "nsg{{ rpx }}"
+        name: "nsg{{ rpfx }}"
         resource_group: "{{ resource_group }}"
   register: output
 
 - assert:
     that:
       - not output.changed
-      - output.state.network_security_group.name == 'nsg{{ rpx }}'
+      - output.state.network_security_group.name == 'nsg{{ rpfx }}'
 
 - name: create a NIC to add an existing NSG to
   azure_rm_networkinterface:
@@ -553,14 +553,14 @@
     virtual_network: "{{ vn.state.id }}"
     subnet: "tn{{ rpfx }}"
     security_group:
-      name: "nsg{{ rpx }}"
+      name: "nsg{{ rpfx }}"
       resource_group: "{{ resource_group }}"
   register: output
 
 - assert:
     that:
       - output.changed
-      - output.state.network_security_group.name == 'nsg{{ rpx }}'
+      - output.state.network_security_group.name == 'nsg{{ rpfx }}'
 
 - name: create a NIC to add an existing NSG to (idempotent)
   azure_rm_networkinterface:
@@ -569,14 +569,14 @@
     virtual_network: "{{ vn.state.id }}"
     subnet: "tn{{ rpfx }}"
     security_group:
-      name: "nsg{{ rpx }}"
+      name: "nsg{{ rpfx }}"
       resource_group: "{{ resource_group }}"
   register: output
 
 - assert:
     that:
       - not output.changed
-      - output.state.network_security_group.name == 'nsg{{ rpx }}'
+      - output.state.network_security_group.name == 'nsg{{ rpfx }}'
 
 - name: Delete the NICs
   azure_rm_networkinterface:
@@ -594,6 +594,6 @@
 
 - name: Delete the NSG
   azure_rm_securitygroup:
-    name: "nsg{{ rpx }}"
+    name: "nsg{{ rpfx }}"
     resource_group: '{{ resource_group }}'
     state: absent


### PR DESCRIPTION
Signed-off-by: Marc Sensenich <sensenichm91@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When creating a NIC and associating an existing NSG at creation, it does not associate the NSG to the NIC. There is also the case of disassociating of the NSG from NICs when updating them if there was a NSG already associated to a NIC.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_networkinterface
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.3
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
