### PR TITLE
Add AWS IAM and AWS EC2 auth method to hashi_vault lookup

### DIFF
--- a/test/support/integration/plugins/lookup/hashi_vault.py
+++ b/test/support/integration/plugins/lookup/hashi_vault.py
@@ -330,12 +330,14 @@ class HashiVault:
         self.client.auth.aws.iam_login(access_key, secret_key, session_token=session_token, header_value=header_value, role=role, region=region, mount_point=mount_point)
 
     def auth_aws_ec2(self, **kwargs):
-        url = "{base}/latest/dynamic/instance-identity/pkcs7".format(base=AWS_EC2_METADATA_URL_BASE)
+        pkcs7 = kwargs.get('pkcs7')
 
-        try:
-            pkcs7 = requests.get(url, timeout=0.1).text.replace('\n', '')
-        except requests.exceptions.ConnectionError:
-            raise AnsibleError("hashi_vault lookup plugin failed to connect to {base}, Make sure you are running from a AWS EC2 instance".format(base=AWS_EC2_METADATA_URL_BASE))
+        if pkcs7 is None:
+          url = "{base}/latest/dynamic/instance-identity/pkcs7".format(base=AWS_EC2_METADATA_URL_BASE)
+          try:
+              pkcs7 = requests.get(url, timeout=0.1).text.replace('\n', '')
+          except requests.exceptions.ConnectionError:
+              raise AnsibleError("hashi_vault lookup plugin failed to connect to {base}, Make sure you are running from a AWS EC2 instance".format(base=AWS_EC2_METADATA_URL_BASE))
 
         nonce = kwargs.get('nonce')
 

--- a/test/support/integration/plugins/lookup/hashi_vault.py
+++ b/test/support/integration/plugins/lookup/hashi_vault.py
@@ -301,15 +301,16 @@ class HashiVault:
         self.client.auth_approle(role_id, secret_id)
 
     def auth_aws_iam(self, **kwargs):
-        access_key = kwargs.get('access_key', os.environ.get('AWS_ACCESS_KEY_ID'))
-        if access_key is None:
-            raise AnsibleError("Authentication method aws iam requires a access_key")
-
-        secret_key = kwargs.get('secret_key', os.environ.get('AWS_SECRET_ACCESS_KEY'))
-        if secret_key is None:
-            raise AnsibleError("Authentication method aws iam requires a secret_key")
-
+        access_key = kwargs.get('access_key')
+        secret_key = kwargs.get('secret_key')
         session_token = kwargs.get('session_token')
+
+        if access_key is None or secret_key is None:
+            import boto3
+            creds = boto3.Session().get_credentials()
+            if creds is None:
+                raise AnsibleError("Authentication method aws iam requires AWS credentials")
+            access_key, secret_key, session_token = creds.access_key, creds.secret_key, creds.token
 
         header_value = kwargs.get('header_value')
 

