### PR TITLE
AWS: check dbname attribute before accessing

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -716,8 +716,7 @@ class RDSDBInstance:
             d["endpoint"] = None
             d["port"] = None
             d["vpc_security_groups"] = None
-        if self.instance.DBName:
-            d['DBName'] = self.instance.DBName
+        d['DBName'] = self.instance.DBName if hasattr(self.instance, 'DBName') else None
         # ReadReplicaSourceDBInstanceIdentifier may or may not exist
         try:
             d["replication_source"] = self.instance.ReadReplicaSourceDBInstanceIdentifier
@@ -810,8 +809,7 @@ class RDS2DBInstance:
         else:
             d['endpoint'] = None
             d['port'] = None
-        if self.instance["DBName"]:
-            d['DBName'] = self.instance['DBName']
+        d['DBName'] = self.instance['DBName'] if hasattr(self.instance, 'DBName') else None
         return d
 
 


### PR DESCRIPTION
##### SUMMARY
Check dbname attribute in instance before accessing it in RDS module

Fixes: #38210

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/rds.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8-devel
```