### PR TITLE
Fix STS assume role error message when role does not exist

### DIFF
--- a/test/integration/targets/sts_assume_role/aliases
+++ b/test/integration/targets/sts_assume_role/aliases
@@ -1,4 +1,3 @@
 cloud/aws
 shippable/aws/group1
 iam_role
-disabled

--- a/test/integration/targets/sts_assume_role/tasks/main.yml
+++ b/test/integration/targets/sts_assume_role/tasks/main.yml
@@ -290,14 +290,14 @@
       assert:
         that:
           - 'result.failed'
-          - "'Not authorized to perform sts:AssumeRole' in result.msg"
+          - "'Access denied' in result.msg"
       when: result.module_stderr is not defined
 
     - name: assert assume not existing sts role
       assert:
         that:
           - 'result.failed'
-          - "'Not authorized to perform sts:AssumeRole' in result.module_stderr"
+          - "'Access denied' in result.module_stderr"
       when: result.module_stderr is defined
 
     # ============================================================


### PR DESCRIPTION
##### SUMMARY
It appears Amazon changed the error provided

Fixes https://app.shippable.com/github/ansible/ansible/runs/85128/67/tests, re-enabled tests

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sts_assume_role

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
```
