### PR TITLE
Add support for setting cwd in docker connection plugin

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -158,6 +158,7 @@ MAGIC_VARIABLE_MAPPING = dict(
 
     # docker TODO: remove
     docker_extra_args=('ansible_docker_extra_args', ),
+    docker_cwd=('ansible_docker_cwd',),
 
     # become
     become=('ansible_become', ),

--- a/test/integration/targets/connection_docker/test_workdir.yml
+++ b/test/integration/targets/connection_docker/test_workdir.yml
@@ -1,0 +1,14 @@
+---
+- hosts: docker
+  tasks:
+    - name: run pwd
+      command: pwd
+      register: pwd
+
+    - name: test custom cwd on supported versions
+      command: test "{{pwd.stdout}}" = "{{ansible_docker_cwd}}"
+      when: old_docker == "false"
+
+    - name: test default cwd on unsupported versions
+      command: test "{{pwd.stdout}}" = "/"
+      when: old_docker == "true"

--- a/test/integration/targets/connection_posix/test.sh
+++ b/test/integration/targets/connection_posix/test.sh
@@ -16,3 +16,14 @@ INVENTORY="../connection_${group}/test_connection.inventory" ./test.sh \
     -e local_tmp=/tmp/ansible-local \
     -e remote_tmp=/tmp/ansible-remote \
     "$@"
+
+DOCKER_VERSION=$(docker version -f '{{ .Client.Version }}')
+CWD=/var/tmp
+
+if ansible all -i localhost, -m assert -a"that={{ docker_version is version('17.09', '>=') }}" -e docker_version=$DOCKER_VERSION; then
+    OLD_DOCKER=false
+else
+    OLD_DOCKER=true
+fi
+
+ansible-playbook test_workdir.yml -i test_connection.inventory -e ansible_docker_cwd=$CWD -e old_docker=$OLD_DOCKER


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a `docker_cwd` option to the docker connection plugin. This option is pulled from the `ansible_docker_cwd` variable.

Fixes https://github.com/ansible/ansible/issues/45766

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins.connection.docker

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (docker_cwd 840614200e) last updated 2018/10/05 17:28:42 (GMT +200)
  config file = None
  configured module search path = ['/Users/nathan/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/nathan/dev/ansible/lib/ansible
  executable location = /Users/nathan/dev/ansible/bin/ansible
  python version = 3.7.0 (default, Jul 23 2018, 20:22:55) [Clang 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
To reproduce:
```yml
---
- hosts: localhost
  tasks:
    - name: start container
      docker_container:
        name: "{{ container_name }}"
        image: "{{ name_space }}:{{ image_tag | default('latest') }}"
        working_dir: "{{ workdir | default(install_path) | default('/') }}"
        state: "{{ action | default('started') }}"

    - name: register container hostname
      add_host:
        name: "{{ container_name }}"
        groups: "{{ name_space }}"
        ansible_connection: docker
        ansible_docker_cwd: /mytest
  vars:
    container_name: hello
    name_space: nginx

- hosts: nginx
  tasks:
    - name: pwd
      command: pwd
      register: pwd
    - name: test
      command: test "{{pwd.stdout}}" = "/mytest"

```

Implemented during [PyConFR](https://www.pycon.fr/)'s sprints.