### PR TITLE
fix yum proxy username/password handling

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -725,20 +725,27 @@ class YumModule(YumDnf):
         # setting system proxy environment and saving old, if exists
         my = self.yum_base()
         namepass = ""
+        proxy_url = ""
         scheme = ["http", "https"]
         old_proxy_env = [os.getenv("http_proxy"), os.getenv("https_proxy")]
         try:
             if my.conf.proxy:
                 if my.conf.proxy_username:
                     namepass = namepass + my.conf.proxy_username
+                    proxy_url = my.conf.proxy
                     if my.conf.proxy_password:
                         namepass = namepass + ":" + my.conf.proxy_password
-                namepass = namepass + '@'
-                for item in scheme:
-                    os.environ[item + "_proxy"] = re.sub(
-                        r"(http://)",
-                        r"\1" + namepass, my.conf.proxy
-                    )
+                elif '@' in my.conf.proxy:
+                    namepass = my.conf.proxy.split('@')[0].split('//')[-1]
+                    proxy_url = my.conf.proxy.replace("{0}@".format(namepass), "")
+
+                if namepass:
+                    namepass = namepass + '@'
+                    for item in scheme:
+                        os.environ[item + "_proxy"] = re.sub(
+                            r"(http://)",
+                            r"\1" + namepass, proxy_url
+                        )
             yield
         except yum.Errors.YumBaseError:
             raise

--- a/test/integration/targets/yum/tasks/main.yml
+++ b/test/integration/targets/yum/tasks/main.yml
@@ -69,3 +69,5 @@
 - include: 'yum_group_remove.yml'
   when:
     - (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version|int > 6)
+
+- include: 'proxy.yml'

--- a/test/integration/targets/yum/tasks/proxy.yml
+++ b/test/integration/targets/yum/tasks/proxy.yml
@@ -1,0 +1,96 @@
+- name: test yum proxy settings
+  block:
+    - yum:
+        name: 'https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/yum/tinyproxy-1.10.0-3.el7.x86_64.rpm'
+        state: installed
+
+    - lineinfile:
+        path: /etc/tinyproxy/tinyproxy.conf
+        line: "BasicAuth testuser testpassword"
+        state: present
+
+    # systemd doesn't play nice with this in a container for some reason
+    - shell: tinyproxy
+      changed_when: false
+
+    - lineinfile:
+        path: /etc/yum.conf
+        line: "proxy=http://testuser:testpassword@127.0.0.1:8888"
+        state: present
+
+    - yum:
+        name: 'https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/yum/ninvaders-0.1.1-18.el7.x86_64.rpm'
+        state: installed
+      register: yum_proxy_result
+
+    - assert:
+        that:
+          - "yum_proxy_result.changed"
+          - "'msg' in yum_proxy_result"
+          - "'rc' in yum_proxy_result"
+
+    - yum:
+        name: ninvaders
+        state: absent
+
+    - lineinfile:
+        path: /etc/yum.conf
+        line: "proxy=http://testuser:testpassword@127.0.0.1:8888"
+        state: absent
+
+    - lineinfile:
+        path: /etc/yum.conf
+        line: "proxy=http://127.0.0.1:8888"
+        state: present
+
+    - lineinfile:
+        path: /etc/yum.conf
+        line: "proxy_username=testuser"
+        state: present
+
+    - lineinfile:
+        path: /etc/yum.conf
+        line: "proxy_password=testpassword"
+        state: present
+
+    - yum:
+        name: 'https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/yum/ninvaders-0.1.1-18.el7.x86_64.rpm'
+        state: installed
+      register: yum_proxy_result
+
+    - assert:
+        that:
+          - "yum_proxy_result.changed"
+          - "'msg' in yum_proxy_result"
+          - "'rc' in yum_proxy_result"
+
+  always:
+    - yum:
+        name: tinyproxy
+        state: absent
+
+    - yum:
+        name: ninvaders
+        state: absent
+
+    - lineinfile:
+        path: /etc/yum.conf
+        line: "proxy=http://testuser:testpassword@127.0.0.1:8888"
+        state: absent
+
+    - lineinfile:
+        path: /etc/yum.conf
+        line: "proxy=http://127.0.0.1:8888"
+        state: absent
+
+    - lineinfile:
+        path: /etc/yum.conf
+        line: "proxy_username=testuser"
+        state: absent
+
+    - lineinfile:
+        path: /etc/yum.conf
+        line: "proxy_password=testpassword"
+        state: absent
+  when:
+    - (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version|int == 7)


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #46249

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (bugfix/46249-yum-http-proxy 6dee70fe82) last updated 2018/09/28 16:26:49 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```

