### PR TITLE
[WIP] foreman inventory plugin - fix file-based caching

### DIFF
--- a/changelogs/fragments/foreman_inventory_plugin_cache.yaml
+++ b/changelogs/fragments/foreman_inventory_plugin_cache.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - foreman inventory plugin - Enable caching via cache plugins by using self.cache instead of
+    self._cache. self.cache is a (user-specified) cache plugin when caching is enabled for
+    inventory, while self._cache is a dictionary that is unused after being populated since
+    it is not stored between uses.

--- a/test/integration/targets/inventory_foreman/inspect_cache.yml
+++ b/test/integration/targets/inventory_foreman/inspect_cache.yml
@@ -1,0 +1,32 @@
+---
+- hosts: localhost
+  vars:
+    foreman_stub_host: "{{ lookup('env', 'FOREMAN_HOST') }}"
+    foreman_stub_port: "{{ lookup('env', 'FOREMAN_PORT') }}"
+    foreman_stub_api_path: /api/v2
+    cached_hosts_key: "http://{{ foreman_stub_host }}:{{ foreman_stub_port }}{{ foreman_stub_api_path }}/hosts"
+  tasks:
+    - name: verify a cache file was created
+      find:
+        path:
+          - ./foreman_cache
+      register: matching_files
+
+    - assert:
+        that:
+          - matching_files.matched == 1
+
+    - name: read the cached inventory
+      set_fact:
+        contents: "{{ lookup('file', matching_files.files.0.path) }}"
+
+    - name: extract all the host names
+      set_fact:
+        cached_hosts: "{{ contents[cached_hosts_key] | json_query('[*].name') }}"
+
+    - assert:
+        that:
+          "'{{ item }}' in cached_hosts"
+      loop:
+        - "v6.example-780.com"
+        - "c4.j1.y5.example-487.com"

--- a/test/integration/targets/inventory_foreman/runme.sh
+++ b/test/integration/targets/inventory_foreman/runme.sh
@@ -9,6 +9,11 @@ export FOREMAN_HOST="${FOREMAN_HOST:-localhost}"
 export FOREMAN_PORT="${FOREMAN_PORT:-8080}"
 FOREMAN_CONFIG=test-config.foreman.yaml
 
+# Set inventory caching environment variables to populate a jsonfile cache
+export ANSIBLE_INVENTORY_CACHE=True
+export ANSIBLE_INVENTORY_CACHE_PLUGIN=jsonfile
+export ANSIBLE_INVENTORY_CACHE_CONNECTION=./foreman_cache
+
 # flag for checking whether cleanup has already fired
 _is_clean=
 
@@ -33,3 +38,7 @@ validate_certs: False
 FOREMAN_YAML
 
 ansible-playbook test_foreman_inventory.yml --connection=local "$@"
+ansible-playbook inspect_cache.yml --connection=local "$@"
+
+# remove inventory cache
+rm -r ./foreman_cache


### PR DESCRIPTION
##### SUMMARY
Partially fixes #45828
This should fix using file-based caches (such as jsonfile) for the foreman inventory plugin.

#40105 Is still a WIP but will enable DB caching for all inventory plugins that are using self.cache

Backport candidate for 2.7.x

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/foreman.py

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
```
