### PR TITLE
Support hostvars in openstack.py dynamic inventory

### DIFF
--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -306,6 +306,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             openstack=server)
         self.inventory.add_host(current_host)
 
+        metadata = server.get('metadata', {})
+        for meta_key in metadata:
+            hostvars[current_host][meta_key] = metadata[meta_key]
+
         for group in self._get_groups_from_server(server, namegroup=namegroup):
             groups[group].append(current_host)
 

--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -307,7 +307,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.inventory.add_host(current_host)
 
         metadata = server.get('metadata', {})
-        for meta_key in metadata:
+        for meta_key, meta_value in server.get('metadata', {}).items():
+            hostvars[current_host][meta_key] = meta_value
             hostvars[current_host][meta_key] = metadata[meta_key]
 
         for group in self._get_groups_from_server(server, namegroup=namegroup):


### PR DESCRIPTION
See #39891

##### SUMMARY
The patch provide a way to create a hostvars for each metadata present in OpenStack instance when using `openstack.py` dynamic inventory

Resolve #39891

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openstack

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (devel db304c27c7) last updated 2018/10/13 09:04:26 (GMT +200)
  config file = None
  configured module search path = [u'/HOME/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /HOME/dev/ansible/lib/ansible
  executable location = /HOME/.pyenv/versions/ansible-dev/bin/ansible
  python version = 2.7.13 (default, Mar 13 2017, 15:38:32) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]

```

##### ADDITIONAL INFORMATION
See #39891
