### PR TITLE
ansible-test: set ulimit to enforce consistent test environment

### DIFF
--- a/test/runner/injector/injector.py
+++ b/test/runner/injector/injector.py
@@ -96,10 +96,10 @@ def main():
         current_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
         new_limit = (nofile_limit, nofile_limit)
         if current_limit > new_limit:
-            logger.debug('RLIMIT_NOFILE: %s -> %s' % (current_limit, new_limit))
+            logger.debug('RLIMIT_NOFILE: %s -> %s', current_limit, new_limit)
             resource.setrlimit(resource.RLIMIT_NOFILE, (nofile_limit, nofile_limit))
         else:
-            logger.debug('RLIMIT_NOFILE: %s' % (current_limit, ))
+            logger.debug('RLIMIT_NOFILE: %s', current_limit)
 
         config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'injector.json')
 

--- a/test/runner/injector/injector.py
+++ b/test/runner/injector/injector.py
@@ -31,6 +31,7 @@ import sys
 import pipes
 import logging
 import getpass
+import resource
 
 logger = logging.getLogger('injector')  # pylint: disable=locally-disabled, invalid-name
 # pylint: disable=locally-disabled, invalid-name
@@ -88,6 +89,17 @@ def main():
 
     try:
         logger.debug('Self: %s', __file__)
+
+        # to achieve a consistent nofile ulimit, set to 16k here, this can affect performance in subprocess.Popen when
+        # being called with close_fds=True on Python (8x the time on some environments)
+        nofile_limit = 16 * 1024
+        current_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+        new_limit = (nofile_limit, nofile_limit)
+        if current_limit > new_limit:
+            logger.debug('RLIMIT_NOFILE: %s -> %s' % (current_limit, new_limit))
+            resource.setrlimit(resource.RLIMIT_NOFILE, (nofile_limit, nofile_limit))
+        else:
+            logger.debug('RLIMIT_NOFILE: %s' % (current_limit, ))
 
         config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'injector.json')
 

--- a/test/runner/lib/cli.py
+++ b/test/runner/lib/cli.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, print_function
 
 import errno
 import os
+import resource
 import sys
 
 from lib.util import (
@@ -83,6 +84,17 @@ def main():
         display.color = config.color
         display.info_stderr = (isinstance(config, SanityConfig) and config.lint) or (isinstance(config, IntegrationConfig) and config.list_targets)
         check_startup()
+
+        # to achieve a consistent nofile ulimit, set to 16k here, this can affect performance in subprocess.Popen when
+        # being called with close_fds=True on Python (8x the time on some environments)
+        nofile_limit = 16 * 1024
+        current_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+        new_limit = (nofile_limit, nofile_limit)
+        if current_limit > new_limit:
+            display.info('RLIMIT_NOFILE: %s -> %s' % (current_limit, new_limit), verbosity=2)
+            resource.setrlimit(resource.RLIMIT_NOFILE, (nofile_limit, nofile_limit))
+        else:
+            display.info('RLIMIT_NOFILE: %s' % (current_limit, ), verbosity=2)
 
         try:
             args.func(config)


### PR DESCRIPTION
##### SUMMARY
Set a ulimit to a max of 16k when running ansible-test. Having a higher ulimit causes performance issues when calling `subprocess.Popen(close_fds=True)` on Python 2. This PR is designed to reduce the limit on Shippable nodes and improve the performance on the newer 16.04 versioned nodes.

Once merged in, we should be able to swap our Shippable nodes over to the new version.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```paste below
devel
```