### PR TITLE
Docs: Cleanup selinux_permissive module docs

### DIFF
--- a/lib/ansible/modules/system/selinux_permissive.py
+++ b/lib/ansible/modules/system/selinux_permissive.py
@@ -19,36 +19,37 @@ DOCUMENTATION = '''
 module: selinux_permissive
 short_description: Change permissive domain in SELinux policy
 description:
-  - Add and remove domain from the list of permissive domain.
+  - Add and remove a domain from the list of permissive domains.
 version_added: "2.0"
 options:
   domain:
     description:
-        - "the domain that will be added or removed from the list of permissive domains"
+        - The domain that will be added or removed from the list of permissive domains.
     required: true
   permissive:
     description:
-        - "indicate if the domain should or should not be set as permissive"
+        - Indicate if the domain should or should not be set as permissive.
     required: true
     type: bool
   no_reload:
     description:
-        - "automatically reload the policy after a change"
-        - "default is set to 'false' as that's what most people would want after changing one domain"
-        - "Note that this doesn't work on older version of the library (example EL 6), the module will silently ignore it in this case"
+        - Disable reloading of the SELinux policy after making change to a domain's permissive setting.
+        - The default is C(no), which causes policy to be reloaded when a domain changes state.
+        - Reloading the policy does not work on older versions of the C(policycoreutils-python) library, for example in EL 6."
     type: bool
     default: 'no'
   store:
     description:
-      - "name of the SELinux policy store to use"
+      - "Name of the SELinux policy store to use."
 notes:
-    - Requires a version of SELinux recent enough ( ie EL 6 or newer )
+    - Requires a recent version of SELinux and C(policycoreutils-python) (EL 6 or newer).
 requirements: [ policycoreutils-python ]
 author: Michael Scherer (@mscherer) <misc@zarb.org>
 '''
 
 EXAMPLES = '''
-- selinux_permissive:
+- name: Change the httpd_t domain to permissive
+  selinux_permissive:
     name: httpd_t
     permissive: true
 '''


### PR DESCRIPTION
**SUMMARY**

This is a small documentation cleanup for the `selinux_permissive` module.

**ISSUE TYPE**
- Docs Pull Request

**COMPONENT NAME**
selinux_permissive

**ANSIBLE VERSION**
```paste below
ansible 2.6.3
  config file = None
  configured module search path = [u'/home/major/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/major/.pyenv/versions/2.7.14/envs/venv-2.7.14/lib/python2.7/site-packages/ansible
  executable location = /home/major/.pyenv/versions/venv-2.7.14/bin/ansible
  python version = 2.7.14 (default, Mar  7 2018, 08:13:01) [GCC 4.2.1 Compatible Clang 5.0.1 (tags/RELEASE_501/final)]
```