### PR TITLE
Start of code-smell test that can find deprecated config items

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/deprecated-config.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/deprecated-config.rst
@@ -1,0 +1,4 @@
+Sanity Tests » deprecated-config
+================================
+
+``DOCUMENTATION`` config is scheduled for removal

--- a/docs/docsite/rst/dev_guide/testing/sanity/deprecated-config.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/deprecated-config.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Sanity Tests » deprecated-config
 ================================
 

--- a/test/sanity/code-smell/deprecated-config.json
+++ b/test/sanity/code-smell/deprecated-config.json
@@ -1,0 +1,5 @@
+{
+    "disabled": true,
+    "always": true,
+    "output": "path-message"
+}

--- a/test/sanity/code-smell/deprecated-config.json
+++ b/test/sanity/code-smell/deprecated-config.json
@@ -1,5 +1,4 @@
 {
-    "disabled": true,
     "always": true,
     "output": "path-message",
     "extensions": [

--- a/test/sanity/code-smell/deprecated-config.json
+++ b/test/sanity/code-smell/deprecated-config.json
@@ -1,5 +1,11 @@
 {
     "disabled": true,
     "always": true,
-    "output": "path-message"
+    "output": "path-message",
+    "extensions": [
+        ".py"
+    ],
+    "prefixes": [
+        "lib/ansible/"
+    ]
 }

--- a/test/sanity/code-smell/deprecated-config.py
+++ b/test/sanity/code-smell/deprecated-config.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# (c) 2018, Matt Martz <matt@sivel.net>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import argparse
+import mmap
+import os
+import re
+
+import yaml
+
+from distutils.version import StrictVersion
+
+import ansible.config
+
+from ansible.plugins.loader import fragment_loader
+from ansible.release import __version__ as ansible_version
+from ansible.utils.plugin_docs import get_docstring
+
+DOC_RE = re.compile(b'^DOCUMENTATION', flags=re.M)
+ANSIBLE_MAJOR = StrictVersion('.'.join(ansible_version.split('.')[:2]))
+
+
+def find_deprecations(o, path=None):
+    if not isinstance(o, (list, dict)):
+        return
+
+    try:
+        items = o.items()
+    except AttributeError:
+        items = enumerate(o)
+
+    for k, v in items:
+        if path is None:
+            this_path = []
+        else:
+            this_path = path[:]
+
+        this_path.append(k)
+
+        if k != 'deprecated':
+            for result in find_deprecations(v, path=this_path):
+                yield result
+        else:
+            try:
+                version = v['version']
+                this_path.append('version')
+            except KeyError:
+                version = v['removed_in']
+                this_path.append('removed_in')
+            if StrictVersion(version) <= ANSIBLE_MAJOR:
+                yield (this_path, version)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'path',
+        help='Path to a directory that will be recursively walked. All .py files will be evaluated '
+             'and any containing DOCUMENTATION will be checked for scheduled deprecations. Default: %(default)s',
+        default=os.path.abspath('ansible/lib'),
+        nargs='?',
+    )
+    args = parser.parse_args()
+
+    plugins = []
+    for root, dirs, filenames in os.walk(args.path):
+        for name in filenames:
+            if os.path.splitext(name)[1] not in ('.py',):
+                continue
+            path = os.path.abspath(os.path.join(root, name))
+
+            with open(path, 'rb') as f:
+                try:
+                    mm = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
+                except ValueError:
+                    continue
+                if DOC_RE.search(mm):
+                    plugins.append(path)
+                mm.close()
+
+    for plugin in plugins:
+        data = {}
+        data['doc'], data['examples'], data['return'], data['metadata'] = get_docstring(plugin, fragment_loader)
+        for result in find_deprecations(data['doc']):
+            print(
+                '%s: %s is scheduled for removal in %s' % (plugin, '.'.join(str(i) for i in result[0]), result[1])
+            )
+
+    base = os.path.join(os.path.dirname(ansible.config.__file__), 'base.yml')
+    with open(base) as f:
+        data = yaml.safe_load(f)
+
+    for result in find_deprecations(data):
+        print('%s: %s is scheduled for removal in %s' % (base, '.'.join(str(i) for i in result[0]), result[1]))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/sanity/code-smell/deprecated-config.py
+++ b/test/sanity/code-smell/deprecated-config.py
@@ -102,7 +102,7 @@ def main():
         data['doc'], data['examples'], data['return'], data['metadata'] = get_docstring(plugin, fragment_loader)
         for result in find_deprecations(data['doc']):
             print(
-                '%s: %s is scheduled for removal in %s' % (plugin, '.'.join(str(i) for i in result[0]), result[1])
+                '%s: %s is scheduled for removal in %s' % (plugin, '.'.join(str(i) for i in result[0][:-2]), result[1])
             )
 
     base = os.path.join(os.path.dirname(ansible.config.__file__), 'base.yml')
@@ -110,7 +110,7 @@ def main():
         data = yaml.safe_load(f)
 
     for result in find_deprecations(data):
-        print('%s: %s is scheduled for removal in %s' % (base, '.'.join(str(i) for i in result[0]), result[1]))
+        print('%s: %s is scheduled for removal in %s' % (base, '.'.join(str(i) for i in result[0][:-2]), result[1]))
 
 
 if __name__ == '__main__':

--- a/test/sanity/code-smell/skip.txt
+++ b/test/sanity/code-smell/skip.txt
@@ -1,0 +1,1 @@
+deprecated-config.py  # disabled by default, to be enabled by the release manager, after branching


### PR DESCRIPTION
##### SUMMARY
Start of code-smell test that can find deprecated config items

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
test/sanity/code-smell/deprecated-config.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```