### PR TITLE
Fix to resolve bug 46671, which now handles checking for Nonetype connection prompt

### DIFF
--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -59,10 +59,7 @@ class TerminalModule(TerminalBase):
 
     def on_become(self, passwd=None):
         conn_prompt = self._get_prompt()
-        if conn_prompt:
-            if conn_prompt.endswith(b'#'):
-                return
-        else:
+        if not conn_prompt or conn_prompt.endswith(b'#'):
             return
 
         cmd = {u'command': u'enable'}

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -58,7 +58,10 @@ class TerminalModule(TerminalBase):
             raise AnsibleConnectionFailure('unable to set terminal parameters')
 
     def on_become(self, passwd=None):
-        if self._get_prompt().endswith(b'#'):
+        if self._get_prompt():
+            if self._get_prompt().endswith(b'#'):
+                return
+        else:
             return
 
         cmd = {u'command': u'enable'}

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -58,8 +58,9 @@ class TerminalModule(TerminalBase):
             raise AnsibleConnectionFailure('unable to set terminal parameters')
 
     def on_become(self, passwd=None):
-        if self._get_prompt():
-            if self._get_prompt().endswith(b'#'):
+        conn_prompt = self._get_prompt()
+        if conn_prompt:
+            if conn_prompt.endswith(b'#'):
                 return
         else:
             return


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR resolves bug #46671 where the exception is thrown in case of Nonetype connection prompt
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/plugins/terminal/ios.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6, 2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
