### PR TITLE
Docs: Fix Python Domain references

### DIFF
--- a/docs/docsite/rst/dev_guide/debugging.rst
+++ b/docs/docsite/rst/dev_guide/debugging.rst
@@ -109,11 +109,11 @@ When you look into the debug_dir you'll see a directory structure like this::
   that are passed to the module, this is the file to do it in.
 
 * The :file:`ansible` directory contains code from
-  :mod:`ansible.module_utils` that is used by the module.  Ansible includes
-  files for any :`module:`ansible.module_utils` imports in the module but not
+  :py:mod:`ansible.module_utils` that is used by the module.  Ansible includes
+  files for any :py:mod:`ansible.module_utils` imports in the module but not
   any files from any other module.  So if your module uses
-  :mod:`ansible.module_utils.url` Ansible will include it for you, but if
-  your module includes :mod:`requests` then you'll have to make sure that
+  :py:mod:`ansible.module_utils.url` Ansible will include it for you, but if
+  your module includes :py:mod:`requests` then you'll have to make sure that
   the python requests library is installed on the system before running the
   module.  You can modify files in this directory if you suspect that the
   module is having a problem in some of this boilerplate code rather than in
@@ -139,7 +139,7 @@ module file and test that the real module works via :command:`ansible` or
     The wrapper provides one more subcommand, ``excommunicate``.  This
     subcommand is very similar to ``execute`` in that it invokes the exploded
     module on the arguments in the :file:`args`.  The way it does this is
-    different, however.  ``excommunicate`` imports the :func:`main`
+    different, however.  ``excommunicate`` imports the :py:func:`main`
     function from the module and then calls that.  This makes excommunicate
     execute the module in the wrapper's process.  This may be useful for
     running the module under some graphical debuggers but it is very different

--- a/docs/docsite/rst/dev_guide/debugging.rst
+++ b/docs/docsite/rst/dev_guide/debugging.rst
@@ -109,11 +109,11 @@ When you look into the debug_dir you'll see a directory structure like this::
   that are passed to the module, this is the file to do it in.
 
 * The :file:`ansible` directory contains code from
-  :py:mod:`ansible.module_utils` that is used by the module.  Ansible includes
-  files for any :py:mod:`ansible.module_utils` imports in the module but not
+  ``ansible.module_utils`` that is used by the module.  Ansible includes
+  files for any ``ansible.module_utils`` imports in the module but not
   any files from any other module.  So if your module uses
-  :py:mod:`ansible.module_utils.url` Ansible will include it for you, but if
-  your module includes :py:mod:`requests` then you'll have to make sure that
+  ``ansible.module_utils.url`` Ansible will include it for you, but if
+  your module includes ``requests`` then you'll have to make sure that
   the python requests library is installed on the system before running the
   module.  You can modify files in this directory if you suspect that the
   module is having a problem in some of this boilerplate code rather than in
@@ -139,7 +139,7 @@ module file and test that the real module works via :command:`ansible` or
     The wrapper provides one more subcommand, ``excommunicate``.  This
     subcommand is very similar to ``execute`` in that it invokes the exploded
     module on the arguments in the :file:`args`.  The way it does this is
-    different, however.  ``excommunicate`` imports the :py:func:`main`
+    different, however.  ``excommunicate`` imports the ``main``
     function from the module and then calls that.  This makes excommunicate
     execute the module in the wrapper's process.  This may be useful for
     running the module under some graphical debuggers but it is very different

--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -44,7 +44,7 @@ Python tips
 
 * When fetching URLs, use ``fetch_url`` or ``open_url`` from ``ansible.module_utils.urls``. Do not use ``urllib2``, which does not natively verify TLS certificates and so is insecure for https.
 * Include a ``main`` function that wraps the normal execution.
-* Call your :py:func:`main` from a conditional so you can import it into unit tests - for example:
+* Call your ``main`` from a conditional so you can import it into unit tests - for example:
 
 	.. code-block:: python
 

--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -44,7 +44,7 @@ Python tips
 
 * When fetching URLs, use ``fetch_url`` or ``open_url`` from ``ansible.module_utils.urls``. Do not use ``urllib2``, which does not natively verify TLS certificates and so is insecure for https.
 * Include a ``main`` function that wraps the normal execution.
-* Call your :func:`main` from a conditional so you can import it into unit tests - for example:
+* Call your :py:func:`main` from a conditional so you can import it into unit tests - for example:
 
 	.. code-block:: python
 

--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -283,18 +283,18 @@ substitutions:
     :ref:`new-style Python modules <flow_python_modules>` under the
     :ref:`Ansiballz` framework the proper way is to instead instantiate an
     `AnsibleModule` and then access the version from
-    :attr:``AnsibleModule.ansible_version``.
+    :py:attr:``AnsibleModule.ansible_version``.
   - :code:`"<<INCLUDE_ANSIBLE_MODULE_COMPLEX_ARGS>>"` is substituted with
     a string which is the Python ``repr`` of the :term:`JSON` encoded module
     parameters.  Using ``repr`` on the JSON string makes it safe to embed in
     a Python file.  In new-style Python modules under the Ansiballz framework
     this is better accessed by instantiating an `AnsibleModule` and
-    then using :attr:`AnsibleModule.params`.
+    then using :py:attr:`AnsibleModule.params`.
   - :code:`<<SELINUX_SPECIAL_FILESYSTEMS>>` substitutes a string which is
     a comma separated list of file systems which have a file system dependent
     security context in SELinux.  In new-style Python modules, if you really
     need this you should instantiate an `AnsibleModule` and then use
-    :attr:`AnsibleModule._selinux_special_fs`.  The variable has also changed
+    :py:attr:`AnsibleModule._selinux_special_fs`.  The variable has also changed
     from a comma separated string of file system names to an actual python
     list of filesystem names.
   - :code:`<<INCLUDE_ANSIBLE_MODULE_JSON_ARGS>>` substitutes the module
@@ -307,7 +307,7 @@ substitutions:
     ``ansible_syslog_facility`` inventory variable that applies to this host.  In
     new-style Python modules this has changed slightly.  If you really need to
     access it, you should instantiate an `AnsibleModule` and then use
-    :attr:`AnsibleModule._syslog_facility` to access it.  It is no longer the
+    :py:attr:`AnsibleModule._syslog_facility` to access it.  It is no longer the
     actual syslog facility and is now the name of the syslog facility.  See
     the :ref:`documentation on internal arguments <flow_internal_arguments>`
     for details.
@@ -363,9 +363,9 @@ Passing args
 In :ref:`module_replacer`, module arguments are turned into a JSON-ified
 string and substituted into the combined module file.  In :ref:`Ansiballz`,
 the JSON-ified string is passed into the module via stdin.  When
-a  :class:`ansible.module_utils.basic.AnsibleModule` is instantiated,
+a  :py:class:`ansible.module_utils.basic.AnsibleModule` is instantiated,
 it parses this string and places the args into
-:attr:`AnsibleModule.params` where it can be accessed by the module's
+:py:attr:`AnsibleModule.params` where it can be accessed by the module's
 other code.
 
 .. note::
@@ -400,7 +400,7 @@ a task's parameters or as a play parameter).  This automatically affects calls
 to :py:meth:`AnsibleModule.log`.  If a module implements its own logging then
 it needs to check this value.  The best way to look at this is for the module
 to instantiate an `AnsibleModule` and then check the value of
-:attr:`AnsibleModule.no_log`.
+:py:attr:`AnsibleModule.no_log`.
 
 .. note::
     ``no_log`` specified in a module's argument_spec are handled by a different mechanism.
@@ -415,7 +415,7 @@ external commands that the module executes.  This can be changed via
 the ``debug`` setting in :file:`ansible.cfg` or the environment variable
 :envvar:`ANSIBLE_DEBUG`.  If, for some reason, a module must access this, it
 should do so by instantiating an `AnsibleModule` and accessing
-:attr:`AnsibleModule._debug`.
+:py:attr:`AnsibleModule._debug`.
 
 _ansible_diff
 ^^^^^^^^^^^^^^^
@@ -424,7 +424,7 @@ This boolean is turned on via the ``--diff`` command line option.  If a module
 supports it, it will tell the module to show a unified diff of changes to be
 made to templated files.  The proper way for a module to access this is by
 instantiating an `AnsibleModule` and accessing
-:attr:`AnsibleModule._diff`.
+:py:attr:`AnsibleModule._diff`.
 
 _ansible_verbosity
 ^^^^^^^^^^^^^^^^^^
@@ -447,9 +447,9 @@ via a comma separated string of filesystem names from :file:`ansible.cfg`::
 If a module cannot use the builtin ``AnsibleModule`` methods to manipulate
 files and needs to know about these special context filesystems, it should
 instantiate an ``AnsibleModule`` and then examine the list in
-:attr:`AnsibleModule._selinux_special_fs`.
+:py:attr:`AnsibleModule._selinux_special_fs`.
 
-This replaces :attr:`ansible.module_utils.basic.SELINUX_SPECIAL_FS` from
+This replaces :py:attr:`ansible.module_utils.basic.SELINUX_SPECIAL_FS` from
 :ref:`module_replacer`.  In module replacer it was a comma separated string of
 filesystem names.  Under Ansiballz it's an actual list.
 
@@ -460,10 +460,10 @@ _ansible_syslog_facility
 
 This parameter controls which syslog facility ansible module logs to.  It may
 be set by changing the ``syslog_facility`` value in :file:`ansible.cfg`.  Most
-modules should just use :meth:`AnsibleModule.log` which will then make use of
+modules should just use :py:meth:`AnsibleModule.log` which will then make use of
 this.  If a module has to use this on its own, it should instantiate an
 `AnsibleModule` and then retrieve the name of the syslog facility from
-:attr:`AnsibleModule._syslog_facility`.  The code will look slightly different
+:py:attr:`AnsibleModule._syslog_facility`.  The code will look slightly different
 than it did under :ref:`module_replacer` due to how hacky the old way was
 
 .. code-block:: python
@@ -485,8 +485,8 @@ _ansible_version
 
 This parameter passes the version of ansible that runs the module.  To access
 it, a module should instantiate an `AnsibleModule` and then retrieve it
-from :attr:`AnsibleModule.ansible_version`.  This replaces
-:attr:`ansible.module_utils.basic.ANSIBLE_VERSION` from
+from :py:attr:`AnsibleModule.ansible_version`.  This replaces
+:py:attr:`ansible.module_utils.basic.ANSIBLE_VERSION` from
 :ref:`module_replacer`.
 
 .. versionadded:: 2.1

--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -283,18 +283,18 @@ substitutions:
     :ref:`new-style Python modules <flow_python_modules>` under the
     :ref:`Ansiballz` framework the proper way is to instead instantiate an
     `AnsibleModule` and then access the version from
-    :py:attr:``AnsibleModule.ansible_version``.
+    ``AnsibleModule.ansible_version``.
   - :code:`"<<INCLUDE_ANSIBLE_MODULE_COMPLEX_ARGS>>"` is substituted with
     a string which is the Python ``repr`` of the :term:`JSON` encoded module
     parameters.  Using ``repr`` on the JSON string makes it safe to embed in
     a Python file.  In new-style Python modules under the Ansiballz framework
     this is better accessed by instantiating an `AnsibleModule` and
-    then using :py:attr:`AnsibleModule.params`.
+    then using ``AnsibleModule.params``.
   - :code:`<<SELINUX_SPECIAL_FILESYSTEMS>>` substitutes a string which is
     a comma separated list of file systems which have a file system dependent
     security context in SELinux.  In new-style Python modules, if you really
     need this you should instantiate an `AnsibleModule` and then use
-    :py:attr:`AnsibleModule._selinux_special_fs`.  The variable has also changed
+    ``AnsibleModule._selinux_special_fs``.  The variable has also changed
     from a comma separated string of file system names to an actual python
     list of filesystem names.
   - :code:`<<INCLUDE_ANSIBLE_MODULE_JSON_ARGS>>` substitutes the module
@@ -307,7 +307,7 @@ substitutions:
     ``ansible_syslog_facility`` inventory variable that applies to this host.  In
     new-style Python modules this has changed slightly.  If you really need to
     access it, you should instantiate an `AnsibleModule` and then use
-    :py:attr:`AnsibleModule._syslog_facility` to access it.  It is no longer the
+    ``AnsibleModule._syslog_facility`` to access it.  It is no longer the
     actual syslog facility and is now the name of the syslog facility.  See
     the :ref:`documentation on internal arguments <flow_internal_arguments>`
     for details.
@@ -341,7 +341,7 @@ ansible module.
       understands scripts on stdin but does not understand zip files.
 
 In Ansiballz, any imports of Python modules from the
-:py:mod:`ansible.module_utils` package trigger inclusion of that Python file
+``ansible.module_utils`` package trigger inclusion of that Python file
 into the zipfile.  Instances of :code:`#<<INCLUDE_ANSIBLE_MODULE_COMMON>>` in
 the module are turned into :code:`from ansible.module_utils.basic import *`
 and :file:`ansible/module-utils/basic.py` is then included in the zipfile.
