### PR TITLE
Make puppet module useable on puppet 6

### DIFF
--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -216,7 +216,7 @@ def main():
 
     if not p['manifest'] and not p['execute']:
         cmd = ("%(base_cmd)s agent --onetime"
-               " --ignorecache --no-daemonize --no-usecacheonfailure --no-splay"
+               " --no-daemonize --no-usecacheonfailure --no-splay"
                " --detailed-exitcodes --verbose --color 0") % dict(base_cmd=base_cmd)
         if p['puppetmaster']:
             cmd += " --server %s" % pipes.quote(p['puppetmaster'])


### PR DESCRIPTION
The unused ignorecache setting has been removed and so you
can't run puppet through this module anymore on puppet 6.

See PUP-8533 / https://tickets.puppetlabs.com/browse/PUP-8533

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- Puppet module

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.6.4
```