### PR TITLE
adds redirect configurations and probes to azure_rm_appgateway

### DIFF
--- a/changelogs/fragments/azure_rm_appgateway-probe.yaml
+++ b/changelogs/fragments/azure_rm_appgateway-probe.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  azure_rm_appgateway - add redirect configurations and probes

--- a/lib/ansible/modules/cloud/azure/azure_rm_appgateway.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_appgateway.py
@@ -138,6 +138,31 @@ options:
             name:
                 description:
                     - Name of the resource that is unique within a resource group. This name can be used to access the resource.
+    redirect_configurations:
+        version_added: "2.8"
+        description:
+            - Redirect configurations of the application gateway resource
+        suboptions:
+            redirect_type:
+                description:
+                    - Redirection type
+                choices:
+                    - 'permanent'
+                    - 'found'
+                    - 'see_other'
+                    - 'temporary'
+            target_listener:
+                description:
+                    - Reference to a listener to redirect the request to
+            include_path:
+                description:
+                    - Include path in the redirected url
+            include_query_string:
+                description:
+                    - Include query string in the redirected url
+            name:
+                description:
+                    - Name of the resource that is unique within a resource group
     ssl_certificates:
         description:
             - SSL certificates of the application gateway resource.
@@ -200,10 +225,42 @@ options:
             name:
                 description:
                     - Resource that is unique within a resource group. This name can be used to access the resource.
+    probes:
+        version_added: "2.8"
+        description:
+            - Probes available to the application gateway resource.
+        suboptions:
+            name:
+                description:
+                    - Name
+            protocol:
+                description:
+                    - Protocol
+                choices:
+                    - 'http'
+                    - 'https'
+            host:
+                description:
+                    - Host
+            path:
+                description:
+                    - Path
+            timeout:
+                description:
+                    - Timeout
+            interval:
+                description:
+                    - Interval
+            unhealthy_threshold:
+                description:
+                    - Unhealthy Threshold
     backend_http_settings_collection:
         description:
             - Backend http settings of the application gateway resource.
         suboptions:
+            probe:
+                description:
+                    - Probe
             port:
                 description:
                     - Port
@@ -295,6 +352,9 @@ options:
             name:
                 description:
                     - Name of the resource that is unique within a resource group. This name can be used to access the resource.
+            redirect_configuration:
+                description:
+                    - Redirect configuration resource of the application gateway
     state:
         description:
             - Assert the state of the Public IP. Use 'present' to create or update a and
@@ -395,6 +455,26 @@ ssl_policy_spec = dict(
 )
 
 
+probe_spec = dict(
+    host=dict(type='str'),
+    interval=dict(type='int'),
+    name=dict(type='str'),
+    path=dict(type='str'),
+    protocol=dict(type='str', choices=['http', 'https']),
+    timeout=dict(type='int'),
+    unhealthy_threshold=dict(type='int')
+)
+
+
+redirect_configuration_spec = dict(
+    include_path=dict(type='bool'),
+    include_query_string=dict(type='bool'),
+    name=dict(type='str'),
+    redirect_type=dict(type='str', choices=['permanent', 'found', 'see_other', 'temporary']),
+    target_listener=dict(type='str')
+)
+
+
 class AzureRMApplicationGateways(AzureRMModuleBase):
     """Configuration class for an Azure RM Application Gateway resource"""
 
@@ -427,6 +507,11 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
             ssl_certificates=dict(
                 type='list'
             ),
+            redirect_configurations=dict(
+                type='list',
+                elements='dict',
+                options=redirect_configuration_spec
+            ),
             frontend_ip_configurations=dict(
                 type='list'
             ),
