### PR TITLE
escape default prompt detection in telnet action plugin

### DIFF
--- a/lib/ansible/plugins/action/telnet.py
+++ b/lib/ansible/plugins/action/telnet.py
@@ -51,7 +51,7 @@ class ActionModule(ActionBase):
 
             login_prompt = self._task.args.get('login_prompt', "login: ")
             password_prompt = self._task.args.get('password_prompt', "Password: ")
-            prompts = self._task.args.get('prompts', ["$ "])
+            prompts = self._task.args.get('prompts', ["\\$ "])
             commands = self._task.args.get('command') or self._task.args.get('commands')
 
             if isinstance(commands, text_type):


### PR DESCRIPTION
This change fixes an issue with the default prompt handling.  The value
needs to be escaped otherwise it does not work when converted to bytes.

