### PR TITLE
added porting guide for PowerShell EAP changes

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -58,6 +58,12 @@ Modules
 
 Major changes in popular modules are detailed here
 
+The exec wrapper that runs PowerShell modules has been changed to set ``$ErrorActionPreference = "Stop"`` globally.
+This may mean that custom modules can fail if they implicitly relied on this behaviour. To get the old behaviour back,
+add ``$ErrorActionPreference = "Continue"`` to the top of the module. This change was made to restore the old behaviour
+of the EAP that was accidentally removed in a previous release and ensure that modules are more resiliant to errors
+that may occur in execution.
+
 
 Modules removed
 ---------------


### PR DESCRIPTION
##### SUMMARY
Add a porting guide reference to the recent changes adding `$ErrorActionPreference = "Stop"` to module execution.

Forgot to add this into https://github.com/ansible/ansible/pull/45334.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
powershell

##### ANSIBLE VERSION
```paste below
devel
```