--- a/test/support/integration/plugins/lookup/hashi_vault.py
+++ b/test/support/integration/plugins/lookup/hashi_vault.py
@@ -123,8 +123,8 @@ EXAMPLES = """
   debug:
       msg: "{{ lookup('hashi_vault', 'secret=secret/hello:value auth_method=aws_iam access_key=access secret_key=secret role=myrole url=http://myvault:8200')}}"
 
-  debug:
 - name: authenticate via AWS EC2 auth
+  debug:
       msg: "{{ lookup('hashi_vault', 'secret=secret/hello:value auth_method=aws_ec2 nonce=my_nonce role=myawsrole url=http://myvault:8200')}}"
 
 # When using KV v2 the PATH should include "data" between the secret engine mount and path (e.g. "secret/data/:path")
@@ -327,17 +327,19 @@ class HashiVault:
         if region is None:
             region = 'us-east-1'
 
-        self.client.auth.aws.iam_login(access_key, secret_key, session_token=session_token, header_value=header_value, role=role, region=region, mount_point=mount_point)
+        self.client.auth.aws.iam_login(access_key, secret_key, session_token=session_token, header_value=header_value, role=role, region=region,
+                                       mount_point=mount_point)
 
     def auth_aws_ec2(self, **kwargs):
         pkcs7 = kwargs.get('pkcs7')
 
         if pkcs7 is None:
-          url = "{base}/latest/dynamic/instance-identity/pkcs7".format(base=AWS_EC2_METADATA_URL_BASE)
-          try:
-              pkcs7 = requests.get(url, timeout=0.1).text.replace('\n', '')
-          except requests.exceptions.ConnectionError:
-              raise AnsibleError("hashi_vault lookup plugin failed to connect to {base}, Make sure you are running from a AWS EC2 instance".format(base=AWS_EC2_METADATA_URL_BASE))
+            url = "{base}/latest/dynamic/instance-identity/pkcs7".format(base=AWS_EC2_METADATA_URL_BASE)
+            try:
+                pkcs7 = requests.get(url, timeout=0.1).text.replace('\n', '')
+            except requests.exceptions.ConnectionError:
+                raise AnsibleError("hashi_vault lookup plugin failed to connect to {base}, Make sure you are running from a AWS EC2 instance".format(
+                    base=AWS_EC2_METADATA_URL_BASE))
 
         nonce = kwargs.get('nonce')
 

--- a/test/support/integration/plugins/lookup/hashi_vault.py
+++ b/test/support/integration/plugins/lookup/hashi_vault.py
@@ -158,6 +158,7 @@ except ImportError:
 
 
 ANSIBLE_HASHI_VAULT_ADDR = 'http://127.0.0.1:8200'
+AWS_EC2_METADATA_URL_BASE = 'http://169.254.169.254'
 
 if os.getenv('VAULT_ADDR') is not None:
     ANSIBLE_HASHI_VAULT_ADDR = os.environ['VAULT_ADDR']
@@ -329,12 +330,12 @@ class HashiVault:
         self.client.auth.aws.iam_login(access_key, secret_key, session_token=session_token, header_value=header_value, role=role, region=region, mount_point=mount_point)
 
     def auth_aws_ec2(self, **kwargs):
-        url = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7"
+        url = "{base}/latest/dynamic/instance-identity/pkcs7".format(base=AWS_EC2_METADATA_URL_BASE)
 
         try:
             pkcs7 = requests.get(url, timeout=0.1).text.replace('\n', '')
         except requests.exceptions.ConnectionError:
-            raise AnsibleError("hashi_vault lookup plugin failed to connect to http://169.254.169.254, Make sure you are running from a AWS EC2 instance")
+            raise AnsibleError("hashi_vault lookup plugin failed to connect to {base}, Make sure you are running from a AWS EC2 instance".format(base=AWS_EC2_METADATA_URL_BASE))
 
         nonce = kwargs.get('nonce')
 

--- a/test/support/integration/plugins/lookup/hashi_vault.py
+++ b/test/support/integration/plugins/lookup/hashi_vault.py
@@ -84,7 +84,7 @@ DOCUMENTATION = """
       default: True
     namespace:
       version_added: "2.8"
-      description: namespace where secrets reside. requires HVAC 0.7.0+ and Vault 0.11+.
+      description: namespace where secrets reside. requires HVAC 0.9.3+ and Vault 0.11+.
 """
 
 EXAMPLES = """
@@ -326,7 +326,7 @@ class HashiVault:
         if region is None:
             region = 'us-east-1'
 
-        self.client.auth_aws_iam(access_key, secret_key, session_token, header_value, mount_point, role, region=region)
+        self.client.auth.aws.iam_login(access_key, secret_key, session_token=session_token, header_value=header_value, role=role, region=region, mount_point=mount_point)
 
     def auth_aws_ec2(self, **kwargs):
         url = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7"
@@ -346,7 +346,7 @@ class HashiVault:
         if mount_point is None:
             mount_point = 'aws'
 
-        self.client.auth_ec2(pkcs7, nonce, role, mount_point=mount_point)
+        self.client.auth.aws.ec2_login(pkcs7, nonce, role=role, mount_point=mount_point)
 
 
 class LookupModule(LookupBase):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Provide Vault AWS Auth method to the lookup.

https://www.vaultproject.io/docs/auth/aws.html

- AWS IAM Auth 

Usage: 

`{{ lookup('hashi_vault', 'secret=secret/hello:value auth_method=aws_iam access_key=access secret_key=secret role=myrole url=http://myvault:8200')}}`

You can skip access_key and secret_key if you set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.

- AWS EC2 Auth 

Usage: 

   `{{ lookup('hashi_vault', 'secret=secret/hello:value auth_method=aws_ec2 nonce=my_nonce role=myrole url=http://myvault:8200')}}`

Lookup will automatically retrieve the instance identity document from instance metadata.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/lookup/hashi_vault.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/ubuntu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ubuntu/test/env/lib/python3.5/site-packages/ansible
  executable location = /home/ubuntu/test/env/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
N/A
