### PR TITLE
[2.6] docker_container: backports of #46594 and #46595

### DIFF
--- a/changelogs/fragments/46594-docker_container-publish-all-ports.yml
+++ b/changelogs/fragments/46594-docker_container-publish-all-ports.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - ``publish_ports: all`` was not used correctly when checking idempotency."

--- a/changelogs/fragments/46595-docker_container-expected_ports.yml
+++ b/changelogs/fragments/46595-docker_container-expected_ports.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - fix idempotency check for published_ports in some special cases."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -267,7 +267,7 @@ options:
       - "Use docker CLI syntax: C(8000), C(9000:8000), or C(0.0.0.0:9000:8000), where 8000 is a
         container port, 9000 is a host port, and 0.0.0.0 is a host interface."
       - Container ports must be exposed either in the Dockerfile or via the C(expose) option.
-      - A value of all will publish all exposed container ports to random host ports, ignoring
+      - A value of C(all) will publish all exposed container ports to random host ports, ignoring
         any other mappings.
       - If C(networks) parameter is provided, will inspect each network to see if there exists
         a bridge network with optional parameter com.docker.network.bridge.host_binding_ipv4.
@@ -1408,7 +1408,8 @@ class Container(DockerBaseClass):
             expected_volumes=config.get('Volumes'),
             expected_binds=host_config.get('Binds'),
             volumes_from=host_config.get('VolumesFrom'),
-            working_dir=config.get('WorkingDir')
+            working_dir=config.get('WorkingDir'),
+            publish_all_ports=host_config.get('PublishAllPorts'),
         )
         if self.parameters.restart_policy:
             config_mapping['restart_retries'] = restart_policy.get('MaximumRetryCount')
@@ -2127,6 +2128,8 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
         # Process legacy ignore options
         if self.module.params['ignore_image']:
             comparisons['image']['comparison'] = 'ignore'
+        # Add implicit options
+        comparisons['publish_all_ports'] = dict(type='value', comparison='strict', name='published_ports')
         self.comparisons = comparisons
 
     def __init__(self, **kwargs):

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1223,7 +1223,7 @@ class Container(DockerBaseClass):
         self.parameters.expected_env = None
         self.parameters_map = dict()
         self.parameters_map['expected_links'] = 'links'
-        self.parameters_map['expected_ports'] = 'published_ports'
+        self.parameters_map['expected_ports'] = 'expected_ports'
         self.parameters_map['expected_exposed'] = 'exposed_ports'
         self.parameters_map['expected_volumes'] = 'volumes'
         self.parameters_map['expected_ulimits'] = 'ulimits'
@@ -2130,6 +2130,7 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
             comparisons['image']['comparison'] = 'ignore'
         # Add implicit options
         comparisons['publish_all_ports'] = dict(type='value', comparison='strict', name='published_ports')
+        comparisons['expected_ports'] = dict(type='dict', comparison=comparisons['published_ports']['comparison'], name='expected_ports')
         self.comparisons = comparisons
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
##### SUMMARY
Backports of #46594 and #46595 to `stable-2.6`: improve `published_ports` handling.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.6.5
```
