### PR TITLE
Try to get host FQDN and IP from facts

### DIFF
--- a/lib/ansible/plugins/callback/mail.py
+++ b/lib/ansible/plugins/callback/mail.py
@@ -74,6 +74,7 @@ from ansible.plugins.callback import CallbackBase
 
 FACTS_NOT_GATHERED_MSG = 'unknown'
 
+
 class CallbackModule(CallbackBase):
     ''' This Ansible callback plugin mails errors to interested parties. '''
     CALLBACK_VERSION = 2.0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

There are cases where it makes sense to provision multiple hosts by running Ansible locally (for instance, when the Ansible logic is baked into a machine image). In these cases, when using the `mail` callback plugin to get failure notifications, it's difficult or impossible to tell which host sent a particular email, since the value of `result._host.get_name()` will always be `localhost`.

This PR attempts to get the host's hostname and IP from the standard `ansible_fqdn` and `ansible_default_ipv4.address` facts, and includes them (if available) in the email subject and body.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`mail` callback plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.5.2
  config file = None
  configured module search path = [u'/Users/ywakeham/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.5.2/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 16:44:08) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
