### PR TITLE
[s3_bucket] Cast tag keys and values to text to match the values returned

### DIFF
--- a/changelogs/fragments/s3_bucket_fix_non_str_tags.yaml
+++ b/changelogs/fragments/s3_bucket_fix_non_str_tags.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - s3_bucket - Prior to 2.6 using non-text tags worked, although was not idempotent. In 2.6
+    waiters were introduced causing non-text tags to be fatal to the module's completion.
+    This fixes the module failure as well as idempotence using integers as tags.

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -230,6 +230,8 @@ def create_or_update_bucket(s3_client, module, location):
         module.fail_json_aws(e, msg="Failed to get bucket tags")
 
     if tags is not None:
+        # Tags are always returned as text
+        tags = dict((to_text(k), to_text(v)) for k, v in tags.items())
         if current_tags_dict != tags:
             if tags:
                 try:


### PR DESCRIPTION
##### SUMMARY
Tags that are integers and not explicitly quoted cause the module to fail.
```
    - s3_bucket:
        name: "{{ bucketname }}"
        tags:
          12345: 123543
```
This should be backported to 2.6.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
s3_bucket

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
```
