### PR TITLE
Fixed win_route module

### DIFF
--- a/changelogs/fragments/win_route.yaml
+++ b/changelogs/fragments/win_route.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_route - Corrected issue where the wrong network interface was used for new static routes. - https://github.com/ansible/ansible/issues/28051

--- a/lib/ansible/modules/windows/win_route.ps1
+++ b/lib/ansible/modules/windows/win_route.ps1
@@ -39,7 +39,7 @@ Function Add-Route {
   if (!($Route)){
     try {
       # Find Interface Index
-      $InterfaceIndex = Find-NetRoute -RemoteIPAddress $IpAddress | Select -First 1 -ExpandProperty InterfaceIndex
+      $InterfaceIndex = Find-NetRoute -RemoteIPAddress $Gateway | Select -First 1 -ExpandProperty InterfaceIndex
 
       # Add network route
       New-NetRoute -DestinationPrefix $Destination -NextHop $Gateway -InterfaceIndex $InterfaceIndex -RouteMetric $Metric -ErrorAction Stop -WhatIf:$CheckMode|out-null 

--- a/test/integration/targets/win_route/tasks/tests.yml
+++ b/test/integration/targets/win_route/tasks/tests.yml
@@ -7,15 +7,20 @@
     state: present
   register: route
 
-- name: check if route successfully addedd
+- name: check if route successfully added
   win_shell: (Get-CimInstance win32_ip4PersistedrouteTable -Filter "Destination = '{{ destination_ip_address }}'").Caption
   register: route_added
 
-- name: test if route successfully addedd
+- name: check route default gateway
+  win_shell: (Get-CimInstance win32_ip4PersistedrouteTable -Filter "Destination = '{{ destination_ip_address }}'").NextHop
+  register: route_gateway
+
+- name: test if route successfully added
   assert:
     that:
       - route is changed
       - route_added.stdout_lines[0] == "{{ destination_ip_address }}"
+      - route_gateway.stdout_lines[0] == "{{ gateway }}"
 
 - name: add a static route to test idempotency
   win_route:

--- a/test/integration/targets/win_route/tasks/tests.yml
+++ b/test/integration/targets/win_route/tasks/tests.yml
@@ -20,7 +20,7 @@
     that:
       - route is changed
       - route_added.stdout_lines[0] == "{{ destination_ip_address }}"
-      - route_gateway.stdout_lines[0] == "{{ gateway }}"
+      - route_gateway.stdout_lines[0] == "{{ default_gateway }}"
 
 - name: add a static route to test idempotency
   win_route:


### PR DESCRIPTION
##### SUMMARY
Changed variable used during route lookup. If the route didn't exist, it would return the default gateway and select the wrong network interface to assign the new static route.
Looking up the requested gateway address would return the correct network interface and assign the route correctly.

Fixes #28051

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_route

##### ANSIBLE VERSION
```ansible 2.8.0.dev0
  config file = /home/shulme/.ansible.cfg
  configured module search path = [u'/home/shulme/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```