### PR TITLE
VMware: Add check mode support to module vmware_host_ntp

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
@@ -131,8 +131,11 @@ class VmwareNtpConfigManager(PyVmomi):
             date_config_spec = vim.host.DateTimeConfig()
             date_config_spec.ntpConfig = ntp_config_spec
             try:
-                host_date_time_manager.UpdateDateTimeConfig(date_config_spec)
-                self.results[host.name]['after_change_ntp_servers'] = host_date_time_manager.dateTimeInfo.ntpConfig.server
+                if self.module.check_mode:
+                    self.results[host.name]['after_change_ntp_servers'] = available_ntp_servers
+                else:
+                    host_date_time_manager.UpdateDateTimeConfig(date_config_spec)
+                    self.results[host.name]['after_change_ntp_servers'] = host_date_time_manager.dateTimeInfo.ntpConfig.server
                 changed = True
             except vim.fault.HostConfigFault as e:
                 self.results[host.name]['error'] = to_native(e.msg)
@@ -195,7 +198,8 @@ def main():
         argument_spec=argument_spec,
         required_one_of=[
             ['cluster_name', 'esxi_hostname'],
-        ]
+        ],
+        supports_check_mode=True
     )
 
     vmware_host_ntp_config = VmwareNtpConfigManager(module)

--- a/test/integration/targets/vmware_host_ntp/tasks/main.yml
+++ b/test/integration/targets/vmware_host_ntp/tasks/main.yml
@@ -145,3 +145,100 @@
   register: present
 
 - debug: var=present
+
+- name: Change facts about all hosts in given cluster in check mode
+  vmware_host_ntp:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    esxi_hostname: "{{ host1 }}"
+    state: present
+    ntp_server:
+      - 0.pool.ntp.org
+    validate_certs: no
+  register: present
+  check_mode: yes
+
+- debug: var=present
+
+- name: Change facts about all hosts in given cluster in check mode
+  vmware_host_ntp:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    esxi_hostname: "{{ host1 }}"
+    state: present
+    ntp_server:
+      - 1.pool.ntp.org
+    validate_certs: no
+  register: present
+  check_mode: yes
+
+- debug: var=present
+
+- name: Change facts about all hosts in given cluster in check mode
+  vmware_host_ntp:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    esxi_hostname: "{{ host1 }}"
+    state: absent
+    ntp_server:
+      - 1.pool.ntp.org
+    validate_certs: no
+  register: present
+  check_mode: yes
+
+- debug: var=present
+
+- name: Change facts about all hosts in given cluster in check mode
+  vmware_host_ntp:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    esxi_hostname: "{{ host1 }}"
+    state: present
+    ntp_server:
+      - 1.pool.ntp.org
+    validate_certs: no
+  register: present
+  check_mode: yes
+
+- debug: var=present
+
+- name: Change facts about all hosts in given cluster in check mode
+  vmware_host_ntp:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    esxi_hostname: "{{ host1 }}"
+    state: present
+    ntp_server:
+      - 2.pool.ntp.org
+      - 3.pool.ntp.org
+      - 4.pool.ntp.org
+    validate_certs: no
+  register: present
+  check_mode: yes
+
+- debug: var=present
+
+- name: Change facts about all hosts in given cluster in check mode
+  vmware_host_ntp:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    esxi_hostname: "{{ host1 }}"
+    state: absent
+    ntp_server:
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org
+      - 2.pool.ntp.org
+      - 3.pool.ntp.org
+      - 4.pool.ntp.org
+      - 6.pool.ntp.org
+    validate_certs: no
+  register: present
+  check_mode: yes
+
+- debug: var=present


### PR DESCRIPTION
##### SUMMARY
The module doesn't execute in check mode.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_ntp

##### ANSIBLE VERSION
```
# ansible --version
ansible 2.6.3
  config file = /root/ansible-vmware/ansible.cfg
  configured module search path = [u'/root/ansible-vmware/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
before:
```
TASK [esxi : Configure NTP] ******************************************************************************************************************************************************************************************************************
```
after:
```
TASK [esxi : Configure NTP] ******************************************************************************************************************************************************************************************************************
changed: [esxi_host -> jump_server] => {"changed": true, "results": {"esxi_host": {"after_change_ntp_servers": ["time1", "time2", "time3"], "available_ntp_servers": [], "current_state": "present", "desired_state": "present", "ntp_servers_to_change": ["time1", "time2", "time3"]}}}
TASK [esxi : Configure NTP] ******************************************************************************************************************************************************************************************************************
changed: [esxi_host -> jump_server] => {"changed": true, "results": {"esxi_host": {"after_change_ntp_servers": ["time4", "time1", "time2", "time3"], "available_ntp_servers": ["time4"], "current_state": "present", "desired_state": "present", "ntp_servers_to_change": ["test", "time1", "time2", "time3"]}}}
```
