### PR TITLE
[stable-2.6] Mocking out __future__ could cause problems

### DIFF
--- a/test/units/modules/remote_management/oneview/oneview_module_loader.py
+++ b/test/units/modules/remote_management/oneview/oneview_module_loader.py
@@ -4,10 +4,10 @@
 import sys
 from ansible.compat.tests.mock import patch, Mock
 
+# FIXME: These should be done inside of a fixture so that they're only mocked during
+# these unittests
 sys.modules['hpOneView'] = Mock()
 sys.modules['hpOneView.oneview_client'] = Mock()
-sys.modules['future'] = Mock()
-sys.modules['__future__'] = Mock()
 
 ONEVIEW_MODULE_UTILS_PATH = 'ansible.module_utils.oneview'
 from ansible.module_utils.oneview import (OneViewModuleException,


### PR DESCRIPTION
(cherry picked from commit 473f70c)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/units/modules/remote_management/oneview/oneview_module_loader.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6.x
```

##### ADDITIONAL INFORMATION
This isn't causing any CI test failures so it's not necessary.  Merging it will help to keep the tests in sync with devel.