@@ -438,6 +523,11 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
             ),
             backend_http_settings_collection=dict(
                 type='list'
+            ),
+            probes=dict(
+                type='list',
+                elements='dict',
+                options=probe_spec
             ),
             http_listeners=dict(
                 type='list'
@@ -534,6 +624,19 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
                     self.parameters["authentication_certificates"] = kwargs[key]
                 elif key == "ssl_certificates":
                     self.parameters["ssl_certificates"] = kwargs[key]
+                elif key == "redirect_configurations":
+                    ev = kwargs[key]
+                    for i in range(len(ev)):
+                        item = ev[i]
+                        if 'redirect_type' in item:
+                            item['redirect_type'] = _snake_to_camel(item['redirect_type'], True)
+                        if 'target_listener' in item:
+                            id = http_listener_id(self.subscription_id,
+                                                  kwargs['resource_group'],
+                                                  kwargs['name'],
+                                                  item['target_listener'])
+                            item['target_listener'] = {'id': id}
+                    self.parameters["redirect_configurations"] = ev
                 elif key == "frontend_ip_configurations":
                     ev = kwargs[key]
                     for i in range(len(ev)):
@@ -550,6 +653,13 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
                     self.parameters["frontend_ports"] = kwargs[key]
                 elif key == "backend_address_pools":
                     self.parameters["backend_address_pools"] = kwargs[key]
+                elif key == "probes":
+                    ev = kwargs[key]
+                    for i in range(len(ev)):
+                        item = ev[i]
+                        if 'protocol' in item:
+                            item['protocol'] = _snake_to_camel(item['protocol'], True)
+                    self.parameters["probes"] = ev
                 elif key == "backend_http_settings_collection":
                     ev = kwargs[key]
                     for i in range(len(ev)):
@@ -558,6 +668,12 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
                             item['protocol'] = _snake_to_camel(item['protocol'], True)
                         if 'cookie_based_affinity' in item:
                             item['cookie_based_affinity'] = _snake_to_camel(item['cookie_based_affinity'], True)
+                        if 'probe' in item:
+                            id = probe_id(self.subscription_id,
+                                          kwargs['resource_group'],
+                                          kwargs['name'],
+                                          item['probe'])
+                            item['probe'] = {'id': id}
                     self.parameters["backend_http_settings_collection"] = ev
                 elif key == "http_listeners":
                     ev = kwargs[key]
@@ -612,6 +728,12 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
                             item['protocol'] = _snake_to_camel(item['protocol'], True)
                         if 'rule_type' in ev:
                             item['rule_type'] = _snake_to_camel(item['rule_type'], True)
+                        if 'redirect_configuration' in item:
+                            id = redirect_configuration_id(self.subscription_id,
+                                                           kwargs['resource_group'],
+                                                           kwargs['name'],
+                                                           item['redirect_configuration'])
+                            item['redirect_configuration'] = {'id': id}
                         ev[i] = item
                     self.parameters["request_routing_rules"] = ev
                 elif key == "etag":
@@ -651,9 +773,11 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
                     self.parameters['sku']['capacity'] != old_response['sku']['capacity'] or
                     not compare_arrays(old_response, self.parameters, 'authentication_certificates') or
                     not compare_arrays(old_response, self.parameters, 'gateway_ip_configurations') or
+                    not compare_arrays(old_response, self.parameters, 'redirect_configurations') or
                     not compare_arrays(old_response, self.parameters, 'frontend_ip_configurations') or
                     not compare_arrays(old_response, self.parameters, 'frontend_ports') or
                     not compare_arrays(old_response, self.parameters, 'backend_address_pools') or
+                    not compare_arrays(old_response, self.parameters, 'probes') or
                     not compare_arrays(old_response, self.parameters, 'backend_http_settings_collection') or
                     not compare_arrays(old_response, self.parameters, 'request_routing_rules') or
                     not compare_arrays(old_response, self.parameters, 'http_listeners')):
@@ -786,6 +910,16 @@ def frontend_port_id(subscription_id, resource_group_name, appgateway_name, name
     )
 
 
