### PR TITLE
Clean up Vault docs in User Guide. (#46188)

### DIFF
--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -343,14 +343,14 @@ Vault Format
 
 A vault encrypted file is a UTF-8 encoded txt file.
 
-The file format includes a new line terminated header.
+The file format includes a newline terminated header.
 
 For example::
 
     $ANSIBLE_VAULT;1.1;AES256
 
 
-The header contains the vault format id, the vault format version, and a cipher id, seperated by semi-colons ';'
+The header contains the vault format id, the vault format version, and a cipher id, separated by semi-colons ';'
 
 The first field ``$ANSIBLE_VAULT`` is the format id. Currently ``$ANSIBLE_VAULT`` is the only valid file format id. This is used to identify files that are vault encrypted (via vault.is_encrypted_file()).
 
@@ -358,7 +358,7 @@ The second field (`1.1`) is the vault format version. All supported versions of 
 
 The '1.0' format is supported for reading only (and will be converted automatically to the '1.1' format on write). The format version is currently used as an exact string compare only (version numbers are not currently 'compared').
 
-The third field (``AES256``) identifies the cipher algorithmn used to encrypt the data. Currently, the only supported cipher is 'AES256'. [vault format 1.0 used 'AES', but current code always uses 'AES256']
+The third field (``AES256``) identifies the cipher algorithm used to encrypt the data. Currently, the only supported cipher is 'AES256'. [vault format 1.0 used 'AES', but current code always uses 'AES256']
 
 Note: In the future, the header could change. Anything after the vault id and version can be considered to depend on the vault format version. This includes the cipher id, and any additional fields that could be after that.
 
@@ -370,11 +370,11 @@ Vault Payload Format 1.1
 
 The vaulttext is a concatenation of the ciphertext and a SHA256 digest with the result 'hexlifyied'.
 
-'hexlify' refers to the hexlify() method of pythons binascii module.
+'hexlify' refers to the ``hexlify()`` method of the Python Standard Library's `binascii <https://docs.python.org/3/library/binascii.html>`_ module.
 
-hexlify()'ied result of:
+hexlify()'ed result of:
 
-- hexlify()'ed string of the salt, followed by a newline ('\n')
+- hexlify()'ed string of the salt, followed by a newline (``0x0a``)
 - hexlify()'ed string of the crypted HMAC, followed by a newline. The HMAC is:
 
   - a `RFC2104 <https://www.ietf.org/rfc/rfc2104.txt>`_ style HMAC
@@ -382,26 +382,26 @@ hexlify()'ied result of:
     - inputs are:
 
       - The AES256 encrypted ciphertext
-      - A PBKDF2 key. This key, the cipher key, and the cipher iv are generated from:
+      - A PBKDF2 key. This key, the cipher key, and the cipher IV are generated from:
 
         - the salt, in bytes
         - 10000 iterations
-        - SHA256() algorithmn
+        - SHA256() algorithm
         - the first 32 bytes are the cipher key
         - the second 32 bytes are the HMAC key
-        - remaining 16 bytes are the cipher iv
+        - remaining 16 bytes are the cipher IV
 
-  -  hexlify()'ed string of the ciphertext. The ciphertext is:
+-  hexlify()'ed string of the ciphertext. The ciphertext is:
 
-    - AES256 encrypted data. The data is encrypted using:
+  - AES256 encrypted data. The data is encrypted using:
 
-      - AES-CTR stream cipher
-      - b_pkey1
-      - iv
-      - a 128 bit counter block seeded from an integer iv
-      - the plaintext
+    - AES-CTR stream cipher
+    - cipher key
+    - IV
+    - a 128 bit counter block seeded from an integer IV
+    - the plaintext
 
-        - the original plaintext
-        - padding up to the AES256 blocksize. (The data used for padding is based on `RFC5652 <https://tools.ietf.org/html/rfc5652#section-6.3>`_)
+      - the original plaintext
+      - padding up to the AES256 blocksize. (The data used for padding is based on `RFC5652 <https://tools.ietf.org/html/rfc5652#section-6.3>`_)
 
 

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -88,7 +88,7 @@ class DistributionFiles:
     }
 
     # We can't include this in SEARCH_STRING because a name match on its keys
-    # causes a fallback to using the first whitespace seperated item from the file content
+    # causes a fallback to using the first whitespace separated item from the file content
     # as the name. For os-release, that is in form 'NAME=Arch'
     OS_RELEASE_ALIAS = {
         'Archlinux': 'Arch Linux'

--- a/lib/ansible/modules/network/iosxr/iosxr_interface.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_interface.py
@@ -74,7 +74,7 @@ options:
   aggregate:
     description:
       - List of Interface definitions. Include multiple interface configurations together,
-        one each on a seperate line
+        one each on a separate line
   delay:
     description:
       - Time in seconds to wait before checking for the operational state on remote

--- a/lib/ansible/modules/network/junos/junos_facts.py
+++ b/lib/ansible/modules/network/junos/junos_facts.py
@@ -354,7 +354,7 @@ def main():
     runable_subsets.difference_update(exclude_subsets)
     runable_subsets.add('default')
 
-    # handle fetching old style facts seperately
+    # handle fetching old style facts separately
     runable_subsets.discard('ofacts')
 
     facts = dict()

--- a/lib/ansible/modules/windows/win_audit_rule.py
+++ b/lib/ansible/modules/windows/win_audit_rule.py
@@ -36,7 +36,7 @@ options:
     required: yes
   rights:
     description:
-      - Comma seperated list of the rights desired. Only required for adding a rule.
+      - Comma separated list of the rights desired. Only required for adding a rule.
       - If I(path) is a file or directory, rights can be any right under MSDN
         FileSystemRights U(https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.filesystemrights.aspx).
       - If I(path) is a registry key, rights can be any right under MSDN
@@ -63,7 +63,7 @@ options:
   audit_flags:
     description:
       - Defines whether to log on failure, success, or both.
-      - To log both define as comma seperated list "Success, Failure".
+      - To log both define as comma separated list "Success, Failure".
     required: yes
     type: list
     choices: [ Failure, Success ]

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -390,7 +390,7 @@ def get_file_vault_secret(filename=None, vault_id=None, encoding=None, loader=No
     return FileVaultSecret(filename=this_path, encoding=encoding, loader=loader)
 
 
-# TODO: mv these classes to a seperate file so we don't pollute vault with 'subprocess' etc
+# TODO: mv these classes to a separate file so we don't pollute vault with 'subprocess' etc
 class FileVaultSecret(VaultSecret):
     def __init__(self, filename=None, encoding=None, loader=None):
         super(FileVaultSecret, self).__init__()


### PR DESCRIPTION
* Fix spelling of 'separate' throughout.

* Various cleanups in the User Guide for Vault.

- Fix spelling of 'algorithm'
- Fix indentation of nested list in payload format
- Fix mysterious refernce to 'b_pkey1'.
- Fix reference to newline as '\n': the backslash is lost when rendered
to the docs website. Specify the hex value for newline instead of the
backslash escape.

* Fix formatting

* Update vault.rst

(cherry picked from commit ab96bbdef9a1a42b7cf3cb08db8056994fa3aaf9)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
backport for 46188
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs.ansible.com
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
