### PR TITLE
docker_container: fix problem with published_ports idempotency

### DIFF
--- a/changelogs/fragments/46595-docker_container-expected_ports.yml
+++ b/changelogs/fragments/46595-docker_container-expected_ports.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - fix idempotency check for published_ports in some special cases."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1314,7 +1314,7 @@ class Container(DockerBaseClass):
         self.parameters.expected_env = None
         self.parameters_map = dict()
         self.parameters_map['expected_links'] = 'links'
-        self.parameters_map['expected_ports'] = 'published_ports'
+        self.parameters_map['expected_ports'] = 'expected_ports'
         self.parameters_map['expected_exposed'] = 'exposed_ports'
         self.parameters_map['expected_volumes'] = 'volumes'
         self.parameters_map['expected_ulimits'] = 'ulimits'
@@ -2294,6 +2294,7 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
                     self.fail("Unknown comparison mode '%s'!" % value)
         # Add implicit options
         comparisons['publish_all_ports'] = dict(type='value', comparison='strict', name='published_ports')
+        comparisons['expected_ports'] = dict(type='dict', comparison=comparisons['published_ports']['comparison'], name='expected_ports')
         # Check legacy values
         if self.module.params['ignore_image'] and comparisons['image']['comparison'] != 'ignore':
             self.module.warn('The ignore_image option has been overridden by the comparisons option!')


### PR DESCRIPTION
##### SUMMARY
`expected_ports` is a dict, not a set (as `published_ports`).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.7.0
```
