### PR TITLE
yum module handle list optional empty strings properly

### DIFF
--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -130,6 +130,9 @@ class YumDnf(with_metaclass(ABCMeta, object)):
 
         some_list.extend(new_list)
 
+        if some_list == [""]:
+            return []
+
         return some_list
 
     @abstractmethod

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -83,6 +83,16 @@
     that:
         - "not yum_result is changed"
 
+- name: install sos again with empty string enablerepo
+  yum: name=sos state=present enablerepo=""
+  register: yum_result
+- name: verify no change on third install with empty string enablerepo
+  assert:
+    that:
+        - "yum_result is success"
+        - "not yum_result is changed"
+
+
 # INSTALL AGAIN WITH LATEST
 - name: install sos again with state latest in check mode
   yum: name=sos state=latest


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #46517

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (bugfix/46517-yum-enablerepo-empty-string-list ec423a4653) last updated 2018/10/08 12:31:05 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, Sep 21 2018, 23:26:48) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```

