### PR TITLE
Feature/reverse combine filter

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -283,11 +283,15 @@ def mandatory(a):
 
 def combine(*terms, **kwargs):
     recursive = kwargs.get('recursive', False)
-    if len(kwargs) > 1 or (len(kwargs) == 1 and 'recursive' not in kwargs):
-        raise AnsibleFilterError("'recursive' is the only valid keyword argument")
+    reverse = kwargs.get('reverse', False)
+
+    for key in kwargs:
+        if key not in ('recursive', 'reverse'):
+            raise AnsibleFilterError(
+                "recursive and reverse are the only valid keyword arguments")
 
     dicts = []
-    for t in terms:
+    for t in (terms[::-1] if reverse else terms):
         if isinstance(t, MutableMapping):
             dicts.append(t)
         elif isinstance(t, list):

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -131,6 +131,13 @@
     that:
       - "users | json_query('[*].hosts[].host') == ['host_a', 'host_b', 'host_c', 'host_d']"
 
+- name: Test combine filter
+  assert:
+    that:
+      - "{{ {'a':1, 'b':2} | combine({'b':3}) == {'a':1, 'b':3} }}"
+      - "{{ {'b':3} | combine({'a':1, 'b':2}) == {'a':1, 'b':2} }}"
+      - "{{ {'a':{'foo':1, 'bar':2}, 'b':2} | combine({'a':{'bar':3, 'baz':4}}, recursive=True) == {'a':{'foo':1, 'bar':3, 'baz':4}, 'b':2} }}"
+
 - name: Test hash filter
   assert:
     that:

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -137,6 +137,7 @@
       - "{{ {'a':1, 'b':2} | combine({'b':3}) == {'a':1, 'b':3} }}"
       - "{{ {'b':3} | combine({'a':1, 'b':2}) == {'a':1, 'b':2} }}"
       - "{{ {'a':{'foo':1, 'bar':2}, 'b':2} | combine({'a':{'bar':3, 'baz':4}}, recursive=True) == {'a':{'foo':1, 'bar':3, 'baz':4}, 'b':2} }}"
+      - "{{ {'a':1, 'b':2} | combine({'b':3}) }} == {{ {'b':3} | combine({'a':1, 'b':2}, reverse=True) }}"
 
 - name: Test hash filter
   assert:


### PR DESCRIPTION
##### SUMMARY

Add a `reverse` flag to the `combine`-filter for merging dicts in reverse order.

Fixes #46215

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

No idea

##### ANSIBLE VERSION

```paste below
ansible 2.8.0.dev0 (feature/reverse-combine-filter e4950f5d84) last updated 2018/09/28 14:05:01 (GMT +200)
  config file = /home/mattiasb/.ansible.cfg
  configured module search path = [u'/home/mattiasb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mattiasb/Code/github.com/ansible/ansible/lib/ansible
  executable location = /home/mattiasb/Code/github.com/ansible/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```

##### ADDITIONAL INFORMATION

One common pattern that I return to when constructing Ansible roles is to have some variables for the role described (with defaults) in `defaults/main.yml` and then apply some defaults or transformations to that data inside `vars/main.yml` (prefixing the variable with `_` to make it clear that the variable is internal and manipulated).

**Example:**
*defaults/main.yml*
```yaml
# A list of objects containing a name and optionally an 
# admin boolean and a list of databases it can write to
db_users: []
```
*vars/main.yml*:
```yaml
_db_user_defaults:
  admin: false
  databases: []

_db_users: >-
  {%- result=[] -%}
  {%- for user in db_users -%}
  {%-     result.append(_db_user_defaults | combine(user)) -%}
  {%- endfor -%}
  {{ result | to_json | from_json }}
```

This allows me to define my variables in my inventory like this:

*inventory/development/group_vars/database/vars.yml*
```yaml
db_users:
  - name: charles
    databases:
      - sales
      - marketing
  - name: nina
  - name: root
    admin: true
```
…while not having to put lots of `default`-filters in my task files.

Now to my problem. See the `_db_users` definition above. If I could reverse the merge-order of combine I could define it like this instead:

*vars/main.yml*:
```yaml
_db_user_defaults:
  admin: false
  databases: []

_db_users: >-
  {{ db_users | map('combine', _db_user_defaults, reverse=True) | list }}
```
Which reads *a lot* nicer.
