### PR TITLE
Backport #46360 for 2.7 - Fix for ignore post_reboot_delay

### DIFF
--- a/changelogs/fragments/win_reboot-post-reboot-delay.yaml
+++ b/changelogs/fragments/win_reboot-post-reboot-delay.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- Fix the win_reboot plugin so that the post_reboot_delay parameter is honored

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -1,5 +1,5 @@
-# (c) 2016-2018, Matt Davis <mdavis@ansible.com>
-# (c) 2018, Sam Doran <sdoran@redhat.com>
+# Copyright: (c) 2016-2018, Matt Davis <mdavis@ansible.com>
+# Copyright: (c) 2018, Sam Doran <sdoran@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
@@ -11,8 +11,8 @@ import time
 from datetime import datetime, timedelta
 
 from ansible.errors import AnsibleError
-from ansible.plugins.action import ActionBase
 from ansible.module_utils._text import to_native, to_text
+from ansible.plugins.action import ActionBase
 
 
 try:
@@ -205,14 +205,6 @@ class ActionModule(ActionBase):
         except AnsibleError:
             display.debug("%s: connect_timeout connection option has not been set" % self._task.action)
 
-        post_reboot_delay = int(self._task.args.get('post_reboot_delay', self._task.args.get('post_reboot_delay_sec', self.DEFAULT_POST_REBOOT_DELAY)))
-        if post_reboot_delay < 0:
-            post_reboot_delay = 0
-
-        if post_reboot_delay != 0:
-            display.vvv("%s: waiting an additional %d seconds" % (self._task.action, post_reboot_delay))
-            time.sleep(post_reboot_delay)
-
         return result
 
     def validate_reboot(self):
@@ -287,6 +279,14 @@ class ActionModule(ActionBase):
             elapsed = datetime.utcnow() - reboot_result['start']
             result['elapsed'] = elapsed.seconds
             return result
+
+        post_reboot_delay = int(self._task.args.get('post_reboot_delay', self._task.args.get('post_reboot_delay_sec', self.DEFAULT_POST_REBOOT_DELAY)))
+        if post_reboot_delay < 0:
+            post_reboot_delay = 0
+
+        if post_reboot_delay != 0:
+            display.vvv("%s: waiting an additional %d seconds" % (self._task.action, post_reboot_delay))
+            time.sleep(post_reboot_delay)
 
         # Make sure reboot was successful
         result = self.validate_reboot()

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -1,4 +1,4 @@
-# (c) 2018, Matt Davis <mdavis@ansible.com>
+# Copyright: (c) 2018, Matt Davis <mdavis@ansible.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
@@ -7,8 +7,8 @@ __metaclass__ = type
 from datetime import datetime
 
 from ansible.errors import AnsibleError
-from ansible.plugins.action import ActionBase
 from ansible.module_utils._text import to_native
+from ansible.plugins.action import ActionBase
 from ansible.plugins.action.reboot import ActionModule as RebootActionModule
 
 try:
@@ -29,9 +29,9 @@ class ActionModule(RebootActionModule, ActionBase):
         'reboot_timeout', 'reboot_timeout_sec', 'shutdown_timeout', 'shutdown_timeout_sec', 'test_command',
     ))
 
+    DEFAULT_BOOT_TIME_COMMAND = "(Get-WmiObject -ClassName Win32_OperatingSystem).LastBootUpTime"
     DEFAULT_CONNECT_TIMEOUT = 5
     DEFAULT_PRE_REBOOT_DELAY = 2
-    DEFAULT_BOOT_TIME_COMMAND = "(Get-WmiObject -ClassName Win32_OperatingSystem).LastBootUpTime"
     DEFAULT_SHUTDOWN_COMMAND_ARGS = '/r /t %d /c "%s"'
     DEFAULT_SUDOABLE = False
 


### PR DESCRIPTION
##### SUMMARY
Backport of #46360 for Ansible 2.7

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`reboot.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```