### PR TITLE
yum module properly check for None config_file

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1306,8 +1306,8 @@ class YumModule(YumDnf):
         if self.conf_file and os.path.exists(self.conf_file):
             self.yum_basecmd += ['-c', self.conf_file]
 
-        if repoq:
-            repoq += ['-c', self.conf_file]
+            if repoq:
+                repoq += ['-c', self.conf_file]
 
         if self.skip_broken:
             self.yum_basecmd.extend(['--skip-broken'])

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -110,6 +110,15 @@
     that:
         - "yum_result is successful"
 
+- name: install sos with state latest in check mode with config file param
+  yum: name=sos state=latest conf_file=/etc/yum.conf
+  check_mode: true
+  register: yum_result
+- name: verify install sos with state latest in check mode with config file param
+  assert:
+    that:
+        - "yum_result is changed"
+
 - name: install sos with state latest in check mode
   yum: name=sos state=latest
   check_mode: true
@@ -134,6 +143,15 @@
   assert:
     that:
         - "not yum_result is changed"
+
+- name: install sos with state latest idempotence with config file param
+  yum: name=sos state=latest
+  register: yum_result
+- name: verify install sos with state latest idempotence with config file param
+  assert:
+    that:
+        - "not yum_result is changed"
+
 
 # Multiple packages
 - name: uninstall sos and bc


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #46485
Fixes #46603
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (bugfix/46603-yum-config-empty c815343346) last updated 2018/10/08 14:20:35 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, Sep 21 2018, 23:26:48) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]

```
