### PR TITLE
VMware: Gather extended datastore facts

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py
@@ -47,6 +47,20 @@ options:
      - If set, facts of datastores belonging this clusters will be returned.
      - This parameter is required, if C(datacenter) is not supplied.
      required: False
+   gather_nfs_mount_info:
+    description:
+    - Gather mount information of NFS datastores.
+    - Disabled per default because this slows down the execution if you have a lot of datastores.
+    type: bool
+    default: false
+    version_added: 2.8
+   gather_vmfs_mount_info:
+    description:
+    - Gather mount information of VMFS datastores.
+    - Disabled per default because this slows down the execution if you have a lot of datastores.
+    type: bool
+    default: false
+    version_added: 2.8
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -89,7 +103,25 @@ datastores:
             "provisioned": 12289211488,
             "type": "VMFS",
             "uncommitted": 9246243936,
-            "url": "ds:///vmfs/volumes/5a69b18a-c03cd88c-36ae-5254001249ce/"
+            "url": "ds:///vmfs/volumes/5a69b18a-c03cd88c-36ae-5254001249ce/",
+            "vmfs_blockSize": 1024,
+            "vmfs_uuid": "5a69b18a-c03cd88c-36ae-5254001249ce",
+            "vmfs_version": "6.81"
+        },
+        {
+            "accessible": true,
+            "capacity": 5497558138880,
+            "datastore_cluster": "datacluster0",
+            "freeSpace": 4279000641536,
+            "maintenanceMode": "normal",
+            "multipleHostAccess": true,
+            "name": "datastore3",
+            "nfs_path": "/vol/datastore3",
+            "nfs_server": "nfs_server1",
+            "provisioned": 1708109410304,
+            "type": "NFS",
+            "uncommitted": 489551912960,
+            "url": "ds:///vmfs/volumes/420b3e73-67070776/"
         },
     ]
 """
@@ -102,6 +134,70 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import (PyVmomi, vmware_argument_spec, get_all_objs,
                                          find_cluster_by_name, get_parent_datacenter)
+
+
+class VMwareHostDatastore(PyVmomi):
+    """ This class populates the datastore list """
+    def __init__(self, module):
+        super(VMwareHostDatastore, self).__init__(module)
+        self.gather_nfs_mount_info = self.module.params['gather_nfs_mount_info']
+        self.gather_vmfs_mount_info = self.module.params['gather_vmfs_mount_info']
+
+    def check_datastore_host(self, esxi_host, datastore):
+        """ Get all datastores of specified ESXi host """
+        esxi = self.find_hostsystem_by_name(esxi_host)
+        if esxi is None:
+            self.module.fail_json(msg="Failed to find ESXi hostname %s " % esxi_host)
+        storage_system = esxi.configManager.storageSystem
+        host_file_sys_vol_mount_info = storage_system.fileSystemVolumeInfo.mountInfo
+        for host_mount_info in host_file_sys_vol_mount_info:
+            if host_mount_info.volume.name == datastore:
+                return host_mount_info
+        return None
+
+    def build_datastore_list(self, datastore_list):
+        """ Build list with datastores """
+        datastores = list()
+        for datastore in datastore_list:
+            summary = datastore.summary
+            datastore_summary = dict()
+            datastore_summary['accessible'] = summary.accessible
+            datastore_summary['capacity'] = summary.capacity
+            datastore_summary['name'] = summary.name
+            datastore_summary['freeSpace'] = summary.freeSpace
+            datastore_summary['maintenanceMode'] = summary.maintenanceMode
+            datastore_summary['multipleHostAccess'] = summary.multipleHostAccess
+            datastore_summary['type'] = summary.type
+            if self.gather_nfs_mount_info or self.gather_vmfs_mount_info:
+                if self.gather_nfs_mount_info and summary.type.startswith("NFS"):
+                    # get mount info from the first ESXi host attached to this NFS datastore
+                    host_mount_info = self.check_datastore_host(summary.datastore.host[0].key.name, summary.name)
+                    datastore_summary['nfs_server'] = host_mount_info.volume.remoteHost
+                    datastore_summary['nfs_path'] = host_mount_info.volume.remotePath
+                if self.gather_vmfs_mount_info and summary.type == "VMFS":
+                    # get mount info from the first ESXi host attached to this VMFS datastore
+                    host_mount_info = self.check_datastore_host(summary.datastore.host[0].key.name, summary.name)
+                    datastore_summary['vmfs_blockSize'] = host_mount_info.volume.blockSize
+                    datastore_summary['vmfs_version'] = host_mount_info.volume.version
+                    datastore_summary['vmfs_uuid'] = host_mount_info.volume.uuid
+            # vcsim does not return uncommitted
+            if not summary.uncommitted:
+                summary.uncommitted = 0
+            datastore_summary['uncommitted'] = summary.uncommitted
+            datastore_summary['url'] = summary.url
+            # Calculated values
+            datastore_summary['provisioned'] = summary.capacity - summary.freeSpace + summary.uncommitted
+            datastore_summary['datastore_cluster'] = 'N/A'
+            if isinstance(datastore.parent, vim.StoragePod):
+                datastore_summary['datastore_cluster'] = datastore.parent.name
+
+            if self.module.params['name']:
+                if datastore_summary['name'] == self.module.params['name']:
+                    datastores.extend([datastore_summary])
+            else:
+                datastores.extend([datastore_summary])
+
+        return datastores
 
 
 class PyVmomiCache(object):
@@ -130,15 +226,18 @@ class PyVmomiCache(object):
 
 
 class PyVmomiHelper(PyVmomi):
+    """ This class gets datastores """
     def __init__(self, module):
         super(PyVmomiHelper, self).__init__(module)
         self.cache = PyVmomiCache(self.content, dc_name=self.params['datacenter'])
 
     def lookup_datastore(self):
+        """ Get datastore(s) per ESXi host or vCenter server """
         datastores = self.cache.get_all_objs(self.content, [vim.Datastore], confine_to_datacenter=True)
         return datastores
 
     def lookup_datastore_by_cluster(self):
+        """ Get datastore(s) per cluster """
         cluster = find_cluster_by_name(self.content, self.params['cluster'])
         if not cluster:
             self.module.fail_json(msg='Failed to find cluster "%(cluster)s"' % self.params)
@@ -147,11 +246,14 @@ class PyVmomiHelper(PyVmomi):
 
 
 def main():
+    """ Main """
     argument_spec = vmware_argument_spec()
     argument_spec.update(
         name=dict(type='str'),
-        cluster=dict(type='str')
         datacenter=dict(type='str', aliases=['datacenter_name']),
+        cluster=dict(type='str'),
+        gather_nfs_mount_info=dict(type='bool', default=False),
+        gather_vmfs_mount_info=dict(type='bool', default=False)
     )
     module = AnsibleModule(argument_spec=argument_spec,
                            required_one_of=[
@@ -168,33 +270,8 @@ def main():
     else:
         dxs = pyv.lookup_datastore()
 
-    datastores = list()
-    for ds in dxs:
-        summary = ds.summary
-        dds = dict()
-        dds['accessible'] = summary.accessible
-        dds['capacity'] = summary.capacity
-        dds['name'] = summary.name
-        dds['freeSpace'] = summary.freeSpace
-        dds['maintenanceMode'] = summary.maintenanceMode
-        dds['multipleHostAccess'] = summary.multipleHostAccess
-        dds['type'] = summary.type
-        # vcsim does not return uncommitted
-        if not summary.uncommitted:
-            summary.uncommitted = 0
-        dds['uncommitted'] = summary.uncommitted
-        dds['url'] = summary.url
-        # Calculated values
-        dds['provisioned'] = summary.capacity - summary.freeSpace + summary.uncommitted
-        dds['datastore_cluster'] = 'N/A'
-        if isinstance(ds.parent, vim.StoragePod):
-            dds['datastore_cluster'] = ds.parent.name
-
-        if module.params['name']:
-            if dds['name'] == module.params['name']:
-                datastores.extend([dds])
-        else:
-            datastores.extend([dds])
+    vmware_host_datastore = VMwareHostDatastore(module)
+    datastores = vmware_host_datastore.build_datastore_list(dxs)
 
     result['datastores'] = datastores
 

--- a/lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py
@@ -157,6 +157,7 @@ def main():
                            required_one_of=[
                                ['cluster', 'datacenter'],
                            ],
+                           supports_check_mode=True
                            )
     result = dict(changed=False)
 

--- a/lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py
@@ -40,6 +40,7 @@ options:
      - Datacenter to search for datastores.
      - This parameter is required, if C(cluster) is not supplied.
      required: False
+     aliases: ['datacenter_name']
    cluster:
      description:
      - Cluster to search for datastores.
@@ -55,7 +56,7 @@ EXAMPLES = '''
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
-    datacenter: '{{ datacenter_name }}'
+    datacenter_name: '{{ datacenter_name }}'
     validate_certs: no
   delegate_to: localhost
   register: facts
@@ -65,7 +66,7 @@ EXAMPLES = '''
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
-    datacenter: '{{ datacenter_name }}'
+    datacenter_name: '{{ datacenter_name }}'
     name: datastore1
   delegate_to: localhost
   register: facts
@@ -149,8 +150,8 @@ def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(
         name=dict(type='str'),
-        datacenter=dict(type='str'),
         cluster=dict(type='str')
+        datacenter=dict(type='str', aliases=['datacenter_name']),
     )
     module = AnsibleModule(argument_spec=argument_spec,
                            required_one_of=[

--- a/test/integration/targets/vmware_datastore_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_datastore_facts/tasks/main.yml
@@ -38,7 +38,7 @@
 
 - set_fact:
     cl1: "{{ clusters['json'][0] }}"
-    
+
 - name: get a list of Datacenters from vcsim
   uri:
     url: http://{{ vcsim }}:5000/govc_find?filter=DC
@@ -54,7 +54,7 @@
 
 - set_fact:
     ds1: "{{ datastores['json'][0] }}"
-  
+
 # Testcase 0001: Get a full list of datastores in a datacenter
 - name: get list of facts about datastores
   vmware_datastore_facts:
@@ -109,3 +109,41 @@
     that:
       - "datastore_facts_0003['datastores'][0]['name'] == ds1 | basename"
       - "datastore_facts_0003['datastores'][0]['capacity'] is defined"
+
+- name: get list of extended facts about one datastore
+  vmware_datastore_facts:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    datacenter: "{{ dc1 | basename }}"
+    name: "{{ ds1 | basename }}"
+    gather_nfs_mount_info: True
+    gather_vmfs_mount_info: True
+  register: datastore_facts_0004
+
+- debug:
+    msg: "{{ datastore_facts_0004 }}"
+
+- assert:
+    that:
+      - "datastore_facts_0004['datastores'][0]['name'] == ds1 | basename"
+      - "datastore_facts_0004['datastores'][0]['capacity'] is defined"
+
+- name: get list of facts about one datastore in check mode
+  vmware_datastore_facts:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    datacenter: "{{ dc1 | basename }}"
+    name: "{{ ds1 | basename }}"
+  register: datastore_facts_0005
+
+- debug:
+    msg: "{{ datastore_facts_0005 }}"
+
+- assert:
+    that:
+      - "datastore_facts_0005['datastores'][0]['name'] == ds1 | basename"
+      - "datastore_facts_0005['datastores'][0]['capacity'] is defined"


### PR DESCRIPTION
##### SUMMARY
* Gather "extended" datastore facts. This is disabled by default, but it can be enabled for NFS or VMFS. Fixes https://github.com/ansible/ansible/issues/46156.
* Add check mode support
* Add datacenter_name alias

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
vmware_datastore_facts

##### ANSIBLE VERSION
```
# ansible --version
ansible 2.6.3
  config file = /root/ansible-vmware/ansible.cfg
  configured module search path = [u'/root/ansible-vmware/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
before (VMFS):
```
ok: [esxi_host] => (item={u'accessible': True, u'freeSpace': 1084649111552, u'multipleHostAccess': None, u'capacity': 12094359470080, u'name': u'datastore_VMFS', u'provisioned': 11009710358528, u'url': u'/vmfs/volumes/5a9944f4-fd97ff15-6605-5cb901957960', u'vmfs_version': u'6.81', u'datastore_cluster': u'N/A', u'vmfs_uuid': u'5a9944f4-fd97ff15-6605-5cb901957960', u'uncommitted': 0, u'vmfs_blockSize': 1024, u'type': u'VMFS', u'maintenanceMode': None}) => {
    "msg": {
        "accessible": true,
        "capacity": 12094359470080,
        "datastore_cluster": "N/A",
        "freeSpace": 1084649111552,
        "maintenanceMode": null,
        "multipleHostAccess": null,
        "name": "datastore_VMFS",
        "provisioned": 11009710358528,
        "type": "VMFS",
        "uncommitted": 0,
        "url": "/vmfs/volumes/5a9944f4-fd97ff15-6605-5cb901957960",
    }
}
```
after (VMFS):
```
ok: [esxi_host] => (item={u'accessible': True, u'freeSpace': 1084649111552, u'multipleHostAccess': None, u'capacity': 12094359470080, u'name': u'datastore_VMFS', u'provisioned': 11009710358528, u'url': u'/vmfs/volumes/5a9944f4-fd97ff15-6605-5cb901957960', u'vmfs_version': u'6.81', u'datastore_cluster': u'N/A', u'vmfs_uuid': u'5a9944f4-fd97ff15-6605-5cb901957960', u'uncommitted': 0, u'vmfs_blockSize': 1024, u'type': u'VMFS', u'maintenanceMode': None}) => {
    "msg": {
        "accessible": true,
        "capacity": 12094359470080,
        "datastore_cluster": "N/A",
        "freeSpace": 1084649111552,
        "maintenanceMode": null,
        "multipleHostAccess": null,
        "name": "datastore_VMFS",
        "provisioned": 11009710358528,
        "type": "VMFS",
        "uncommitted": 0,
        "url": "/vmfs/volumes/5a9944f4-fd97ff15-6605-5cb901957960",
        "vmfs_blockSize": 1024,
        "vmfs_uuid": "5a9944f4-fd97ff15-6605-5cb901957960",
        "vmfs_version": "6.81"
    }
}
```
before (NFS):
```
ok: [esxi_host] => (item={u'accessible': True, u'freeSpace': 4243891847168, u'multipleHostAccess': None, u'capacity': 5497558138880, u'name': u'datastore_NFS', u'provisioned': 1253666291712, u'url': u'/vmfs/volumes/420b3e73-69070776', u'datastore_cluster': u'N/A', u'nfs_path': u'/vol/datastore_NFS', u'uncommitted': 0, u'nfs_server': u'nfs_server', u'type': u'NFS', u'maintenanceMode': None}) => {
    "msg": {
        "accessible": true,
        "capacity": 5497558138880,
        "datastore_cluster": "N/A",
        "freeSpace": 4243891847168,
        "maintenanceMode": null,
        "multipleHostAccess": null,
        "name": "datastore_NFS",
        "provisioned": 1253666291712,
        "type": "NFS",
        "uncommitted": 0,
        "url": "/vmfs/volumes/420b3e73-69070776"
    }
}
```
after (NFS):
```
ok: [esxi_host] => (item={u'accessible': True, u'freeSpace': 4243891847168, u'multipleHostAccess': None, u'capacity': 5497558138880, u'name': u'datastore_NFS', u'provisioned': 1253666291712, u'url': u'/vmfs/volumes/420b3e73-69070776', u'datastore_cluster': u'N/A', u'nfs_path': u'/vol/datastore_NFS', u'uncommitted': 0, u'nfs_server': u'nfs_server', u'type': u'NFS', u'maintenanceMode': None}) => {
    "msg": {
        "accessible": true,
        "capacity": 5497558138880,
        "datastore_cluster": "N/A",
        "freeSpace": 4243891847168,
        "maintenanceMode": null,
        "multipleHostAccess": null,
        "name": "datastore_NFS",
        "nfs_path": "/vol/datastore_NFS",
        "nfs_server": “nfs_server”,
        "provisioned": 1253666291712,
        "type": "NFS",
        "uncommitted": 0,
        "url": "/vmfs/volumes/420b3e73-69070776"
    }
}
```