### PR TITLE
Stable 2.5

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -302,7 +302,7 @@ Another option to loop control is ``pause``, which allows you to control the tim
       loop_control:
         pause: 3
 
-.. versionadded:: 2.7
+.. versionadded:: 2.5
 
 If you need to keep track of where you are in a loop, you can use the ``index_var`` option to loop control to specify a variable name to contain the current loop index.::
 


### PR DESCRIPTION
##### SUMMARY
The 2.5 branch of the documentation says that using a loop's `index_var` with `loop_control` is only available with Ansible 2.7 but it works with Ansible 2.5

The 2.6 and 2.7 branches correctly say 2.5.

Fixes #46222

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.5.1
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```