### PR TITLE
Include dependency role names in `role_names`.

### DIFF
--- a/changelogs/fragments/46483-role_names-change.yaml
+++ b/changelogs/fragments/46483-role_names-change.yaml
@@ -1,0 +1,11 @@
+minor_changes:
+  - magic variables - added a new ``ansible_role_names`` magic variable to include the names of roles being applied to
+    the host both directly and indirectly (via dependencies).
+  - magic variabels - added a new ``ansible_play_role_names`` magic variable to mimic the old functionality of
+    ``role_names``. This variable only lists the names of roles being applied to the host directly, and does not
+    include those added via dependencies
+  - magic variables - added a new ``ansible_dependent_role_names`` magic variable to contain the names of roles
+    applied to the host indirectly, via dependencies.
+deprecated_features:
+  - magic variables - documented the deprecation of the ``role_names`` magic variable in favor of either
+    ``ansible_role_names`` (including dependency role names) or ``ansible_play_role_names`` (excluding dependencies).

--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -49,6 +49,9 @@ ansible_verbosity
 ansible_version
    Dictionary/map that contains information about the current running version of ansible, it has the following keys: full, major, minor, revision and string.
 
+dependent_role_names
+    The names of the roles currently imported into the current play as dependencies of other plays
+
 group_names
     List of groups the current host is part of
 
@@ -79,6 +82,10 @@ play_hosts
 ansible_play_name
     The name of the currently executed play. Added in ``2.8``.
 
+play_role_names
+    The names of the roles currently imported into the current play. This list does **not** contain the role names that are
+    implicitly included via dependencies.
+
 playbook_dir
     The path to the directory of the playbook that was passed to the ``ansible-playbook`` command line.
 
@@ -86,7 +93,8 @@ role_name:
     The name of the currently executed role
 
 role_names
-    The names of the rules currently imported into the current play.
+    The names of the roles currently imported into the current play, or roles referenced as dependencies of the roles
+    imported into the current play.
 
 role_path
     The path to the dir of the currently running role

--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -90,10 +90,6 @@ play_hosts
 ansible_play_name
     The name of the currently executed play. Added in ``2.8``.
 
-play_role_names
-    The names of the roles currently imported into the current play. This list does **not** contain the role names that are
-    implicitly included via dependencies.
-
 playbook_dir
     The path to the directory of the playbook that was passed to the ``ansible-playbook`` command line.
 

--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -10,6 +10,9 @@ These variables are directly not settable by the user, Ansible will always overr
 ansible_check_mode
     Boolean that indicates if we are in check mode or not
 
+ansible_dependent_role_names
+    The names of the roles currently imported into the current play as dependencies of other plays
+
 ansible_diff_mode
     Boolean that indicates if we are in diff mode or not
 
@@ -31,8 +34,16 @@ ansible_play_hosts
 ansible_play_hosts_all
     List of all the hosts that were targeted by the play
 
+ansible_play_role_names
+    The names of the roles currently imported into the current play. This list does **not** contain the role names that are
+    implicitly included via dependencies.
+
 ansible_playbook_python
     The path to the python interpreter being used by Ansible on the controller
+
+ansible_role_names
+    The names of the roles currently imported into the current play, or roles referenced as dependencies of the roles
+    imported into the current play.
 
 ansible_run_tags
     Contents of the ``--tags`` CLI option, which specifies which tags will be included for the current run.
@@ -48,9 +59,6 @@ ansible_verbosity
 
 ansible_version
    Dictionary/map that contains information about the current running version of ansible, it has the following keys: full, major, minor, revision and string.
-
-dependent_role_names
-    The names of the roles currently imported into the current play as dependencies of other plays
 
 group_names
     List of groups the current host is part of
@@ -93,8 +101,7 @@ role_name:
     The name of the currently executed role
 
 role_names
-    The names of the roles currently imported into the current play, or roles referenced as dependencies of the roles
-    imported into the current play.
+    Deprecated, the same as ansible_play_role_names
 
 role_path
     The path to the dir of the currently running role

--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -38,6 +38,8 @@ STATIC_VARS = [
     'playbook_dir',
     'play_hosts',
     'role_names',
+    'play_role_names',
+    'dependent_role_names',
     'ungrouped',
 ]
 

