### PR TITLE
Docs: iptables module cleanup

### DIFF
--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -15,13 +15,13 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: iptables
-short_description: Modify the systems iptables
+short_description: Modify iptables rules
 version_added: "2.0"
 author:
 - Linus Unnebäck (@LinusU) <linus@folkdatorn.se>
 - Sébastien DA ROCHA (@sebastiendarocha)
 description:
-  - Iptables is used to set up, maintain, and inspect the tables of IP packet
+  - C(iptables) is used to set up, maintain, and inspect the tables of IP packet
     filter rules in the Linux kernel.
   - This module does not handle the saving and/or loading of rules, but rather
     only manipulates the current rules that are present in memory. This is the
@@ -64,10 +64,14 @@ options:
     default: ipv4
   chain:
     description:
-      - Chain to operate on.
-      - "This option can either be the name of a user defined chain or any of
-        the builtin chains: 'INPUT', 'FORWARD', 'OUTPUT', 'PREROUTING',
-        'POSTROUTING', 'SECMARK', 'CONNSECMARK'."
+      - "Specify the iptables chain to modify. This could be a user-defined chain or one of the standard iptables chains:"
+      - C(INPUT)
+      - C(FORWARD)
+      - C(OUTPUT)
+      - C(PREROUTING)
+      - C(POSTROUTING)
+      - C(SECMARK)
+      - C(CONNSECMARK)
   protocol:
     description:
       - The protocol of the rule or of the packet to check.
@@ -227,9 +231,14 @@ options:
   ctstate:
     description:
       - "C(ctstate) is a list of the connection states to match in the conntrack
-        module.
-        Possible states are: 'INVALID', 'NEW', 'ESTABLISHED', 'RELATED',
-        'UNTRACKED', 'SNAT', 'DNAT'"
+        module. Possible states are:"
+      - C(INVALID)
+      - C(NEW)
+      - C(ESTABLISHED)
+      - C(RELATED)
+      - C(UNTRACKED)
+      - C(SNAT)
+      - C(DNAT)
     choices: [ DNAT, ESTABLISHED, INVALID, NEW, RELATED, SNAT, UNTRACKED ]
     default: []
   limit:


### PR DESCRIPTION
##### SUMMARY
This is a small cleanup of the iptables module docs.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
iptables

##### ANSIBLE VERSION
```
ansible 2.6.5
  config file = None
  configured module search path = [u'/home/major/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/major/.pyenv/versions/2.7.14/envs/venv-2.7.14/lib/python2.7/site-packages/ansible
  executable location = /home/major/.pyenv/versions/venv-2.7.14/bin/ansible
  python version = 2.7.14 (default, Mar  7 2018, 08:13:01) [GCC 4.2.1 Compatible Clang 5.0.1 (tags/RELEASE_501/final)]

```
