### PR TITLE
updates language about documentation versions and releases on index page

### DIFF
--- a/docs/docsite/rst/index.rst
+++ b/docs/docsite/rst/index.rst
@@ -15,9 +15,9 @@ We believe simplicity is relevant to all sizes of environments, so we design for
 Ansible manages machines in an agent-less manner. There is never a question of how to
 upgrade remote daemons or the problem of not being able to manage systems because daemons are uninstalled.  Because OpenSSH is one of the most peer-reviewed open source components, security exposure is greatly reduced. Ansible is decentralized--it relies on your existing OS credentials to control access to remote machines. If needed, Ansible can easily connect with Kerberos, LDAP, and other centralized authentication management systems.
 
-This documentation covers the current released version of Ansible (2.6) and also some development version features.  For recent features, we note in each section the version of Ansible where the feature was added.
+This documentation covers the version of Ansible noted in the upper left corner of this page. We maintain multiple versions of Ansible and of the documentation, so please be sure you are using the version of the documentation that covers the version of Ansible you're using. For recent features, we note the version of Ansible where the feature was added.
 
-Ansible releases a new major release of Ansible approximately every two months.  The core application evolves somewhat conservatively, valuing simplicity in language design and setup. However, the community around new modules and plugins being developed and contributed moves very quickly, adding many new modules in each release.
+Ansible releases a new major release of Ansible approximately three to four times per year. The core application evolves somewhat conservatively, valuing simplicity in language design and setup. However, the community around new modules and plugins being developed and contributed moves very quickly, adding many new modules in each release.
 
 
 .. toctree::


### PR DESCRIPTION
##### SUMMARY
Related to #46356.

The index page on the docsite talks about covering "the latest released version and some development features" but we haven't handled the docs that way in a long time. This is an interim fix - revisit this language when we deal with versions more generally - see #37049 and #45651 and  #28553 and #41782. See also https://github.com/ansible/proposals/issues/60.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
2.7

