### PR TITLE
VMware: Add check mode support to module vmware_host_firewall_facts

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_firewall_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_firewall_facts.py
@@ -143,7 +143,8 @@ def main():
         argument_spec=argument_spec,
         required_one_of=[
             ['cluster_name', 'esxi_hostname'],
-        ]
+        ],
+        supports_check_mode=True
     )
 
     vmware_host_firewall = FirewallFactsManager(module)

--- a/test/integration/targets/vmware_host_firewall_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_firewall_facts/tasks/main.yml
@@ -80,3 +80,33 @@
     that:
       - "not firewall_0002_results.changed"
       - "firewall_0002_results.hosts_firewall_facts is defined"
+
+- name: Gather firewall facts for all ESXi host from given cluster in check mode
+  vmware_host_firewall_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    cluster_name: "{{ ccr1 }}"
+  register: firewall_0003_results
+  check_mode: yes
+
+- assert:
+    that:
+      - "not firewall_0003_results.changed"
+      - "firewall_0003_results.hosts_firewall_facts is defined"
+
+- name: Gather firewall facts for ESXi host in check mode
+  vmware_host_firewall_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    esxi_hostname: "{{ host1 }}"
+  register: firewall_0004_results
+  check_mode: yes
+
+- assert:
+    that:
+      - "not firewall_0004_results.changed"
+      - "firewall_0004_results.hosts_firewall_facts is defined"


### PR DESCRIPTION
##### SUMMARY
The module doesn't execute in check mode. Now it has the same behavior as the vmware_host_facts module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_firewall_facts

##### ANSIBLE VERSION
```
# ansible --version
ansible 2.6.3
  config file = /root/ansible-vmware/ansible.cfg
  configured module search path = [u'/root/ansible-vmware/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
before:
```
TASK [esxi : Gather host firewall facts] *****************************************************************************************************************************************************************************************************
```
after:
```
TASK [esxi : Gather host firewall facts] *****************************************************************************************************************************************************************************************************
ok: [esxi_host -> jump_server] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
```