### PR TITLE
WIP: Check that union Jinja filter can be chained

### DIFF
--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -54,7 +54,12 @@ def unique(environment, a, case_sensitive=False, attribute=None):
     error = None
     try:
         if HAS_UNIQUE:
-            c = set(do_unique(environment, a, case_sensitive=case_sensitive, attribute=attribute))
+            c = do_unique(environment, a, case_sensitive=case_sensitive, attribute=attribute)
+            if isinstance(a, collections.Hashable):
+                c = set(c)
+            else:
+                c = list(c)
+
     except Exception as e:
         if case_sensitive or attribute:
             raise AnsibleFilterError("Jinja2's unique filter failed and we cannot fall back to Ansible's version "

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -237,3 +237,19 @@
     that:
             - "'00:00:00' | random_mac is match('^00:00:00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"
             - "'00:00:00' | random_mac != '00:00:00' | random_mac"
+
+- name: Verify that union can be chained
+  vars:
+    unions: '{{ [1,2,3]|union([4,5])|union([6,7]) }}'
+  assert:
+    that:
+      - "unions|type_debug == 'list'"
+      - "unions|length == 7"
+
+- name: Test union with unhashable item
+  vars:
+    unions: '{{ [1,2,3]|union([{}]) }}'
+  assert:
+    that:
+      - "unions|type_debug == 'list'"
+      - "unions|length == 4"


### PR DESCRIPTION
##### SUMMARY
`set` filters: fix `unexpected templating type error`. This error occurs with Jinja 2.10 since 32ec69d, for example when `union` filters are chained:

    $ ansible all -i localhost, -mdebug -a"msg={{ []|union([])|union([]) }}"
    localhost | FAILED! => {
        "msg": "Unexpected templating type error occurred on ({{ []|union([])|union([]) }}):
                unsupported operand type(s) for +: 'set' and 'list'"
    }

Integration tests provided (Note that only FreeBSD builds provide Jinja 2.10).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/filter/mathstuff.py

##### ANSIBLE VERSION
```paste below
2.8
```