### PR TITLE
feat(ec2.py): enhance regions input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ coverage.xml
 /test/units/cover-html
 /test/integration/targets/*/backup/
 /test/cache/*
+metadata-*.json
 # Development
 /test/develop
 venv

--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -13,6 +13,8 @@
 # separated list of regions. E.g. 'us-east-1,us-west-1,us-west-2' and do not
 # provide the 'regions_exclude' option. If this is set to 'auto', AWS_REGION or
 # AWS_DEFAULT_REGION environment variable will be read to determine the region.
+# And also you can use 'ec2.py --regions="us-gov-west-1, cn-north-1"' option to
+# override settings in ec2.ini
 regions = all
 regions_exclude = us-gov-west-1, cn-north-1
 

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -1,3 +1,4 @@
+boto
 boto3
 placebo
 cryptography

--- a/test/units/contrib/inventory/test_ec2_inventory.py
+++ b/test/units/contrib/inventory/test_ec2_inventory.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def ec2_inventory():
+    # contrib's dirstruct doesn't contain __init__.py files
+    # import ec2 inventory manually
+    inventory_dir = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__), '..', '..', '..', '..', 'contrib',
+            'inventory'))
+    sys.path.append(inventory_dir)
+
+    try:
+        ec2 = pytest.importorskip('ec2')
+    finally:
+        # cleanup so that path is not polluted with other scripts
+        sys.path.remove(inventory_dir)
+
+    return ec2
+
+
+@pytest.fixture
+def mock_euca(mocker):
+    regionMock = mocker.MagicMock()
+    regionMock.name = 'us-gov-west-1'
+    m = mocker.MagicMock(region=regionMock)
+
+    return m
+
+
+@pytest.fixture
+def mock_regions(mocker):
+    mock1 = mocker.MagicMock()
+    mock1.name = 'ap-northest-1'
+    mock2 = mocker.MagicMock()
+    mock2.name = 'us-east-1'
+    mock3 = mocker.MagicMock()
+    mock3.name = 'us-gov-west-1'
+    mock4 = mocker.MagicMock()
+    mock4.name = 'cn-north-1'
+
+    return [
+        mock1,
+        mock2,
+        mock3,
+        mock4,
+    ]
+
+
+@pytest.fixture
+def mock_ec2_regions_call(mocker, mock_regions, ec2_inventory):
+    return mocker.patch('ec2.ec2.regions',
+                        mocker.MagicMock(return_value=mock_regions))
+
+
+@pytest.fixture
+def mock_connect_euca_call(mocker, mock_euca, ec2_inventory):
+    return mocker.patch('ec2.boto.connect_euca',
+                        mocker.MagicMock(return_value=mock_euca))
+
+
+def test_read_regions_setting_no_regions_option_no_eucalyptus(
+        mock_ec2_regions_call, ec2_inventory):
+    eucalyptus = False
+    eucalyptus_host = []
+    credentials = {}
+
+    # only use comma
+    config_regions = 'ap-northest-1,us-east-1,us-gov-west-1,cn-north-1'
+    config_regions_exclude = 'us-east-1,us-gov-west-1'
+    args_regions = None
+    expected = ['ap-northest-1', 'cn-north-1']
+    actual = ec2_inventory.Ec2Inventory._read_regions_setting(
+        eucalyptus, eucalyptus_host, credentials, args_regions, config_regions,
+        config_regions_exclude)
+    assert expected == actual
+
+    # mix space and comma
+    config_regions = 'ap-northest-1,  us-east-1,  us-gov-west-1,cn-north-1'
+    config_regions_exclude = 'us-east-1, us-gov-west-1'
+    args_regions = None
+    expected = ['ap-northest-1', 'cn-north-1']
+    actual = ec2_inventory.Ec2Inventory._read_regions_setting(
+        eucalyptus, eucalyptus_host, credentials, args_regions, config_regions,
+        config_regions_exclude)
+    assert expected == actual
+
+    config_regions = 'all'
+    config_regions_exclude = 'us-east-1, us-gov-west-1'
+    args_regions = None
+    expected = ['ap-northest-1', 'cn-north-1']
+
+    with mock_ec2_regions_call:
+        actual = ec2_inventory.Ec2Inventory._read_regions_setting(
+            eucalyptus, eucalyptus_host, credentials, args_regions,
+            config_regions, config_regions_exclude)
+    assert expected == actual
+
+    config_regions = 'auto'
+    config_regions_exclude = 'us-east-1, us-gov-west-1'
+    args_regions = None
+    expected = ['cn-north-1']
+    os.environ['AWS_REGION'] = 'cn-north-1'
+    actual = ec2_inventory.Ec2Inventory._read_regions_setting(
+        eucalyptus, eucalyptus_host, credentials, args_regions, config_regions,
+        config_regions_exclude)
+    assert expected == actual
+    del os.environ['AWS_REGION']
+
+    config_regions = 'auto'
+    config_regions_exclude = 'us-gov-west-1'
+    args_regions = None
+    expected = ['us-east-1']
+    os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
+    actual = ec2_inventory.Ec2Inventory._read_regions_setting(
+        eucalyptus, eucalyptus_host, credentials, args_regions, config_regions,
+        config_regions_exclude)
+    assert expected == actual
+    del os.environ['AWS_DEFAULT_REGION']
+
+
+def test_read_regions_setting_with_regions_option_no_eucalyptus(ec2_inventory):
+    eucalyptus = False
+    eucalyptus_host = []
+    credentials = {}
+
+    # only use comma
+    config_regions = 'will skip this setting'
+    config_regions_exclude = 'us-east-1,us-gov-west-1'
+    args_regions = 'us-east-1,us-gov-west-1,cn-north-1'
+    expected = ['cn-north-1']
+    actual = ec2_inventory.Ec2Inventory._read_regions_setting(
+        eucalyptus, eucalyptus_host, credentials, args_regions, config_regions,
+        config_regions_exclude)
+    assert expected == actual
+
+    # mix space and comma
+    config_regions = 'will skip this setting'
+    config_regions_exclude = 'us-east-1,us-gov-west-1'
+    args_regions = 'us-east-1,  us-gov-west-1,cn-north-1'
+    expected = ['cn-north-1']
+    actual = ec2_inventory.Ec2Inventory._read_regions_setting(
+        eucalyptus, eucalyptus_host, credentials, args_regions, config_regions,
+        config_regions_exclude)
+    assert expected == actual
+
+
+def test_read_regions_setting_no_regions_option_with_eucalyptus(
+        mock_connect_euca_call, ec2_inventory):
+    eucalyptus = True
+    eucalyptus_host = ['ad-hoc']
+    credentials = {'key': 'value'}
+
+    config_regions = 'all'
+    config_regions_exclude = 'us-east-1'
+    args_regions = None
+    expected = ['us-gov-west-1']
+    with mock_connect_euca_call:
+        actual = ec2_inventory.Ec2Inventory._read_regions_setting(
+            eucalyptus, eucalyptus_host, credentials, args_regions,
+            config_regions, config_regions_exclude)
+    assert expected == actual


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enhance regions input like below:

1. add `--regions` option
   currently there is no option for regions, so add this for handy
2. support space and comma for region input
   because in ec2.ini, input for `regions_exclude` uses `comma and space`, but `regions` can not, it is a little confused, Add this to make them consistent
3. fix logic to always exclude regions specified
   seems `regions_exclude` does not be used for all the conditions, so add logic to exclude every time
4. fix logic to call eucalyptus, there is no usage like `self.regions.append(boto.connect_euca(host=self.eucalyptus_host).region.name, **self.credentials)`, shoule be `self.regions.append(boto.connect_euca(host=self.eucalyptus_host, **self.credentials).region.name)`
5. add unittest for regions part in ec2.py
6. add docs for options usage
7. refactor a little for unit test easily

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
contrib/inventory/ec2.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
  config file = None
  configured module search path = ['/Users/hanzhou/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/var/pyenv/versions/3.6.4/envs/3.6.4/lib/python3.6/site-packages/ansible
  executable location = /usr/local/var/pyenv/versions/3.6.4/bin/ansible
  python version = 3.6.4 (default, Mar 23 2018, 19:03:30) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
