### PR TITLE
slack: Add validate_certs option in plugin

### DIFF
--- a/lib/ansible/plugins/callback/slack.py
+++ b/lib/ansible/plugins/callback/slack.py
@@ -42,6 +42,16 @@ DOCUMENTATION = '''
         ini:
           - section: callback_slack
             key: username
+      validate_certs:
+        description: validate the SSL certificate of the Slack server. (For HTTPS URLs)
+        version_added: "2.8"
+        env:
+          - name: SLACK_VALIDATE_CERTS
+        ini:
+          - section: callback_slack
+            key: validate_certs
+        default: True
+        type: bool
 '''
 
 import json
@@ -99,6 +109,7 @@ class CallbackModule(CallbackBase):
         self.channel = self.get_option('channel')
         self.username = self.get_option('username')
         self.show_invocation = (self._display.verbosity > 1)
+        self.validate_certs = self.get_option('validate_certs')
 
         if self.webhook_url is None:
             self.disabled = True
@@ -121,7 +132,7 @@ class CallbackModule(CallbackBase):
         self._display.debug(data)
         self._display.debug(self.webhook_url)
         try:
-            response = open_url(self.webhook_url, data=data)
+            response = open_url(self.webhook_url, data=data, validate_certs=self.validate_certs)
             return response.read()
         except Exception as e:
             self._display.warning('Could not submit message to Slack: %s' %


### PR DESCRIPTION
##### SUMMARY
This fix adds a configurable parameter for slack plugin.

Fixes: #45682

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/slack.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8-devel
```