@@ -352,7 +352,7 @@ the zipfile as well.
 .. warning::
     At present, the Ansiballz Framework cannot determine whether an import
     should be included if it is a relative import.  Always use an absolute
-    import that has :py:mod:`ansible.module_utils` in it to allow Ansiballz to
+    import that has ``ansible.module_utils`` in it to allow Ansiballz to
     determine that the file should be included.
 
 .. _flow_passing_module_args:
@@ -363,14 +363,14 @@ Passing args
 In :ref:`module_replacer`, module arguments are turned into a JSON-ified
 string and substituted into the combined module file.  In :ref:`Ansiballz`,
 the JSON-ified string is passed into the module via stdin.  When
-a  :py:class:`ansible.module_utils.basic.AnsibleModule` is instantiated,
+a  ``ansible.module_utils.basic.AnsibleModule`` is instantiated,
 it parses this string and places the args into
-:py:attr:`AnsibleModule.params` where it can be accessed by the module's
+``AnsibleModule.params`` where it can be accessed by the module's
 other code.
 
 .. note::
     Internally, the `AnsibleModule` uses the helper function,
-    :py:func:`ansible.module_utils.basic._load_params`, to load the parameters
+    ``ansible.module_utils.basic._load_params``, to load the parameters
     from stdin and save them into an internal global variable.  Very dynamic
     custom modules which need to parse the parameters prior to instantiating
     an ``AnsibleModule`` may use ``_load_params`` to retrieve the
