### PR TITLE
Do not try to encode metadata if it is None

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_compute_instance.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_instance.py
@@ -1106,7 +1106,7 @@ def raise_if_errors(response, err_path, module):
 
 
 def encode_request(request, module):
-    if 'metadata' in request:
+    if 'metadata' in request and request['metadata'] is not None:
         request['metadata'] = metadata_encoder(request['metadata'])
     return request
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In the [gcp_compute_instance module](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/google/gcp_compute_instance.py),  when not specifying the metadata key or leaving it undefined, it crashes trying to iterate on a None here: https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/google/gcp_compute_instance.py#L1138

This PR addresses it by skipping the call to [`metadata_encoder()`](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/google/gcp_compute_instance.py#L1110) if `request['metadata']` is `None`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_compute_instance

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0.post0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/tpicariello/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/tpicariello/.pyenv/batcheval/local/lib/python2.7/site-packages/ansible
  executable location = /home/tpicariello/.pyenv/project/bin/ansible
  python version = 2.7.12 (default, Jul 18 2016, 15:02:52) [GCC 4.8.4]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Omitting the metadata key in the example given by the doc allows to reproduce the issue:
```yaml
- name: create a instance
  gcp_compute_instance:
      name: "test_object"
      machine_type: n1-standard-1
      disks:
      - auto_delete: true
        boot: true
        source: "{{ disk }}"
      network_interfaces:
      - network: "{{ network }}"
        access_configs:
        - name: External NAT
          nat_ip: "{{ address }}"
          type: ONE_TO_ONE_NAT
      zone: us-central1-a
      project: "test_project"
      auth_kind: "service_account"
      service_account_file: "/tmp/auth.pem"
      state: present
```
