### PR TITLE
VMware: Enable paths with spaces to be specified in vsphere_copy

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vsphere_copy.py
+++ b/lib/ansible/modules/cloud/vmware/vsphere_copy.py
@@ -94,14 +94,14 @@ import socket
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import urlencode
+from ansible.module_utils.six.moves.urllib.parse import urlencode, quote
 from ansible.module_utils._text import to_native
 from ansible.module_utils.urls import open_url
 
 
 def vmware_path(datastore, datacenter, path):
     ''' Constructs a URL path that VSphere accepts reliably '''
-    path = "/folder/%s" % path.lstrip("/")
+    path = "/folder/%s" % quote(path.lstrip("/"))
     # Due to a software bug in vSphere, it fails to handle ampersand in datacenter names
     # The solution is to do what vSphere does (when browsing) and double-encode ampersands, maybe others ?
     datacenter = datacenter.replace('&', '%26')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There are cases when a target path on a vSphere datastore contains spaces.  An example would be when copying file(s) to a VM directory for a VM with spaces in its name.  The current code in vsphere_copy does not urlencode the spaces into '%20'.  This pull request adds the capability.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vsphere_copy module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (vsphereCopy 1cfa4c1228) last updated 2018/10/09 17:46:32 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /ansible/lib/ansible
  executable location = /ansible/bin/ansible
  python version = 2.7.15 (default, Sep 12 2018, 02:38:23) [GCC 6.4.0]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
