### PR TITLE
The sshkey option is available in version 2.7 and above

### DIFF
--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -82,7 +82,7 @@ options:
     description:
       - Specifies the SSH public key to configure
         for the given username.  This argument accepts a valid SSH key value.
-    version_added: "2.6"
+    version_added: "2.7"
   nopassword:
     description:
       - Defines the username without assigning


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
[The ios_module of devel document](https://docs.ansible.com/ansible/devel/modules/ios_user_module.html#ios-user-module) saids `sshkey (added in 2.6)`.

But In Ansible 2.6, sshkey option is not available. It available in Ansible 2.7.
So I fixed  `(added in 2.7)`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
- task
```paste below
  tasks:
    - name: ios user
      ios_user:
        name: admin01
        privilege: 15
        sshkey: "{{ lookup('file',  '~/.ssh/admin01_id_rsa.pub') }}"
```

- in Ansible 2.7.0rc3
```
(ansible27) [vagrant@centos7 nw]$ ansible-playbook -i inventory/inventory.ini ios_user_test
.yml -l ios

PLAY [network] *******************************************************************************

TASK [ios user] ******************************************************************************
changed: [ios01]
PLAY RECAP ***********************************************************************************
ios01                      : ok=1    changed=1    unreachable=0    failed=0
```

but ...
- in Ansible 2.6.4
```
(ansible26) [vagrant@centos7 nw]$ ansible-playbook -i inventory/inventory.ini ios_user_test.yml -l ios

PLAY [network] *******************************************************************************************************************************************

TASK [ios user] ******************************************************************************************************************************************
fatal: [ios01]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ios_user) module: sshkey Supported parameters include: aggregate, auth_pass, authorize, configured_password, host, name, nopassword, password, port, privilege, provider, purge, ssh_keyfile, state, timeout, update_password, username, view"}

PLAY RECAP ***********************************************************************************************************************************************
ios01                      : ok=0    changed=0    unreachable=0    failed=1
```