### PR TITLE
yes, we do run validate_modules in Shippable (#46280)

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_documentation.rst
+++ b/docs/docsite/rst/dev_guide/testing_documentation.rst
@@ -17,7 +17,7 @@ To check the HTML output of your module documentation:
 
 To build the HTML documentation for multiple modules, use a comma-separated list of module names: ``MODULES=my_code,my_other_code make webdocs``.
 
-To ensure that your documentation matches your ``argument_spec``, run the ``validate-modules`` test. Note that this option isn't currently enabled in Shippable due to the time it takes to run.
+To ensure that your documentation matches your ``argument_spec``, run the ``validate-modules`` test.
 
 .. code-block:: bash
 


### PR DESCRIPTION
(cherry picked from commit 66eb5681f4c3e3cc45416a537c55974b25bd5402)

##### SUMMARY
Removes misleading text from documentation that suggested Shippable wasn't validating the module documentation against module argspec. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.7
