### PR TITLE
[stable-2.7] Update the minimum python versions to install (#46230)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -240,7 +240,7 @@ static_setup_params = dict(
     license='GPLv3+',
     # Ansible will also make use of a system copy of python-six and
     # python-selectors2 if installed but use a Bundled copy if it's not.
-    python_requires='>=2.6,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
     package_dir={'': 'lib'},
     packages=find_packages('lib'),
     package_data={
@@ -266,8 +266,9 @@ static_setup_params = dict(
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
         'Natural Language :: English',
         'Operating System :: POSIX',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
* Update the minimum python versions to install

This will prevent modern pip from installing ansible-2.7.x in
python-2.6.  Users will get the Ansible-2.6.x maintenance releases
instead.
(cherry picked from commit ccf41bb)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
setup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7.0
```
