### PR TITLE
module/systemd: fix logic determining if a service needs to be enabled

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -443,7 +443,7 @@ def main():
                 enabled = True
             elif rc == 1:
                 # if not a user or global user service and both init script and unit file exist stdout should have enabled/disabled, otherwise use rc entries
-                if module.params['scope'] == 'system' and \
+                if module.params['scope'] in (None, 'system') and \
                         not module.params['user'] and \
                         is_initd and \
                         (not out.strip().endswith('disabled') or sysv_is_enabled(unit)):

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -446,7 +446,8 @@ def main():
                 if module.params['scope'] in (None, 'system') and \
                         not module.params['user'] and \
                         is_initd and \
-                        (not out.strip().endswith('disabled') or sysv_is_enabled(unit)):
+                        not out.strip().endswith('disabled') and \
+                        sysv_is_enabled(unit):
                     enabled = True
 
             # default to current state


### PR DESCRIPTION
##### SUMMARY

 Fix logic determining whether a service with both systemd and initd files is enabled or disabled.

In situations where systemd thinks service is disabled, but rc.d symlinks mark it as enabled,
this module wrongly assumes the service is enabled.

Fix this logic: disabled means disabled

Only when the output from does NOT include disabled, consider the status of rc.d symlinks.
This essentially replicates the fixes done to the systemd handling in the "service" module in 3c89a21e0c0

Fixes #22303

Fixes #44409

Fixes #39116

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
systemd

##### ANSIBLE VERSION
```
ansible 2.6.4
  config file = None
  configured module search path = [u'/Users/vlad/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.6.4/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
```
Manual setup for the test-case:
  systemctl disable postgresql ; mv /etc/rc5.d/K02postgresql /etc/rc5.d/S02postgresql
(Not sure how exactly it happens naturally - but it does happen on our LXC/LXD containers)

Before this change:
ansible -m service  -a 'name=postgresql enabled=yes'
responds with changed: False
After this change: 
responds with changed: True
```