--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -28,6 +28,9 @@ from ansible.template import Templar
 STATIC_VARS = [
     'ansible_version',
     'ansible_play_hosts',
+    'ansible_dependent_role_names',
+    'ansible_play_role_names',
+    'ansible_role_names',
     'inventory_hostname',
     'inventory_hostname_short',
     'inventory_file',
@@ -38,8 +41,6 @@ STATIC_VARS = [
     'playbook_dir',
     'play_hosts',
     'role_names',
-    'play_role_names',
-    'dependent_role_names',
     'ungrouped',
 ]
 

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -451,7 +451,20 @@ class VariableManager:
         variables['ansible_playbook_python'] = sys.executable
 
         if play:
-            variables['role_names'] = [r._role_name for r in play.roles]
+            # This is a list of all role names of all dependencies for all roles for this play
+            dependency_role_names = list(set([d._role_name for r in play.roles for d in r.get_all_dependencies()]))
+            # This is a list of all role names of all roles for this play
+            play_role_names = [r._role_name for r in play.roles]
+
+            # role_names includes all role names, dependent or directly referenced by the play
+            variables['role_names'] = list(set(dependency_role_names + play_role_names))
+            # play_role_names includes the names of all roles directly referenced by this play
+            # roles that are implicitly referenced via dependencies are not listed.
+            variables['play_role_names'] = play_role_names
+            # dependent_role_names includes the names of all roles that are referenced via dependencies
+            # dependencies that are also explicitly named as roles are included in this list
+            variables['dependent_role_names'] = dependency_role_names
+
             variables['ansible_play_name'] = play.get_name()
 
         if task:

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -456,14 +456,17 @@ class VariableManager:
             # This is a list of all role names of all roles for this play
             play_role_names = [r._role_name for r in play.roles]
 
-            # role_names includes all role names, dependent or directly referenced by the play
-            variables['role_names'] = list(set(dependency_role_names + play_role_names))
-            # play_role_names includes the names of all roles directly referenced by this play
+            # ansible_role_names includes all role names, dependent or directly referenced by the play
+            variables['ansible_role_names'] = list(set(dependency_role_names + play_role_names))
+            # ansible_play_role_names includes the names of all roles directly referenced by this play
             # roles that are implicitly referenced via dependencies are not listed.
-            variables['play_role_names'] = play_role_names
-            # dependent_role_names includes the names of all roles that are referenced via dependencies
+            variables['ansible_play_role_names'] = play_role_names
+            # ansible_dependent_role_names includes the names of all roles that are referenced via dependencies
             # dependencies that are also explicitly named as roles are included in this list
-            variables['dependent_role_names'] = dependency_role_names
+            variables['ansible_dependent_role_names'] = dependency_role_names
+
+            # DEPRECATED: role_names should be deprecated in favor of ansible_role_names or ansible_play_role_names
+            variables['role_names'] = variables['ansible_play_role_names']
 
             variables['ansible_play_name'] = play.get_name()
 

--- a/test/integration/targets/special_vars/tasks/main.yml
+++ b/test/integration/targets/special_vars/tasks/main.yml
@@ -23,7 +23,7 @@
   include_vars: "{{output_dir}}/special_vars.yaml"
 
 
-- name: veriy all test vars are defined
+- name: verify all test vars are defined
   assert:
     that:
         - 'item in hostvars[inventory_hostname].keys()'
@@ -35,3 +35,24 @@
     - test_template_fullpath
     - test_template_run_date
     - test_ansible_managed
+
+- name: ensure that role_name exists in role_names, ansible_play_role_names, ansible_role_names, and not in ansible_dependent_role_names
+  assert:
+    that:
+      - "role_name in role_names"
+      - "role_name in ansible_play_role_names"
+      - "role_name in ansible_role_names"
+      - "role_name not in ansible_dependent_role_names"
+
+- name: ensure that our dependency (prepare_tests) exists in ansible_role_names and ansible_dependent_role_names, but not in role_names or ansible_play_role_names
+  assert:
+    that:
+      - "'prepare_tests' in ansible_role_names"
+      - "'prepare_tests' in ansible_dependent_role_names"
+      - "'prepare_tests' not in role_names"
+      - "'prepare_tests' not in ansible_play_role_names"
+
+- name: ensure that ansible_role_names is the sum of ansible_play_role_names and ansible_dependent_role_names
+  assert:
+    that:
+      - "(ansible_play_role_names + ansible_dependent_role_names)|unique == ansible_role_names"

--- a/test/integration/targets/special_vars/tasks/main.yml
+++ b/test/integration/targets/special_vars/tasks/main.yml
@@ -55,4 +55,4 @@
 - name: ensure that ansible_role_names is the sum of ansible_play_role_names and ansible_dependent_role_names
   assert:
     that:
-      - "(ansible_play_role_names + ansible_dependent_role_names)|unique == ansible_role_names"
+      - "(ansible_play_role_names + ansible_dependent_role_names)|unique|sort|list == ansible_role_names|sort|list"


### PR DESCRIPTION
-Change: Include dependency role names in `role_names`.
-Add: `play_role_names` magic variable to include only explicitly named roles (formerly `role_names`).
-Add: `dependent_role_names` magic variable to include all dependency names for all roles.

##### SUMMARY
As per #16068, the `role_names` magic variable only contains the role names of roles explicitly listed in the current play. This PR is to change this functionality to be aware of dependencies.

The main rationale is that once your tree of roles grows, you inevitably introduce conflicts between roles, to prevent these conflicts from happening, one would want to add an early failure when a role is being installed that conflicts with an already existing one.
The easiest way to do this is to check what other roles are active, and notify accordingly. This would work with `role_names`, but **only** if the role was explicitly listed in the playbook. If the role was included by means of a dependency, it would not show up, and you would have to do other manual checking to prevent this.

Therefore we introduce 2 new magic variables, and redefine one:

- `role_names` now includes all role names, including those of dependencies. The most common use case when checking in role_names is to see if the target host is affected by a specific role. The addition of dependencies to this list would not break those use cases, but instead would make them more accurate.
- `play_role_names` assumes the role of the former `role_names`, only listing explicitly listed roles as per the play. Should there be a requirement to see if a role is explicitly configured, this list can be used
- `dependent_role_names` lists all roles that are included because they are a dependency of another role. This means they may include roles that are also defined in `play_role_names`, so a check against `play_role_names` can verify whether a specific role is _only_ a dependency, or _both_ a dependency _and_ explicitly required.

Documentation has been adjusted (and added) for these magic variables.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Magic Variables

##### ANSIBLE VERSION
```paste below
ansible 2.7.0rc4.post0
```
Please note that this affects ansible versions 2.0.0 up until `master`

##### ADDITIONAL INFORMATION
Given a setup of 2 roles (A and B, for ease of use), where A/meta/main.yml lists B as a dependency, `role_names` would show `['A']`. This makes it impossible to detect whether or not B will be installed on a host.

After this change, `role_names` would show `['A', 'B']`, `play_role_names` shows `['A']`, and `dependent_role_names` shows `['B']`
