### PR TITLE
Fix module state when attempting to stop stopped ec2 instance

### DIFF
--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -159,7 +159,7 @@ class ElasticLoadBalancerV2(object):
         if self.subnets is not None:
             # Convert subnets to subnet_mappings format for comparison
             for subnet in self.subnets:
-                subnet_mappings.append({'SubnetId': subnet})
+                subnet_mappings.append({ 'SubnetId': subnet })
 
         if self.subnet_mappings is not None:
             # Use this directly since we're comparing as a mapping
@@ -168,7 +168,7 @@ class ElasticLoadBalancerV2(object):
         # Build a subnet_mapping style struture of what's currently
         # on the load balancer
         for subnet in self.elb['AvailabilityZones']:
-            this_mapping = {'SubnetId': subnet['SubnetId']}
+            this_mapping = { 'SubnetId': subnet['SubnetId'] }
             for address in subnet['LoadBalancerAddresses']:
                 if 'AllocationId' in address:
                     this_mapping['AllocationId'] = address['AllocationId']

--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -416,6 +416,7 @@ class NetworkLoadBalancer(ElasticLoadBalancerV2):
 
         self.module.fail_json(msg='Modifying subnets and elastic IPs is not supported for Network Load Balancer')
 
+
 class ELBListeners(object):
 
     def __init__(self, connection, module, elb_arn):

--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -159,7 +159,7 @@ class ElasticLoadBalancerV2(object):
         if self.subnets is not None:
             # Convert subnets to subnet_mappings format for comparison
             for subnet in self.subnets:
-                subnet_mappings.append({ 'SubnetId': subnet })
+                subnet_mappings.append({'SubnetId': subnet})
 
         if self.subnet_mappings is not None:
             # Use this directly since we're comparing as a mapping
@@ -168,7 +168,7 @@ class ElasticLoadBalancerV2(object):
         # Build a subnet_mapping style struture of what's currently
         # on the load balancer
         for subnet in self.elb['AvailabilityZones']:
-            this_mapping = { 'SubnetId': subnet['SubnetId'] }
+            this_mapping = {'SubnetId': subnet['SubnetId']}
             for address in subnet['LoadBalancerAddresses']:
                 if 'AllocationId' in address:
                     this_mapping['AllocationId'] = address['AllocationId']

--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -159,7 +159,7 @@ class ElasticLoadBalancerV2(object):
         if self.subnets is not None:
             # Convert subnets to subnet_mappings format for comparison
             for subnet in self.subnets:
-                subnet_mappings.append({'SubnetId': subnet})
+                subnet_mappings.append({ 'SubnetId': subnet })
 
         if self.subnet_mappings is not None:
             # Use this directly since we're comparing as a mapping
@@ -168,7 +168,7 @@ class ElasticLoadBalancerV2(object):
         # Build a subnet_mapping style struture of what's currently
         # on the load balancer
         for subnet in self.elb['AvailabilityZones']:
-            this_mapping = {'SubnetId': subnet['SubnetId']}
+            this_mapping = { 'SubnetId': subnet['SubnetId'] }
             for address in subnet['LoadBalancerAddresses']:
                 if 'AllocationId' in address:
                     this_mapping['AllocationId'] = address['AllocationId']
@@ -416,6 +416,10 @@ class NetworkLoadBalancer(ElasticLoadBalancerV2):
 
         self.module.fail_json(msg='Modifying subnets and elastic IPs is not supported for Network Load Balancer')
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> Fix support for SubnetMappings and EIPs in NLB
 
 class ELBListeners(object):
 

--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -159,7 +159,7 @@ class ElasticLoadBalancerV2(object):
         if self.subnets is not None:
             # Convert subnets to subnet_mappings format for comparison
             for subnet in self.subnets:
-                subnet_mappings.append({ 'SubnetId': subnet })
+                subnet_mappings.append({'SubnetId': subnet})
 
         if self.subnet_mappings is not None:
             # Use this directly since we're comparing as a mapping
@@ -168,7 +168,7 @@ class ElasticLoadBalancerV2(object):
         # Build a subnet_mapping style struture of what's currently
         # on the load balancer
         for subnet in self.elb['AvailabilityZones']:
-            this_mapping = { 'SubnetId': subnet['SubnetId'] }
+            this_mapping = {'SubnetId': subnet['SubnetId']}
             for address in subnet['LoadBalancerAddresses']:
                 if 'AllocationId' in address:
                     this_mapping['AllocationId'] = address['AllocationId']
@@ -415,11 +415,6 @@ class NetworkLoadBalancer(ElasticLoadBalancerV2):
         """
 
         self.module.fail_json(msg='Modifying subnets and elastic IPs is not supported for Network Load Balancer')
-
-<<<<<<< HEAD
-=======
-
->>>>>>> Fix support for SubnetMappings and EIPs in NLB
 
 class ELBListeners(object):
 

--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -1349,7 +1349,7 @@ def change_instance_state(filters, desired_state, ec2=None):
                 resp = ec2.terminate_instances(InstanceIds=[inst['InstanceId']])
                 [changed.add(i['InstanceId']) for i in resp['TerminatingInstances']]
             if desired_state == 'STOPPED':
-                if inst['State']['Name'] in ('stopping', 'stopped'):
+                if inst['State']['Name'] in ('stopping','stopped'):
                     unchanged.add(inst['InstanceId'])
                     continue
                 resp = ec2.stop_instances(InstanceIds=[inst['InstanceId']])

--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -1349,7 +1349,7 @@ def change_instance_state(filters, desired_state, ec2=None):
                 resp = ec2.terminate_instances(InstanceIds=[inst['InstanceId']])
                 [changed.add(i['InstanceId']) for i in resp['TerminatingInstances']]
             if desired_state == 'STOPPED':
-                if inst['State']['Name'] in ('stopping','stopped'):
+                if inst['State']['Name'] in ('stopping', 'stopped'):
                     unchanged.add(inst['InstanceId'])
                     continue
                 resp = ec2.stop_instances(InstanceIds=[inst['InstanceId']])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module (before this PR) attempts to deal with a desired state of "stopped" by setting a filter to only return instances that are able to be stopped. However, it only sets that filter if the caller didn't supply a filter. Later code that sets the instance to stopped expects never to be reached if the instance is already stopped. 

The changes here ensure we don't try to stop instances that are already stopped, and that the code reports the correct status for this non-event.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #46710 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See #46710 for repro and additional info.
<!--- Paste verbatim command output below, e.g. before and after your change -->

