### PR TITLE
azure_rm_common: use __version__ from module_util (#46184)

### DIFF
--- a/changelogs/fragments/azure-version.yaml
+++ b/changelogs/fragments/azure-version.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- use proper module_util to get Ansible version for Azure requests

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -14,12 +14,9 @@ import json
 from os.path import expanduser
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ansible_release import __version__ as ANSIBLE_VERSION
 from ansible.module_utils.six.moves import configparser
 import ansible.module_utils.six.moves.urllib.parse as urlparse
-try:
-    from ansible.release import __version__ as ANSIBLE_VERSION
-except ImportError:
-    ANSIBLE_VERSION = 'unknown'
 
 AZURE_COMMON_ARGS = dict(
     auth_source=dict(


### PR DESCRIPTION
(cherry picked from commit 02c11e6b51ff8fd19523f2dbf9c25eb51f39778e)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/46184

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_common

##### ANSIBLE VERSION
```paste below
2.7
```