### PR TITLE
Add link check to `make sdist`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,8 +231,12 @@ install_manpages:
 	gzip -9 $(wildcard ./docs/man/man1/ansible*.1)
 	cp $(wildcard ./docs/man/man1/ansible*.1.gz) $(PREFIX)/man/man1/
 
+.PHONY: sdist_check
+sdist_check:
+	$(PYTHON) packaging/sdist/check-link-behavior.py
+
 .PHONY: sdist
-sdist: clean docs
+sdist: sdist_check clean docs
 	$(PYTHON) setup.py sdist
 
 .PHONY: sdist_upload

--- a/packaging/sdist/check-link-behavior.py
+++ b/packaging/sdist/check-link-behavior.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""Checks for link behavior required for sdist to retain symlinks."""
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import os
+import platform
+import shutil
+import sys
+import tempfile
+
+
+def main():
+    """Main program entry point."""
+    temp_dir = tempfile.mkdtemp()
+
+    target_path = os.path.join(temp_dir, 'file.txt')
+    symlink_path = os.path.join(temp_dir, 'symlink.txt')
+    hardlink_path = os.path.join(temp_dir, 'hardlink.txt')
+
+    try:
+        with open(target_path, 'w'):
+            pass
+
+        os.symlink(target_path, symlink_path)
+        os.link(symlink_path, hardlink_path)
+
+        if not os.path.islink(symlink_path):
+            abort('Symbolic link not created.')
+
+        if not os.path.islink(hardlink_path):
+            # known issue on MacOS (Darwin)
+            abort('Hard link of symbolic link created as a regular file.')
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+def abort(reason):
+    """
+    :type reason: str
+    """
+    sys.exit('ERROR: %s\n'
+             'This will prevent symbolic links from being preserved in the resulting tarball.\n'
+             'Aborting creation of sdist on platform: %s'
+             % (reason, platform.system()))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY

Add link check to `make sdist`.

This will cause `make sdist` to fail on platforms which create hard links of symbolic links as regular files, such as MacOS (Darwin).

This prevents accidental creation of an sdist tarball without the necessary symbolic links.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Makefile

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (sdist-check d1d50223ab) last updated 2018/10/08 12:51:49 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
