### PR TITLE
Handle dnf immutable mutable datatypes

### DIFF
--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -505,13 +505,26 @@ class DnfModule(YumDnf):
         # Set installroot
         conf.installroot = installroot
 
+        # Handle different DNF versions immutable mutable datatypes and
+        # dnf v1/v2/v3
+        #
+        # In DNF < 3.0 are lists, and modifying them works
+        # In DNF >= 3.0 < 3.6 are lists, but modifying them doesn't work
+        # In DNF >= 3.6 have been turned into tuples, to communicate that modifying them doesn't work
+        #
+        # https://www.happyassassin.net/2018/06/27/adams-debugging-adventures-the-immutable-mutable-object/
+        #
         # Set excludes
         if self.exclude:
-            conf.exclude(self.exclude)
-
+            _excludes = list(conf.exclude)
+            _excludes.extend(self.exclude)
+            conf.exclude = _excludes
         # Set disable_excludes
         if self.disable_excludes:
-            conf.disable_excludes.append(self.disable_excludes)
+            _disable_excludes = list(conf.disable_excludes)
+            if self.disable_excludes not in _disable_excludes:
+                _disable_excludes.append(self.disable_excludes)
+                conf.disable_excludes = _disable_excludes
 
         # Set releasever
         if self.releasever is not None:


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In DNF < 3.0 are lists, and modifying them works
In DNF >= 3.0 < 3.6 are lists, but modifying them doesn't work
In DNF >= 3.6 have been turned into tuples, to communicate that
modifying them doesn't work

Further explanation of this is available via Adam Williamson (@AdamWill) from the Fedora QA Team.

https://www.happyassassin.net/2018/06/27/adams-debugging-adventures-the-immutable-mutable-object/

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dnf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
$ ansible --version
ansible 2.8.0.dev0 (modules/dnf 79edc96ac9) last updated 2018/09/26 12:24:29 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```

