### PR TITLE
[2.7] route53: fix CAA record ordering for idempotency

### DIFF
--- a/changelogs/fragments/46049-route53-caa-ordering.txt
+++ b/changelogs/fragments/46049-route53-caa-ordering.txt
@@ -1,0 +1,2 @@
+bugfixes:
+- "route53 - fix CAA record ordering for idempotency."


### PR DESCRIPTION
##### SUMMARY
Backport of #46049: fix CAA record ordering for idempotency in the route53 module.

Does not contain the integration tests added in #46049 per request of @ryansb.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
route53

##### ANSIBLE VERSION
```
2.7.0
```
