### PR TITLE
[stable-2.7] Update synchronize.py, mention variable ansible_rsync_path ... #41870

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -114,9 +114,10 @@ options:
   rsync_path:
     description:
       - Specify the rsync command to run on the remote host. See C(--rsync-path) on the rsync man page.
+      - To specify the rsync command to run on the local host, you need to set this your task var C(ansible_rsync_path).
   rsync_timeout:
     description:
-      - Specify a --timeout for the rsync command in seconds.
+      - Specify a C(--timeout) for the rsync command in seconds.
     default: 0
   set_remote_user:
     description:
@@ -301,6 +302,19 @@ EXAMPLES = '''
     src: /tmp/path_a/foo.txt
     dest: /tmp/path_b/foo.txt
     link_dest: /tmp/path_a/
+
+# Specify the rsync binary to use on remote host and on local host
+- hosts: groupofhosts
+  vars:
+        ansible_rsync_path: "/usr/gnu/bin/rsync"
+
+  tasks:
+    - name: copy /tmp/localpath/ to remote location /tmp/remotepath
+      synchronize:
+        src: "/tmp/localpath/"
+        dest: "/tmp/remotepath"
+        rsync_path: "/usr/gnu/bin/rsync"
+
 '''
 
 


### PR DESCRIPTION
##### SUMMARY


… different local rsync binary (#41870)

* Update synchronize.py

If you want a different rsync binary on the local side, you need to set task variable ansible_rsync_path.
See examples.

Variable ansible_rsync_path looks to not be documented anywhere. If documented, needs to be said that is does not belong to synchronise options, instead belongs to tasks. (Sorry, I have no better wording)
(cherry picked from commit c44de1069ca137280350781b13bab13f01ecd95a)


##### ISSUE TYPE
- Docs Pull Request
