### PR TITLE
Improve ansible-test environment checking between tests.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -743,6 +743,8 @@ def command_integration_filtered(args, targets, all_targets):
 
     results = {}
 
+    current_environment = None  # type: EnvironmentDescription | None
+
     for target in targets_iter:
         if args.start_at and not found:
             found = target.name == args.start_at
@@ -759,7 +761,8 @@ def command_integration_filtered(args, targets, all_targets):
 
         cloud_environment = get_cloud_environment(args, target)
 
-        original_environment = EnvironmentDescription(args)
+        original_environment = current_environment if current_environment else EnvironmentDescription(args)
+        current_environment = None
 
         display.info('>>> Environment Description\n%s' % original_environment, verbosity=3)
 
@@ -818,8 +821,10 @@ def command_integration_filtered(args, targets, all_targets):
                     display.verbosity = args.verbosity = 6
 
             start_time = time.time()
-            original_environment.validate(target.name, throw=True)
+            current_environment = EnvironmentDescription(args)
             end_time = time.time()
+
+            EnvironmentDescription.check(original_environment, current_environment, target.name, throw=True)
 
             results[target.name]['validation_seconds'] = int(end_time - start_time)
 

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1543,10 +1543,8 @@ class EnvironmentDescription(object):
         versions += list(set(v.split('.')[0] for v in SUPPORTED_PYTHON_VERSIONS))
 
         python_paths = dict((v, find_executable('python%s' % v, required=False)) for v in sorted(versions))
-        python_versions = dict((v, self.get_version([python_paths[v], '-V'], warnings)) for v in sorted(python_paths) if python_paths[v])
-
         pip_paths = dict((v, find_executable('pip%s' % v, required=False)) for v in sorted(versions))
-        pip_versions = dict((v, self.get_version([pip_paths[v], '--version'], warnings)) for v in sorted(pip_paths) if pip_paths[v])
+        program_versions = dict((v, self.get_version([python_paths[v], 'test/runner/versions.py'], warnings)) for v in sorted(python_paths) if python_paths[v])
         pip_interpreters = dict((v, self.get_shebang(pip_paths[v])) for v in sorted(pip_paths) if pip_paths[v])
         known_hosts_hash = self.get_hash(os.path.expanduser('~/.ssh/known_hosts'))
 
@@ -1558,9 +1556,8 @@ class EnvironmentDescription(object):
 
         self.data = dict(
             python_paths=python_paths,
-            python_versions=python_versions,
             pip_paths=pip_paths,
-            pip_versions=pip_versions,
+            program_versions=program_versions,
             pip_interpreters=pip_interpreters,
             known_hosts_hash=known_hosts_hash,
             warnings=warnings,
@@ -1678,7 +1675,7 @@ class EnvironmentDescription(object):
         """
         :type command: list[str]
         :type warnings: list[str]
-        :rtype: str
+        :rtype: list[str]
         """
         try:
             stdout, stderr = raw_command(command, capture=True, cmd_verbosity=2)
@@ -1686,7 +1683,7 @@ class EnvironmentDescription(object):
             warnings.append(u'%s' % ex)
             return None  # all failures are equal, we don't care why it failed, only that it did
 
-        return (stdout or '').strip() + (stderr or '').strip()
+        return [line.strip() for line in ((stdout or '').strip() + (stderr or '').strip()).splitlines()]
 
     @staticmethod
     def get_shebang(path):

--- a/test/runner/versions.py
+++ b/test/runner/versions.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+"""Show python and pip versions."""
+
+import os
+import sys
+
+try:
+    import pip
+except ImportError:
+    pip = None
+
+print(sys.version)
+
+if pip:
+    print('pip %s from %s' % (pip.__version__, os.path.dirname(pip.__file__)))


### PR DESCRIPTION
##### SUMMARY

Improve ansible-test environment checking between tests:

- Add unified diff output to environment validation.
- Compare Python interpreters by version to pip shebangs.
- Query `pip.__version__` instead of using `pip --version`.
- Remove redundant environment scan between tests.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (at-env-fixup 923b1e85b8) last updated 2018/10/03 16:19:28 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
