### PR TITLE
Restore license agreement (#45809)

### DIFF
--- a/docs/docsite/rst/community/contributor_license_agreement.rst
+++ b/docs/docsite/rst/community/contributor_license_agreement.rst
@@ -1,0 +1,7 @@
+.. _contributor_license_agreement:
+
+******************************
+Contributors License Agreement
+******************************
+
+By contributing you agree that these contributions are your own (or approved by your employer) and you grant a full, complete, irrevocable copyright license to all users and developers of the project, present and future, pursuant to the license of the project.

--- a/docs/docsite/rst/community/index.rst
+++ b/docs/docsite/rst/community/index.rst
@@ -21,8 +21,5 @@ To get started, please read and understand the :ref:`code_of_conduct`, and then 
    maintainers
    release_managers
    communication
+   contributor_license_agreement
    other_tools_and_programs
-   
-
-
-

--- a/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
@@ -117,8 +117,8 @@ Read the complete :ref:`module metadata specification <ansible_metadata_block>` 
   serializable.  A common pitfall is to try returning an object via
   exit_json().  Instead, convert the fields you need from the object into the
   fields of a dictionary and return the dictionary.
-* When fetching URLs, please use either fetch_url or open_url from ansible.module_utils.urls 
-  rather than urllib2; urllib2 does not natively verify TLS certificates and so is insecure for https. 
+* When fetching URLs, please use either fetch_url or open_url from ansible.module_utils.urls
+  rather than urllib2; urllib2 does not natively verify TLS certificates and so is insecure for https.
 * facts modules must return facts in the ansible_facts field of the :ref:`result
   dictionary<common_return_values>`.
 * modules that are purely about fact gathering need to implement check_mode.

--- a/docs/docsite/rst/dev_guide/index.rst
+++ b/docs/docsite/rst/dev_guide/index.rst
@@ -8,7 +8,6 @@ The purpose of this guide is to document all of the paths available to you for i
 
 To get started, select one of the following topics.
 
-
 .. toctree::
    :maxdepth: 2
 


### PR DESCRIPTION
* adds page for CLA in community docs with link from community index

(partial cherry pick from commit f430f60541899792356efd3ba7f31f7324731f10)

##### SUMMARY
Restore CLA to 2.6 docs

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.6

