### PR TITLE
Add mod route53_record.py

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -211,7 +211,7 @@ set:
 
 EXAMPLES = '''
 # Add new.foo.com as an A record with 3 IPs and wait until the changes have been replicated
-- route53:
+- route53_record:
       state: present
       zone: foo.com
       record: new.foo.com
@@ -221,7 +221,7 @@ EXAMPLES = '''
       wait: yes
 
 # Update new.foo.com as an A record with a list of 3 IPs and wait until the changes have been replicated
-- route53:
+- route53_record:
       state: present
       zone: foo.com
       record: new.foo.com
@@ -234,7 +234,7 @@ EXAMPLES = '''
       wait: yes
 
 # Retrieve the details for new.foo.com
-- route53:
+- route53_record:
       state: get
       zone: foo.com
       record: new.foo.com
@@ -242,7 +242,7 @@ EXAMPLES = '''
   register: rec
 
 # Delete new.foo.com A record using the results from the get command
-- route53:
+- route53_record:
       state: absent
       zone: foo.com
       record: "{{ rec.set.record }}"
@@ -252,7 +252,7 @@ EXAMPLES = '''
 
 # Add an AAAA record.  Note that because there are colons in the value
 # that the IPv6 address must be quoted. Also shows using the old form command=create.
-- route53:
+- route53_record:
       command: create
       zone: foo.com
       record: localhost.foo.com
@@ -263,7 +263,7 @@ EXAMPLES = '''
 # Add a SRV record with multiple fields for a service on port 22222
 # For more information on SRV records see:
 # https://en.wikipedia.org/wiki/SRV_record
-- route53:
+- route53_record:
       state: present
       zone: foo.com
       record: "_example-service._tcp.foo.com"
@@ -272,7 +272,7 @@ EXAMPLES = '''
 
 # Add a TXT record. Note that TXT and SPF records must be surrounded
 # by quotes when sent to Route 53:
-- route53:
+- route53_record:
       state: present
       zone: foo.com
       record: localhost.foo.com
@@ -281,7 +281,7 @@ EXAMPLES = '''
       value: '"bar"'
 
 # Add an alias record that points to an Amazon ELB:
-- route53:
+- route53_record:
       state: present
       zone: foo.com
       record: elb.foo.com
@@ -291,7 +291,7 @@ EXAMPLES = '''
       alias_hosted_zone_id: "{{ elb_zone_id }}"
 
 # Retrieve the details for elb.foo.com
-- route53:
+- route53_record:
       state: get
       zone: foo.com
       record: elb.foo.com
@@ -299,7 +299,7 @@ EXAMPLES = '''
   register: rec
 
 # Delete an alias record using the results from the get command
-- route53:
+- route53_record:
       state: absent
       zone: foo.com
       record: "{{ rec.set.record }}"
@@ -310,7 +310,7 @@ EXAMPLES = '''
       alias_hosted_zone_id: "{{ rec.set.alias_hosted_zone_id }}"
 
 # Add an alias record that points to an Amazon ELB and evaluates it health:
-- route53:
+- route53_record:
     state: present
     zone: foo.com
     record: elb.foo.com
@@ -321,7 +321,7 @@ EXAMPLES = '''
     alias_evaluate_target_health: True
 
 # Add an AAAA record with Hosted Zone ID.
-- route53:
+- route53_record:
       state: present
       zone: foo.com
       hosted_zone_id: Z2AABBCCDDEEFF
@@ -331,7 +331,7 @@ EXAMPLES = '''
       value: "::1"
 
 # Use a routing policy to distribute traffic:
-- route53:
+- route53_record:
       state: present
       zone: foo.com
       record: www.foo.com
@@ -344,7 +344,7 @@ EXAMPLES = '''
       health_check: "d994b780-3150-49fd-9205-356abdd42e75"
 
 # Add a CAA record (RFC 6844):
-- route53:
+- route53_record:
       state: present
       zone: example.com
       record: example.com

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -413,7 +413,8 @@ class AWSRoute53Record(object):
 
 
 def main():
