### PR TITLE
async tests: add stability

### DIFF
--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -239,7 +239,7 @@
       state: absent
 
   - name: run fire and forget async task with custom dir
-    command: sleep 1
+    command: echo moo
     register: async_fandf_custom_dir
     async: 5
     poll: 0
@@ -273,9 +273,7 @@
       - async_fandf_custom_dir_fail is failed
       - async_fandf_custom_dir_fail.msg == "could not find job"
       - async_fandf_custom_dir_result is successful
-      - async_fandf_custom_dir_result is finished
       - async_fandf_custom_dir_dep_result is successful
-      - async_fandf_custom_dir_dep_result is finished
 
   always:
   - name: remove custom tmp dir after test


### PR DESCRIPTION
##### SUMMARY
Changes the test to be a bit more reliable, we just verify we could get the job information when using the custom async dir as that is what we care about here.

This test only exists in devel right now as it uses a feature that was only added recently.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
async

##### ANSIBLE VERSION
```paste below
devel
```