### PR TITLE
Update playbooks_delegation.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_delegation.rst
+++ b/docs/docsite/rst/user_guide/playbooks_delegation.rst
@@ -195,7 +195,7 @@ The directive `delegate_facts` may be set to `True` to assign the task's gathere
           loop: "{{groups['dbservers']}}"
 
 The above will gather facts for the machines in the dbservers group and assign the facts to those machines and not to app_servers.
-This way you can lookup `hostvars['dbhost1']['default_ipv4']['address']` even though dbservers were not part of the play, or left out by using `--limit`.
+This way you can lookup `hostvars['dbhost1']['ansible_default_ipv4']['address']` even though dbservers were not part of the play, or left out by using `--limit`.
 
 
 .. _run_once:


### PR DESCRIPTION
Fix example variable lookup.

+label: docsite_pr

##### SUMMARY
Small error in the docs. 
Using the code based on the example got me: 
```
"AnsibleUndefinedVariable: 'dict object' has no attribute 'default_ipv4'"
```

I fixed it.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
playbooks_delegation.rst

##### ANSIBLE VERSION

```paste below
devel
```