### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,15 @@
-prune hacking
 include README.rst
 include COPYING
 include SYMLINK_CACHE.json
 include requirements.txt
 include .coveragerc
+include shippable.yml
+include tox.ini
+include bin/ansible-test
 include examples/hosts
 include examples/ansible.cfg
+include examples/scripts/ConfigureRemotingForAnsible.ps1
+include examples/scripts/upgrade_to_ps3.ps1
 recursive-include lib/ansible/executor/powershell *
 recursive-include lib/ansible/module_utils/csharp *
 recursive-include lib/ansible/module_utils/powershell *
@@ -20,3 +24,5 @@ include MANIFEST.in
 include changelogs/CHANGELOG*.rst
 include contrib/README.md
 recursive-include contrib/inventory *
+exclude test/sanity/code-smell/botmeta.*
+exclude docs/docsite/rst/dev_guide/testing/sanity/botmeta.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -25,4 +25,3 @@ include changelogs/CHANGELOG*.rst
 include contrib/README.md
 recursive-include contrib/inventory *
 exclude test/sanity/code-smell/botmeta.*
-exclude docs/docsite/rst/dev_guide/testing/sanity/botmeta.rst


### PR DESCRIPTION
##### SUMMARY

Update MANIFEST.in:

- Remove unnecessary prune.
- Include files needed by tests.
- Exclude botmeta sanity test and docs.

These changes permit sanity tests to pass on sdist output.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

MANIFEST.in

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (manifest-update 30b38f885c) last updated 2018/10/04 10:27:30 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
