### PR TITLE
Update set_fact doc to reflect updated caching options

### DIFF
--- a/lib/ansible/modules/utilities/logic/set_fact.py
+++ b/lib/ansible/modules/utilities/logic/set_fact.py
@@ -21,8 +21,8 @@ module: set_fact
 short_description: Set host facts from a task
 description:
     - This module allows setting new variables.  Variables are set on a host-by-host basis just like facts discovered by the setup module.
-    - These variables will be available to subsequent plays during an ansible-playbook run, but will not be saved across executions even if you use
-      a fact cache.
+    - These variables will be available to subsequent plays during an ansible-playbook run. Variables can also be saved across executions
+      using a fact cache by setting C(cacheable) to C(yes) in the module's parameters.
     - Per the standard Ansible variable precedence rules, many other types of variables have a higher priority, so this value may be overridden.
       See L(Variable Precedence Guide,../user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) for more information.
     - This module is also supported for Windows targets.

--- a/lib/ansible/modules/utilities/logic/set_fact.py
+++ b/lib/ansible/modules/utilities/logic/set_fact.py
@@ -21,8 +21,9 @@ module: set_fact
 short_description: Set host facts from a task
 description:
     - This module allows setting new variables.  Variables are set on a host-by-host basis just like facts discovered by the setup module.
-    - These variables will be available to subsequent plays during an ansible-playbook run. Variables can also be saved across executions
-      using a fact cache by setting C(cacheable) to C(yes) in the module's parameters.
+    - These variables will be available to subsequent plays during an ansible-playbook run.
+    - Set C(cacheable) to C(yes) to save variables across executions
+      using a fact cache. Variables created with set_fact have different precedence depending on whether they are or are not cached.
     - Per the standard Ansible variable precedence rules, many other types of variables have a higher priority, so this value may be overridden.
       See L(Variable Precedence Guide,../user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) for more information.
     - This module is also supported for Windows targets.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #31806. I have updated the docs header for the ```set_fact``` module to reflect the change it received in version 2.4 to persist variables using the fact cache. (using the ```cacheable``` property)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
set_fact

##### ANSIBLE VERSION
v2.8 (devel branch)
