### PR TITLE
Specify region in IP facts

### DIFF
--- a/lib/ansible/modules/cloud/scaleway/scaleway_ip_facts.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_ip_facts.py
@@ -22,11 +22,23 @@ author:
   - "Yanis Guenane (@Spredzy)"
   - "Remy Leone (@sieben)"
 extends_documentation_fragment: scaleway
+options:
+  region:
+    version_added: "2.8"
+    description:
+     - Scaleway region to use (for example par1).
+    required: true
+    choices:
+      - ams1
+      - EMEA-NL-EVS
+      - par1
+      - EMEA-FR-PAR1
 '''
 
 EXAMPLES = r'''
 - name: Gather Scaleway ips facts
   scaleway_ip_facts:
+    region: par1
 '''
 
 RETURN = r'''
@@ -52,7 +64,10 @@ scaleway_ip_facts:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.scaleway import (
-    Scaleway, ScalewayException, scaleway_argument_spec
+    Scaleway,
+    ScalewayException,
+    scaleway_argument_spec,
+    SCALEWAY_LOCATION,
 )
 
 
@@ -62,10 +77,17 @@ class ScalewayIpFacts(Scaleway):
         super(ScalewayIpFacts, self).__init__(module)
         self.name = 'ips'
 
+        region = module.params["region"]
+        self.module.params['api_url'] = SCALEWAY_LOCATION[region]["api_endpoint"]
+
 
 def main():
+    argument_spec = scaleway_argument_spec()
+    argument_spec.update(dict(
+        region=dict(required=True, choices=SCALEWAY_LOCATION.keys()),
+    ))
     module = AnsibleModule(
-        argument_spec=scaleway_argument_spec(),
+        argument_spec=argument_spec,
         supports_check_mode=True,
     )
 

--- a/test/legacy/roles/scaleway_ip_facts/tasks/main.yml
+++ b/test/legacy/roles/scaleway_ip_facts/tasks/main.yml
@@ -1,5 +1,8 @@
+# SCW_API_KEY='XXX' ansible-playbook ./test/legacy/scaleway.yml --tags test_scaleway_ip_facts
+
 - name: Get ip informations and register it in a variable
   scaleway_ip_facts:
+    region: par1
   register: ips
 
 - name: Display ips variable
@@ -10,3 +13,17 @@
   assert:
     that:
       - ips is success
+
+- name: Get ip informations and register it in a variable
+  scaleway_ip_facts:
+    region: ams1
+  register: ips_ams1
+
+- name: Display ips variable
+  debug:
+    var: ips_ams1
+
+- name: Ensure retrieval of ips facts is success
+  assert:
+    that:
+      - ips_ams1 is success


### PR DESCRIPTION
##### SUMMARY

Specify region in IP facts

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- scaleway_ip_facts

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (region_ip_facts 253edd12df) last updated 2018/09/27 16:52:35 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```