### PR TITLE
fix wording for silencing a sensu client (#46250)

### DIFF
--- a/lib/ansible/modules/monitoring/sensu_silence.py
+++ b/lib/ansible/modules/monitoring/sensu_silence.py
@@ -50,7 +50,7 @@ options:
   subscription:
     description:
       - Specifies the subscription which the silence entry applies to.
-      - To create a silence entry for a client append C(client:) to client name.
+      - To create a silence entry for a client prepend C(client:) to client name.
         Example - C(client:server1.example.dev)
     required: true
     default: []


### PR DESCRIPTION
(cherry picked from commit dae217204557446d4f7a1456b6fe7978ae5c3153)

##### SUMMARY
Corrects "append" to "prepend" in `sensu_silence` module docs.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.7
