### PR TITLE
docker_container: require image if state is not absent

### DIFF
--- a/changelogs/fragments/46233-docker_container-image.yaml
+++ b/changelogs/fragments/46233-docker_container-image.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - ``image`` must be specified if ``state`` is not ``absent``."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -140,8 +140,8 @@ options:
     version_added: "2.2"
   image:
     description:
-      - Repository path and tag used to create the container. If an image is not found or pull is true, the image
-        will be pulled from the registry. If no tag is included, 'latest' will be used.
+      - Repository path and tag used to create the container. If an image is not found or C(pull) is
+        I(true), the image will be pulled from the registry. If no tag is included, 'latest' will be used.
       - Must be specified if C(state) is not I(absent).
   init:
     description:
@@ -339,25 +339,25 @@ options:
       - List of security options in the form of C("label:user:User")
   state:
     description:
-      - 'I(absent) - A container matching the specified name will be stopped and removed. Use force_kill to kill the container
-         rather than stopping it. Use keep_volumes to retain volumes associated with the removed container.'
+      - 'I(absent) - A container matching the specified name will be stopped and removed. Use C(force_kill) to kill the container
+         rather than stopping it. Use C(keep_volumes) to retain volumes associated with the removed container.'
       - 'I(present) - Asserts the existence of a container matching the name and any provided configuration parameters. If no
         container matches the name, a container will be created. If a container matches the name but the provided configuration
         does not match, the container will be updated, if it can be. If it cannot be updated, it will be removed and re-created
         with the requested config. Image version will be taken into account when comparing configuration. To ignore image
-        version use the ignore_image option. Use the recreate option to force the re-creation of the matching container. Use
-        force_kill to kill the container rather than stopping it. Use keep_volumes to retain volumes associated with a removed
+        version use the C(ignore_image) option. Use the C(recreate) option to force the re-creation of the matching container. Use
+        C(force_kill) to kill the container rather than stopping it. Use C(keep_volumes) to retain volumes associated with a removed
         container.'
       - 'I(started) - Asserts there is a running container matching the name and any provided configuration. If no container
         matches the name, a container will be created and started. If a container matching the name is found but the
         configuration does not match, the container will be updated, if it can be. If it cannot be updated, it will be removed
         and a new container will be created with the requested configuration and started. Image version will be taken into
-        account when comparing configuration. To ignore image version use the ignore_image option. Use recreate to always
-        re-create a matching container, even if it is running. Use restart to force a matching container to be stopped and
-        restarted. Use force_kill to kill a container rather than stopping it. Use keep_volumes to retain volumes associated
+        account when comparing configuration. To ignore image version use the C(ignore_image) option. Use C(recreate) to always
+        re-create a matching container, even if it is running. Use C(restart) to force a matching container to be stopped and
+        restarted. Use C(force_kill) to kill a container rather than stopping it. Use C(keep_volumes) to retain volumes associated
         with a removed container.'
       - 'I(stopped) - Asserts that the container is first I(present), and then if the container is running moves it to a stopped
-        state. Use force_kill to kill a container rather than stopping it.'
+        state. Use C(force_kill) to kill a container rather than stopping it.'
     default: started
     choices:
       - absent

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -142,6 +142,7 @@ options:
     description:
       - Repository path and tag used to create the container. If an image is not found or pull is true, the image
         will be pulled from the registry. If no tag is included, 'latest' will be used.
+      - Must be specified if C(state) is not I(absent).
   init:
     description:
       - Run an init inside the container that forwards signals and reaps processes.
@@ -2288,8 +2289,12 @@ def main():
         working_dir=dict(type='str'),
     )
 
+    # If state is not absent, image must be there since docker_container
+    # must be able to create the container.
     required_if = [
-        ('state', 'present', ['image'])
+        ('state', 'present', ['image']),
+        ('state', 'started', ['image']),
+        ('state', 'stopped', ['image']),
     ]
 
     client = AnsibleDockerClientContainer(

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -447,6 +447,7 @@
 
 - name: debug (start)
   docker_container:
+    image: alpine:3.8
     name: "{{ cname }}"
     state: started
     debug: yes

--- a/test/integration/targets/docker_container/tasks/tests/start-stop.yml
+++ b/test/integration/targets/docker_container/tasks/tests/start-stop.yml
@@ -57,6 +57,7 @@
 
 - name: Start container (check)
   docker_container:
+    image: alpine:3.8
     name: "{{ cname }}"
     state: started
   check_mode: yes
@@ -64,18 +65,21 @@
 
 - name: Start container
   docker_container:
+    image: alpine:3.8
     name: "{{ cname }}"
     state: started
   register: start_2
 
 - name: Start container (idempotent)
   docker_container:
+    image: alpine:3.8
     name: "{{ cname }}"
     state: started
   register: start_3
 
 - name: Start container (idempotent check)
   docker_container:
+    image: alpine:3.8
     name: "{{ cname }}"
     state: started
   check_mode: yes


### PR DESCRIPTION
##### SUMMARY
If `state` is not `absent`, `docker_container` needs to be able to recreate the container. For this, it needs to know `image`. If `image` is not given, strange errors will occur; see #21188.

Fixes #21188.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.7.0
```
