### PR TITLE
Backport/2.7/42456 - Added SSL Support to consul_kv lookup plugin

### DIFF
--- a/changelogs/fragments/42456-consul_kv-lookup.yaml
+++ b/changelogs/fragments/42456-consul_kv-lookup.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - added capability to set the scheme for the consul_kv lookup.
+  - added optional certificate and certificate verification for consul_kv lookups


### PR DESCRIPTION
##### SUMMARY

Backport the fix for #40877 to stable-2.7 branch.
Added the params scheme, cert and verify to the consul_kv lookup module

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lookup/consul_kv

##### ANSIBLE VERSION
```
ansible 2.5.3 (stable-2.5 9d8d1de182) last updated 2018/05/22 09:25:46 (GMT +200)
  config file = /mnt/c/Projekte/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/lib/ansible
  executable location = /opt/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```
