### PR TITLE
plugin_filter: check for type error

### DIFF
--- a/changelogs/fragments/46658-plugin_filter-improve_error_handling.yaml
+++ b/changelogs/fragments/46658-plugin_filter-improve_error_handling.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Parsing plugin filter may raise TypeError, gracefully handle this exception and let user know about the syntax error in plugin filter file.

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -574,10 +574,9 @@ class Jinja2Loader(PluginLoader):
 
 def _load_plugin_filter():
     filters = defaultdict(frozenset)
-
+    user_set = False
     if C.PLUGIN_FILTERS_CFG is None:
         filter_cfg = '/etc/ansible/plugin_filters.yml'
-        user_set = False
     else:
         filter_cfg = C.PLUGIN_FILTERS_CFG
         user_set = True
@@ -605,11 +604,17 @@ def _load_plugin_filter():
         if version == u'1.0':
             # Modules and action plugins share the same blacklist since the difference between the
             # two isn't visible to the users
-            filters['ansible.modules'] = frozenset(filter_data['module_blacklist'])
+            try:
+                filters['ansible.modules'] = frozenset(filter_data['module_blacklist'])
+            except TypeError:
+                display.warning(u'Unable to parse the plugin filter file {0} as'
+                                u' module_blacklist is not a list.'
+                                u' Skipping.'.format(filter_cfg))
+                return filters
             filters['ansible.plugins.action'] = filters['ansible.modules']
         else:
             display.warning(u'The plugin filter file, {0} was a version not recognized by this'
-                            u' version of Ansible. Skipping.')
+                            u' version of Ansible. Skipping.'.format(filter_cfg))
     else:
         if user_set:
             display.warning(u'The plugin filter file, {0} does not exist.'

--- a/test/integration/targets/plugin_filtering/no_blacklist_module.ini
+++ b/test/integration/targets/plugin_filtering/no_blacklist_module.ini
@@ -1,0 +1,3 @@
+[defaults]
+retry_files_enabled = False
+plugin_filters_cfg = ./no_blacklist_module.yml

--- a/test/integration/targets/plugin_filtering/no_blacklist_module.yml
+++ b/test/integration/targets/plugin_filtering/no_blacklist_module.yml
@@ -1,0 +1,3 @@
+---
+filter_version: 1.0
+module_blacklist:

--- a/test/integration/targets/plugin_filtering/runme.sh
+++ b/test/integration/targets/plugin_filtering/runme.sh
@@ -22,6 +22,15 @@ if test $? != 0 ; then
 fi
 
 #
+# Check that if no modules are blacklisted then Ansible should not through traceback
+#
+ANSIBLE_CONFIG=no_blacklist_module.ini ansible-playbook tempfile.yml  -i ../../inventory -vvv "$@"
+if test $? != 0 ; then
+	echo "### Failed to run tempfile with no modules blacklisted"
+	exit 1
+fi
+
+#
 # Check that with these modules filtered out, all of these modules fail to be found
 #
 ANSIBLE_CONFIG=filter_modules.ini ansible-playbook copy.yml -i ../../inventory -v "$@"


### PR DESCRIPTION
##### SUMMARY
Parsing plugin filter may raise TypeError, gracefully handle this exception
and let user know about the syntax error in plugin filter file.

Fixes: #46658

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/loader.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8-devel
```
