### PR TITLE
azure_rm_virtualmachine - adding support for StandardSSD_LRS

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -146,6 +146,7 @@ options:
             - Managed OS disk type
         choices:
             - Standard_LRS
+            - StandardSSD_LRS
             - Premium_LRS
         version_added: "2.4"
     os_disk_name:
@@ -191,6 +192,7 @@ options:
                     - Managed data disk type
                 choices:
                     - Standard_LRS
+                    - StandardSSD_LRS
                     - Premium_LRS
                 version_added: "2.4"
             storage_account_name:
@@ -713,7 +715,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             os_disk_caching=dict(type='str', aliases=['disk_caching'], choices=['ReadOnly', 'ReadWrite'],
                                  default='ReadOnly'),
             os_disk_size_gb=dict(type='int'),
-            managed_disk_type=dict(type='str', choices=['Standard_LRS', 'Premium_LRS']),
+            managed_disk_type=dict(type='str', choices=['Standard_LRS', 'StandardSSD_LRS', 'Premium_LRS']),
             os_disk_name=dict(type='str'),
             os_type=dict(type='str', choices=['Linux', 'Windows'], default='Linux'),
             public_ip_allocation_method=dict(type='str', choices=['Dynamic', 'Static', 'Disabled'], default='Static',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
StandardSSD_LRS have been introduced (generally available) in June 2018.
This change will add support for this.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualmachine
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.4
  config file = /home/rnsc/<redacted>/ansible/ansible.cfg
  configured module search path = [u'/home/rnsc/VE/local/lib/python2.7/site-packages/ara/plugins/modules']
  ansible python module location = /home/rnsc/VE/local/lib/python2.7/site-packages/ansible
  executable location = /home/rnsc/VE/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This is my first PR, I hope I understood the procedure correctly.
Not sure how to work it out if I want to have the feature backported to 2.6 along with 2.7 support.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
