### PR TITLE
Backport #46147 for 2.7 - Add OpenBSD support to reboot

### DIFF
--- a/changelogs/fragments/reboot_openbsd_support.yaml
+++ b/changelogs/fragments/reboot_openbsd_support.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - reboot - add support for OpenBSD

--- a/lib/ansible/modules/system/reboot.py
+++ b/lib/ansible/modules/system/reboot.py
@@ -20,8 +20,8 @@ options:
   pre_reboot_delay:
     description:
       - Seconds for shutdown to wait before requesting reboot.
-      - On Linux and macOS, this is converted to minutes and rounded down. If less than 60, it will be set to 0.
-      - On Solaris and FreeBSD, this will be seconds.
+      - On Linux, macOS, and OpenBSD this is converted to minutes and rounded down. If less than 60, it will be set to 0.
+      - On Solaris and FreeBSD this will be seconds.
     default: 0
     type: int
   post_reboot_delay:

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -42,18 +42,24 @@ class ActionModule(ActionBase):
 
     DEPRECATED_ARGS = {}
 
+    BOOT_TIME_COMMANDS = {
+        'openbsd': "/sbin/sysctl kern.boottime",
+    }
+
     SHUTDOWN_COMMANDS = {
         'linux': DEFAULT_SHUTDOWN_COMMAND,
         'freebsd': DEFAULT_SHUTDOWN_COMMAND,
         'sunos': '/usr/sbin/shutdown',
         'darwin': '/sbin/shutdown',
+        'openbsd': DEFAULT_SHUTDOWN_COMMAND,
     }
 
     SHUTDOWN_COMMAND_ARGS = {
         'linux': '-r {delay_min} "{message}"',
         'freebsd': '-r +{delay_sec}s "{message}"',
         'sunos': '-y -g {delay_sec} -r "{message}"',
-        'darwin': '-r +{delay_min_macos} "{message}"'
+        'darwin': '-r +{delay_min_macos} "{message}"',
+        'openbsd': '-r +{delay_min} "{message}"',
     }
 
     def __init__(self, *args, **kwargs):
@@ -96,7 +102,13 @@ class ActionModule(ActionBase):
     def get_system_boot_time(self):
         stdout = u''
         stderr = u''
-        command_result = self._low_level_execute_command(self.DEFAULT_BOOT_TIME_COMMAND, sudoable=self.DEFAULT_SUDOABLE)
+
+        # Determine the system distribution in order to use the correct shutdown command arguments
+        uname_result = self._low_level_execute_command('uname')
+        distribution = uname_result['stdout'].strip().lower()
+
+        boot_time_command = self.BOOT_TIME_COMMANDS.get(distribution, self.DEFAULT_BOOT_TIME_COMMAND)
+        command_result = self._low_level_execute_command(boot_time_command, sudoable=self.DEFAULT_SUDOABLE)
 
         # For single board computers, e.g., Raspberry Pi, that lack a real time clock and are using fake-hwclock
         # launched by systemd, the update of utmp/wtmp is not done correctly.


### PR DESCRIPTION
##### SUMMARY
Backport of #46147  for Ansible 2.7

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`reboot.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```