### PR TITLE
Make default_operation optional in netconf_config module (#46333)

### DIFF
--- a/changelogs/fragments/netconf_config_default_operation.yaml
+++ b/changelogs/fragments/netconf_config_default_operation.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- netconf_config - Make default_operation optional in netconf_config module (https://github.com/ansible/ansible/pull/46333)

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -71,7 +71,6 @@ options:
       option completely replaces the configuration in the C(target) datastore. If the value is none the C(target)
       datastore is unaffected by the configuration in the config option, unless and until the incoming configuration
       data uses the C(operation) operation to request a different operation.
-    default: merge
     choices: ['merge', 'replace', 'none']
     version_added: "2.7"
   confirm:
@@ -231,7 +230,7 @@ def main():
         source_datastore=dict(aliases=['source']),
         format=dict(choices=['xml', 'text'], default='xml'),
         lock=dict(choices=['never', 'always', 'if-supported'], default='always'),
-        default_operation=dict(choices=['merge', 'replace', 'none'], default='merge'),
+        default_operation=dict(choices=['merge', 'replace', 'none']),
         confirm=dict(type='int', default=0),
         confirm_commit=dict(type='bool', default=False),
         error_option=dict(choices=['stop-on-error', 'continue-on-error', 'rollback-on-error'], default='stop-on-error'),


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #46257

*  As per netconf rfc default-operation value is optional,
   hence removing the default value for default_operation
   option.
 Merged to devel https://github.com/ansible/ansible/pull/46333
(cherry picked from commit 5e6eb921aed82ddfeaa8b8c791bda04e39ba2a34)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
