### PR TITLE
ansible_parent_role_name/path variables for when a role is being included by another role

### DIFF
--- a/changelogs/fragments/include-role-name.yaml
+++ b/changelogs/fragments/include-role-name.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+  - magic variables - added a new ``ansible_parent_role_names`` magic variable that, when a role is included by another
+    role, contains a list of all parent roles.
+  - magic variables - added a new ``ansible_parent_role_paths`` magic variable that, when a role is included by another
+    role, contains a list of all parent role paths.

--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -31,6 +31,16 @@ ansible_loop
 ansible_loop_var
     The name of the value provided to ``loop_control.loop_var``. Added in ``2.8``
 
+ansible_parent_role_names
+    When the current role is being executed by means of an :ref:`include_role <include_role_module>` or :ref:`import_role <import_role_module>` action, this variable contains a list of all parent roles, with the most recent role (i.e. the role that included/imported this role) being the first item in the list.
+    When multiple inclusions occur, this list lists the *last* role (i.e. the role that included this role) as the *first* item in the list. It is also possible that a specific role exists more than once in this list.
+
+    For example: When role **A** includes role **B**, inside role B, ``ansible_parent_role_names`` will equal to ``['A']``. If role **B** then includes role **C**, the list becomes ``['B', 'A']``.
+
+ansible_parent_role_paths
+    When the current role is being executed by means of an :ref:`include_role <include_role_module>` or :ref:`import_role <import_role_module>` action, this variable contains a list of all parent roles, with the most recent role (i.e. the role that included/imported this role) being the first item in the list.
+    Please refer to ``ansible_parent_role_names`` for the order of items in this list.
+
 ansible_play_batch
     List of active hosts in the current play run limited by the serial, aka 'batch'. Failed/Unreachable hosts are not considered 'active'.
 
@@ -100,7 +110,7 @@ playbook_dir
     The path to the directory of the playbook that was passed to the ``ansible-playbook`` command line.
 
 role_name
-    The name of the currently executed role
+    The name of the role currently being executed.
 
 role_names
     Deprecated, the same as ansible_play_role_names

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -166,4 +166,6 @@ class IncludeRole(TaskInclude):
         v = super(IncludeRole, self).get_include_params()
         if self._parent_role:
             v.update(self._parent_role.get_role_params())
+            v.setdefault('ansible_parent_role_names', []).insert(0, self._parent_role.get_name())
+            v.setdefault('ansible_parent_role_paths', []).insert(0, self._parent_role._role_path)
         return v

--- a/test/integration/targets/include_parent_role_vars/aliases
+++ b/test/integration/targets/include_parent_role_vars/aliases
@@ -1,0 +1,2 @@
+# Continuation of special_vars integration tests to test special variables set on role inclusion.
+hidden

--- a/test/integration/targets/include_parent_role_vars/tasks/included_by_other_role.yml
+++ b/test/integration/targets/include_parent_role_vars/tasks/included_by_other_role.yml
@@ -1,0 +1,37 @@
+# Copyright 2019 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: ensure our parent role tree to contain only our direct parent item
+  assert:
+    that:
+      - "ansible_parent_role_names == ['special_vars']"
+
+- name: ensure that ansible_parent_role_paths has the same length as ansible_parent_role_names
+  assert:
+    that:
+      - "ansible_parent_role_names|length == ansible_parent_role_paths|length"
+
+- name: attempt to import ourselves
+  import_role:
+    name: "include_parent_role_vars"
+    tasks_from: "included_by_ourselves.yml"
+
+- name: ensure our parent role tree to contain only our direct parent item after importing
+  assert:
+    that:
+      - "ansible_parent_role_names == ['special_vars']"
+
+- name: attempt to include ourselves
+  include_role:
+    name: "include_parent_role_vars"
+    tasks_from: "included_by_ourselves.yml"
+
+- name: ensure our parent role tree to contain only our direct parent item after including
+  assert:
+    that:
+      - "ansible_parent_role_names == ['special_vars']"
+
+- name: ensure that ansible_parent_role_paths has the same length as ansible_parent_role_names
+  assert:
+    that:
+      - "ansible_parent_role_names|length == ansible_parent_role_paths|length"

