### PR TITLE
Added iostype details in network ios_facts module

### DIFF
--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -83,6 +83,10 @@ ansible_net_version:
   description: The operating system version running on the remote device
   returned: always
   type: string
+ansible_net_iostype:
+  description: The operating system type (IOS or IOS-XE) running on the remote device
+  returned: always
+  type: string
 ansible_net_hostname:
   description: The configured hostname of the device
   returned: always
@@ -176,6 +180,7 @@ class Default(FactsBase):
         data = self.responses[0]
         if data:
             self.facts['version'] = self.parse_version(data)
+            self.facts['iostype'] = self.parse_iostype(data)
             self.facts['serialnum'] = self.parse_serialnum(data)
             self.facts['model'] = self.parse_model(data)
             self.facts['image'] = self.parse_image(data)
@@ -186,6 +191,13 @@ class Default(FactsBase):
         match = re.search(r'Version (\S+?)(?:,\s|\s)', data)
         if match:
             return match.group(1)
+
+    def parse_iostype(self, data):
+        match = re.search(r'\S+(X86_64_LINUX_IOSD-UNIVERSALK9-M)(\S+)', data)
+        if match:
+            return "IOS-XE"
+        else:
+            return "IOS"
 
     def parse_hostname(self, data):
         match = re.search(r'^(.+) uptime', data, re.M)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As part of Cisco network devices inventory, we need to be able to differentiate between IOS vs IOS-XE devices. IOS-XE devices (ASR, ISR 4000, CSR1000V) run IOSd and have a very similar CLI as IOS devices [https://en.wikipedia.org/wiki/Cisco_IOS_XE](https://en.wikipedia.org/wiki/Cisco_IOS_XE). 

The current ios_facts module uses the CLI 'show version' command to gather Cisco IOS details. Since IOS-XE devices run a Linux kernel, we can capture the following output 'X86_64_LINUX_IOSD-UNIVERSALK9-M' from the same command to determine whether it is an IOS-XE device. If not, we return IOS as the iostype.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_facts module.
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
  config file = None
  configured module search path = [u'/Users/sebastianpouplin/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sebastianpouplin/.pyenv/versions/2.7.15/envs/ansible_venv/lib/python2.7/site-packages/ansible
  executable location = /Users/sebastianpouplin/.pyenv/versions/ansible_venv/bin/ansible
  python version = 2.7.15 (default, Jul 30 2018, 17:17:13) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
PLAY [Gather Cisco IOS/IOSXE Inventory Facts] ************************************************************************************************************************************************************

TASK [Collect Facts] *************************************************************************************************************************************************************************************
ok: [CSR1000V_RTR1]
ok: [CSR1000V_RTR2]

TASK [Print Version] *************************************************************************************************************************************************************************************
ok: [CSR1000V_RTR1] => {
    "msg": "IOS-XE"
}
ok: [CSR1000V_RTR2] => {
    "msg": "IOS-XE"
}

PLAY RECAP ***********************************************************************************************************************************************************************************************
CSR1000V_RTR1              : ok=2    changed=0    unreachable=0    failed=0    skipped=0
CSR1000V_RTR2              : ok=2    changed=0    unreachable=0    failed=0    skipped=0
```