### PR TITLE
[Backport 2.7] Fix the quoting of vhost and other names in rabbitmq_binding

### DIFF
--- a/changelogs/fragments/45543-rabbitmq_bindings-fix-quote.yaml
+++ b/changelogs/fragments/45543-rabbitmq_bindings-fix-quote.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix the quoting of vhost and other names in rabbitmq_binding

--- a/lib/ansible/modules/messaging/rabbitmq_binding.py
+++ b/lib/ansible/modules/messaging/rabbitmq_binding.py
@@ -125,11 +125,11 @@ class RabbitMqBinding(object):
         self.base_url = 'http://{0}:{1}/api/bindings'.format(self.login_host,
                                                              self.login_port)
         self.url = '{0}/{1}/e/{2}/{3}/{4}/{5}'.format(self.base_url,
-                                                      urllib_parse.quote(self.vhost),
-                                                      urllib_parse.quote(self.name),
+                                                      urllib_parse.quote(self.vhost, safe=''),
+                                                      urllib_parse.quote(self.name, safe=''),
                                                       self.destination_type,
-                                                      self.destination,
-                                                      self.routing_key)
+                                                      urllib_parse.quote(self.destination, safe=''),
+                                                      urllib_parse.quote(self.routing_key))
         self.result = {
             'changed': False,
             'name': self.module.params['name'],
@@ -247,10 +247,10 @@ class RabbitMqBinding(object):
         :return:
         """
         self.url = '{0}/{1}/e/{2}/{3}/{4}'.format(self.base_url,
-                                                  urllib_parse.quote(self.vhost),
-                                                  urllib_parse.quote(self.name),
+                                                  urllib_parse.quote(self.vhost, safe=''),
+                                                  urllib_parse.quote(self.name, safe=''),
                                                   self.destination_type,
-                                                  urllib_parse.quote(self.destination))
+                                                  urllib_parse.quote(self.destination, safe=''))
         self.api_result = self.request.post(self.url,
                                             auth=self.authentication,
                                             headers={"content-type": "application/json"},


### PR DESCRIPTION
##### SUMMARY
* [rabbitmq_binding] Fix the quoting of vhost and other names, which was broken in PR #35651
* Merge missing urllib_parse.quote from PR #42422
* Missed one line, where  also needs to be escaped, i.e., the destination

(cherry picked from commit d5f8738bf2dcdbc370b113e77653c78d38845410)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/45543-rabbitmq_bindings-fix-quote.yaml
lib/ansible/modules/messaging/rabbitmq_binding.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
Stable-2.7
```