### PR TITLE
[aws] Fix IAM role name parsing to come from the ARN

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
@@ -466,8 +466,8 @@ class Ec2Metadata(object):
         new_fields = {}
         for key, value in fields.items():
             split_fields = key[len(uri):].split('/')
-            if len(split_fields) == 3 and split_fields[0:2] == ['iam', 'security-credentials']:
-                new_fields[self._prefix % "iam-instance-profile-role"] = split_fields[2]
+            if len(split_fields) == 2 and split_fields[0:2] == ['iam', 'info_instanceprofilearn']:
+                new_fields[self._prefix % "iam-instance-profile-role"] = value.split('/')[1]
             if len(split_fields) > 1 and split_fields[1]:
                 new_key = "-".join(split_fields)
                 new_fields[self._prefix % new_key] = value


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The change in #38664 (removal of the underscore check) actually caused the keys from the IAM role security credentials JSON dictionary to leak out into the parsing of the IAM role from the URL (`169.254.169.254/latest/meta-data/iam/security-credentials/<role name>`). This affects 2.6 and 2.7.

(cherry picked from commit fe6b7f6b5d1aff0e86802c4bbe4c5c4410ed9ee9)

Backport of https://github.com/ansible/ansible/pull/45534


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
