### PR TITLE
mongodb_lookup: fixed documentation and better error messages

### DIFF
--- a/lib/ansible/plugins/lookup/mongodb.py
+++ b/lib/ansible/plugins/lookup/mongodb.py
@@ -167,7 +167,7 @@ class LookupModule(LookupBase):
         try:
             return self._run_helper(terms)
         except Exception as e:
-            print(u"There was an exception on the mongodb_lookup: {}".format(to_native(e)))
+            print(u"There was an exception on the mongodb_lookup: {0}".format(to_native(e)))
             raise e
 
     def _run_helper(self, terms):
@@ -177,7 +177,7 @@ class LookupModule(LookupBase):
         for term in terms:
             for required_parameter in [u"database", u"collection"]:
                 if required_parameter not in term:
-                    raise AnsibleError(u"missing mandatory parameter [{}]".format(required_parameter))
+                    raise AnsibleError(u"missing mandatory parameter [{0}]".format(required_parameter))
 
             connection_string = term.get(u'connection_string', u"mongodb://localhost")
             database = term[u"database"]

--- a/lib/ansible/plugins/lookup/mongodb.py
+++ b/lib/ansible/plugins/lookup/mongodb.py
@@ -18,6 +18,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from ansible.module_utils.six import string_types, integer_types
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 DOCUMENTATION = '''
@@ -31,7 +32,7 @@ DOCUMENTATION = '''
     options:
         connect_string:
             description:
-                - Can be any valid MongoDB connection string, supporting authentication, replicasets, etc.
+                - Can be any valid MongoDB connection string, supporting authentication, replica sets, etc.
                 - "More info at U(https://docs.mongodb.org/manual/reference/connection-string/)"
             default: "mongodb://localhost/"
         database:
@@ -62,7 +63,7 @@ DOCUMENTATION = '''
             type: integer
         sort:
             description:
-                - Sorting rules. Please notice the constats are replaced by strings.
+                - Sorting rules. Please use the strings "ASCENDING" and "DESCENDING" to set the order. Check the example for more information.
             type: list
             default: "[]"
     notes:
@@ -72,7 +73,7 @@ DOCUMENTATION = '''
 '''
 
 EXAMPLES = '''
-- hosts: all
+- hosts: localhost
   gather_facts: false
   vars:
     mongodb_parameters:
@@ -81,19 +82,23 @@ EXAMPLES = '''
       #optional
       collection: "startup_log"
       connection_string: "mongodb://localhost/"
-      extra_connection_parameters: { "ssl" : True , "ssl_certfile": /etc/self_signed_certificate.pem" }
+      # extra_connection_parameters: { "ssl" : True , "ssl_certfile": /etc/self_signed_certificate.pem" }
       #optional query  parameters, we accept any parameter from the normal mongodb query.
-      filter:  { "hostname": "batman" }
+      # filter:  { "hostname": "batman" }
       projection: { "pid": True    , "_id" : False , "hostname" : True }
       skip: 0
       limit: 1
       sort:  [ [ "startTime" , "ASCENDING" ] , [ "age", "DESCENDING" ] ]
   tasks:
-    - debug: msg="Mongo has already started with the following PID [{{ item.pid }}]"
-      with_mongodb: "{{mongodb_parameters}}"
+    - debug: msg="Mongo has already started with the following PID [{{ item.pid }}] - full_data {{ item }} "
+      with_items:
+      - "{{ lookup('mongodb', mongodb_parameters) }}"
 '''
 
 import datetime
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
 
 try:
     from pymongo import ASCENDING, DESCENDING
@@ -108,10 +113,6 @@ except ImportError:
         pymongo_found = True
 else:
     pymongo_found = True
-
-
-from ansible.errors import AnsibleError
-from ansible.plugins.lookup import LookupBase
 
 
 class LookupModule(LookupBase):
@@ -163,49 +164,20 @@ class LookupModule(LookupBase):
             return u"{0}".format(result)
 
     def run(self, terms, variables, **kwargs):
+        try:
+            return self._run_helper(terms)
+        except Exception as e:
+            print(u"There was an exception on the mongodb_lookup: {}".format(to_native(e)))
+            raise e
 
+    def _run_helper(self, terms):
+        if not pymongo_found:
+            raise AnsibleError(u"pymongo is required in the master node (this machine) for mongodb lookup.")
         ret = []
         for term in terms:
-            u'''
-            Makes a MongoDB query and returns the output as a valid list of json.
-            Timestamps are converted to epoch integers/longs.
-
-            Here is a sample playbook that uses it:
-
--------------------------------------------------------------------------------
-- hosts: all
-  gather_facts: false
-
-  vars:
-    mongodb_parameters:
-      #optional parameter, default = "mongodb://localhost/"
-      # connection_string: "mongodb://localhost/"
-
-      #mandatory parameters
-      database: 'local'
-      collection: "startup_log"
-
-      #optional query  parameters
-      #we accept any parameter from the normal mongodb query.
-      # the official documentation is here
-      # https://api.mongodb.org/python/current/api/pymongo/collection.html?highlight=find#pymongo.collection.Collection.find
-      #   filter:  { "hostname": "batman" }
-      #   projection: { "pid": True    , "_id" : False , "hostname" : True }
-      #   skip: 0
-      #   limit: 1
-      #   sort:  [ [ "startTime" , "ASCENDING" ] , [ "age", "DESCENDING" ] ]
-      #   extra_connection_parameters = { }
-
-      # dictionary with extra parameters like ssl, ssl_keyfile, maxPoolSize etc...
-      # the full list is available here. It varies from PyMongo version
-      # https://api.mongodb.org/python/current/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient
-
-  tasks:
-    - debug: msg="Mongo has already started with the following PID [{{ item.pid }}] - full_data {{ item }} "
-      with_items:
-      - "{{ lookup('mongodb', mongodb_parameters) }}"
--------------------------------------------------------------------------------
-            '''
+            for required_parameter in [u"database", u"collection"]:
+                if required_parameter not in term:
+                    raise AnsibleError(u"missing mandatory parameter [{}]".format(required_parameter))
 
             connection_string = term.get(u'connection_string', u"mongodb://localhost")
             database = term[u"database"]


### PR DESCRIPTION
##### SUMMARY
I am the original author of the plugin. 
After receiving an email with a support question, I realized:
  * the documentation has been update (by somebody else) and had an invalid ansible syntax, therefore it was not working
  * the plugin was not loudly complaining in case pymongo was not present
  * the plugin was not properly displaying error messages in ansible 2.8 ( when I wrote it, ansible was at version 2.3)

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME

mongodb_lookup

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (fix_mongodb_lookup 8f744587e9) last updated 2018/10/06 13:52:09 (GMT -200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/mdiez/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/extra/u/rootfs/home/ubuntu/code/ansible/lib/ansible
  executable location = /mnt/extra/u/rootfs/home/ubuntu/code/ansible/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION

The biggest problem that I fixed was in the example usage in the documentation:

As one can see here: https://docs.ansible.com/ansible/latest/plugins/lookup/mongodb.html

it eventually says
```
    - debug: msg="Mongo has already started with the following PID [{{ item.pid }}]"
      with_mongodb: "{{mongodb_parameters}}"

```

which makes no sense since the mongodb lookup does not return an `item` object.

The second change is that sometime between `ansible 2.3` and `devel`, my plugin stopped writing error messages. So I am now using `AnsibleError`, which works !

Last but not least somehow I forgot to check if `pymongo` was installed. And it took me 3 years to find it out. Oops...

