### PR TITLE
Bug 42787 create volume with label

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -103,6 +103,8 @@ BYTE_SUFFIXES = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
 
 
 if not HAS_DOCKER_PY:
+    docker_version = None
+
     # No docker-py. Create a place holder client to allow
     # instantiation of AnsibleModule and proper error handing
     class Client(object):  # noqa: F811

--- a/test/units/modules/cloud/docker/test_docker_volume.py
+++ b/test/units/modules/cloud/docker/test_docker_volume.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2018 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+import json
+
+import pytest
+
+from ansible.modules.cloud.docker import docker_volume
+from ansible.module_utils import docker_common
+
+pytestmark = pytest.mark.usefixtures('patch_ansible_module')
+
+TESTCASE_DOCKER_VOLUME = [
+    {
+        'name': 'daemon_config',
+        'state': 'present'
+    }
+]
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_DOCKER_VOLUME, indirect=['patch_ansible_module'])
+def test_create_volume_on_invalid_docker_version(mocker, capfd):
+    mocker.patch.object(docker_common, 'HAS_DOCKER_PY', True)
+    mocker.patch.object(docker_common, 'docker_version', '1.8.0')
+
+    with pytest.raises(SystemExit):
+        docker_volume.main()
+
+    out, dummy = capfd.readouterr()
+    results = json.loads(out)
+    assert results['failed']
+    assert 'Error: docker / docker-py version is 1.8.0. Minimum version required is 1.10.0.' in results['msg']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add check on docker-py minimal version (which is 1.10.0) for docker-volume. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible/ansible/issues/42787
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (bug-42787-create-volume-with-label df3b051189) last updated 2018/10/05 11:31:46 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/raph/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/raph/contributions/ansible/lib/ansible
  executable location = /home/raph/contributions/ansible/bin/ansible
  python version = 3.6.3 (default, Jan 30 2018, 11:22:59) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
