### PR TITLE
Add Iterable in 2.7 _collections_compat

### DIFF
--- a/lib/ansible/module_utils/common/_collections_compat.py
+++ b/lib/ansible/module_utils/common/_collections_compat.py
@@ -18,6 +18,7 @@ try:
         Mapping, MutableMapping,
         Sequence, MutableSequence,
         Set, MutableSet,
+        Iterable,
     )
 except ImportError:
     """Use old lib location under 2.6-3.2."""
@@ -26,4 +27,5 @@ except ImportError:
         Mapping, MutableMapping,
         Sequence, MutableSequence,
         Set, MutableSet,
+        Iterable,
     )


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add Iterable in 2.7 _collections_compat
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/common/_collections_compat.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```
