### PR TITLE
Purging logging configuration before running playbook

### DIFF
--- a/test/integration/targets/nxos_logging/tests/common/basic.yaml
+++ b/test/integration/targets/nxos_logging/tests/common/basic.yaml
@@ -3,6 +3,11 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+- name: Purge logging configuration first
+  nxos_logging:
+    purge: true
+    provider: "{{ connection }}"
+
 - name: Set up console logging
   nxos_logging: &clog
     dest: console

--- a/test/integration/targets/nxos_logging/tests/common/purge.yaml
+++ b/test/integration/targets/nxos_logging/tests/common/purge.yaml
@@ -1,6 +1,11 @@
 ---
 - debug: msg="START connection={{ ansible_connection }} nxos_logging purge test"
 
+- name: Purge logging configuration first
+  nxos_logging:
+    purge: true
+    provider: "{{ connection }}"
+
 - block:
 
     - name: Set up console logging


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Purging logging configuration prior to running test playbooks.  Only impacts latest devel (2.8).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_logging

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (purge_test 3d40fc8657) last updated 2018/09/29 09:45:20 (GMT -400)
  config file = None
  configured module search path = [u'/Users/tmstoner/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/tmstoner/ansible/lib/ansible
  executable location = /Users/tmstoner/ansible/bin/ansible
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
