### PR TITLE
Backport #46455 for 2.6 - Add documentation on underlying tools in user module

### DIFF
--- a/changelogs/fragments/user-docs-underlying-tools.yaml
+++ b/changelogs/fragments/user-docs-underlying-tools.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - add documentation on what underlying tools are used on each platform (https://github.com/ansible/ansible/issues/44266)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #46455 for Ansible 2.6
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
`user.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6
```