### PR TITLE
Fix Grafana dashboard module to create dashboard if not exists (46152)

### DIFF
--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -66,11 +66,6 @@ options:
     version_added: 2.7
     description:
       - uid of the dasboard to export when C(state) is C(export) or C(absent).
-<<<<<<< a7de0bd139759f1d05f238e069153c183859de1a
-=======
-      - uid of the dashboard to create and update when C(state) is C(present).
-        If uid is not provided, the module uses uid provided in json file
->>>>>>> Fix grafana dashboard - force getting uid from module
   path:
     description:
       - The path to the json file containing the Grafana dashboard to import or export.
@@ -254,12 +249,10 @@ def grafana_create_dashboard(module, data):
     else:
         if data.get('uid'):
             uid = data['uid']
-            payload['dashboard']['uid'] = uid
         elif 'uid' in payload['dashboard']:
             uid = payload['dashboard']['uid']
         else:
             uid = None
-
 
     # test if dashboard already exists
     dashboard_exists, dashboard = grafana_dashboard_exists(
@@ -274,16 +267,11 @@ def grafana_create_dashboard(module, data):
             result['changed'] = False
         else:
             # update
-<<<<<<< a7de0bd139759f1d05f238e069153c183859de1a
             if 'overwrite' in data and data['overwrite']:
-=======
-            if uid is not None:
-                payload["dashboard"].pop("id")
-            if 'overwrite' in data and data['overwrite'] == True:
->>>>>>> Fix grafana dashboard - force getting uid from module
                 payload['overwrite'] = True
             if 'message' in data and data['message']:
                 payload['message'] = data['message']
+
             r, info = fetch_url(module, '%s/api/dashboards/db' %
                                 data['grafana_url'], data=json.dumps(payload), headers=headers, method='POST')
             if info['status'] == 200:
@@ -304,10 +292,7 @@ def grafana_create_dashboard(module, data):
         # create
         if 'id' in payload["dashboard"]:
             payload["dashboard"].pop("id")
-<<<<<<< 1a70828cfe03a69612df0353bc55386d99c608ff
-=======
 
->>>>>>> Fix grafana dashboard - remove duplicate about uid management (#46152)
         r, info = fetch_url(module, '%s/api/dashboards/db' %
                             data['grafana_url'], data=json.dumps(payload), headers=headers, method='POST')
         if info['status'] == 200:

--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -292,6 +292,10 @@ def grafana_create_dashboard(module, data):
         # create
         if 'id' in payload["dashboard"]:
             payload["dashboard"].pop("id")
+<<<<<<< 1a70828cfe03a69612df0353bc55386d99c608ff
+=======
+
+>>>>>>> Fix grafana dashboard - remove duplicate about uid management (#46152)
         r, info = fetch_url(module, '%s/api/dashboards/db' %
                             data['grafana_url'], data=json.dumps(payload), headers=headers, method='POST')
         if info['status'] == 200:

--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -292,13 +292,6 @@ def grafana_create_dashboard(module, data):
         # create
         if 'id' in payload["dashboard"]:
             payload["dashboard"].pop("id")
-<<<<<<< 8004a78b9e2fbca3f80301983dd57a634cb5b1ee
-
-        #raise GrafanaAPIException("{}".format(payload))
-=======
-        if 'uid' in payload["dashboard"]:
-            payload["dashboard"].pop("uid")
->>>>>>> Fix grafana dashboard remove comment in the code (PR #46525)
         r, info = fetch_url(module, '%s/api/dashboards/db' %
                             data['grafana_url'], data=json.dumps(payload), headers=headers, method='POST')
         if info['status'] == 200:

--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -290,7 +290,8 @@ def grafana_create_dashboard(module, data):
                     'Unable to update the dashboard %s : %s' % (uid, body['message']))
     else:
         # create
-        payload["dashboard"].pop("id")
+        if 'id' in payload["dashboard"]:
+            payload["dashboard"].pop("id")
 
         #raise GrafanaAPIException("{}".format(payload))
         r, info = fetch_url(module, '%s/api/dashboards/db' %

--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -66,6 +66,11 @@ options:
     version_added: 2.7
     description:
       - uid of the dasboard to export when C(state) is C(export) or C(absent).
+<<<<<<< a7de0bd139759f1d05f238e069153c183859de1a
+=======
+      - uid of the dashboard to create and update when C(state) is C(present).
+        If uid is not provided, the module uses uid provided in json file
+>>>>>>> Fix grafana dashboard - force getting uid from module
   path:
     description:
       - The path to the json file containing the Grafana dashboard to import or export.
@@ -249,10 +254,12 @@ def grafana_create_dashboard(module, data):
     else:
         if data.get('uid'):
             uid = data['uid']
+            payload['dashboard']['uid'] = uid
         elif 'uid' in payload['dashboard']:
             uid = payload['dashboard']['uid']
         else:
             uid = None
+
 
     # test if dashboard already exists
     dashboard_exists, dashboard = grafana_dashboard_exists(
@@ -267,11 +274,16 @@ def grafana_create_dashboard(module, data):
             result['changed'] = False
         else:
             # update
+<<<<<<< a7de0bd139759f1d05f238e069153c183859de1a
             if 'overwrite' in data and data['overwrite']:
+=======
+            if uid is not None:
+                payload["dashboard"].pop("id")
+            if 'overwrite' in data and data['overwrite'] == True:
+>>>>>>> Fix grafana dashboard - force getting uid from module
                 payload['overwrite'] = True
             if 'message' in data and data['message']:
                 payload['message'] = data['message']
-
             r, info = fetch_url(module, '%s/api/dashboards/db' %
                                 data['grafana_url'], data=json.dumps(payload), headers=headers, method='POST')
             if info['status'] == 200:

--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -292,8 +292,13 @@ def grafana_create_dashboard(module, data):
         # create
         if 'id' in payload["dashboard"]:
             payload["dashboard"].pop("id")
+<<<<<<< 8004a78b9e2fbca3f80301983dd57a634cb5b1ee
 
         #raise GrafanaAPIException("{}".format(payload))
+=======
+        if 'uid' in payload["dashboard"]:
+            payload["dashboard"].pop("uid")
+>>>>>>> Fix grafana dashboard remove comment in the code (PR #46525)
         r, info = fetch_url(module, '%s/api/dashboards/db' %
                             data['grafana_url'], data=json.dumps(payload), headers=headers, method='POST')
         if info['status'] == 200:


### PR DESCRIPTION
##### SUMMARY
This PR fixes issue #46152

This PR does the following : 
- When we load the JSON file, add dashboard key at top level if not exists
- If we create the dashboard, we remove the keys "id" and "uid" from the payload which should not be present

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
grafana_dashboard module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (jori_fix_46152 6d61e8dcc0) last updated 2018/10/05 10:56:42 (GMT +200)
  config file = None
  configured module search path = ['/Users/jdelannoye/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jdelannoye/Projects/Ansible/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 3.7.0 (default, Jun 29 2018, 20:13:53) [Clang 8.0.0 (clang-800.0.42.1)]
```
