### PR TITLE
Fix lzma import (#44725)

### DIFF
--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -145,15 +145,11 @@ from traceback import format_exc
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible.module_utils.six import PY3
 
-if PY3:
-    try:
-        import lzma
-        HAS_LZMA = True
-    except ImportError:
-        HAS_LZMA = False
-else:
+try:
+    import lzma
+    HAS_LZMA = True
+except ImportError:
     try:
         from backports import lzma
         HAS_LZMA = True


### PR DESCRIPTION
Python 2.7 may have the lzma module, or it may need to use the backports.lzma
module, depending on the user setup. Test for features rather than Python
version.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
archive

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (devel 5803d73400) last updated 2018/09/26 16:07:31 (GMT +200)
  config file = None
  configured module search path = ['/home/cyril/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/ansible/lib/ansible
  executable location = /tmp/ansible/p/bin/ansible
  python version = 3.6.6+ (default, Sep  1 2018, 01:05:25) [GCC 8.2.0]
```

##### ADDITIONAL INFORMATION
None
