### PR TITLE
win_route - Added support for specifying network interface

### DIFF
--- a/lib/ansible/modules/windows/win_route.py
+++ b/lib/ansible/modules/windows/win_route.py
@@ -7,7 +7,7 @@
 # This is a windows documentation stub.  Actual code lives in the .ps1
 # file of the same name.
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
+ANSIBLE_METADATA = {'metadata_version': '1.2',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
@@ -32,6 +32,11 @@ options:
         - Metric used by the static route.
     type: int
     default: 1
+  interface:
+    description:
+        - The network interface name by the static route.
+    required: yes
+    version_added: '2.7'
   state:
     description:
       - If C(absent), it removes a network static route.
@@ -51,11 +56,13 @@ EXAMPLES = r'''
     destination: 192.168.2.10/32
     gateway: 192.168.1.1
     metric: 1
+    interface: Ethernet0
     state: present
 
 - name: Remove a network static route
   win_route:
     destination: 192.168.2.10/32
+    interface: Ethernet1
     state: absent
 '''
 RETURN = r'''

--- a/lib/ansible/modules/windows/win_route.py
+++ b/lib/ansible/modules/windows/win_route.py
@@ -7,7 +7,7 @@
 # This is a windows documentation stub.  Actual code lives in the .ps1
 # file of the same name.
 
-ANSIBLE_METADATA = {'metadata_version': '1.2',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
@@ -36,7 +36,7 @@ options:
     description:
         - The network interface name by the static route.
     required: yes
-    version_added: '2.7'
+    version_added: '2.8'
   state:
     description:
       - If C(absent), it removes a network static route.

--- a/test/integration/targets/win_route/defaults/main.yml
+++ b/test/integration/targets/win_route/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 default_gateway: 192.168.1.1
 destination_ip_address: 192.168.2.10
-interface_name: Ethernet0
+interface_name: "Ethernet 2"

--- a/test/integration/targets/win_route/defaults/main.yml
+++ b/test/integration/targets/win_route/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 default_gateway: 192.168.1.1
 destination_ip_address: 192.168.2.10
+interface_name: Ethernet0

--- a/test/integration/targets/win_route/tasks/tests.yml
+++ b/test/integration/targets/win_route/tasks/tests.yml
@@ -4,14 +4,15 @@
     destination: "{{ destination_ip_address }}/32"
     gateway: "{{ default_gateway }}"
     metric: 1
+    interface: "{{ interface_name }}"
     state: present
   register: route
 
-- name: check if route successfully addedd
+- name: check if route successfully added
   win_shell: (Get-CimInstance win32_ip4PersistedrouteTable -Filter "Destination = '{{ destination_ip_address }}'").Caption
   register: route_added
 
-- name: test if route successfully addedd
+- name: test if route successfully added
   assert:
     that:
       - route is changed
@@ -22,6 +23,7 @@
     destination: "{{ destination_ip_address }}/32"
     gateway: "{{ default_gateway }}"
     metric: 1
+    interface: "{{ interface_name }}"
     state: present
   register: idempotent_route
 
@@ -34,6 +36,7 @@
 - name: remove route
   win_route:
     destination: "{{ destination_ip_address }}/32"
+    interface: "{{ interface_name }}"
     state: absent
   register: route_removed
 
@@ -50,6 +53,7 @@
 - name: remove static route to test idempotency
   win_route:
     destination: "{{ destination_ip_address }}/32"
+    interface: "{{ interface_name }}"
     state: absent
   register: idempotent_route_removed
 
@@ -64,6 +68,7 @@
     destination: "715.18.0.0/32"
     gateway: "{{ default_gateway }}"
     metric: 1
+    interface: "{{ interface_name }}"
     state: present
   ignore_errors: yes
   register: wrong_ip


### PR DESCRIPTION
##### SUMMARY
Added interface parameter so users can select the specific interface used by the static route. The original method query and incorrectly retrieve the wrong interface, usually the default gateway. Thus rendering the module pointless. This fixes the issue and adds functionality.
Updated documentation also.

Fixes #28051

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_route

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
  config file = /home/shulme/.ansible.cfg
  configured module search path = [u'/home/shulme/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
