### PR TITLE
hashi_vault lookup - docs: add commas, spacing into examples

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -56,27 +56,27 @@ DOCUMENTATION = """
 
 EXAMPLES = """
 - debug:
-    msg: "{{ lookup('hashi_vault', 'secret=secret/hello:value token=c975b780-d1be-8016-866b-01d0f9b688a5 url=http://myvault:8200')}}"
+    msg: "{{ lookup('hashi_vault', secret=secret/hello:value, token=c975b780-d1be-8016-866b-01d0f9b688a5, url=http://myvault:8200) }}"
 
 - name: Return all secrets from a path
   debug:
-    msg: "{{ lookup('hashi_vault', 'secret=secret/hello token=c975b780-d1be-8016-866b-01d0f9b688a5 url=http://myvault:8200')}}"
+    msg: "{{ lookup('hashi_vault', secret=secret/hello, token=c975b780-d1be-8016-866b-01d0f9b688a5, url=http://myvault:8200) }}"
 
 - name: Vault that requires authentication via LDAP
   debug:
-      msg: "{{ lookup('hashi_vault', 'secret=secret/hello:value auth_method=ldap mount_point=ldap username=myuser password=mypas url=http://myvault:8200')}}"
+    msg: "{{ lookup('hashi_vault', secret=secret/hello:value, auth_method=ldap, mount_point=ldap, username=myuser, password=mypas, url=http://myvault:8200) }}"
 
 - name: Using an ssl vault
   debug:
-      msg: "{{ lookup('hashi_vault', 'secret=secret/hola:value token=c975b780-d1be-8016-866b-01d0f9b688a5 url=https://myvault:8200 validate_certs=False')}}"
+    msg: "{{ lookup('hashi_vault', secret=secret/hola:value, token=c975b780-d1be-8016-866b-01d0f9b688a5, url=https://myvault:8200, validate_certs=False) }}"
 
 - name: using certificate auth
   debug:
-      msg: "{{ lookup('hashi_vault', 'secret=secret/hi:value token=xxxx-xxx-xxx url=https://myvault:8200 validate_certs=True cacert=/cacert/path/ca.pem')}}"
+    msg: "{{ lookup('hashi_vault', secret=secret/hi:value, token=xxxx-xxx-xxx, url=https://myvault:8200, validate_certs=True, cacert=/cacert/path/ca.pem) }}"
 
 - name: authenticate with a Vault app role
   debug:
-      msg: "{{ lookup('hashi_vault', 'secret=secret/hello:value auth_method=approle role_id=myroleid secret_id=mysecretid url=http://myvault:8200')}}"
+    msg: "{{ lookup('hashi_vault', secret=secret/hello:value, auth_method=approle, role_id=myroleid, secret_id=mysecretid, url=http://myvault:8200) }}"
 """
 
 RETURN = """

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -60,23 +60,23 @@ EXAMPLES = """
 
 - name: Return all secrets from a path
   debug:
-    msg: "{{ lookup('hashi_vault', secret=secret/hello, token=c975b780-d1be-8016-866b-01d0f9b688a5, url=http://myvault:8200) }}"
+    msg: "{{ lookup('hashi_vault', secret='secret/hello', token='c975b780-d1be-8016-866b-01d0f9b688a5', url='http://myvault:8200') }}"
 
 - name: Vault that requires authentication via LDAP
   debug:
-    msg: "{{ lookup('hashi_vault', secret=secret/hello:value, auth_method=ldap, mount_point=ldap, username=myuser, password=mypas, url=http://myvault:8200) }}"
+    msg: "{{ lookup('hashi_vault', secret='secret/hello:value', auth_method='ldap', mount_point='ldap', username='myuser', password='mypas', url='http://myvault:8200') }}"
 
 - name: Using an ssl vault
   debug:
-    msg: "{{ lookup('hashi_vault', secret=secret/hola:value, token=c975b780-d1be-8016-866b-01d0f9b688a5, url=https://myvault:8200, validate_certs=False) }}"
+    msg: "{{ lookup('hashi_vault', secret='secret/hola:value', token='c975b780-d1be-8016-866b-01d0f9b688a5', url='https://myvault:8200', validate_certs=False) }}"
 
 - name: using certificate auth
   debug:
-    msg: "{{ lookup('hashi_vault', secret=secret/hi:value, token=xxxx-xxx-xxx, url=https://myvault:8200, validate_certs=True, cacert=/cacert/path/ca.pem) }}"
+    msg: "{{ lookup('hashi_vault', secret='secret/hi:value', token='xxxx-xxx-xxx', url='https://myvault:8200', validate_certs=True, cacert='/cacert/path/ca.pem') }}"
 
 - name: authenticate with a Vault app role
   debug:
-    msg: "{{ lookup('hashi_vault', secret=secret/hello:value, auth_method=approle, role_id=myroleid, secret_id=mysecretid, url=http://myvault:8200) }}"
+    msg: "{{ lookup('hashi_vault', secret='secret/hello:value', auth_method='approle', role_id='myroleid', secret_id='mysecretid', url='http://myvault:8200') }}"
 """
 
 RETURN = """

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -56,7 +56,7 @@ DOCUMENTATION = """
 
 EXAMPLES = """
 - debug:
-    msg: "{{ lookup('hashi_vault', secret=secret/hello:value, token=c975b780-d1be-8016-866b-01d0f9b688a5, url=http://myvault:8200) }}"
+    msg: "{{ lookup('hashi_vault', secret='secret/hello:value', token='c975b780-d1be-8016-866b-01d0f9b688a5', url='http://myvault:8200') }}"
 
 - name: Return all secrets from a path
   debug:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Adds commas into the examples
- Make spacing more consistent among examples
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault lookup plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6.4
```