+def redirect_configuration_id(subscription_id, resource_group_name, appgateway_name, name):
+    """Generate the id for a redirect configuration"""
+    return '/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Network/applicationGateways/{2}/redirectConfigurations/{3}'.format(
+        subscription_id,
+        resource_group_name,
+        appgateway_name,
+        name
+    )
+
+
 def ssl_certificate_id(subscription_id, resource_group_name, ssl_certificate_name, name):
     """Generate the id for a frontend port"""
     return '/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Network/applicationGateways/{2}/sslCertificates/{3}'.format(
@@ -799,6 +933,16 @@ def ssl_certificate_id(subscription_id, resource_group_name, ssl_certificate_nam
 def backend_address_pool_id(subscription_id, resource_group_name, appgateway_name, name):
     """Generate the id for an address pool"""
     return '/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Network/applicationGateways/{2}/backendAddressPools/{3}'.format(
+        subscription_id,
+        resource_group_name,
+        appgateway_name,
+        name
+    )
+
+
+def probe_id(subscription_id, resource_group_name, appgateway_name, name):
+    """Generate the id for a probe"""
+    return '/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Network/applicationGateways/{2}/probes/{3}'.format(
         subscription_id,
         resource_group_name,
         appgateway_name,

--- a/test/integration/targets/azure_rm_appgateway/tasks/main.yml
+++ b/test/integration/targets/azure_rm_appgateway/tasks/main.yml
@@ -54,14 +54,25 @@
     frontend_ports:
       - port: 90
         name: ag_frontend_port
+      - port: 80
+        name: http_frontend_port
     backend_address_pools:
       - backend_addresses:
           - ip_address: 10.0.0.4
         name: test_backend_address_pool
+    probes:
+     - name: custom_probe
+       protocol: http
+       host: 10.0.0.4
+       path: /healthz
+       interval: 30
+       timeout: 30
+       unhealthy_threshold: 3
     backend_http_settings_collection:
       - port: 80
         protocol: http
         cookie_based_affinity: enabled
+        probe: custom_probe
         name: sample_appgateway_http_settings
     http_listeners:
       - frontend_ip_configuration: sample_gateway_frontend_ip_config
@@ -69,12 +80,26 @@
         protocol: https
         ssl_certificate: cert2
         name: sample_http_listener
+      - frontend_ip_configuration: sample_gateway_frontend_ip_config
+        frontend_port: http_frontend_port
+        protocol: http
+        name: http_listener
     request_routing_rules:
       - rule_type: basic
         backend_address_pool: test_backend_address_pool
         backend_http_settings: sample_appgateway_http_settings
         http_listener: sample_http_listener
         name: rule1
+      - rule_type: basic
+        http_listener: http_listener
+        redirect_configuration: redirect_site_to_https
+        name: http_redirect_rule
+    redirect_configurations:
+     - redirect_type: permanent
+       target_listener: sample_http_listener
+       include_path: true
+       include_query_string: true
+       name: redirect_site_to_https
   check_mode: yes
   register: output
 - name: Assert the resource instance is well created
@@ -119,14 +144,25 @@
     frontend_ports:
       - port: 90
         name: ag_frontend_port
+      - port: 80
+        name: http_frontend_port
     backend_address_pools:
       - backend_addresses:
           - ip_address: 10.0.0.4
         name: test_backend_address_pool
+    probes:
+     - name: custom_probe
+       protocol: http
+       host: 10.0.0.4
+       path: /healthz
+       interval: 30
+       timeout: 30
+       unhealthy_threshold: 3
     backend_http_settings_collection:
       - port: 80
         protocol: http
         cookie_based_affinity: enabled
+        probe: custom_probe
         name: sample_appgateway_http_settings
     http_listeners:
       - frontend_ip_configuration: sample_gateway_frontend_ip_config
@@ -134,12 +170,26 @@
         protocol: https
         ssl_certificate: cert2
         name: sample_http_listener
+      - frontend_ip_configuration: sample_gateway_frontend_ip_config
+        frontend_port: http_frontend_port
+        protocol: http
+        name: http_listener
     request_routing_rules:
       - rule_type: Basic
         backend_address_pool: test_backend_address_pool
         backend_http_settings: sample_appgateway_http_settings
         http_listener: sample_http_listener
         name: rule1
+      - rule_type: Basic
+        http_listener: http_listener
+        redirect_configuration: redirect_site_to_https
+        name: http_redirect_rule
+    redirect_configurations:
+     - redirect_type: permanent
+       target_listener: sample_http_listener
+       include_path: true
+       include_query_string: true
+       name: redirect_site_to_https
   register: output
 - name: Assert the resource instance is well created
   assert:
@@ -179,14 +229,25 @@
     frontend_ports:
       - port: 90
         name: ag_frontend_port
+      - port: 80
+        name: http_frontend_port
     backend_address_pools:
       - backend_addresses:
           - ip_address: 10.0.0.4
         name: test_backend_address_pool
+    probes:
+     - name: custom_probe
+       protocol: http
+       host: 10.0.0.4
+       path: /healthz
+       interval: 30
+       timeout: 30
+       unhealthy_threshold: 3
     backend_http_settings_collection:
       - port: 80
         protocol: http
         cookie_based_affinity: enabled
+        probe: custom_probe
         name: sample_appgateway_http_settings
     http_listeners:
       - frontend_ip_configuration: sample_gateway_frontend_ip_config
@@ -194,12 +255,26 @@
         protocol: https
         ssl_certificate: cert2
         name: sample_http_listener
+      - frontend_ip_configuration: sample_gateway_frontend_ip_config
+        frontend_port: http_frontend_port
+        protocol: http
+        name: http_listener
     request_routing_rules:
       - rule_type: Basic
         backend_address_pool: test_backend_address_pool
         backend_http_settings: sample_appgateway_http_settings
         http_listener: sample_http_listener
         name: rule1
+      - rule_type: Basic
+        http_listener: http_listener
+        redirect_configuration: redirect_site_to_https
+        name: http_redirect_rule
+    redirect_configurations:
+     - redirect_type: permanent
+       target_listener: sample_http_listener
+       include_path: true
+       include_query_string: true
+       name: redirect_site_to_https
   register: output
 - name: Assert the resource instance is well created
   assert:
@@ -239,14 +314,25 @@
     frontend_ports:
       - port: 90
         name: ag_frontend_port
+      - port: 80
+        name: http_frontend_port
     backend_address_pools:
       - backend_addresses:
           - ip_address: 10.0.0.4
         name: test_backend_address_pool
+    probes:
+     - name: custom_probe
+       protocol: http
+       host: 10.0.0.4
+       path: /healthz
+       interval: 30
+       timeout: 30
+       unhealthy_threshold: 3
     backend_http_settings_collection:
       - port: 81
         protocol: http
         cookie_based_affinity: enabled
+        probe: custom_probe
         name: sample_appgateway_http_settings
     http_listeners:
       - frontend_ip_configuration: sample_gateway_frontend_ip_config
@@ -254,12 +340,26 @@
         protocol: https
         ssl_certificate: cert2
         name: sample_http_listener
+      - frontend_ip_configuration: sample_gateway_frontend_ip_config
+        frontend_port: http_frontend_port
+        protocol: http
+        name: http_listener
     request_routing_rules:
       - rule_type: Basic
         backend_address_pool: test_backend_address_pool
         backend_http_settings: sample_appgateway_http_settings
         http_listener: sample_http_listener
         name: rule1
+      - rule_type: Basic
+        http_listener: http_listener
+        redirect_configuration: redirect_site_to_https
+        name: http_redirect_rule
+    redirect_configurations:
+     - redirect_type: permanent
+       target_listener: sample_http_listener
+       include_path: true
+       include_query_string: true
+       name: redirect_site_to_https
   register: output
 - name: Assert the resource instance is well created
   assert:


### PR DESCRIPTION
##### SUMMARY
Adds redirect configurations and probes to the azure_rm_appgateway module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm_appgateway

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.8.0.dev0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
Allows custom health probes to be set on the Application Gateway which is useful if the gateway is fronting a Kubernetes cluster with Nginx Ingress.  Also, allows redirect configurations to be set allowing one to redirect HTTP to HTTPS for example.