### PR TITLE
ec2_asg: Retry Autoscaling Group delete calls when scaling activity is in progress

### DIFF
--- a/changelogs/fragments/ec2_asg_retry_deletion_when_busy.yaml
+++ b/changelogs/fragments/ec2_asg_retry_deletion_when_busy.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Retry deleting the autoscaling group if there are scaling activities in progress.

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -523,7 +523,7 @@ def update_asg(connection, **params):
     connection.update_auto_scaling_group(**params)
 
 
-@AWSRetry.backoff(**backoff_params)
+@AWSRetry.backoff(catch_extra_error_codes=['ScalingActivityInProgress'], **backoff_params)
 def delete_asg(connection, asg_name, force_delete):
     connection.delete_auto_scaling_group(AutoScalingGroupName=asg_name, ForceDelete=force_delete)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Sometimes when deleting an ASG, the marker for "scaling activity" is eventually consistent and can cause deletes to fail. This change enables retry for deleting ASGs that are in the process of scaling. 


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
