### PR TITLE
Backport #46455 for 2.7 - Add documentation on underlying tools in user module

### DIFF
--- a/changelogs/fragments/user-docs-underlying-tools.yaml
+++ b/changelogs/fragments/user-docs-underlying-tools.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - add documentation on what underlying tools are used on each platform (https://github.com/ansible/ansible/issues/44266)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -24,6 +24,13 @@ notes:
   - For Windows targets, use the M(win_user) module instead.
   - On SunOS platforms, the shadow file is backed up automatically since this module edits it directly.
     On other platforms, the shadow file is backed up by the underlying tools used by this module.
+  - On macOS, this module uses C(dscl) to create, modify, and delete accounts. C(dseditgroup) is used to
+    modify group membership. Accounts are hidden from the login window by modifying
+    C(/Library/Preferences/com.apple.loginwindow.plist).
+  - On FreeBSD, this module uses C(pw useradd) and C(chpass) to create, C(pw usermod) and C(chpass) to modify,
+    C(pw userdel) remove, C(pw lock) to lock, and C(pw unlock) to unlock accounts.
+  - On all other platforms, this module uses C(useradd) to create, C(usermod) to modify, and
+    C(userdel) to remove accounts.
 description:
     - Manage user accounts and user attributes.
     - For Windows targets, use the M(win_user) module instead.
@@ -78,6 +85,8 @@ options:
             - Optionally set the user's shell.
             - On macOS, before version 2.5, the default shell for non-system users was /usr/bin/false.
               Since 2.5, the default shell for non-system users on macOS is /bin/bash.
+            - On other operating systems, the default shell is determined by the underlying tool being
+              used. See Notes for details.
     home:
         description:
             - Optionally set the user's home directory.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #46455 for Ansible 2.7

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
`user.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```