### PR TITLE
Improve stability of Docker integration tests.

### DIFF
--- a/test/integration/targets/docker_stack/tasks/test_stack.yml
+++ b/test/integration/targets/docker_stack/tasks/test_stack.yml
@@ -1,3 +1,8 @@
+- name: Make sure we're not already using Docker swarm
+  docker_swarm:
+    state: absent
+    force: true
+
 - name: Create a Swarm cluster
   docker_swarm:
     state: present

--- a/test/integration/targets/docker_swarm/tasks/test_swarm.yml
+++ b/test/integration/targets/docker_swarm/tasks/test_swarm.yml
@@ -1,3 +1,8 @@
+- name: Make sure we're not already using Docker swarm
+  docker_swarm:
+    state: absent
+    force: true
+
 - name: Test parameters with state=present
   docker_swarm:
     state: present

--- a/test/integration/targets/setup_docker/tasks/main.yml
+++ b/test/integration/targets/setup_docker/tasks/main.yml
@@ -16,3 +16,8 @@
       pip:
         state: present
         name: 'docker{{ extra_packages }}'
+
+    - name: Make sure we're not using Docker swarm
+      docker_swarm:
+        state: absent
+        force: true

--- a/test/integration/targets/setup_docker/tasks/main.yml
+++ b/test/integration/targets/setup_docker/tasks/main.yml
@@ -16,8 +16,3 @@
       pip:
         state: present
         name: 'docker{{ extra_packages }}'
-
-    - name: Make sure we're not using Docker swarm
-      docker_swarm:
-        state: absent
-        force: true


### PR DESCRIPTION
##### SUMMARY

Improve stability of Docker integration tests.

This avoids issues where a swarm is already in use when the test starts.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Docker integration tests

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (docker-test-fix 2a84a3d159) last updated 2018/09/21 13:20:55 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
