### PR TITLE
docs: add Support section for plugin types

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -384,7 +384,7 @@ Status
 ------
 {% if not deprecated %}
 
-{%   set support = { 'core': 'The Ansible Core Team', 'network': 'The Ansible Network Team', 'certified': 'an Ansible Partner', 'community': 'The Ansible Community', 'curated': 'A Third Party'} %}
+{%   set support = { 'core': 'the Ansible Core Team', 'network': 'the Ansible Network Team', 'certified': 'an Ansible Partner', 'community': 'the Ansible Community', 'curated': 'a Third Party'} %}
 {%   set module_states = { 'preview': 'it is not guaranteed to have a backwards compatible interface', 'stableinterface': 'the maintainers for this module guarantee that no backward incompatible interface changes will be made'} %}
 
 {%   if metadata %}
@@ -396,12 +396,20 @@ This @{ plugin_type }@ is flagged as **@{cur_state}@** which means that @{module
 
 {%     endif %}
 
-{%     if metadata.supported_by in ('core', 'network') %}
+{%     if metadata.supported_by %}
 
 Support
 ~~~~~~~
+{%       set supported_by = support[metadata.supported_by] %}
+This @{ plugin_type }@ is supported by @{ supported_by }@, see :ref:`Module Maintenance & Support <modules_support>` for more info.
+
+For a list of other modules that are also supported by @{ supported_by }@, see :ref:`here <@{ metadata.supported_by }@_supported>`.
+{%       if metadata.supported_by in ('core', 'network') %}
+
 For more information about Red Hat's support of this @{ plugin_type }@,
 please refer to this `Knowledge Base article <https://access.redhat.com/articles/rhel-top-support-policies/>`_
+{%       endif %}
+
 {%     endif %}
 
 {%   endif %}

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -401,7 +401,7 @@ This @{ plugin_type }@ is flagged as **@{cur_state}@** which means that @{module
 Support
 ~~~~~~~
 {%       set supported_by = support[metadata.supported_by] %}
-This @{ plugin_type }@ is supported by @{ supported_by }@, see :ref:`Module Maintenance & Support <modules_support>` for more info.
+This @{ plugin_type }@ is flagged as **@{metadata.supported_by}@** which means that it is supported by @{ supported_by }@. See :ref:`Module Maintenance & Support <modules_support>` for more info.
 
 For a list of other modules that are also supported by @{ supported_by }@, see :ref:`here <@{ metadata.supported_by }@_supported>`.
 {%       if metadata.supported_by in ('core', 'network') %}

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -398,13 +398,18 @@ This @{ plugin_type }@ is flagged as **@{cur_state}@** which means that @{module
 
 {%     if metadata.supported_by %}
 
+Maintenance
+-----------
+
+{%       set supported_by = support[metadata.supported_by] %}
+This @{ plugin_type }@ is flagged as **@{metadata.supported_by}@** which means that it is maintained by @{ supported_by }@. See :ref:`Module Maintenance & Support <modules_support>` for more info.
+
+For a list of other modules that are also maintained by @{ supported_by }@, see :ref:`here <@{ metadata.supported_by }@_supported>`.
+
+{%       if metadata.supported_by in ('core', 'network') %}
+
 Support
 ~~~~~~~
-{%       set supported_by = support[metadata.supported_by] %}
-This @{ plugin_type }@ is flagged as **@{metadata.supported_by}@** which means that it is supported by @{ supported_by }@. See :ref:`Module Maintenance & Support <modules_support>` for more info.
-
-For a list of other modules that are also supported by @{ supported_by }@, see :ref:`here <@{ metadata.supported_by }@_supported>`.
-{%       if metadata.supported_by in ('core', 'network') %}
 
 For more information about Red Hat's support of this @{ plugin_type }@,
 please refer to this `Knowledge Base article <https://access.redhat.com/articles/rhel-top-support-policies/>`_


### PR DESCRIPTION
##### SUMMARY
Always show the Support section for plugins that contains supported_by in the metadata. Currently this will only be displayed when the plugin is core or network supported and even in those cases it doesn't explicitly say what they are, just links to a Red Hat document. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
```paste below
devel
```

##### ADDITIONAL INFORMATION
Here's an example of a core module before

![image](https://user-images.githubusercontent.com/8462645/46511186-70e98c80-c890-11e8-85c2-45ae06848dc8.png)

And after the changes

![image](https://user-images.githubusercontent.com/8462645/46514891-fb87b700-c8a3-11e8-8b28-63133d4e2339.png)

Here's an example of a community module before

![image](https://user-images.githubusercontent.com/8462645/46511215-a0989480-c890-11e8-9b09-2b83a9be43ec.png)

And after the changes

![image](https://user-images.githubusercontent.com/8462645/46514897-ffb3d480-c8a3-11e8-916c-ac2c6dc8aa53.png)