### PR TITLE
Document `--` args separator in encrypt_string cmd

### DIFF
--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -102,7 +102,7 @@ class VaultCLI(CLI):
             self.parser.add_option('--stdin-name', dest='encrypt_string_stdin_name',
                                    default=None,
                                    help="Specify the variable name for stdin")
-            self.parser.set_usage("usage: %prog encrypt_string [--prompt] [options] string_to_encrypt")
+            self.parser.set_usage("usage: %prog encrypt_string [--prompt] [options] [--] string_to_encrypt")
         elif self.action == "rekey":
             self.parser.set_usage("usage: %prog rekey [options] file_name")
 


### PR DESCRIPTION
Fixes #46574

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vault

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
devel
```

##### ADDITIONAL INFORMATION
See #46574