### PR TITLE
Corrected typo

### DIFF
--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -31,7 +31,7 @@ ansible_play_hosts_all
 ansible_playbook_python
     The path to the python interpreter being used by Ansible on the controller
 
-ansible_serach_path
+ansible_search_path
     Current search path for action plugins and lookups, i.e where we search for relative paths when you do ``template: src=myfile``
 
 ansible_verbosity


### PR DESCRIPTION

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Corrected typo ansible_serach_path --> ansible_search_path

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Current version of the documentation contains typo in the variable name 'ansible_serach_path' which isn't recognized by the ansible version 2.6.4.
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.4
  config file = None
  configured module search path = [u'/Users/andriitrykush/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/andriitrykush/Library/Python/2.7/lib/python/site-packages/ansible
  executable location = /Users/andriitrykush/Library/Python/2.7/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```