### PR TITLE
Add a flip-filter

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1203,6 +1203,62 @@ To format a date using a string (like with the shell date command), use the "str
 
 .. note:: To get all string possibilities, check https://docs.python.org/2/library/time.html#time.strftime
 
+Filter-manipulating Filters
+```````````````````````````
+
+.. versionadded:: 2.8
+
+You can use the `flip` filter to apply a filter but with arguments flipped in
+reverse order. Example ::
+
+    {{ list1 | flip('difference', list2) }}
+
+… is the same as:
+
+    {{ list2 | difference(list1) }}
+
+This becomes useful with filters like `map` where you can't easily re-order the
+arguments yourself.
+
+Say that you have a role that takes a list of users to add to a system. You want
+to ensure some default values and apply some overrides before using the value in
+your role's task. You could do it like this:
+
+`roles/users/defaults/main.yml`:
+
+.. code-block:: yaml
+
+    ---
+    # A list of user objects
+    users: []
+
+`roles/users/vars/main.yml`:
+
+.. code-block:: yaml
+
+    ---
+    # Ensure we don't delete users and that we never overwrite passwords after
+    # creation
+    _users_overrides:
+      state: present
+      update_password: on_create
+
+    # Add users to `guest` by default and generate an ssh-key.
+    _users_defaults:
+      groups:
+        - guest
+      generate_ssh_key: true
+
+    # A list of users with overrides and defaults applied (this is what your
+    # tasks will use)
+    _users: >-
+      {{ users
+       | map('flip', 'combine', _users_defaults)
+       | map('combine', _users_overrides)
+       | list
+      }}
+
+
 Combination Filters
 ````````````````````
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -39,7 +39,7 @@ import datetime
 from functools import partial
 from random import Random, SystemRandom, shuffle, random
 
-from jinja2.filters import environmentfilter, do_groupby as _do_groupby
+from jinja2.filters import environmentfilter, contextfilter, do_groupby as _do_groupby
 
 from ansible.errors import AnsibleError, AnsibleFilterError
 from ansible.module_utils.six import iteritems, string_types, integer_types, reraise
@@ -60,6 +60,12 @@ except ImportError:
     display = Display()
 
 UUID_NAMESPACE_ANSIBLE = uuid.UUID('361E6D51-FAEC-444A-9079-341386DA8E2E')
+
+
+@contextfilter
+def flip(context, value, name, *args, **kwargs):
+    args = args[::-1] + (value,)
+    return context.environment.call_filter(name, args[0], args[1:], kwargs=kwargs, context=context)
 
 
 def to_yaml(a, *args, **kw):
@@ -635,6 +641,9 @@ class FilterModule(object):
 
             # debug
             'type_debug': lambda o: o.__class__.__name__,
+
+            # functions
+            'flip': flip,
 
             # Data structures
             'combine': combine,

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -144,6 +144,15 @@
       - '"{{ "hash" | hash("sha1") }}" == "2346ad27d7568ba9896f1b7da6b5991251debdf2"'
       - '"{{ "café" | hash("sha1") }}" == "f424452a9673918c6f09b0cdd35b20be8e6ae7d7"'
 
+- name: Test flip filter
+  assert:
+    that:
+      - "'one-arg-identity' | upper == 'one-arg-identity' | flip('upper')"
+      - "'two-args' | hash('sha1') == 'sha1' | flip('hash', 'two-args')"
+      - "{'three-args': true, 'arg':1 } | combine({'arg':2}, {'arg':3}) == {'arg':3} | flip('combine', {'arg':2}, {'three-args': true, 'arg':1})"
+      - "{'test':{'kwargs':1}} | combine({'test':{'kwargs':2}}, recursive=True) == {'test':{'kwargs':2}} | flip('combine', {'test':{'kwargs':1}}, recursive=True)"
+      - "[{'a':'user-set'}, {'b':'user-set'}] | map('flip', 'combine', {'a':'default', 'b': 'default'}) | list == [{'a':'user-set', 'b':'default'}, {'a':'default', 'b':'user-set'}]"
+
 - debug:
     var: "'http://mary:MySecret@www.acme.com:9000/dir/index.html?query=term#fragment' | urlsplit"
     verbosity: 1

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -131,6 +131,13 @@
     that:
       - "users | json_query('[*].hosts[].host') == ['host_a', 'host_b', 'host_c', 'host_d']"
 
+- name: Test combine filter
+  assert:
+    that:
+      - "{'a':1, 'b':2} | combine({'b':3}) == {'a':1, 'b':3}"
+      - "{'b':3} | combine({'a':1, 'b':2}) == {'a':1, 'b':2}"
+      - "{'a':{'foo':1, 'bar':2}, 'b':2} | combine({'a':{'bar':3, 'baz':4}}, recursive=True) == {'a':{'foo':1, 'bar':3, 'baz':4}, 'b':2}"
+
 - name: Test hash filter
   assert:
     that:


### PR DESCRIPTION
##### SUMMARY

Add a flip-filter that can be used to apply arguments in reverse order to another filter.

Useful in combination with `map` and similar filters.

Also, see: #46255 and #46215 .

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

No idea.

##### ANSIBLE VERSION
```paste below
ansible --version
ansible 2.8.0.dev0 (feature/flip-filter 97ef190cd6) last updated 2018/10/01 13:18:12 (GMT +200)
  config file = /home/mattiasb/.ansible.cfg
  configured module search path = [u'/home/mattiasb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mattiasb/Code/github.com/ansible/ansible/lib/ansible
  executable location = /home/mattiasb/Code/github.com/ansible/ansible/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```

##### ADDITIONAL INFORMATION

From the documentation added for this PR:

--------------------------

You can use the `flip` filter to apply a filter but with arguments flipped in
reverse order. Example ::

    {{ list1 | flip('difference', list2) }}

… is the same as:

    {{ list2 | difference(list1) }}

This becomes useful with filters like `map` where you can't easily re-order the
arguments yourself.

Say that you have a role that takes a list of users to add to a system. You want
to ensure some default values and apply some overrides before using the value in
your role's task. You could do it like this:

`roles/users/defaults/main.yml`:
```yaml
    # A list of user objects
    users: []
```

`roles/users/vars/main.yml`:
```yaml
    # Ensure we don't delete users and that we never overwrite passwords after
    # creation
    _users_overrides:
      state: present
      update_password: on_create

    # Add users to `guest` by default and generate an ssh-key.
    _users_defaults:
      groups:
        - guest
      generate_ssh_key: true

    # A list of users with overrides and defaults applied (this is what your
    # tasks will use)
    _users: >-
      {{ users
       | map('flip', 'combine', _users_defaults)
       | map('combine', _users_overrides)
       | list
      }}
```

Ping @bcoca and @gundalow who's been involved on my journey to get my use-case solved. ☺