### PR TITLE
Correct invalid example in jenkins_script docs

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_script.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_script.py
@@ -72,7 +72,7 @@ EXAMPLES = '''
     password: admin
 
 - name: Setting master using a variable to hold a more complicate script
-  vars:
+  set_fact:
     setmaster_mode: |
         import jenkins.model.*
         instance = Jenkins.getInstance()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`jenkins_script` docs include invalid ansible syntax.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`jenkins_script` module.