### PR TITLE
Add sudo_password parameter to homebrew_cask

### DIFF
--- a/lib/ansible/modules/packaging/os/homebrew_cask.py
+++ b/lib/ansible/modules/packaging/os/homebrew_cask.py
@@ -484,6 +484,24 @@ class HomebrewCask(object):
         self.message = "You must select a cask to install."
         raise HomebrewCaskException(self.message)
 
+    # sudo_password fix ---------------------- {{{
+    def _run_command_with_sudo_password(self, cmd):
+        sudo_askpass_file = tempfile.NamedTemporaryFile()
+        sudo_askpass_file.write("#!/bin/sh\n\necho '" + self.sudo_password + "'\n")
+        os.chmod(sudo_askpass_file.name, 0o700)
+        sudo_askpass_file.file.close()
+
+        rc, out, err = self.module.run_command(
+            cmd,
+            environ_update={'SUDO_ASKPASS': sudo_askpass_file.name}
+        )
+
+        sudo_askpass_file.close()
+        self.module.add_cleanup_file(sudo_askpass_file.name)
+
+        return (rc, out, err)
+    # /sudo_password fix --------------------- }}}
+
     # updated -------------------------------- {{{
     def _update_homebrew(self):
         rc, out, err = self.module.run_command([
@@ -517,27 +535,18 @@ class HomebrewCask(object):
             self.message = 'Casks would be upgraded.'
             raise HomebrewCaskException(self.message)
 
+        opts = (
+            [self.brew_path, 'cask', 'upgrade']
+        )
+
+        cmd = [opt for opt in opts if opt]
+
         rc, out, err = '', '', ''
 
         if self.sudo_password:
-            sudo_askpass_file = tempfile.NamedTemporaryFile()
-            sudo_askpass_file.write("#!/bin/sh\n\necho '" + self.sudo_password + "'\n")
-            os.chmod(sudo_askpass_file.name, 0o700)
-            sudo_askpass_file.file.close()
-
-            rc, out, err = self.module.run_command([
-                self.brew_path,
-                'cask',
-                'upgrade',
-            ], environ_update={'SUDO_ASKPASS': sudo_askpass_file.name})
-
-            sudo_askpass_file.close()
+            rc, out, err = self._run_command_with_sudo_password(cmd)
         else:
-            rc, out, err = self.module.run_command([
-                self.brew_path,
-                'cask',
-                'upgrade',
-            ])
+            rc, out, err = self.module.run_command(cmd)
 
         if rc == 0:
             if re.search(r'==> No Casks to upgrade', out.strip(), re.IGNORECASE):
@@ -585,17 +594,7 @@ class HomebrewCask(object):
         rc, out, err = '', '', ''
 
         if self.sudo_password:
-            sudo_askpass_file = tempfile.NamedTemporaryFile()
-            sudo_askpass_file.write("#!/bin/sh\n\necho '" + self.sudo_password + "'\n")
-            os.chmod(sudo_askpass_file.name, 0o700)
-            sudo_askpass_file.file.close()
-
-            rc, out, err = self.module.run_command(
-                cmd,
-                environ_update={'SUDO_ASKPASS': sudo_askpass_file.name}
-            )
-
-            sudo_askpass_file.close()
+            rc, out, err = self._run_command_with_sudo_password(cmd)
         else:
             rc, out, err = self.module.run_command(cmd)
 
@@ -659,17 +658,7 @@ class HomebrewCask(object):
         rc, out, err = '', '', ''
 
         if self.sudo_password:
-            sudo_askpass_file = tempfile.NamedTemporaryFile()
-            sudo_askpass_file.write("#!/bin/sh\n\necho '" + self.sudo_password + "'\n")
-            os.chmod(sudo_askpass_file.name, 0o700)
-            sudo_askpass_file.file.close()
-
-            rc, out, err = self.module.run_command(
-                cmd,
-                environ_update={'SUDO_ASKPASS': sudo_askpass_file.name}
-            )
-
-            sudo_askpass_file.close()
+            rc, out, err = self._run_command_with_sudo_password(cmd)
         else:
             rc, out, err = self.module.run_command(cmd)
 
@@ -722,17 +711,7 @@ class HomebrewCask(object):
         rc, out, err = '', '', ''
 
         if self.sudo_password:
-            sudo_askpass_file = tempfile.NamedTemporaryFile()
-            sudo_askpass_file.write("#!/bin/sh\n\necho '" + self.sudo_password + "'\n")
-            os.chmod(sudo_askpass_file.name, 0o700)
-            sudo_askpass_file.file.close()
-
-            rc, out, err = self.module.run_command(
-                cmd,
-                environ_update={'SUDO_ASKPASS': sudo_askpass_file.name}
-            )
-
-            sudo_askpass_file.close()
+            rc, out, err = self._run_command_with_sudo_password(cmd)
         else:
             rc, out, err = self.module.run_command(cmd)
 

--- a/lib/ansible/modules/packaging/os/homebrew_cask.py
+++ b/lib/ansible/modules/packaging/os/homebrew_cask.py
@@ -486,18 +486,19 @@ class HomebrewCask(object):
 
     # sudo_password fix ---------------------- {{{
     def _run_command_with_sudo_password(self, cmd):
-        sudo_askpass_file = tempfile.NamedTemporaryFile()
-        sudo_askpass_file.write("#!/bin/sh\n\necho '" + self.sudo_password + "'\n")
-        os.chmod(sudo_askpass_file.name, 0o700)
-        sudo_askpass_file.file.close()
+        rc, out, err = '', '', ''
 
-        rc, out, err = self.module.run_command(
-            cmd,
-            environ_update={'SUDO_ASKPASS': sudo_askpass_file.name}
-        )
+        with tempfile.NamedTemporaryFile() as sudo_askpass_file:
+            sudo_askpass_file.write("#!/bin/sh\n\necho '" + self.sudo_password + "'\n")
+            os.chmod(sudo_askpass_file.name, 0o700)
+            sudo_askpass_file.file.close()
 
-        sudo_askpass_file.close()
-        self.module.add_cleanup_file(sudo_askpass_file.name)
+            rc, out, err = self.module.run_command(
+                cmd,
+                environ_update={'SUDO_ASKPASS': sudo_askpass_file.name}
+            )
+
+            self.module.add_cleanup_file(sudo_askpass_file.name)
 
         return (rc, out, err)
     # /sudo_password fix --------------------- }}}

--- a/lib/ansible/modules/packaging/os/homebrew_cask.py
+++ b/lib/ansible/modules/packaging/os/homebrew_cask.py
@@ -141,6 +141,7 @@ import os
 import re
 import tempfile
 
+from ansible.module_utils._text import to_bytes
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems, string_types
 
@@ -489,7 +490,7 @@ class HomebrewCask(object):
         rc, out, err = '', '', ''
 
         with tempfile.NamedTemporaryFile() as sudo_askpass_file:
-            sudo_askpass_file.write("#!/bin/sh\n\necho '" + self.sudo_password + "'\n")
+            sudo_askpass_file.write(b"#!/bin/sh\n\necho '%s'\n" % to_bytes(self.sudo_password))
             os.chmod(sudo_askpass_file.name, 0o700)
             sudo_askpass_file.file.close()
 


### PR DESCRIPTION
##### SUMMARY
This fixes #29403.  This is assuming that `ansible_become_pass` is inaccessible in modules.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
homebrew_cask

##### ANSIBLE VERSION
```
± ansible --version
ansible 2.8.0.dev0 (homebrew_cask_sudo_fix 2f53e49024) last updated 2018/10/04 04:28:35 (GMT -400)
  config file = /Users/dan/.ansible.cfg
  configured module search path = ['/Users/dan/src/ansible/library']
  ansible python module location = /Users/dan/src/ansible/lib/ansible
  executable location = /Users/dan/src/ansible/bin/ansible
  python version = 3.6.3 (default, Oct 21 2017, 11:37:52) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION
Could really use a code review + some testers for this PR.