### PR TITLE
VMware: Add check mode support to module vmware_host_dns_facts

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_dns_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_dns_facts.py
@@ -117,7 +117,8 @@ def main():
         argument_spec=argument_spec,
         required_one_of=[
             ['cluster_name', 'esxi_hostname'],
-        ]
+        ],
+        supports_check_mode=True
     )
 
     vmware_dns_config = VmwareDnsFactsManager(module)

--- a/test/integration/targets/vmware_host_dns_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_dns_facts/tasks/main.yml
@@ -83,3 +83,35 @@
     that:
         - all_hosts_dns_result.hosts_dns_facts
         - not all_hosts_dns_result.changed
+
+- name: gather DNS facts about all hosts in given cluster in check mode
+  vmware_host_dns_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    cluster_name: "{{ ccr1 }}"
+    validate_certs: no
+  register: all_hosts_dns_result_check_mode
+  check_mode: yes
+
+- name: ensure DNS facts are gathered for all hosts in given cluster
+  assert:
+    that:
+        - all_hosts_dns_result_check_mode.hosts_dns_facts
+        - not all_hosts_dns_result_check_mode.changed
+
+- name: gather DNS facts about host system in check mode
+  vmware_host_dns_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    esxi_hostname: "{{ host1 }}"
+    validate_certs: no
+  register: all_hosts_dns_result_check_mode
+  check_mode: yes
+
+- name: ensure DNS facts are gathered about host system
+  assert:
+    that:
+        - all_hosts_dns_result_check_mode.hosts_dns_facts
+        - not all_hosts_dns_result_check_mode.changed


### PR DESCRIPTION
##### SUMMARY
The module doesn't execute in check mode.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_dns_facts

##### ANSIBLE VERSION
```
# ansible --version
ansible 2.6.3
  config file = /root/ansible-vmware/ansible.cfg
  configured module search path = [u'/root/ansible-vmware/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
before (check mode)
```
TASK [esxi : Gather DNS facts about ESXi Host] 
```
after (check mode)
```
TASK [esxi : Gather DNS facts about ESXi Host] ***********************************************************************************************************************************************************************************************
ok: [esxi_host -> jump_server] => {"changed": false, "hosts_dns_facts": {"esxi_host_fqdn": {"dhcp": false, "domain_name": "domain", "host_name": "esxi_host", "ip_address": ["xxx.xxx.xxx.xxx", "xxx.xxx.xxx.xxx", "xxx.xxx.xxx.xxx", "xxx.xxx.xxx.xxx", "xxx.xxx.xxx.xxx"], "search_doamin": ["search_domain1", "search_domain2", "search_domain3"], "virtual_nic_device": null}}}
```