### PR TITLE
check SSL certs depending on FOREMAN_SSL_VERIFY

### DIFF
--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -107,7 +107,7 @@ class CallbackModule(CallbackBase):
         else:
             self._disable_plugin('The `requests` python module is not installed.')
 
-        if self.ssl_verify == True:
+        if self.ssl_verify:
             if self.FOREMAN_URL.startswith('https://'):
                 if not os.path.exists(self.FOREMAN_SSL_CERT[0]):
                     self._disable_plugin('FOREMAN_SSL_CERT %s not found.' % self.FOREMAN_SSL_CERT[0])

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -111,7 +111,7 @@ class CallbackModule(CallbackBase):
             if self.FOREMAN_URL.startswith('https://'):
                 if not os.path.exists(self.FOREMAN_SSL_CERT[0]):
                     self._disable_plugin('FOREMAN_SSL_CERT %s not found.' % self.FOREMAN_SSL_CERT[0])
-                
+
                 if not os.path.exists(self.FOREMAN_SSL_CERT[1]):
                     self._disable_plugin('FOREMAN_SSL_KEY %s not found.' % self.FOREMAN_SSL_CERT[1])
 

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -111,7 +111,7 @@ class CallbackModule(CallbackBase):
             if self.FOREMAN_URL.startswith('https://'):
                 if not os.path.exists(self.FOREMAN_SSL_CERT[0]):
                     self._disable_plugin('FOREMAN_SSL_CERT %s not found.' % self.FOREMAN_SSL_CERT[0])
-                 
+                
                 if not os.path.exists(self.FOREMAN_SSL_CERT[1]):
                     self._disable_plugin('FOREMAN_SSL_KEY %s not found.' % self.FOREMAN_SSL_CERT[1])
 

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -107,12 +107,13 @@ class CallbackModule(CallbackBase):
         else:
             self._disable_plugin('The `requests` python module is not installed.')
 
-        if self.FOREMAN_URL.startswith('https://'):
-            if not os.path.exists(self.FOREMAN_SSL_CERT[0]):
-                self._disable_plugin('FOREMAN_SSL_CERT %s not found.' % self.FOREMAN_SSL_CERT[0])
-
-            if not os.path.exists(self.FOREMAN_SSL_CERT[1]):
-                self._disable_plugin('FOREMAN_SSL_KEY %s not found.' % self.FOREMAN_SSL_CERT[1])
+        if self.ssl_verify == True:
+            if self.FOREMAN_URL.startswith('https://'):
+                if not os.path.exists(self.FOREMAN_SSL_CERT[0]):
+                    self._disable_plugin('FOREMAN_SSL_CERT %s not found.' % self.FOREMAN_SSL_CERT[0])
+                 
+                if not os.path.exists(self.FOREMAN_SSL_CERT[1]):
+                    self._disable_plugin('FOREMAN_SSL_KEY %s not found.' % self.FOREMAN_SSL_CERT[1])
 
     def _disable_plugin(self, msg):
         self.disabled = True


### PR DESCRIPTION
##### SUMMARY
Foreman callback plugin is getting disabled even after FOREMAN_SSL_VERIFY variable is set
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible/plugins/callback/foreman.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.3
  config file = /opt/ansible/2.6.3/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/2.6.3/lib/python2.7/site-packages/ansible
  executable location = /opt/ansible/2.6.3/bin/ansible
  python version = 2.7.14 (default, Dec  4 2017, 20:10:15) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```
