### PR TITLE
Fix ec2_group for EC2-Classic accounts

### DIFF
--- a/changelogs/fragments/fix_ec2_group_vpc_precedence_classic.yaml
+++ b/changelogs/fragments/fix_ec2_group_vpc_precedence_classic.yaml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - The patch fixing the regression of no longer preferring matching security
+    groups in the same VPC https://github.com/ansible/ansible/pull/45787
+    (which was also backported to 2.6) broke EC2-Classic accounts.
+    https://github.com/ansible/ansible/pull/46242 removes the assumption that
+    security groups must be in a VPC.

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -856,7 +856,7 @@ def group_exists(client, module, vpc_id, group_id, name):
         groups = dict((group['GroupId'], group) for group in all_groups)
         groups.update(dict((group['GroupName'], group) for group in all_groups))
         if vpc_id:
-            vpc_wins = dict((group['GroupName'], group) for group in all_groups if group['VpcId'] == vpc_id)
+            vpc_wins = dict((group['GroupName'], group) for group in all_groups if group.get('VpcId') and group['VpcId'] == vpc_id)
             groups.update(vpc_wins)
         # maintain backwards compatibility by using the last matching group
         return security_groups[-1], groups


### PR DESCRIPTION
##### SUMMARY
EC2-Classic can have security groups with or without VPCs. I can't reproduce since I don't have a legacy account, but this seems straightforward to fix. The patch that introduced this was backported already to 2.6 so this needs to be backported as well. I'll add WIP to the 2.7 patch until this can be cherry-picked to that PR as well.

Fixes #46241

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ec2_group

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0
```