### PR TITLE
support for ecs tasks with awsvpc network mode

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -66,8 +66,8 @@ options:
       - "A dictionary array of targets to add to or update for the rule, in the
         form C({ id: [string], arn: [string], role_arn: [string], input: [valid JSON string],
         input_path: [valid JSONPath string], ecs_parameters: {task_definition_arn: [string], task_count: [int]},
-        launch_type: "FARGATE", network_configuration: {awsvpc_configuration: {subnets: [string],
-        security_groups: [string], assign_public_ip: "ENABLED" }).
+        launch_type: 'FARGATE', network_configuration: {awsvpc_configuration: {subnets: [string],
+        security_groups: [string], assign_public_ip: 'ENABLED' }).
         I(id) [required] is the unique target assignment ID. I(arn) (required)
         is the Amazon Resource Name associated with the target. I(role_arn) (optional) is The Amazon Resource Name
         of the IAM role to be used for this target when the rule is triggered. I(input)
@@ -311,7 +311,7 @@ class CloudWatchEventRule(object):
                     }
                     if 'security_groups' in target['ecs_parameters']['network_configuration']['awsvpc_configuration']:
                         target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['SecurityGroups'] = \
-                        target['ecs_parameters']['network_configuration']['awsvpc_configuration']['security_groups']
+                            target['ecs_parameters']['network_configuration']['awsvpc_configuration']['security_groups']
             targets_request.append(target_request)
         return targets_request
 

--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -67,7 +67,7 @@ options:
         form C({ id: [string], arn: [string], role_arn: [string], input: [valid JSON string],
         input_path: [valid JSONPath string], ecs_parameters: {task_definition_arn: [string], task_count: [int]},
         launch_type: 'FARGATE', network_configuration: {awsvpc_configuration: {subnets: [string],
-        security_groups: [string], assign_public_ip: 'ENABLED' }).
+        security_groups: [string], assign_public_ip: 'ENABLED|DISABLED' }).
         I(id) [required] is the unique target assignment ID. I(arn) (required)
         is the Amazon Resource Name associated with the target. I(role_arn) (optional) is The Amazon Resource Name
         of the IAM role to be used for this target when the rule is triggered. I(input)

--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -66,8 +66,8 @@ options:
       - "A dictionary array of targets to add to or update for the rule, in the
         form C({ id: [string], arn: [string], role_arn: [string], input: [valid JSON string],
         input_path: [valid JSONPath string], ecs_parameters: {task_definition_arn: [string], task_count: [int]},
-        launch_type: "FARGATE | EC2", network_configuration: {awsvpc_configuration: {subnets: [string],
-        security_groups: [string], assign_public_ip: "ENABLED | DISABLED" }).
+        launch_type: "FARGATE", network_configuration: {awsvpc_configuration: {subnets: [string],
+        security_groups: [string], assign_public_ip: "ENABLED" }).
         I(id) [required] is the unique target assignment ID. I(arn) (required)
         is the Amazon Resource Name associated with the target. I(role_arn) (optional) is The Amazon Resource Name
         of the IAM role to be used for this target when the rule is triggered. I(input)
@@ -310,7 +310,8 @@ class CloudWatchEventRule(object):
                         'AssignPublicIp': target['ecs_parameters']['network_configuration']['awsvpc_configuration']['assign_public_ip']
                     }
                     if 'security_groups' in target['ecs_parameters']['network_configuration']['awsvpc_configuration']:
-                        target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['SecurityGroups'] = target['ecs_parameters']['network_configuration']['awsvpc_configuration']['security_groups']
+                        target_request['EcsParameters']['NetworkConfiguration']['awsvpcConfiguration']['SecurityGroups'] = \
+                        target['ecs_parameters']['network_configuration']['awsvpc_configuration']['security_groups']
             targets_request.append(target_request)
         return targets_request
 

--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -300,7 +300,10 @@ class CloudWatchEventRule(object):
                 if 'task_count' in target['ecs_parameters']:
                     target_request['EcsParameters']['TaskCount'] = ecs_parameters['task_count']
                 if 'launch_type' in target['ecs_parameters']:
-                    target_request['EcsParameters']['LaunchType'] = ecs_parameters['launch_type']
+                    if self.module.botocore_at_least('1.11.0'):
+                        target_request['EcsParameters']['LaunchType'] = ecs_parameters['launch_type']
+                    else:
+                        self.module.fail_json(msg='botocore needs to be version 1.11.0 or higher to use launch_type in ecs_parameters')
                 if 'network_configuration' in target['ecs_parameters']:
                     target_request['EcsParameters']['NetworkConfiguration'] = {
                         'awsvpcConfiguration': target['ecs_parameters']['network_configuration']['awsvpc_configuration']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding support for scheduling ECS Tasks with launch type FARGATE or awsvpc network mode, via Cloudwatch Events Rules.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudwatchevent_rule.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Creating a CloudWatch Events Rule for an ECS task Target with Launch Type FARGATE or awsvpc network mode requires additional data. The changes from this PR will add support for pushing following extra fields to AWS:
launch_type
subnets
security_groups
assign_public_ip

