### PR TITLE
Add support for OpenBSD to the (new) reboot module

### DIFF
--- a/changelogs/fragments/reboot_openbsd_support.yaml
+++ b/changelogs/fragments/reboot_openbsd_support.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - reboot - add support for OpenBSD

--- a/lib/ansible/modules/system/reboot.py
+++ b/lib/ansible/modules/system/reboot.py
@@ -20,7 +20,7 @@ options:
   pre_reboot_delay:
     description:
       - Seconds for shutdown to wait before requesting reboot.
-      - On Linux and macOS, this is converted to minutes and rounded down. If less than 60, it will be set to 0.
+      - On Linux, macOS and OpenBSD, this is converted to minutes and rounded down. If less than 60, it will be set to 0.
       - On Solaris and FreeBSD, this will be seconds.
     default: 0
     type: int

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -42,18 +42,24 @@ class ActionModule(ActionBase):
 
     DEPRECATED_ARGS = {}
 
+    BOOT_TIME_COMMANDS = {
+        'openbsd': "/sbin/sysctl kern.boottime",
+    }
+
     SHUTDOWN_COMMANDS = {
         'linux': DEFAULT_SHUTDOWN_COMMAND,
         'freebsd': DEFAULT_SHUTDOWN_COMMAND,
         'sunos': '/usr/sbin/shutdown',
         'darwin': '/sbin/shutdown',
+        'openbsd': DEFAULT_SHUTDOWN_COMMAND,
     }
 
     SHUTDOWN_COMMAND_ARGS = {
         'linux': '-r {delay_min} "{message}"',
         'freebsd': '-r +{delay_sec}s "{message}"',
         'sunos': '-y -g {delay_sec} -r "{message}"',
-        'darwin': '-r +{delay_min_macos} "{message}"'
+        'darwin': '-r +{delay_min_macos} "{message}"',
+        'openbsd': '-r +{delay_min} "{message}"',
     }
 
     def __init__(self, *args, **kwargs):
@@ -96,7 +102,13 @@ class ActionModule(ActionBase):
     def get_system_boot_time(self):
         stdout = u''
         stderr = u''
-        command_result = self._low_level_execute_command(self.DEFAULT_BOOT_TIME_COMMAND, sudoable=self.DEFAULT_SUDOABLE)
+
+        # Determine the system distribution in order to use the correct shutdown command arguments
+        uname_result = self._low_level_execute_command('uname')
+        distribution = uname_result['stdout'].strip().lower()
+
+        boot_time_command = self.BOOT_TIME_COMMANDS.get(distribution, self.DEFAULT_BOOT_TIME_COMMAND)
+        command_result = self._low_level_execute_command(boot_time_command, sudoable=self.DEFAULT_SUDOABLE)
 
         # For single board computers, e.g., Raspberry Pi, that lack a real time clock and are using fake-hwclock
         # launched by systemd, the update of utmp/wtmp is not done correctly.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I heard about the upcoming reboot module but it doesn't work on OpenBSD because of the commands it uses. This PR fixes this!

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

lack of support is a bug, right? ;)

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
reboot
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/danj/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/venv/ansible/lib/python2.7/site-packages/ansible
  executable location = /usr/local/venv/ansible/bin/ansible
  python version = 2.7.15 (default, Aug 27 2018, 10:53:50) [GCC 4.2.1 Compatible OpenBSD Clang 6.0.0 (tags/RELEASE_600/final)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before:
```paste below
odessa-root | FAILED! => {
    "changed": false, 
    "msg": "reboot: failed to get host boot time info, rc: 1, stdout: who: unknown option -- b\r\nusage: who [-HmqTu] [file]\r\n       who am i\r\ncat: /proc/sys/kernel/random/boot_id: No such file or directory\r\n, stderr: Shared connection to 10.20.20.10 closed.\r\nShared connection to 10.20.20.10 closed.\r\n", 
    "reboot": false
}
```
after:
```
odessa-root | CHANGED => {
    "changed": true, 
    "elapsed": 57, 
    "rebooted": true
}
```

I picked /sbin/sysctl kern.boottime because it seems to match the 'who -b' from Linux:
$ /sbin/sysctl kern.boottime
kern.boottime=Tue Sep 25 20:42:43 2018

On OpenBSD, shutdown -r time takes time in minutes, see the man for confirmation: https://man.openbsd.org/shutdown#r

Is there anything else you need? Can it goes into 2.7 please? :3

Thanks!