### PR TITLE
module mongodb_user fix roles default value (#46443)

### DIFF
--- a/changelogs/fragments/46443-mongodb_user-fix-roles-default-value.yaml
+++ b/changelogs/fragments/46443-mongodb_user-fix-roles-default-value.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - mongodb_user - apply "readWrite" as default value for parameter roles (https://github.com/ansible/ansible/issues/46443)

--- a/changelogs/fragments/46443-mongodb_user-fix-roles-default-value.yaml
+++ b/changelogs/fragments/46443-mongodb_user-fix-roles-default-value.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - mongodb_user - apply "readWrite" as default value for parameter roles (https://github.com/ansible/ansible/issues/46443)
+  - mongodb_user - Change value for parameter roles to empty (https://github.com/ansible/ansible/issues/46443)

--- a/changelogs/fragments/46443-mongodb_user-fix-roles-default-value.yaml
+++ b/changelogs/fragments/46443-mongodb_user-fix-roles-default-value.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - mongodb_user - Change value for parameter roles to empty (https://github.com/ansible/ansible/issues/46443)
+- mongodb_user - Change value for parameter roles to empty (https://github.com/ansible/ansible/issues/46443)

--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -342,7 +342,7 @@ def main():
             name=dict(required=True, aliases=['user']),
             password=dict(aliases=['pass'], no_log=True),
             ssl=dict(default=False, type='bool'),
-            roles=dict(default=None, type='list'),
+            roles=dict(default="readWrite", type='list'),
             state=dict(default='present', choices=['absent', 'present']),
             update_password=dict(default="always", choices=["always", "on_create"]),
             ssl_cert_reqs=dict(default='CERT_REQUIRED', choices=['CERT_NONE', 'CERT_OPTIONAL', 'CERT_REQUIRED']),

--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -77,7 +77,6 @@ options:
               'dbAdminAnyDatabase'
             - "Or the following dictionary '{ db: DATABASE_NAME, role: ROLE_NAME }'."
             - "This param requires pymongo 2.5+. If it is a string, mongodb 2.4+ is also required. If it is a dictionary, mongo 2.6+  is required."
-        default: "readWrite"
     state:
         description:
             - The database user state
@@ -342,7 +341,7 @@ def main():
             name=dict(required=True, aliases=['user']),
             password=dict(aliases=['pass'], no_log=True),
             ssl=dict(default=False, type='bool'),
-            roles=dict(default="readWrite", type='list'),
+            roles=dict(default=None, type='list'),
             state=dict(default='present', choices=['absent', 'present']),
             update_password=dict(default="always", choices=["always", "on_create"]),
             ssl_cert_reqs=dict(default='CERT_REQUIRED', choices=['CERT_NONE', 'CERT_OPTIONAL', 'CERT_REQUIRED']),

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -377,7 +377,7 @@ lib/ansible/modules/database/mongodb/mongodb_parameter.py E317
 lib/ansible/modules/database/mongodb/mongodb_parameter.py E323
 lib/ansible/modules/database/mongodb/mongodb_parameter.py E326
 lib/ansible/modules/database/mongodb/mongodb_user.py E322
-lib/ansible/modules/database/mongodb/mongodb_user.py E324
+lib/ansible/modules/database/mongodb/mongodb_user.py E325
 lib/ansible/modules/database/mysql/mysql_replication.py E325
 lib/ansible/modules/database/mysql/mysql_replication.py E326
 lib/ansible/modules/database/mysql/mysql_user.py E322

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -377,7 +377,6 @@ lib/ansible/modules/database/mongodb/mongodb_parameter.py E317
 lib/ansible/modules/database/mongodb/mongodb_parameter.py E323
 lib/ansible/modules/database/mongodb/mongodb_parameter.py E326
 lib/ansible/modules/database/mongodb/mongodb_user.py E322
-lib/ansible/modules/database/mongodb/mongodb_user.py E325
 lib/ansible/modules/database/mysql/mysql_replication.py E325
 lib/ansible/modules/database/mysql/mysql_replication.py E326
 lib/ansible/modules/database/mysql/mysql_user.py E322


### PR DESCRIPTION
##### SUMMARY
Fixes issue #46443 

Add default value for the parameter "roles"

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mongodb_user module

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (jori_fix_46443 51667a5753) last updated 2018/10/05 11:30:00 (GMT +200)
  config file = None
  configured module search path = ['/Users/jdelannoye/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jdelannoye/Projects/Ansible/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 3.7.0 (default, Jun 29 2018, 20:13:53) [Clang 8.0.0 (clang-800.0.42.1)]
```
