### PR TITLE
Register missing parameter reboot_timeout

### DIFF
--- a/changelogs/fragments/reboot_missing_parameter.yaml
+++ b/changelogs/fragments/reboot_missing_parameter.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- reboot - add reboot_timeout parameter to the list of parameters so it can be used.

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -28,7 +28,7 @@ class TimedOutException(Exception):
 
 class ActionModule(ActionBase):
     TRANSFERS_FILES = False
-    _VALID_ARGS = frozenset(('connect_timeout', 'msg', 'post_reboot_delay', 'pre_reboot_delay', 'test_command'))
+    _VALID_ARGS = frozenset(('connect_timeout', 'msg', 'post_reboot_delay', 'pre_reboot_delay', 'test_command', 'reboot_timeout'))
 
     DEFAULT_REBOOT_TIMEOUT = 600
     DEFAULT_CONNECT_TIMEOUT = None


### PR DESCRIPTION
##### SUMMARY
reboot_timeout isn't registered so if one tries using it, ansible will error out.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
reboot
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
$ ansible --version                                                                                                                       
ansible 2.8.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/danj/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/venv/ansible/lib/python2.7/site-packages/ansible
  executable location = /usr/local/venv/ansible/bin/ansible
  python version = 2.7.15 (default, Sep 28 2018, 14:26:01) [GCC 4.2.1 Compatible OpenBSD Clang 6.0.0 (tags/RELEASE_600/final)]
```

##### ADDITIONAL INFORMATION
Before my patch (verbosity doesn't change anything in the failure case)
```paste below
TASK [reboot host] ****************************************************************************************************************************************************************************
fatal: [lama-root]: FAILED! => {"changed": false, "msg": "Invalid options for reboot: reboot_timeout"}
```
After my patch
```paste below
TASK [reboot host] ****************************************************************************************************************************************************************************
changed: [lama-root]
```

What do you think @samdoran?