### PR TITLE
PR HAProxy Drain mode then MAINT not working as expected

### DIFF
--- a/changelogs/fragments/46515-haproxy_module_change_drain_value
+++ b/changelogs/fragments/46515-haproxy_module_change_drain_value
@@ -1,0 +1,2 @@
+minor_changes:
+  - haproxy - change drain value from None to no

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -317,7 +317,9 @@ class HAProxy(object):
             if state is not None:
                 self.execute(Template(cmd).substitute(pxname=backend, svname=svname))
                 if self.wait:
-                    self.wait_until_status(backend, svname, wait_for_status)
+                    if self.wait_until_status(backend, svname, wait_for_status) is not True:
+                        self.module.fail_json(msg="Can't get the status %s expected" % (svname))
+
 
     def get_state_for(self, pxname, svname):
         """

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -320,7 +320,6 @@ class HAProxy(object):
                     if self.wait_until_status(backend, svname, wait_for_status) is not True:
                         self.module.fail_json(msg="Can't get the status %s expected" % (svname))
 
-
     def get_state_for(self, pxname, svname):
         """
         Find the state of specific services. When pxname is not set, get all backends for a specific host.

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -37,9 +37,9 @@ options:
   drain:
     description:
       - Wait until the server has no active connections or until the timeout
-        determined by wait_interval and wait_retries is reached.  After this
-        step, the server status is switch to 'MAINT'. This overrides shutdown_sessions
-        option (considered as "yes"). This option must be used only with state "disabled"
+        determined by I(wait_interval) and I(wait_retries) is reached.  After this
+        step, the server status is switch to C(MAINT). This overrides shutdown_sessions
+        option (considered as C(yes)). This option must be used only with I(state=disabled)
     version_added: "2.4"
     default: 'no'
   host:

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -347,7 +347,6 @@ class HAProxy(object):
             state = self.get_state_for(pxname, svname)
 
             if self._drain and state[0]['scur'] == '0':
-                # We disable self.wait to avoid a recursive loop and waiting at each step
                 return self.disable_after_drain(pxname, svname)
             else:
                 if state[0]["status"] == status and not self._drain:
@@ -396,9 +395,12 @@ class HAProxy(object):
             self.execute_for_backends(cmd, backend, host, status)
 
     def disable_after_drain(self, pxname, svname):
+        # We disable self.wait to avoid a recursive loop and waiting at each step
+        old_wait = self.wait
         self.wait = False
         self.disabled(self.host, self.backend, self.shutdown_sessions)
         state = self.get_state_for(pxname, svname)
+        self.wait = old_wait
         if state[0]["status"] == "MAINT":
             return True
         else:


### PR DESCRIPTION
##### SUMMARY
This pull request fixes #37591
This fixes include fix for #30833 as it is needed to start the module

I propose to change a little bit the behaviour : 
- drain should be used only with the state disabled
- we explicitly say that it overrides shutdown_connection parameters. So at the end of the waiting period, we switch to MAINT status

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`haproxy.py`

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (jori_fix_37591 cb4168c272) last updated 2018/10/04 22:46:24 (GMT +200)
  config file = None
  configured module search path = ['/Users/jdelannoye/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jdelannoye/Projects/Ansible/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 3.7.0 (default, Jun 29 2018, 20:13:53) [Clang 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION
I tested drain behaviour with a VM and Haproxy installed with web server as backend

