### PR TITLE
hpilo_boot: Don't hard-fail when system is ON, report status instead

### DIFF
--- a/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
+++ b/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
@@ -180,7 +180,8 @@ def main():
         power_status = ilo.get_host_power_status()
 
         if not force and power_status == 'ON':
-            module.fail_json(msg='HP iLO (%s) reports that the server is already powered on !' % host)
+            module.warn('HP iLO (%s) reports that the server is already powered on!' % host)
+            module.exit_json(changed=False, power=power_status, **status)
 
         if power_status == 'ON':
             ilo.warm_boot_server()


### PR DESCRIPTION
##### SUMMARY
This module won't reboot a server when it's already ON, probably out of caution.
While this may be helpful, there is currently no way to "ensure power is ON". When power is on, the module will fail, which is not pretty.

The intention of this change is to make the module more idempotent by consistently reporting the changed state and yet allowing to ensure power ON without failing the task.

The warning may not even be needed. This could be considered breaking change (if anyone relied on the module failure) but the module is in `preview` state now.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hpilo_boot

##### ANSIBLE VERSION
devel / N/A

##### ADDITIONAL INFORMATION
N/A
