### PR TITLE
Introduce  `aws_profile` option in serverless module

### DIFF
--- a/lib/ansible/modules/cloud/misc/serverless.py
+++ b/lib/ansible/modules/cloud/misc/serverless.py
@@ -68,6 +68,11 @@ options:
     required: false
     default: false
     version_added: "2.7"
+  aws_profile:
+    description:
+      - Allows an AWS profile to be passed for credentials to the serverless command, equivalent to serverless `--aws-profile` option.
+    required: false
+    version_added: "2.8"
 notes:
    - Currently, the `serverless` command must be in the path of the node executing the task. In the future this may be a flag.
 requirements: [ "serverless", "yaml" ]
@@ -174,7 +179,8 @@ def main():
             deploy=dict(default=True, type='bool', required=False),
             serverless_bin_path=dict(required=False, type='path'),
             force=dict(default=False, required=False),
-            verbose=dict(default=False, required=False)
+            verbose=dict(default=False, required=False),
+            aws_profile=dict(default='', required=False)
         ),
     )
 
@@ -190,6 +196,7 @@ def main():
     force = module.params.get('force', False)
     verbose = module.params.get('verbose', False)
     serverless_bin_path = module.params.get('serverless_bin_path')
+    aws_profile = module.params.get('aws_profile')
 
     if serverless_bin_path is not None:
         command = serverless_bin_path + " "
@@ -215,6 +222,8 @@ def main():
         command += '--stage {} '.format(stage)
     if verbose:
         command += '--verbose '
+    if aws_profile:
+        command += '--aws-profile {} '.format(aws_profile)
 
     rc, out, err = module.run_command(command, cwd=service_path)
     if rc != 0:


### PR DESCRIPTION
##### SUMMARY
Allows specifying aws_profile option for providing AWS credentials when executing serverless framework deployment. As documented by serverless https://serverless.com/framework/docs/providers/aws/guide/credentials#using-the-aws-profile-option

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
serverless

##### ANSIBLE VERSION
```
ansible 2.7.0
  config file = None
  configured module search path = [u'/Users/mine/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mine/.virtualenvs/dev/lib/python2.7/site-packages/ansible
  executable location = /Users/mine/.virtualenvs/dev/bin/ansible
  python version = 2.7.15 (default, Aug 22 2018, 16:36:18) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
```
changed: [localhost] => {
    "changed": true,
    "command": "serverless deploy --force --region ap-southeast-2 --verbose --aws-profile production ",
    "invocation": {
        "module_args": {
            "aws_profile": "production",
            "deploy": true,
            "force": "False",
            "functions": null,
            "region": "ap-southeast-2",
            "serverless_bin_path": null,
            "service_path": "/Users/mine/coderepos/src/services/analytics",
            "stage": "",
            "state": "present",
            "verbose": "True"
        }
    },
    "out": "<redacted>",
    "service_name": "analytics-service",
    "state": "present"
}
```
