### PR TITLE
enchance yaml filter documentation

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -33,6 +33,16 @@ It's also possible to change the indentation of both (new in version 2.2)::
     {{ some_variable | to_nice_json(indent=2) }}
     {{ some_variable | to_nice_yaml(indent=8) }}
 
+``to_yaml`` and ``to_nice_yaml`` filters use `PyYAML library`_ which defaults output length to 80 symbols and might replace spaces with a new line in case of longer length.
+To avoid such behaviour and generate long lines it is possible to use ``width`` option::
+
+    {{ some_variable | to_yaml(indent=8, width=1337) }}
+    {{ some_variable | to_nice_yaml(indent=8, width=1337) }}
+
+While it would be nicer to use a construction like ``float("inf")`` instead of hardcoded number, unfortunately the filter doesn't support proxying python functions. However it also supports passing through other YAML parameters.
+Full list can be found in `PyYAML documentation`_.
+
+
 Alternatively, you may be reading in some already formatted data::
 
     {{ some_variable | from_json }}
@@ -1249,6 +1259,11 @@ to be added to core so everyone can make use of them.
 .. _Jinja2 map() docs: http://jinja.pocoo.org/docs/dev/templates/#map
 
 .. _builtin filters: http://jinja.pocoo.org/docs/templates/#builtin-filters
+
+.. _PyYAML library: https://pyyaml.org/
+
+.. _PyYAML documentation: https://pyyaml.org/wiki/PyYAMLDocumentation
+
 
 .. seealso::
 

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -33,14 +33,15 @@ It's also possible to change the indentation of both (new in version 2.2)::
     {{ some_variable | to_nice_json(indent=2) }}
     {{ some_variable | to_nice_yaml(indent=8) }}
 
-``to_yaml`` and ``to_nice_yaml`` filters use `PyYAML library`_ which defaults output length to 80 symbols and might replace spaces with a new line in case of longer length.
+
+``to_yaml`` and ``to_nice_yaml`` filters use `PyYAML library`_ which has a default 80 symbol string length limit. That causes unexpected line break after 80th symbol (if there is a space after 80th symbol)
 To avoid such behaviour and generate long lines it is possible to use ``width`` option::
 
     {{ some_variable | to_yaml(indent=8, width=1337) }}
     {{ some_variable | to_nice_yaml(indent=8, width=1337) }}
 
-While it would be nicer to use a construction like ``float("inf")`` instead of hardcoded number, unfortunately the filter doesn't support proxying python functions. However it also supports passing through other YAML parameters.
-Full list can be found in `PyYAML documentation`_.
+While it would be nicer to use a construction like ``float("inf")`` instead of hardcoded number, unfortunately the filter doesn't support proxying python functions.
+Note that it also supports passing through other YAML parameters. Full list can be found in `PyYAML documentation`_.
 
 
 Alternatively, you may be reading in some already formatted data::


### PR DESCRIPTION
##### SUMMARY
Minor enhancement to *yaml filters documentation.

`to*_yaml` filters use PyYAML library which has a default 80 symbol string length limit. That causes line break after 80th symbol (if there is a space). Which is very unexpected. Added a hint on how to deal with the issue, so people won't need to waste their time on investigation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
documentation

##### ANSIBLE VERSION
```paste below
ansible 2.7.0
```

##### ADDITIONAL INFORMATION
Spent quite a while to figure out the root cause of a unexpected line break. As there was no hint in the documentation about it, I thought it might be helpful to a person who will face the same issue in future.