@@ -389,7 +389,7 @@ Both :ref:`module_replacer` and :ref:`Ansiballz` send additional arguments to
 the module beyond those which the user specified in the playbook.  These
 additional arguments are internal parameters that help implement global
 Ansible features.  Modules often do not need to know about these explicitly as
-the features are implemented in :py:mod:`ansible.module_utils.basic` but certain
+the features are implemented in ``ansible.module_utils.basic`` but certain
 features need support from the module so it's good to know about them.
 
 _ansible_no_log
@@ -397,10 +397,10 @@ _ansible_no_log
 
 This is a boolean.  If it's True then the playbook specified ``no_log`` (in
 a task's parameters or as a play parameter).  This automatically affects calls
-to :py:meth:`AnsibleModule.log`.  If a module implements its own logging then
+to ``AnsibleModule.log``.  If a module implements its own logging then
 it needs to check this value.  The best way to look at this is for the module
 to instantiate an `AnsibleModule` and then check the value of
-:py:attr:`AnsibleModule.no_log`.
+``AnsibleModule.no_log``.
 
 .. note::
     ``no_log`` specified in a module's argument_spec are handled by a different mechanism.
@@ -409,13 +409,13 @@ _ansible_debug
 ^^^^^^^^^^^^^^^
 
 This is a boolean that turns on more verbose logging.  If a module uses
