### PR TITLE
skip installing linux-image-extra in CI as it shouldn't be needed

### DIFF
--- a/test/integration/targets/setup_docker/tasks/Debian.yml
+++ b/test/integration/targets/setup_docker/tasks/Debian.yml
@@ -2,16 +2,6 @@
   shell: uname -r
   register: os_version
 
-- name: Install packages for Trusty
-  apt:
-    name: "{{ item }}"
-    state: present
-    update_cache: yes
-  with_items:
-  - "linux-image-extra-{{ os_version.stdout }}"
-  - linux-image-extra-virtual 
-  when: ansible_distribution_release == 'trusty'
-
 - name: Install pre-reqs
   apt:
     name: "{{ item }}"


### PR DESCRIPTION
##### SUMMARY
Trying to fix an issue when using a newer Shippable node version https://app.shippable.com/github/ansible/ansible/runs/85476/14/console.

This isn't needed when running in CI as we are already running in a Docker container for Ubuntu 14.04. It is needed if running `ansible-test` manually against an Ubuntu 14.04 host but due to the age and small scenario we will remove it from the setup tasks to get CI working.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
docker_setup

##### ANSIBLE VERSION
```paste below
devel
```