### PR TITLE
django_manage: fix createsuperuser idempotence

### DIFF
--- a/lib/ansible/modules/web_infrastructure/django_manage.py
+++ b/lib/ansible/modules/web_infrastructure/django_manage.py
@@ -174,6 +174,10 @@ def createcachetable_filter_output(line):
     return "Already exists" not in line
 
 
+def createsuperuser_filter_output(line):
+    return "Already exists" not in line
+
+
 def flush_filter_output(line):
     return "Installed" in line and "Installed 0 object" not in line
 
@@ -251,6 +255,8 @@ def main():
     )
 
     command = module.params['command']
+    command_first_word = command.split(" ")[0]
+
     app_path = module.params['app_path']
     virtualenv = module.params['virtualenv']
 
@@ -289,6 +295,8 @@ def main():
     if rc != 0:
         if command == 'createcachetable' and 'table' in err and 'already exists' in err:
             out = 'Already exists.'
+        if 'createsuperuser' in command_first_word and 'UNIQUE constraint failed' in err:
+            out = 'Already exists.'
         else:
             if "Unknown command:" in err:
                 _fail(module, cmd, err, "Unknown django command: %s" % command)
@@ -298,6 +306,7 @@ def main():
 
     lines = out.split('\n')
     filt = globals().get(command + "_filter_output", None)
+    filt = filt or globals().get(command_first_word + "_filter_output", None)
     if filt:
         filtered_output = list(filter(filt, lines))
         if len(filtered_output):


### PR DESCRIPTION
##### SUMMARY
Fixes #29786

There is an issue with createsuperuser idempotence. When the user already exists, the role failed. 
Now we try to create the user and if it already exist, we don't show an error message.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

django_manage

##### ANSIBLE VERSION

```ansible 2.8.0.dev0 (ice3/issue_29786 ac6baadacf) last updated 2018/10/05 17:00:08 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/mfalce/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mfalce/Documents/geek/pyconfr2018/ansible/lib/ansible
  executable location = /home/mfalce/Documents/geek/pyconfr2018/ansible/bin/ansible
  python version = 3.6.6 (default, Sep 12 2018, 18:26:19) [GCC 8.0.1 20180414 (experimental) [trunk revision 259383]]

```

##### ADDITIONAL INFORMATION

