### PR TITLE
fix for possible azure_rm_manageddisk_facts crash

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
@@ -157,7 +157,7 @@ def managed_disk_to_dict(managed_disk):
         source_resource_uri=create_data.source_resource_id,
         disk_size_gb=managed_disk.disk_size_gb,
         os_type=managed_disk.os_type.value if managed_disk.os_type else None,
-        storage_account_type=managed_disk.sku.name.value,
+        storage_account_type=managed_disk.sku.name.value if managed_disk.sku else None,
         managed_by=managed_disk.managed_by
     )
 


### PR DESCRIPTION
##### SUMMARY
Encountered an issue when returned managed disk didn't have SKU returned.

Module is not crashing in most of the circumstances, we encountered it in following circumstances:

- querying single managed disk - passed
- querying all managed disks from the resource group - crashed on one of them
 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_managed_disk
azure_rm_managed_disk_facts

##### ANSIBLE VERSION
2.7

##### ADDITIONAL INFORMATION

