### PR TITLE
Ovirt_disk - Add ability to refresh passthrough disks

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -146,6 +146,16 @@ options:
                your playbook accordingly to not export the disk all the time.
                This option is valid only for template disks."
         version_added: "2.4"
+    host:
+        description:
+            - "When the hypervisor name is specified the newly created disk or
+               an existing disk will refresh its information about the
+               underlying storage( Disk size, Serial, Product ID, Vendor ID ...)
+               The specified host will be used for gathering the storage
+               related information. This option is only valid for passthrough
+               disks. This option requires at least the logical_unit.id to be
+               specified"
+        version_added: "2.8"
 extends_documentation_fragment: ovirt
 '''
 
@@ -578,11 +588,25 @@ def main():
         sparsify=dict(default=None, type='bool'),
         openstack_volume_type=dict(default=None),
         image_provider=dict(default=None),
+        host=dict(default=None),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
+
+    lun = module.params.get('logical_unit')
+    host = module.params['host']
+    # Fail when host is specified with the LUN id. Lun id is needed to identify
+    # an existing disk if already available inthe environment.
+    if host and lun.get("id") is None:
+        module.fail_json(
+            msg="Can not use parameter host ({0!s}) without "
+            "specifying the logical_unit id".format(host)
+        )
+
+    if module._name == 'ovirt_disks':
+        module.deprecate("The 'ovirt_disks' module is being renamed 'ovirt_disk'", version=2.8)
 
     check_sdk(module)
     check_params(module)
@@ -599,7 +623,6 @@ def main():
             service=disks_service,
         )
 
-        lun = module.params.get('logical_unit')
         if lun:
             disk = _search_by_lun(disks_service, lun.get('id'))
 
@@ -689,6 +712,18 @@ def main():
                     )
             elif state == 'detached':
                 ret = disk_attachments_module.remove()
+
+        # When the host parameter is specified and the disk is not being
+        # removed, refresh the information about the LUN.
+        if state != 'absent' and host:
+            hosts_service = connection.system_service().hosts_service()
+            hosts = hosts_service.list(search='name={0!s}'.format(host))
+            if len(hosts) > 0:
+                host_service = hosts[0]
+            else:
+                module.fail_json(msg='Host "{0!s}" does not exist'.format(host))
+
+            disks_service.disk_service(disk.id).refresh_lun(host_service)
 
         module.exit_json(**ret)
     except Exception as e:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -597,7 +597,7 @@ def main():
     host = module.params['host']
     # Fail when host is specified with the LUN id. Lun id is needed to identify
     # an existing disk if already available inthe environment.
-    if (host and lun is None) or (host and lun.get("id") is None ):
+    if (host and lun is None) or (host and lun.get("id") is None):
         module.fail_json(
             msg="Can not use parameter host ({0!s}) without "
             "specifying the logical_unit id".format(host)


### PR DESCRIPTION
A new parameter "host" is added. When this parameter is specified the newly
created disk or an existing disk will refresh its information about the
underlying storage via the specified host. This option is only valid for
passthrough disks. This option requires at least the logical_unit.id to be
specified.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A new parameter "host" is added. When this parameter is specified the newly created disk or an existing disk will refresh its information about the underlying storage via the specified host. This option is only valid for passthrough disks. This option requires at least the logical_unit.id to be specified.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_disk
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.3
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
This pull request is a copy of [pull-45646](https://github.com/ansible/ansible/pull/45646)
I broke the branch so badly so I rather create a new request. My apologies for that.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
./hacking/test-module -m ./lib/ansible/modules/cloud/ovirt/ovirt_disk.py -a "name=MyDisk01 logical_unit=id=36001405fb6247061a564688a9baa34dba host=RHV-H01"
```
