### PR TITLE
Fix for typo in developing aci modules documentation

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general_aci.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_aci.rst
@@ -131,7 +131,7 @@ The ACIModule has six main methods that are used by the modules:
 * construct_url
 * get_existing
 * payload
-* git_diff
+* get_diff
 * post_config
 * delete_config
 


### PR DESCRIPTION
Fix for typo in developing aci modules documentation. git_diff should be get_diff.

##### SUMMARY
git_diff changed to get_diff

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
> Developing Cisco ACI modules documentation

##### ANSIBLE VERSION
/

##### ADDITIONAL INFORMATION
/
