### PR TITLE
spotinst_aws_elastigroup module: adding version to Rancher integration

### DIFF
--- a/lib/ansible/modules/cloud/spotinst/spotinst_aws_elastigroup.py
+++ b/lib/ansible/modules/cloud/spotinst/spotinst_aws_elastigroup.py
@@ -23,6 +23,7 @@ description:
 requirements:
   - spotinst >= 1.0.21
   - python >= 2.7
+  - spotinst_sdk >= 1.0.38
 options:
 
   credentials_path:

--- a/lib/ansible/modules/cloud/spotinst/spotinst_aws_elastigroup.py
+++ b/lib/ansible/modules/cloud/spotinst/spotinst_aws_elastigroup.py
@@ -264,6 +264,7 @@ options:
     description:
       - (Object) The Rancher integration configuration.;
         Expects the following keys -
+        version (String),
         access_key (String),
         secret_key (String),
         master_host (String)
@@ -882,7 +883,8 @@ right_scale_fields = ('account_id',
 
 rancher_fields = ('access_key',
                   'secret_key',
-                  'master_host')
+                  'master_host',
+                  'version')
 
 chef_fields = ('chef_server',
                'organization',


### PR DESCRIPTION
##### SUMMARY
Added version to rancher_fields 
Added spotinst_sdk version requirements 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
spotinst_aws_elastigroup.py

##### ANSIBLE VERSION
```
ansible 2.6.5
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Sep  5 2018, 04:46:44) [GCC 6.3.0 20170516]
```
