### PR TITLE
VMware: Add check mode support to module vmware_host_service_manager

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_service_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_service_manager.py
@@ -148,20 +148,24 @@ class VmwareServiceManager(PyVmomi):
                 try:
                     if self.desired_state in ['start', 'present']:
                         if not actual_service_state:
-                            host_service_system.StartService(id=self.service_name)
+                            if not self.module.check_mode:
+                                host_service_system.StartService(id=self.service_name)
                             changed_state = True
                     elif self.desired_state in ['stop', 'absent']:
                         if actual_service_state:
-                            host_service_system.StopService(id=self.service_name)
+                            if not self.module.check_mode:
+                                host_service_system.StopService(id=self.service_name)
                             changed_state = True
                     elif self.desired_state == 'restart':
-                        host_service_system.RestartService(id=self.service_name)
+                        if not self.module.check_mode:
+                            host_service_system.RestartService(id=self.service_name)
                         changed_state = True
 
                     if self.desired_policy:
                         if actual_service_policy != self.desired_policy:
-                            host_service_system.UpdateServicePolicy(id=self.service_name,
-                                                                    policy=self.desired_policy)
+                            if not self.module.check_mode:
+                                host_service_system.UpdateServicePolicy(id=self.service_name,
+                                                                        policy=self.desired_policy)
                             changed_state = True
 
                     host_service_state.append(changed_state)
@@ -205,7 +209,8 @@ def main():
         argument_spec=argument_spec,
         required_one_of=[
             ['cluster_name', 'esxi_hostname'],
-        ]
+        ],
+        supports_check_mode=True
     )
 
     vmware_host_service = VmwareServiceManager(module)

--- a/test/integration/targets/vmware_host_service_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_service_manager/tasks/main.yml
@@ -83,7 +83,41 @@
     state: absent
   register: single_hosts_result
 
-- name: ensure facts are gathered for all hosts
+- name: ensure facts are gathered
   assert:
     that:
         - single_hosts_result.changed == False
+
+- name: Start ntpd service on all hosts in given cluster in check mode
+  vmware_host_service_manager:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    cluster_name: "{{ ccr1 }}"
+    service_name: ntpd
+    state: present
+  register: all_hosts_result_check_mode
+  check_mode: yes
+
+- name: ensure facts are gathered for all hosts
+  assert:
+    that:
+        - all_hosts_result_check_mode.changed
+
+- name: Stop ntpd service on a given host in check mode
+  vmware_host_service_manager:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    esxi_hostname: "{{ host1 }}"
+    service_name: ntpd
+    state: absent
+  register: single_hosts_result_check_mode
+  check_mode: yes
+
+- name: ensure facts are gathered
+  assert:
+    that:
+        - single_hosts_result_check_mode.changed == False


### PR DESCRIPTION
##### SUMMARY
The module doesn't execute in check mode.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_service_manager

##### ANSIBLE VERSION
```
# ansible --version
ansible 2.6.3
  config file = /root/ansible-vmware/ansible.cfg
  configured module search path = [u'/root/ansible-vmware/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
before:
```
TASK [esxi : Enable and start ESXi Shell] ****************************************************************************************************************************************************************************************************
after:
```
TASK [esxi : Enable and start ESXi Shell] ****************************************************************************************************************************************************************************************************
changed: [esxi_host -> jump_server] => {"changed": true, "results": {"esxi_host": {"actual_service_policy": "off", "actual_service_state": "stopped", "changed": true, "desired_service_policy": "on", "desired_service_state": "start", "error": "", "service_name": "TSM"}}}
```
