### PR TITLE
[Backport 2.7]: Only delete key from redis in-memory cache if present

### DIFF
--- a/changelogs/fragments/35120-redis_inventory_plugin_flush_cache.yaml
+++ b/changelogs/fragments/35120-redis_inventory_plugin_flush_cache.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Only delete host key from redis in-memory cache if present.

--- a/lib/ansible/plugins/cache/redis.py
+++ b/lib/ansible/plugins/cache/redis.py
@@ -116,7 +116,8 @@ class CacheModule(BaseCacheModule):
         return (self._db.zrank(self._keys_set, key) is not None)
 
     def delete(self, key):
-        del self._cache[key]
+        if key in self._cache:
+            del self._cache[key]
         self._db.delete(self._make_key(key))
         self._db.zrem(self._keys_set, key)
 


### PR DESCRIPTION

##### SUMMARY
Fixes #35120 : the redis cache plugin keeps key/value
entries in an in-memory cache to avoid hitting the
redis database each time.

The problem is that a cache entry is only set when
a value is get or set but it is always deleted when
trying to delete a value.

When the --flush-cache ansible-playbook option is used,
the redis cache plugin is first asked to remove every
entry corresponding to every hostname present in the inventory.
As no value as been set/get so far, it then tries to delete
an unexisting value from the cache and hence crashes with
a KeyError exception.

(cherry picked from commit ee3dfef016e1f863b1392b50dab190d256d383ee)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/35120-redis_inventory_plugin_flush_cache.yaml
lib/ansible/plugins/cache/redis.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
Stable-2.7
```
