### PR TITLE
[2.7] Fix sts_assume_role integration tests (#46026)

### DIFF
--- a/test/integration/targets/sts_assume_role/tasks/main.yml
+++ b/test/integration/targets/sts_assume_role/tasks/main.yml
@@ -290,14 +290,14 @@
       assert:
         that:
           - 'result.failed'
-          - "'Not authorized to perform sts:AssumeRole' in result.msg"
+          - "'Access denied' in result.msg"
       when: result.module_stderr is not defined
 
     - name: assert assume not existing sts role
       assert:
         that:
           - 'result.failed'
-          - "'Not authorized to perform sts:AssumeRole' in result.module_stderr"
+          - "'Access denied' in result.module_stderr"
       when: result.module_stderr is defined
 
     # ============================================================


### PR DESCRIPTION
* Fix the STS assume role error message assertion when the role to assume does not exist.

(cherry picked from commit 18dc928e28ae35bf9b786c8a48558ff83cc3a6a2)

##### SUMMARY
Backport #46026

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
