### PR TITLE
RabbitMQ documentation suggests that deleting queues/exchanges is not implemented, but it is

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_exchange.py
+++ b/lib/ansible/modules/messaging/rabbitmq_exchange.py
@@ -31,7 +31,6 @@ options:
     state:
         description:
             - Whether the exchange should be present or absent
-            - Only present implemented atm
         choices: [ "present", "absent" ]
         required: false
         default: present

--- a/lib/ansible/modules/messaging/rabbitmq_queue.py
+++ b/lib/ansible/modules/messaging/rabbitmq_queue.py
@@ -31,7 +31,6 @@ options:
     state:
         description:
             - Whether the queue should be present or absent
-            - Only present implemented atm
         choices: [ "present", "absent" ]
         default: present
     login_user:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Documentation for these modules says that `state: absent` is not implemented for either module, however deletion is in the code and it appears to work correctly  
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rabbitmq_queue
rabbitmq_exchange

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.4.3.0
  config file = /Users/marcjay/dev/ansible.cfg
  configured module search path = [u'/Users/marcjay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/marcjay/dev/.venv/lib/python2.7/site-packages/ansible
  executable location = /Users/marcjay/dev/.venv/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```