### PR TITLE
[stable-2.6] Fix issues with PLUGIN_FILTERS_CFG config handling (#45994)

### DIFF
--- a/changelogs/fragments/plugin-filters-cfg.yaml
+++ b/changelogs/fragments/plugin-filters-cfg.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- PLUGIN_FILTERS_CFG - Ensure that the value is treated as type=path, and that we use the standard section of ``defaults`` instead of ``default`` (https://github.com/ansible/ansible/pull/45994)

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1502,6 +1502,13 @@ PLUGIN_FILTERS_CFG:
   ini:
   - key: plugin_filters_cfg
     section: default
+    deprecated:
+      why: Specifying "plugin_filters_cfg" under the "default" section is deprecated
+      version: "2.12"
+      alternatives: the "defaults" section instead
+  - key: plugin_filters_cfg
+    section: defaults
+  type: path
 RETRY_FILES_ENABLED:
   name: Retry files
   default: True


### PR DESCRIPTION
* Ensure that the value of PLUGIN_FILTERS_CFG is treated as type=path, and that we use the standard section of 'defaults' instead of 'default'

* deprecate the default section

* Don't add version_added for the corrected section
(cherry picked from commit 172137c)


Co-authored-by: Matt Martz <matt@sivel.net>