### PR TITLE
Perform full RETURN schema validation in one step, don't try to loop

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -823,10 +823,15 @@ class ModuleValidator(Validator):
             else:
                 error_message = error
 
+            if path:
+                combined_path = '%s.%s' % (name, '.'.join(path))
+            else:
+                combined_path = name
+
             self.reporter.error(
                 path=self.object_path,
                 code=error_code,
-                msg='%s.%s: %s' % (name, '.'.join(path), error_message)
+                msg='%s: %s' % (combined_path, error_message)
             )
 
     def _validate_docs(self):
@@ -980,7 +985,6 @@ class ModuleValidator(Validator):
                     msg='No EXAMPLES provided'
                 )
             else:
-                examples_exists = True
                 _, errors, traces = parse_yaml(doc_info['EXAMPLES']['value'],
                                                doc_info['EXAMPLES']['lineno'],
                                                self.name, 'EXAMPLES', load_all=True)
@@ -997,7 +1001,6 @@ class ModuleValidator(Validator):
                     )
 
             if not bool(doc_info['RETURN']['value']):
-                returns_exists = True
                 if self._is_new_module():
                     self.reporter.error(
                         path=self.object_path,
@@ -1014,9 +1017,7 @@ class ModuleValidator(Validator):
                 data, errors, traces = parse_yaml(doc_info['RETURN']['value'],
                                                   doc_info['RETURN']['lineno'],
                                                   self.name, 'RETURN')
-                if data:
-                    for ret_key in data:
-                        self._validate_docs_schema(data[ret_key], return_schema(data[ret_key]), 'RETURN.%s' % ret_key, 319)
+                self._validate_docs_schema(data, return_schema, 'RETURN', 319)
 
                 for error in errors:
                     self.reporter.error(

--- a/test/sanity/validate-modules/utils.py
+++ b/test/sanity/validate-modules/utils.py
@@ -26,7 +26,6 @@ import yaml.reader
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.parsing.convert_bool import boolean
 
 
 class AnsibleTextIOWrapper(TextIOWrapper):


### PR DESCRIPTION
##### SUMMARY
Perform full RETURN schema validation in one step, don't try to loop

This will address issues where `RETURN` is provided in some other type than supported.

Example:
```
lib/ansible/modules/system/ping.py:0:0: E319 RETURN: expected a dictionary
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/sanity/validate-modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```