### PR TITLE
ovirt_host_network: check for empty user_opts

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -222,7 +222,8 @@ def get_bond_options(mode, usr_opts):
     )
 
     opts_dict = DEFAULT_MODE_OPTS.get(mode, {})
-    opts_dict.update(**usr_opts)
+    if usr_opts is not None:
+        opts_dict.update(**usr_opts)
 
     options.extend(
         [otypes.Option(name=opt, value=value)


### PR DESCRIPTION
##### SUMMARY
With no bond.options given, the get_bond_options function gets called with usr_opts defaulting to None which results in a TypeError when opts_dict is update()'ed with NoneType.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ovirt_host_network

##### ANSIBLE VERSION
```
2.8.0
```