### PR TITLE
doc: index_var: fix version added (#37982)

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -302,7 +302,7 @@ Another option to loop control is ``pause``, which allows you to control the tim
       loop_control:
         pause: 3
 
-.. versionadded:: 2.7
+.. versionadded:: 2.5
 
 If you need to keep track of where you are in a loop, you can use the ``index_var`` option to loop control to specify a variable name to contain the current loop index.::
 


### PR DESCRIPTION
e9b0a4ccb42854329b33b06624379c6122b67bd7 is present since v2.5.0b1

(cherry picked from commit 2a604f6fe6555e6635c060a1934f5b4c92c35204)

##### SUMMARY
Corrects the `version_added` note for using `index_var` with `loop_control`.
Closes #46222 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.5
