### PR TITLE
Do not append msg to verbose tasks

### DIFF
--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -71,6 +71,7 @@ class CallbackModule(CallbackBase):
 
         if self._run_is_verbose(result):
             task_result = "%s %s: %s" % (task_host, msg, self._dump_results(result._result, indent=4))
+            return task_result
 
         if self.delegated_vars:
             task_delegate_host = self.delegated_vars['ansible_host']


### PR DESCRIPTION
##### SUMMARY
Fixes #46681 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
unixy.py callback plugin

##### ANSIBLE VERSION
```
ansible 2.6.3
  config file = /home/ally/.ansible.cfg
  configured module search path = [u'/home/ally/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ally/.local/lib/python2.7/site-packages/ansible
  executable location = /home/ally/.local/bin/ansible
  python version = 2.7.13 (default, Sep 26 2018, 18:42:22) [GCC 6.3.0 20170516]

```

##### ADDITIONAL INFORMATION
Testing artifact:
```
#Before
debug...
  localhost ok: {
    "changed": false,
    "msg": "Success."
} | msg: Success.

#After
debug...
  localhost ok: {
    "changed": false,
    "msg": "Success."
}
```
