### PR TITLE
Update axapi_call_v3 for clearer errors and succeeding ssl cert uploads

### DIFF
--- a/lib/ansible/module_utils/network/a10/a10.py
+++ b/lib/ansible/module_utils/network/a10/a10.py
@@ -118,11 +118,11 @@ def axapi_call_v3(module, url, method=None, body=None, signature=None):
         if info['body'] is not None:
             error_message = json.loads(info['body']).get('response').get('err').get('msg')
         module.fail_json(msg="failed to connect (status code %s), error was: %s " % (info['status'], error_message))
-    
-    # in at least one case (uploading an ssl cert) the api simply returns HTTP 204 which would result in status == fail 
+
+    # in at least one case (uploading an ssl cert) the api simply returns HTTP 204 which would result in status == fail
     elif info['status'] == 204:
         return {"response": {"status": "OK", "msg": "HTTP %s %s" % (info['status'], ' equals success')}}
-    
+
     try:
         raw_data = rsp.read()
         data = json.loads(raw_data)

--- a/lib/ansible/module_utils/network/a10/a10.py
+++ b/lib/ansible/module_utils/network/a10/a10.py
@@ -116,7 +116,8 @@ def axapi_call_v3(module, url, method=None, body=None, signature=None):
     if not rsp or info['status'] >= 400:
         error_message = info.get('msg', 'no error given')
         if info['body'] is not None:
-            error_message = json.loads(info['body']).get('response').get('err').get('msg')
+            error_message = json.loads(info['body']).get('response', {'msg': 'no error given'})\
+                    .get('err', {'msg': 'no error given'}).get('msg')
         module.fail_json(msg="failed to connect (status code %s), error was: %s " % (info['status'], error_message))
 
     # in at least one case (uploading an ssl cert) the api simply returns HTTP 204 which would result in status == fail

--- a/lib/ansible/module_utils/network/a10/a10.py
+++ b/lib/ansible/module_utils/network/a10/a10.py
@@ -117,7 +117,7 @@ def axapi_call_v3(module, url, method=None, body=None, signature=None):
         error_message = info.get('msg', 'no error given')
         if info['body'] is not None:
             error_message = json.loads(info['body']).get('response', {'msg': 'no error given'})\
-                    .get('err', {'msg': 'no error given'}).get('msg')
+                .get('err', {'msg': 'no error given'}).get('msg')
         module.fail_json(msg="failed to connect (status code %s), error was: %s " % (info['status'], error_message))
 
     # in at least one case (uploading an ssl cert) the api simply returns HTTP 204 which would result in status == fail


### PR DESCRIPTION
##### SUMMARY
The error messages should now be much clearer as to what exactly was the reason for the failure of an api call.
Furthermore there is a specific case where the API does not return the expected data structure but instead only returns HTTP 204.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (devel afd8b97fb1) last updated 2018/09/18 16:26:55 (GMT +200)
```

##### ADDITIONAL INFORMATION
```
before:
"msg": "failed to connect (status code 400), error was HTTP Error 400: Bad Request",

after:
"msg": "failed to connect (status code 400), error was: Failed to handle object \"server\". Object already exists"
```
