### PR TITLE
Add logstash_plugin example for lower heap size

### DIFF
--- a/lib/ansible/modules/monitoring/logstash_plugin.py
+++ b/lib/ansible/modules/monitoring/logstash_plugin.py
@@ -62,6 +62,13 @@ EXAMPLES = '''
   logstash_plugin:
     state: absent
     name: logstash-filter-multiline
+
+- name: install Logstash plugin with alternate heap size
+  logstash_plugin:
+    state: present
+    name: logstash-input-beats
+  environment:
+    LS_JAVA_OPTS: "-Xms256m -Xmx256m"
 '''
 
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In a scenario where you've set your logstash heap size high, you may need to set your heap lower in order to execute logstash-plugin while logstash is still running.

Here's an example of someone running into insufficient memory while executing logstash-plugin: https://discuss.elastic.co/t/logstash-plugin-and-jvm-options/99646

This scenario is probably fairly common, so it may be worth documenting as an example.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
logstash_plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
