### PR TITLE
Azure VM: Adds feature to choose Availability Zone for VM

### DIFF
--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -3,6 +3,7 @@
       storage_account: "{{ resource_group | hash('md5') | truncate(24, True, '') }}"
       vm_name1: "vm1{{ resource_group | hash('md5') | truncate(5, True, '') }}"
       vm_name2: "vm2{{ resource_group | hash('md5') | truncate(5, True, '') }}"
+      vm_name3: "vm3{{ resource_group | hash('md5') | truncate(5, True, '') }}"
       abs_name1: "avbs1{{ resource_group | hash('md5') | truncate(3, True, '') }}"
       abs_name2: "avbs2{{ resource_group | hash('md5') | truncate(3, True, '') }}"
 
@@ -63,6 +64,35 @@
       subnet: "{{ vm_name1 }}"
       public_ip_name: "{{ vm_name1 }}"
       security_group: "{{ vm_name1 }}"
+
+- name: Create virtual machine In Availability zone
+  azure_rm_virtualmachine:
+    admin_username: adminuser
+    admin_password: Password123!
+    resource_group: "{{ resource_group }}"
+    name: "{{ vm_name3 }}"
+    password: PASSWORD
+    vm_size: Standard_A0
+    availability_zone: 1
+    public_ip_allocation_method: Disabled
+    location: centralus
+    image:
+       offer: UbuntuServer
+       publisher: Canonical
+       sku: 16.04-LTS
+       version: latest
+    managed_disk_type: Standard_LRS
+
+- assert:
+      that:
+        - azure_vm.zones == ["1"]
+
+- name: Delete VM
+  azure_rm_virtualmachine:
+      resource_group: "{{ resource_group }}"
+      name: "{{ vm_name3 }}"
+      state: absent
+      vm_size: Standard_A0
 
 - name: Create virtual machine with a single NIC
   register: output


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change makes it possible for `azure_rm_virtualmachine` users to choose on which Availability Zone their Azure Virtual Machine will be created.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #40596 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualmachine

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
