### PR TITLE
Test django_manage

### DIFF
--- a/lib/ansible/modules/web_infrastructure/django_manage.py
+++ b/lib/ansible/modules/web_infrastructure/django_manage.py
@@ -137,7 +137,7 @@ EXAMPLES = """
 import os
 import sys
 
-from ansible.utils.shlex import shlex_split
+import shlex
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -259,7 +259,7 @@ def main():
         value = module.params[param]
         if param in specific_boolean_params:
             value = module.boolean(value)
-        command_name = shlex_split(command)[0]  # Else it fails with arguments
+        command_name = shlex.split(command)[0]  # Else it fails with arguments
         if value and param not in command_allowed_param_map.get(command_name, []):
             module.fail_json(msg='%s param is incompatible with command=%s' % (param, command))
 

--- a/lib/ansible/modules/web_infrastructure/django_manage.py
+++ b/lib/ansible/modules/web_infrastructure/django_manage.py
@@ -137,6 +137,7 @@ EXAMPLES = """
 import os
 import sys
 
+from ansible.utils.shlex import shlex_split
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -258,7 +259,8 @@ def main():
         value = module.params[param]
         if param in specific_boolean_params:
             value = module.boolean(value)
-        if value and param not in command_allowed_param_map[command]:
+        command_name = shlex_split(command)[0]  # Else it fails with arguments
+        if value and param not in command_allowed_param_map.get(command_name, []):
             module.fail_json(msg='%s param is incompatible with command=%s' % (param, command))
 
     for param in command_required_param_map.get(command, ()):

--- a/test/units/modules/conftest.py
+++ b/test/units/modules/conftest.py
@@ -26,3 +26,5 @@ def patch_ansible_module(request, mocker):
         raise Exception('Malformed data to the patch_ansible_module pytest fixture')
 
     mocker.patch('ansible.module_utils.basic._ANSIBLE_ARGS', to_bytes(args))
+
+    return args

--- a/test/units/modules/web_infrastructure/test_django_manage.py
+++ b/test/units/modules/web_infrastructure/test_django_manage.py
@@ -1,0 +1,79 @@
+import json
+
+import pytest
+from ansible.modules.web_infrastructure import django_manage
+
+pytestmark = pytest.mark.usefixtures('patch_ansible_module')
+
+TESTCASE_NO_ARGUMENTS = [
+    'cleanup',
+    'validate',
+    'my_custom_command',
+]
+
+TESTCASE_NO_INPUT_COMMANDS = [
+    "flush",
+    "syncdb",
+    "migrate",
+    "test",
+    "collectstatic",
+]
+
+
+def base_test(mocker, module_arguments):
+    arguments_as_dict = json.loads(module_arguments)['ANSIBLE_MODULE_ARGS']
+
+    def dummy_run_command(module, cmd, *args, **kwargs):
+        return 0, "", ""
+
+    mocker.patch.object(django_manage.AnsibleModule,
+                        'run_command',
+                        new=dummy_run_command)
+    mocker.spy(django_manage.AnsibleModule, 'run_command')
+
+    with pytest.raises(SystemExit):
+        django_manage.main()
+
+    return arguments_as_dict
+
+
+@pytest.mark.parametrize(argnames='patch_ansible_module',
+                         argvalues=[
+                             {
+                                 "command": cmd_name,
+                                 "app_path": "dummy.path.to.module"
+                             }
+                             for cmd_name in TESTCASE_NO_ARGUMENTS
+                         ],
+                         indirect=['patch_ansible_module'])
+def test_no_arguments(mocker, patch_ansible_module):
+    arguments = base_test(mocker=mocker, module_arguments=patch_ansible_module)
+
+    assert django_manage.AnsibleModule.run_command.call_count == 1
+
+    arg_list = django_manage.AnsibleModule.run_command.call_args_list
+    args, kwargs = arg_list[0]
+
+    assert args[1] == './manage.py {}'.format(arguments["command"])
+    assert kwargs['cwd'] == arguments["app_path"]
+
+
+@pytest.mark.parametrize(argnames='patch_ansible_module',
+                         argvalues=[
+                             {
+                                 "command": cmd_name,
+                                 "app_path": "dummy.path.to.module"
+                             }
+                             for cmd_name in TESTCASE_NO_INPUT_COMMANDS
+                         ],
+                         indirect=['patch_ansible_module'])
+def test_no_input_commands(mocker, patch_ansible_module):
+    arguments = base_test(mocker=mocker, module_arguments=patch_ansible_module)
+
+    assert django_manage.AnsibleModule.run_command.call_count == 1
+
+    arg_list = django_manage.AnsibleModule.run_command.call_args_list
+    args, kwargs = arg_list[0]
+
+    assert args[1] == './manage.py {} --noinput'.format(arguments["command"])
+    assert kwargs['cwd'] == arguments["app_path"]

--- a/test/units/modules/web_infrastructure/test_django_manage.py
+++ b/test/units/modules/web_infrastructure/test_django_manage.py
@@ -19,11 +19,13 @@ TESTCASE_NO_INPUT_COMMANDS = [
     "collectstatic",
 ]
 
+
+def dummy_run_command(module, cmd, *args, **kwargs):
+    return 0, "", ""
+
+
 def base_test(mocker, module_arguments):
     arguments_as_dict = json.loads(module_arguments)['ANSIBLE_MODULE_ARGS']
-
-    def dummy_run_command(module, cmd, *args, **kwargs):
-        return 0, "", ""
 
     mocker.patch.object(django_manage.AnsibleModule,
                         'run_command',
@@ -53,7 +55,7 @@ def test_no_arguments(mocker, patch_ansible_module):
     arg_list = django_manage.AnsibleModule.run_command.call_args_list
     args, kwargs = arg_list[0]
 
-    assert args[1] == './manage.py {}'.format(arguments["command"])
+    assert args[1] == './manage.py %s' % arguments["command"]
     assert kwargs['cwd'] == arguments["app_path"]
 
 
@@ -74,7 +76,7 @@ def test_no_input_commands(mocker, patch_ansible_module):
     arg_list = django_manage.AnsibleModule.run_command.call_args_list
     args, kwargs = arg_list[0]
 
-    assert args[1] == './manage.py {} --noinput'.format(arguments["command"])
+    assert args[1] == './manage.py %s --noinput' % arguments["command"]
     assert kwargs['cwd'] == arguments["app_path"]
 
 
@@ -98,5 +100,5 @@ def test_failfast_with_arguments(mocker, patch_ansible_module):
     arg_list = django_manage.AnsibleModule.run_command.call_args_list
     args, kwargs = arg_list[0]
 
-    assert args[1] == './manage.py {} --failfast'.format(arguments["command"])
+    assert args[1] == './manage.py %s --failfast' % arguments["command"]
     assert kwargs['cwd'] == arguments["app_path"]


### PR DESCRIPTION
##### SUMMARY
Add simple and incomplete tests for `django_manage`. 

Also fixes #42027, with an associated test.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
django_manage

##### ANSIBLE VERSION

```
  ansible 2.8.0.dev0 (test_django_manage e2df69fe4a) last updated 2018/10/04 17:52:50 (GMT +200)
  config file = None
  configured module search path = ['/home/raphael/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/raphael/workspace/ansible/lib/ansible
  executable location = /home/raphael/workspace/ansible/bin/ansible
  python version = 3.6.6 (default, Oct  3 2018, 14:06:32) [GCC 5.4.0 20160609]

```