-:py:meth:`AnsibleModule.debug` rather than :py:meth:`AnsibleModule.log` then
+``AnsibleModule.debug`` rather than ``AnsibleModule.log`` then
 the messages are only logged if this is True.  This also turns on logging of
 external commands that the module executes.  This can be changed via
 the ``debug`` setting in :file:`ansible.cfg` or the environment variable
 :envvar:`ANSIBLE_DEBUG`.  If, for some reason, a module must access this, it
 should do so by instantiating an `AnsibleModule` and accessing
-:py:attr:`AnsibleModule._debug`.
+``AnsibleModule._debug``.
 
 _ansible_diff
 ^^^^^^^^^^^^^^^
@@ -424,7 +424,7 @@ This boolean is turned on via the ``--diff`` command line option.  If a module
 supports it, it will tell the module to show a unified diff of changes to be
 made to templated files.  The proper way for a module to access this is by
 instantiating an `AnsibleModule` and accessing
-:py:attr:`AnsibleModule._diff`.
+``AnsibleModule._diff``.
 
 _ansible_verbosity
 ^^^^^^^^^^^^^^^^^^
@@ -447,9 +447,9 @@ via a comma separated string of filesystem names from :file:`ansible.cfg`::
 If a module cannot use the builtin ``AnsibleModule`` methods to manipulate
 files and needs to know about these special context filesystems, it should
 instantiate an ``AnsibleModule`` and then examine the list in
-:py:attr:`AnsibleModule._selinux_special_fs`.
+``AnsibleModule._selinux_special_fs``.
 
