### PR TITLE
Add new module compare_files_dates for Makefile alike playbooks

### DIFF
--- a/lib/ansible/modules/files/compare_files_dates.py
+++ b/lib/ansible/modules/files/compare_files_dates.py
@@ -116,15 +116,30 @@ by_target:
     returned: success
     type: complex
     sample: { 'target1': [ 'source1', 'source2' ], 'target2': [ 'source1'] }
+    contains:
+        target_file_name:
+            description: list of source files newer than the target file used as key
+            type: list
+            sample:
+                - source_file_1
+                - source_file_2
 by_source:
     description: a dictionary with source files as keys and a list of older target files as value
     returned: success
     type: complex
     sample: { 'source1': [ 'target1', 'target3' ], 'source2': [ 'target2'] }
+    contains:
+        source_file_name:
+            description: list of target files older than the source file used as key
+            type: list
+            sample:
+                - target_file_1
+                - target_file_3
 count:
     description: number of pairs of source/target files
     returned: success
     type: int
+    sample: 0
 '''
 
 import errno

--- a/lib/ansible/modules/files/compare_files_dates.py
+++ b/lib/ansible/modules/files/compare_files_dates.py
@@ -1,0 +1,203 @@
+#!/usr/bin/python
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or # https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+import errno
+import os
+import stat
+
+# import module snippets
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: compare_files_dates
+version_added: "2.8"
+short_description: compare make-alike source and target files by their date
+description:
+     - Source and target files are compared based on their modification time.
+     - This results in differently structured list containing files where the
+       target is older than the source.
+     - Missing targets are handled like older, missing sources lead to a
+       failed task.
+options:
+  sources:
+    description:
+      - a list of source files to be compared with the target files
+    type: list
+    required: true
+  targets:
+    description:
+      - a list of target files to be compared with the source files
+    type: list
+    required: true
+  follow:
+    description:
+      - Whether to follow symlinks.
+    type: bool
+    default: 'no'
+author: Eric Lavarde (@ericzolf)
+'''
+
+EXAMPLES = '''
+# We first compare all sources with all targets files:
+
+- name: compare sources with targets
+  compare_files_dates:
+    sources:
+    - source.local.A
+    - source.local.B
+    targets:
+    - target.local.A
+    - target.local.B
+  register: res
+
+# The result contains a list of all pairs of source/target files where the
+# target is older than the source, which can loop through:
+
+- name: add one by one sources to targets (we could also compile them)
+  shell: cat "{{ item.0 }}" >> {{ item.1 }}
+  loop: "{{ res.pairs }}"
+
+# Another approach is to go through the dict of target files, which have as
+# value a list of the newer sources:
+
+- name: add at once sources to targets (we could also compile them)
+  shell: "cat {{ item.value | map('quote') | join(' ') }} > {{ item.key }}"
+  loop: "{{ res.by_target | dict2items }}"
+
+# Taking a more complex but also more flexible approach, we define first
+# a dependency tree of target and sources files, like this:
+
+dependencies:
+  target.local.1:
+  - source.local.1
+  - source.local.2
+  target.local.2:
+  - source.local.2
+  target.local.3:
+  - source.local.2
+  - source.local.3
+
+# Then we go through the tree using a loop, capturing the result in a quite
+# complex structure for further use (we'll try to make this easier in a
+# future version):
+
+- name: compare sources with targets
+  compare_files_dates:
+    targets: "{{ item.key }}"
+    sources: "{{ item.value }}"
+  loop: "{{ dependencies | dict2items }}"
+  register: res
+
+# Using the json_query filter, we can then grab the information we need, either
+# one by one:
+
+- name: add one by one sources to targets (we could also compile them)
+  shell: cat "{{ item.0 }}" >> "{{ item.1 }}"
+  loop: "{{ res | json_query('results[*].pairs[]') }}"
+
+# or similarly to the simpler example, all at once:
+
+- name: add at once sources to targets (we could also compile them)
+  shell: "cat {{ item.value | map('quote') | join(' ') }} > {{ item.key }}"
+  loop: "{{ res | json_query('results[*].by_target') | combine() | dict2items }}"
+'''
+
+RETURN = r'''
+pairs:
+    description: list of pairs of source and target files where the target is older than the source
+    returned: success
+    type: list
+    sample: [ [ 'source1', 'target1' ], [ 'source1', 'target2' ] ]
+by_target:
+    description: a dictionary with target files as keys and a list of newer source files as value
+    returned: success
+    type: complex
+    sample: { 'target1': [ 'source1', 'source2' ], 'target2': [ 'source1'] }
+by_source:
+    description: a dictionary with source files as keys and a list of older target files as value
+    returned: success
+    type: complex
+    sample: { 'source1': [ 'target1', 'target3' ], 'source2': [ 'target2'] }
+count:
+    description: number of pairs of source/target files
+    returned: success
+    type: integer
+'''
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            sources=dict(required=True, type='list'),
+            targets=dict(required=True, type='list'),
+            follow=dict(type='bool', default='no')
+        ),
+        supports_check_mode=True,
+    )
+
+    sources = module.params.get('sources')
+    targets = module.params.get('targets')
+    follow = module.params.get('follow')
+
+    files_pairs = []
+    files_by_target = {}
+    files_by_source = {}
+    files_count = 0
+
+    # main stat data
+    for target in targets:
+        b_target = to_bytes(target, errors='surrogate_or_strict')
+        try:
+            if follow:
+                st_target = os.stat(b_target)
+            else:
+                st_target = os.lstat(b_target)
+            mtime_target = st_target.st_mtime
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                mtime_target = 0  # if the file doesn't exist
+            else:
+                module.fail_json(msg=target + ": " + e.strerror)
+
+        for source in sources:
+            b_source = to_bytes(source, errors='surrogate_or_strict')
+            try:
+                if follow:
+                    st_source = os.stat(b_source)
+                else:
+                    st_source = os.lstat(b_source)
+                mtime_source = st_source.st_mtime
+            except OSError as e:
+                module.fail_json(msg=source + ": " + e.strerror)
+            if mtime_target < mtime_source:
+                files_count += 1
+                files_pairs.append((source, target))
+                if target in files_by_target:
+                    files_by_target[target].append(source)
+                else:
+                    files_by_target[target] = [source]
+                if source in files_by_source:
+                    files_by_source[source].append(target)
+                else:
+                    files_by_source[source] = [target]
+
+    module.exit_json(changed=False,
+                     pairs=files_pairs,
+                     by_target=files_by_target,
+                     by_source=files_by_source,
+                     count=files_count)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/files/compare_files_dates.py
+++ b/lib/ansible/modules/files/compare_files_dates.py
@@ -3,15 +3,6 @@
 # GNU General Public License v3.0+ (see COPYING or # https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-
