### PR TITLE
VMware: Added secure boot enable/disable to vmware_guest_boot_manager.

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
@@ -74,6 +74,7 @@ vm_boot_facts:
         "current_boot_retry_enabled": true,
         "current_enter_bios_setup": true,
         "current_boot_firmware": "bios",
+        "current_secure_boot_enabled": false,
     }
 """
 
@@ -143,6 +144,7 @@ class VmBootFactsManager(PyVmomi):
                 current_boot_retry_enabled=self.vm.config.bootOptions.bootRetryEnabled,
                 current_boot_retry_delay=self.vm.config.bootOptions.bootRetryDelay,
                 current_boot_firmware=self.vm.config.firmware,
+                current_secure_boot_enabled=self.vm.config.bootOptions.efiSecureBootEnabled
             )
 
         self.module.exit_json(changed=False, vm_boot_facts=results)

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
@@ -77,6 +77,7 @@ options:
      - Choose if EFI secure boot should be enabled.
      type: 'bool'
      default: False
+     version_added: '2.8'
 extends_documentation_fragment: vmware.documentation
 '''
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
@@ -93,7 +93,7 @@ EXAMPLES = r'''
     boot_retry_enabled: True
     boot_retry_delay: 22300
     boot_firmware: bios
-    secure_boot_enabled: True
+    secure_boot_enabled: False
     boot_order:
       - floppy
       - cdrom
@@ -120,12 +120,12 @@ vm_boot_status:
         "current_boot_retry_enabled": true,
         "current_enter_bios_setup": true,
         "current_boot_firmware": "bios",
-        "current_secure_boot_enabled": true,
+        "current_secure_boot_enabled": false,
         "previous_boot_delay": 10,
         "previous_boot_retry_delay": 10000,
         "previous_boot_retry_enabled": true,
         "previous_enter_bios_setup": false,
-        "previous_boot_firmware": "bios",
+        "previous_boot_firmware": "efi",
         "previous_secure_boot_enabled": true,
         "previous_boot_order": [
             "ethernet",
@@ -255,13 +255,14 @@ class VmBootManager(PyVmomi):
             boot_firmware_required = True
 
         if self.vm.config.bootOptions.efiSecureBootEnabled != self.params.get('secure_boot_enabled'):
-            if self.params.get('secure_boot_enabled') is True and self.params.get('boot_firmware') == "bios":
+            if self.params.get('secure_boot_enabled') and self.params.get('boot_firmware') == "bios":
                 self.module.fail_json(msg="EFI secure boot cannot be enabled when boot_firmware = bios, but both are specified")
 
             # If the user is not specifying boot_firmware, make sure they aren't trying to enable it on a
             # system with boot_firmware already set to 'bios'
-            if self.params.get('secure_boot_enabled') is True and self.params.get('boot_firmware') is None:
-                if self.vm.config.firmware == 'bios':
+            if self.params.get('secure_boot_enabled') and \
+               self.params.get('boot_firmware') is None and \
+               self.vm.config.firmware == 'bios':
                     self.module.fail_json(msg="EFI secure boot cannot be enabled when boot_firmware = bios.  VM's boot_firmware currently set to bios")
 
             kwargs.update({'efiSecureBootEnabled': self.params.get('secure_boot_enabled')})


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Modifying the boot order has no effect on VMs with secure_boot enabled.  This pull request adds the state of secure_boot to facts and the ability to enable/disable secure_boot for the VM.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest_boot_manager module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (vsphereCopy 1cfa4c1228) last updated 2018/10/09 17:46:32 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /ansible/lib/ansible
  executable location = /ansible/bin/ansible
  python version = 2.7.15 (default, Sep 12 2018, 02:38:23) [GCC 6.4.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
