### PR TITLE
docker_container: fix behavior when image is not specified

### DIFF
--- a/changelogs/fragments/46322-docker_container-image-not-given.yaml
+++ b/changelogs/fragments/46322-docker_container-image-not-given.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - the behavior is improved in case ``image`` is not specified, but needed for (re-)creating the container."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1936,8 +1936,10 @@ class ContainerManager(DockerBaseClass):
                 self.log("differences")
                 self.log(differences, pretty_print=True)
                 image_to_use = self.parameters.image
+                if not image_to_use and container and container.Image:
+                    image_to_use = container.Image
                 if not image_to_use:
-                    self.fail('Cannot recreate container when image is not specified!')
+                    self.fail('Cannot recreate container when image is not specified or cannot be extracted from current container!')
                 if container.running:
                     self.container_stop(container.Id)
                 self.container_remove(container.Id)

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1912,7 +1912,10 @@ class ContainerManager(DockerBaseClass):
         container = self._get_container(self.parameters.name)
 
         # If the image parameter was passed then we need to deal with the image
-        # version comparison, otherwise we should not care
+        # version comparison. Otherwise we handle this depending on whether
+        # the container already runs or not; in the former case, in case the
+        # container needs to be restarted, we use the existing container's
+        # image ID.
         image = self._get_image()
         self.log(image, pretty_print=True)
         if not container.exists:


### PR DESCRIPTION
##### SUMMARY
When `image` is not specified, but the container needs to be re-created for some reason (restart, configuration changed, etc.), currently simply nothing happens (without any user feedback). This is a consequence of #41678, which simply does not run the configuration check when `image` is not specified.

This PR replaces the change in #41678 with slightly more sophisticated code:
 1. If the container doesn't exist yet, a (useful) error is returned because `image` is really needed in this place.
 2. If the container already exists, the container's image ID is used for recreation.

Fixes #21188, fixes #27960.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.8.0
```
