### PR TITLE
add add iptables physdev option

### DIFF
--- a/changelogs/fragments/46421-add-iptables-physdev-option.yaml
+++ b/changelogs/fragments/46421-add-iptables-physdev-option.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+   - Adding ``physdev`` parameter to iptables module. (https://github.com/ansible/ansible/pull/46421)

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -125,6 +125,17 @@ options:
             description:
                 - Flags to be set.
             type: list
+  physdev:
+    description:
+      - Matches on the bridge port input and output devices enslaved to a bridge
+        device.
+      - "C(physdev) expects a dict with a key C(filter), which specifies the
+        filter option for the bridge interface. The value can be one of: 'in',
+        'out', 'is-in', 'is-out', 'is-bridged'."
+      - If the filter type is 'in' or 'out', an interface name C(device) is
+        required.
+    default: {}
+    version_added: "2.9"
   match:
     description:
       - Specifies a match to use, that is, an extension module that tests for

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -495,6 +495,7 @@ def append_tcp_flags(rule, param, flag):
         if 'flags' in param and 'flags_set' in param:
             rule.extend([flag, ','.join(param['flags']), ','.join(param['flags_set'])])
 
+
 def append_physdev(rule, param, flag):
     if param:
         if 'filter' in param:
@@ -502,6 +503,7 @@ def append_physdev(rule, param, flag):
             if param['filter'] == 'in' or param['filter'] == 'out':
                 if 'device' in param:
                     rule.extend([param['device']])
+
 
 def append_match_flag(rule, param, flag, negatable):
     if param == 'match':

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -552,6 +552,11 @@ def construct_rule(params):
         append_match(rule, params['src_range'] or params['dst_range'], 'iprange')
         append_param(rule, params['src_range'], '--src-range', False)
         append_param(rule, params['dst_range'], '--dst-range', False)
+    if 'physdev' in params['match']:
+        append_physdev(rule, params['physdev'], '--physdev')
+    elif params['physdev']:
+        append_match(rule, params['physdev'], 'physdev')
+        append_physdev(rule, params['physdev'], '--physdev')
     append_match(rule, params['limit'] or params['limit_burst'], 'limit')
     append_param(rule, params['limit'], '--limit', False)
     append_param(rule, params['limit_burst'], '--limit-burst', False)
@@ -666,6 +671,7 @@ def main():
             ctstate=dict(type='list', default=[]),
             src_range=dict(type='str'),
             dst_range=dict(type='str'),
+            physdev=dict(type='dict', default={}),
             limit=dict(type='str'),
             limit_burst=dict(type='str'),
             uid_owner=dict(type='str'),

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -495,6 +495,13 @@ def append_tcp_flags(rule, param, flag):
         if 'flags' in param and 'flags_set' in param:
             rule.extend([flag, ','.join(param['flags']), ','.join(param['flags_set'])])
 
+def append_physdev(rule, param, flag):
+    if param:
+        if 'filter' in param:
+            rule.extend([flag + '-' + param['filter']])
+            if param['filter'] == 'in' or param['filter'] == 'out':
+                if 'device' in param:
+                    rule.extend([param['device']])
 
 def append_match_flag(rule, param, flag, negatable):
     if param == 'match':


### PR DESCRIPTION
##### SUMMARY
Add the opportunity to filter within bridge interfaces.
The physdev function is required if you want to add iptables rules, which should filter the traffic for an interface that is enslaved to a bridge.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
iptables module - lib/ansible/modules/system/iptables.py

##### ANSIBLE VERSION
```
ansible 2.5.6
```