### PR TITLE
Switch CI from FreeBSD 11.1 to 11.2.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -47,7 +47,7 @@ matrix:
     - env: T=osx/10.11/1
     - env: T=rhel/7.5/1
     - env: T=freebsd/10.4/1
-    - env: T=freebsd/11.1/1
+    - env: T=freebsd/11.2/1
     - env: T=linux/centos6/1
     - env: T=linux/centos7/1
     - env: T=linux/fedora24/1
@@ -60,7 +60,7 @@ matrix:
     - env: T=osx/10.11/2
     - env: T=rhel/7.5/2
     - env: T=freebsd/10.4/2
-    - env: T=freebsd/11.1/2
+    - env: T=freebsd/11.2/2
     - env: T=linux/centos6/2
     - env: T=linux/centos7/2
     - env: T=linux/fedora24/2
@@ -73,7 +73,7 @@ matrix:
     - env: T=osx/10.11/3
     - env: T=rhel/7.5/3
     - env: T=freebsd/10.4/3
-    - env: T=freebsd/11.1/3
+    - env: T=freebsd/11.2/3
     - env: T=linux/centos6/3
     - env: T=linux/centos7/3
     - env: T=linux/fedora24/3


### PR DESCRIPTION
##### SUMMARY

Switch CI from FreeBSD 11.1 to 11.2.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

shippable.yml

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (freebsd-11.2 5eabf0d34c) last updated 2018/10/05 16:04:46 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
