### PR TITLE
docs: Update links to module sources

### DIFF
--- a/docs/docsite/rst/reference_appendices/common_return_values.rst
+++ b/docs/docsite/rst/reference_appendices/common_return_values.rst
@@ -92,10 +92,8 @@ This key contains a list of dictionaries that will be presented to the user. Key
 
    :ref:`all_modules`
        Learn about available modules
-   `GitHub Core modules directory <https://github.com/ansible/ansible-modules-core/tree/devel>`_
-       Browse source of core modules
-   `Github Extras modules directory <https://github.com/ansible/ansible-modules-extras/tree/devel>`_
-       Browse source of extras modules.
+   `GitHub modules directory <https://github.com/ansible/ansible/tree/devel/lib/ansible/modules>`_
+       Browse source of core and extras modules
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        Development mailing list
    `irc.freenode.net <http://irc.freenode.net>`_


### PR DESCRIPTION
##### SUMMARY
The documentation still points to the old links for the [core](https://github.com/ansible/ansible-modules-core/tree/devel) and [extras](https://github.com/ansible/ansible-modules-extras/tree/devel) modules. This PR updates the links to the main ansible repository.

##### ISSUE TYPE
- Docs Pull Request