-    argument_spec = (dict(
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
         state=dict(aliases=['command'], choices=['present', 'absent', 'get', 'create', 'delete'], required=True),
         zone=dict(required=True),
         hosted_zone_id=dict(required=False, default=None),
@@ -429,7 +430,6 @@ def main():
         private_zone=dict(required=False, type='bool', default=False),
         identifier=dict(required=False, default=None),
         weight=dict(required=False, type='int'),
-        region=dict(aliases=['aws_region', 'ec2_region']),
         health_check=dict(required=False),
         failover=dict(required=False, choices=['PRIMARY', 'SECONDARY']),
         vpc_id=dict(required=False),

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (c) Ansible Project
 # Copyright: (c) 2018, Shuang Wang <ooocamel@icloud.com>

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -13,8 +13,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'status': ['preview'],
-                     'supported_by': 'community',
-                     'metadata_version': '1.1'}
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
 
 DOCUMENTATION = '''
 ---
@@ -36,3 +36,76 @@ EXAMPLES = '''
 
 RETURN = '''
 '''
+
+try:
+    import botocore
+except ImportError:
+    pass  # Handled by AnsibleAWSModule
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils._text import to_native
+from ansible.module_utils.ec2 import (
+    AWSRetry,
+    boto3_conn,
+    ec2_argument_spec,
+    get_aws_connection_info,
+    camel_dict_to_snake_dict,
+    boto3_tag_list_to_ansible_dict,
+    ansible_dict_to_boto3_filter_list,
+    ansible_dict_to_boto3_tag_list,
+    compare_aws_tags
+)
+
+
+class AWSRoute53Record(object):
+    def __init__(self, module=None, results=None):
+        self._module = module
+        self._results = results
+        self._connection = self._module.client('ec2')
+        self._check_mode = self._module.check_mode
+        self.warnings = []
+
+    def _read_zone(self):
+        pass
+
+    def _create_record(self):
+        pass
+
+    def _read_record(self):
+        pass
+
+    def _update_record(self):
+        pass
+
+    def _delete_record(self):
+        pass
+
+    def ensure_present(self):
+        pass
+
+    def ensure_absent(self):
+        pass
+
+    def process(self):
+        pass
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+
+    argument_spec.update(dict(
+    ))
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+    results = dict(changed=False)
+
+record_controller = AWSRoute53Record(module=module, results=results)
+record_controller.process()
+
+module.exit_json(**results)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+
+# Copyright: (c) Ansible Project
+# Copyright: (c) 2018, Shuang Wang <ooocamel@icloud.com>
+
+# This code refactors the module route53.py of Ansible in order to support boto3.
+# Rename route53 to route53_record for the consistency with other route53_xxx modules.
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+ __metaclass__ = type
+
+ ANSIBLE_METADATA = {'status': ['preview'],
+                     'supported_by': 'community',
+                     'metadata_version': '1.1'}
+
+ DOCUMENTATION = '''
+ ---
+ module: route53_record
+ version_added: "2.8"
+ author: Shuang Wang (@ptux)
+ short_description: add or delete entries in Amazons Route53 DNS service
+requirements:
+  - botocore
+  - boto3
+  - python >= 2.7
+extends_documentation_fragment:
+  - aws
+  - ec2
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+'''

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -4,24 +4,24 @@
 # Copyright: (c) 2018, Shuang Wang <ooocamel@icloud.com>
 
 # This code refactors the module route53.py of Ansible in order to support boto3.
-# Rename route53 to route53_record for the consistency with other route53_xxx modules.
+# Name this module [route53_record] for the consistency with other route53_xxx modules.
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
- __metaclass__ = type
+__metaclass__ = type
 
- ANSIBLE_METADATA = {'status': ['preview'],
+ANSIBLE_METADATA = {'status': ['preview'],
                      'supported_by': 'community',
                      'metadata_version': '1.1'}
 
- DOCUMENTATION = '''
- ---
- module: route53_record
- version_added: "2.8"
- author: Shuang Wang (@ptux)
- short_description: add or delete entries in Amazons Route53 DNS service
+DOCUMENTATION = '''
+---
+module: route53_record
+version_added: "2.8"
+author: Shuang Wang (@ptux)
+short_description: add or delete entries in Amazons Route53 DNS service
 requirements:
   - botocore
   - boto3

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -21,7 +21,8 @@ DOCUMENTATION = '''
 module: route53_record
 version_added: "2.8"
 author: Shuang Wang (@ptux)
-short_description: add or delete entries in Amazons Route53 DNS service
+short_description: Manages DNS records in Amazons Route53 service
+description: Creates,deletes,updates,reads DNS records in Amazons Route53 service
 requirements:
   - botocore
   - boto3
@@ -132,10 +133,10 @@ def main():
     )
     results = dict(changed=False)
 
-record_controller = AWSRoute53Record(module=module, results=results)
-record_controller.process()
+    record_controller = AWSRoute53Record(module=module, results=results)
+    record_controller.process()
 
-module.exit_json(**results)
+    module.exit_json(**results)
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -369,13 +369,11 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.ec2 import (
     AWSRetry,
     boto3_conn,
+    boto_exception,
     ec2_argument_spec,
     get_aws_connection_info,
-    camel_dict_to_snake_dict,
-    boto3_tag_list_to_ansible_dict,
-    ansible_dict_to_boto3_filter_list,
-    ansible_dict_to_boto3_tag_list,
-    compare_aws_tags
+    snake_dict_to_camel_dict,
+    camel_dict_to_snake_dict
 )
 
 

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -50,8 +50,9 @@ options:
     required: true
   ttl:
     description:
-      - The TTL to give the new record
-    default: 3600 (one hour)
+      - The TTL(seconds) to give the new record
+    type: int
+    default: 3600
   type:
     description:
       - The type of DNS record to create
@@ -77,6 +78,7 @@ options:
   overwrite:
     description:
       - Whether an existing record should be overwritten on create if values do not match
+    type: bool
   retry_interval:
     description:
       - In the case that route53 is still servicing a prior request, this module will wait and try again after this many seconds. If you have many
@@ -112,6 +114,7 @@ options:
     description:
       - Failover resource record sets only. Whether this is the primary or
         secondary resource record set. Allowed values are PRIMARY and SECONDARY
+    choices: [PRIMARY, SECONDARY]
   vpc_id:
     description:
       - "When used in conjunction with private_zone: true, this will only modify records in the private hosted zone attached to this VPC."
@@ -410,8 +413,8 @@ class AWSRoute53Record(object):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = (dict(
+        region=dict(aliases=['aws_region', 'ec2_region']),
         state=dict(aliases=['command'], choices=['present', 'absent', 'get', 'create', 'delete'], required=True),
         zone=dict(required=True),
         hosted_zone_id=dict(required=False, default=None),

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -414,7 +414,6 @@ class AWSRoute53Record(object):
 
 def main():
     argument_spec = (dict(
-        region=dict(aliases=['aws_region', 'ec2_region']),
         state=dict(aliases=['command'], choices=['present', 'absent', 'get', 'create', 'delete'], required=True),
         zone=dict(required=True),
         hosted_zone_id=dict(required=False, default=None),
@@ -430,7 +429,7 @@ def main():
         private_zone=dict(required=False, type='bool', default=False),
         identifier=dict(required=False, default=None),
         weight=dict(required=False, type='int'),
-        region=dict(required=False),
+        region=dict(aliases=['aws_region', 'ec2_region']),
         health_check=dict(required=False),
         failover=dict(required=False, choices=['PRIMARY', 'SECONDARY']),
         vpc_id=dict(required=False),

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -20,22 +20,340 @@ DOCUMENTATION = '''
 ---
 module: route53_record
 version_added: "2.8"
-author: Shuang Wang (@ptux)
 short_description: Manages DNS records in Amazons Route53 service
 description: Creates,deletes,updates,reads DNS records in Amazons Route53 service
+author: Shuang Wang (@ptux)
+
 requirements:
   - botocore
   - boto3
   - python >= 2.7
+
+options:
+  state:
+    description:
+      - Specifies the state of the resource record. As of Ansible 2.4, the I(command) option has been changed
+        to I(state) as default and the choices 'present' and 'absent' have been added, but I(command) still works as well.
+    required: true
+    aliases: [ 'command' ]
+    choices: [ 'present', 'absent', 'get', 'create', 'delete' ]
+  zone:
+    description:
+      - The DNS zone to modify
+    required: true
+  hosted_zone_id:
+    description:
+      - The Hosted Zone ID of the DNS zone to modify
+  record:
+    description:
+      - The full DNS record to create or delete
+    required: true
+  ttl:
+    description:
+      - The TTL to give the new record
+    default: 3600 (one hour)
+  type:
+    description:
+      - The type of DNS record to create
+    required: true
+    choices: [ 'A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'CAA', 'NS', 'SOA' ]
+  alias:
+    description:
+      - Indicates if this is an alias record.
+    type: bool
+    default: 'no'
+  alias_hosted_zone_id:
+    description:
+      - The hosted zone identifier.
+  alias_evaluate_target_health:
+    description:
+      - Whether or not to evaluate an alias target health. Useful for aliases to Elastic Load Balancers.
+    type: bool
+    default: no
+  value:
+    description:
+      - The new value when creating a DNS record.  YAML lists or multiple comma-spaced values are allowed for non-alias records.
+      - When deleting a record all values for the record must be specified or Route53 will not delete it.
+  overwrite:
+    description:
+      - Whether an existing record should be overwritten on create if values do not match
+  retry_interval:
+    description:
+      - In the case that route53 is still servicing a prior request, this module will wait and try again after this many seconds. If you have many
+        domain names, the default of 500 seconds may be too long.
+    default: 500
+  private_zone:
+    description:
+      - If set to C(yes), the private zone matching the requested name within the domain will be used if there are both public and private zones.
+        The default is to use the public zone.
+    type: bool
+    default: 'no'
+  identifier:
+    description:
+      - Have to be specified for Weighted, latency-based and failover resource record sets only. An identifier
+        that differentiates among multiple resource record sets that have the
+        same combination of DNS name and type.
+  weight:
+    description:
+      - Weighted resource record sets only. Among resource record sets that
+        have the same combination of DNS name and type, a value that
+        determines what portion of traffic for the current resource record set
+        is routed to the associated location.
+  region:
+    description:
+      - Latency-based resource record sets only Among resource record sets
+        that have the same combination of DNS name and type, a value that
+        determines which region this should be associated with for the
+        latency-based routing
+  health_check:
+    description:
+      - Health check to associate with this record
+  failover:
+    description:
+      - Failover resource record sets only. Whether this is the primary or
+        secondary resource record set. Allowed values are PRIMARY and SECONDARY
+  vpc_id:
+    description:
+      - "When used in conjunction with private_zone: true, this will only modify records in the private hosted zone attached to this VPC."
+      - This allows you to have multiple private hosted zones, all with the same name, attached to different VPCs.
+  wait:
+    description:
+      - Wait until the changes have been replicated to all Amazon Route 53 DNS servers.
+    type: bool
+    default: 'no'
+  wait_timeout:
+    description:
+      - How long to wait for the changes to be replicated, in seconds.
+    default: 300
+
 extends_documentation_fragment:
   - aws
   - ec2
 '''
 
-EXAMPLES = '''
+RETURN = '''
+nameservers:
+  description: nameservers associated with the zone
+  returned: when state is 'get'
+  type: list
+  sample:
+  - ns-1036.awsdns-00.org.
+  - ns-516.awsdns-00.net.
+  - ns-1504.awsdns-00.co.uk.
+  - ns-1.awsdns-00.com.
+set:
+  description: info specific to the resource record
+  returned: when state is 'get'
+  type: complex
+  contains:
+    alias:
+      description: whether this is an alias
+      returned: always
+      type: bool
+      sample: false
+    failover:
+      description: ""
+      returned: always
+      type: NoneType
+      sample: null
+    health_check:
+      description: health_check associated with this record
+      returned: always
+      type: NoneType
+      sample: null
+    identifier:
+      description: ""
+      returned: always
+      type: NoneType
+      sample: null
+    record:
+      description: domain name for the record set
+      returned: always
+      type: string
+      sample: new.foo.com.
+    region:
+      description: ""
+      returned: always
+      type:
+      sample:
+    ttl:
+      description: resource record cache TTL
+      returned: always
+      type: string
+      sample: '3600'
+    type:
+      description: record set type
+      returned: always
+      type: string
+      sample: A
+    value:
+      description: value
+      returned: always
+      type: string
+      sample: 52.43.18.27
+    values:
+      description: values
+      returned: always
+      type: list
+      sample:
+      - 52.43.18.27
+    weight:
+      description: weight of the record
+      returned: always
+      type: string
+      sample: '3'
+    zone:
+      description: zone this record set belongs to
+      returned: always
+      type: string
+      sample: foo.bar.com.
 '''
 
-RETURN = '''
+EXAMPLES = '''
+# Add new.foo.com as an A record with 3 IPs and wait until the changes have been replicated
+- route53:
+      state: present
+      zone: foo.com
+      record: new.foo.com
+      type: A
+      ttl: 7200
+      value: 1.1.1.1,2.2.2.2,3.3.3.3
+      wait: yes
+
+# Update new.foo.com as an A record with a list of 3 IPs and wait until the changes have been replicated
+- route53:
+      state: present
+      zone: foo.com
+      record: new.foo.com
+      type: A
+      ttl: 7200
+      value:
+        - 1.1.1.1
+        - 2.2.2.2
+        - 3.3.3.3
+      wait: yes
+
+# Retrieve the details for new.foo.com
+- route53:
+      state: get
+      zone: foo.com
+      record: new.foo.com
+      type: A
+  register: rec
+
+# Delete new.foo.com A record using the results from the get command
+- route53:
+      state: absent
+      zone: foo.com
+      record: "{{ rec.set.record }}"
+      ttl: "{{ rec.set.ttl }}"
+      type: "{{ rec.set.type }}"
+      value: "{{ rec.set.value }}"
+
+# Add an AAAA record.  Note that because there are colons in the value
+# that the IPv6 address must be quoted. Also shows using the old form command=create.
+- route53:
+      command: create
+      zone: foo.com
+      record: localhost.foo.com
+      type: AAAA
+      ttl: 7200
+      value: "::1"
+
+# Add a SRV record with multiple fields for a service on port 22222
+# For more information on SRV records see:
+# https://en.wikipedia.org/wiki/SRV_record
+- route53:
+      state: present
+      zone: foo.com
+      record: "_example-service._tcp.foo.com"
+      type: SRV
+      value: "0 0 22222 host1.foo.com,0 0 22222 host2.foo.com"
+
+# Add a TXT record. Note that TXT and SPF records must be surrounded
+# by quotes when sent to Route 53:
+- route53:
+      state: present
+      zone: foo.com
+      record: localhost.foo.com
+      type: TXT
+      ttl: 7200
+      value: '"bar"'
+
+# Add an alias record that points to an Amazon ELB:
+- route53:
+      state: present
+      zone: foo.com
+      record: elb.foo.com
+      type: A
+      value: "{{ elb_dns_name }}"
+      alias: True
+      alias_hosted_zone_id: "{{ elb_zone_id }}"
+
+# Retrieve the details for elb.foo.com
+- route53:
+      state: get
+      zone: foo.com
+      record: elb.foo.com
+      type: A
+  register: rec
+
+# Delete an alias record using the results from the get command
+- route53:
+      state: absent
+      zone: foo.com
+      record: "{{ rec.set.record }}"
+      ttl: "{{ rec.set.ttl }}"
+      type: "{{ rec.set.type }}"
+      value: "{{ rec.set.value }}"
+      alias: True
+      alias_hosted_zone_id: "{{ rec.set.alias_hosted_zone_id }}"
+
+# Add an alias record that points to an Amazon ELB and evaluates it health:
+- route53:
+    state: present
+    zone: foo.com
+    record: elb.foo.com
+    type: A
+    value: "{{ elb_dns_name }}"
+    alias: True
+    alias_hosted_zone_id: "{{ elb_zone_id }}"
+    alias_evaluate_target_health: True
+
+# Add an AAAA record with Hosted Zone ID.
+- route53:
+      state: present
+      zone: foo.com
+      hosted_zone_id: Z2AABBCCDDEEFF
+      record: localhost.foo.com
+      type: AAAA
+      ttl: 7200
+      value: "::1"
+
+# Use a routing policy to distribute traffic:
+- route53:
+      state: present
+      zone: foo.com
+      record: www.foo.com
+      type: CNAME
+      value: host1.foo.com
+      ttl: 30
+      # Routing policy
+      identifier: "host1@www"
+      weight: 100
+      health_check: "d994b780-3150-49fd-9205-356abdd42e75"
+
+# Add a CAA record (RFC 6844):
+- route53:
+      state: present
+      zone: example.com
+      record: example.com
+      type: CAA
+      value:
+        - 0 issue "ca.example.net"
+        - 0 issuewild ";"
+        - 0 iodef "mailto:security@example.com"
+
 '''
 
 try:
@@ -137,6 +455,7 @@ def main():
     record_controller.process()
 
     module.exit_json(**results)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -30,7 +30,7 @@ options:
       - Specifies the state of the resource record.
     required: true
     choices: [ 'present', 'absent' ]
-  hosted_zone:
+  hosted_zone_name:
     description:
       - The DNS zone to modify
     required: true
@@ -53,7 +53,7 @@ options:
     choices: [ 'A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'CAA', 'NS', 'SOA' ]
   record_set_value:
     description:
-      - The new value when creating a DNS record. 
+      - The new value when creating a DNS record.
   wait:
     description:
       - Wait until the changes have been replicated to all Amazon Route 53 DNS servers.
@@ -79,6 +79,18 @@ nameservers:
   - ns-516.awsdns-00.net.
   - ns-1504.awsdns-00.co.uk.
   - ns-1.awsdns-00.com.
+'''
+
+EXAMPLES = '''
+# Add new.foo.com as an A record with 3 IPs and wait until the changes have been replicated
+- route53:
+      state: present
+      zone: foo.com
+      record: new.foo.com
+      type: A
+      ttl: 7200
+      value: 1.1.1.1,2.2.2.2,3.3.3.3
+      wait: yes
 '''
 
 try:
@@ -199,6 +211,7 @@ def main():
     record_controller = AWSRoute53Record(module=module, results=results)
     record_controller.process()
     module.exit_json(**results)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -77,12 +77,14 @@ ResourceRecords:
     returned: always
     type: list
     sample: ['Value': 192.0.2.1, 'Value': 192.0.2.2]
-TTL: 
+
+TTL:
     description: record_set_name
     returned: always
     type: string
     sample: "300"
-Type: 
+
+Type:
     description: record_set_name
     returned: always
     type: string
@@ -106,13 +108,13 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-import time
+#import time
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import (
 #    AWSRetry,
     boto3_conn,
     boto_exception,
-    ec2_argument_spec,
+    ec2_argument_spec
 #    get_aws_connection_info,
 #    snake_dict_to_camel_dict,
 #    camel_dict_to_snake_dict
@@ -162,10 +164,12 @@ class AWSRoute53Record(object):
         record_set_ttl = self._module.params['record_set_ttl']
         record_set_value = self._module.params['record_set_value']
         list_record_set_value = [{'Value': value} for value in record_set_value]
-        record_set_spec = {'Name': record_set_name,
-                            'ResourceRecords': list_record_set_value,
-                            'TTL': record_set_ttl,
-                            'Type': record_set_type}
+        record_set_spec = {
+            'Name': record_set_name,
+            'ResourceRecords': list_record_set_value,
+            'TTL': record_set_ttl,
+            'Type': record_set_type
+            }
         if record_set_spec in resource_record_sets:
             record_exists = True
         return record_exists

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -104,14 +104,11 @@ class AWSRoute53Record(object):
             results = self._ensure_absent()
 
     def _ensure_present(self):
-        pass
         results = dict(changed=False)
         record_exists = False
-        
         return results
 
     def _ensure_absent(self):
-        pass
         results = dict(changed=False)
         record_exists = False
         return results
@@ -187,10 +184,10 @@ def main():
         required_if=required_if,
         supports_check_mode=True
     )
-
+    results = dict(changed=False)
     aws_route53_record = AWSRoute53Record(module=ansible_aws_module)
     aws_route53_record.process()
-    module.exit_json(**results)
+    aws_route53_record.exit_json(**results)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -86,8 +86,8 @@ Status:
 SubmittedAt:
     description: The date and time that the change request was submitted.
     returned: changed
-    type: datetime
-    sample: 2018-09-25T02:03:51.365000+00:00
+    type: string
+    sample: '2018-09-25T02:03:51.365000+00:00'
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -11,8 +11,8 @@ DOCUMENTATION = '''
 ---
 module: route53_record
 version_added: "2.8"
-short_description: Manages DNS records in Amazon Route53 service.
-description: Creates,deletes,updates,reads DNS records in Amazon Route53 service.
+short_description: Creates,deletes DNS records in Amazon Route53 service.
+description: Creates,deletes DNS records in Amazon Route53 service.
 author: Shuang Wang (@ptux)
 
 requirements:
@@ -66,23 +66,39 @@ extends_documentation_fragment:
 '''
 
 RETURN = '''
-name:
-    description: hosted zone name
-    returned: when hosted zone exists
+Name:
+    description: record_set_name
+    returned: always
     type: string
-    sample: "private.local."
+    sample: "sample.example.com"
+
+ResourceRecords:
+    description: record_set_name
+    returned: always
+    type: list
+    sample: ['Value': 192.0.2.1, 'Value': 192.0.2.2]
+TTL: 
+    description: record_set_name
+    returned: always
+    type: string
+    sample: "300"
+Type: 
+    description: record_set_name
+    returned: always
+    type: string
+    sample: "A"
 '''
 
 EXAMPLES = '''
-# Add new.foo.com as an A record with 3 IPs and wait until the changes have been replicated
+# Add new A record and wait until the changes replicated
 - route53_record:
-      state: present
-      zone: foo.com
-      record: new.foo.com
-      type: A
-      ttl: 7200
-      value: 1.1.1.1,2.2.2.2,3.3.3.3
-      wait: yes
+    state: present
+    hosted_zone: example.com
+    record_set_name: sample.example.com
+    record_set_type: A
+    record_set_ttl: 300
+    record_set_value: 192.0.2.1
+    wait: yes
 '''
 
 try:
@@ -146,10 +162,10 @@ class AWSRoute53Record(object):
         record_set_ttl = self._module.params['record_set_ttl']
         record_set_value = self._module.params['record_set_value']
         list_record_set_value = [{'Value': value} for value in record_set_value]
-        record_set_spec = { 'Name': record_set_name,
+        record_set_spec = {'Name': record_set_name,
                             'ResourceRecords': list_record_set_value,
                             'TTL': record_set_ttl,
-                            'Type': record_set_type }
+                            'Type': record_set_type}
         if record_set_spec in resource_record_sets:
             record_exists = True
         return record_exists
@@ -177,14 +193,11 @@ class AWSRoute53Record(object):
         # todo: hanlde IsTruncated true
         hosted_zone_name = self._module.params['hosted_zone_name']
         hosted_zone_id = self._get_hosted_zone_id(hosted_zone_name)
-        resource_record_sets = self._connection.list_resource_record_sets(HostedZoneId = hosted_zone_id)['ResourceRecordSets']
+        resource_record_sets = self._connection.list_resource_record_sets(HostedZoneId=hosted_zone_id)['ResourceRecordSets']
         return resource_record_sets
 
     def _create_record(self):
         #      self._connection.change_resource_record_sets(**kwargs)
-        pass
-
-    def _update_record(self):
         pass
 
     def _delete_record(self):

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -81,13 +81,13 @@ Status:
     description: The current state of the request.
     returned: changed
     type: string
-    sample: 'PENDING'|'INSYNC'
+    sample: 'PENDING'
 
 SubmittedAt:
     description: The date and time that the change request was submitted.
     returned: changed
     type: datetime
-    sample: "2018-09-25T02:03:51.365000+00:00"
+    sample: 2018-09-25T02:03:51.365000+00:00
 '''
 
 EXAMPLES = '''
@@ -202,7 +202,7 @@ class AWSRoute53Record(object):
                             'Type': self._module.params['record_set_type'],
                             # 'SetIdentifier': 'string',
                             # 'Weight': 123,
-                            # 'Region': 'us-east-1' | 'us-east-2' | 'us-west-1' | 'us-west-2' | 'ca-central-1' | 'eu-west-1' | 'eu-west-2' | 'eu-west-3' | 'eu-central-1' | 'ap-southeast-1' | 'ap-southeast-2' | 'ap-northeast-1' | 'ap-northeast-2' | 'ap-northeast-3' | 'sa-east-1' | 'cn-north-1' | 'cn-northwest-1' | 'ap-south-1',
+                            # 'Region': 'us-east-1' | 'us-east-2' |
                             # 'GeoLocation': {
                             # 'ContinentCode': 'string',
                             # 'CountryCode': 'string',

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -403,10 +403,10 @@ class AWSRoute53Record(object):
                 if zone is None:
                     self._module.fail_json(msg="zone id not exists: %s" % hosted_zone_id)
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                self._module.fail_json_aws(e, msg="Couldn't get zone by hosted zone id")
+                self._module.fail_json_aws(e, msg="couldn't get zone by hosted zone id")
         else:
             self._module.fail_json(msg="hosted zone id is requied.")
-
+        self._module.fail_json(msg=zone)
         return zone
 
     def _get_zone_by_name(self):
@@ -422,14 +422,17 @@ class AWSRoute53Record(object):
             if zone is None:
                 self._module.fail_json(msg="zone name not exists: %s" % zone_name)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            self._module.fail_json_aws(e, msg="Couldn't get zone by hosted zone name")
+            self._module.fail_json_aws(e, msg="couldn't get zone by hosted zone name")
 
         return zone
 
     def _create_record(self):
+        #      self._connection.change_resource_record_sets(**kwargs)
         pass
 
     def _get_record(self):
+        #      self._connection.list_resource_record_sets(**kwargs)
+        # Lists the resource record sets in a specified hosted zone.
         pass
 
     def _update_record(self):

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -1,12 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
-# Copyright: (c) Ansible Project
 # Copyright: (c) 2018, Shuang Wang <ooocamel@icloud.com>
-
-# This code refactors the module route53.py of Ansible in order to support boto3.
-# Name this module [route53_record] for the consistency with other route53_xxx modules.
-
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -33,93 +27,33 @@ requirements:
 options:
   state:
     description:
-      - Specifies the state of the resource record. As of Ansible 2.4, the I(command) option has been changed
-        to I(state) as default and the choices 'present' and 'absent' have been added, but I(command) still works as well.
+      - Specifies the state of the resource record.
     required: true
-    aliases: [ 'command' ]
-    choices: [ 'present', 'absent', 'get', 'create', 'delete' ]
-  zone:
+    choices: [ 'present', 'absent' ]
+  hosted_zone:
     description:
       - The DNS zone to modify
     required: true
   hosted_zone_id:
     description:
       - The Hosted Zone ID of the DNS zone to modify
-  record:
+  record_set_name:
     description:
       - The full DNS record to create or delete
     required: true
-  ttl:
+  record_set_ttl:
     description:
       - The TTL(seconds) to give the new record
     type: int
     default: 3600
-  type:
+  record_set_type:
     description:
       - The type of DNS record to create
     required: true
     choices: [ 'A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'CAA', 'NS', 'SOA' ]
-  alias:
+  record_set_value:
     description:
-      - Indicates if this is an alias record.
-    type: bool
-    default: 'no'
-  alias_hosted_zone_id:
-    description:
-      - The hosted zone identifier.
-  alias_evaluate_target_health:
-    description:
-      - Whether or not to evaluate an alias target health. Useful for aliases to Elastic Load Balancers.
-    type: bool
-    default: no
-  value:
-    description:
-      - The new value when creating a DNS record.  YAML lists or multiple comma-spaced values are allowed for non-alias records.
-      - When deleting a record all values for the record must be specified or Route53 will not delete it.
-  overwrite:
-    description:
-      - Whether an existing record should be overwritten on create if values do not match
-    type: bool
-  retry_interval:
-    description:
-      - In the case that route53 is still servicing a prior request, this module will wait and try again after this many seconds. If you have many
-        domain names, the default of 500 seconds may be too long.
-    default: 500
-  private_zone:
-    description:
-      - If set to C(yes), the private zone matching the requested name within the domain will be used if there are both public and private zones.
-        The default is to use the public zone.
-    type: bool
-    default: 'no'
-  identifier:
-    description:
-      - Have to be specified for Weighted, latency-based and failover resource record sets only. An identifier
-        that differentiates among multiple resource record sets that have the
-        same combination of DNS name and type.
-  weight:
-    description:
-      - Weighted resource record sets only. Among resource record sets that
-        have the same combination of DNS name and type, a value that
-        determines what portion of traffic for the current resource record set
-        is routed to the associated location.
-  region:
-    description:
-      - Latency-based resource record sets only Among resource record sets
-        that have the same combination of DNS name and type, a value that
-        determines which region this should be associated with for the
-        latency-based routing
-  health_check:
-    description:
-      - Health check to associate with this record
-  failover:
-    description:
-      - Failover resource record sets only. Whether this is the primary or
-        secondary resource record set. Allowed values are PRIMARY and SECONDARY
-    choices: [PRIMARY, SECONDARY]
-  vpc_id:
-    description:
-      - "When used in conjunction with private_zone: true, this will only modify records in the private hosted zone attached to this VPC."
-      - This allows you to have multiple private hosted zones, all with the same name, attached to different VPCs.
+      - The new value when creating a DNS record. 
   wait:
     description:
       - Wait until the changes have been replicated to all Amazon Route 53 DNS servers.
@@ -145,219 +79,6 @@ nameservers:
   - ns-516.awsdns-00.net.
   - ns-1504.awsdns-00.co.uk.
   - ns-1.awsdns-00.com.
-set:
-  description: info specific to the resource record
-  returned: when state is 'get'
-  type: complex
-  contains:
-    alias:
-      description: whether this is an alias
-      returned: always
-      type: bool
-      sample: false
-    failover:
-      description: ""
-      returned: always
-      type: NoneType
-      sample: null
-    health_check:
-      description: health_check associated with this record
-      returned: always
-      type: NoneType
-      sample: null
-    identifier:
-      description: ""
-      returned: always
-      type: NoneType
-      sample: null
-    record:
-      description: domain name for the record set
-      returned: always
-      type: string
-      sample: new.foo.com.
-    region:
-      description: ""
-      returned: always
-      type:
-      sample:
-    ttl:
-      description: resource record cache TTL
-      returned: always
-      type: string
-      sample: '3600'
-    type:
-      description: record set type
-      returned: always
-      type: string
-      sample: A
-    value:
-      description: value
-      returned: always
-      type: string
-      sample: 52.43.18.27
-    values:
-      description: values
-      returned: always
-      type: list
-      sample:
-      - 52.43.18.27
-    weight:
-      description: weight of the record
-      returned: always
-      type: string
-      sample: '3'
-    zone:
-      description: zone this record set belongs to
-      returned: always
-      type: string
-      sample: foo.bar.com.
-'''
-
-EXAMPLES = '''
-# Add new.foo.com as an A record with 3 IPs and wait until the changes have been replicated
-- route53_record:
-      state: present
-      zone: foo.com
-      record: new.foo.com
-      type: A
-      ttl: 7200
-      value: 1.1.1.1,2.2.2.2,3.3.3.3
-      wait: yes
-
-# Update new.foo.com as an A record with a list of 3 IPs and wait until the changes have been replicated
-- route53_record:
-      state: present
-      zone: foo.com
-      record: new.foo.com
-      type: A
-      ttl: 7200
-      value:
-        - 1.1.1.1
-        - 2.2.2.2
-        - 3.3.3.3
-      wait: yes
-
-# Retrieve the details for new.foo.com
-- route53_record:
-      state: get
-      zone: foo.com
-      record: new.foo.com
-      type: A
-  register: rec
-
-# Delete new.foo.com A record using the results from the get command
-- route53_record:
-      state: absent
-      zone: foo.com
-      record: "{{ rec.set.record }}"
-      ttl: "{{ rec.set.ttl }}"
-      type: "{{ rec.set.type }}"
-      value: "{{ rec.set.value }}"
-
-# Add an AAAA record.  Note that because there are colons in the value
-# that the IPv6 address must be quoted. Also shows using the old form command=create.
-- route53_record:
-      command: create
-      zone: foo.com
-      record: localhost.foo.com
-      type: AAAA
-      ttl: 7200
-      value: "::1"
-
-# Add a SRV record with multiple fields for a service on port 22222
-# For more information on SRV records see:
-# https://en.wikipedia.org/wiki/SRV_record
-- route53_record:
-      state: present
-      zone: foo.com
-      record: "_example-service._tcp.foo.com"
-      type: SRV
-      value: "0 0 22222 host1.foo.com,0 0 22222 host2.foo.com"
-
-# Add a TXT record. Note that TXT and SPF records must be surrounded
-# by quotes when sent to Route 53:
-- route53_record:
-      state: present
-      zone: foo.com
-      record: localhost.foo.com
-      type: TXT
-      ttl: 7200
-      value: '"bar"'
-
-# Add an alias record that points to an Amazon ELB:
-- route53_record:
-      state: present
-      zone: foo.com
-      record: elb.foo.com
-      type: A
-      value: "{{ elb_dns_name }}"
-      alias: True
-      alias_hosted_zone_id: "{{ elb_zone_id }}"
-
-# Retrieve the details for elb.foo.com
-- route53_record:
-      state: get
-      zone: foo.com
-      record: elb.foo.com
-      type: A
-  register: rec
-
-# Delete an alias record using the results from the get command
-- route53_record:
-      state: absent
-      zone: foo.com
-      record: "{{ rec.set.record }}"
-      ttl: "{{ rec.set.ttl }}"
-      type: "{{ rec.set.type }}"
-      value: "{{ rec.set.value }}"
-      alias: True
-      alias_hosted_zone_id: "{{ rec.set.alias_hosted_zone_id }}"
-
-# Add an alias record that points to an Amazon ELB and evaluates it health:
-- route53_record:
-    state: present
-    zone: foo.com
-    record: elb.foo.com
-    type: A
-    value: "{{ elb_dns_name }}"
-    alias: True
-    alias_hosted_zone_id: "{{ elb_zone_id }}"
-    alias_evaluate_target_health: True
-
-# Add an AAAA record with Hosted Zone ID.
-- route53_record:
-      state: present
-      zone: foo.com
-      hosted_zone_id: Z2AABBCCDDEEFF
-      record: localhost.foo.com
-      type: AAAA
-      ttl: 7200
-      value: "::1"
-
-# Use a routing policy to distribute traffic:
-- route53_record:
-      state: present
-      zone: foo.com
-      record: www.foo.com
-      type: CNAME
-      value: host1.foo.com
-      ttl: 30
-      # Routing policy
-      identifier: "host1@www"
-      weight: 100
-      health_check: "d994b780-3150-49fd-9205-356abdd42e75"
-
-# Add a CAA record (RFC 6844):
-- route53_record:
-      state: present
-      zone: example.com
-      record: example.com
-      type: CAA
-      value:
-        - 0 issue "ca.example.net"
-        - 0 issuewild ";"
-        - 0 iodef "mailto:security@example.com"
-
 '''
 
 try:
@@ -384,11 +105,13 @@ class AWSRoute53Record(object):
         self._results = results
         self._connection = self._module.client('route53')
         self._check_mode = self._module.check_mode
-        self.warnings = []
+
+    def process(self):
+        zone = self._get_zone_by_name()
 
     def _get_zone_by_id(self, zone_id=None):
         """gets a zone by id"""
-        zone = None
+        hosted_zone = None
         if self._module.params['hosted_zone_id'] is not None:
             hosted_zone_id = self._module.params['hosted_zone_id']
         else:
@@ -396,35 +119,34 @@ class AWSRoute53Record(object):
 
         if hosted_zone_id is not None:
             try:
-                zone = self._connection.get_hosted_zone(Id=hosted_zone_id)
-                zone_name = zone['HostedZone']['Name'].rstrip('.')
-                if not self._module.params['zone'] == zone_name:
-                    self._module.fail_json(msg="hosted zone id not matches zone name")
-                if zone is None:
-                    self._module.fail_json(msg="zone id not exists: %s" % hosted_zone_id)
+                hosted_zone = self._connection.get_hosted_zone(Id=hosted_zone_id)
+                hosted_zone_name = hosted_zone['HostedZone']['Name'].rstrip('.')
+                if not self._module.params['hosted_zone_name'] == hosted_zone_name:
+                    self._module.fail_json(msg="hosted_zone_id not matches hosted_zone_name")
+                if hosted_zone is None:
+                    self._module.fail_json(msg="hosted zone id not exists: %s" % hosted_zone_id)
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                self._module.fail_json_aws(e, msg="couldn't get zone by hosted zone id")
+                self._module.fail_json_aws(e, msg="couldn't get hosted zone by hosted_zone_id")
         else:
             self._module.fail_json(msg="hosted zone id is requied.")
-        self._module.fail_json(msg=zone)
-        return zone
+        return hosted_zone
 
     def _get_zone_by_name(self):
         """gets a zone by name"""
         try:
-            zone_name = self._module.params['zone']
+            hosted_zone_name = self._module.params['hosted_zone_name']
             hosted_zones = self._connection.list_hosted_zones().get('HostedZones', [])
-            zone = None
+            hosted_zone = None
             for dic in hosted_zones:
-                if dic.get('Name').rstrip('.') == zone_name:
-                    zone_id = dic.get('Id')
-                    zone = self._get_zone_by_id(zone_id)
-            if zone is None:
-                self._module.fail_json(msg="zone name not exists: %s" % zone_name)
+                if dic.get('Name').rstrip('.') == hosted_zone_name:
+                    hosted_zone_id = dic.get('Id')
+                    hosted_zone = self._get_zone_by_id(hosted_zone_id)
+            if hosted_zone is None:
+                self._module.fail_json(msg="hosted zone name not exists: %s" % zone_name)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            self._module.fail_json_aws(e, msg="couldn't get zone by hosted zone name")
+            self._module.fail_json_aws(e, msg="couldn't get hosted zone by hosted_zone_name")
 
-        return zone
+        return hosted_zone
 
     def _create_record(self):
         #      self._connection.change_resource_record_sets(**kwargs)
@@ -441,64 +163,42 @@ class AWSRoute53Record(object):
     def _delete_record(self):
         pass
 
-    def ensure_present(self):
+    def _ensure_present(self):
         pass
 
-    def ensure_absent(self):
+    def _ensure_absent(self):
         pass
-
-    def process(self):
-        zone = self._get_zone_by_id()
-#        zone = self._get_zone_by_name()
 
 
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        state=dict(aliases=['command'], choices=['present', 'absent', 'get', 'create', 'delete'], required=True),
-        zone=dict(required=True),
+        hosted_zone_name=dict(required=True),
         hosted_zone_id=dict(required=False, default=None),
-        record=dict(required=True),
-        ttl=dict(required=False, type='int', default=3600),
-        type=dict(choices=['A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'CAA', 'NS', 'SOA'], required=True),
-        alias=dict(required=False, type='bool'),
-        alias_hosted_zone_id=dict(required=False),
-        alias_evaluate_target_health=dict(required=False, type='bool', default=False),
-        value=dict(required=False, type='list'),
-        overwrite=dict(required=False, type='bool'),
-        retry_interval=dict(required=False, default=500),
-        private_zone=dict(required=False, type='bool', default=False),
-        identifier=dict(required=False, default=None),
-        weight=dict(required=False, type='int'),
-        health_check=dict(required=False),
-        failover=dict(required=False, choices=['PRIMARY', 'SECONDARY']),
-        vpc_id=dict(required=False),
+        record_set_name=dict(required=True),
+        record_set_type=dict(choices=['A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'CAA', 'NS', 'SOA'], required=True),
+        record_set_ttl=dict(required=False, type='int', default=3600),
+        record_set_value=dict(required=False, type='list'),
+        state=dict(choices=['present', 'absent'], required=True),
         wait=dict(required=False, type='bool', default=False),
-        wait_timeout=dict(required=False, type='int', default=300),
+        wait_timeout=dict(required=False, type='int', default=300)
     ))
 
-    required_if = [('state', 'present', ['value']),
-                   ('state', 'absent', ['value']),
-                   ('state', 'delete', ['value']),
-                   ('state', 'create', ['value'])]
-    required_together = [['alias', 'alias_hosted_zone_id']]
-    mutually_exclusive = [('failover', 'region', 'weight')]
+    required_if = [('state', 'present', ['record_set_value']),
+                   ('state', 'absent', ['record_set_value']),
+                   ('state', 'delete', ['record_set_value']),
+                   ('state', 'create', ['record_set_value'])]
 
     module = AnsibleAWSModule(
         argument_spec=argument_spec,
         required_if=required_if,
-        required_together=required_together,
-        mutually_exclusive=mutually_exclusive,
         supports_check_mode=True
     )
 
     results = dict(changed=False)
-
     record_controller = AWSRoute53Record(module=module, results=results)
     record_controller.process()
-
     module.exit_json(**results)
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -154,7 +154,7 @@ class AWSRoute53Record(object):
                     hosted_zone_id = dic.get('Id')
                     hosted_zone = self._get_zone_by_id(hosted_zone_id)
             if hosted_zone is None:
-                self._module.fail_json(msg="hosted zone name not exists: %s" % zone_name)
+                self._module.fail_json(msg="hosted zone name not exists: %s" % hosted_zone_name)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self._module.fail_json_aws(e, msg="couldn't get hosted zone by hosted_zone_name")
 

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -3,10 +3,6 @@
 # Copyright: (c) 2018, Shuang Wang <ooocamel@icloud.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
-
-__metaclass__ = type
-
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'metadata_version': '1.1'}
@@ -22,7 +18,7 @@ author: Shuang Wang (@ptux)
 requirements:
   - botocore
   - boto3
-  - python >= 2.7
+  - python >= 2.6
 
 options:
   state:
@@ -70,27 +66,11 @@ extends_documentation_fragment:
 '''
 
 RETURN = '''
-nameservers:
-  description: nameservers associated with the zone
-  returned: when state is 'get'
-  type: list
-  sample:
-  - ns-1036.awsdns-00.org.
-  - ns-516.awsdns-00.net.
-  - ns-1504.awsdns-00.co.uk.
-  - ns-1.awsdns-00.com.
+results
 '''
 
 EXAMPLES = '''
-# Add new.foo.com as an A record with 3 IPs and wait until the changes have been replicated
-- route53:
-      state: present
-      zone: foo.com
-      record: new.foo.com
-      type: A
-      ttl: 7200
-      value: 1.1.1.1,2.2.2.2,3.3.3.3
-      wait: yes
+examples
 '''
 
 try:
@@ -98,8 +78,8 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
+import time
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils._text import to_native
 from ansible.module_utils.ec2 import (
     AWSRetry,
     boto3_conn,
@@ -119,7 +99,17 @@ class AWSRoute53Record(object):
         self._check_mode = self._module.check_mode
 
     def process(self):
-        zone = self._get_zone_by_name()
+        hosted_zone = self._get_zone_by_name()
+        if state == 'present':
+            changed, result = _ensure_present()
+        elif state == 'absent':
+            changed, result = _ensure_absent()
+
+    def _ensure_present(self):
+        pass
+
+    def _ensure_absent(self):
+        pass
 
     def _get_zone_by_id(self, zone_id=None):
         """gets a zone by id"""
@@ -160,25 +150,19 @@ class AWSRoute53Record(object):
 
         return hosted_zone
 
-    def _create_record(self):
-        #      self._connection.change_resource_record_sets(**kwargs)
-        pass
-
     def _get_record(self):
         #      self._connection.list_resource_record_sets(**kwargs)
         # Lists the resource record sets in a specified hosted zone.
+        pass
+
+    def _create_record(self):
+        #      self._connection.change_resource_record_sets(**kwargs)
         pass
 
     def _update_record(self):
         pass
 
     def _delete_record(self):
-        pass
-
-    def _ensure_present(self):
-        pass
-
-    def _ensure_absent(self):
         pass
 
 
@@ -197,10 +181,7 @@ def main():
     ))
 
     required_if = [('state', 'present', ['record_set_value']),
-                   ('state', 'absent', ['record_set_value']),
-                   ('state', 'delete', ['record_set_value']),
-                   ('state', 'create', ['record_set_value'])]
-
+                   ('state', 'absent', ['record_set_value'])]
     module = AnsibleAWSModule(
         argument_spec=argument_spec,
         required_if=required_if,

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -66,11 +66,23 @@ extends_documentation_fragment:
 '''
 
 RETURN = '''
-results
+name:
+    description: hosted zone name
+    returned: when hosted zone exists
+    type: string
+    sample: "private.local."
 '''
 
 EXAMPLES = '''
-examples
+# Add new.foo.com as an A record with 3 IPs and wait until the changes have been replicated
+- route53_record:
+      state: present
+      zone: foo.com
+      record: new.foo.com
+      type: A
+      ttl: 7200
+      value: 1.1.1.1,2.2.2.2,3.3.3.3
+      wait: yes
 '''
 
 try:

--- a/lib/ansible/modules/cloud/amazon/route53_record.py
+++ b/lib/ansible/modules/cloud/amazon/route53_record.py
@@ -108,16 +108,16 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-#import time
+# import time
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import (
-#    AWSRetry,
+    # AWSRetry,
     boto3_conn,
     boto_exception,
     ec2_argument_spec
-#    get_aws_connection_info,
-#    snake_dict_to_camel_dict,
-#    camel_dict_to_snake_dict
+    # get_aws_connection_info,
+    # snake_dict_to_camel_dict,
+    # camel_dict_to_snake_dict
 )
 
 
@@ -169,7 +169,7 @@ class AWSRoute53Record(object):
             'ResourceRecords': list_record_set_value,
             'TTL': record_set_ttl,
             'Type': record_set_type
-            }
+        }
         if record_set_spec in resource_record_sets:
             record_exists = True
         return record_exists

--- a/test/integration/targets/route53_record/aliases
+++ b/test/integration/targets/route53_record/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+shippable/aws/group1

--- a/test/integration/targets/route53_record/tasks/main.yml
+++ b/test/integration/targets/route53_record/tasks/main.yml
@@ -1,0 +1,55 @@
+---
+- block:
+
+    # ============================================================
+    - name: set connection information for all tasks
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          aws_access_key: "{{ aws_access_key }}"
+          aws_secret_key: "{{ aws_secret_key }}"
+          security_token: "{{ security_token }}"
+          region: "{{ aws_region }}"
+      no_log: true
+
+    - name: Create VPC for use in testing
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        cidr_block: 10.22.32.0/23
+        tags:
+          Name: Ansible ec2_instance Testing VPC
+        tenancy: default
+        <<: *aws_connection_info
+      register: testing_vpc
+
+    # ============================================================
+    - name: Create a public zone
+      route53_zone:
+        zone: "{{ resource_prefix }}.public"
+        comment: original comment
+        state: present
+        <<: *aws_connection_info
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+          - output.comment == 'original comment'
+          - output.name == '{{ resource_prefix }}.public.'
+          - not output.private_zone
+
+    # ============================================================
+    - name: Create a public zone (CHECK MODE)
+      route53_zone:
+        zone: "{{ resource_prefix }}.check.public"
+        comment: original comment
+        state: present
+        <<: *aws_connection_info
+      register: output
+      check_mode: yes
+
+    - assert:
+        that:
+          - output.changed
+          - output.comment == 'original comment'
+          - output.name == '{{ resource_prefix }}.check.public.'
+          - not output.private_zone


### PR DESCRIPTION
##### SUMMARY

I'm going to add a new module `route53_record.py`

* **support boto3**
This is why I start coding.

* **consistent module name**
This is why I name it `route53_record`.
Keep a consistency with other existing modules(route53_zone,route53_facts,route53_health_check).

* **consistent option name**
This is why I give up compatibility with existing module `route53`. 
I use options name which AWS route53 console menu uses.

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME
route53_record.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION
