### PR TITLE
Use unicode instead of bytes in reboot plugin

### DIFF
--- a/changelogs/fragments/reboot-unicode-string.yaml
+++ b/changelogs/fragments/reboot-unicode-string.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - reboot - use unicode instead of bytes for stdout and stderr to match the
+    type returned from low_level_execute()

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -94,8 +94,8 @@ class ActionModule(ActionBase):
         return reboot_command
 
     def get_system_boot_time(self):
-        stdout = b''
-        stderr = b''
+        stdout = u''
+        stderr = u''
         command_result = self._low_level_execute_command(self.DEFAULT_BOOT_TIME_COMMAND, sudoable=self.DEFAULT_SUDOABLE)
 
         # For single board computers, e.g., Raspberry Pi, that lack a real time clock and are using fake-hwclock


### PR DESCRIPTION
##### SUMMARY

The stdout and stderr values returned from `self._low_level_execute()` are text, not bytes. This results in an error in Python 3 since `str` and `bytes` cannot be concatenated.

Changing to unicode allows this to work without error in Python 2 and Python 3.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
`reboot.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
2.7
```
