### PR TITLE
Backport 473f70c stable 2.6

### DIFF
--- a/lib/ansible/executor/task_result.py
+++ b/lib/ansible/executor/task_result.py
@@ -110,7 +110,7 @@ class TaskResult:
         else:
             ignore = _IGNORE
 
-        if self._result.get('_ansible_no_log', False):
+        if self._task.no_log or self._result.get('_ansible_no_log', False):
             x = {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result"}
             for preserve in _PRESERVE:
                 if preserve in self._result:

--- a/lib/ansible/modules/cloud/google/gce_net.py
+++ b/lib/ansible/modules/cloud/google/gce_net.py
@@ -272,7 +272,7 @@ def sorted_allowed_list(allowed_list):
     # sort by protocol
     allowed_by_protocol = sorted(allowed_list, key=lambda x: x['IPProtocol'])
     # sort the ports list
-    return sorted(allowed_by_protocol, key=lambda y: y.get('ports', []).sort())
+    return sorted(allowed_by_protocol, key=lambda y: sorted(y.get('ports', [])))
 
 
 def main():

--- a/test/integration/targets/no_log/no_log_local.yml
+++ b/test/integration/targets/no_log/no_log_local.yml
@@ -63,3 +63,30 @@
       - name: args should be logged when task-level no_log overrides play-level
         shell: echo "LOG_ME_OVERRIDE"
         no_log: false
+
+      - name: Add a fake host for next play
+        add_host:
+            hostname: fake
+
+- name: use 'fake' unreachable host to force unreachable error
+  hosts: fake
+  gather_facts: no
+  connection: ssh
+  tasks:
+    - name: Fail to run a lineinfile task
+      vars:
+        logins:
+          - machine: foo
+            login: bar
+            password: DO_NOT_LOG_UNREACHABLE_ITEM
+          - machine: two
+            login: three
+            password: DO_NOT_LOG_UNREACHABLE_ITEM
+      lineinfile:
+        path: /dev/null
+        mode: 0600
+        create: true
+        insertafter: EOF
+        line: "machine {{ item.machine }} login {{ item.login }} password {{ item.password }}"
+      loop: "{{ logins }}"
+      no_log: true

--- a/test/units/modules/remote_management/oneview/oneview_module_loader.py
+++ b/test/units/modules/remote_management/oneview/oneview_module_loader.py
@@ -4,10 +4,10 @@
 import sys
 from ansible.compat.tests.mock import patch, Mock
 
+# FIXME: These should be done inside of a fixture so that they're only mocked during
+# these unittests
 sys.modules['hpOneView'] = Mock()
 sys.modules['hpOneView.oneview_client'] = Mock()
-sys.modules['future'] = Mock()
-sys.modules['__future__'] = Mock()
 
 ONEVIEW_MODULE_UTILS_PATH = 'ansible.module_utils.oneview'
 from ansible.module_utils.oneview import (OneViewModuleException,


### PR DESCRIPTION
(cherry picked from commit 473f70c)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
test/units/modules/remote_management/oneview/oneview_module_loader.py/

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6.x
```
##### ADDITIONAL INFO

This isn't necessary for 2.6 but would keep the test code in sync.