### PR TITLE
Update win_scheduled_task.py

### DIFF
--- a/lib/ansible/modules/windows/win_scheduled_task.py
+++ b/lib/ansible/modules/windows/win_scheduled_task.py
@@ -186,9 +186,22 @@ options:
         - Allows you to define the repetition action of the trigger that defines how often the task is run and how long the repetition pattern is repeated
           after the task is started.
         - It takes in the following keys, C(duration), C(interval), C(stop_at_duration_end)
-        - Optional- C(duration) is how long the pattern is repeated and is written in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S). If not included the duration will be indefinitely.
-        - C(interval) is the amount of time between earch restart of the task and is written in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S).
-        - C(stop_at_duration_end) is a boolean value that indicates if a running instance of the task is stopped at the end of the repetition pattern.
+        suboptions:
+          duration:
+            description:
+            - Defines how long the pattern is repeated.
+            - The value is in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S).
+            - Defaults to repeat indefinitely.
+            type: str
+          interval:
+            description:
+            - The amount of time between earch restart of the task/
+            - The value is written in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S).
+            type: str
+          stop_at_duration_end:
+            description:
+            - Whether a running instance of the task is stopped at the end of the repetition pattern.
+            type: bool
     version_added: '2.5'
 
   # Principal options

--- a/lib/ansible/modules/windows/win_scheduled_task.py
+++ b/lib/ansible/modules/windows/win_scheduled_task.py
@@ -186,7 +186,7 @@ options:
         - Allows you to define the repetition action of the trigger that defines how often the task is run and how long the repetition pattern is repeated
           after the task is started.
         - It takes in the following keys, C(duration), C(interval), C(stop_at_duration_end)
-        - C(duration) is how long the pattern is repeated and is written in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S).
+        - Optional- C(duration) is how long the pattern is repeated and is written in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S). If not included the duration will be indefinitely.
         - C(interval) is the amount of time between earch restart of the task and is written in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S).
         - C(stop_at_duration_end) is a boolean value that indicates if a running instance of the task is stopped at the end of the repetition pattern.
     version_added: '2.5'

--- a/lib/ansible/modules/windows/win_scheduled_task.py
+++ b/lib/ansible/modules/windows/win_scheduled_task.py
@@ -191,7 +191,7 @@ options:
             description:
             - Defines how long the pattern is repeated.
             - The value is in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S).
-            - Defaults to repeat indefinitely.
+            - By default this is not set which means it will repeat indefinitely
             type: str
           interval:
             description:

--- a/lib/ansible/modules/windows/win_scheduled_task.py
+++ b/lib/ansible/modules/windows/win_scheduled_task.py
@@ -191,7 +191,7 @@ options:
             description:
             - Defines how long the pattern is repeated.
             - The value is in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S).
-            - By default this is not set which means it will repeat indefinitely
+            - By default this is not set which means it will repeat indefinitely.
             type: str
           interval:
             description:

--- a/lib/ansible/modules/windows/win_scheduled_task.py
+++ b/lib/ansible/modules/windows/win_scheduled_task.py
@@ -195,7 +195,7 @@ options:
             type: str
           interval:
             description:
-            - The amount of time between earch restart of the task/
+            - The amount of time between each restart of the task.
             - The value is written in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S).
             type: str
           stop_at_duration_end:

--- a/test/sanity/validate-modules/schema.py
+++ b/test/sanity/validate-modules/schema.py
@@ -61,7 +61,7 @@ suboption_schema = Schema(
         'version_added': Any(float, *string_types),
         'default': Any(None, float, int, bool, list, dict, *string_types),
         # Note: Types are strings, not literal bools, such as True or False
-        'type': Any(None, "bool"),
+        'type': Any(None, 'str', 'list', 'dict', 'bool', 'int', 'float', 'path', 'raw', 'jsonarg', 'json', 'bytes', 'bits'),
         # Recursive suboptions
         'suboptions': Any(None, *list({str_type: Self} for str_type in string_types)),
     },
@@ -82,7 +82,7 @@ option_schema = Schema(
         'default': Any(None, float, int, bool, list, dict, *string_types),
         'suboptions': Any(None, *list_dict_suboption_schema),
         # Note: Types are strings, not literal bools, such as True or False
-        'type': Any(None, 'str', 'list', 'dict', 'bool', 'int', 'float', 'path', 'raw', 'jsonarg', 'json', 'bytes', 'bits')
+        'type': Any(None, 'str', 'list', 'dict', 'bool', 'int', 'float', 'path', 'raw', 'jsonarg', 'json', 'bytes', 'bits'),
     },
     extra=PREVENT_EXTRA
 )


### PR DESCRIPTION
The duration of a task trigger can be null, that will cause it to run indefinitely. This took me a little trial and error to figure out.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
