### PR TITLE
Fix ansible-test encoding issues for exceptions.

### DIFF
--- a/test/runner/lib/cli.py
+++ b/test/runner/lib/cli.py
@@ -91,10 +91,10 @@ def main():
 
         display.review_warnings()
     except ApplicationWarning as ex:
-        display.warning(str(ex))
+        display.warning(u'%s' % ex)
         exit(0)
     except ApplicationError as ex:
-        display.error(str(ex))
+        display.error(u'%s' % ex)
         exit(1)
     except KeyboardInterrupt:
         exit(2)

--- a/test/runner/lib/cover.py
+++ b/test/runner/lib/cover.py
@@ -76,7 +76,7 @@ def command_coverage_combine(args):
         try:
             original.read_file(coverage_file)
         except Exception as ex:  # pylint: disable=locally-disabled, broad-except
-            display.error(str(ex))
+            display.error(u'%s' % ex)
             continue
 
         for filename in original.measured_files():

--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -32,7 +32,7 @@ def find_target_completion(target_func, prefix):
         matches = walk_completion_targets(targets, prefix, short)
         return matches
     except Exception as ex:  # pylint: disable=locally-disabled, broad-except
-        return [str(ex)]
+        return [u'%s' % ex]
 
 
 def walk_completion_targets(targets, prefix, short=False):


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test encoding issues for exceptions.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (at-unicode-fix 866b5c8a6a) last updated 2018/10/02 12:22:27 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
