### PR TITLE
VMware: Improve module vmware_host_config_manager

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py
@@ -16,9 +16,9 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = r'''
 ---
 module: vmware_host_config_manager
-short_description: Manage advance configurations about an ESXi host
+short_description: Manage advanced system settings of an ESXi host
 description:
-- This module can be used to manage advance configuration information about an ESXi host when ESXi hostname or Cluster name is given.
+- This module can be used to manage advanced system settings of an ESXi host when ESXi hostname or Cluster name is given.
 version_added: '2.5'
 author:
 - Abhijeet Kasurde (@Akasurde)
@@ -31,23 +31,23 @@ options:
   cluster_name:
     description:
     - Name of the cluster.
-    - Settings are applied to every ESXi host system in given cluster.
+    - Settings are applied to every ESXi host in given cluster.
     - If C(esxi_hostname) is not given, this parameter is required.
   esxi_hostname:
     description:
     - ESXi hostname.
-    - Settings are applied to this ESXi host system.
+    - Settings are applied to this ESXi host.
     - If C(cluster_name) is not given, this parameter is required.
   options:
     description:
-    - A dictionary of advance configuration parameters.
+    - A dictionary of advanced system settings.
     - Invalid options will cause module to error.
     default: {}
 extends_documentation_fragment: vmware.documentation
 '''
 
 EXAMPLES = r'''
-- name: Manage Log level setting for all ESXi Host in given Cluster
+- name: Manage Log level setting for all ESXi hosts in given Cluster
   vmware_host_config_manager:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
@@ -57,7 +57,7 @@ EXAMPLES = r'''
         'Config.HostAgent.log.level': 'info'
   delegate_to: localhost
 
-- name: Manage Log level setting for an ESXi Host
+- name: Manage Log level setting for an ESXi host
   vmware_host_config_manager:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
@@ -67,7 +67,7 @@ EXAMPLES = r'''
         'Config.HostAgent.log.level': 'verbose'
   delegate_to: localhost
 
-- name: Manage multiple settings for an ESXi Host
+- name: Manage multiple settings for an ESXi host
   vmware_host_config_manager:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'

--- a/test/integration/targets/vmware_host_config_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_config_manager/tasks/main.yml
@@ -86,3 +86,37 @@
   assert:
     that:
         - all_hosts_result.changed
+
+- name: Change facts about all hosts in given cluster in check mode
+  vmware_host_config_manager:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    cluster_name: "{{ ccr1 }}"
+    options:
+      'Config.HostAgent.log.level': 'verbose'
+    validate_certs: no
+  register: all_hosts_result_check_mode
+  check_mode: yes
+
+- name: ensure changes are done to all hosts
+  assert:
+    that:
+        - all_hosts_result_check_mode.changed
+
+- name: Change facts about a given host in check mode
+  vmware_host_config_manager:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    esxi_hostname: "{{ host1 }}"
+    options:
+      'Config.HostAgent.log.level': 'info'
+    validate_certs: no
+  register: host_result_check_mode
+  check_mode: yes
+
+- name: ensure changes are done to given hosts
+  assert:
+    that:
+        - all_hosts_result_check_mode.changed


### PR DESCRIPTION
##### SUMMARY
The module doesn't execute in check mode and you cannot see if the settings need to be changed. You also cannot see which settings were changed or need to be changed if you run the play in verbose mode.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_config_manager

##### ANSIBLE VERSION
```
# ansible --version
ansible 2.6.3
  config file = /root/ansible-vmware/ansible.cfg
  configured module search path = [u'/root/ansible-vmware/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
before (check mode):
TASK [esxi : Configure persistent logs (Syslog)] *********************************************************************************************************************************************************************************************
before:
```
TASK [esxi : Configure persistent logs (Syslog)] *********************************************************************************************************************************************************************************************
changed: [esxi_host -> jump_server] => {"changed"}
```
after (check mode):
```
TASK [esxi : Configure persistent logs (Syslog)] *********************************************************************************************************************************************************************************************
changed: [esxi_host -> jump_server] => {"changed": true, "msg": "Syslog.global.logDirUnique, Syslog.global.defaultRotate, and Syslog.global.defaultSize would be changed."}
```
after:
```
TASK [esxi : Configure persistent logs (Syslog)] *********************************************************************************************************************************************************************************************
changed: [esxi_host -> jump_server] => {"changed": true, "msg": "Syslog.global.logDirUnique, Syslog.global.defaultRotate, and Syslog.global.defaultSize changed."}
```
