### PR TITLE
plugin_formatter.py: Improve the output when processing docs

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -185,7 +185,9 @@ def write_data(text, output_dir, outputname, module=None):
         fname = os.path.join(output_dir, outputname)
         fname = fname.replace(".py", "")
 
-        update_file_if_different(fname, to_bytes(text))
+        updated = update_file_if_different(fname, to_bytes(text))
+        if updated:
+            display.display("rendering: %s" % module)
     else:
         print(text)
 
@@ -401,7 +403,6 @@ def too_old(added):
 def process_plugins(module_map, templates, outputname, output_dir, ansible_version, plugin_type):
     for module in module_map:
 
-        display.display("rendering: %s" % module)
         fname = module_map[module]['path']
         display.vvvvv(pp.pformat(('process_plugins info: ', module_map[module])))
 
@@ -657,6 +658,8 @@ def main():
     validate_options(options)
     display.verbosity = options.verbosity
     plugin_type = options.plugin_type
+
+    display.display("Evaluating %s files..." % plugin_type)
 
     # prep templating
     templates = jinja2_environment(options.template_dir, options.type, plugin_type)

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -187,8 +187,8 @@ def write_data(text, output_dir, outputname, module=None):
 
         try:
             updated = update_file_if_different(fname, to_bytes(text))
-        except:
-            display.display("while rendering %s, an error occured:" % module)
+        except Exception as e:
+            display.display("while rendering %s, an error occured: %s" % (module, e))
             raise
         if updated:
             display.display("rendering: %s" % module)

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -196,10 +196,14 @@ def write_data(text, output_dir, outputname, module=None):
         print(text)
 
 
+IS_STDOUT_TTY = sys.stdout.isatty()
+
+
 def show_progress(progress):
     '''Show a little process indicator.'''
-    sys.stdout.write('\r%s\r' % ("-/|\\"[progress % 4]))
-    sys.stdout.flush()
+    if IS_STDOUT_TTY:
+        sys.stdout.write('\r%s\r' % ("-/|\\"[progress % 4]))
+        sys.stdout.flush()
 
 
 def get_plugin_info(module_dir, limit_to=None, verbose=False):

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -185,7 +185,11 @@ def write_data(text, output_dir, outputname, module=None):
         fname = os.path.join(output_dir, outputname)
         fname = fname.replace(".py", "")
 
-        updated = update_file_if_different(fname, to_bytes(text))
+        try:
+            updated = update_file_if_different(fname, to_bytes(text))
+        except:
+            display.display("while rendering %s, an error occured:" % module)
+            raise
         if updated:
             display.display("rendering: %s" % module)
     else:

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -701,15 +701,18 @@ def main():
 
     categories['all'] = {'_modules': plugin_info.keys()}
 
-    display.vvv(pp.pformat(categories))
-    display.vvvvv(pp.pformat(plugin_info))
+    if display.verbosity >= 3:
+        display.vvv(pp.pformat(categories))
+    if display.verbosity >= 5:
+        display.vvvvv(pp.pformat(plugin_info))
 
     # Transform the data
     if options.type == 'rst':
         display.v('Generating rst')
         for key, record in plugin_info.items():
             display.vv(key)
-            display.vvvvv(pp.pformat(('record', record)))
+            if display.verbosity >= 5:
+                display.vvvvv(pp.pformat(('record', record)))
             if record.get('doc', None):
                 short_desc = record['doc']['short_description'].rstrip('.')
                 if short_desc is None:

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -196,6 +196,12 @@ def write_data(text, output_dir, outputname, module=None):
         print(text)
 
 
+def show_progress(progress):
+    '''Show a little process indicator.'''
+    sys.stdout.write('\r%s\r' % ("-/|\\"[progress % 4]))
+    sys.stdout.flush()
+
+
 def get_plugin_info(module_dir, limit_to=None, verbose=False):
     '''
     Returns information about plugins and the categories that they belong to
@@ -237,6 +243,7 @@ def get_plugin_info(module_dir, limit_to=None, verbose=False):
         glob.glob("%s/*/*/*/*.py" % module_dir)
     )
 
+    module_index = 0
     for module_path in files:
         # Do not list __init__.py files
         if module_path.endswith('__init__.py'):
@@ -271,6 +278,9 @@ def get_plugin_info(module_dir, limit_to=None, verbose=False):
         #
         # Regular module to process
         #
+
+        module_index += 1
+        show_progress(module_index)
 
         # use ansible core library to parse out doc metadata YAML and plaintext examples
         doc, examples, returndocs, metadata = plugin_docs.get_docstring(module_path, fragment_loader, verbose=verbose)
@@ -405,7 +415,9 @@ def too_old(added):
 
 
 def process_plugins(module_map, templates, outputname, output_dir, ansible_version, plugin_type):
-    for module in module_map:
+    for module_index, module in enumerate(module_map):
+
+        show_progress(module_index)
 
         fname = module_map[module]['path']
         display.vvvvv(pp.pformat(('process_plugins info: ', module_map[module])))

--- a/lib/ansible/utils/_build_helpers.py
+++ b/lib/ansible/utils/_build_helpers.py
@@ -36,3 +36,6 @@ def update_file_if_different(filename, b_data):
     if b_data_old != b_data:
         with open(filename, 'wb') as f:
             f.write(b_data)
+        return True
+
+    return False


### PR DESCRIPTION
##### SUMMARY
Currently the plugin_formatter reports

    rendering <file>

for every module/plugin, even if it's not really changing anything on disk.

This PR changes the output, and will print for every module/plugin_type a single message: 

    Evaluating <plugin_type> files...

and only reports files that are changed back to the user.

This makes it more obvious what files the build process picks up as being changed.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
plugin_formatter

##### ANSIBLE VERSION
v2.8