### PR TITLE
[docs] Fix typo in ec2_vpc_nat_gateway module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway.py
@@ -151,7 +151,7 @@ EXAMPLES = '''
 
 RETURN = '''
 create_time:
-  description: The ISO 8601 date time formatin UTC.
+  description: The ISO 8601 date time format in UTC.
   returned: In all cases.
   type: string
   sample: "2016-03-05T05:19:20.282000+00:00'"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added space between `format` and `in` on return value `create_time`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vpc_nat_gateway

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Go to https://docs.ansible.com/ansible/2.6/modules/ec2_vpc_nat_gateway_module.html#return-values and see the typo on `create_time` return value.