### PR TITLE
Backport #46585 for 2.7 - Register missing parameter reboot_timeout

### DIFF
--- a/changelogs/fragments/reboot_missing_parameter.yaml
+++ b/changelogs/fragments/reboot_missing_parameter.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- reboot - add reboot_timeout parameter to the list of parameters so it can be used.

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -28,7 +28,7 @@ class TimedOutException(Exception):
 
 class ActionModule(ActionBase):
     TRANSFERS_FILES = False
-    _VALID_ARGS = frozenset(('connect_timeout', 'msg', 'post_reboot_delay', 'pre_reboot_delay', 'test_command'))
+    _VALID_ARGS = frozenset(('connect_timeout', 'msg', 'post_reboot_delay', 'pre_reboot_delay', 'test_command', 'reboot_timeout'))
 
     DEFAULT_REBOOT_TIMEOUT = 600
     DEFAULT_CONNECT_TIMEOUT = None


### PR DESCRIPTION
##### SUMMARY
Backport of #46585 for Ansible 2.7

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
```
reboot.py
```

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```