### PR TITLE
Add API pagination support to Scaleway inventory

### DIFF
--- a/lib/ansible/module_utils/scaleway.py
+++ b/lib/ansible/module_utils/scaleway.py
@@ -40,9 +40,8 @@ def parse_pagination_link(header):
             match = rc_relation.match(relation)
             if not match:
                 raise ScalewayException('Scaleway API answered with an invalid relation in the Link pagination header')
-            else:
-                data = match.groupdict()
-                parsed_relations[data['relation']] = data['target_IRI']
+            data = match.groupdict()
+            parsed_relations[data['relation']] = data['target_IRI']
         return parsed_relations
 
 

--- a/lib/ansible/module_utils/scaleway.py
+++ b/lib/ansible/module_utils/scaleway.py
@@ -2,7 +2,6 @@ import json
 import re
 import sys
 
-from ansible.errors import AnsibleError
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.urls import fetch_url
 
@@ -15,6 +14,12 @@ def scaleway_argument_spec():
         api_timeout=dict(type='int', default=30, aliases=['timeout']),
         validate_certs=dict(default=True, type='bool'),
     )
+
+
+class ScalewayException(Exception):
+
+    def __init__(self, message):
+        self.message = message
 
 
 # Specify a complete Link header, for validation purposes
@@ -37,16 +42,10 @@ def parse_pagination_link(header):
                 data = match.groupdict()
                 parsed_relations[data['relation']] = data['target_IRI']
             else:
-                raise AnsibleError('Scaleway API answered with an invalid relation in the Link pagination header')
+                raise ScalewayException('Scaleway API answered with an invalid relation in the Link pagination header')
         return parsed_relations
     else:
-        raise AnsibleError('Scaleway API answered with an invalid Link pagination header')
-
-
-class ScalewayException(Exception):
-
-    def __init__(self, message):
-        self.message = message
+        raise ScalewayException('Scaleway API answered with an invalid Link pagination header')
 
 
 class Response(object):

--- a/lib/ansible/module_utils/scaleway.py
+++ b/lib/ansible/module_utils/scaleway.py
@@ -17,13 +17,20 @@ def scaleway_argument_spec():
     )
 
 
+# Specify a complete Link header, for validation purposes
+R_LINK_HEADER = r'''</[a-z]+\?page=[0-9]+&per_page=[0-9]+&>;
+    \srel="(first|previous|next|last)"
+    (,</[a-z]+\?page=[0-9]+&per_page=[0-9]+&>;
+    \srel="(first|previous|next|last))*"'''
+# Specify a single relation, for iteration and string extraction purposes
+R_RELATION = r'<(?P<target_IRI>/[a-z]+\?page=(?P<page>[0-9]+)&per_page=([0-9]+)&)>; rel="(?P<relation>first|previous|next|last)"'
+
+
 def parse_pagination_link(header):
-    r_link_header = r'</[a-z]+\?page=[0-9]+&per_page=[0-9]+&>; rel="(first|previous|next|last)"(,</[a-z]+\?page=[0-9]+&per_page=[0-9]+&>; rel="(first|previous|next|last))*"'
-    r_relation = r'<(?P<target_IRI>/[a-z]+\?page=(?P<page>[0-9]+)&per_page=([0-9]+)&)>; rel="(?P<relation>first|previous|next|last)"'
-    if re.match(r_link_header, header):
+    if re.match(R_LINK_HEADER, header, re.VERBOSE):
         relations = header.split(',')
         parsed_relations = {}
-        rc_relation = re.compile(r_relation)
+        rc_relation = re.compile(R_RELATION)
         for relation in relations:
             match = rc_relation.match(relation)
             if match:

