### PR TITLE
command: add stdin_newline option

### DIFF
--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -58,6 +58,12 @@ options:
     description:
       - Set the stdin of the command directly to the specified value.
     version_added: "2.4"
+  stdin_newline:
+    version_added: "2.8"
+    description:
+      - add a newline at the end of C(stdin)
+    type: bool
+    default: yes
 notes:
     -  If you want to run a command through the shell (say you are using C(<), C(>), C(|), etc), you actually want the M(shell) module instead.
        Parsing shell metacharacters can lead to unexpected commands being executed if quoting is not done correctly so it is more secure to
@@ -189,6 +195,7 @@ def main():
             # The default for this really comes from the action plugin
             warn=dict(type='bool', default=True),
             stdin=dict(required=False),
+            stdin_newline=dict(type='bool', default=True),
         ),
         supports_check_mode=True,
     )
@@ -201,6 +208,7 @@ def main():
     removes = module.params['removes']
     warn = module.params['warn']
     stdin = module.params['stdin']
+    stdin_newline = module.params['stdin_newline']
 
     if not shell and executable:
         module.warn("As of Ansible 2.4, the parameter 'executable' is no longer supported with the 'command' module. Not using '%s'." % executable)
@@ -255,7 +263,7 @@ def main():
     startd = datetime.datetime.now()
 
     if not module.check_mode:
-        rc, out, err = module.run_command(args, executable=executable, use_unsafe_shell=shell, encoding=None, data=stdin)
+        rc, out, err = module.run_command(args, executable=executable, use_unsafe_shell=shell, encoding=None, data=stdin, binary_data=(not stdin_newline))
     elif creates or removes:
         rc = 0
         out = err = b'Command would have run if not in check mode'


### PR DESCRIPTION
Currently the "stdin" option allow to set the stdin of the command.
But a newline is always added at it's end.

"stdin_newline" option allow the user not to add this newline.