-This replaces :py:attr:`ansible.module_utils.basic.SELINUX_SPECIAL_FS` from
+This replaces ``ansible.module_utils.basic.SELINUX_SPECIAL_FS`` from
 :ref:`module_replacer`.  In module replacer it was a comma separated string of
 filesystem names.  Under Ansiballz it's an actual list.
 
@@ -460,10 +460,10 @@ _ansible_syslog_facility
 
 This parameter controls which syslog facility ansible module logs to.  It may
 be set by changing the ``syslog_facility`` value in :file:`ansible.cfg`.  Most
-modules should just use :py:meth:`AnsibleModule.log` which will then make use of
+modules should just use ``AnsibleModule.log`` which will then make use of
 this.  If a module has to use this on its own, it should instantiate an
 `AnsibleModule` and then retrieve the name of the syslog facility from
-:py:attr:`AnsibleModule._syslog_facility`.  The code will look slightly different
+``AnsibleModule._syslog_facility``.  The code will look slightly different
 than it did under :ref:`module_replacer` due to how hacky the old way was
 
 .. code-block:: python
@@ -485,8 +485,8 @@ _ansible_version
 
 This parameter passes the version of ansible that runs the module.  To access
 it, a module should instantiate an `AnsibleModule` and then retrieve it
-from :py:attr:`AnsibleModule.ansible_version`.  This replaces
-:py:attr:`ansible.module_utils.basic.ANSIBLE_VERSION` from
+from ``AnsibleModule.ansible_version``.  This replaces
+``ansible.module_utils.basic.ANSIBLE_VERSION`` from
 :ref:`module_replacer`.
 
 .. versionadded:: 2.1

--- a/docs/docsite/rst/dev_guide/developing_python_3.rst
+++ b/docs/docsite/rst/dev_guide/developing_python_3.rst
@@ -68,15 +68,15 @@ they can be an array of text.  Text is what we think of as letters, digits,
 numbers, other printable symbols, and a small number of unprintable "symbols"
 (control codes).
 
-In Python 2, the two types for these (:py:class:`str` for bytes and
-:py:class:`unicode` for text) are often used interchangeably.  When dealing only
+In Python 2, the two types for these (``str`` for bytes and
+``unicode`` for text) are often used interchangeably.  When dealing only
 with ASCII characters, the strings can be combined, compared, and converted
 from one type to another automatically.  When non-ASCII characters are
 introduced, Python 2 starts throwing exceptions due to not knowing what encoding
 the non-ASCII characters should be in.
 
-Python 3 changes this behavior by making the separation between bytes (:py:class:`bytes`)
-and text (:py:class:`str`) more strict.  Python 3 will throw an exception when
+Python 3 changes this behavior by making the separation between bytes (``bytes``)
+and text (``str``) more strict.  Python 3 will throw an exception when
 trying to combine and compare the two types.  The programmer has to explicitly
 convert from one type to the other to mix values from each.
 