--- a/test/integration/targets/include_parent_role_vars/tasks/included_by_ourselves.yml
+++ b/test/integration/targets/include_parent_role_vars/tasks/included_by_ourselves.yml
@@ -1,0 +1,14 @@
+# Copyright 2019 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: check if the inclusion tree shows ourself twice as well as our initial parent
+  assert:
+    that:
+      - "ansible_parent_role_names|length == 2"
+      - "ansible_parent_role_names[0] == 'include_parent_role_vars'"  # Since we included ourselves, we're the top level
+      - "ansible_parent_role_names[1] == 'special_vars'"
+
+- name: ensure that ansible_parent_role_paths has the same length as ansible_parent_role_names
+  assert:
+    that:
+      - "ansible_parent_role_names|length == ansible_parent_role_paths|length"

--- a/test/integration/targets/include_parent_role_vars/tasks/main.yml
+++ b/test/integration/targets/include_parent_role_vars/tasks/main.yml
@@ -1,0 +1,21 @@
+# Copyright 2019 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+- name: ensure our parent role tree to contain only our direct parent item
+  assert:
+    that:
+      - "ansible_parent_role_names == ['special_vars']"
+
+- name: ensure that ansible_parent_role_paths has the same length as ansible_parent_role_names
+  assert:
+    that:
+      - "ansible_parent_role_names|length == ansible_parent_role_paths|length"
+
+# task importing should not affect ansible_parent_role_names
+- name: test task-importing after we've been included by another role
+  import_tasks: "included_by_other_role.yml"
+
+# task inclusion should not affect ansible_parent_role_names
+- name: test task-inclusion after we've been included by another role
+  include_tasks: "included_by_other_role.yml"

--- a/test/integration/targets/special_vars/aliases
+++ b/test/integration/targets/special_vars/aliases
@@ -1,1 +1,2 @@
 shippable/posix/group2
+needs/target/include_parent_role_vars

--- a/test/integration/targets/special_vars/tasks/main.yml
+++ b/test/integration/targets/special_vars/tasks/main.yml
@@ -56,3 +56,45 @@
   assert:
     that:
       - "(ansible_play_role_names + ansible_dependent_role_names)|unique|sort|list == ansible_role_names|sort|list"
+
+- name: check that ansible_parent_role_names is normally unset when not included/imported (before including other roles)
+  assert:
+    that:
+      - "ansible_parent_role_names is undefined"
+      - "ansible_parent_role_paths is undefined"
+
+- name: ansible_parent_role_names - test functionality by including another role
+  include_role:
+    name: include_parent_role_vars
+    tasks_from: included_by_other_role.yml
+
+- name: check that ansible_parent_role_names is normally unset when not included/imported (after including other role)
+  assert:
+    that:
+      - "ansible_parent_role_names is undefined"
+      - "ansible_parent_role_paths is undefined"
+
+- name: ansible_parent_role_names - test functionality by importing another role
+  import_role:
+    name: include_parent_role_vars
+    tasks_from: included_by_other_role.yml
+
+- name: check that ansible_parent_role_names is normally unset when not included/imported (after importing other role)
+  assert:
+    that:
+      - "ansible_parent_role_names is undefined"
+      - "ansible_parent_role_paths is undefined"
+
+- name: ansible_parent_role_names - test functionality by including another role
+  include_role:
+    name: include_parent_role_vars
+
+- name: check that ansible_parent_role_names is normally unset when not included/imported (after both import and inlcude)
+  assert:
+    that:
+      - "ansible_parent_role_names is undefined"
+      - "ansible_parent_role_paths is undefined"
+
+- name: ansible_parent_role_names - test functionality by importing another role
+  import_role:
+    name: include_parent_role_vars


### PR DESCRIPTION
##### SUMMARY
Currently it is not possible for roles to detect when they are being directly included by another role.

This PR does the following:
- When a role is being included, set the `ansible_parent_role_name` to the name of the role that included this role.
- When a role is being included, set the `ansible_parent_role_path` to the path of the role that included this role.
- Document the `role_name` magic variable. It existed, but there was no existing documentation. Its companion `role_path` was already documented.

The main rationale for this is that we currently have a large set of roles that, in addition of providing with a state that is being managed, also expose a set of extra callable task files to allow other roles to easily perform tasks related to that role, without having to duplicate logic several dozen times.

During these includes, it is often required to send an identifier along, so that comments can indicate which role/feature requested these actions. Currently this is done by passing variables to each include_role action, but this proves to be prone to error.
The `role_name` variable already exists, but since this only stores the current executing role, it doesn't help trace down the source if the role was included otherwise.

The proposed new magic variables do specifically that; letting the included roles know who included them, so that it's easier to build conditions that only run (or should never run) when tasks are being included, and to be able to better debug the source of configuration.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Magic Variables

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.7.0
```
but this affects all versions.

##### ADDITIONAL INFORMATION
