### PR TITLE
incorrect playbook_keywords ref

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.5.rst
@@ -89,7 +89,7 @@ You will run into errors because Ansible reads name in this context as a keyword
         - { role: myrole, vars: {name: Justin, othervar: othervalue}, become: True}
 
 
-For a full list of keywords see ::ref::`Playbook Keywords`.
+For a full list of keywords see :ref:`playbook_keywords`.
 
 Migrating from with_X to loop
 -----------------------------


### PR DESCRIPTION
##### SUMMARY
Broken link to playbook_keywords from Ansible 2.5 Porting Guide.

```rst
For a full list of keywords see ::ref::Playbook Keywords.

```

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.5.html#fixed-handling-of-keywords-and-inline-variables

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (playbook_keywords_fix 84c4ba916a) last updated 2018/10/04 11:10:08 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/devel/lib/ansible
  executable location = /root/devel/bin/ansible
  python version = 2.7.12 (default, Nov 18 2016, 22:54:56) [GCC 4.6.4]
```

##### ADDITIONAL INFORMATION
