### PR TITLE
influxdb_user - Allows updates to user privileges

### DIFF
--- a/changelogs/fragments/influxdb_user-admin-role-update.yaml
+++ b/changelogs/fragments/influxdb_user-admin-role-update.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - influxdb_user - Implemented the update of the admin role of a user

--- a/lib/ansible/modules/database/influxdb/influxdb_user.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_user.py
@@ -85,17 +85,17 @@ import ansible.module_utils.influxdb as influx
 
 
 def find_user(module, client, user_name):
-    name = None
+    user_result = None
 
     try:
-        names = client.get_list_users()
-        for u_name in names:
-            if u_name['user'] == user_name:
-                name = u_name
+        users = client.get_list_users()
+        for user in users:
+            if user['user'] == user_name:
+                user_result = user
                 break
     except ansible.module_utils.urls.ConnectionError as e:
         module.fail_json(msg=str(e))
-    return name
+    return user_result
 
 
 def check_user_password(module, client, user_name, user_password):
@@ -119,8 +119,6 @@ def set_user_password(module, client, user_name, user_password):
             client.set_user_password(user_name, user_password)
         except ansible.module_utils.urls.ConnectionError as e:
             module.fail_json(msg=str(e))
-
-    module.exit_json(changed=True)
 
 
 def create_user(module, client, user_name, user_password, admin):
@@ -166,10 +164,23 @@ def main():
 
     if state == 'present':
         if user:
-            if check_user_password(module, client, user_name, user_password):
-                module.exit_json(changed=False)
-            else:
+            changed = False
+
+            if not check_user_password(module, client, user_name, user_password):
                 set_user_password(module, client, user_name, user_password)
+                changed = True
+
+            try:
+                if admin and not user['admin']:
+                    client.grant_admin_privileges(user_name)
+                    changed = True
+                elif not admin and user['admin']:
+                    client.revoke_admin_privileges(user_name)
+                    changed = True
+            except influx.exceptions.InfluxDBClientError as e:
+                module.fail_json(msg=str(e))
+
+            module.exit_json(changed=changed)
         else:
             create_user(module, client, user_name, user_password, admin)
 

--- a/lib/ansible/modules/database/influxdb/influxdb_user.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_user.py
@@ -35,6 +35,7 @@ options:
   admin:
     description:
       - Whether the user should be in the admin role or not.
+      - Since version 2.8, the role will also be updated.
     default: no
     type: bool
   state:


### PR DESCRIPTION
##### SUMMARY
Addresses a lack of a feature described in issue #46617

The influxdb_user module won't change a user's admin privileges if the user on record's privileges differ from the playbook. This change allows for that.

I also renamed some variables in the find_user function to better describe the return value. It is a user dict, not a username.

##### ISSUE TYPE
* Feature Pull Request

##### COMPONENT NAME
influxdb_user