### PR TITLE
fix wording for silencing a sensu client

### DIFF
--- a/lib/ansible/modules/monitoring/sensu_silence.py
+++ b/lib/ansible/modules/monitoring/sensu_silence.py
@@ -50,7 +50,7 @@ options:
   subscription:
     description:
       - Specifies the subscription which the silence entry applies to.
-      - To create a silence entry for a client append C(client:) to client name.
+      - To create a silence entry for a client prepend C(client:) to client name.
         Example - C(client:server1.example.dev)
     required: true
     default: []


### PR DESCRIPTION
##### SUMMARY
Tiny tiny tiny change: currently says to append `client:` to subscription to silence a client, when it should be prepended

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
sensu_silence.py

##### ANSIBLE VERSION
```
ansible 2.6.4
  config file = None
  configured module search path = [u'/Users/buckleyd/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/buckleyd/.virtualenvs/ansible_devel/lib/python2.7/site-packages/ansible
  executable location = /Users/buckleyd/.virtualenvs/ansible_devel/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```
