### PR TITLE
VMware: added documentation for missing netplan support

### DIFF
--- a/docs/docsite/rst/vmware/vmware_troubleshooting.rst
+++ b/docs/docsite/rst/vmware/vmware_troubleshooting.rst
@@ -22,8 +22,87 @@ When debugging or creating a new issue, you will need information about your VMw
     $ export GOVC_URL=https://ESXI_OR_VCENTER_HOSTNAME:443
     $ govc find /
 
+Known issues
+============
 
-Troubleshooting Item 
+
+Network settings with vmware_guest in Ubuntu 18.04
+--------------------------------------------------
+
+Setting the network with ``vmware_guest`` in Ubuntu 18.04 is known to be broken, due to missing support for ``netplan`` in the ``open-vm-tools``.
+This issue is tracked via:
+
+* https://github.com/vmware/open-vm-tools/issues/240
+* https://github.com/ansible/ansible/issues/41133
+
+Potential Workaround
+^^^^^^^^^^^^^^^^^^^^
+
+There are several workarounds for this issue.
+
+1) Modifying the Ubuntu 18.04 images and installing ``ifupdown`` in them via ``sudo apt install ifupdown``.
+   If so you need to remove ``netplan`` via ``sudo apt remove netplan.io`` and you need stop ``systemd-networkd`` via ``sudo systemctl disable systemctl-networkd``.
+
+2) You can generate the ``systemd-networkd`` files with a task in your vmware Ansible role:
+
+.. code-block:: yaml
+
+   - name: make sure cache directory exists
+     file: path="{{ inventory_dir }}/cache" state=directory
+     delegate_to: localhost
+
+   - name: generate network templates
+     template: src=network.j2 dest="{{ inventory_dir }}/cache/{{ inventory_hostname }}.network"
+     delegate_to: localhost
+
+   - name: copy generated files to vm
+     vmware_guest_file_operation:
+       hostname: "{{ vmware_general.hostname }}"
+       username: "{{ vmware_username }}"
+       password: "{{ vmware_password }}"
+       datacenter: "{{ vmware_general.datacenter }}"
+       validate_certs: "{{ vmware_general.validate_certs }}"
+       vm_id: "{{ inventory_hostname }}"
+       vm_username: root
+       vm_password: "{{ template_password }}"
+       copy:
+           src: "{{ inventory_dir }}/cache/{{ inventory_hostname }}.network"
+           dest: "/etc/systemd/network/ens160.network"
+           overwrite: False
+     delegate_to: localhost
+
+   - name: restart systemd-networkd
+     vmware_vm_shell:
+       hostname: "{{ vmware_general.hostname }}"
+       username: "{{ vmware_username }}"
+       password: "{{ vmware_password }}"
+       datacenter: "{{ vmware_general.datacenter }}"
+       folder: /vm
+       vm_id: "{{ inventory_hostname}}"
+       vm_username: root
+       vm_password: "{{ template_password }}"
+       vm_shell: /bin/systemctl
+       vm_shell_args: " restart systemd-networkd"
+     delegate_to: localhost
+
+   - name: restart systemd-resolved
+     vmware_vm_shell:
+       hostname: "{{ vmware_general.hostname }}"
+       username: "{{ vmware_username }}"
+       password: "{{ vmware_password }}"
+       datacenter: "{{ vmware_general.datacenter }}"
+       folder: /vm
+       vm_id: "{{ inventory_hostname}}"
+       vm_username: root
+       vm_password: "{{ template_password }}"
+       vm_shell: /bin/systemctl
+       vm_shell_args: " restart systemd-resolved"
+     delegate_to: localhost
+
+3) Wait for ``netplan`` support in ``open-vm-tools``
+
+
+Troubleshooting Item
 ====================
 
 Description


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently there is no `netplan` support in open-vm-tools. Therefore it's
nice to have a quick workaround in our documentation

Workaround Documentation for: https://github.com/ansible/ansible/issues/41133
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
[x] Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
for all versions

