### PR TITLE
Add chdir support to win_package

### DIFF
--- a/changelogs/fragments/win_package_chdir.yaml
+++ b/changelogs/fragments/win_package_chdir.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_package - added the ``chdir`` option to specify the working directory used when installing and uninstalling a package.

--- a/lib/ansible/modules/windows/win_package.ps1
+++ b/lib/ansible/modules/windows/win_package.ps1
@@ -357,7 +357,7 @@ if ($state -eq "absent") {
                 try {
                     $process_result = Run-Command @command_args
                 } catch {
-                    Fail-Json -obj $result -message "failed to run uninstall process ($command_args['command']): $($_.Exception.Message)"
+                    Fail-Json -obj $result -message "failed to run uninstall process ($($command_args['command'])): $($_.Exception.Message)"
                 }
 
                 if (($log_path -ne $null) -and (Test-Path -Path $log_path)) {
@@ -443,7 +443,7 @@ if ($state -eq "absent") {
                 try {
                     $process_result = Run-Command @command_args
                 } catch {
-                    Fail-Json -obj $result -message "failed to run install process ($command_args['command']): $($_.Exception.Message)"
+                    Fail-Json -obj $result -message "failed to run install process ($($command_args['command'])): $($_.Exception.Message)"
                 }
 
                 if (($log_path -ne $null) -and (Test-Path -Path $log_path)) {

--- a/lib/ansible/modules/windows/win_package.ps1
+++ b/lib/ansible/modules/windows/win_package.ps1
@@ -16,6 +16,7 @@ $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "b
 $arguments = Get-AnsibleParam -obj $params -name "arguments"
 $expected_return_code = Get-AnsibleParam -obj $params -name "expected_return_code" -type "list" -default @(0, 3010)
 $path = Get-AnsibleParam -obj $params -name "path" -type "str"
+$chdir = Get-AnsibleParam -obj $params -name "chdir" -type "path"
 $product_id = Get-AnsibleParam -obj $params -name "product_id" -type "str" -aliases "productid"
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "absent","present" -aliases "ensure"
 $username = Get-AnsibleParam -obj $params -name "username" -type "str" -aliases "user_name"
@@ -424,15 +425,20 @@ if ($state -eq "absent") {
             }
 
             if (-not $check_mode) {
-                $install_command = Argv-ToString -arguments $install_arguments
+                $command_args = @{
+                    command = Argv-ToString -arguments $install_arguments
+                }
                 if ($arguments -ne $null) {
-                    $install_command += " $arguments"
+                    $command_args['command'] += " $arguments"
+                }
+                if ($chdir) {
+                    $command_args['working_directory'] = $chdir
                 }
 
                 try {
-                    $process_result = Run-Command -command $install_command
+                    $process_result = Run-Command @command_args
                 } catch {
-                    Fail-Json -obj $result -message "failed to run install process ($install_command): $($_.Exception.Message)"
+                    Fail-Json -obj $result -message "failed to run install process ($command_args['command']): $($_.Exception.Message)"
                 }
 
                 if (($log_path -ne $null) -and (Test-Path -Path $log_path)) {

--- a/lib/ansible/modules/windows/win_package.ps1
+++ b/lib/ansible/modules/windows/win_package.ps1
@@ -344,15 +344,20 @@ if ($state -eq "absent") {
             }
 
             if (-not $check_mode) {
-                $uninstall_command = Argv-ToString -arguments $uninstall_arguments
+                $command_args = @{
+                    command = Argv-ToString -arguments $uninstall_arguments
+                }
                 if ($arguments -ne $null) {
-                    $uninstall_command += " $arguments"
+                    $command_args['command'] += " $arguments"
+                }
+                if ($chdir) {
+                    $command_args['working_directory'] = $chdir
                 }
 
                 try {
-                    $process_result = Run-Command -command $uninstall_command
+                    $process_result = Run-Command @command_args
                 } catch {
-                    Fail-Json -obj $result -message "failed to run uninstall process ($uninstall_command): $($_.Exception.Message)"
+                    Fail-Json -obj $result -message "failed to run uninstall process ($command_args['command']): $($_.Exception.Message)"
                 }
 
                 if (($log_path -ne $null) -and (Test-Path -Path $log_path)) {

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -32,6 +32,11 @@ options:
       module will escape the arguments as necessary, it is recommended to use a
       string when dealing with MSI packages due to the unique escaping issues
       with msiexec.
+  chdir:
+    description:
+    - Set the specified path as the current working directory before installing a package.
+    type: path
+    version_added: '2.8'
   creates_path:
     description:
     - Will check the existance of the path specified and use the result to

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -34,7 +34,8 @@ options:
       with msiexec.
   chdir:
     description:
-    - Set the specified path as the current working directory before installing a package.
+    - Set the specified path as the current working directory before installing
+      or uninstalling a package.
     type: path
     version_added: '2.8'
   creates_path:


### PR DESCRIPTION
##### SUMMARY
I had a package that used the current directory a instead of it's own directory and hung when it couldn't find its own files.

I had thought about making it default to use the package directory as working directory, but I didn't want to assume that this would suit everyone.

The method is taken from win_command.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_package

##### ANSIBLE VERSION
```
ansible 2.6.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ere-mid-sl/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```
