### PR TITLE
Correct cron.py documentation examples

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -157,13 +157,13 @@ EXAMPLES = '''
   cron:
     name: PATH
     env: yes
-    value: /opt/bin
+    job: /opt/bin
 
 - name: Creates an entry like "APP_HOME=/srv/app" and insert it after PATH declaration
   cron:
     name: APP_HOME
     env: yes
-    value: /srv/app
+    job: /srv/app
     insertafter: PATH
 
 - name: Creates a cron file under /etc/cron.d


### PR DESCRIPTION
<!--- Your description here -->
Correct wrong parameter usage in cron module examples
+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The documentation examples state the use of the "value" parameter for environment variables while this should be the "job" parameter.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cron

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/linuxadmin/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
