### PR TITLE
win_chocolatey: remove test packages after tests are run

### DIFF
--- a/test/integration/targets/win_chocolatey/tasks/main.yml
+++ b/test/integration/targets/win_chocolatey/tasks/main.yml
@@ -91,6 +91,11 @@
     include_tasks: tests.yml
 
   always:
+  - name: ensure test package is uninstalled after tests
+    win_chocolatey:
+      name: '{{ test_choco_packages }}'
+      state: absent
+
   - name: remove test sources
     win_chocolatey_source:
       name: '{{ item }}'


### PR DESCRIPTION
##### SUMMARY
In the win_chocolatey tests we install a package from a custom source which is added as part of the test. Unfortunately there may be complications on the end user's Chocolatey install after the tests have run as the source is removed. This change makes sure the packages are also removed at the end of the test run.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_chocolatey

##### ANSIBLE VERSION
```paste below
devel
stable-2.7
```