### PR TITLE
Add region parameters to security groups facts

### DIFF
--- a/lib/ansible/modules/cloud/scaleway/scaleway_security_group_facts.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_security_group_facts.py
@@ -21,12 +21,24 @@ version_added: "2.7"
 author:
   - "Yanis Guenane (@Spredzy)"
   - "Remy Leone (@sieben)"
+options:
+  region:
+    version_added: "2.8"
+    description:
+     - Scaleway region to use (for example par1).
+    required: true
+    choices:
+      - ams1
+      - EMEA-NL-EVS
+      - par1
+      - EMEA-FR-PAR1
 extends_documentation_fragment: scaleway
 '''
 
 EXAMPLES = r'''
 - name: Gather Scaleway security groups facts
   scaleway_security_group_facts:
+    region: par1
 '''
 
 RETURN = r'''
@@ -56,7 +68,10 @@ scaleway_security_group_facts:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.scaleway import (
-    Scaleway, ScalewayException, scaleway_argument_spec
+    Scaleway,
+    ScalewayException,
+    scaleway_argument_spec,
+    SCALEWAY_LOCATION,
 )
 
 
@@ -66,10 +81,17 @@ class ScalewaySecurityGroupFacts(Scaleway):
         super(ScalewaySecurityGroupFacts, self).__init__(module)
         self.name = 'security_groups'
 
+        region = module.params["region"]
+        self.module.params['api_url'] = SCALEWAY_LOCATION[region]["api_endpoint"]
+
 
 def main():
+    argument_spec = scaleway_argument_spec()
+    argument_spec.update(dict(
+        region=dict(required=True, choices=SCALEWAY_LOCATION.keys()),
+    ))
     module = AnsibleModule(
-        argument_spec=scaleway_argument_spec(),
+        argument_spec=argument_spec,
         supports_check_mode=True,
     )
 

--- a/test/legacy/roles/scaleway_security_group_facts/tasks/main.yml
+++ b/test/legacy/roles/scaleway_security_group_facts/tasks/main.yml
@@ -1,5 +1,8 @@
+# SCW_API_KEY='XXX' ansible-playbook ./test/legacy/scaleway.yml --tags test_scaleway_security_group_facts
+
 - name: Get security group informations and register it in a variable
   scaleway_security_group_facts:
+    region: par1
   register: security_groups
 
 - name: Display security_groups variable
@@ -10,3 +13,17 @@
   assert:
     that:
       - security_groups is success
+
+- name: Get security group informations and register it in a variable (AMS1)
+  scaleway_security_group_facts:
+    region: ams1
+  register: ams1_security_groups
+
+- name: Display security_groups variable (AMS1)
+  debug:
+    var: ams1_security_groups
+
+- name: Ensure retrieval of security groups facts is success (AMS1)
+  assert:
+    that:
+      - ams1_security_groups is success


### PR DESCRIPTION
##### SUMMARY

Add region parameters to security groups facts

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- scaleway_security_group_facts

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (region_sg_facts c4c89518d9) last updated 2018/09/27 16:55:34 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```