### PR TITLE
updates latest in docs conf.py

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -28,7 +28,7 @@ import os
 sys.path.insert(0, os.path.join('ansible', 'lib'))
 sys.path.append(os.path.abspath(os.path.join('..', '_extensions')))
 
-VERSION = '2.6'
+VERSION = '2.7'
 AUTHOR = 'Ansible, Inc'
 
 


### PR DESCRIPTION
##### SUMMARY
Related to #46399.
Updates the version displayed on the `latest` documentation on docs,ansible.com.

Merge and backport to 2.7 before building the docsite from `stable-2.7` with `Old_version=no`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
2.7
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
