### PR TITLE
VMware: Implement wait_for_customization, implements #43082

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -202,6 +202,12 @@ options:
     - "vmware-tools needs to be installed on the given virtual machine in order to work with this parameter."
     default: 'no'
     type: bool
+  wait_for_customization:
+    description:
+    - Wait until vCenter detects all guest customizations as successfully completed.
+    default: 'no'
+    type: bool
+    version_added: '2.8'
   state_change_timeout:
     description:
     - If the C(state) is set to C(shutdownguest), by default the module will return immediately after sending the shutdown signal.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1286,9 +1286,9 @@ class PyVmomiHelper(PyVmomi):
                     pg_obj = self.cache.find_obj(self.content, [vim.dvs.DistributedVirtualPortgroup], network_name)
 
                 if (nic.device.backing and
-                   (not hasattr(nic.device.backing, 'port') or
-                    (nic.device.backing.port.portgroupKey != pg_obj.key or
-                     nic.device.backing.port.switchUuid != pg_obj.config.distributedVirtualSwitch.uuid))):
+                    (not hasattr(nic.device.backing, 'port') or
+                     (nic.device.backing.port.portgroupKey != pg_obj.key or
+                      nic.device.backing.port.switchUuid != pg_obj.config.distributedVirtualSwitch.uuid))):
                     nic_change_detected = True
 
                 dvs_port_connection = vim.dvs.PortConnection()
@@ -2315,8 +2315,9 @@ class PyVmomiHelper(PyVmomi):
                 while thispoll <= poll:
                     eventsFinishedFailed = self.get_vm_events(['CustomizationSucceeded', 'CustomizationFailed'])
                     if len(eventsFinishedFailed):
-                        if not isinstance(eventsFinishedFailed[0],vim.event.CustomizationSucceeded):
-                            raise RuntimeError('Customization failed with error {}:\n{}'.format(eventsFinishedFailed[0]._wsdlName,eventsFinishedFailed[0].fullFormattedMessage))
+                        if not isinstance(eventsFinishedFailed[0], vim.event.CustomizationSucceeded):
+                            raise RuntimeError('Customization failed with error {0}:\n{1}'.format(
+                                eventsFinishedFailed[0]._wsdlName, eventsFinishedFailed[0].fullFormattedMessage))
                         break
                     else:
                         time.sleep(sleep)


### PR DESCRIPTION
##### SUMMARY

Add the parameter `wait_for_customization` to the `vmware_guest` module to allow Ansible to wait for all guest customizations to complete.

Fixes #43082

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (vmware_guest_wait_customization db1fdc85c2) last updated 2018/10/08 16:07:45 (GMT +200)
  config file = None
  configured module search path = ['/home/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/Private/ansible-1/lib/ansible
  executable location = /home/user/Private/ansible-1/bin/ansible
  python version = 3.7.0 (default, Sep 15 2018, 19:13:07) [GCC 8.2.1 20180831]
```