-import errno
-import os
-import stat
-
-# import module snippets
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_bytes
-
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -76,17 +67,18 @@ EXAMPLES = '''
   loop: "{{ res.by_target | dict2items }}"
 
 # Taking a more complex but also more flexible approach, we define first
-# a dependency tree of target and sources files, like this:
+# a dependency tree of target and sources files, e.g. like this:
 
-dependencies:
-  target.local.1:
-  - source.local.1
-  - source.local.2
-  target.local.2:
-  - source.local.2
-  target.local.3:
-  - source.local.2
-  - source.local.3
+- set_fact:
+    dependencies:
+      target.local.1:
+      - source.local.1
+      - source.local.2
+      target.local.2:
+      - source.local.2
+      target.local.3:
+      - source.local.2
+      - source.local.3
 
 # Then we go through the tree using a loop, capturing the result in a quite
 # complex structure for further use (we'll try to make this easier in a
@@ -132,8 +124,16 @@ by_source:
 count:
     description: number of pairs of source/target files
     returned: success
-    type: integer
+    type: int
 '''
+
+import errno
+import os
+import stat
+
+# import module snippets
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY

This new module should allow to use playbooks for similar use cases
as for Makefiles, by comparing source and target files and sending
back lists of files where source is newer than target, for use in
further tasks (see examples in the module itself).

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

compare_files_dates

##### ANSIBLE VERSION

```paste below
ansible-3 2.6.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/ericl/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible-3
  python version = 3.6.6 (default, Jul 19 2018, 14:25:17) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```

##### ADDITIONAL INFORMATION

The module documentation itself should be self-explaining (if not, let me know, and I'll improve).

But in a nutshell, the first line of the Makefile at https://www.gnu.org/software/make/manual/make.html#Simple-Makefile could be expressed (shortened) as:

```yaml
vars:
  objects:
  - main.o
  - kbd.o
  - command.o
tasks:
- compare_files_dates:
    sources: "{{ objects }}"
    targets: "edit"
  register: cc_res
- command: cc -o edit {{ cc_res.by_target['edit'] | map('quote'} | join(' ') }}
  when: cc_res.count > 0
```

and the rest similarly (probably with a smart loop as shown in the module's examples).
