### PR TITLE
Fix parametrize warning in unit tests.

### DIFF
--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -965,7 +965,7 @@ PRIVACY_POLICY_URL="http://www.intel.com/privacy"
 ]
 
 
-@pytest.mark.parametrize("stdin, testcase", product([{}], TESTSETS), ids=lambda x: x['name'], indirect=['stdin'])
+@pytest.mark.parametrize("stdin, testcase", product([{}], TESTSETS), ids=lambda x: x.get('name'), indirect=['stdin'])
 def test_distribution_version(am, mocker, testcase):
     """tests the distribution parsing code of the Facts class
 


### PR DESCRIPTION
##### SUMMARY

Fix parametrize warning in unit tests.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

unit tests

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (units-fix 65f09f30a0) last updated 2018/10/05 16:33:43 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
