### PR TITLE
Fix ansible-test docker python version handling.

### DIFF
--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -1,11 +1,11 @@
-default name=quay.io/ansible/default-test-container:1.2.0
+default name=quay.io/ansible/default-test-container:1.2.0 python=3
 centos6 name=quay.io/ansible/centos6-test-container:1.4.0 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.4.0 seccomp=unconfined
 fedora24 name=quay.io/ansible/fedora24-test-container:1.4.0 seccomp=unconfined
 fedora25 name=quay.io/ansible/fedora25-test-container:1.4.0 seccomp=unconfined
-fedora26py3 name=quay.io/ansible/fedora26py3-test-container:1.4.0
-fedora27py3 name=quay.io/ansible/fedora27py3-test-container:1.4.0
+fedora26py3 name=quay.io/ansible/fedora26py3-test-container:1.4.0 python=3
+fedora27py3 name=quay.io/ansible/fedora27py3-test-container:1.4.0 python=3
 opensuse42.3 name=quay.io/ansible/opensuse42.3-test-container:1.4.0 seccomp=unconfined
 ubuntu1404 name=quay.io/ansible/ubuntu1404-test-container:1.4.0 seccomp=unconfined
 ubuntu1604 name=quay.io/ansible/ubuntu1604-test-container:1.4.0 seccomp=unconfined
-ubuntu1604py3 name=quay.io/ansible/ubuntu1604py3-test-container:1.4.0 seccomp=unconfined
+ubuntu1604py3 name=quay.io/ansible/ubuntu1604py3-test-container:1.4.0 seccomp=unconfined python=3

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -52,6 +52,7 @@ from lib.util import (
     get_available_port,
     generate_pip_command,
     find_python,
+    get_docker_completion,
 )
 
 from lib.docker_util import (
@@ -1457,15 +1458,9 @@ def get_integration_docker_filter(args, targets):
             display.warning('Excluding tests marked "%s" which require --docker-privileged to run under docker: %s'
                             % (skip.rstrip('/'), ', '.join(skipped)))
 
-    docker_image = args.docker.split('@')[0]  # strip SHA for proper tag comparison
-
     python_version = 2  # images are expected to default to python 2 unless otherwise specified
 
-    if docker_image.endswith('py3'):
-        python_version = 3  # docker images ending in 'py3' are expected to default to python 3
-
-    if docker_image.endswith(':default'):
-        python_version = 3  # docker images tagged 'default' are expected to default to python 3
+    python_version = int(get_docker_completion().get(args.docker_raw).get('python', str(python_version)))
 
     if args.python:  # specifying a numeric --python option overrides the default python
         if args.python.startswith('3'):


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test docker python version handling.

This removes the old name based version detection behavior and uses versions defined in the docker completion file instead, as the new containers do not follow the old naming scheme.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (at-default-version-fix 12bba24e84) last updated 2018/09/21 14:45:10 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
