### PR TITLE
Changed django_manage to return changed as boolean consistently

### DIFF
--- a/lib/ansible/modules/web_infrastructure/django_manage.py
+++ b/lib/ansible/modules/web_infrastructure/django_manage.py
@@ -301,7 +301,7 @@ def main():
     if filt:
         filtered_output = list(filter(filt, lines))
         if len(filtered_output):
-            changed = filtered_output
+            changed = True
 
     module.exit_json(changed=changed, out=out, cmd=cmd, app_path=app_path, virtualenv=virtualenv,
                      settings=module.params['settings'], pythonpath=module.params['pythonpath'])


### PR DESCRIPTION
##### SUMMARY

I've changed the `django_manage` module to return a `bool` data type as `changed` result in accordance with other modules I looked at. I noticed this issue because ARA (https://github.com/openstack/ara/) fails to save the result otherwise.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
django_manage

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.4
  config file = None
  configured module search path = ['/home/florian/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/florian/.local/venvs/ansible/lib/python3.6/site-packages/ansible
  executable location = /home/florian/.local/bin/ansible
  python version = 3.6.6+ (default, Sep  1 2018, 01:05:25) [GCC 8.2.0]

```

