### PR TITLE
win_chocolatey: remove test packages after tests are run (#46431)

### DIFF
--- a/test/integration/targets/win_chocolatey/tasks/main.yml
+++ b/test/integration/targets/win_chocolatey/tasks/main.yml
@@ -91,6 +91,11 @@
     include_tasks: tests.yml
 
   always:
+  - name: ensure test package is uninstalled after tests
+    win_chocolatey:
+      name: '{{ test_choco_packages }}'
+      state: absent
+
   - name: remove test sources
     win_chocolatey_source:
       name: '{{ item }}'


### PR DESCRIPTION
(cherry picked from commit 1de88cbaa93c20266336bb41e2ca1556e643229e)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/46431

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_chocolatey

##### ANSIBLE VERSION
```paste below
devel
```