### PR TITLE
skip installing linux-image-extra in CI as it shouldn't be needed (#46101)

### DIFF
--- a/test/integration/targets/setup_docker/tasks/Debian.yml
+++ b/test/integration/targets/setup_docker/tasks/Debian.yml
@@ -2,16 +2,6 @@
   shell: uname -r
   register: os_version
 
-- name: Install packages for Trusty
-  apt:
-    name: "{{ item }}"
-    state: present
-    update_cache: yes
-  with_items:
-  - "linux-image-extra-{{ os_version.stdout }}"
-  - linux-image-extra-virtual 
-  when: ansible_distribution_release == 'trusty'
-
 - name: Install pre-reqs
   apt:
     name: "{{ item }}"


### PR DESCRIPTION
(cherry picked from commit 40379b76b1dc76d7d32224fe1409fa4d4cb1a9af)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/46101

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
docker

##### ANSIBLE VERSION
```paste below
2.7
```