### PR TITLE
Fixing assigning ssl certificate to http listener in app gateway (#45…

### DIFF
--- a/changelogs/fragments/45830-fixed-assigning-ssl-certificate.yaml
+++ b/changelogs/fragments/45830-fixed-assigning-ssl-certificate.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- "Fixed: Appropriate code to expand value was missing so assigning SSL
+   certificate is not working as described in the documentation.
+   https://github.com/ansible/ansible/pull/45830"

--- a/lib/ansible/modules/cloud/azure/azure_rm_appgateway.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_appgateway.py
@@ -577,6 +577,12 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
                                                   kwargs['name'],
                                                   item['frontend_port'])
                             item['frontend_port'] = {'id': id}
+                        if 'ssl_certificate' in item:
+                            id = ssl_certificate_id(self.subscription_id,
+                                                    kwargs['resource_group'],
+                                                    kwargs['name'],
+                                                    item['ssl_certificate'])
+                            item['ssl_certificate'] = {'id': id}
                         if 'protocol' in item:
                             item['protocol'] = _snake_to_camel(item['protocol'], True)
                         ev[i] = item
@@ -777,6 +783,16 @@ def frontend_port_id(subscription_id, resource_group_name, appgateway_name, name
         subscription_id,
         resource_group_name,
         appgateway_name,
+        name
+    )
+
+
+def ssl_certificate_id(subscription_id, resource_group_name, ssl_certificate_name, name):
+    """Generate the id for a frontend port"""
+    return '/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Network/applicationGateways/{2}/sslCertificates/{3}'.format(
+        subscription_id,
+        resource_group_name,
+        ssl_certificate_name,
         name
     )
 

--- a/test/integration/targets/azure_rm_appgateway/tasks/main.yml
+++ b/test/integration/targets/azure_rm_appgateway/tasks/main.yml
@@ -66,6 +66,8 @@
     http_listeners:
       - frontend_ip_configuration: sample_gateway_frontend_ip_config
         frontend_port: ag_frontend_port
+        protocol: https
+        ssl_certificate: cert2
         name: sample_http_listener
     request_routing_rules:
       - rule_type: basic
@@ -129,6 +131,8 @@
     http_listeners:
       - frontend_ip_configuration: sample_gateway_frontend_ip_config
         frontend_port: ag_frontend_port
+        protocol: https
+        ssl_certificate: cert2
         name: sample_http_listener
     request_routing_rules:
       - rule_type: Basic
@@ -187,6 +191,8 @@
     http_listeners:
       - frontend_ip_configuration: sample_gateway_frontend_ip_config
         frontend_port: ag_frontend_port
+        protocol: https
+        ssl_certificate: cert2
         name: sample_http_listener
     request_routing_rules:
       - rule_type: Basic
@@ -245,6 +251,8 @@
     http_listeners:
       - frontend_ip_configuration: sample_gateway_frontend_ip_config
         frontend_port: ag_frontend_port
+        protocol: https
+        ssl_certificate: cert2
         name: sample_http_listener
     request_routing_rules:
       - rule_type: Basic


### PR DESCRIPTION
…830)

* fixed ssl certificate reference

* modified test

(cherry picked from commit 83645963fb8eeda6dccc53a838b5a529de20de04)

##### SUMMARY
Backporting appgateway bug

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_appgateway

##### ANSIBLE VERSION
2.7

##### ADDITIONAL INFORMATION

