### PR TITLE
Fixes Error with elasticsearch_plugin and Java prompts

### DIFF
--- a/lib/ansible/modules/database/misc/elasticsearch_plugin.py
+++ b/lib/ansible/modules/database/misc/elasticsearch_plugin.py
@@ -186,6 +186,8 @@ def install_plugin(module, plugin_bin, plugin_name, version, src, url, proxy_hos
     else:
         cmd_args.append(plugin_name)
 
+    cmd_args.append("--batch")    
+    
     cmd = " ".join(cmd_args)
 
     if module.check_mode:

--- a/lib/ansible/modules/database/misc/elasticsearch_plugin.py
+++ b/lib/ansible/modules/database/misc/elasticsearch_plugin.py
@@ -186,8 +186,8 @@ def install_plugin(module, plugin_bin, plugin_name, version, src, url, proxy_hos
     else:
         cmd_args.append(plugin_name)
 
-    cmd_args.append("--batch")    
-    
+    cmd_args.append("--batch")
+
     cmd = " ".join(cmd_args)
 
     if module.check_mode:


### PR DESCRIPTION
##### SUMMARY
Fixes errors when installing elasticsearch plugins on Elasticsearch 6.3+ which is caused by the new(ish?) Java security warning.  The --batch argument silences these verbose warnings allowing the plugin to execute successfully.

Fixes #45892

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
elasticsearch_plugin

##### ANSIBLE VERSION
```
ansible 2.6.4
  config file = /Users/troyfontaine/.ansible.cfg
  configured module search path = [u'/Users/troyfontaine/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/troyfontaine/.pyenv/versions/2.7.13/lib/python2.7/site-packages/ansible
  executable location = /Users/troyfontaine/.pyenv/versions/2.7.13/bin/ansible
  python version = 2.7.13 (default, Aug 17 2017, 10:55:06) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```

##### ADDITIONAL INFORMATION

