### PR TITLE
Fixed typo in asa_config module again

### DIFF
--- a/lib/ansible/modules/network/asa/asa_config.py
+++ b/lib/ansible/modules/network/asa/asa_config.py
@@ -179,7 +179,7 @@ vars:
   register: bgp
   when: bgp_default_config is defined
 
-- name: configure ASA (>=9.2) BGP neighbor in default/singel context mode
+- name: configure ASA (>=9.2) BGP neighbor in default/single context mode
   asa_config:
     lines:
       - "bgp router-id {{ bgp_router_id }}"


### PR DESCRIPTION
<!--- Your description here -->

+label: docsite_pr

##### SUMMARY
Fixed typo in a networking module doc.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
2.8
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
