### PR TITLE
Add ability to have formatted group names using ec2 tags

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -57,6 +57,9 @@ vpc_destination_variable = ip_address
 #destination_format = {0}.{1}.example.com
 #destination_format_tags = Name,environment
 
+#destination_group_format = {0}
+#destination_group_format_tags = Service
+
 # To tag instances on EC2 with the resource records that point to them from
 # Route53, set 'route53' to True.
 route53 = False

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -376,6 +376,15 @@ class Ec2Inventory(object):
             self.destination_format = None
             self.destination_format_tags = None
 
+        # Destination Group Name
+        if config.has_option('ec2', 'destination_group_format') and \
+                config.has_option('ec2', 'destination_group_format_tags'):
+            self.destination_group_format = config.get('ec2', 'destination_group_format')
+            self.destination_group_format_tags = config.get('ec2', 'destination_group_format_tags').split(',')
+        else:
+            self.destination_group_format = None
+            self.destination_group_format_tags = None
+
         # Route53
         self.route53_enabled = config.getboolean('ec2', 'route53')
         self.route53_hostnames = config.get('ec2', 'route53_hostnames')
@@ -1041,6 +1050,10 @@ class Ec2Inventory(object):
 
         # Inventory: Group by tag keys
         if self.group_by_tag_keys:
+            if self.destination_group_format and self.destination_group_format_tags:
+                key = self.destination_group_format.format(*[getattr(instance, 'tags').get(tag, '') for tag in self.destination_group_format_tags])
+            self.push(self.inventory, key, hostname)
+
             for k, v in instance.tags.items():
                 if self.expand_csv_tags and v and ',' in v:
                     values = map(lambda x: x.strip(), v.split(','))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds ability to have group names from ec2 tags, example configuration looks like:
```
destination_group_format = {0}-{1}
destination_group_format_tags = Service,Environment
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2.py dynamic inventory script

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.4
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Sometimes it is useful to be able to group hosts by some specific format, which could be cleaner and more custom. It can be used in playbooks in a more flexible way. For example:
**Tags**:
_App_: foo-bar
_Role_:  dev-foo-bar-Broker 
_Service_: dev-foo-bar
_Environment_: dev

Original tag grouping: `tag_Role_dev_foo_bar 
With parameters 
```
destination_group_format = {0}={1}
destination_group_format_tags = App,Environment
```
Could become: `foo-bar-dev`