### PR TITLE
[ovirt_vm] validate memory parameter for ovirt_vm

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -166,7 +166,7 @@ def convert_to_bytes(param):
     param = ''.join(param.split())
 
     # Convert to bytes:
-    if param[-3].lower() in ['k', 'm', 'g', 't', 'p']:
+    if len(param) > 3 and param[-3].lower() in ['k', 'm', 'g', 't', 'p']:
         return int(param[:-3]) * BYTES_MAP.get(param[-3:].lower(), 1)
     elif param.isdigit():
         return int(param) * 2**10


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
https://github.com/ansible/ansible/issues/46697

##### COMPONENT NAME
ovirt_vm

##### ANSIBLE VERSION

```
ansible 2.7.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```

##### ADDITIONAL INFORMATION
the suggestion is to validate that the value in the memory clause is always greater than 3, since the minimum value will always be 4

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ValueError: Unsupported value(IEC supported): '1GB'
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported value(IEC supported): '1GB'"}

```
