### PR TITLE
Use specified loopvar in include_role example loop

### DIFF
--- a/lib/ansible/modules/utilities/logic/include_role.py
+++ b/lib/ansible/modules/utilities/logic/include_role.py
@@ -85,7 +85,7 @@ EXAMPLES = """
 
 - name: Use role in loop
   include_role:
-    name: myrole
+    name: '{{ roleinputvar }}'
   with_items:
     - '{{ roleinput1 }}'
     - '{{ roleinput2 }}'


### PR DESCRIPTION
##### SUMMARY
The loop example for the include_role module provides a loop variable and a 2-item list, but they're never used. This corrects that problem.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
include_role

##### ANSIBLE VERSION
```paste below
ansible 2.6.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/user1/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.6 (default, Jul 19 2018, 14:25:17) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```