### PR TITLE
Docs: Cleanup make module docs

### DIFF
--- a/lib/ansible/modules/system/make.py
+++ b/lib/ansible/modules/system/make.py
@@ -25,41 +25,42 @@ description:
 options:
   target:
     description:
-      - The target to run
+      - The target to run.
+      - "Examples: C(install) or C(test)"
   params:
     description:
       - Any extra parameters to pass to make
   chdir:
     description:
-      - cd into this directory before running make
+      - Change to this directory before running make
     required: true
   file:
     description:
-      - Use file as a Makefile
+      - Use a custom Makefile
     version_added: 2.5
 '''
 
 EXAMPLES = '''
-# Build the default target
-- make:
+- name: Build the default target
+  make:
     chdir: /home/ubuntu/cool-project
 
-# Run `install` target as root
-- make:
+- name: Run 'install' target as root
+  make:
     chdir: /home/ubuntu/cool-project
     target: install
   become: yes
 
-# Pass in extra arguments to build
-- make:
+- name: Build 'all' target with extra arguments
+  make:
     chdir: /home/ubuntu/cool-project
     target: all
     params:
       NUM_THREADS: 4
       BACKEND: lapack
 
-# Pass a file as a Makefile
-- make:
+- name: Build 'all' target with a custom Makefile
+  make:
     chdir: /home/ubuntu/cool-project
     target: all
     file: /some-project/Makefile


### PR DESCRIPTION
##### SUMMARY
This is a small cleanup of the documentation for the `make` Ansible module.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
make

##### ANSIBLE VERSION
```
ansible 2.6.5
  config file = None
  configured module search path = [u'/home/major/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/major/.pyenv/versions/2.7.14/envs/venv-2.7.14/lib/python2.7/site-packages/ansible
  executable location = /home/major/.pyenv/versions/venv-2.7.14/bin/ansible
  python version = 2.7.14 (default, Mar  7 2018, 08:13:01) [GCC 4.2.1 Compatible Clang 5.0.1 (tags/RELEASE_501/final)]
```