### PR TITLE
Do not send "Connection: close" when requesting a tunnel

### DIFF
--- a/changelogs/fragments/urls-proxy-validate.yaml
+++ b/changelogs/fragments/urls-proxy-validate.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- 'urls - When validating SSL certs using an a non-SSL proxy, do not send "Connection: close" when requesting a tunnel. This prevents some proxy servers from dropping the connection (https://github.com/ansible/ansible/issues/32750)'

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -588,7 +588,7 @@ class SSLValidationHandler(urllib_request.BaseHandler):
     http://stackoverflow.com/questions/1087227/validate-ssl-certificates-with-python
     http://techknack.net/python-urllib2-handlers/
     '''
-    CONNECT_COMMAND = "CONNECT %s:%s HTTP/1.0\r\nConnection: close\r\n"
+    CONNECT_COMMAND = "CONNECT %s:%s HTTP/1.0\r\n"
 
     def __init__(self, hostname, port):
         self.hostname = hostname


### PR DESCRIPTION
##### SUMMARY

When validating SSL certs using an a non-SSL proxy, do not send "Connection: close" when requesting a tunnel. This prevents some proxy servers from dropping the connection

RFC2817 section 5.2 (or any other section) does not specify use of sending `Connection: close` and specifically squid seems to have issues with sending this.

Fixes #32750 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/urls.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.5
2.6
2.7
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```