### PR TITLE
kibana_plugin: Use update plugin command syntax

### DIFF
--- a/lib/ansible/modules/database/misc/kibana_plugin.py
+++ b/lib/ansible/modules/database/misc/kibana_plugin.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2016, Thierno IB. BARRY @barryib
+# Copyright (c) 2016, Thierno IB. BARRY @barryib
 # Sponsored by Polyconseil http://polyconseil.fr.
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -10,9 +10,11 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
 
 
 DOCUMENTATION = '''
@@ -20,44 +22,44 @@ DOCUMENTATION = '''
 module: kibana_plugin
 short_description: Manage Kibana plugins
 description:
-    - Manages Kibana plugins.
+    - This module can be used to manage Kibana plugins.
 version_added: "2.2"
 author: Thierno IB. BARRY (@barryib)
 options:
     name:
-        description:
-            - Name of the plugin to install
-        required: True
+      description:
+      - Name of the plugin to install.
+      required: True
     state:
-        description:
-            - Desired state of a plugin.
-        choices: ["present", "absent"]
-        default: present
+      description:
+      - Desired state of a plugin.
+      choices: ["present", "absent"]
+      default: present
     url:
-        description:
-            - Set exact URL to download the plugin from.
-              For local file, prefix its absolute path with file://
+      description:
+      - Set exact URL to download the plugin from.
+      - For local file, prefix its absolute path with file://
     timeout:
-        description:
-            - "Timeout setting: 30s, 1m, 1h..."
-        default: 1m
+      description:
+      - "Timeout setting: 30s, 1m, 1h etc."
+      default: 1m
     plugin_bin:
-        description:
-            - Location of the plugin binary
-        default: /opt/kibana/bin/kibana
+      description:
+      - Location of the Kibana binary.
+      default: /opt/kibana/bin/kibana
     plugin_dir:
-        description:
-            - Your configured plugin directory specified in Kibana
-        default: /opt/kibana/installedPlugins/
+      description:
+      - Your configured plugin directory specified in Kibana.
+      default: /opt/kibana/installedPlugins/
     version:
-        description:
-            - Version of the plugin to be installed.
-              If plugin exists with previous version, it will NOT be updated if C(force) is not set to yes
+      description:
+      - Version of the plugin to be installed.
+      - If plugin exists with previous version, plugin will NOT be updated unless C(force) is set to yes.
     force:
-        description:
-            - Delete and re-install the plugin. Can be useful for plugins update
-        type: bool
-        default: 'no'
+      description:
+      - Delete and re-install the plugin. Can be useful for plugins update.
+      type: bool
+      default: 'no'
 '''
 
 EXAMPLES = '''
@@ -80,7 +82,7 @@ EXAMPLES = '''
 
 RETURN = '''
 cmd:
-    description: the launched command during plugin mangement (install / remove)
+    description: the launched command during plugin management (install / remove)
     returned: success
     type: string
 name:
@@ -110,7 +112,7 @@ state:
 '''
 
 import os
-
+from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -151,11 +153,19 @@ def parse_error(string):
         return string
 
 
-def install_plugin(module, plugin_bin, plugin_name, url, timeout):
-    cmd_args = [plugin_bin, "plugin", PACKAGE_STATE_MAP["present"], plugin_name]
+def install_plugin(module, plugin_bin, plugin_name, url, timeout, kibana_version='4.6'):
+    if LooseVersion(kibana_version) > LooseVersion('4.6'):
+        kibana_plugin_bin = os.path.join(os.path.dirname(plugin_bin), 'kibana-plugin')
+        cmd_args = [kibana_plugin_bin, "install"]
+        if url:
+            cmd_args.append(url)
+        else:
+            cmd_args.append(plugin_name)
+    else:
+        cmd_args = [plugin_bin, "plugin", PACKAGE_STATE_MAP["present"], plugin_name]
 
-    if url:
-        cmd_args.append("--url %s" % url)
+        if url:
+            cmd_args.append("--url %s" % url)
 
     if timeout:
         cmd_args.append("--timeout %s" % timeout)
@@ -173,8 +183,12 @@ def install_plugin(module, plugin_bin, plugin_name, url, timeout):
     return True, cmd, out, err
 
 
-def remove_plugin(module, plugin_bin, plugin_name):
-    cmd_args = [plugin_bin, "plugin", PACKAGE_STATE_MAP["absent"], plugin_name]
+def remove_plugin(module, plugin_bin, plugin_name, kibana_version='4.6'):
+    if LooseVersion(kibana_version) > LooseVersion('4.6'):
+        kibana_plugin_bin = os.path.join(os.path.dirname(plugin_bin), 'kibana-plugin')
+        cmd_args = [kibana_plugin_bin, "remove", plugin_name]
+    else:
+        cmd_args = [plugin_bin, "plugin", PACKAGE_STATE_MAP["absent"], plugin_name]
 
     cmd = " ".join(cmd_args)
 
@@ -187,6 +201,16 @@ def remove_plugin(module, plugin_bin, plugin_name):
         module.fail_json(msg=reason)
 
     return True, cmd, out, err
+
+
+def get_kibana_version(module, plugin_bin):
+    cmd_args = [plugin_bin, '--version']
+    cmd = " ".join(cmd_args)
+    rc, out, err = module.run_command(cmd)
+    if rc != 0:
+        module.fail_json(msg="Failed to get Kibana version : %s" % err)
+
+    return out.strip()
 
 
 def main():
@@ -213,22 +237,26 @@ def main():
     version = module.params["version"]
     force = module.params["force"]
 
+    changed, cmd, out, err = False, '', '', ''
+
+    kibana_version = get_kibana_version(module, plugin_bin)
+
     present = is_plugin_present(parse_plugin_repo(name), plugin_dir)
 
     # skip if the state is correct
     if (present and state == "present" and not force) or (state == "absent" and not present and not force):
         module.exit_json(changed=False, name=name, state=state)
 
-    if (version):
+    if version:
         name = name + '/' + version
 
     if state == "present":
         if force:
             remove_plugin(module, plugin_bin, name)
-        changed, cmd, out, err = install_plugin(module, plugin_bin, name, url, timeout)
+        changed, cmd, out, err = install_plugin(module, plugin_bin, name, url, timeout, kibana_version)
 
     elif state == "absent":
-        changed, cmd, out, err = remove_plugin(module, plugin_bin, name)
+        changed, cmd, out, err = remove_plugin(module, plugin_bin, name, kibana_version)
 
     module.exit_json(changed=changed, cmd=cmd, name=name, state=state, url=url, timeout=timeout, stdout=out, stderr=err)
 


### PR DESCRIPTION
##### SUMMARY
From 4.6 version onwards, Kibana plugins are installed or removed using
'kibana-plugin' command. This fix updates module with respective syntax.

Fixes: #27722

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/database/misc/kibana_plugin.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8-devel
```