### PR TITLE
VMware: Add check mode support to module vmware_host_acceptance

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_acceptance.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_acceptance.py
@@ -17,9 +17,10 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = r'''
 ---
 module: vmware_host_acceptance
-short_description: Manage acceptance level of ESXi host
+short_description: Manage the host acceptance level of an ESXi host
 description:
-- This module can be used to manage acceptance level of an ESXi host.
+- This module can be used to manage the host acceptance level of an ESXi host.
+- The host acceptance level controls the acceptance level of each VIB on a ESXi host.
 version_added: '2.5'
 author:
 - Abhijeet Kasurde (@Akasurde)

--- a/test/integration/targets/vmware_host_acceptance/tasks/main.yml
+++ b/test/integration/targets/vmware_host_acceptance/tasks/main.yml
@@ -61,3 +61,21 @@
 - assert:
     that:
       - host_acceptance_facts.facts is defined
+
+- name: Change acceptance level of given hosts in check mode
+  vmware_host_acceptance:
+    hostname: "{{ vcsim }}"
+    username: "{{ user }}"
+    password: "{{ passwd }}"
+    esxi_hostname: "{{ host1 }}"
+    validate_certs: no
+    acceptance_level: vmware_certified
+    state: present
+  register: host_acceptance_facts_check_mode
+  check_mode: yes
+
+- debug: var=host_acceptance_facts_check_mode
+
+- assert:
+    that:
+      - host_acceptance_facts_check_mode.facts is defined


### PR DESCRIPTION
##### SUMMARY
The module doesn't execute in check mode and you cannot see if the acceptance level needs to be changed.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_acceptance

##### ANSIBLE VERSION
```
# ansible --version
ansible 2.6.3
  config file = /root/ansible-vmware/ansible.cfg
  configured module search path = [u'/root/ansible-vmware/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
before:
```
TASK [esxi : Configure Host Image Profile Acceptance Level] 
```
after:
```
TASK [esxi : Configure Host Image Profile Acceptance Level] *************************************************************************************************************************************************************
changed: [esxi_host -> jump_server] => {"changed": true, "facts": {"esxi_host": {"error": "NA", "level": "community"}}}
```
