### PR TITLE
[Backport-2.6] Ignore empty result of rabbitmqctl list_user_permissions

### DIFF
--- a/changelogs/fragments/34863-rabbitmq_user_unpack_fix.yaml
+++ b/changelogs/fragments/34863-rabbitmq_user_unpack_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Ignore empty result of rabbitmqctl list_user_permissions.

--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -172,7 +172,7 @@ class RabbitMqUser(object):
         return False
 
     def _get_permissions(self):
-        perms_out = self._exec(['list_user_permissions', self.username], True)
+        perms_out = [perm for perm in self._exec(['list_user_permissions', self.username], True) if perm.strip()]
 
         perms_list = list()
         for perm in perms_out:


### PR DESCRIPTION
##### SUMMARY
Fix #34863

(cherry picked from commit a7221dd28976f0734b081b0f5c501e93aaa9c2b7)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/34863-rabbitmq_user_unpack_fix.yaml
lib/ansible/modules/messaging/rabbitmq_user.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
Stable-2.6
```