### PR TITLE
Add missing bracket in documentation

### DIFF
--- a/lib/ansible/plugins/lookup/chef_databag.py
+++ b/lib/ansible/plugins/lookup/chef_databag.py
@@ -15,7 +15,7 @@ DOCUMENTATION = """
          The lookup order mirrors the one from Chef, all folders in the base path are walked back looking for the following configuration
          file in order : .chef/knife.rb, ~/.chef/knife.rb, /etc/chef/client.rb"
     requirements:
-        - "pychef (python library https://pychef.readthedocs.io `pip install pychef`"
+        - "pychef (python library https://pychef.readthedocs.io `pip install pychef`)"
     options:
         name:
           description:


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/plugins/lookup/chef_databag.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
devel-2.8
```