### PR TITLE
yes, we do run validate_modules in Shippable

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_documentation.rst
+++ b/docs/docsite/rst/dev_guide/testing_documentation.rst
@@ -17,7 +17,7 @@ To check the HTML output of your module documentation:
 
 To build the HTML documentation for multiple modules, use a comma-separated list of module names: ``MODULES=my_code,my_other_code make webdocs``.
 
-To ensure that your documentation matches your ``argument_spec``, run the ``validate-modules`` test. Note that this option isn't currently enabled in Shippable due to the time it takes to run.
+To ensure that your documentation matches your ``argument_spec``, run the ``validate-modules`` test.
 
 .. code-block:: bash
 


### PR DESCRIPTION
##### SUMMARY
Documentation suggested that Shippable does not run `validate_modules`. It now does, so correcting the docs.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
Shippable

##### ANSIBLE VERSION
2.8