@@ -95,7 +95,7 @@ Controller string strategy: the Unicode Sandwich
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In controller-side code we use a strategy known as the Unicode Sandwich (named
-after Python 2's :py:class:`unicode` text type).  For Unicode Sandwich we know that
+after Python 2's ``unicode`` text type).  For Unicode Sandwich we know that
 at the border of our code and the outside world (for example, file and network IO,
 environment variables, and some library calls) we are going to receive bytes.
 We need to transform these bytes into text and use that throughout the
@@ -189,7 +189,7 @@ to the filesystem, it can be more convenient to transform to bytes right away
 and manipulate in bytes.
 
 .. warning:: Make sure all variables passed to a function are the same type.
-    If you're working with something like :py:meth:`os.path.join` which takes
+    If you're working with something like ``os.path.join`` which takes
     multiple strings and uses them in combination, you need to make sure that
     all the types are the same (either all bytes or all text).  Mixing
     bytes and text will cause tracebacks.
@@ -271,17 +271,17 @@ to make certain constructs act the same way on Python 2 and Python 3:
     __metaclass__ = type
 
 ``__metaclass__ = type`` makes all classes defined in the file into new-style
-classes without explicitly inheriting from :py:class:`object`.
+classes without explicitly inheriting from ``object``.
 
 The ``__future__`` imports do the following:
 
-:absolute_import: Makes imports look in :py:attr:`sys.path` for the modules being
+:absolute_import: Makes imports look in ``sys.path`` for the modules being
     imported, skipping the directory in which the module doing the importing
     lives.  If the code wants to use the directory in which the module doing
     the importing, there's a new dot notation to do so.
 :division: Makes division of integers always return a float.  If you need to
    find the quotient use ``x // y`` instead of ``x / y``.
-:print_function: Changes :py:func:`print` from a keyword into a function.
+:print_function: Changes ``print`` from a keyword into a function.
 
 .. seealso::
     * `PEP 0328: Absolute Imports <https://www.python.org/dev/peps/pep-0328/#guido-s-decision>`_

--- a/docs/docsite/rst/dev_guide/developing_python_3.rst
+++ b/docs/docsite/rst/dev_guide/developing_python_3.rst
@@ -68,15 +68,15 @@ they can be an array of text.  Text is what we think of as letters, digits,
 numbers, other printable symbols, and a small number of unprintable "symbols"
 (control codes).
 
-In Python 2, the two types for these (:class:`str` for bytes and
-:class:`unicode` for text) are often used interchangeably.  When dealing only
+In Python 2, the two types for these (:py:class:`str` for bytes and
+:py:class:`unicode` for text) are often used interchangeably.  When dealing only
 with ASCII characters, the strings can be combined, compared, and converted
 from one type to another automatically.  When non-ASCII characters are
 introduced, Python 2 starts throwing exceptions due to not knowing what encoding
 the non-ASCII characters should be in.
 
-Python 3 changes this behavior by making the separation between bytes (:class:`bytes`)
-and text (:class:`str`) more strict.  Python 3 will throw an exception when
+Python 3 changes this behavior by making the separation between bytes (:py:class:`bytes`)
+and text (:py:class:`str`) more strict.  Python 3 will throw an exception when
 trying to combine and compare the two types.  The programmer has to explicitly
 convert from one type to the other to mix values from each.
 
@@ -95,7 +95,7 @@ Controller string strategy: the Unicode Sandwich
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In controller-side code we use a strategy known as the Unicode Sandwich (named
-after Python 2's :class:`unicode` text type).  For Unicode Sandwich we know that
+after Python 2's :py:class:`unicode` text type).  For Unicode Sandwich we know that
 at the border of our code and the outside world (for example, file and network IO,
 environment variables, and some library calls) we are going to receive bytes.
 We need to transform these bytes into text and use that throughout the
@@ -189,7 +189,7 @@ to the filesystem, it can be more convenient to transform to bytes right away
 and manipulate in bytes.
 
 .. warning:: Make sure all variables passed to a function are the same type.
-    If you're working with something like :func:`os.path.join` which takes
+    If you're working with something like :py:meth:`os.path.join` which takes
     multiple strings and uses them in combination, you need to make sure that
     all the types are the same (either all bytes or all text).  Mixing
     bytes and text will cause tracebacks.
@@ -271,17 +271,17 @@ to make certain constructs act the same way on Python 2 and Python 3:
     __metaclass__ = type
 
 ``__metaclass__ = type`` makes all classes defined in the file into new-style
-classes without explicitly inheriting from :class:`object`.
+classes without explicitly inheriting from :py:class:`object`.
 
 The ``__future__`` imports do the following:
 
-:absolute_import: Makes imports look in :attr:`sys.path` for the modules being
+:absolute_import: Makes imports look in :py:attr:`sys.path` for the modules being
     imported, skipping the directory in which the module doing the importing
     lives.  If the code wants to use the directory in which the module doing
     the importing, there's a new dot notation to do so.
 :division: Makes division of integers always return a float.  If you need to
    find the quotient use ``x // y`` instead of ``x / y``.
-:print_function: Changes :func:`print` from a keyword into a function.
+:print_function: Changes :py:func:`print` from a keyword into a function.
 
 .. seealso::
     * `PEP 0328: Absolute Imports <https://www.python.org/dev/peps/pep-0328/#guido-s-decision>`_

--- a/docs/docsite/rst/dev_guide/testing/sanity/use-argspec-type-path.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/use-argspec-type-path.rst
@@ -5,7 +5,7 @@ The AnsibleModule argument_spec knows of several types beyond the standard pytho
 these is ``path``.  When used, type ``path`` ensures that an argument is a string and expands any
 shell variables and tilde characters.
 
-This test looks for use of :meth:`os.path.expanduser` in modules.  When found, it tells the user to
+This test looks for use of :py:meth:`os.path.expanduser` in modules.  When found, it tells the user to
 replace it with ``type='path'`` in the module's argument_spec or list it as a false positive in the
 test.
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/use-argspec-type-path.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/use-argspec-type-path.rst
@@ -5,7 +5,7 @@ The AnsibleModule argument_spec knows of several types beyond the standard pytho
 these is ``path``.  When used, type ``path`` ensures that an argument is a string and expands any
 shell variables and tilde characters.
 
-This test looks for use of :py:meth:`os.path.expanduser` in modules.  When found, it tells the user to
+This test looks for use of ``os.path.expanduser`` in modules.  When found, it tells the user to
 replace it with ``type='path'`` in the module's argument_spec or list it as a false positive in the
 test.
 

--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -165,7 +165,7 @@ simulating an API. As for 'six', the 'mock' python package is bundled with Ansib
 Ensuring failure cases are visible with mock objects
 ----------------------------------------------------
 
-Functions like :meth:`module.fail_json` are normally expected to terminate execution. When you
+Functions like :py:meth:`module.fail_json` are normally expected to terminate execution. When you
 run with a mock module object this doesn't happen since the mock always returns another mock
 from a function call. You can set up the mock to raise an exception as shown above, or you can
 assert that these functions have not been called in each test. For example::
@@ -278,8 +278,8 @@ There are two problems with running the main function of a module:
 
 * Since the module is supposed to accept arguments on ``STDIN`` it is a bit difficult to
   set up the arguments correctly so that the module will get them as parameters.
-* All modules should finish by calling either the :meth:`module.fail_json` or
-  :meth:`module.exit_json`, but these won't work correctly in a testing environment.
+* All modules should finish by calling either the :py:meth:`module.fail_json` or
+  :py:meth:`module.exit_json`, but these won't work correctly in a testing environment.
 
 Passing Arguments
 -----------------
@@ -289,7 +289,7 @@ Passing Arguments
 
 To pass arguments to a module correctly, use a function that stores the
 parameters in a special string variable.  Module creation and argument processing is
-handled through the :class:`AnsibleModule` object in the basic section of the utilities. Normally
+handled through the :py:class:`AnsibleModule` object in the basic section of the utilities. Normally
 this accepts input on ``STDIN``, which is not convenient for unit testing. When the special
 variable is set it will be treated as if the input came on ``STDIN`` to the module.::
 
@@ -315,9 +315,9 @@ Handling exit correctly
 .. This section should be updated once https://github.com/ansible/ansible/pull/31456 is
    closed since the exit and failure functions below will be provided in a library file.
 
-The :meth:`module.exit_json` function won't work properly in a testing environment since it
+The :py:meth:`module.exit_json` function won't work properly in a testing environment since it
 writes error information to ``STDOUT`` upon exit, where it
-is difficult to examine. This can be mitigated by replacing it (and :meth:`module.fail_json`) with
+is difficult to examine. This can be mitigated by replacing it (and :py:meth:`module.fail_json`) with
 a function that raises an exception::
 
     def exit_json(*args, **kwargs):
@@ -337,7 +337,7 @@ testing for the correct exception::
        with self.assertRaises(AnsibleExitJson) as result:
            my_module.main()
 
-The same technique can be used to replace :meth:`module.fail_json` (which is used for failure
+The same technique can be used to replace :py:meth:`module.fail_json` (which is used for failure
 returns from modules) and for the ``aws_module.fail_json_aws()`` (used in modules for Amazon
 Web Services).
 
@@ -364,10 +364,10 @@ the arguments as above, set up the appropriate exit exception and then run the m
 Handling calls to external executables
 --------------------------------------
 
-Module must use :meth:`AnsibleModule.run_command` in order to execute an external command. This
+Module must use :py:meth:`AnsibleModule.run_command` in order to execute an external command. This
 method needs to be mocked:
 
-Here is a simple mock of :meth:`AnsibleModule.run_command` (taken from :file:`test/units/modules/packaging/os/test_rhn_register.py`)::
+Here is a simple mock of :py:meth:`AnsibleModule.run_command` (taken from :file:`test/units/modules/packaging/os/test_rhn_register.py`)::
 
         with patch.object(basic.AnsibleModule, 'run_command') as run_command:
             run_command.return_value = 0, '', ''  # successful execution, no output
@@ -384,7 +384,7 @@ A Complete Example
 ------------------
 
 The following example is a complete skeleton that reuses the mocks explained above and adds a new
-mock for :meth:`Ansible.get_bin_path`::
+mock for :py:meth:`Ansible.get_bin_path`::
 
     import json
 

--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -165,7 +165,7 @@ simulating an API. As for 'six', the 'mock' python package is bundled with Ansib
 Ensuring failure cases are visible with mock objects
 ----------------------------------------------------
 
-Functions like :py:meth:`module.fail_json` are normally expected to terminate execution. When you
+Functions like ``module.fail_json`` are normally expected to terminate execution. When you
 run with a mock module object this doesn't happen since the mock always returns another mock
 from a function call. You can set up the mock to raise an exception as shown above, or you can
 assert that these functions have not been called in each test. For example::
@@ -278,8 +278,8 @@ There are two problems with running the main function of a module:
 
 * Since the module is supposed to accept arguments on ``STDIN`` it is a bit difficult to
   set up the arguments correctly so that the module will get them as parameters.
-* All modules should finish by calling either the :py:meth:`module.fail_json` or
-  :py:meth:`module.exit_json`, but these won't work correctly in a testing environment.
+* All modules should finish by calling either the ``module.fail_json`` or
+  ``module.exit_json``, but these won't work correctly in a testing environment.
 
 Passing Arguments
 -----------------
@@ -289,7 +289,7 @@ Passing Arguments
 
 To pass arguments to a module correctly, use a function that stores the
 parameters in a special string variable.  Module creation and argument processing is
-handled through the :py:class:`AnsibleModule` object in the basic section of the utilities. Normally
+handled through the ``AnsibleModule`` object in the basic section of the utilities. Normally
 this accepts input on ``STDIN``, which is not convenient for unit testing. When the special
 variable is set it will be treated as if the input came on ``STDIN`` to the module.::
 
@@ -315,9 +315,9 @@ Handling exit correctly
 .. This section should be updated once https://github.com/ansible/ansible/pull/31456 is
    closed since the exit and failure functions below will be provided in a library file.
 
-The :py:meth:`module.exit_json` function won't work properly in a testing environment since it
+The ``module.exit_json`` function won't work properly in a testing environment since it
 writes error information to ``STDOUT`` upon exit, where it
-is difficult to examine. This can be mitigated by replacing it (and :py:meth:`module.fail_json`) with
+is difficult to examine. This can be mitigated by replacing it (and ``module.fail_json``) with
 a function that raises an exception::
 
     def exit_json(*args, **kwargs):
@@ -337,7 +337,7 @@ testing for the correct exception::
        with self.assertRaises(AnsibleExitJson) as result:
            my_module.main()
 
-The same technique can be used to replace :py:meth:`module.fail_json` (which is used for failure
+The same technique can be used to replace ``module.fail_json`` (which is used for failure
 returns from modules) and for the ``aws_module.fail_json_aws()`` (used in modules for Amazon
 Web Services).
 
@@ -364,10 +364,10 @@ the arguments as above, set up the appropriate exit exception and then run the m
 Handling calls to external executables
 --------------------------------------
 
-Module must use :py:meth:`AnsibleModule.run_command` in order to execute an external command. This
+Module must use ``AnsibleModule.run_command`` in order to execute an external command. This
 method needs to be mocked:
 
-Here is a simple mock of :py:meth:`AnsibleModule.run_command` (taken from :file:`test/units/modules/packaging/os/test_rhn_register.py`)::
+Here is a simple mock of ``AnsibleModule.run_command`` (taken from :file:`test/units/modules/packaging/os/test_rhn_register.py`)::
 
         with patch.object(basic.AnsibleModule, 'run_command') as run_command:
             run_command.return_value = 0, '', ''  # successful execution, no output
@@ -384,7 +384,7 @@ A Complete Example
 ------------------
 
 The following example is a complete skeleton that reuses the mocks explained above and adds a new
-mock for :py:meth:`Ansible.get_bin_path`::
+mock for ``Ansible.get_bin_path``::
 
     import json
 


### PR DESCRIPTION
##### SUMMARY
So this fixes the Python Domain references, but it doesn't fix getting
the warnings.

http://www.sphinx-doc.org/en/1.5.2/domains.html#the-python-domain

This was recently introduced, so I wonder how this is supposed to work
in our setup. Are we lacking something in the Sphinx setup to make this
work ?

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
dev_guide build warning fixes

##### ANSIBLE VERSION
v2.8