### PR TITLE
[2.5] Add 'auto' to documented default enabled inventory plugins (#46621)

### DIFF
--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -2,7 +2,7 @@
 
 
 Inventory Plugins
------------------
+=================
 
 Inventory plugins allow users to point at data sources to compile the inventory of hosts that Ansible uses to target tasks, either via the ``-i /path/to/file`` and/or ``-i 'host1, host2`` command line parameters or from other configuration sources.
 
@@ -10,7 +10,7 @@ Inventory plugins allow users to point at data sources to compile the inventory 
 .. _enabling_inventory:
 
 Enabling Inventory Plugins
-++++++++++++++++++++++++++
+--------------------------
 
 Most inventory plugins shipped with Ansible are disabled by default and need to be whitelisted in your
 :ref:`ansible.cfg <ansible_configuration_settings>` file in order to function.  This is how the default whitelist looks in the
@@ -19,7 +19,7 @@ config file that ships with Ansible:
 .. code-block:: ini
 
    [inventory]
-   enable_plugins = host_list, script, yaml, ini
+   enable_plugins = host_list, script, yaml, ini, auto
 
 This list also establishes the order in which each plugin tries to parse an inventory source. Any plugins left out of the list will not be considered, so you can 'optimize' your inventory loading by minimizing it to what you actually use. For example:
 
@@ -32,7 +32,7 @@ This list also establishes the order in which each plugin tries to parse an inve
 .. _using_inventory:
 
 Using Inventory Plugins
-+++++++++++++++++++++++
+-----------------------
 
 The only requirement for using an inventory plugin after it is enabled is to provide an inventory source to parse.
 Ansible will try to use the list of enabled inventory plugins, in order, against each inventory source provided.
@@ -42,7 +42,7 @@ Once an inventory plugin succeeds at parsing a source, the any remaining invento
 .. _inventory_plugin_list:
 
 Plugin List
-+++++++++++
+-----------
 
 You can use ``ansible-doc -t inventory -l`` to see the list of available plugins. 
 Use ``ansible-doc -t inventory <plugin name>`` to see plugin-specific documentation and examples.

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -308,7 +308,7 @@
 #any_errors_fatal = False
 
 [inventory]
-# enable inventory plugins, default: 'host_list', 'script', 'yaml', 'ini'
+# enable inventory plugins, default: 'host_list', 'script', 'yaml', 'ini', 'auto'
 #enable_plugins = host_list, virtualbox, yaml, constructed
 
 # ignore these extensions when parsing a directory as inventory source


### PR DESCRIPTION
##### SUMMARY
Backport #46621 

* Correct default inventory plugins enabled in docs and example/ansible.cfg

* Fix headers

(cherry picked from commit 43d12c11be9d95f35e8d188c4d49945cf35c7005)

##### ISSUE TYPE
- Docs Pull Request
