### PR TITLE
Fixed the ssl-certs in netbox plugin

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -63,6 +63,7 @@ EXAMPLES = '''
 
 plugin: netbox
 api_endpoint: http://localhost:8000
+validate_certs: True
 group_by:
   - device_roles
 query_filters:
@@ -135,7 +136,7 @@ class InventoryModule(BaseInventoryPlugin):
     NAME = 'netbox'
 
     def _fetch_information(self, url):
-        response = open_url(url, headers=self.headers, timeout=self.timeout, validate_certs=False)
+        response = open_url(url, headers=self.headers, timeout=self.timeout, validate_certs=self.validate_certs)
 
         try:
             raw_data = to_text(response.read(), errors='surrogate_or_strict')
@@ -368,6 +369,7 @@ class InventoryModule(BaseInventoryPlugin):
         token = self.get_option("token")
         self.api_endpoint = self.get_option("api_endpoint")
         self.timeout = self.get_option("timeout")
+        self.validate_certs = self.get_option("validate_certs")
         self.headers = {
             'Authorization': "Token %s" % token,
             'User-Agent': "ansible %s Python %s" % (ansible_version, python_version.split(' ')[0]),

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -135,7 +135,7 @@ class InventoryModule(BaseInventoryPlugin):
     NAME = 'netbox'
 
     def _fetch_information(self, url):
-        response = open_url(url, headers=self.headers, timeout=self.timeout)
+        response = open_url(url, headers=self.headers, timeout=self.timeout, validate_certs=False)
 
         try:
             raw_data = to_text(response.read(), errors='surrogate_or_strict')


### PR DESCRIPTION
##### SUMMARY
Fixed the ssl-certs verification error in netbox plugin 

Fixed #46542

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
netbox inventory plugin

##### ANSIBLE VERSION
```
ansible 2.6.5
  config file = /Users/netbx-ansible/ansible.cfg
  configured module search path = [u'/Users/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Sep  5 2018, 14:52:04) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
```
~/netbx-ansible> ansible-inventory -vvv --list -i netbox_inventory.yml
{
    "_meta": {
        "hostvars": {
            "sw-xyz": {
                "device_roles": [
                    "ACI Leaf"
                ],
                "device_types": [
                    "xyz"
                ],
                "manufacturers": [
                    "xyz"
                ],
                "racks": [
                    "xyz"
                ],
                "sites": [
                    "xyz"
                ],
                "tenants": [
                    "abc"
                ]
            }
        }
    },
    "all": {
        "children": [
            "sites_region-name",
            "ungrouped"
        ]
    },
    "sites_region-name": {
        "hosts": [
            "region-specific"
        ]
    },
    "ungrouped": {}
}
```