--- a/lib/ansible/module_utils/scaleway.py
+++ b/lib/ansible/module_utils/scaleway.py
@@ -24,7 +24,7 @@ class ScalewayException(Exception):
 
 # Specify a complete Link header, for validation purposes
 R_LINK_HEADER = r'''<[^>]+>;\srel="(first|previous|next|last)"
-    (,<[^>]+>;\srel="(first|previous|next|last))*"'''
+    (,<[^>]+>;\srel="(first|previous|next|last)")*'''
 # Specify a single relation, for iteration and string extraction purposes
 R_RELATION = r'<(?P<target_IRI>[^>]+)>; rel="(?P<relation>first|previous|next|last)"'
 

--- a/lib/ansible/module_utils/scaleway.py
+++ b/lib/ansible/module_utils/scaleway.py
@@ -30,20 +30,20 @@ R_RELATION = r'<(?P<target_IRI>[^>]+)>; rel="(?P<relation>first|previous|next|la
 
 
 def parse_pagination_link(header):
-    if re.match(R_LINK_HEADER, header, re.VERBOSE):
+    if not re.match(R_LINK_HEADER, header, re.VERBOSE):
+        raise ScalewayException('Scaleway API answered with an invalid Link pagination header')
+    else:
         relations = header.split(',')
         parsed_relations = {}
         rc_relation = re.compile(R_RELATION)
         for relation in relations:
             match = rc_relation.match(relation)
-            if match:
+            if not match:
+                raise ScalewayException('Scaleway API answered with an invalid relation in the Link pagination header')
+            else:
                 data = match.groupdict()
                 parsed_relations[data['relation']] = data['target_IRI']
-            else:
-                raise ScalewayException('Scaleway API answered with an invalid relation in the Link pagination header')
         return parsed_relations
-    else:
-        raise ScalewayException('Scaleway API answered with an invalid Link pagination header')
 
 
 class Response(object):

--- a/lib/ansible/module_utils/scaleway.py
+++ b/lib/ansible/module_utils/scaleway.py
@@ -23,12 +23,10 @@ class ScalewayException(Exception):
 
 
 # Specify a complete Link header, for validation purposes
-R_LINK_HEADER = r'''</[a-z]+\?page=[0-9]+&per_page=[0-9]+&>;
-    \srel="(first|previous|next|last)"
-    (,</[a-z]+\?page=[0-9]+&per_page=[0-9]+&>;
-    \srel="(first|previous|next|last))*"'''
+R_LINK_HEADER = r'''<[^>]+>;\srel="(first|previous|next|last)"
+    (,<[^>]+>;\srel="(first|previous|next|last))*"'''
 # Specify a single relation, for iteration and string extraction purposes
-R_RELATION = r'<(?P<target_IRI>/[a-z]+\?page=(?P<page>[0-9]+)&per_page=([0-9]+)&)>; rel="(?P<relation>first|previous|next|last)"'
+R_RELATION = r'<(?P<target_IRI>[^>]+)>; rel="(?P<relation>first|previous|next|last)"'
 
 
 def parse_pagination_link(header):

--- a/lib/ansible/plugins/inventory/scaleway.py
+++ b/lib/ansible/plugins/inventory/scaleway.py
@@ -116,12 +116,10 @@ def _fetch_information(token, url):
         link = response.getheader('Link')
         if not link:
             return results
-        else:
-            relations = parse_pagination_link(link)
-            if 'next' not in relations:
-                return results
-            else:
-                paginated_url = urllib_parse.urljoin(paginated_url, relations['next'])
+        relations = parse_pagination_link(link)
+        if 'next' not in relations:
+            return results
+        paginated_url = urllib_parse.urljoin(paginated_url, relations['next'])
 
 
 def _build_server_url(api_endpoint):

--- a/lib/ansible/plugins/inventory/scaleway.py
+++ b/lib/ansible/plugins/inventory/scaleway.py
@@ -94,10 +94,9 @@ import ansible.module_utils.six.moves.urllib.parse as urllib_parse
 
 
 def _fetch_information(token, url):
-    last = False
     results = []
     paginated_url = url
-    while not last:
+    while True:
         try:
             response = open_url(paginated_url,
                                 headers={'X-Auth-Token': token,
@@ -115,15 +114,14 @@ def _fetch_information(token, url):
             raise AnsibleError("Incorrect format from the Scaleway API response")
 
         link = response.getheader('Link')
-        if link:
+        if not link:
+            return results
+        else:
             relations = parse_pagination_link(link)
             if 'next' not in relations:
-                last = True
+                return results
             else:
                 paginated_url = urllib_parse.urljoin(paginated_url, relations['next'])
-        else:
-            last = True
-    return results
 
 
 def _build_server_url(api_endpoint):

--- a/lib/ansible/plugins/inventory/scaleway.py
+++ b/lib/ansible/plugins/inventory/scaleway.py
@@ -92,6 +92,7 @@ from ansible.module_utils._text import to_native
 
 import ansible.module_utils.six.moves.urllib.parse as urllib_parse
 
+
 def _fetch_information(token, url):
     last = False
     results = []
@@ -116,7 +117,7 @@ def _fetch_information(token, url):
         link = response.getheader('Link')
         if link:
             relations = parse_pagination_link(link)
-            if not 'next' in relations:
+            if 'next' not in relations:
                 last = True
             else:
                 paginated_url = urllib_parse.urljoin(paginated_url, relations['next'])


### PR DESCRIPTION
##### SUMMARY
Add API pagination support to Scaleway inventory, don't settle for only 50 results!

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/scaleway.py
module_utils/scaleway.py

##### ANSIBLE VERSION
Patch was tested as working on a 86 servers set in the following environment:
```
ansible 2.6.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/johann/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.0 (default, Jul 15 2018, 10:44:58) [GCC 8.1.1 20180531]
```

##### ADDITIONAL INFORMATION
Previous inventory version didn't support pagination on Scaleway API calls. Responses were thus cut at 50 objects, ordered by server creation date (from newest to oldest).

Scaleway uses a header-based pagination, based on RFC 5988
https://developer.scaleway.com/#header-pagination
https://tools.ietf.org/html/rfc5988

This logic should be applicable to other Scaleway API calls (IP, images, storage, etc).