### PR TITLE
[Backport-2.7] VMware: honor "wait_for_ip_address" when powering on a VM

### DIFF
--- a/changelogs/fragments/45226-vmware_wait_for_ip_address.yaml
+++ b/changelogs/fragments/45226-vmware_wait_for_ip_address.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware - honor "wait_for_ip_address" when powering on a VM

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -557,7 +557,7 @@ from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.vmware import (find_obj, gather_vm_facts, get_all_objs,
                                          compile_folder_path_for_object, serialize_spec,
                                          vmware_argument_spec, set_vm_power_state, PyVmomi,
-                                         find_dvs_by_name, find_dvspg_by_name)
+                                         find_dvs_by_name, find_dvspg_by_name, wait_for_vm_ip)
 
 
 class PyVmomiDeviceHelper(object):
@@ -2389,6 +2389,11 @@ def main():
             tmp_result = set_vm_power_state(pyv.content, vm, module.params['state'], module.params['force'], module.params['state_change_timeout'])
             if tmp_result['changed']:
                 result["changed"] = True
+                if module.params['state'] in ['poweredon', 'restarted', 'rebootguest'] and module.params['wait_for_ip_address']:
+                    wait_result = wait_for_vm_ip(pyv.content, vm)
+                    if not wait_result:
+                        module.fail_json(msg='Waiting for IP address timed out')
+                    tmp_result['instance'] = wait_result
             if not tmp_result["failed"]:
                 result["failed"] = False
             result['instance'] = tmp_result['instance']


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Harald Albers <github@albersweb.de>
(cherry picked from commit a9c829bdf2fcf3dc9f32c9587f61890d23fe8e7a)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/45226-vmware_wait_for_ip_address.yaml
lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
Stable-2.7
```