### PR TITLE
Docs: Keep the module index clean

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -689,7 +689,7 @@ def main():
             display.vv(key)
             display.vvvvv(pp.pformat(('record', record)))
             if record.get('doc', None):
-                short_desc = record['doc']['short_description']
+                short_desc = record['doc']['short_description'].rstrip('.')
                 if short_desc is None:
                     display.warning('short_description for %s is None' % key)
                     short_desc = ''

--- a/lib/ansible/parsing/plugin_docs.py
+++ b/lib/ansible/parsing/plugin_docs.py
@@ -103,6 +103,7 @@ def read_docstub(filename):
             capturing = True
             doc_stub.append(line)
 
-    data = AnsibleLoader(r"".join(doc_stub), file_name=filename).get_single_data()
+    short_description = r''.join(doc_stub).strip().rstrip('.')
+    data = AnsibleLoader(short_description, file_name=filename).get_single_data()
 
     return data


### PR DESCRIPTION
##### SUMMARY
A lot of modules have a short_description with a trailing dot even
though we don't want trailing dots in the index.

We could:
1. document this and hope contributors read it and remember it
2. create a CI test and report failure and ask it to be fixed
3. simply remove it when creating the document index

I chose option 3 so we don't have to learn contributors even more rules
for things that shouldn't matter.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
module docs index

##### ANSIBLE VERSION
v2.8