### PR TITLE
Remove extra parameter in format_exc

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -995,7 +995,7 @@ class AzureRMAuth(object):
                 try:
                     self._cloud_environment = azure_cloud.get_cloud_from_metadata_endpoint(raw_cloud_env)
                 except Exception as e:
-                    self.fail("cloud_environment {0} could not be resolved: {1}".format(raw_cloud_env, e.message), exception=traceback.format_exc(e))
+                    self.fail("cloud_environment {0} could not be resolved: {1}".format(raw_cloud_env, e.message), exception=traceback.format_exc())
 
         if self.credentials.get('subscription_id', None) is None and self.credentials.get('credentials') is None:
             self.fail("Credentials did not include a subscription_id value.")

--- a/lib/ansible/modules/cloud/amazon/dynamodb_table.py
+++ b/lib/ansible/modules/cloud/amazon/dynamodb_table.py
@@ -459,7 +459,7 @@ def main():
                 module.fail_json(msg='boto3 connection does not have tag_resource(), likely due to using an old version')
             boto3_sts = boto3_conn(module, conn_type='client', resource='sts', region=region, endpoint=ec2_url, **aws_connect_kwargs)
         except botocore.exceptions.NoCredentialsError as e:
-            module.fail_json(msg='cannot connect to AWS', exception=traceback.format_exc(e))
+            module.fail_json(msg='cannot connect to AWS', exception=traceback.format_exc())
     else:
         boto3_dynamodb = None
         boto3_sts = None

--- a/lib/ansible/modules/cloud/amazon/execute_lambda.py
+++ b/lib/ansible/modules/cloud/amazon/execute_lambda.py
@@ -237,7 +237,7 @@ def main():
                          exception=traceback.format_exc())
     except botocore.exceptions.ParamValidationError as ve:
         module.fail_json(msg="Parameters to `invoke` failed to validate",
-                         exception=traceback.format_exc(ve))
+                         exception=traceback.format_exc())
     except Exception as e:
         module.fail_json(msg="Unexpected failure while invoking Lambda function",
                          exception=traceback.format_exc())


### PR DESCRIPTION
##### SUMMARY
`traceback.format_exc()` does not take any argument, this fix remove
such occurances.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/azure_rm_common.py
lib/ansible/modules/cloud/amazon/dynamodb_table.py
lib/ansible/modules/cloud/amazon/execute_lambda.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8-devel
```