### PR TITLE
Docs: Fix ftype list in sefcontext module

### DIFF
--- a/lib/ansible/modules/system/sefcontext.py
+++ b/lib/ansible/modules/system/sefcontext.py
@@ -27,16 +27,16 @@ options:
     aliases: [ path ]
   ftype:
     description:
-    - File type.
-    - The following file type options can be passed;
-      C(a) for all files,
-      C(b) for block devices,
-      C(c) for character devices,
-      C(d) for directories,
-      C(f) for regular files,
-      C(l) for symbolic links,
-      C(p) for named pipes,
-      C(s) for socket files.
+    - The file type that should have SELinux contexts applied.
+    - "The following file type options are available:"
+    - C(a) for all files,
+    - C(b) for block devices,
+    - C(c) for character devices,
+    - C(d) for directories,
+    - C(f) for regular files,
+    - C(l) for symbolic links,
+    - C(p) for named pipes,
+    - C(s) for socket files.
     type: str
     default: a
   setype:


### PR DESCRIPTION
##### SUMMARY
The file type list in the `sefcontext` module documentation does not display
the list of file types. Adjust the YAML formatting to ensure the list is
displayed.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
sefcontext module

##### ANSIBLE VERSION
```
ansible 2.6.5
  config file = None
  configured module search path = [u'/home/major/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/major/.pyenv/versions/2.7.14/envs/venv-2.7.14/lib/python2.7/site-packages/ansible
  executable location = /home/major/.pyenv/versions/venv-2.7.14/bin/ansible
  python version = 2.7.14 (default, Mar  7 2018, 08:13:01) [GCC 4.2.1 Compatible Clang 5.0.1 (tags/RELEASE_501/final)]
```