### PR TITLE
fixed nxos_aaa_server_host issue with type 7 encrypt key

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_aaa_server_host.py
+++ b/lib/ansible/modules/network/nxos/nxos_aaa_server_host.py
@@ -309,6 +309,8 @@ def main():
             delta = proposed
         else:
             for key, value in proposed.items():
+                if key == 'encrypt_type':
+                    delta[key] = value
                 if value != existing.get(key):
                     if value != 'default' or existing.get(key):
                         delta[key] = value

--- a/test/integration/targets/nxos_aaa_server_host/tests/common/radius.yaml
+++ b/test/integration/targets/nxos_aaa_server_host/tests/common/radius.yaml
@@ -130,6 +130,24 @@
 
   - assert: *false
 
+  - name: "Configure radius server with new type 7 encryption key"
+    nxos_aaa_server_host:
+      server_type: radius
+      address: 8.8.8.8
+      host_timeout: 25
+      auth_port: 2083
+      acct_port: 2084
+      encrypt_type: 7
+      key: helloback
+      provider: "{{ connection }}"
+      state: present
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - "'key 7' in result.updates[0]"
+
   - name: "Configure radius server with default key"
     nxos_aaa_server_host: &configure_radius_defkey
       server_type: radius

--- a/test/integration/targets/nxos_aaa_server_host/tests/common/radius.yaml
+++ b/test/integration/targets/nxos_aaa_server_host/tests/common/radius.yaml
@@ -131,7 +131,7 @@
   - assert: *false
 
   - name: "Configure radius server with new type 7 encryption key"
-    nxos_aaa_server_host:
+    nxos_aaa_server_host: &configure_radius_new_type7
       server_type: radius
       address: 8.8.8.8
       host_timeout: 25
@@ -147,6 +147,12 @@
       that:
         - "result.changed == true"
         - "'key 7' in result.updates[0]"
+
+  - name: "Check Idempotence"
+    nxos_aaa_server_host: *configure_radius_new_type7
+    register: result
+
+  - assert: *false
 
   - name: "Configure radius server with default key"
     nxos_aaa_server_host: &configure_radius_defkey

--- a/test/integration/targets/nxos_aaa_server_host/tests/common/tacacs.yaml
+++ b/test/integration/targets/nxos_aaa_server_host/tests/common/tacacs.yaml
@@ -134,7 +134,7 @@
   - assert: *false
 
   - name: "Configure tacacs server with new type 7 encryption key"
-    nxos_aaa_server_host:
+    nxos_aaa_server_host: &configure_tacacs_new_type7
       server_type: tacacs
       address: 8.8.8.8
       host_timeout: 25
@@ -149,6 +149,12 @@
       that:
         - "result.changed == true"
         - "'key 7' in result.updates[0]"
+
+  - name: "Check Idempotence"
+    nxos_aaa_server_host: *configure_tacacs_new_type7
+    register: result
+
+  - assert: *false
 
   - name: "Configure tacacs server with default key"
     nxos_aaa_server_host: &configure_tacacs_defkey

--- a/test/integration/targets/nxos_aaa_server_host/tests/common/tacacs.yaml
+++ b/test/integration/targets/nxos_aaa_server_host/tests/common/tacacs.yaml
@@ -133,6 +133,23 @@
 
   - assert: *false
 
+  - name: "Configure tacacs server with new type 7 encryption key"
+    nxos_aaa_server_host:
+      server_type: tacacs
+      address: 8.8.8.8
+      host_timeout: 25
+      tacacs_port: 89
+      encrypt_type: 7
+      key: helloback
+      provider: "{{ connection }}"
+      state: present
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - "'key 7' in result.updates[0]"
+
   - name: "Configure tacacs server with default key"
     nxos_aaa_server_host: &configure_tacacs_defkey
       server_type: tacacs


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #46014 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_aaa_server_host

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel a9680ee3ef) last updated 2018/09/21 10:33:18 (GMT +000)
  config file = /home/vagrant/netdev/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This PR fixes issue mentioned in #46014 
Tested on 93180YC-EX running NXOS: version 7.0(3)I6(1)
Added test cases as well.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
