### PR TITLE
VMware: Add check mode support to module vmware_host_firewall_manager

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
@@ -170,10 +170,11 @@ class VmwareFirewallManager(PyVmomi):
                 current_rule_state = self.firewall_facts[host.name][rule_name]['enabled']
                 if current_rule_state != rule_enabled:
                     try:
-                        if rule_enabled:
-                            firewall_system.EnableRuleset(id=rule_name)
-                        else:
-                            firewall_system.DisableRuleset(id=rule_name)
+                        if not self.module.check_mode:
+                            if rule_enabled:
+                                firewall_system.EnableRuleset(id=rule_name)
+                            else:
+                                firewall_system.DisableRuleset(id=rule_name)
                         fw_change_list.append(True)
                     except vim.fault.NotFound as not_found:
                         self.module.fail_json(msg="Failed to enable rule set %s as"
@@ -206,7 +207,8 @@ def main():
         argument_spec=argument_spec,
         required_one_of=[
             ['cluster_name', 'esxi_hostname'],
-        ]
+        ],
+        supports_check_mode=True
     )
 
     vmware_firewall_manager = VmwareFirewallManager(module)

--- a/lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
@@ -13,7 +13,7 @@ ANSIBLE_METADATA = {
     'supported_by': 'community'
 }
 
-DOCUMENTATION = r'''
+DOCUMENTATION = '''
 ---
 module: vmware_host_firewall_manager
 short_description: Manage firewall configurations about an ESXi host

--- a/test/integration/targets/vmware_host_firewall_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_firewall_manager/tasks/main.yml
@@ -84,7 +84,6 @@
     - DC0_C0_H1
     - DC0_C0_H2
 
-
 - name: Disable vvold for {{ host1 }}
   vmware_host_firewall_manager:
     hostname: "{{ vcsim }}"
@@ -111,5 +110,67 @@
         - host_result.rule_set_state[item]['vvold']['current_state'] == False
         - host_result.rule_set_state[item]['vvold']['desired_state'] == False
         - host_result.rule_set_state[item]['vvold']['previous_state'] == True
+  with_items:
+    - "{{ host1 }}"
+
+- name: Enable vvold rule set on all hosts of {{ ccr1 }} in check mode
+  vmware_host_firewall_manager:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    cluster_name: "{{ ccr1 }}"
+    rules:
+      - name: vvold
+        enabled: True
+  register: all_hosts_result_check_mode
+  check_mode: yes
+
+- debug: msg="{{ all_hosts_result_check_mode }}"
+
+- name: ensure everything is changed for all hosts of {{ ccr1 }}
+  assert:
+    that:
+        - all_hosts_result_check_mode.changed
+        - all_hosts_result_check_mode.rule_set_state is defined
+
+- name: ensure facts are gathered for all hosts of {{ ccr1 }}
+  assert:
+    that:
+        - all_hosts_result_check_mode.rule_set_state[item]['vvold']['current_state'] == True
+        - all_hosts_result_check_mode.rule_set_state[item]['vvold']['desired_state'] == True
+        - all_hosts_result_check_mode.rule_set_state[item]['vvold']['previous_state'] == False
+  with_items:
+    - DC0_C0_H0
+    - DC0_C0_H1
+    - DC0_C0_H2
+
+- name: Disable vvold for {{ host1 }} in check mode
+  vmware_host_firewall_manager:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    esxi_hostname: "{{ host1 }}"
+    rules:
+      - name: vvold
+        enabled: False
+  register: host_result_check_mode
+  check_mode: yes
+
+- debug: msg="{{ host_result_check_mode }}"
+
+- name: ensure vvold is disabled for {{ host1 }}
+  assert:
+    that:
+        - host_result_check_mode.changed == False
+        - host_result_check_mode.rule_set_state is defined
+
+- name: ensure facts are gathered for {{ host1 }}
+  assert:
+    that:
+        - host_result_check_mode.rule_set_state[item]['vvold']['current_state'] == False
+        - host_result_check_mode.rule_set_state[item]['vvold']['desired_state'] == False
+        - host_result_check_mode.rule_set_state[item]['vvold']['previous_state'] == False
   with_items:
     - "{{ host1 }}"


### PR DESCRIPTION
##### SUMMARY
The module doesn't execute in check mode.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_firewall_manager

##### ANSIBLE VERSION
```
# ansible --version
ansible 2.6.3
  config file = /root/ansible-vmware/ansible.cfg
  configured module search path = [u'/root/ansible-vmware/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
before:
```
TASK [esxi : Enable Syslog firewall rule set] ************************************************************************************************************************************************************************************************
```
after:
```
TASK [esxi : Enable Syslog firewall rule set] ************************************************************************************************************************************************************************************************
changed: [esxi_host -> jump_server] => {"changed": true, "rule_set_state": {"esxi_host": {"syslog": {"current_state": true, "desired_state": true, "previous_state": false}}}}
```
