### PR TITLE
fix digitalocean inventory tags endpoint

### DIFF
--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -221,7 +221,7 @@ class DoManager:
         return resp['droplet']
 
     def all_tags(self):
-        resp = self.send('tags/')
+        resp = self.send('tags')
         return resp['tags']
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
the digitalocean inventory plugin uses URI ending with 'tags/' for tags discovery.

however, for tags this doesn't work:
```
$ curl -s -X GET -H "Content-Type: application/json" -H "Authorization: Bearer ${DO_API_TOKEN}" "https://api.digitalocean.com/v2/tags/"|jq
{
  "id": "not_found",
  "message": "The resource you were accessing could not be found."
}
```

(surprisingly it does work for droplets and some other DO resources)

however, as per DO API documentation, removing '/' from the tail of URI works:
```
$ curl -s -X GET -H "Content-Type: application/json" -H "Authorization: Bearer ${DO_API_TOKEN}" "https://api.digitalocean.com/v2/tags"|jq
{
...good response with tags...
}
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
contrib/inventory/digitalocean.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
(the issue is not relevant to ansible itself)
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
export DO_API_TOKEN=<your_digitalocean_token>
cd ansible/contrib/inventory
(make sure to remove cache! for some reason, --refresh-cache didn't work for me properly at some point)
python digital_ocean.py  --tags
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Traceback (most recent call last):
  File "digital_ocean.py", line 551, in <module>
    DigitalOceanInventory()
  File "digital_ocean.py", line 297, in __init__
    self.load_from_digital_ocean('tags')
  File "digital_ocean.py", line 426, in load_from_digital_ocean
    self.data['tags'] = self.manager.all_tags()
  File "digital_ocean.py", line 225, in all_tags
    return resp['tags']
KeyError: 'tags'
```