### PR TITLE
VMware: Add check mode support to module vmware_host_config_facts

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_config_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_config_facts.py
@@ -106,7 +106,8 @@ def main():
         argument_spec=argument_spec,
         required_one_of=[
             ['cluster_name', 'esxi_hostname'],
-        ]
+        ],
+        supports_check_mode=True
     )
 
     vmware_host_config = VmwareConfigFactsManager(module)

--- a/test/integration/targets/vmware_host_config_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_config_facts/tasks/main.yml
@@ -80,3 +80,33 @@
   assert:
     that:
         - single_hosts_result.hosts_facts
+
+- name: gather facts about all hosts in given cluster in check mode
+  vmware_host_config_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    cluster_name: "{{ ccr1 }}"
+  register: all_hosts_result_check_mode
+  check_mode: yes
+
+- name: ensure facts are gathered for all hosts
+  assert:
+    that:
+        - all_hosts_result_check_mode.hosts_facts
+
+- name: gather facts about a given host in check mode
+  vmware_host_config_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    esxi_hostname: "{{ host1 }}"
+  register: single_hosts_result_check_mode
+  check_mode: yes
+
+- name: ensure facts are gathered for all hosts
+  assert:
+    that:
+        - single_hosts_result_check_mode.hosts_facts


### PR DESCRIPTION
##### SUMMARY
The module doesn't execute in check mode. Now it has the same behavior as the vmware_host_facts module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_config_facts

##### ANSIBLE VERSION
```
# ansible --version
ansible 2.6.3
  config file = /root/ansible-vmware/ansible.cfg
  configured module search path = [u'/root/ansible-vmware/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
before:
```
TASK [esxi : Gather advanced system settings facts] ******************************************************************************************************************************************************************************************
```
after:
```
TASK [esxi : Gather advanced system settings facts] ******************************************************************************************************************************************************************************************
ok: [esxi_host -> jump_server] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
```