### PR TITLE
[AWS] Enable Route53 integration tests

### DIFF
--- a/test/integration/targets/route53/aliases
+++ b/test/integration/targets/route53/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-unsupported
+shippable/aws/group3

--- a/test/integration/targets/route53/aliases
+++ b/test/integration/targets/route53/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-shippable/aws/group3
+shippable/aws/group1

--- a/test/integration/targets/route53/tasks/main.yml
+++ b/test/integration/targets/route53/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# tasks file for Route53
+# tasks file for Route53 integration tests
 
 - set_fact:
     zone_one: '{{ resource_prefix | replace("-", "") }}.one.fakeansible.com.'
@@ -49,6 +49,68 @@
       that:
         - non_qdn is not failed
         - non_qdn is not changed
+
+  - name: Create a multi-value A record with values in different order
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'order_test.{{ zone_one }}'
+      type: A
+      value:
+        - 4.5.6.7
+        - 1.2.3.4
+    register: mv_a_record
+  - assert:
+      that:
+        - mv_a_record is not failed
+        - mv_a_record is changed
+
+  - name: Create same multi-value A record with values in different order
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'order_test.{{ zone_one }}'
+      type: A
+      value:
+        - 4.5.6.7
+        - 1.2.3.4
+    register: mv_a_record
+  - assert:
+      that:
+        - mv_a_record is not failed
+        - mv_a_record is not changed
+
+  - name: Remove a member from multi-value A record with values in different order
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'order_test.{{ zone_one }}'
+      type: A
+      value:
+        - 4.5.6.7
+    register: del_a_record
+    ignore_errors: true
+  - name: This should fail, because `overwrite` is false
+    assert:
+      that:
+        - del_a_record is failed
+
+  - name: Remove a member from multi-value A record with values in different order
+    route53:
+      state: present
+      zone: '{{ zone_one }}'
+      record: 'order_test.{{ zone_one }}'
+      overwrite: true
+      type: A
+      value:
+        - 4.5.6.7
+    register: del_a_record
+    ignore_errors: true
+  - name: This should fail, because `overwrite` is false
+    assert:
+      that:
+        - del_a_record is not failed
+        - del_a_record is changed
 
   - name: Create a LetsEncrypt CAA record
     route53:
@@ -129,7 +191,3 @@
     retries: 10
     until: delete_two is not failed
     when: false
-
-
-#TODO(ryansb) build internal-vpc integration tests
-#- include_tasks: internal_zone.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Enables tests introduced in https://github.com/ansible/ansible/pull/46049


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
