### PR TITLE
[stable-2.7] The sshkey option is available in version 2.7 and above (#46103)

### DIFF
--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -82,7 +82,7 @@ options:
     description:
       - Specifies the SSH public key to configure
         for the given username.  This argument accepts a valid SSH key value.
-    version_added: "2.6"
+    version_added: "2.7"
   nopassword:
     description:
       - Defines the username without assigning


### PR DESCRIPTION
(cherry picked from commit 8213096b7fb6f60f43199743baeb95d4343116f5)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request
