### PR TITLE
OpenShift and k8s inventory plugins: fix "resource field is not json serializable"

### DIFF
--- a/lib/ansible/plugins/inventory/openshift.py
+++ b/lib/ansible/plugins/inventory/openshift.py
@@ -159,8 +159,7 @@ class InventoryModule(K8sInventoryModule):
         self.inventory.add_child(namespace_group, namespace_routes_group)
         for route in obj.items:
             route_name = route.metadata.name
-            route_labels = {} if not route.metadata.labels else route.metadata.labels
-            route_annotations = {} if not route.metadata.annotations else route.metadata.annotations
+            route_annotations = {} if not route.metadata.annotations else dict(route.metadata.annotations)
 
             self.inventory.add_host(route_name)
 
@@ -170,6 +169,9 @@ class InventoryModule(K8sInventoryModule):
                     group_name = 'label_{0}_{1}'.format(key, value)
                     self.inventory.add_group(group_name)
                     self.inventory.add_child(group_name, route_name)
+                route_labels = dict(route.metadata.labels)
+            else:
+                route_labels = {}
 
             self.inventory.add_child(namespace_routes_group, route_name)
 
@@ -189,4 +191,4 @@ class InventoryModule(K8sInventoryModule):
                 self.inventory.set_variable(route_name, 'path', route.spec.path)
 
             if hasattr(route.spec.port, 'targetPort') and route.spec.port.targetPort:
-                self.inventory.set_variable(route_name, 'port', route.spec.port)
+                self.inventory.set_variable(route_name, 'port', dict(route.spec.port))


### PR DESCRIPTION
##### SUMMARY
**Note that this fix requires #45826 (first three commits come from #45826, last commit contains the fix)** #45826 should be merged first.

Fix `TypeError: Object of type 'ResourceField' is not JSON serializable`

Test command: `ANSIBLE_INVENTORY_ENABLED=openshift ansible-inventory -i test.yml --list -vvv`

```
$ cat test.yml
plugin: openshift
connections: []
```

Exception was:

* Python 3.6:

    ```
    ansible-inventory 2.8.0.dev0 (devel 05e3b5d632) last updated 2018/09/26 01:43:44 (GMT +200)
     config file = None
     configured module search path = ['$HOME/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
      ansible python module location = $HOME/ansible/lib/ansible
      executable location = $HOME/ansible/bin/ansible-inventory
      python version = 3.6.6+ (default, Sep  1 2018, 01:05:25) [GCC 8.2.0]
    No config file found; using defaults
    Parsed ansible/test.yml inventory source with openshift plugin
    ERROR! Unexpected Exception, this is probably a bug: Object of type 'ResourceField' is not JSON serializable
    the full traceback was:
    
    Traceback (most recent call last):
      File "ansible/bin/ansible-inventory", line 118, in <module>
        exit_code = cli.run()
      File "ansible/lib/ansible/cli/inventory.py", line 181, in run
        results = self.dump(results)
      File "ansible/lib/ansible/cli/inventory.py", line 199, in dump
        results = json.dumps(stuff, cls=AnsibleJSONEncoder, sort_keys=True, indent=4)
      File "/usr/lib/python3.6/json/__init__.py", line 238, in dumps
        **kw).encode(obj)
      File "/usr/lib/python3.6/json/encoder.py", line 201, in encode
        chunks = list(chunks)
      File "/usr/lib/python3.6/json/encoder.py", line 430, in _iterencode
        yield from _iterencode_dict(o, _current_indent_level)
      File "/usr/lib/python3.6/json/encoder.py", line 404, in _iterencode_dict
        yield from chunks
      File "/usr/lib/python3.6/json/encoder.py", line 404, in _iterencode_dict
        yield from chunks
      File "/usr/lib/python3.6/json/encoder.py", line 404, in _iterencode_dict
        yield from chunks
      File "/usr/lib/python3.6/json/encoder.py", line 437, in _iterencode
        o = _default(o)
      File "ansible/lib/ansible/parsing/ajson.py", line 66, in default
        value = super(AnsibleJSONEncoder, self).default(o)
      File "/usr/lib/python3.6/json/encoder.py", line 180, in default
        o.__class__.__name__)
    TypeError: Object of type 'ResourceField' is not JSON serializable
    ```

* Python 2.7
    ```
    ansible-inventory 2.8.0.dev0 (devel 05e3b5d632) last updated 2018/09/26 01:43:44 (GMT +200)
      config file = None
      configured module search path = [u'$HOME/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
      ansible python module location = $HOME/ansible/lib/ansible
      executable location = $HOME/ansible/bin/ansible-inventory
      python version = 2.7.14 (default, Sep 17 2017, 18:50:44) [GCC 7.2.0]
    No config file found; using defaults
    Parsed $HOME/ansible/test.yml inventory source with openshift plugin
    ERROR! Unexpected Exception, this is probably a bug: {u'openshift.io/build.name': u'ansiblemaint-apb-1',
     u'openshift.io/scc': u'privileged'} is not JSON serializable
    the full traceback was:
    
    Traceback (most recent call last):
      File "ansible/bin/ansible-inventory", line 118, in <module>
        exit_code = cli.run()
      File "ansible/lib/ansible/cli/inventory.py", line 181, in run
        results = self.dump(results)
      File "ansible/lib/ansible/cli/inventory.py", line 199, in dump
        results = json.dumps(stuff, cls=AnsibleJSONEncoder, sort_keys=True, indent=4)
      File "/usr/lib/python2.7/json/__init__.py", line 251, in dumps
        sort_keys=sort_keys, **kw).encode(obj)
      File "/usr/lib/python2.7/json/encoder.py", line 209, in encode
        chunks = list(chunks)
      File "/usr/lib/python2.7/json/encoder.py", line 434, in _iterencode
        for chunk in _iterencode_dict(o, _current_indent_level):
      File "/usr/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
        for chunk in chunks:
      File "/usr/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
        for chunk in chunks:
      File "/usr/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
        for chunk in chunks:
      File "/usr/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
        for chunk in chunks:
      File "/usr/lib/python2.7/json/encoder.py", line 442, in _iterencode
        o = _default(o)
      File "ansible/lib/ansible/parsing/ajson.py", line 66, in default
        value = super(AnsibleJSONEncoder, self).default(o)
      File "/usr/lib/python2.7/json/encoder.py", line 184, in default
        raise TypeError(repr(o) + " is not JSON serializable")
    TypeError: {u'openshift.io/build.name': u'ansiblemaint-apb-1',
     u'openshift.io/scc': u'privileged'} is not JSON serializable
    ```

Fixes #44408 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openshift and k8s inventory plugins

##### ANSIBLE VERSION
```paste below
2.8
```