### PR TITLE
Fortinet FortiManager Device Group Module

### DIFF
--- a/lib/ansible/modules/network/fortimanager/fmgr_device_group.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_device_group.py
@@ -1,0 +1,354 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community"
+}
+
+DOCUMENTATION = '''
+---
+module: fmgr_device_group
+version_added: "2.6"
+author: Luke Weighall, Andrew Welsh
+short_description: Alter FortiManager device groups
+description:
+  - Add or edit device groups and assign devices to device groups FortiManager Device Manager using jsonrpc API
+
+options:
+  adom:
+    description:
+      - The ADOM the configuration should belong to.
+    required: true
+
+  vdom:
+    description:
+      - The VDOM of on the Fortigate you want to add, must match the device in FMGR. Usually root.
+    required: true
+
+  host:
+    description:
+      - The FortiManager's Address.
+    required: true
+
+  username:
+    description:
+      - The username to log into the FortiManager
+    required: true
+  password:
+    description:
+      - The password associated with the username account.
+    required: false
+
+  state:
+    description:
+      - The desired state of the specified object.
+      - absent will delete the object if it exists. If grp_members is defined, only members are deleted.
+      - present will create the configuration if needed.
+      - To delete a grp_name, you must omit the grp_members field in the playbook task while setting to absent
+    required: true
+    default: present
+
+    choices: ["absent", "present"]
+  grp_name:
+    description:
+      - The name of the device group.
+    required: false
+
+  grp_desc:
+    description:
+      - The description of the device group.
+    required: false
+
+  grp_members:
+    description:
+      - A comma separated list of device names or device groups to be added as members to the device group.
+      - If Group Members are defined, and state="absent", only group members will be removed.
+      - If you want to delete a group itself, you must omit this parameter from the task in playbook
+      - Otherwise module assumes
+    required: false
+
+'''
+
+
+EXAMPLES = '''
+- name: CREATE DEVICE GROUP
+  fmgr_device_group:
+    host: "{{inventory_hostname}}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    grp_name: "TestGroup"
+    grp_desc: "CreatedbyAnsible"
+    adom: "ansible"
+    state: "present"
+
+- name: CREATE DEVICE GROUP 2
+  fmgr_device_group:
+    host: "{{inventory_hostname}}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    grp_name: "AnsibleGroup"
+    grp_desc: "CreatedbyAnsible"
+    adom: "ansible"
+    state: "present"
+
+- name: ADD DEVICES TO DEVICE GROUP
+  fmgr_device_group:
+    host: "{{inventory_hostname}}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    state: "present"
+    grp_name: "TestGroup"
+    grp_members: "FGT1,FGT2"
+    adom: "ansible"
+    vdom: "root"
+
+- name: REMOVE DEVICES TO DEVICE GROUP
+  fmgr_device_group:
+    host: "{{inventory_hostname}}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    state: "absent"
+    grp_name: "TestGroup"
+    grp_members: "FGT1,FGT2"
+    adom: "ansible"
+
+- name: DELETE DEVICE GROUP
+  fmgr_device_group:
+    host: "{{inventory_hostname}}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    grp_name: "AnsibleGroup"
+    grp_desc: "CreatedbyAnsible"
+    state: "absent"
+    adom: "ansible"
+'''
+RETURN = """
+api_result:
+  description: full API response, includes status code and message
+  returned: always
+  type: string
+"""
+
+from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils.network.fortimanager.fortimanager import AnsibleFortiManager
+
+
+# check for pyFMG lib
+try:
+    from pyFMG.fortimgr import FortiManager
+    HAS_PYFMGR = True
+except ImportError:
+    HAS_PYFMGR = False
+
+
+def get_groups(fmg, paramgram):
+    """
+    This method is used GET the HA PEERS of a FortiManager Node
+    """
+
+    datagram = {
+        "method": "get"
+    }
+
+    url = '/dvmdb/adom/{adom}/group'.format(adom=paramgram["adom"])
+    response = fmg.get(url, datagram)
+    return response
+
+
+def add_device_group(fmg, paramgram):
+    """
+    This method is used to add device groups
+    """
+
+    datagram = {
+        "name": paramgram["grp_name"],
+        "desc": paramgram["grp_desc"],
+        "os_type": "fos"
+    }
+
+    url = '/dvmdb/adom/{adom}/group'.format(adom=paramgram["adom"])
+    response = fmg.add(url, datagram)
+    return response
+
+
+def delete_device_group(fmg, paramgram):
+    """
+    This method is used to add devices to the FMGR
+    """
+
+    datagram = {
+        "adom": paramgram["adom"],
+        "name": paramgram["grp_name"]
+    }
+
+    url = '/dvmdb/adom/{adom}/group/{grp_name}'.format(adom=paramgram["adom"], grp_name=paramgram["grp_name"])
+    response = fmg.delete(url, datagram)
+    return response
+
+
+def add_group_member(fmg, paramgram):
+    """
+    This method is used to update device groups add members
+    """
+    response = None
+    device_member_list = paramgram["grp_members"].replace(' ', '')
+    device_member_list = device_member_list.split(',')
+
+    for dev_name in device_member_list:
+        datagram = {'name': dev_name, 'vdom': paramgram["vdom"]}
+
+        url = '/dvmdb/adom/{adom}/group/{grp_name}/object member'.format(adom=paramgram["adom"],
+                                                                         grp_name=paramgram["grp_name"])
+        response = fmg.add(url, datagram)
+
+    return response
+
+
+def delete_group_member(fmg, paramgram):
+    """
+    This method is used to update device groups add members
+    """
+    response = None
+    device_member_list = paramgram["grp_members"].replace(' ', '')
+    device_member_list = device_member_list.split(',')
+
+    for dev_name in device_member_list:
+        datagram = {'name': dev_name, 'vdom': paramgram["vdom"]}
+
+        url = '/dvmdb/adom/{adom}/group/{grp_name}/object member'.format(adom=paramgram["adom"],
+                                                                         grp_name=paramgram["grp_name"])
+        response = fmg.delete(url, datagram)
+
+    return response
+
+
+# FUNCTION/METHOD FOR LOGGING OUT AND ANALYZING ERROR CODES
+def fmgr_logout(fmg, module, msg="NULL", results=(), good_codes=(0,), logout_on_fail=True, logout_on_success=False):
+    """
+    THIS METHOD CONTROLS THE LOGOUT AND ERROR REPORTING AFTER AN METHOD OR FUNCTION RUNS
+    """
+
+    # VALIDATION ERROR (NO RESULTS, JUST AN EXIT)
+    if msg != "NULL" and len(results) == 0:
+        try:
+            fmg.logout()
+        except:
+            pass
+        module.fail_json(msg=msg)
+
+    # SUBMISSION ERROR
+    if len(results) > 0:
+        if msg == "NULL":
+            try:
+                msg = results[1]['status']['message']
+            except:
+                msg = "No status message returned from pyFMG. Possible that this was a GET with a tuple result."
+
+            if results[0] not in good_codes:
+                if logout_on_fail:
+                    fmg.logout()
+                    module.fail_json(msg=msg, **results[1])
+                else:
+                    return_msg = msg + " -- LOGOUT ON FAIL IS OFF, MOVING ON"
+                    return return_msg
+            else:
+                if logout_on_success:
+                    fmg.logout()
+                    module.exit_json(msg=msg, **results[1])
+                else:
+                    return_msg = msg + " -- LOGOUT ON SUCCESS IS OFF, MOVING ON TO REST OF CODE"
+                    return return_msg
+
+
+def main():
+    argument_spec = dict(
+        adom=dict(required=False, type="str", default="root"),
+        vdom=dict(required=False, type="str", default="root"),
+        host=dict(required=True, type="str"),
+        username=dict(fallback=(env_fallback, ["ANSIBLE_NET_USERNAME"])),
+        password=dict(fallback=(env_fallback, ["ANSIBLE_NET_PASSWORD"]), no_log=True),
+        state=dict(choices=["absent", "present"], type="str", default="present"),
+        grp_desc=dict(required=False, type="str"),
+        grp_name=dict(required=True, type="str"),
+        grp_members=dict(required=False, type="str"),
+    )
+
+    module = AnsibleModule(argument_spec, supports_check_mode=True, )
+
+    # handle params passed via provider and insure they are represented as the data type expected by fortimanager
+    paramgram = {
+        "state": module.params["state"],
+        "grp_name": module.params["grp_name"],
+        "grp_desc": module.params["grp_desc"],
+        "grp_members": module.params["grp_members"],
+        "adom": module.params["adom"],
+        "vdom": module.params["vdom"]
+    }
+
+    # validate required arguments are passed; not used in argument_spec to allow params to be called from provider
+    # check if params are set
+    if module.params["host"] is None or module.params["username"] is None or module.params["password"] is None:
+        module.fail_json(msg="Host and username are required for connection")
+
+    # CHECK IF LOGIN FAILED
+    fmg = AnsibleFortiManager(module, module.params["host"], module.params["username"], module.params["password"])
+    response = fmg.login()
+    if response[1]['status']['code'] != 0:
+        module.fail_json(msg="Connection to FortiManager Failed")
+    else:
+        # START SESSION LOGIC
+
+        # PROCESS THE GROUP ADDS FIRST
+        if paramgram["grp_name"] is not None and paramgram["state"] == "present":
+            # add device group
+            results = add_device_group(fmg, paramgram)
+            if not results[0] == 0 and not results[0] == -2:
+                fmgr_logout(fmg, module, msg="Failed to Add Device Group", results=results, good_codes=[0])
+
+        # PROCESS THE GROUP MEMBER ADDS
+        if paramgram["grp_members"] is not None and paramgram["state"] == "present":
+            # assign devices to device group
+            results = add_group_member(fmg, paramgram)
+            if not results[0] == 0 and not results[0] == -2:
+                fmgr_logout(fmg, module, msg="Failed to Add Group Member(s)", results=results, good_codes=[0])
+
+        # PROCESS THE GROUP MEMBER DELETES
+        if paramgram["grp_members"] is not None and paramgram["state"] == "absent":
+            # remove devices grom a group
+            results = delete_group_member(fmg, paramgram)
+            if not results[0] == 0:
+                fmgr_logout(fmg, module, msg="Failed to Delete Group Member(s)", results=results, good_codes=[0])
+
+        # PROCESS THE GROUP DELETES, ONLY IF GRP_MEMBERS IS NOT NULL TOO
+        if paramgram["grp_name"] is not None and paramgram["state"] == "absent" and paramgram["grp_members"] is None:
+            # delete device group
+            results = delete_device_group(fmg, paramgram)
+            if not results[0] == 0:
+                fmgr_logout(fmg, module, msg="Failed to Delete Device Group", results=results, good_codes=[0])
+
+    # RETURN THE RESULTS
+    return module.exit_json(**results[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ansible/modules/network/fortimanager/fmgr_device_group.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_device_group.py
@@ -28,7 +28,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: fmgr_device_group
-version_added: "2.6"
+version_added: "2.8"
 author: Luke Weighall, Andrew Welsh
 short_description: Alter FortiManager device groups
 description:
@@ -38,12 +38,14 @@ options:
   adom:
     description:
       - The ADOM the configuration should belong to.
-    required: true
+    required: false
+    default: root
 
   vdom:
     description:
       - The VDOM of on the Fortigate you want to add, must match the device in FMGR. Usually root.
-    required: true
+    required: false
+    default: root
 
   host:
     description:

--- a/lib/ansible/modules/network/fortimanager/fmgr_device_group.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_device_group.py
@@ -29,7 +29,10 @@ DOCUMENTATION = '''
 ---
 module: fmgr_device_group
 version_added: "2.8"
-author: Luke Weighall, Andrew Welsh
+author:
+    - Luke Weighall (@lweighall)
+    - Andrew Welsh (@Ghilli3)
+    - Jim Huber (@p4r4n0y1ng)
 short_description: Alter FortiManager device groups.
 description:
   - Add or edit device groups and assign devices to device groups FortiManager Device Manager using JSON RPC API.

--- a/lib/ansible/modules/network/fortimanager/fmgr_device_group.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_device_group.py
@@ -38,12 +38,14 @@ options:
   adom:
     description:
       - The ADOM the configuration should belong to.
-    required: true
+    required: false
+    default: root
 
   vdom:
     description:
       - The VDOM of the Fortigate you want to add, must match the device in FMGR. Usually root.
-    required: true
+    required: false
+    default: root
 
   host:
     description:

--- a/lib/ansible/modules/network/fortimanager/fmgr_device_group.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_device_group.py
@@ -30,32 +30,31 @@ DOCUMENTATION = '''
 module: fmgr_device_group
 version_added: "2.8"
 author: Luke Weighall, Andrew Welsh
-short_description: Alter FortiManager device groups
+short_description: Alter FortiManager device groups.
 description:
-  - Add or edit device groups and assign devices to device groups FortiManager Device Manager using jsonrpc API
+  - Add or edit device groups and assign devices to device groups FortiManager Device Manager using JSON RPC API.
 
 options:
   adom:
     description:
       - The ADOM the configuration should belong to.
-    required: false
-    default: root
+    required: true
 
   vdom:
     description:
-      - The VDOM of on the Fortigate you want to add, must match the device in FMGR. Usually root.
-    required: false
-    default: root
+      - The VDOM of the Fortigate you want to add, must match the device in FMGR. Usually root.
+    required: true
 
   host:
     description:
-      - The FortiManager's Address.
+      - The FortiManager's address.
     required: true
 
   username:
     description:
-      - The username to log into the FortiManager
+      - The username to log into the FortiManager.
     required: true
+
   password:
     description:
       - The password associated with the username account.
@@ -66,11 +65,11 @@ options:
       - The desired state of the specified object.
       - absent will delete the object if it exists. If grp_members is defined, only members are deleted.
       - present will create the configuration if needed.
-      - To delete a grp_name, you must omit the grp_members field in the playbook task while setting to absent
+      - To delete a grp_name, you must omit the grp_members field in the playbook task while setting to absent.
     required: true
     default: present
-
     choices: ["absent", "present"]
+
   grp_name:
     description:
       - The name of the device group.
@@ -85,8 +84,7 @@ options:
     description:
       - A comma separated list of device names or device groups to be added as members to the device group.
       - If Group Members are defined, and state="absent", only group members will be removed.
-      - If you want to delete a group itself, you must omit this parameter from the task in playbook
-      - Otherwise module assumes
+      - If you want to delete a group itself, you must omit this parameter from the task in playbook.
     required: false
 
 '''
@@ -324,28 +322,28 @@ def main():
         if paramgram["grp_name"] is not None and paramgram["state"] == "present":
             # add device group
             results = add_device_group(fmg, paramgram)
-            if not results[0] == 0 and not results[0] == -2:
+            if results[0] != 0 and results[0] != -2:
                 fmgr_logout(fmg, module, msg="Failed to Add Device Group", results=results, good_codes=[0])
 
         # PROCESS THE GROUP MEMBER ADDS
         if paramgram["grp_members"] is not None and paramgram["state"] == "present":
             # assign devices to device group
             results = add_group_member(fmg, paramgram)
-            if not results[0] == 0 and not results[0] == -2:
+            if results[0] != 0 and results[0] != -2:
                 fmgr_logout(fmg, module, msg="Failed to Add Group Member(s)", results=results, good_codes=[0])
 
         # PROCESS THE GROUP MEMBER DELETES
         if paramgram["grp_members"] is not None and paramgram["state"] == "absent":
             # remove devices grom a group
             results = delete_group_member(fmg, paramgram)
-            if not results[0] == 0:
+            if results[0] != 0:
                 fmgr_logout(fmg, module, msg="Failed to Delete Group Member(s)", results=results, good_codes=[0])
 
         # PROCESS THE GROUP DELETES, ONLY IF GRP_MEMBERS IS NOT NULL TOO
         if paramgram["grp_name"] is not None and paramgram["state"] == "absent" and paramgram["grp_members"] is None:
             # delete device group
             results = delete_device_group(fmg, paramgram)
-            if not results[0] == 0:
+            if results[0] != 0:
                 fmgr_logout(fmg, module, msg="Failed to Delete Device Group", results=results, good_codes=[0])
 
     # RETURN THE RESULTS

--- a/test/units/modules/network/fortimanager/fixtures/test_fmgr_device_group.json
+++ b/test/units/modules/network/fortimanager/fixtures/test_fmgr_device_group.json
@@ -1,0 +1,226 @@
+{
+   "add_group_member": [
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvmdb/adom/ansible/group/TestGroup/object member"
+         }, 
+         "paramgram_used": {
+            "grp_desc": null, 
+            "adom": "ansible", 
+            "grp_members": "FGT1,FGT2", 
+            "state": "present", 
+            "grp_name": "TestGroup", 
+            "vdom": "root"
+         }, 
+         "post_method": "add"
+      }, 
+      {
+         "paramgram_used": {
+            "grp_desc": null, 
+            "adom": "ansible", 
+            "grp_members": "FGT1,FGT2", 
+            "state": "present", 
+            "grp_name": "TestGroup", 
+            "vdom": "root"
+         }, 
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvmdb/adom/ansible/group/TestGroup/object member"
+         }, 
+         "post_method": "add"
+      }, 
+      {
+         "paramgram_used": {
+            "grp_desc": null, 
+            "adom": "ansible", 
+            "grp_members": "FGT3", 
+            "state": "present", 
+            "grp_name": "testtest", 
+            "vdom": "root"
+         }, 
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvmdb/adom/ansible/group/testtest/object member"
+         }, 
+         "post_method": "add"
+      }
+   ], 
+   "delete_device_group": [
+      {
+         "paramgram_used": {
+            "grp_desc": "CreatedbyAnsible", 
+            "adom": "ansible", 
+            "grp_members": null, 
+            "state": "absent", 
+            "grp_name": "TestGroup", 
+            "vdom": "root"
+         }, 
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvmdb/adom/ansible/group/TestGroup"
+         }, 
+         "post_method": "delete"
+      }, 
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvmdb/adom/ansible/group/testtest"
+         }, 
+         "paramgram_used": {
+            "grp_desc": "CreatedbyAnsible", 
+            "adom": "ansible", 
+            "grp_members": null, 
+            "state": "absent", 
+            "grp_name": "testtest", 
+            "vdom": "root"
+         }, 
+         "post_method": "delete"
+      }
+   ], 
+   "add_device_group": [
+      {
+         "paramgram_used": {
+            "grp_desc": "CreatedbyAnsible", 
+            "adom": "ansible", 
+            "grp_members": null, 
+            "state": "present", 
+            "grp_name": "TestGroup", 
+            "vdom": "root"
+         }, 
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvmdb/adom/ansible/group"
+         }, 
+         "post_method": "add"
+      }, 
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvmdb/adom/ansible/group"
+         }, 
+         "paramgram_used": {
+            "grp_desc": "CreatedbyAnsible", 
+            "adom": "ansible", 
+            "grp_members": null, 
+            "state": "present", 
+            "grp_name": "testtest", 
+            "vdom": "root"
+         }, 
+         "post_method": "add"
+      }, 
+      {
+         "paramgram_used": {
+            "grp_desc": null, 
+            "adom": "ansible", 
+            "grp_members": "FGT1,FGT2", 
+            "state": "present", 
+            "grp_name": "TestGroup", 
+            "vdom": "root"
+         }, 
+         "raw_response": {
+            "status": {
+               "message": "Object already exists", 
+               "code": -2
+            }, 
+            "url": "/dvmdb/adom/ansible/group"
+         }, 
+         "post_method": "add"
+      }, 
+      {
+         "raw_response": {
+            "status": {
+               "message": "Object already exists", 
+               "code": -2
+            }, 
+            "url": "/dvmdb/adom/ansible/group"
+         }, 
+         "paramgram_used": {
+            "grp_desc": null, 
+            "adom": "ansible", 
+            "grp_members": "FGT3", 
+            "state": "present", 
+            "grp_name": "testtest", 
+            "vdom": "root"
+         }, 
+         "post_method": "add"
+      }
+   ], 
+   "delete_group_member": [
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvmdb/adom/ansible/group/testtest/object member"
+         }, 
+         "paramgram_used": {
+            "grp_desc": null, 
+            "adom": "ansible", 
+            "grp_members": "FGT3", 
+            "state": "absent", 
+            "grp_name": "testtest", 
+            "vdom": "root"
+         }, 
+         "post_method": "delete"
+      }, 
+      {
+         "paramgram_used": {
+            "grp_desc": null, 
+            "adom": "ansible", 
+            "grp_members": "FGT1,FGT2", 
+            "state": "absent", 
+            "grp_name": "TestGroup", 
+            "vdom": "root"
+         }, 
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvmdb/adom/ansible/group/TestGroup/object member"
+         }, 
+         "post_method": "delete"
+      }, 
+      {
+         "raw_response": {
+            "status": {
+               "message": "OK", 
+               "code": 0
+            }, 
+            "url": "/dvmdb/adom/ansible/group/TestGroup/object member"
+         }, 
+         "paramgram_used": {
+            "grp_desc": null, 
+            "adom": "ansible", 
+            "grp_members": "FGT1,FGT2", 
+            "state": "absent", 
+            "grp_name": "TestGroup", 
+            "vdom": "root"
+         }, 
+         "post_method": "delete"
+      }
+   ]
+}

--- a/test/units/modules/network/fortimanager/test_fmgr_device_group.py
+++ b/test/units/modules/network/fortimanager/test_fmgr_device_group.py
@@ -202,25 +202,7 @@ def test_add_group_member(fixture_data, mocker):
     # vdom: root
     # mode: add
     #
-    assert output['raw_response']['status']['code'] == 0
-    paramgram_used = {
-        'grp_desc': None,
-        'adom': 'ansible',
-        'grp_members': 'FGT1,FGT2',
-        'state': 'present',
-        'grp_name': 'TestGroup',
-        'vdom': 'root',
-        'mode': 'add'}
-    output = fmgr_device_group.add_group_member(fmg_instance, paramgram_used)
-    #
-    # grp_desc: None
-    # adom: ansible
-    # grp_members: FGT1,FGT2
-    # state: present
-    # grp_name: TestGroup
-    # vdom: root
-    # mode: add
-    #
+
     assert output['raw_response']['status']['code'] == 0
     paramgram_used = {
         'grp_desc': None,
@@ -287,24 +269,3 @@ def test_delete_group_member(fixture_data, mocker):
     # vdom: root
     # mode: delete
     #
-    assert output['raw_response']['status']['code'] == 0
-    paramgram_used = {
-        'grp_desc': None,
-        'adom': 'ansible',
-        'grp_members': 'FGT1,FGT2',
-        'state': 'absent',
-        'grp_name': 'TestGroup',
-        'vdom': 'root',
-        'mode': 'delete'}
-    output = fmgr_device_group.delete_group_member(
-        fmg_instance, paramgram_used)
-    #
-    # grp_desc: None
-    # adom: ansible
-    # grp_members: FGT1,FGT2
-    # state: absent
-    # grp_name: TestGroup
-    # vdom: root
-    # mode: delete
-    #
-    assert output['raw_response']['status']['code'] == 0

--- a/test/units/modules/network/fortimanager/test_fmgr_device_group.py
+++ b/test/units/modules/network/fortimanager/test_fmgr_device_group.py
@@ -1,19 +1,17 @@
-# (c) 2016 Red Hat Inc.
+# Copyright 2018 Fortinet, Inc.
 #
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
+# This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# Ansible is distributed in the hope that it will be useful,
+# This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
@@ -27,7 +25,9 @@ import pytest
 try:
     from ansible.modules.network.fortimanager import fmgr_device_group
 except ImportError:
-    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+    pytest.skip(
+        "Could not load required modules for testing",
+        allow_module_level=True)
 
 fmg_instance = FortiManager("1.1.1.1", "admin", "")
 
@@ -49,12 +49,21 @@ def fixture_data(request):
     return request.param.get(func_name, None)
 
 
-
 def test_add_device_group(fixture_data, mocker):
-    mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
-    paramgram_used = {'grp_desc': 'CreatedbyAnsible', 'adom': 'ansible', 'grp_members': None, 'state': 'present', 'grp_name': 'TestGroup', 'vdom': 'root', 'mode': 'add'}
+    mocker.patch(
+        "pyFMG.fortimgr.FortiManager._post_request",
+        side_effect=fixture_data)
+
+    paramgram_used = {
+        'grp_desc': 'CreatedbyAnsible',
+        'adom': 'ansible',
+        'grp_members': None,
+        'state': 'present',
+        'grp_name': 'TestGroup',
+        'vdom': 'root',
+        'mode': 'add'}
     output = fmgr_device_group.add_device_group(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # grp_desc: CreatedbyAnsible
     # adom: ansible
     # grp_members: None
@@ -62,10 +71,18 @@ def test_add_device_group(fixture_data, mocker):
     # grp_name: TestGroup
     # vdom: root
     # mode: add
-    ##################################################
-    assert output['raw_response']['status']['code'] == 0    paramgram_used = {'grp_desc': 'CreatedbyAnsible', 'adom': 'ansible', 'grp_members': None, 'state': 'present', 'grp_name': 'testtest', 'vdom': 'root', 'mode': 'add'}
+    #
+    assert output['raw_response']['status']['code'] == 0
+    paramgram_used = {
+        'grp_desc': 'CreatedbyAnsible',
+        'adom': 'ansible',
+        'grp_members': None,
+        'state': 'present',
+        'grp_name': 'testtest',
+        'vdom': 'root',
+        'mode': 'add'}
     output = fmgr_device_group.add_device_group(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # grp_desc: CreatedbyAnsible
     # adom: ansible
     # grp_members: None
@@ -73,10 +90,18 @@ def test_add_device_group(fixture_data, mocker):
     # grp_name: testtest
     # vdom: root
     # mode: add
-    ##################################################
-    assert output['raw_response']['status']['code'] == 0    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT1,FGT2', 'state': 'present', 'grp_name': 'TestGroup', 'vdom': 'root', 'mode': 'add'}
+    #
+    assert output['raw_response']['status']['code'] == 0
+    paramgram_used = {
+        'grp_desc': None,
+        'adom': 'ansible',
+        'grp_members': 'FGT1,FGT2',
+        'state': 'present',
+        'grp_name': 'TestGroup',
+        'vdom': 'root',
+        'mode': 'add'}
     output = fmgr_device_group.add_device_group(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # grp_desc: None
     # adom: ansible
     # grp_members: FGT1,FGT2
@@ -84,10 +109,18 @@ def test_add_device_group(fixture_data, mocker):
     # grp_name: TestGroup
     # vdom: root
     # mode: add
-    ##################################################
-    assert output['raw_response']['status']['code'] == -2    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT3', 'state': 'present', 'grp_name': 'testtest', 'vdom': 'root', 'mode': 'add'}
+    #
+    assert output['raw_response']['status']['code'] == -2
+    paramgram_used = {
+        'grp_desc': None,
+        'adom': 'ansible',
+        'grp_members': 'FGT3',
+        'state': 'present',
+        'grp_name': 'testtest',
+        'vdom': 'root',
+        'mode': 'add'}
     output = fmgr_device_group.add_device_group(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # grp_desc: None
     # adom: ansible
     # grp_members: FGT3
@@ -95,14 +128,26 @@ def test_add_device_group(fixture_data, mocker):
     # grp_name: testtest
     # vdom: root
     # mode: add
-    ##################################################
+    #
     assert output['raw_response']['status']['code'] == -2
 
+
 def test_delete_device_group(fixture_data, mocker):
-    mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
-    paramgram_used = {'grp_desc': 'CreatedbyAnsible', 'adom': 'ansible', 'grp_members': None, 'state': 'absent', 'grp_name': 'TestGroup', 'vdom': 'root', 'mode': 'delete'}
-    output = fmgr_device_group.delete_device_group(fmg_instance, paramgram_used)
-    ##################################################
+    mocker.patch(
+        "pyFMG.fortimgr.FortiManager._post_request",
+        side_effect=fixture_data)
+
+    paramgram_used = {
+        'grp_desc': 'CreatedbyAnsible',
+        'adom': 'ansible',
+        'grp_members': None,
+        'state': 'absent',
+        'grp_name': 'TestGroup',
+        'vdom': 'root',
+        'mode': 'delete'}
+    output = fmgr_device_group.delete_device_group(
+        fmg_instance, paramgram_used)
+    #
     # grp_desc: CreatedbyAnsible
     # adom: ansible
     # grp_members: None
@@ -110,10 +155,19 @@ def test_delete_device_group(fixture_data, mocker):
     # grp_name: TestGroup
     # vdom: root
     # mode: delete
-    ##################################################
-    assert output['raw_response']['status']['code'] == 0    paramgram_used = {'grp_desc': 'CreatedbyAnsible', 'adom': 'ansible', 'grp_members': None, 'state': 'absent', 'grp_name': 'testtest', 'vdom': 'root', 'mode': 'delete'}
-    output = fmgr_device_group.delete_device_group(fmg_instance, paramgram_used)
-    ##################################################
+    #
+    assert output['raw_response']['status']['code'] == 0
+    paramgram_used = {
+        'grp_desc': 'CreatedbyAnsible',
+        'adom': 'ansible',
+        'grp_members': None,
+        'state': 'absent',
+        'grp_name': 'testtest',
+        'vdom': 'root',
+        'mode': 'delete'}
+    output = fmgr_device_group.delete_device_group(
+        fmg_instance, paramgram_used)
+    #
     # grp_desc: CreatedbyAnsible
     # adom: ansible
     # grp_members: None
@@ -121,14 +175,25 @@ def test_delete_device_group(fixture_data, mocker):
     # grp_name: testtest
     # vdom: root
     # mode: delete
-    ##################################################
+    #
     assert output['raw_response']['status']['code'] == 0
+
 
 def test_add_group_member(fixture_data, mocker):
-    mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
-    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT1,FGT2', 'state': 'present', 'grp_name': 'TestGroup', 'vdom': 'root', 'mode': 'add'}
+    mocker.patch(
+        "pyFMG.fortimgr.FortiManager._post_request",
+        side_effect=fixture_data)
+
+    paramgram_used = {
+        'grp_desc': None,
+        'adom': 'ansible',
+        'grp_members': 'FGT1,FGT2',
+        'state': 'present',
+        'grp_name': 'TestGroup',
+        'vdom': 'root',
+        'mode': 'add'}
     output = fmgr_device_group.add_group_member(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # grp_desc: None
     # adom: ansible
     # grp_members: FGT1,FGT2
@@ -136,10 +201,18 @@ def test_add_group_member(fixture_data, mocker):
     # grp_name: TestGroup
     # vdom: root
     # mode: add
-    ##################################################
-    assert output['raw_response']['status']['code'] == 0    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT1,FGT2', 'state': 'present', 'grp_name': 'TestGroup', 'vdom': 'root', 'mode': 'add'}
+    #
+    assert output['raw_response']['status']['code'] == 0
+    paramgram_used = {
+        'grp_desc': None,
+        'adom': 'ansible',
+        'grp_members': 'FGT1,FGT2',
+        'state': 'present',
+        'grp_name': 'TestGroup',
+        'vdom': 'root',
+        'mode': 'add'}
     output = fmgr_device_group.add_group_member(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # grp_desc: None
     # adom: ansible
     # grp_members: FGT1,FGT2
@@ -147,10 +220,18 @@ def test_add_group_member(fixture_data, mocker):
     # grp_name: TestGroup
     # vdom: root
     # mode: add
-    ##################################################
-    assert output['raw_response']['status']['code'] == 0    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT3', 'state': 'present', 'grp_name': 'testtest', 'vdom': 'root', 'mode': 'add'}
+    #
+    assert output['raw_response']['status']['code'] == 0
+    paramgram_used = {
+        'grp_desc': None,
+        'adom': 'ansible',
+        'grp_members': 'FGT3',
+        'state': 'present',
+        'grp_name': 'testtest',
+        'vdom': 'root',
+        'mode': 'add'}
     output = fmgr_device_group.add_group_member(fmg_instance, paramgram_used)
-    ##################################################
+    #
     # grp_desc: None
     # adom: ansible
     # grp_members: FGT3
@@ -158,14 +239,26 @@ def test_add_group_member(fixture_data, mocker):
     # grp_name: testtest
     # vdom: root
     # mode: add
-    ##################################################
+    #
     assert output['raw_response']['status']['code'] == 0
 
+
 def test_delete_group_member(fixture_data, mocker):
-    mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
-    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT3', 'state': 'absent', 'grp_name': 'testtest', 'vdom': 'root', 'mode': 'delete'}
-    output = fmgr_device_group.delete_group_member(fmg_instance, paramgram_used)
-    ##################################################
+    mocker.patch(
+        "pyFMG.fortimgr.FortiManager._post_request",
+        side_effect=fixture_data)
+
+    paramgram_used = {
+        'grp_desc': None,
+        'adom': 'ansible',
+        'grp_members': 'FGT3',
+        'state': 'absent',
+        'grp_name': 'testtest',
+        'vdom': 'root',
+        'mode': 'delete'}
+    output = fmgr_device_group.delete_group_member(
+        fmg_instance, paramgram_used)
+    #
     # grp_desc: None
     # adom: ansible
     # grp_members: FGT3
@@ -173,10 +266,19 @@ def test_delete_group_member(fixture_data, mocker):
     # grp_name: testtest
     # vdom: root
     # mode: delete
-    ##################################################
-    assert output['raw_response']['status']['code'] == 0    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT1,FGT2', 'state': 'absent', 'grp_name': 'TestGroup', 'vdom': 'root', 'mode': 'delete'}
-    output = fmgr_device_group.delete_group_member(fmg_instance, paramgram_used)
-    ##################################################
+    #
+    assert output['raw_response']['status']['code'] == 0
+    paramgram_used = {
+        'grp_desc': None,
+        'adom': 'ansible',
+        'grp_members': 'FGT1,FGT2',
+        'state': 'absent',
+        'grp_name': 'TestGroup',
+        'vdom': 'root',
+        'mode': 'delete'}
+    output = fmgr_device_group.delete_group_member(
+        fmg_instance, paramgram_used)
+    #
     # grp_desc: None
     # adom: ansible
     # grp_members: FGT1,FGT2
@@ -184,10 +286,19 @@ def test_delete_group_member(fixture_data, mocker):
     # grp_name: TestGroup
     # vdom: root
     # mode: delete
-    ##################################################
-    assert output['raw_response']['status']['code'] == 0    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT1,FGT2', 'state': 'absent', 'grp_name': 'TestGroup', 'vdom': 'root', 'mode': 'delete'}
-    output = fmgr_device_group.delete_group_member(fmg_instance, paramgram_used)
-    ##################################################
+    #
+    assert output['raw_response']['status']['code'] == 0
+    paramgram_used = {
+        'grp_desc': None,
+        'adom': 'ansible',
+        'grp_members': 'FGT1,FGT2',
+        'state': 'absent',
+        'grp_name': 'TestGroup',
+        'vdom': 'root',
+        'mode': 'delete'}
+    output = fmgr_device_group.delete_group_member(
+        fmg_instance, paramgram_used)
+    #
     # grp_desc: None
     # adom: ansible
     # grp_members: FGT1,FGT2
@@ -195,5 +306,5 @@ def test_delete_group_member(fixture_data, mocker):
     # grp_name: TestGroup
     # vdom: root
     # mode: delete
-    ##################################################
+    #
     assert output['raw_response']['status']['code'] == 0

--- a/test/units/modules/network/fortimanager/test_fmgr_device_group.py
+++ b/test/units/modules/network/fortimanager/test_fmgr_device_group.py
@@ -1,0 +1,199 @@
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+from pyFMG.fortimgr import FortiManager
+import pytest
+
+try:
+    from ansible.modules.network.fortimanager import fmgr_device_group
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+fmg_instance = FortiManager("1.1.1.1", "admin", "")
+
+
+def load_fixtures():
+    fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures') + "/{filename}.json".format(
+        filename=os.path.splitext(os.path.basename(__file__))[0])
+    try:
+        with open(fixture_path, "r") as fixture_file:
+            fixture_data = json.load(fixture_file)
+    except IOError:
+        return []
+    return [fixture_data]
+
+
+@pytest.fixture(scope="function", params=load_fixtures())
+def fixture_data(request):
+    func_name = request.function.__name__.replace("test_", "")
+    return request.param.get(func_name, None)
+
+
+
+def test_add_device_group(fixture_data, mocker):
+    mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
+    paramgram_used = {'grp_desc': 'CreatedbyAnsible', 'adom': 'ansible', 'grp_members': None, 'state': 'present', 'grp_name': 'TestGroup', 'vdom': 'root', 'mode': 'add'}
+    output = fmgr_device_group.add_device_group(fmg_instance, paramgram_used)
+    ##################################################
+    # grp_desc: CreatedbyAnsible
+    # adom: ansible
+    # grp_members: None
+    # state: present
+    # grp_name: TestGroup
+    # vdom: root
+    # mode: add
+    ##################################################
+    assert output['raw_response']['status']['code'] == 0    paramgram_used = {'grp_desc': 'CreatedbyAnsible', 'adom': 'ansible', 'grp_members': None, 'state': 'present', 'grp_name': 'testtest', 'vdom': 'root', 'mode': 'add'}
+    output = fmgr_device_group.add_device_group(fmg_instance, paramgram_used)
+    ##################################################
+    # grp_desc: CreatedbyAnsible
+    # adom: ansible
+    # grp_members: None
+    # state: present
+    # grp_name: testtest
+    # vdom: root
+    # mode: add
+    ##################################################
+    assert output['raw_response']['status']['code'] == 0    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT1,FGT2', 'state': 'present', 'grp_name': 'TestGroup', 'vdom': 'root', 'mode': 'add'}
+    output = fmgr_device_group.add_device_group(fmg_instance, paramgram_used)
+    ##################################################
+    # grp_desc: None
+    # adom: ansible
+    # grp_members: FGT1,FGT2
+    # state: present
+    # grp_name: TestGroup
+    # vdom: root
+    # mode: add
+    ##################################################
+    assert output['raw_response']['status']['code'] == -2    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT3', 'state': 'present', 'grp_name': 'testtest', 'vdom': 'root', 'mode': 'add'}
+    output = fmgr_device_group.add_device_group(fmg_instance, paramgram_used)
+    ##################################################
+    # grp_desc: None
+    # adom: ansible
+    # grp_members: FGT3
+    # state: present
+    # grp_name: testtest
+    # vdom: root
+    # mode: add
+    ##################################################
+    assert output['raw_response']['status']['code'] == -2
+
+def test_delete_device_group(fixture_data, mocker):
+    mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
+    paramgram_used = {'grp_desc': 'CreatedbyAnsible', 'adom': 'ansible', 'grp_members': None, 'state': 'absent', 'grp_name': 'TestGroup', 'vdom': 'root', 'mode': 'delete'}
+    output = fmgr_device_group.delete_device_group(fmg_instance, paramgram_used)
+    ##################################################
+    # grp_desc: CreatedbyAnsible
+    # adom: ansible
+    # grp_members: None
+    # state: absent
+    # grp_name: TestGroup
+    # vdom: root
+    # mode: delete
+    ##################################################
+    assert output['raw_response']['status']['code'] == 0    paramgram_used = {'grp_desc': 'CreatedbyAnsible', 'adom': 'ansible', 'grp_members': None, 'state': 'absent', 'grp_name': 'testtest', 'vdom': 'root', 'mode': 'delete'}
+    output = fmgr_device_group.delete_device_group(fmg_instance, paramgram_used)
+    ##################################################
+    # grp_desc: CreatedbyAnsible
+    # adom: ansible
+    # grp_members: None
+    # state: absent
+    # grp_name: testtest
+    # vdom: root
+    # mode: delete
+    ##################################################
+    assert output['raw_response']['status']['code'] == 0
+
+def test_add_group_member(fixture_data, mocker):
+    mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
+    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT1,FGT2', 'state': 'present', 'grp_name': 'TestGroup', 'vdom': 'root', 'mode': 'add'}
+    output = fmgr_device_group.add_group_member(fmg_instance, paramgram_used)
+    ##################################################
+    # grp_desc: None
+    # adom: ansible
+    # grp_members: FGT1,FGT2
+    # state: present
+    # grp_name: TestGroup
+    # vdom: root
+    # mode: add
+    ##################################################
+    assert output['raw_response']['status']['code'] == 0    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT1,FGT2', 'state': 'present', 'grp_name': 'TestGroup', 'vdom': 'root', 'mode': 'add'}
+    output = fmgr_device_group.add_group_member(fmg_instance, paramgram_used)
+    ##################################################
+    # grp_desc: None
+    # adom: ansible
+    # grp_members: FGT1,FGT2
+    # state: present
+    # grp_name: TestGroup
+    # vdom: root
+    # mode: add
+    ##################################################
+    assert output['raw_response']['status']['code'] == 0    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT3', 'state': 'present', 'grp_name': 'testtest', 'vdom': 'root', 'mode': 'add'}
+    output = fmgr_device_group.add_group_member(fmg_instance, paramgram_used)
+    ##################################################
+    # grp_desc: None
+    # adom: ansible
+    # grp_members: FGT3
+    # state: present
+    # grp_name: testtest
+    # vdom: root
+    # mode: add
+    ##################################################
+    assert output['raw_response']['status']['code'] == 0
+
+def test_delete_group_member(fixture_data, mocker):
+    mocker.patch("pyFMG.fortimgr.FortiManager._post_request", side_effect=fixture_data)
+    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT3', 'state': 'absent', 'grp_name': 'testtest', 'vdom': 'root', 'mode': 'delete'}
+    output = fmgr_device_group.delete_group_member(fmg_instance, paramgram_used)
+    ##################################################
+    # grp_desc: None
+    # adom: ansible
+    # grp_members: FGT3
+    # state: absent
+    # grp_name: testtest
+    # vdom: root
+    # mode: delete
+    ##################################################
+    assert output['raw_response']['status']['code'] == 0    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT1,FGT2', 'state': 'absent', 'grp_name': 'TestGroup', 'vdom': 'root', 'mode': 'delete'}
+    output = fmgr_device_group.delete_group_member(fmg_instance, paramgram_used)
+    ##################################################
+    # grp_desc: None
+    # adom: ansible
+    # grp_members: FGT1,FGT2
+    # state: absent
+    # grp_name: TestGroup
+    # vdom: root
+    # mode: delete
+    ##################################################
+    assert output['raw_response']['status']['code'] == 0    paramgram_used = {'grp_desc': None, 'adom': 'ansible', 'grp_members': 'FGT1,FGT2', 'state': 'absent', 'grp_name': 'TestGroup', 'vdom': 'root', 'mode': 'delete'}
+    output = fmgr_device_group.delete_group_member(fmg_instance, paramgram_used)
+    ##################################################
+    # grp_desc: None
+    # adom: ansible
+    # grp_members: FGT1,FGT2
+    # state: absent
+    # grp_name: TestGroup
+    # vdom: root
+    # mode: delete
+    ##################################################
+    assert output['raw_response']['status']['code'] == 0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This module allows the add/set/delete of device groups within FortiManager.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
fmgr_device_group.py
test_fmgr_device_group.py
fixtures/test_fmgr_device_group.json
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/ansible_modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
