### PR TITLE
VMware: add multiple vlan ranges support #46150

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -42,7 +42,7 @@ options:
     vlan_id:
         description:
             - The VLAN ID that should be configured with the portgroup, use 0 for no VLAN.
-            - 'If C(vlan_trunk) is configured to be I(true), this can be a range, example: 1-4094.'
+            - 'If C(vlan_trunk) is configured to be I(true), this can be a range, example: 1-4094 or a combination of multiple ranges and numbers, example: 1-200, 205, 400-4094.'
         required: True
     num_ports:
         description:
@@ -159,7 +159,7 @@ EXAMPLES = '''
     password: '{{ vcenter_password }}'
     portgroup_name: vlan-trunk-portrgoup
     switch_name: dvSwitch
-    vlan_id: 1-1000
+    vlan_id: 1-1000, 1005, 1100-1200
     vlan_trunk: True
     num_ports: 120
     portgroup_type: earlyBinding
@@ -257,8 +257,14 @@ class VMwareDvsPortgroup(PyVmomi):
         config.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
         if self.module.params['vlan_trunk']:
             config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec()
-            vlan_id_start, vlan_id_end = self.module.params['vlan_id'].split('-')
-            config.defaultPortConfig.vlan.vlanId = [vim.NumericRange(start=int(vlan_id_start.strip()), end=int(vlan_id_end.strip()))]
+            vlan_id_list = []
+            for vlan_id_splitted in self.module.params['vlan_id'].split(','):
+                try:
+                    vlan_id_start, vlan_id_end = vlan_id_splitted.split('-')
+                    vlan_id_list.append(vim.NumericRange(start=int(vlan_id_start.strip()), end=int(vlan_id_end.strip())))
+                except ValueError:
+                    vlan_id_list.append(vim.NumericRange(start=int(vlan_id_splitted.strip()), end=int(vlan_id_splitted.strip())))
+            config.defaultPortConfig.vlan.vlanId = vlan_id_list
         else:
             config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
             config.defaultPortConfig.vlan.vlanId = int(self.module.params['vlan_id'])

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -42,7 +42,7 @@ options:
     vlan_id:
         description:
             - The VLAN ID that should be configured with the portgroup, use 0 for no VLAN.
-            - 'If C(vlan_trunk) is configured to be I(true), this can be a range, example: 1-4094 or a combination of multiple ranges and numbers, example: 1-200, 205, 400-4094.'
+            - 'If C(vlan_trunk) is configured to be I(true), this can be a combination of multiple ranges and numbers, example: 1-200, 205, 400-4094.'
         required: True
     num_ports:
         description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding multiple vlan ranges support for the vmware portgroup vlan trunk.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #46150

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_dvs_portgroup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel 8cf0513ac3) last updated 2018/10/08 18:00:53 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mikey/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/Mikey.Smet/GIT/community-git/ansible/ansible/lib/ansible
  executable location = /mnt/c/Users/Mikey.Smet/GIT/community-git/ansible/ansible/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```
