### PR TITLE
cache plugins - fix _uri option documentation

### DIFF
--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -18,7 +18,6 @@ DOCUMENTATION = '''
         required: True
         description:
           - Path in which the cache plugin will save the JSON files
-        type: list
         env:
           - name: ANSIBLE_CACHE_PLUGIN_CONNECTION
         ini:

--- a/lib/ansible/plugins/cache/pickle.py
+++ b/lib/ansible/plugins/cache/pickle.py
@@ -18,7 +18,6 @@ DOCUMENTATION = '''
         required: True
         description:
           - Path in which the cache plugin will save the files
-        type: list
         env:
           - name: ANSIBLE_CACHE_PLUGIN_CONNECTION
         ini:

--- a/lib/ansible/plugins/cache/yaml.py
+++ b/lib/ansible/plugins/cache/yaml.py
@@ -18,7 +18,6 @@ DOCUMENTATION = '''
         required: True
         description:
           - Path in which the cache plugin will save the files
-        type: list
         env:
           - name: ANSIBLE_CACHE_PLUGIN_CONNECTION
         ini:


### PR DESCRIPTION
##### SUMMARY
 Remove `type: list` from the _uri options for cache plugins that expect strings

Memcached appears to work with _uri as a list. The other cache plugins setting type: list for _uri appear unused and setting _uri to a list doesn't really work as anticipated.

```
(python2.7.13) 15:24:47 [ansible]$ ansible-config dump --only-changed
CACHE_PLUGIN(/Users/shertel/ansible/ansible.cfg) = jsonfile
CACHE_PLUGIN_CONNECTION(/Users/shertel/ansible/ansible.cfg) = ['/tmp/test']
CACHE_PLUGIN_TIMEOUT(/Users/shertel/ansible/ansible.cfg) = 100
```

Using localhost leads to the path `['/tmp/test']/localhost` being used for facts instead of `/tmp/test/localhost`

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/plugins/cache/jsonfile.py
lib/ansible/plugins/cache/pickle.py
lib/ansible/plugins/cache/yaml.py

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
```
