### PR TITLE
fix premature exit when RG doesn't exist (#46013)

### DIFF
--- a/changelogs/fragments/azure_rm_deployment_fix_45941.yaml
+++ b/changelogs/fragments/azure_rm_deployment_fix_45941.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- azure_rm_deployment - fixed regression that prevents resource group from being created (https://github.com/ansible/ansible/issues/45941)

--- a/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
@@ -491,7 +491,8 @@ class AzureRMDeploymentManager(AzureRMModuleBase):
 
         if self.append_tags and self.tags:
             try:
-                rg = self.get_resource_group(self.resource_group_name)
+                # fetch the RG directly (instead of using the base helper) since we don't want to exit if it's missing
+                rg = self.rm_client.resource_groups.get(self.resource_group_name)
                 if rg.tags:
                     self.tags = dict(self.tags, **rg.tags)
             except CloudError:


### PR DESCRIPTION
##### SUMMARY
(backport #46013 to stable-2.7)

* fixes #45941
* corrects regression introduced by #26104; when the resource group doesn't exist, the module exits prematurely with an error instead of creating it.

(cherry picked from commit 3b52d968e678a9055a5b3e38185c889e1ddc027f)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_deployment

##### ANSIBLE VERSION
2.7.0rc3

##### ADDITIONAL INFORMATION

