### PR TITLE
allow update_cache as stand alone operation for yum/dnf

### DIFF
--- a/changelogs/fragments/yumdnf-update-cache.yaml
+++ b/changelogs/fragments/yumdnf-update-cache.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "yum and dnf can now perform C(update_cache) as a standalone operation for consistency with other package manager modules"

--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -48,7 +48,7 @@ yumdnf_argument_spec = dict(
         lock_poll=dict(type='int', default=-1),
         lock_timeout=dict(type='int', default=10),
     ),
-    required_one_of=[['name', 'list']],
+    required_one_of=[['name', 'list', 'update_cache']],
     mutually_exclusive=[['name', 'list']],
     supports_check_mode=True,
 )

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -580,7 +580,7 @@ class DnfModule(YumDnf):
             base.fill_sack(load_system_repo='auto')
         except dnf.exceptions.RepoError as e:
             self.module.fail_json(
-                msg="{}".format(to_text(e)),
+                msg="{0}".format(to_text(e)),
                 results=[],
                 rc=1
             )
@@ -595,7 +595,7 @@ class DnfModule(YumDnf):
                 base.update_cache()
             except dnf.exceptions.RepoError as e:
                 self.module.fail_json(
-                    msg="{}".format(to_text(e)),
+                    msg="{0}".format(to_text(e)),
                     results=[],
                     rc=1
                 )

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -576,7 +576,14 @@ class DnfModule(YumDnf):
         base = dnf.Base()
         self._configure_base(base, conf_file, disable_gpg_check, installroot)
         self._specify_repositories(base, disablerepo, enablerepo)
-        base.fill_sack(load_system_repo='auto')
+        try:
+            base.fill_sack(load_system_repo='auto')
+        except dnf.exceptions.RepoError as e:
+            self.module.fail_json(
+                msg="{}".format(to_text(e)),
+                results=[],
+                rc=1
+            )
         if self.bugfix:
             key = {'advisory_type__eq': 'bugfix'}
             base._update_security_filters = [base.sack.query().filter(**key)]
@@ -584,7 +591,14 @@ class DnfModule(YumDnf):
             key = {'advisory_type__eq': 'security'}
             base._update_security_filters = [base.sack.query().filter(**key)]
         if self.update_cache:
-            base.update_cache()
+            try:
+                base.update_cache()
+            except dnf.exceptions.RepoError as e:
+                self.module.fail_json(
+                    msg="{}".format(to_text(e)),
+                    results=[],
+                    rc=1
+                )
         return base
 
     def list_items(self, command):
@@ -1040,6 +1054,18 @@ class DnfModule(YumDnf):
                     msg="Autoremove should be used alone or with state=absent",
                     results=[],
                 )
+
+        if self.update_cache and not self.names and not self.list:
+            self.base = self._base(
+                self.conf_file, self.disable_gpg_check, self.disablerepo,
+                self.enablerepo, self.installroot
+            )
+            self.module.exit_json(
+                msg="Cache updated",
+                changed=False,
+                results=[],
+                rc=0
+            )
 
         # Set state as installed by default
         # This is not set in AnsibleModule() because the following shouldn't happend

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1461,6 +1461,23 @@ class YumModule(YumDnf):
         if error_msgs:
             self.module.fail_json(msg='. '.join(error_msgs))
 
+        if self.update_cache and not self.names and not self.list:
+            rc, stdout, stderr = self.module.run_command(self.yum_basecmd + ['clean', 'expire-cache'])
+            if rc == 0:
+                self.module.exit_json(
+                    changed=False,
+                    msg="Cache updated",
+                    rc=rc,
+                    results=[]
+                )
+            else:
+                self.module.exit_json(
+                    changed=False,
+                    msg="Failed to update cache",
+                    rc=rc,
+                    results=[stderr],
+                )
+
         # fedora will redirect yum to dnf, which has incompatibilities
         # with how this module expects yum to operate. If yum-deprecated
         # is available, use that instead to emulate the old behaviors.


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
yum and dnf can now perform C(update_cache) as a standalone operation for consistency with other package manager modules

Fixes #40068
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum
dnf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
$ ansible --version
ansible 2.8.0.dev0 (features/40068-yumdnf-update-cache b822680c9d) last updated 2018/09/26 16:41:38 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


