### PR TITLE
ec2_asg: adding explanation of replace_all_instances

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -82,7 +82,7 @@ options:
       - Desired number of instances in group, if unspecified then the current group value will be used.
   replace_all_instances:
     description:
-      - In a rolling fashion, replace all instances with an old launch configuration with one from the current launch configuration. 
+      - In a rolling fashion, replace all instances that used the old launch configuration with one from the new launch configuration. 
         It increases the ASG size by replace_batch_size, waits for the new instances to be up and running. 
         After that, it terminates a batch of old instances, waits for the replacements, and repeats, until all old instances are replaced. 
         Once that's done the ASG size is reduced back to the expected size.

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -83,7 +83,9 @@ options:
   replace_all_instances:
     description:
       - In a rolling fashion, replace all instances with an old launch configuration with one from the current launch configuration. 
-        It increases the ASG size by replace_batch_size, waits for the new instances to be up and running. After that, it terminates a batch of old instances, waits for the replacements, and repeats, until all old instances are replaced. Once that's done the ASG size is reduced back to the expected size.
+        It increases the ASG size by replace_batch_size, waits for the new instances to be up and running. 
+        After that, it terminates a batch of old instances, waits for the replacements, and repeats, until all old instances are replaced. 
+        Once that's done the ASG size is reduced back to the expected size.
     version_added: "1.8"
     default: 'no'
   replace_batch_size:

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -82,7 +82,7 @@ options:
       - Desired number of instances in group, if unspecified then the current group value will be used.
   replace_all_instances:
     description:
-      - In a rolling fashion, replace all instances with an old launch configuration with one from the current launch configuration.
+      - In a rolling fashion, replace all instances with an old launch configuration with one from the current launch configuration. How does it roll them out ?
     version_added: "1.8"
     default: 'no'
   replace_batch_size:

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -83,7 +83,7 @@ options:
   replace_all_instances:
     description:
       - In a rolling fashion, replace all instances that used the old launch configuration with one from the new launch configuration. 
-        It increases the ASG size by replace_batch_size, waits for the new instances to be up and running. 
+        It increases the ASG size by C(replace_batch_size), waits for the new instances to be up and running. 
         After that, it terminates a batch of old instances, waits for the replacements, and repeats, until all old instances are replaced. 
         Once that's done the ASG size is reduced back to the expected size.
     version_added: "1.8"

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -82,7 +82,8 @@ options:
       - Desired number of instances in group, if unspecified then the current group value will be used.
   replace_all_instances:
     description:
-      - In a rolling fashion, replace all instances with an old launch configuration with one from the current launch configuration. How does it roll them out ?
+      - In a rolling fashion, replace all instances with an old launch configuration with one from the current launch configuration. 
+        It increases the ASG size by replace_batch_size, waits for the new instances to be up and running. After that, it terminates a batch of old instances, waits for the replacements, and repeats, until all old instances are replaced. Once that's done the ASG size is reduced back to the expected size.
     version_added: "1.8"
     default: 'no'
   replace_batch_size:

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -82,9 +82,9 @@ options:
       - Desired number of instances in group, if unspecified then the current group value will be used.
   replace_all_instances:
     description:
-      - In a rolling fashion, replace all instances that used the old launch configuration with one from the new launch configuration. 
-        It increases the ASG size by C(replace_batch_size), waits for the new instances to be up and running. 
-        After that, it terminates a batch of old instances, waits for the replacements, and repeats, until all old instances are replaced. 
+      - In a rolling fashion, replace all instances that used the old launch configuration with one from the new launch configuration.
+        It increases the ASG size by C(replace_batch_size), waits for the new instances to be up and running.
+        After that, it terminates a batch of old instances, waits for the replacements, and repeats, until all old instances are replaced.
         Once that's done the ASG size is reduced back to the expected size.
     version_added: "1.8"
     default: 'no'


### PR DESCRIPTION
How does "replace_all_instances" work? does it increase the number of instances by 1 in the Load balancer and it scales in a server and waits for it to complete its health check, OR   does it terminate a node a that causes an autoscale event to happen and then adds a new server?
+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
ec2_asg

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
