### PR TITLE
hashi_vault: allow mount_point for approle auth

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -181,10 +181,11 @@ class HashiVault:
             raise AnsibleError("Authentication method ldap requires a password")
 
         mount_point = kwargs.get('mount_point')
-        if mount_point is None:
-            mount_point = 'ldap'
 
-        self.client.auth_ldap(username, password, mount_point)
+        if not mount_point:
+            self.client.auth_ldap(username, password)
+        else:
+            self.client.auth_ldap(username, password, mount_point)
 
     def boolean_or_cacert(self, validate_certs, cacert):
         validate_certs = boolean(validate_certs, strict=False)
@@ -206,7 +207,12 @@ class HashiVault:
         if secret_id is None:
             raise AnsibleError("Authentication method app role requires a secret_id")
 
-        self.client.auth_approle(role_id, secret_id)
+        mount_point = kwargs.get('mount_point')
+
+        if not mount_point:
+            self.client.auth_approle(role_id, secret_id)
+        else:
+            self.client.auth_approle(role_id, secret_id, mount_point)
 
 
 class LookupModule(LookupBase):


### PR DESCRIPTION
##### SUMMARY
mount_point parameter is not used when using approle authentication

Default values are removed ('ldap' for LDAP, 'AppRole' for approle) because there
is already default values in hvac library

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hashi_vault

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.5.10
  config file = /Users/bbayszczak/Documents/git/proctool/ansible/ansible.cfg
  configured module search path = [u'/Users/bbayszczak/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/bbayszczak/.pyenv/versions/2.7.14/envs/ansible_venv/lib/python2.7/site-packages/ansible
  executable location = /Users/bbayszczak/.pyenv/versions/ansible_venv/bin/ansible
  python version = 2.7.14 (default, Apr 17 2018, 13:45:08) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```

##### ADDITIONAL INFORMATION
Lookup request
```Lookup
"{{ lookup('hashi_vault', 'secret=path/to/secret:key auth_method=approle mount_point={{ vault_access.mount_point }} role_id={{ vault_access.role_id }} secret_id={{ vault_access.secret_id }} url={{ vault_access.url }}')}}"
```

Before
```Before
An unhandled exception occurred while running the lookup plugin 'hashi_vault'. Error was a <class 'hvac.exceptions.InternalServerError'>, original message: failed to validate credentials: invalid role_id 
```

After
```After
Secret correctly returned
```
