### PR TITLE
Add cloud_platforms to the galaxy role templates

### DIFF
--- a/lib/ansible/galaxy/data/apb/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/apb/meta/main.yml.j2
@@ -39,6 +39,19 @@ galaxy_info:
   #   - 7
   #   - 99.99
 
+  #
+  # Provide a list of supported cloud platforms.
+  #
+  # cloud_platforms:
+  #   - amazon
+  #   - azure
+  #   - centurylink
+  #   - google
+  #   - openstack
+  #   - ovirt
+  #   - rackspace
+  #   - vmware
+
   galaxy_tags:
     - apb
     # List tags for your role here, one per line. A tag is a keyword that describes

--- a/lib/ansible/galaxy/data/container/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/container/meta/main.yml.j2
@@ -47,6 +47,19 @@ galaxy_info:
   #   - 7
   #   - 99.99
 
+  #
+  # Provide a list of supported cloud platforms.
+  #
+  # cloud_platforms:
+  #   - amazon
+  #   - azure
+  #   - centurylink
+  #   - google
+  #   - openstack
+  #   - ovirt
+  #   - rackspace
+  #   - vmware
+
   galaxy_tags:
     - container
     # List tags for your role here, one per line. A tag is a keyword that describes

--- a/lib/ansible/galaxy/data/default/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/meta/main.yml.j2
@@ -47,6 +47,19 @@ galaxy_info:
   #   - 7
   #   - 99.99
 
+  #
+  # Provide a list of supported cloud platforms.
+  #
+  # cloud_platforms:
+  #   - amazon
+  #   - azure
+  #   - centurylink
+  #   - google
+  #   - openstack
+  #   - ovirt
+  #   - rackspace
+  #   - vmware
+
   galaxy_tags: []
     # List tags for your role here, one per line. A tag is a keyword that describes
     # and categorizes the role. Users find roles by searching for tags. Be sure to

--- a/lib/ansible/galaxy/data/network/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/network/meta/main.yml.j2
@@ -44,6 +44,19 @@ galaxy_info:
   #   - 7
   #   - 99.99
 
+  #
+  # Provide a list of supported cloud platforms.
+  #
+  # cloud_platforms:
+  #   - amazon
+  #   - azure
+  #   - centurylink
+  #   - google
+  #   - openstack
+  #   - ovirt
+  #   - rackspace
+  #   - vmware
+
   galaxy_tags: []
     # List tags for your role here, one per line. A tag is a keyword that describes
     # and categorizes the role. Users find roles by searching for tags. Be sure to


### PR DESCRIPTION
##### SUMMARY
A new categorization by Cloud Platform was added to ansible roles in Galaxy, tracked in https://github.com/ansible/galaxy/issues/157 and https://trello.com/c/CdYwgWFG.

This PR adds it to the four available galaxy role template types.
The available cloud platforms were taken from
https://github.com/ansible/galaxy/blob/8e0bc2e6fa4040f68f7c976df1ebc1351c359837/galaxy/main/migrations/0107_cloud_platforms.py

Signed-off-by: Harald Albers <github@albersweb.de>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
```

##### ADDITIONAL INFORMATION
Once this is merged, the corresponding item in https://github.com/ansible/galaxy/issues/157 should be checked.
ping @chouseknecht for review