### PR TITLE
Add `systemctl daemon-reexec` to `systemd` module

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -48,6 +48,13 @@ options:
         type: bool
         default: 'no'
         aliases: [ daemon-reload ]
+    daemon_reexec:
+        description:
+            - run daemon_reexec command before doing any other operations, the systemd manager will serialize the manager state.
+        type: bool
+        default: 'no'
+        aliases: [ daemon-reexec ]
+        version_added: "2.8"
     user:
         description:
             - (deprecated) run ``systemctl`` talking to the service manager of the calling user, rather than the service manager
@@ -306,6 +313,7 @@ def main():
             force=dict(type='bool'),
             masked=dict(type='bool'),
             daemon_reload=dict(type='bool', default=False, aliases=['daemon-reload']),
+            daemon_reexec=dict(type='bool', default=False, aliases=['daemon-reexec']),
             user=dict(type='bool'),
             scope=dict(type='str', choices=['system', 'user', 'global']),
             no_block=dict(type='bool', default=False),
@@ -355,6 +363,12 @@ def main():
         (rc, out, err) = module.run_command("%s daemon-reload" % (systemctl))
         if rc != 0:
             module.fail_json(msg='failure %d during daemon-reload: %s' % (rc, err))
+
+    # Run daemon-reexec
+    if module.params['daemon_reexec'] and not module.check_mode:
+        (rc, out, err) = module.run_command("%s daemon-reexec" % (systemctl))
+        if rc != 0:
+            module.fail_json(msg='failure %d during daemon-reexec: %s' % (rc, err))
 
     if unit:
         found = False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add systemctl daemon-reexec to systemd module
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
systemd
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
"2.8"

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: systemctl daemon-reexec
  - systemd:
       daemon_reexec=yes
```
Closes: #38880

Signed-off-by: Susant Sahani <susant@redhat.com>
