### PR TITLE
Add unixy option to display only 'changed' output

### DIFF
--- a/changelogs/fragments/52760-fix-last-task-time-with-multiple-plays.yaml
+++ b/changelogs/fragments/52760-fix-last-task-time-with-multiple-plays.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - profile_tasks callback - Fix the last task time when running multiple plays (https://github.com/ansible/ansible/issues/52760)

--- a/lib/ansible/module_utils/kubevirt.py
+++ b/lib/ansible/module_utils/kubevirt.py
@@ -255,11 +255,13 @@ class KubeVirtRawModule(KubernetesRawModule):
         if machine_type:
             template_spec['domain']['machine']['type'] = machine_type
 
-        # Define cloud init disk if defined:
-        self._define_cloud_init(cloud_init_nocloud, template_spec)
-
         # Define disks
         self._define_disks(disks, template_spec)
+
+        # Define cloud init disk if defined:
+        # Note, that this must be called after _define_disks, so the cloud_init
+        # is not first in order and it's not used as boot disk:
+        self._define_cloud_init(cloud_init_nocloud, template_spec)
 
         # Define interfaces:
         self._define_interfaces(interfaces, template_spec)

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -280,7 +280,10 @@ class RedfishUtils(object):
         controller_list = []
         controller_results = []
         # Get these entries, but does not fail if not found
-        properties = ['Name', 'Status']
+        properties = ['CacheSummary', 'FirmwareVersion', 'Identifiers',
+                      'Location', 'Manufacturer', 'Model', 'Name',
+                      'PartNumber', 'SerialNumber', 'SpeedGbps', 'Status']
+        key = "StorageControllers"
 
         # Find Storage service
         response = self.get_request(self.root_uri + self.systems_uri)
@@ -288,41 +291,45 @@ class RedfishUtils(object):
             return response
         data = response['data']
 
-        if 'SimpleStorage' not in data:
-            return {'ret': False, 'msg': "SimpleStorage resource not found"}
+        if 'Storage' not in data:
+            return {'ret': False, 'msg': "Storage resource not found"}
 
         # Get a list of all storage controllers and build respective URIs
-        storage_uri = data["SimpleStorage"]["@odata.id"]
+        storage_uri = data['Storage']["@odata.id"]
         response = self.get_request(self.root_uri + storage_uri)
         if response['ret'] is False:
             return response
         result['ret'] = True
         data = response['data']
 
-        for controller in data[u'Members']:
-            controller_list.append(controller[u'@odata.id'])
+        # Loop through Members and their StorageControllers
+        # and gather properties from each StorageController
+        if data[u'Members']:
+            for storage_member in data[u'Members']:
+                storage_member_uri = storage_member[u'@odata.id']
+                response = self.get_request(self.root_uri + storage_member_uri)
+                data = response['data']
 
-        for c in controller_list:
-            controller = {}
-            uri = self.root_uri + c
-            response = self.get_request(uri)
-            if response['ret'] is False:
-                return response
-            data = response['data']
-
-            for property in properties:
-                if property in data:
-                    controller[property] = data[property]
-            controller_results.append(controller)
-        result["entries"] = controller_results
-        return result
+                if key in data:
+                    controller_list = data[key]
+                    for controller in controller_list:
+                        controller_result = {}
+                        for property in properties:
+                            if property in controller:
+                                controller_result[property] = controller[property]
+                        controller_results.append(controller_result)
+                result['entries'] = controller_results
+            return result
+        else:
+            return {'ret': False, 'msg': "Storage resource not found"}
 
     def get_disk_inventory(self):
         result = {}
         controller_list = []
         disk_results = []
         # Get these entries, but does not fail if not found
-        properties = ['Name', 'Manufacturer', 'Model', 'Status', 'CapacityBytes']
+        properties = ['Name', 'Manufacturer', 'Model', 'Status',
+                      'CapacityBytes']
 
         # Find Storage service
         response = self.get_request(self.root_uri + self.systems_uri)

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -734,11 +734,10 @@ class RedfishUtils(object):
         fan_results = []
         key = "Thermal"
         # Get these entries, but does not fail if not found
-        properties = ['FanName', 'Reading', 'Status']
+        properties = ['FanName', 'Reading', 'ReadingUnits', 'Status']
 
         # Go through list
         for chassis_uri in self.chassis_uri_list:
-            fan = {}
             response = self.get_request(self.root_uri + chassis_uri)
             if response['ret'] is False:
                 return response
@@ -754,12 +753,12 @@ class RedfishUtils(object):
                 data = response['data']
 
                 for device in data[u'Fans']:
+                    fan = {}
                     for property in properties:
                         if property in device:
                             fan[property] = device[property]
-
                     fan_results.append(fan)
-                result["entries"] = fan_results
+        result["entries"] = fan_results
         return result
 
     def get_cpu_inventory(self):

--- a/lib/ansible/modules/cloud/azure/azure_rm_keyvaultkey.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_keyvaultkey.py
@@ -89,6 +89,7 @@ try:
     from azure.keyvault.models import KeyAttributes, JsonWebKey
     from azure.common.credentials import ServicePrincipalCredentials
     from azure.keyvault.models.key_vault_error import KeyVaultErrorException
+    from msrestazure.azure_active_directory import MSIAuthentication
     from OpenSSL import crypto
 except ImportError:
     # This is handled in azure_rm_common
@@ -137,25 +138,7 @@ class AzureRMKeyVaultKey(AzureRMModuleBase):
             setattr(self, key, kwargs[key])
 
         # Create KeyVaultClient
-        def auth_callback(server, resource, scope):
-            if self.credentials['client_id'] is None or self.credentials['secret'] is None:
-                self.fail('Please specify client_id, secret and tenant to access azure Key Vault.')
-
-            tenant = self.credentials.get('tenant')
-            if not self.credentials['tenant']:
-                tenant = "common"
-
-            authcredential = ServicePrincipalCredentials(
-                client_id=self.credentials['client_id'],
-                secret=self.credentials['secret'],
-                tenant=tenant,
-                cloud_environment=self._cloud_environment,
-                resource="https://vault.azure.net")
-
-            token = authcredential.token
-            return token['token_type'], token['access_token']
-
-        self.client = KeyVaultClient(KeyVaultAuthentication(auth_callback))
+        self.client = self.get_keyvault_client()
 
         results = dict()
         changed = False
@@ -194,6 +177,35 @@ class AzureRMKeyVaultKey(AzureRMModuleBase):
                 self.results['state']['status'] = 'Deleted'
 
         return self.results
+
+    def get_keyvault_client(self):
+        try:
+            self.log("Get KeyVaultClient from MSI")
+            credentials = MSIAuthentication(resource='https://vault.azure.net')
+            return KeyVaultClient(credentials)
+        except Exception:
+            self.log("Get KeyVaultClient from service principal")
+
+        # Create KeyVault Client using KeyVault auth class and auth_callback
+        def auth_callback(server, resource, scope):
+            if self.credentials['client_id'] is None or self.credentials['secret'] is None:
+                self.fail('Please specify client_id, secret and tenant to access azure Key Vault.')
+
+            tenant = self.credentials.get('tenant')
+            if not self.credentials['tenant']:
+                tenant = "common"
+
+            authcredential = ServicePrincipalCredentials(
+                client_id=self.credentials['client_id'],
+                secret=self.credentials['secret'],
+                tenant=tenant,
+                cloud_environment=self._cloud_environment,
+                resource="https://vault.azure.net")
+
+            token = authcredential.token
+            return token['token_type'], token['access_token']
+
+        return KeyVaultClient(KeyVaultAuthentication(auth_callback))
 
     def get_key(self, name, version=''):
         ''' Gets an existing key '''

--- a/lib/ansible/modules/cloud/azure/azure_rm_keyvaultsecret.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_keyvaultsecret.py
@@ -84,6 +84,7 @@ try:
     from azure.keyvault import KeyVaultClient, KeyVaultAuthentication, KeyVaultId
     from azure.common.credentials import ServicePrincipalCredentials
     from azure.keyvault.models.key_vault_error import KeyVaultErrorException
+    from msrestazure.azure_active_directory import MSIAuthentication
 except ImportError:
     # This is handled in azure_rm_common
     pass
@@ -128,26 +129,8 @@ class AzureRMKeyVaultSecret(AzureRMModuleBase):
         for key in list(self.module_arg_spec.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
 
-        # Create KeyVault Client using KeyVault auth class and auth_callback
-        def auth_callback(server, resource, scope):
-            if self.credentials['client_id'] is None or self.credentials['secret'] is None:
-                self.fail('Please specify client_id, secret and tenant to access azure Key Vault.')
-
-            tenant = self.credentials.get('tenant')
-            if not self.credentials['tenant']:
-                tenant = "common"
-
-            authcredential = ServicePrincipalCredentials(
-                client_id=self.credentials['client_id'],
-                secret=self.credentials['secret'],
-                tenant=tenant,
-                cloud_environment=self._cloud_environment,
-                resource="https://vault.azure.net")
-
-            token = authcredential.token
-            return token['token_type'], token['access_token']
-
-        self.client = KeyVaultClient(KeyVaultAuthentication(auth_callback))
+        # Create KeyVault Client
+        self.client = self.get_keyvault_client()
 
         results = dict()
         changed = False
@@ -185,6 +168,35 @@ class AzureRMKeyVaultSecret(AzureRMModuleBase):
                 self.results['state']['status'] = 'Deleted'
 
         return self.results
+
+    def get_keyvault_client(self):
+        try:
+            self.log("Get KeyVaultClient from MSI")
+            credentials = MSIAuthentication(resource='https://vault.azure.net')
+            return KeyVaultClient(credentials)
+        except Exception:
+            self.log("Get KeyVaultClient from service principal")
+
+        # Create KeyVault Client using KeyVault auth class and auth_callback
+        def auth_callback(server, resource, scope):
+            if self.credentials['client_id'] is None or self.credentials['secret'] is None:
+                self.fail('Please specify client_id, secret and tenant to access azure Key Vault.')
+
+            tenant = self.credentials.get('tenant')
+            if not self.credentials['tenant']:
+                tenant = "common"
+
+            authcredential = ServicePrincipalCredentials(
+                client_id=self.credentials['client_id'],
+                secret=self.credentials['secret'],
+                tenant=tenant,
+                cloud_environment=self._cloud_environment,
+                resource="https://vault.azure.net")
+
+            token = authcredential.token
+            return token['token_type'], token['access_token']
+
+        return KeyVaultClient(KeyVaultAuthentication(auth_callback))
 
     def get_secret(self, name, version=''):
         ''' Gets an existing secret '''

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlconfiguration.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlconfiguration.py
@@ -90,7 +90,7 @@ class Actions:
     NoAction, Create, Update, Delete = range(4)
 
 
-class AzureRMConfigurations(AzureRMModuleBase):
+class AzureRMPostgreSqlConfigurations(AzureRMModuleBase):
 
     def __init__(self):
         self.module_arg_spec = dict(
@@ -125,9 +125,9 @@ class AzureRMConfigurations(AzureRMModuleBase):
         self.state = None
         self.to_do = Actions.NoAction
 
-        super(AzureRMConfigurations, self).__init__(derived_arg_spec=self.module_arg_spec,
-                                                    supports_check_mode=True,
-                                                    supports_tags=False)
+        super(AzureRMPostgreSqlConfigurations, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                              supports_check_mode=True,
+                                                              supports_tags=False)
 
     def exec_module(self, **kwargs):
 
@@ -234,7 +234,7 @@ class AzureRMConfigurations(AzureRMModuleBase):
 
 def main():
     """Main execution"""
-    AzureRMConfigurations()
+    AzureRMPostgreSqlConfigurations()
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqldatabase.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqldatabase.py
@@ -109,7 +109,7 @@ class Actions:
     NoAction, Create, Update, Delete = range(4)
 
 
-class AzureRMDatabases(AzureRMModuleBase):
+class AzureRMPostgreSqlDatabases(AzureRMModuleBase):
     """Configuration class for an Azure RM PostgreSQL Database resource"""
 
     def __init__(self):
@@ -154,9 +154,9 @@ class AzureRMDatabases(AzureRMModuleBase):
         self.state = None
         self.to_do = Actions.NoAction
 
-        super(AzureRMDatabases, self).__init__(derived_arg_spec=self.module_arg_spec,
-                                               supports_check_mode=True,
-                                               supports_tags=False)
+        super(AzureRMPostgreSqlDatabases, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                         supports_check_mode=True,
+                                                         supports_tags=False)
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
@@ -300,7 +300,7 @@ class AzureRMDatabases(AzureRMModuleBase):
 
 def main():
     """Main execution"""
-    AzureRMDatabases()
+    AzureRMPostgreSqlDatabases()
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqldatabase_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqldatabase_facts.py
@@ -111,7 +111,7 @@ except ImportError:
     pass
 
 
-class AzureRMDatabasesFacts(AzureRMModuleBase):
+class AzureRMPostgreSqlDatabasesFacts(AzureRMModuleBase):
     def __init__(self):
         # define user inputs into argument
         self.module_arg_spec = dict(
@@ -134,7 +134,7 @@ class AzureRMDatabasesFacts(AzureRMModuleBase):
         self.resource_group = None
         self.server_name = None
         self.name = None
-        super(AzureRMDatabasesFacts, self).__init__(self.module_arg_spec, supports_tags=False)
+        super(AzureRMPostgreSqlDatabasesFacts, self).__init__(self.module_arg_spec, supports_tags=False)
 
     def exec_module(self, **kwargs):
         for key in self.module_arg_spec:
@@ -194,7 +194,7 @@ class AzureRMDatabasesFacts(AzureRMModuleBase):
 
 
 def main():
-    AzureRMDatabasesFacts()
+    AzureRMPostgreSqlDatabasesFacts()
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlfirewallrule.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlfirewallrule.py
@@ -93,7 +93,7 @@ class Actions:
     NoAction, Create, Update, Delete = range(4)
 
 
-class AzureRMFirewallRules(AzureRMModuleBase):
+class AzureRMPostgreSqlFirewallRules(AzureRMModuleBase):
     """Configuration class for an Azure RM PostgreSQL firewall rule resource"""
 
     def __init__(self):
@@ -133,9 +133,9 @@ class AzureRMFirewallRules(AzureRMModuleBase):
         self.state = None
         self.to_do = Actions.NoAction
 
-        super(AzureRMFirewallRules, self).__init__(derived_arg_spec=self.module_arg_spec,
-                                                   supports_check_mode=True,
-                                                   supports_tags=False)
+        super(AzureRMPostgreSqlFirewallRules, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                             supports_check_mode=True,
+                                                             supports_tags=False)
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
@@ -268,7 +268,7 @@ class AzureRMFirewallRules(AzureRMModuleBase):
 
 def main():
     """Main execution"""
-    AzureRMFirewallRules()
+    AzureRMPostgreSqlFirewallRules()
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
@@ -148,7 +148,7 @@ class Actions:
     NoAction, Create, Update, Delete = range(4)
 
 
-class AzureRMServers(AzureRMModuleBase):
+class AzureRMPostgreSqlServers(AzureRMModuleBase):
     """Configuration class for an Azure RM PostgreSQL Server resource"""
 
     def __init__(self):
@@ -205,9 +205,9 @@ class AzureRMServers(AzureRMModuleBase):
         self.state = None
         self.to_do = Actions.NoAction
 
-        super(AzureRMServers, self).__init__(derived_arg_spec=self.module_arg_spec,
-                                             supports_check_mode=True,
-                                             supports_tags=True)
+        super(AzureRMPostgreSqlServers, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                       supports_check_mode=True,
+                                                       supports_tags=True)
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
@@ -373,7 +373,7 @@ class AzureRMServers(AzureRMModuleBase):
 
 def main():
     """Main execution"""
-    AzureRMServers()
+    AzureRMPostgreSqlServers()
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver_facts.py
@@ -160,7 +160,7 @@ except ImportError:
     pass
 
 
-class AzureRMServersFacts(AzureRMModuleBase):
+class AzureRMPostgreSqlServersFacts(AzureRMModuleBase):
     def __init__(self):
         # define user inputs into argument
         self.module_arg_spec = dict(
@@ -182,7 +182,7 @@ class AzureRMServersFacts(AzureRMModuleBase):
         self.resource_group = None
         self.name = None
         self.tags = None
-        super(AzureRMServersFacts, self).__init__(self.module_arg_spec, supports_tags=False)
+        super(AzureRMPostgreSqlServersFacts, self).__init__(self.module_arg_spec, supports_tags=False)
 
     def exec_module(self, **kwargs):
         for key in self.module_arg_spec:
@@ -247,7 +247,7 @@ class AzureRMServersFacts(AzureRMModuleBase):
 
 
 def main():
-    AzureRMServersFacts()
+    AzureRMPostgreSqlServersFacts()
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/kubevirt/kubevirt_cdi_upload.py
+++ b/lib/ansible/modules/cloud/kubevirt/kubevirt_cdi_upload.py
@@ -1,0 +1,177 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+
+module: kubevirt_cdi_upload
+
+short_description: Upload local VM images to CDI Upload Proxy.
+
+version_added: "2.8"
+
+author: KubeVirt Team (@kubevirt)
+
+
+description:
+  - Use Openshift Python SDK to create UploadTokenRequest objects.
+  - Transfer contents of local files to the CDI Upload Proxy.
+
+options:
+  pvc_name:
+    description:
+      - Use to specify the name of the target PersistentVolumeClaim.
+    required: true
+  pvc_namespace:
+    description:
+      - Use to specify the namespace of the target PersistentVolumeClaim.
+    required: true
+  upload_host:
+    description:
+      - URL containing the host and port on which the CDI Upload Proxy is available.
+      - "More info: U(https://github.com/kubevirt/containerized-data-importer/blob/master/doc/upload.md#expose-cdi-uploadproxy-service)"
+  upload_host_verify_ssl:
+    description:
+      - Whether or not to verify the CDI Upload Proxy's SSL certificates against your system's CA trust store.
+    default: true
+    type: bool
+  path:
+    description:
+      - Path of local image file to transfer.
+  merge_type:
+    description:
+      - Whether to override the default patch merge approach with a specific type. By default, the strategic
+        merge will typically be used.
+    type: list
+    choices: [ json, merge, strategic-merge ]
+
+extends_documentation_fragment:
+  - k8s_auth_options
+
+requirements:
+  - python >= 2.7
+  - openshift >= 0.8.2
+  - requests >= 2.0.0
+'''
+
+EXAMPLES = '''
+- name: Upload local image to pvc-vm1
+  kubevirt_cdi_upload:
+    pvc_namespace: default
+    pvc_name: pvc-vm1
+    upload_host: https://localhost:8443
+    upload_host_verify_ssl: false
+    path: /tmp/cirros-0.4.0-x86_64-disk.img
+'''
+
+RETURN = '''# '''
+
+import copy
+import traceback
+
+from collections import defaultdict
+
+from ansible.module_utils.k8s.common import AUTH_ARG_SPEC
+from ansible.module_utils.k8s.raw import KubernetesRawModule
+
+# 3rd party imports
+try:
+    import requests
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
+
+
+SERVICE_ARG_SPEC = {
+    'pvc_name': {'required': True},
+    'pvc_namespace': {'required': True},
+    'upload_host': {'required': True},
+    'upload_host_verify_ssl': {
+        'type': 'bool',
+        'default': True
+    },
+    'path': {'required': True},
+    'merge_type': {
+        'type': 'list',
+        'choices': ['json', 'merge', 'strategic-merge']
+    },
+}
+
+
+class KubeVirtCDIUpload(KubernetesRawModule):
+    def __init__(self, *args, **kwargs):
+        super(KubeVirtCDIUpload, self).__init__(*args, k8s_kind='UploadTokenRequest', **kwargs)
+
+        if not HAS_REQUESTS:
+            self.fail("This module requires the python 'requests' package. Try `pip install requests`.")
+
+    @property
+    def argspec(self):
+        """ argspec property builder """
+        argument_spec = copy.deepcopy(AUTH_ARG_SPEC)
+        argument_spec.update(SERVICE_ARG_SPEC)
+        return argument_spec
+
+    def execute_module(self):
+        """ Module execution """
+
+        API = 'v1alpha1'
+        KIND = 'UploadTokenRequest'
+
+        self.client = self.get_api_client()
+
+        api_version = 'upload.cdi.kubevirt.io/{0}'.format(API)
+        pvc_name = self.params.get('pvc_name')
+        pvc_namespace = self.params.get('pvc_namespace')
+        upload_host = self.params.get('upload_host')
+        upload_host_verify_ssl = self.params.get('upload_host_verify_ssl')
+        path = self.params.get('path')
+
+        definition = defaultdict(defaultdict)
+
+        definition['kind'] = KIND
+        definition['apiVersion'] = api_version
+
+        def_meta = definition['metadata']
+        def_meta['name'] = pvc_name
+        def_meta['namespace'] = pvc_namespace
+
+        def_spec = definition['spec']
+        def_spec['pvcName'] = pvc_name
+
+        # Let's check the file's there before we do anything else
+        imgfile = open(path, 'rb')
+
+        resource = self.find_resource(KIND, api_version, fail=True)
+        definition = self.set_defaults(resource, definition)
+        result = self.perform_action(resource, definition)
+
+        headers = {'Authorization': "Bearer {0}".format(result['result']['status']['token'])}
+        files = {'file': imgfile}
+        url = "{0}/{1}/upload".format(upload_host, API)
+        requests.post(url, files=files, headers=headers, verify=upload_host_verify_ssl)
+
+        self.exit_json(changed=True)
+
+
+def main():
+    module = KubeVirtCDIUpload()
+    try:
+        module.execute_module()
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/kubevirt/kubevirt_vm.py
+++ b/lib/ansible/modules/cloud/kubevirt/kubevirt_vm.py
@@ -159,8 +159,8 @@ EXAMPLES = '''
       namespace: vms
       memory: 1024M
       cloud_init_nocloud:
-        #cloud-config
         userData: |-
+          #cloud-config
           password: fedora
           chpasswd: { expire: False }
       disks:

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -107,7 +107,7 @@ options:
         description:
             - SAN extension to attach to the certificate signing request.
             - This can either be a 'comma separated string' or a YAML list.
-            - Values should be prefixed by their options. (i.e., C(email), C(URI), C(DNS), C(RID), C(IP), C(dirName),
+            - Values must be prefixed by their options. (i.e., C(email), C(URI), C(DNS), C(RID), C(IP), C(dirName),
               C(otherName) and the ones specific to your CA)
             - Note that if no SAN is specified, but a common name, the common
               name will be added as a SAN except if C(useCommonNameForSAN) is

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -233,6 +233,8 @@ options:
             media_type:
                 description:
                     - Media type that will be used to send the message.
+                    - Set to C(all) for all media types
+                default: 'all'
             host_groups:
                 type: list
                 description:
@@ -664,6 +666,8 @@ class Zapi(object):
 
         """
         try:
+            if str(mediatype_name).lower() == 'all':
+                return '0'
             mediatype_list = self._zapi.mediatype.get({
                 'output': 'extend',
                 'selectInventory': 'extend',
@@ -672,7 +676,7 @@ class Zapi(object):
             if len(mediatype_list) < 1:
                 self._module.fail_json(msg="Media type not found: %s" % mediatype_name)
             else:
-                return mediatype_list[0]
+                return mediatype_list[0]['mediatypeid']
         except Exception as e:
             self._module.fail_json(msg="Failed to get mediatype '%s': %s" % (mediatype_name, e))
 
@@ -913,7 +917,7 @@ class Operations(object):
                 'default_msg': '0' if 'message' in operation or 'subject' in operation else '1',
                 'mediatypeid': self._zapi_wrapper.get_mediatype_by_mediatype_name(
                     operation.get('media_type')
-                )['mediatypeid'] if operation.get('media_type') is not None else None,
+                ) if operation.get('media_type') is not None else '0',
                 'message': operation.get('message'),
                 'subject': operation.get('subject'),
             }

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -1612,6 +1612,7 @@ def cleanup_data(obj):
 def main():
     """Main ansible module function
     """
+
     module = AnsibleModule(
         argument_spec=dict(
             server_url=dict(type='str', required=True, aliases=['url']),
@@ -1633,12 +1634,290 @@ def main():
             recovery_default_subject=dict(type='str', required=False, default=None),
             acknowledge_default_message=dict(type='str', required=False, default=None),
             acknowledge_default_subject=dict(type='str', required=False, default=None),
-            conditions=dict(type='list', required=False, default=None),
+            conditions=dict(
+                type='list',
+                required=False,
+                elements='dict',
+                options=dict(
+                    formulaid=dict(type='str', required=False),
+                    operator=dict(type='str', required=True),
+                    type=dict(type='str', required=True),
+                    value=dict(type='str', required=True),
+                    value2=dict(type='str', required=False)
+                )
+            ),
             formula=dict(type='str', required=False, default=None),
             eval_type=dict(type='str', required=False, default=None, choices=['andor', 'and', 'or', 'custom_expression']),
-            operations=dict(type='list', required=False, default=None),
-            recovery_operations=dict(type='list', required=False, default=[]),
-            acknowledge_operations=dict(type='list', required=False, default=[])
+            operations=dict(
+                type='list',
+                required=False,
+                elements='dict',
+                options=dict(
+                    type=dict(
+                        type='str',
+                        required=True,
+                        choices=[
+                            'send_message',
+                            'remote_command',
+                            'add_host',
+                            'remove_host',
+                            'add_to_host_group',
+                            'remove_from_host_group',
+                            'link_to_template',
+                            'unlink_from_template',
+                            'enable_host',
+                            'disable_host',
+                            'set_host_inventory_mode',
+                        ]
+                    ),
+                    esc_period=dict(type='int', required=False),
+                    esc_step_from=dict(type='int', required=False, default=1),
+                    esc_step_to=dict(type='int', required=False, default=1),
+                    # when type is remote_command
+                    command_type=dict(
+                        type='str',
+                        required=False,
+                        choices=[
+                            'custom_script',
+                            'ipmi',
+                            'ssh',
+                            'telnet',
+                            'global_script'
+                        ]
+                    ),
+                    command=dict(type='str', required=False),
+                    execute_on=dict(
+                        type='str',
+                        required=False,
+                        choices=['agent', 'server', 'proxy']
+                    ),
+                    password=dict(type='str', required=False),
+                    port=dict(type='int', required=False),
+                    run_on_groups=dict(type='list', required=False),
+                    run_on_hosts=dict(type='list', required=False),
+                    script_name=dict(type='str', required=False),
+                    ssh_auth_type=dict(
+                        type='str',
+                        required=False,
+                        default='password',
+                        choices=['password', 'public_key']
+                    ),
+                    ssh_privatekey_file=dict(type='str', required=False),
+                    ssh_publickey_file=dict(type='str', required=False),
+                    username=dict(type='str', required=False),
+                    # when type is send_message
+                    media_type=dict(type='str', required=False),
+                    subject=dict(type='str', required=False),
+                    message=dict(type='str', required=False),
+                    send_to_groups=dict(type='list', required=False),
+                    send_to_users=dict(type='list', required=False),
+                    # when type is add_to_host_group or remove_from_host_group
+                    host_groups=dict(type='list', required=False),
+                    # when type is set_host_inventory_mode
+                    inventory=dict(type='str', required=False),
+                    # when type is link_to_template or unlink_from_template
+                    templates=dict(type='list', required=False)
+                ),
+                required_if=[
+                    ['type', 'remote_command', ['command_type']],
+                    ['type', 'remote_command', ['run_on_groups', 'run_on_hosts'], True],
+                    ['command_type', 'custom_script', [
+                        'command',
+                        'execute_on'
+                    ]],
+                    ['command_type', 'ipmi', ['command']],
+                    ['command_type', 'ssh', [
+                        'command',
+                        'password',
+                        'username',
+                        'port',
+                        'ssh_auth_type',
+                        'ssh_privatekey_file',
+                        'ssh_publickey_file'
+                    ]],
+                    ['command_type', 'telnet', [
+                        'command',
+                        'password',
+                        'username',
+                        'port'
+                    ]],
+                    ['command_type', 'global_script', ['script_name']],
+                    ['type', 'add_to_host_group', ['host_groups']],
+                    ['type', 'remove_from_host_group', ['host_groups']],
+                    ['type', 'link_to_template', ['templates']],
+                    ['type', 'unlink_from_template', ['templates']],
+                    ['type', 'set_host_inventory_mode', ['inventory']],
+                    ['type', 'send_message', ['send_to_users', 'send_to_groups'], True]
+                ]
+            ),
+            recovery_operations=dict(
+                type='list',
+                required=False,
+                default=[],
+                elements='dict',
+                options=dict(
+                    type=dict(
+                        type='str',
+                        required=True,
+                        choices=[
+                            'send_message',
+                            'remote_command',
+                            'notify_all_involved'
+                        ]
+                    ),
+                    # when type is remote_command
+                    command_type=dict(
+                        type='str',
+                        required=False,
+                        choices=[
+                            'custom_script',
+                            'ipmi',
+                            'ssh',
+                            'telnet',
+                            'global_script'
+                        ]
+                    ),
+                    command=dict(type='str', required=False),
+                    execute_on=dict(
+                        type='str',
+                        required=False,
+                        choices=['agent', 'server', 'proxy']
+                    ),
+                    password=dict(type='str', required=False),
+                    port=dict(type='int', required=False),
+                    run_on_groups=dict(type='list', required=False),
+                    run_on_hosts=dict(type='list', required=False),
+                    script_name=dict(type='str', required=False),
+                    ssh_auth_type=dict(
+                        type='str',
+                        required=False,
+                        default='password',
+                        choices=['password', 'public_key']
+                    ),
+                    ssh_privatekey_file=dict(type='str', required=False),
+                    ssh_publickey_file=dict(type='str', required=False),
+                    username=dict(type='str', required=False),
+                    # when type is send_message
+                    media_type=dict(type='str', required=False),
+                    subject=dict(type='str', required=False),
+                    message=dict(type='str', required=False),
+                    send_to_groups=dict(type='list', required=False),
+                    send_to_users=dict(type='list', required=False),
+                ),
+                required_if=[
+                    ['type', 'remote_command', ['command_type']],
+                    ['type', 'remote_command', [
+                        'run_on_groups',
+                        'run_on_hosts'
+                    ], True],
+                    ['command_type', 'custom_script', [
+                        'command',
+                        'execute_on'
+                    ]],
+                    ['command_type', 'ipmi', ['command']],
+                    ['command_type', 'ssh', [
+                        'command',
+                        'password',
+                        'username',
+                        'port',
+                        'ssh_auth_type',
+                        'ssh_privatekey_file',
+                        'ssh_publickey_file'
+                    ]],
+                    ['command_type', 'telnet', [
+                        'command',
+                        'password',
+                        'username',
+                        'port'
+                    ]],
+                    ['command_type', 'global_script', ['script_name']],
+                    ['type', 'send_message', ['send_to_users', 'send_to_groups'], True]
+                ]
+            ),
+            acknowledge_operations=dict(
+                type='list',
+                required=False,
+                default=[],
+                elements='dict',
+                options=dict(
+                    type=dict(
+                        type='str',
+                        required=True,
+                        choices=[
+                            'send_message',
+                            'remote_command',
+                            'notify_all_involved'
+                        ]
+                    ),
+                    # when type is remote_command
+                    command_type=dict(
+                        type='str',
+                        required=False,
+                        choices=[
+                            'custom_script',
+                            'ipmi',
+                            'ssh',
+                            'telnet',
+                            'global_script'
+                        ]
+                    ),
+                    command=dict(type='str', required=False),
+                    execute_on=dict(
+                        type='str',
+                        required=False,
+                        choices=['agent', 'server', 'proxy']
+                    ),
+                    password=dict(type='str', required=False),
+                    port=dict(type='int', required=False),
+                    run_on_groups=dict(type='list', required=False),
+                    run_on_hosts=dict(type='list', required=False),
+                    script_name=dict(type='str', required=False),
+                    ssh_auth_type=dict(
+                        type='str',
+                        required=False,
+                        default='password',
+                        choices=['password', 'public_key']
+                    ),
+                    ssh_privatekey_file=dict(type='str', required=False),
+                    ssh_publickey_file=dict(type='str', required=False),
+                    username=dict(type='str', required=False),
+                    # when type is send_message
+                    media_type=dict(type='str', required=False),
+                    subject=dict(type='str', required=False),
+                    message=dict(type='str', required=False),
+                    send_to_groups=dict(type='list', required=False),
+                    send_to_users=dict(type='list', required=False),
+                ),
+                required_if=[
+                    ['type', 'remote_command', ['command_type']],
+                    ['type', 'remote_command', [
+                        'run_on_groups',
+                        'run_on_hosts'
+                    ], True],
+                    ['command_type', 'custom_script', [
+                        'command',
+                        'execute_on'
+                    ]],
+                    ['command_type', 'ipmi', ['command']],
+                    ['command_type', 'ssh', [
+                        'command',
+                        'password',
+                        'username',
+                        'port',
+                        'ssh_auth_type',
+                        'ssh_privatekey_file',
+                        'ssh_publickey_file'
+                    ]],
+                    ['command_type', 'telnet', [
+                        'command',
+                        'password',
+                        'username',
+                        'port'
+                    ]],
+                    ['command_type', 'global_script', ['script_name']],
+                    ['type', 'send_message', ['send_to_users', 'send_to_groups'], True]
+                ]
+            )
         ),
         supports_check_mode=True
     )

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host_facts.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host_facts.py
@@ -137,7 +137,6 @@ class Host(object):
         listed_hostnames = []
         for zabbix_host in hosts:
             if zabbix_host['name'] in listed_hostnames:
-                self._zapi.host.delete([zabbix_host['hostid']])
                 continue
             unique_hosts.append(zabbix_host)
             listed_hostnames.append(zabbix_host['name'])

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -566,12 +566,6 @@ def main():
             filename = url_filename(info['url'])
         dest = os.path.join(dest, filename)
 
-    # If the remote URL exists, we're done with check mode
-    if module.check_mode:
-        os.remove(tmpsrc)
-        result['changed'] = True
-        module.exit_json(msg=info.get('msg', ''), **result)
-
     # raise an error if there is no tmpsrc file
     if not os.path.exists(tmpsrc):
         os.remove(tmpsrc)
@@ -598,6 +592,13 @@ def main():
         if not os.access(os.path.dirname(dest), os.W_OK):
             os.remove(tmpsrc)
             module.fail_json(msg="Destination %s is not writable" % (os.path.dirname(dest)), **result)
+
+    if module.check_mode:
+        if os.path.exists(tmpsrc):
+            os.remove(tmpsrc)
+        result['changed'] = ('checksum_dest' not in result or
+                             result['checksum_src'] != result['checksum_dest'])
+        module.exit_json(msg=info.get('msg', ''), **result)
 
     backup_file = None
     if result['checksum_src'] != result['checksum_dest']:

--- a/lib/ansible/modules/network/fortios/fortios_wireless_controller_setting.py
+++ b/lib/ansible/modules/network/fortios/fortios_wireless_controller_setting.py
@@ -1,0 +1,449 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_wireless_controller_setting
+short_description: VDOM wireless controller configuration in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS by allowing the
+      user to set and modify wireless_controller feature and setting category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.2
+version_added: "2.8"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+       description:
+            - FortiOS or FortiGate ip address.
+       required: true
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        required: true
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS
+              protocol
+        type: bool
+        default: true
+    wireless_controller_setting:
+        description:
+            - VDOM wireless controller configuration.
+        default: null
+        suboptions:
+            account-id:
+                description:
+                    - FortiCloud customer account ID.
+            country:
+                description:
+                    - Country or region in which the FortiGate is located. The country determines the 802.11 bands and channels that are available.
+                choices:
+                    - NA
+                    - AL
+                    - DZ
+                    - AO
+                    - AR
+                    - AM
+                    - AU
+                    - AT
+                    - AZ
+                    - BH
+                    - BD
+                    - BB
+                    - BY
+                    - BE
+                    - BZ
+                    - BO
+                    - BA
+                    - BR
+                    - BN
+                    - BG
+                    - KH
+                    - CL
+                    - CN
+                    - CO
+                    - CR
+                    - HR
+                    - CY
+                    - CZ
+                    - DK
+                    - DO
+                    - EC
+                    - EG
+                    - SV
+                    - EE
+                    - FI
+                    - FR
+                    - GE
+                    - DE
+                    - GR
+                    - GL
+                    - GD
+                    - GU
+                    - GT
+                    - HT
+                    - HN
+                    - HK
+                    - HU
+                    - IS
+                    - IN
+                    - ID
+                    - IR
+                    - IE
+                    - IL
+                    - IT
+                    - JM
+                    - JO
+                    - KZ
+                    - KE
+                    - KP
+                    - KR
+                    - KW
+                    - LV
+                    - LB
+                    - LI
+                    - LT
+                    - LU
+                    - MO
+                    - MK
+                    - MY
+                    - MT
+                    - MX
+                    - MC
+                    - MA
+                    - MZ
+                    - MM
+                    - NP
+                    - NL
+                    - AN
+                    - AW
+                    - NZ
+                    - NO
+                    - OM
+                    - PK
+                    - PA
+                    - PG
+                    - PY
+                    - PE
+                    - PH
+                    - PL
+                    - PT
+                    - PR
+                    - QA
+                    - RO
+                    - RU
+                    - RW
+                    - SA
+                    - RS
+                    - ME
+                    - SG
+                    - SK
+                    - SI
+                    - ZA
+                    - ES
+                    - LK
+                    - SE
+                    - SD
+                    - CH
+                    - SY
+                    - TW
+                    - TZ
+                    - TH
+                    - TT
+                    - TN
+                    - TR
+                    - AE
+                    - UA
+                    - GB
+                    - US
+                    - PS
+                    - UY
+                    - UZ
+                    - VE
+                    - VN
+                    - YE
+                    - ZB
+                    - ZW
+                    - JP
+                    - CA
+            duplicate-ssid:
+                description:
+                    - Enable/disable allowing Virtual Access Points (VAPs) to use the same SSID name in the same VDOM.
+                choices:
+                    - enable
+                    - disable
+            fapc-compatibility:
+                description:
+                    - Enable/disable FAP-C series compatibility.
+                choices:
+                    - enable
+                    - disable
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+  tasks:
+  - name: VDOM wireless controller configuration.
+    fortios_wireless_controller_setting:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      wireless_controller_setting:
+        account-id: "<your_own_value>"
+        country: "NA"
+        duplicate-ssid: "enable"
+        fapc-compatibility: "enable"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password)
+
+
+def filter_wireless_controller_setting_data(json):
+    option_list = ['account-id', 'country', 'duplicate-ssid',
+                   'fapc-compatibility']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def flatten_multilists_attributes(data):
+    multilist_attrs = []
+
+    for attr in multilist_attrs:
+        try:
+            path = "data['" + "']['".join(elem for elem in attr) + "']"
+            current_val = eval(path)
+            flattened_val = ' '.join(elem for elem in current_val)
+            exec(path + '= flattened_val')
+        except BaseException:
+            pass
+
+    return data
+
+
+def wireless_controller_setting(data, fos):
+    vdom = data['vdom']
+    wireless_controller_setting_data = data['wireless_controller_setting']
+    flattened_data = flatten_multilists_attributes(wireless_controller_setting_data)
+    filtered_data = filter_wireless_controller_setting_data(flattened_data)
+    return fos.set('wireless-controller',
+                   'setting',
+                   data=filtered_data,
+                   vdom=vdom)
+
+
+def fortios_wireless_controller(data, fos):
+    login(data, fos)
+
+    if data['wireless_controller_setting']:
+        resp = wireless_controller_setting(data, fos)
+
+    fos.logout()
+    return not resp['status'] == "success", resp['status'] == "success", resp
+
+
+def main():
+    fields = {
+        "host": {"required": True, "type": "str"},
+        "username": {"required": True, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "wireless_controller_setting": {
+            "required": False, "type": "dict",
+            "options": {
+                "account-id": {"required": False, "type": "str"},
+                "country": {"required": False, "type": "str",
+                            "choices": ["NA", "AL", "DZ",
+                                        "AO", "AR", "AM",
+                                        "AU", "AT", "AZ",
+                                        "BH", "BD", "BB",
+                                        "BY", "BE", "BZ",
+                                        "BO", "BA", "BR",
+                                        "BN", "BG", "KH",
+                                        "CL", "CN", "CO",
+                                        "CR", "HR", "CY",
+                                        "CZ", "DK", "DO",
+                                        "EC", "EG", "SV",
+                                        "EE", "FI", "FR",
+                                        "GE", "DE", "GR",
+                                        "GL", "GD", "GU",
+                                        "GT", "HT", "HN",
+                                        "HK", "HU", "IS",
+                                        "IN", "ID", "IR",
+                                        "IE", "IL", "IT",
+                                        "JM", "JO", "KZ",
+                                        "KE", "KP", "KR",
+                                        "KW", "LV", "LB",
+                                        "LI", "LT", "LU",
+                                        "MO", "MK", "MY",
+                                        "MT", "MX", "MC",
+                                        "MA", "MZ", "MM",
+                                        "NP", "NL", "AN",
+                                        "AW", "NZ", "NO",
+                                        "OM", "PK", "PA",
+                                        "PG", "PY", "PE",
+                                        "PH", "PL", "PT",
+                                        "PR", "QA", "RO",
+                                        "RU", "RW", "SA",
+                                        "RS", "ME", "SG",
+                                        "SK", "SI", "ZA",
+                                        "ES", "LK", "SE",
+                                        "SD", "CH", "SY",
+                                        "TW", "TZ", "TH",
+                                        "TT", "TN", "TR",
+                                        "AE", "UA", "GB",
+                                        "US", "PS", "UY",
+                                        "UZ", "VE", "VN",
+                                        "YE", "ZB", "ZW",
+                                        "JP", "CA"]},
+                "duplicate-ssid": {"required": False, "type": "str",
+                                   "choices": ["enable", "disable"]},
+                "fapc-compatibility": {"required": False, "type": "str",
+                                       "choices": ["enable", "disable"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+    try:
+        from fortiosapi import FortiOSAPI
+    except ImportError:
+        module.fail_json(msg="fortiosapi module is required")
+
+    fos = FortiOSAPI()
+
+    is_error, has_changed, result = fortios_wireless_controller(module.params, fos)
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_wireless_controller_utm_profile.py
+++ b/lib/ansible/modules/network/fortios/fortios_wireless_controller_utm_profile.py
@@ -1,0 +1,316 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_wireless_controller_utm_profile
+short_description: Configure UTM (Unified Threat Management) profile in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS by allowing the
+      user to set and modify wireless_controller feature and utm_profile category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.2
+version_added: "2.8"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+       description:
+            - FortiOS or FortiGate ip address.
+       required: true
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        required: true
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS
+              protocol
+        type: bool
+        default: true
+    wireless_controller_utm_profile:
+        description:
+            - Configure UTM (Unified Threat Management) profile.
+        default: null
+        suboptions:
+            state:
+                description:
+                    - Indicates whether to create or remove the object
+                choices:
+                    - present
+                    - absent
+            antivirus-profile:
+                description:
+                    - AntiVirus profile name. Source antivirus.profile.name.
+            application-list:
+                description:
+                    - Application control list name. Source application.list.name.
+            comment:
+                description:
+                    - Comment.
+            ips-sensor:
+                description:
+                    - IPS sensor name. Source ips.sensor.name.
+            name:
+                description:
+                    - UTM profile name.
+                required: true
+            scan-botnet-connections:
+                description:
+                    - Block or monitor connections to Botnet servers or disable Botnet scanning.
+                choices:
+                    - disable
+                    - block
+                    - monitor
+            utm-log:
+                description:
+                    - Enable/disable UTM logging.
+                choices:
+                    - enable
+                    - disable
+            webfilter-profile:
+                description:
+                    - WebFilter profile name. Source webfilter.profile.name.
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+  tasks:
+  - name: Configure UTM (Unified Threat Management) profile.
+    fortios_wireless_controller_utm_profile:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      wireless_controller_utm_profile:
+        state: "present"
+        antivirus-profile: "<your_own_value> (source antivirus.profile.name)"
+        application-list: "<your_own_value> (source application.list.name)"
+        comment: "Comment."
+        ips-sensor: "<your_own_value> (source ips.sensor.name)"
+        name: "default_name_7"
+        scan-botnet-connections: "disable"
+        utm-log: "enable"
+        webfilter-profile: "<your_own_value> (source webfilter.profile.name)"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password)
+
+
+def filter_wireless_controller_utm_profile_data(json):
+    option_list = ['antivirus-profile', 'application-list', 'comment',
+                   'ips-sensor', 'name', 'scan-botnet-connections',
+                   'utm-log', 'webfilter-profile']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def flatten_multilists_attributes(data):
+    multilist_attrs = []
+
+    for attr in multilist_attrs:
+        try:
+            path = "data['" + "']['".join(elem for elem in attr) + "']"
+            current_val = eval(path)
+            flattened_val = ' '.join(elem for elem in current_val)
+            exec(path + '= flattened_val')
+        except BaseException:
+            pass
+
+    return data
+
+
+def wireless_controller_utm_profile(data, fos):
+    vdom = data['vdom']
+    wireless_controller_utm_profile_data = data['wireless_controller_utm_profile']
+    flattened_data = flatten_multilists_attributes(wireless_controller_utm_profile_data)
+    filtered_data = filter_wireless_controller_utm_profile_data(flattened_data)
+    if wireless_controller_utm_profile_data['state'] == "present":
+        return fos.set('wireless-controller',
+                       'utm-profile',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif wireless_controller_utm_profile_data['state'] == "absent":
+        return fos.delete('wireless-controller',
+                          'utm-profile',
+                          mkey=filtered_data['name'],
+                          vdom=vdom)
+
+
+def fortios_wireless_controller(data, fos):
+    login(data, fos)
+
+    if data['wireless_controller_utm_profile']:
+        resp = wireless_controller_utm_profile(data, fos)
+
+    fos.logout()
+    return not resp['status'] == "success", resp['status'] == "success", resp
+
+
+def main():
+    fields = {
+        "host": {"required": True, "type": "str"},
+        "username": {"required": True, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "wireless_controller_utm_profile": {
+            "required": False, "type": "dict",
+            "options": {
+                "state": {"required": True, "type": "str",
+                          "choices": ["present", "absent"]},
+                "antivirus-profile": {"required": False, "type": "str"},
+                "application-list": {"required": False, "type": "str"},
+                "comment": {"required": False, "type": "str"},
+                "ips-sensor": {"required": False, "type": "str"},
+                "name": {"required": True, "type": "str"},
+                "scan-botnet-connections": {"required": False, "type": "str",
+                                            "choices": ["disable", "block", "monitor"]},
+                "utm-log": {"required": False, "type": "str",
+                            "choices": ["enable", "disable"]},
+                "webfilter-profile": {"required": False, "type": "str"}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+    try:
+        from fortiosapi import FortiOSAPI
+    except ImportError:
+        module.fail_json(msg="fortiosapi module is required")
+
+    fos = FortiOSAPI()
+
+    is_error, has_changed, result = fortios_wireless_controller(module.params, fos)
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_wireless_controller_vap.py
+++ b/lib/ansible/modules/network/fortios/fortios_wireless_controller_vap.py
@@ -1,0 +1,1318 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_wireless_controller_vap
+short_description: Configure Virtual Access Points (VAPs) in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS by allowing the
+      user to set and modify wireless_controller feature and vap category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.2
+version_added: "2.8"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+       description:
+            - FortiOS or FortiGate ip address.
+       required: true
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        required: true
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS
+              protocol
+        type: bool
+        default: true
+    wireless_controller_vap:
+        description:
+            - Configure Virtual Access Points (VAPs).
+        default: null
+        suboptions:
+            state:
+                description:
+                    - Indicates whether to create or remove the object
+                choices:
+                    - present
+                    - absent
+            acct-interim-interval:
+                description:
+                    - WiFi RADIUS accounting interim interval (60 - 86400 sec, default = 0).
+            alias:
+                description:
+                    - Alias.
+            auth:
+                description:
+                    - Authentication protocol.
+                choices:
+                    - psk
+                    - radius
+                    - usergroup
+            broadcast-ssid:
+                description:
+                    - Enable/disable broadcasting the SSID (default = enable).
+                choices:
+                    - enable
+                    - disable
+            broadcast-suppression:
+                description:
+                    - Optional suppression of broadcast messages. For example, you can keep DHCP messages, ARP broadcasts, and so on off of the wireless
+                       network.
+                choices:
+                    - dhcp-up
+                    - dhcp-down
+                    - dhcp-starvation
+                    - arp-known
+                    - arp-unknown
+                    - arp-reply
+                    - arp-poison
+                    - arp-proxy
+                    - netbios-ns
+                    - netbios-ds
+                    - ipv6
+                    - all-other-mc
+                    - all-other-bc
+            captive-portal-ac-name:
+                description:
+                    - Local-bridging captive portal ac-name.
+            captive-portal-macauth-radius-secret:
+                description:
+                    - Secret key to access the macauth RADIUS server.
+            captive-portal-macauth-radius-server:
+                description:
+                    - Captive portal external RADIUS server domain name or IP address.
+            captive-portal-radius-secret:
+                description:
+                    - Secret key to access the RADIUS server.
+            captive-portal-radius-server:
+                description:
+                    - Captive portal RADIUS server domain name or IP address.
+            captive-portal-session-timeout-interval:
+                description:
+                    - Session timeout interval (0 - 864000 sec, default = 0).
+            dhcp-lease-time:
+                description:
+                    - DHCP lease time in seconds for NAT IP address.
+            dhcp-option82-circuit-id-insertion:
+                description:
+                    - Enable/disable DHCP option 82 circuit-id insert (default = disable).
+                choices:
+                    - style-1
+                    - style-2
+                    - disable
+            dhcp-option82-insertion:
+                description:
+                    - Enable/disable DHCP option 82 insert (default = disable).
+                choices:
+                    - enable
+                    - disable
+            dhcp-option82-remote-id-insertion:
+                description:
+                    - Enable/disable DHCP option 82 remote-id insert (default = disable).
+                choices:
+                    - style-1
+                    - disable
+            dynamic-vlan:
+                description:
+                    - Enable/disable dynamic VLAN assignment.
+                choices:
+                    - enable
+                    - disable
+            eap-reauth:
+                description:
+                    - Enable/disable EAP re-authentication for WPA-Enterprise security.
+                choices:
+                    - enable
+                    - disable
+            eap-reauth-intv:
+                description:
+                    - EAP re-authentication interval (1800 - 864000 sec, default = 86400).
+            eapol-key-retries:
+                description:
+                    - Enable/disable retransmission of EAPOL-Key frames (message 3/4 and group message 1/2) (default = enable).
+                choices:
+                    - disable
+                    - enable
+            encrypt:
+                description:
+                    - Encryption protocol to use (only available when security is set to a WPA type).
+                choices:
+                    - TKIP
+                    - AES
+                    - TKIP-AES
+            external-fast-roaming:
+                description:
+                    - Enable/disable fast roaming or pre-authentication with external APs not managed by the FortiGate (default = disable).
+                choices:
+                    - enable
+                    - disable
+            external-logout:
+                description:
+                    - URL of external authentication logout server.
+            external-web:
+                description:
+                    - URL of external authentication web server.
+            fast-bss-transition:
+                description:
+                    - Enable/disable 802.11r Fast BSS Transition (FT) (default = disable).
+                choices:
+                    - disable
+                    - enable
+            fast-roaming:
+                description:
+                    - Enable/disable fast-roaming, or pre-authentication, where supported by clients (default = disable).
+                choices:
+                    - enable
+                    - disable
+            ft-mobility-domain:
+                description:
+                    - Mobility domain identifier in FT (1 - 65535, default = 1000).
+            ft-over-ds:
+                description:
+                    - Enable/disable FT over the Distribution System (DS).
+                choices:
+                    - disable
+                    - enable
+            ft-r0-key-lifetime:
+                description:
+                    - Lifetime of the PMK-R0 key in FT, 1-65535 minutes.
+            gtk-rekey:
+                description:
+                    - Enable/disable GTK rekey for WPA security.
+                choices:
+                    - enable
+                    - disable
+            gtk-rekey-intv:
+                description:
+                    - GTK rekey interval (1800 - 864000 sec, default = 86400).
+            hotspot20-profile:
+                description:
+                    - Hotspot 2.0 profile name.
+            intra-vap-privacy:
+                description:
+                    - Enable/disable blocking communication between clients on the same SSID (called intra-SSID privacy) (default = disable).
+                choices:
+                    - enable
+                    - disable
+            ip:
+                description:
+                    - IP address and subnet mask for the local standalone NAT subnet.
+            key:
+                description:
+                    - WEP Key.
+            keyindex:
+                description:
+                    - WEP key index (1 - 4).
+            ldpc:
+                description:
+                    - VAP low-density parity-check (LDPC) coding configuration.
+                choices:
+                    - disable
+                    - rx
+                    - tx
+                    - rxtx
+            local-authentication:
+                description:
+                    - Enable/disable AP local authentication.
+                choices:
+                    - enable
+                    - disable
+            local-bridging:
+                description:
+                    - Enable/disable bridging of wireless and Ethernet interfaces on the FortiAP (default = disable).
+                choices:
+                    - enable
+                    - disable
+            local-lan:
+                description:
+                    - Allow/deny traffic destined for a Class A, B, or C private IP address (default = allow).
+                choices:
+                    - allow
+                    - deny
+            local-standalone:
+                description:
+                    - Enable/disable AP local standalone (default = disable).
+                choices:
+                    - enable
+                    - disable
+            local-standalone-nat:
+                description:
+                    - Enable/disable AP local standalone NAT mode.
+                choices:
+                    - enable
+                    - disable
+            mac-auth-bypass:
+                description:
+                    - Enable/disable MAC authentication bypass.
+                choices:
+                    - enable
+                    - disable
+            mac-filter:
+                description:
+                    - Enable/disable MAC filtering to block wireless clients by mac address.
+                choices:
+                    - enable
+                    - disable
+            mac-filter-list:
+                description:
+                    - Create a list of MAC addresses for MAC address filtering.
+                suboptions:
+                    id:
+                        description:
+                            - ID.
+                        required: true
+                    mac:
+                        description:
+                            - MAC address.
+                    mac-filter-policy:
+                        description:
+                            - Deny or allow the client with this MAC address.
+                        choices:
+                            - allow
+                            - deny
+            mac-filter-policy-other:
+                description:
+                    - Allow or block clients with MAC addresses that are not in the filter list.
+                choices:
+                    - allow
+                    - deny
+            max-clients:
+                description:
+                    - Maximum number of clients that can connect simultaneously to the VAP (default = 0, meaning no limitation).
+            max-clients-ap:
+                description:
+                    - Maximum number of clients that can connect simultaneously to each radio (default = 0, meaning no limitation).
+            me-disable-thresh:
+                description:
+                    - Disable multicast enhancement when this many clients are receiving multicast traffic.
+            mesh-backhaul:
+                description:
+                    - Enable/disable using this VAP as a WiFi mesh backhaul (default = disable). This entry is only available when security is set to a WPA
+                       type or open.
+                choices:
+                    - enable
+                    - disable
+            mpsk:
+                description:
+                    - Enable/disable multiple pre-shared keys (PSKs.)
+                choices:
+                    - enable
+                    - disable
+            mpsk-concurrent-clients:
+                description:
+                    - Number of pre-shared keys (PSKs) to allow if multiple pre-shared keys are enabled.
+            mpsk-key:
+                description:
+                    - Pre-shared keys that can be used to connect to this virtual access point.
+                suboptions:
+                    comment:
+                        description:
+                            - Comment.
+                    concurrent-clients:
+                        description:
+                            - Number of clients that can connect using this pre-shared key.
+                    key-name:
+                        description:
+                            - Pre-shared key name.
+                        required: true
+                    passphrase:
+                        description:
+                            - WPA Pre-shared key.
+            multicast-enhance:
+                description:
+                    - Enable/disable converting multicast to unicast to improve performance (default = disable).
+                choices:
+                    - enable
+                    - disable
+            multicast-rate:
+                description:
+                    - Multicast rate (0, 6000, 12000, or 24000 kbps, default = 0).
+                choices:
+                    - 0
+                    - 6000
+                    - 12000
+                    - 24000
+            name:
+                description:
+                    - Virtual AP name.
+                required: true
+            okc:
+                description:
+                    - Enable/disable Opportunistic Key Caching (OKC) (default = enable).
+                choices:
+                    - disable
+                    - enable
+            passphrase:
+                description:
+                    - WPA pre-shard key (PSK) to be used to authenticate WiFi users.
+            pmf:
+                description:
+                    - Protected Management Frames (PMF) support (default = disable).
+                choices:
+                    - disable
+                    - enable
+                    - optional
+            pmf-assoc-comeback-timeout:
+                description:
+                    - Protected Management Frames (PMF) comeback maximum timeout (1-20 sec).
+            pmf-sa-query-retry-timeout:
+                description:
+                    - Protected Management Frames (PMF) SA query retry timeout interval (1 - 5 100s of msec).
+            portal-message-override-group:
+                description:
+                    - Replacement message group for this VAP (only available when security is set to a captive portal type).
+            portal-message-overrides:
+                description:
+                    - Individual message overrides.
+                suboptions:
+                    auth-disclaimer-page:
+                        description:
+                            - Override auth-disclaimer-page message with message from portal-message-overrides group.
+                    auth-login-failed-page:
+                        description:
+                            - Override auth-login-failed-page message with message from portal-message-overrides group.
+                    auth-login-page:
+                        description:
+                            - Override auth-login-page message with message from portal-message-overrides group.
+                    auth-reject-page:
+                        description:
+                            - Override auth-reject-page message with message from portal-message-overrides group.
+            portal-type:
+                description:
+                    - Captive portal functionality. Configure how the captive portal authenticates users and whether it includes a disclaimer.
+                choices:
+                    - auth
+                    - auth+disclaimer
+                    - disclaimer
+                    - email-collect
+                    - cmcc
+                    - cmcc-macauth
+                    - auth-mac
+            probe-resp-suppression:
+                description:
+                    - Enable/disable probe response suppression (to ignore weak signals) (default = disable).
+                choices:
+                    - enable
+                    - disable
+            probe-resp-threshold:
+                description:
+                    - Minimum signal level/threshold in dBm required for the AP response to probe requests (-95 to -20, default = -80).
+            ptk-rekey:
+                description:
+                    - Enable/disable PTK rekey for WPA-Enterprise security.
+                choices:
+                    - enable
+                    - disable
+            ptk-rekey-intv:
+                description:
+                    - PTK rekey interval (1800 - 864000 sec, default = 86400).
+            qos-profile:
+                description:
+                    - Quality of service profile name.
+            quarantine:
+                description:
+                    - Enable/disable station quarantine (default = enable).
+                choices:
+                    - enable
+                    - disable
+            radio-2g-threshold:
+                description:
+                    - Minimum signal level/threshold in dBm required for the AP response to receive a packet in 2.4G band (-95 to -20, default = -79).
+            radio-5g-threshold:
+                description:
+                    - Minimum signal level/threshold in dBm required for the AP response to receive a packet in 5G band(-95 to -20, default = -76).
+            radio-sensitivity:
+                description:
+                    - Enable/disable software radio sensitivity (to ignore weak signals) (default = disable).
+                choices:
+                    - enable
+                    - disable
+            radius-mac-auth:
+                description:
+                    - Enable/disable RADIUS-based MAC authentication of clients (default = disable).
+                choices:
+                    - enable
+                    - disable
+            radius-mac-auth-server:
+                description:
+                    - RADIUS-based MAC authentication server.
+            radius-mac-auth-usergroups:
+                description:
+                    - Selective user groups that are permitted for RADIUS mac authentication.
+                suboptions:
+                    name:
+                        description:
+                            - User group name.
+                        required: true
+            radius-server:
+                description:
+                    - RADIUS server to be used to authenticate WiFi users.
+            rates-11a:
+                description:
+                    - Allowed data rates for 802.11a.
+                choices:
+                    - 1
+                    - 1-basic
+                    - 2
+                    - 2-basic
+                    - 5.5
+                    - 5.5-basic
+                    - 11
+                    - 11-basic
+                    - 6
+                    - 6-basic
+                    - 9
+                    - 9-basic
+                    - 12
+                    - 12-basic
+                    - 18
+                    - 18-basic
+                    - 24
+                    - 24-basic
+                    - 36
+                    - 36-basic
+                    - 48
+                    - 48-basic
+                    - 54
+                    - 54-basic
+            rates-11ac-ss12:
+                description:
+                    - Allowed data rates for 802.11ac with 1 or 2 spatial streams.
+                choices:
+                    - mcs0/1
+                    - mcs1/1
+                    - mcs2/1
+                    - mcs3/1
+                    - mcs4/1
+                    - mcs5/1
+                    - mcs6/1
+                    - mcs7/1
+                    - mcs8/1
+                    - mcs9/1
+                    - mcs10/1
+                    - mcs11/1
+                    - mcs0/2
+                    - mcs1/2
+                    - mcs2/2
+                    - mcs3/2
+                    - mcs4/2
+                    - mcs5/2
+                    - mcs6/2
+                    - mcs7/2
+                    - mcs8/2
+                    - mcs9/2
+                    - mcs10/2
+                    - mcs11/2
+            rates-11ac-ss34:
+                description:
+                    - Allowed data rates for 802.11ac with 3 or 4 spatial streams.
+                choices:
+                    - mcs0/3
+                    - mcs1/3
+                    - mcs2/3
+                    - mcs3/3
+                    - mcs4/3
+                    - mcs5/3
+                    - mcs6/3
+                    - mcs7/3
+                    - mcs8/3
+                    - mcs9/3
+                    - mcs10/3
+                    - mcs11/3
+                    - mcs0/4
+                    - mcs1/4
+                    - mcs2/4
+                    - mcs3/4
+                    - mcs4/4
+                    - mcs5/4
+                    - mcs6/4
+                    - mcs7/4
+                    - mcs8/4
+                    - mcs9/4
+                    - mcs10/4
+                    - mcs11/4
+            rates-11bg:
+                description:
+                    - Allowed data rates for 802.11b/g.
+                choices:
+                    - 1
+                    - 1-basic
+                    - 2
+                    - 2-basic
+                    - 5.5
+                    - 5.5-basic
+                    - 11
+                    - 11-basic
+                    - 6
+                    - 6-basic
+                    - 9
+                    - 9-basic
+                    - 12
+                    - 12-basic
+                    - 18
+                    - 18-basic
+                    - 24
+                    - 24-basic
+                    - 36
+                    - 36-basic
+                    - 48
+                    - 48-basic
+                    - 54
+                    - 54-basic
+            rates-11n-ss12:
+                description:
+                    - Allowed data rates for 802.11n with 1 or 2 spatial streams.
+                choices:
+                    - mcs0/1
+                    - mcs1/1
+                    - mcs2/1
+                    - mcs3/1
+                    - mcs4/1
+                    - mcs5/1
+                    - mcs6/1
+                    - mcs7/1
+                    - mcs8/2
+                    - mcs9/2
+                    - mcs10/2
+                    - mcs11/2
+                    - mcs12/2
+                    - mcs13/2
+                    - mcs14/2
+                    - mcs15/2
+            rates-11n-ss34:
+                description:
+                    - Allowed data rates for 802.11n with 3 or 4 spatial streams.
+                choices:
+                    - mcs16/3
+                    - mcs17/3
+                    - mcs18/3
+                    - mcs19/3
+                    - mcs20/3
+                    - mcs21/3
+                    - mcs22/3
+                    - mcs23/3
+                    - mcs24/4
+                    - mcs25/4
+                    - mcs26/4
+                    - mcs27/4
+                    - mcs28/4
+                    - mcs29/4
+                    - mcs30/4
+                    - mcs31/4
+            schedule:
+                description:
+                    - VAP schedule name.
+            security:
+                description:
+                    - Security mode for the wireless interface (default = wpa2-only-personal).
+                choices:
+                    - open
+                    - captive-portal
+                    - wep64
+                    - wep128
+                    - wpa-personal
+                    - wpa-personal+captive-portal
+                    - wpa-enterprise
+                    - wpa-only-personal
+                    - wpa-only-personal+captive-portal
+                    - wpa-only-enterprise
+                    - wpa2-only-personal
+                    - wpa2-only-personal+captive-portal
+                    - wpa2-only-enterprise
+                    - osen
+            security-exempt-list:
+                description:
+                    - Optional security exempt list for captive portal authentication.
+            security-obsolete-option:
+                description:
+                    - Enable/disable obsolete security options.
+                choices:
+                    - enable
+                    - disable
+            security-redirect-url:
+                description:
+                    - Optional URL for redirecting users after they pass captive portal authentication.
+            selected-usergroups:
+                description:
+                    - Selective user groups that are permitted to authenticate.
+                suboptions:
+                    name:
+                        description:
+                            - User group name.
+                        required: true
+            split-tunneling:
+                description:
+                    - Enable/disable split tunneling (default = disable).
+                choices:
+                    - enable
+                    - disable
+            ssid:
+                description:
+                    - IEEE 802.11 service set identifier (SSID) for the wireless interface. Users who wish to use the wireless network must configure their
+                       computers to access this SSID name.
+            tkip-counter-measure:
+                description:
+                    - Enable/disable TKIP counter measure.
+                choices:
+                    - enable
+                    - disable
+            usergroup:
+                description:
+                    - Firewall user group to be used to authenticate WiFi users.
+                suboptions:
+                    name:
+                        description:
+                            - User group name.
+                        required: true
+            utm-profile:
+                description:
+                    - UTM profile name.
+            vdom:
+                description:
+                    - Name of the VDOM that the Virtual AP has been added to. Source system.vdom.name.
+            vlan-auto:
+                description:
+                    - Enable/disable automatic management of SSID VLAN interface.
+                choices:
+                    - enable
+                    - disable
+            vlan-pool:
+                description:
+                    - VLAN pool.
+                suboptions:
+                    id:
+                        description:
+                            - ID.
+                        required: true
+                    wtp-group:
+                        description:
+                            - WTP group name.
+            vlan-pooling:
+                description:
+                    - Enable/disable VLAN pooling, to allow grouping of multiple wireless controller VLANs into VLAN pools (default = disable). When set to
+                       wtp-group, VLAN pooling occurs with VLAN assignment by wtp-group.
+                choices:
+                    - wtp-group
+                    - round-robin
+                    - hash
+                    - disable
+            vlanid:
+                description:
+                    - Optional VLAN ID.
+            voice-enterprise:
+                description:
+                    - Enable/disable 802.11k and 802.11v assisted Voice-Enterprise roaming (default = disable).
+                choices:
+                    - disable
+                    - enable
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+  tasks:
+  - name: Configure Virtual Access Points (VAPs).
+    fortios_wireless_controller_vap:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      wireless_controller_vap:
+        state: "present"
+        acct-interim-interval: "3"
+        alias: "<your_own_value>"
+        auth: "psk"
+        broadcast-ssid: "enable"
+        broadcast-suppression: "dhcp-up"
+        captive-portal-ac-name: "<your_own_value>"
+        captive-portal-macauth-radius-secret: "<your_own_value>"
+        captive-portal-macauth-radius-server: "<your_own_value>"
+        captive-portal-radius-secret: "<your_own_value>"
+        captive-portal-radius-server: "<your_own_value>"
+        captive-portal-session-timeout-interval: "13"
+        dhcp-lease-time: "14"
+        dhcp-option82-circuit-id-insertion: "style-1"
+        dhcp-option82-insertion: "enable"
+        dhcp-option82-remote-id-insertion: "style-1"
+        dynamic-vlan: "enable"
+        eap-reauth: "enable"
+        eap-reauth-intv: "20"
+        eapol-key-retries: "disable"
+        encrypt: "TKIP"
+        external-fast-roaming: "enable"
+        external-logout: "<your_own_value>"
+        external-web: "<your_own_value>"
+        fast-bss-transition: "disable"
+        fast-roaming: "enable"
+        ft-mobility-domain: "28"
+        ft-over-ds: "disable"
+        ft-r0-key-lifetime: "30"
+        gtk-rekey: "enable"
+        gtk-rekey-intv: "32"
+        hotspot20-profile: "<your_own_value>"
+        intra-vap-privacy: "enable"
+        ip: "<your_own_value>"
+        key: "<your_own_value>"
+        keyindex: "37"
+        ldpc: "disable"
+        local-authentication: "enable"
+        local-bridging: "enable"
+        local-lan: "allow"
+        local-standalone: "enable"
+        local-standalone-nat: "enable"
+        mac-auth-bypass: "enable"
+        mac-filter: "enable"
+        mac-filter-list:
+         -
+            id:  "47"
+            mac: "<your_own_value>"
+            mac-filter-policy: "allow"
+        mac-filter-policy-other: "allow"
+        max-clients: "51"
+        max-clients-ap: "52"
+        me-disable-thresh: "53"
+        mesh-backhaul: "enable"
+        mpsk: "enable"
+        mpsk-concurrent-clients: "56"
+        mpsk-key:
+         -
+            comment: "Comment."
+            concurrent-clients: "<your_own_value>"
+            key-name: "<your_own_value>"
+            passphrase: "<your_own_value>"
+        multicast-enhance: "enable"
+        multicast-rate: "0"
+        name: "default_name_64"
+        okc: "disable"
+        passphrase: "<your_own_value>"
+        pmf: "disable"
+        pmf-assoc-comeback-timeout: "68"
+        pmf-sa-query-retry-timeout: "69"
+        portal-message-override-group: "<your_own_value>"
+        portal-message-overrides:
+            auth-disclaimer-page: "<your_own_value>"
+            auth-login-failed-page: "<your_own_value>"
+            auth-login-page: "<your_own_value>"
+            auth-reject-page: "<your_own_value>"
+        portal-type: "auth"
+        probe-resp-suppression: "enable"
+        probe-resp-threshold: "<your_own_value>"
+        ptk-rekey: "enable"
+        ptk-rekey-intv: "80"
+        qos-profile: "<your_own_value>"
+        quarantine: "enable"
+        radio-2g-threshold: "<your_own_value>"
+        radio-5g-threshold: "<your_own_value>"
+        radio-sensitivity: "enable"
+        radius-mac-auth: "enable"
+        radius-mac-auth-server: "<your_own_value>"
+        radius-mac-auth-usergroups:
+         -
+            name: "default_name_89"
+        radius-server: "<your_own_value>"
+        rates-11a: "1"
+        rates-11ac-ss12: "mcs0/1"
+        rates-11ac-ss34: "mcs0/3"
+        rates-11bg: "1"
+        rates-11n-ss12: "mcs0/1"
+        rates-11n-ss34: "mcs16/3"
+        schedule: "<your_own_value>"
+        security: "open"
+        security-exempt-list: "<your_own_value>"
+        security-obsolete-option: "enable"
+        security-redirect-url: "<your_own_value>"
+        selected-usergroups:
+         -
+            name: "default_name_103"
+        split-tunneling: "enable"
+        ssid: "<your_own_value>"
+        tkip-counter-measure: "enable"
+        usergroup:
+         -
+            name: "default_name_108"
+        utm-profile: "<your_own_value>"
+        vdom: "<your_own_value> (source system.vdom.name)"
+        vlan-auto: "enable"
+        vlan-pool:
+         -
+            id:  "113"
+            wtp-group: "<your_own_value>"
+        vlan-pooling: "wtp-group"
+        vlanid: "116"
+        voice-enterprise: "disable"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password)
+
+
+def filter_wireless_controller_vap_data(json):
+    option_list = ['acct-interim-interval', 'alias', 'auth',
+                   'broadcast-ssid', 'broadcast-suppression', 'captive-portal-ac-name',
+                   'captive-portal-macauth-radius-secret', 'captive-portal-macauth-radius-server', 'captive-portal-radius-secret',
+                   'captive-portal-radius-server', 'captive-portal-session-timeout-interval', 'dhcp-lease-time',
+                   'dhcp-option82-circuit-id-insertion', 'dhcp-option82-insertion', 'dhcp-option82-remote-id-insertion',
+                   'dynamic-vlan', 'eap-reauth', 'eap-reauth-intv',
+                   'eapol-key-retries', 'encrypt', 'external-fast-roaming',
+                   'external-logout', 'external-web', 'fast-bss-transition',
+                   'fast-roaming', 'ft-mobility-domain', 'ft-over-ds',
+                   'ft-r0-key-lifetime', 'gtk-rekey', 'gtk-rekey-intv',
+                   'hotspot20-profile', 'intra-vap-privacy', 'ip',
+                   'key', 'keyindex', 'ldpc',
+                   'local-authentication', 'local-bridging', 'local-lan',
+                   'local-standalone', 'local-standalone-nat', 'mac-auth-bypass',
+                   'mac-filter', 'mac-filter-list', 'mac-filter-policy-other',
+                   'max-clients', 'max-clients-ap', 'me-disable-thresh',
+                   'mesh-backhaul', 'mpsk', 'mpsk-concurrent-clients',
+                   'mpsk-key', 'multicast-enhance', 'multicast-rate',
+                   'name', 'okc', 'passphrase',
+                   'pmf', 'pmf-assoc-comeback-timeout', 'pmf-sa-query-retry-timeout',
+                   'portal-message-override-group', 'portal-message-overrides', 'portal-type',
+                   'probe-resp-suppression', 'probe-resp-threshold', 'ptk-rekey',
+                   'ptk-rekey-intv', 'qos-profile', 'quarantine',
+                   'radio-2g-threshold', 'radio-5g-threshold', 'radio-sensitivity',
+                   'radius-mac-auth', 'radius-mac-auth-server', 'radius-mac-auth-usergroups',
+                   'radius-server', 'rates-11a', 'rates-11ac-ss12',
+                   'rates-11ac-ss34', 'rates-11bg', 'rates-11n-ss12',
+                   'rates-11n-ss34', 'schedule', 'security',
+                   'security-exempt-list', 'security-obsolete-option', 'security-redirect-url',
+                   'selected-usergroups', 'split-tunneling', 'ssid',
+                   'tkip-counter-measure', 'usergroup', 'utm-profile',
+                   'vdom', 'vlan-auto', 'vlan-pool',
+                   'vlan-pooling', 'vlanid', 'voice-enterprise']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def flatten_multilists_attributes(data):
+    multilist_attrs = []
+
+    for attr in multilist_attrs:
+        try:
+            path = "data['" + "']['".join(elem for elem in attr) + "']"
+            current_val = eval(path)
+            flattened_val = ' '.join(elem for elem in current_val)
+            exec(path + '= flattened_val')
+        except BaseException:
+            pass
+
+    return data
+
+
+def wireless_controller_vap(data, fos):
+    vdom = data['vdom']
+    wireless_controller_vap_data = data['wireless_controller_vap']
+    flattened_data = flatten_multilists_attributes(wireless_controller_vap_data)
+    filtered_data = filter_wireless_controller_vap_data(flattened_data)
+    if wireless_controller_vap_data['state'] == "present":
+        return fos.set('wireless-controller',
+                       'vap',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif wireless_controller_vap_data['state'] == "absent":
+        return fos.delete('wireless-controller',
+                          'vap',
+                          mkey=filtered_data['name'],
+                          vdom=vdom)
+
+
+def fortios_wireless_controller(data, fos):
+    login(data, fos)
+
+    if data['wireless_controller_vap']:
+        resp = wireless_controller_vap(data, fos)
+
+    fos.logout()
+    return not resp['status'] == "success", resp['status'] == "success", resp
+
+
+def main():
+    fields = {
+        "host": {"required": True, "type": "str"},
+        "username": {"required": True, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "wireless_controller_vap": {
+            "required": False, "type": "dict",
+            "options": {
+                "state": {"required": True, "type": "str",
+                          "choices": ["present", "absent"]},
+                "acct-interim-interval": {"required": False, "type": "int"},
+                "alias": {"required": False, "type": "str"},
+                "auth": {"required": False, "type": "str",
+                         "choices": ["psk", "radius", "usergroup"]},
+                "broadcast-ssid": {"required": False, "type": "str",
+                                   "choices": ["enable", "disable"]},
+                "broadcast-suppression": {"required": False, "type": "str",
+                                          "choices": ["dhcp-up", "dhcp-down", "dhcp-starvation",
+                                                      "arp-known", "arp-unknown", "arp-reply",
+                                                      "arp-poison", "arp-proxy", "netbios-ns",
+                                                      "netbios-ds", "ipv6", "all-other-mc",
+                                                      "all-other-bc"]},
+                "captive-portal-ac-name": {"required": False, "type": "str"},
+                "captive-portal-macauth-radius-secret": {"required": False, "type": "str"},
+                "captive-portal-macauth-radius-server": {"required": False, "type": "str"},
+                "captive-portal-radius-secret": {"required": False, "type": "str"},
+                "captive-portal-radius-server": {"required": False, "type": "str"},
+                "captive-portal-session-timeout-interval": {"required": False, "type": "int"},
+                "dhcp-lease-time": {"required": False, "type": "int"},
+                "dhcp-option82-circuit-id-insertion": {"required": False, "type": "str",
+                                                       "choices": ["style-1", "style-2", "disable"]},
+                "dhcp-option82-insertion": {"required": False, "type": "str",
+                                            "choices": ["enable", "disable"]},
+                "dhcp-option82-remote-id-insertion": {"required": False, "type": "str",
+                                                      "choices": ["style-1", "disable"]},
+                "dynamic-vlan": {"required": False, "type": "str",
+                                 "choices": ["enable", "disable"]},
+                "eap-reauth": {"required": False, "type": "str",
+                               "choices": ["enable", "disable"]},
+                "eap-reauth-intv": {"required": False, "type": "int"},
+                "eapol-key-retries": {"required": False, "type": "str",
+                                      "choices": ["disable", "enable"]},
+                "encrypt": {"required": False, "type": "str",
+                            "choices": ["TKIP", "AES", "TKIP-AES"]},
+                "external-fast-roaming": {"required": False, "type": "str",
+                                          "choices": ["enable", "disable"]},
+                "external-logout": {"required": False, "type": "str"},
+                "external-web": {"required": False, "type": "str"},
+                "fast-bss-transition": {"required": False, "type": "str",
+                                        "choices": ["disable", "enable"]},
+                "fast-roaming": {"required": False, "type": "str",
+                                 "choices": ["enable", "disable"]},
+                "ft-mobility-domain": {"required": False, "type": "int"},
+                "ft-over-ds": {"required": False, "type": "str",
+                               "choices": ["disable", "enable"]},
+                "ft-r0-key-lifetime": {"required": False, "type": "int"},
+                "gtk-rekey": {"required": False, "type": "str",
+                              "choices": ["enable", "disable"]},
+                "gtk-rekey-intv": {"required": False, "type": "int"},
+                "hotspot20-profile": {"required": False, "type": "str"},
+                "intra-vap-privacy": {"required": False, "type": "str",
+                                      "choices": ["enable", "disable"]},
+                "ip": {"required": False, "type": "str"},
+                "key": {"required": False, "type": "str"},
+                "keyindex": {"required": False, "type": "int"},
+                "ldpc": {"required": False, "type": "str",
+                         "choices": ["disable", "rx", "tx",
+                                     "rxtx"]},
+                "local-authentication": {"required": False, "type": "str",
+                                         "choices": ["enable", "disable"]},
+                "local-bridging": {"required": False, "type": "str",
+                                   "choices": ["enable", "disable"]},
+                "local-lan": {"required": False, "type": "str",
+                              "choices": ["allow", "deny"]},
+                "local-standalone": {"required": False, "type": "str",
+                                     "choices": ["enable", "disable"]},
+                "local-standalone-nat": {"required": False, "type": "str",
+                                         "choices": ["enable", "disable"]},
+                "mac-auth-bypass": {"required": False, "type": "str",
+                                    "choices": ["enable", "disable"]},
+                "mac-filter": {"required": False, "type": "str",
+                               "choices": ["enable", "disable"]},
+                "mac-filter-list": {"required": False, "type": "list",
+                                    "options": {
+                                        "id": {"required": True, "type": "int"},
+                                        "mac": {"required": False, "type": "str"},
+                                        "mac-filter-policy": {"required": False, "type": "str",
+                                                              "choices": ["allow", "deny"]}
+                                    }},
+                "mac-filter-policy-other": {"required": False, "type": "str",
+                                            "choices": ["allow", "deny"]},
+                "max-clients": {"required": False, "type": "int"},
+                "max-clients-ap": {"required": False, "type": "int"},
+                "me-disable-thresh": {"required": False, "type": "int"},
+                "mesh-backhaul": {"required": False, "type": "str",
+                                  "choices": ["enable", "disable"]},
+                "mpsk": {"required": False, "type": "str",
+                         "choices": ["enable", "disable"]},
+                "mpsk-concurrent-clients": {"required": False, "type": "int"},
+                "mpsk-key": {"required": False, "type": "list",
+                             "options": {
+                                 "comment": {"required": False, "type": "str"},
+                                 "concurrent-clients": {"required": False, "type": "str"},
+                                 "key-name": {"required": True, "type": "str"},
+                                 "passphrase": {"required": False, "type": "str"}
+                             }},
+                "multicast-enhance": {"required": False, "type": "str",
+                                      "choices": ["enable", "disable"]},
+                "multicast-rate": {"required": False, "type": "str",
+                                   "choices": ["0", "6000", "12000",
+                                               "24000"]},
+                "name": {"required": True, "type": "str"},
+                "okc": {"required": False, "type": "str",
+                        "choices": ["disable", "enable"]},
+                "passphrase": {"required": False, "type": "str"},
+                "pmf": {"required": False, "type": "str",
+                        "choices": ["disable", "enable", "optional"]},
+                "pmf-assoc-comeback-timeout": {"required": False, "type": "int"},
+                "pmf-sa-query-retry-timeout": {"required": False, "type": "int"},
+                "portal-message-override-group": {"required": False, "type": "str"},
+                "portal-message-overrides": {"required": False, "type": "dict",
+                                             "options": {
+                                                 "auth-disclaimer-page": {"required": False, "type": "str"},
+                                                 "auth-login-failed-page": {"required": False, "type": "str"},
+                                                 "auth-login-page": {"required": False, "type": "str"},
+                                                 "auth-reject-page": {"required": False, "type": "str"}
+                                             }},
+                "portal-type": {"required": False, "type": "str",
+                                "choices": ["auth", "auth+disclaimer", "disclaimer",
+                                            "email-collect", "cmcc", "cmcc-macauth",
+                                            "auth-mac"]},
+                "probe-resp-suppression": {"required": False, "type": "str",
+                                           "choices": ["enable", "disable"]},
+                "probe-resp-threshold": {"required": False, "type": "str"},
+                "ptk-rekey": {"required": False, "type": "str",
+                              "choices": ["enable", "disable"]},
+                "ptk-rekey-intv": {"required": False, "type": "int"},
+                "qos-profile": {"required": False, "type": "str"},
+                "quarantine": {"required": False, "type": "str",
+                               "choices": ["enable", "disable"]},
+                "radio-2g-threshold": {"required": False, "type": "str"},
+                "radio-5g-threshold": {"required": False, "type": "str"},
+                "radio-sensitivity": {"required": False, "type": "str",
+                                      "choices": ["enable", "disable"]},
+                "radius-mac-auth": {"required": False, "type": "str",
+                                    "choices": ["enable", "disable"]},
+                "radius-mac-auth-server": {"required": False, "type": "str"},
+                "radius-mac-auth-usergroups": {"required": False, "type": "list",
+                                               "options": {
+                                                   "name": {"required": True, "type": "str"}
+                                               }},
+                "radius-server": {"required": False, "type": "str"},
+                "rates-11a": {"required": False, "type": "str",
+                              "choices": ["1", "1-basic", "2",
+                                          "2-basic", "5.5", "5.5-basic",
+                                          "11", "11-basic", "6",
+                                          "6-basic", "9", "9-basic",
+                                          "12", "12-basic", "18",
+                                          "18-basic", "24", "24-basic",
+                                          "36", "36-basic", "48",
+                                          "48-basic", "54", "54-basic"]},
+                "rates-11ac-ss12": {"required": False, "type": "str",
+                                    "choices": ["mcs0/1", "mcs1/1", "mcs2/1",
+                                                "mcs3/1", "mcs4/1", "mcs5/1",
+                                                "mcs6/1", "mcs7/1", "mcs8/1",
+                                                "mcs9/1", "mcs10/1", "mcs11/1",
+                                                "mcs0/2", "mcs1/2", "mcs2/2",
+                                                "mcs3/2", "mcs4/2", "mcs5/2",
+                                                "mcs6/2", "mcs7/2", "mcs8/2",
+                                                "mcs9/2", "mcs10/2", "mcs11/2"]},
+                "rates-11ac-ss34": {"required": False, "type": "str",
+                                    "choices": ["mcs0/3", "mcs1/3", "mcs2/3",
+                                                "mcs3/3", "mcs4/3", "mcs5/3",
+                                                "mcs6/3", "mcs7/3", "mcs8/3",
+                                                "mcs9/3", "mcs10/3", "mcs11/3",
+                                                "mcs0/4", "mcs1/4", "mcs2/4",
+                                                "mcs3/4", "mcs4/4", "mcs5/4",
+                                                "mcs6/4", "mcs7/4", "mcs8/4",
+                                                "mcs9/4", "mcs10/4", "mcs11/4"]},
+                "rates-11bg": {"required": False, "type": "str",
+                               "choices": ["1", "1-basic", "2",
+                                           "2-basic", "5.5", "5.5-basic",
+                                           "11", "11-basic", "6",
+                                           "6-basic", "9", "9-basic",
+                                           "12", "12-basic", "18",
+                                           "18-basic", "24", "24-basic",
+                                           "36", "36-basic", "48",
+                                           "48-basic", "54", "54-basic"]},
+                "rates-11n-ss12": {"required": False, "type": "str",
+                                   "choices": ["mcs0/1", "mcs1/1", "mcs2/1",
+                                               "mcs3/1", "mcs4/1", "mcs5/1",
+                                               "mcs6/1", "mcs7/1", "mcs8/2",
+                                               "mcs9/2", "mcs10/2", "mcs11/2",
+                                               "mcs12/2", "mcs13/2", "mcs14/2",
+                                               "mcs15/2"]},
+                "rates-11n-ss34": {"required": False, "type": "str",
+                                   "choices": ["mcs16/3", "mcs17/3", "mcs18/3",
+                                               "mcs19/3", "mcs20/3", "mcs21/3",
+                                               "mcs22/3", "mcs23/3", "mcs24/4",
+                                               "mcs25/4", "mcs26/4", "mcs27/4",
+                                               "mcs28/4", "mcs29/4", "mcs30/4",
+                                               "mcs31/4"]},
+                "schedule": {"required": False, "type": "str"},
+                "security": {"required": False, "type": "str",
+                             "choices": ["open", "captive-portal", "wep64",
+                                         "wep128", "wpa-personal", "wpa-personal+captive-portal",
+                                         "wpa-enterprise", "wpa-only-personal", "wpa-only-personal+captive-portal",
+                                         "wpa-only-enterprise", "wpa2-only-personal", "wpa2-only-personal+captive-portal",
+                                         "wpa2-only-enterprise", "osen"]},
+                "security-exempt-list": {"required": False, "type": "str"},
+                "security-obsolete-option": {"required": False, "type": "str",
+                                             "choices": ["enable", "disable"]},
+                "security-redirect-url": {"required": False, "type": "str"},
+                "selected-usergroups": {"required": False, "type": "list",
+                                        "options": {
+                                            "name": {"required": True, "type": "str"}
+                                        }},
+                "split-tunneling": {"required": False, "type": "str",
+                                    "choices": ["enable", "disable"]},
+                "ssid": {"required": False, "type": "str"},
+                "tkip-counter-measure": {"required": False, "type": "str",
+                                         "choices": ["enable", "disable"]},
+                "usergroup": {"required": False, "type": "list",
+                              "options": {
+                                  "name": {"required": True, "type": "str"}
+                              }},
+                "utm-profile": {"required": False, "type": "str"},
+                "vdom": {"required": False, "type": "str"},
+                "vlan-auto": {"required": False, "type": "str",
+                              "choices": ["enable", "disable"]},
+                "vlan-pool": {"required": False, "type": "list",
+                              "options": {
+                                  "id": {"required": True, "type": "int"},
+                                  "wtp-group": {"required": False, "type": "str"}
+                              }},
+                "vlan-pooling": {"required": False, "type": "str",
+                                 "choices": ["wtp-group", "round-robin", "hash",
+                                             "disable"]},
+                "vlanid": {"required": False, "type": "int"},
+                "voice-enterprise": {"required": False, "type": "str",
+                                     "choices": ["disable", "enable"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+    try:
+        from fortiosapi import FortiOSAPI
+    except ImportError:
+        module.fail_json(msg="fortiosapi module is required")
+
+    fos = FortiOSAPI()
+
+    is_error, has_changed, result = fortios_wireless_controller(module.params, fos)
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_wireless_controller_wids_profile.py
+++ b/lib/ansible/modules/network/fortios/fortios_wireless_controller_wids_profile.py
@@ -1,0 +1,618 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_wireless_controller_wids_profile
+short_description: Configure wireless intrusion detection system (WIDS) profiles in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS by allowing the
+      user to set and modify wireless_controller feature and wids_profile category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.2
+version_added: "2.8"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+       description:
+            - FortiOS or FortiGate ip address.
+       required: true
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        required: true
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS
+              protocol
+        type: bool
+        default: true
+    wireless_controller_wids_profile:
+        description:
+            - Configure wireless intrusion detection system (WIDS) profiles.
+        default: null
+        suboptions:
+            state:
+                description:
+                    - Indicates whether to create or remove the object
+                choices:
+                    - present
+                    - absent
+            ap-auto-suppress:
+                description:
+                    - Enable/disable on-wire rogue AP auto-suppression (default = disable).
+                choices:
+                    - enable
+                    - disable
+            ap-bgscan-disable-day:
+                description:
+                    - Optionally turn off scanning for one or more days of the week. Separate the days with a space. By default, no days are set.
+                choices:
+                    - sunday
+                    - monday
+                    - tuesday
+                    - wednesday
+                    - thursday
+                    - friday
+                    - saturday
+            ap-bgscan-disable-end:
+                description:
+                    - "End time, using a 24-hour clock in the format of hh:mm, for disabling background scanning (default = 00:00)."
+            ap-bgscan-disable-start:
+                description:
+                    - "Start time, using a 24-hour clock in the format of hh:mm, for disabling background scanning (default = 00:00)."
+            ap-bgscan-duration:
+                description:
+                    - Listening time on a scanning channel (10 - 1000 msec, default = 20).
+            ap-bgscan-idle:
+                description:
+                    - Waiting time for channel inactivity before scanning this channel (0 - 1000 msec, default = 0).
+            ap-bgscan-intv:
+                description:
+                    - Period of time between scanning two channels (1 - 600 sec, default = 1).
+            ap-bgscan-period:
+                description:
+                    - Period of time between background scans (60 - 3600 sec, default = 600).
+            ap-bgscan-report-intv:
+                description:
+                    - Period of time between background scan reports (15 - 600 sec, default = 30).
+            ap-fgscan-report-intv:
+                description:
+                    - Period of time between foreground scan reports (15 - 600 sec, default = 15).
+            ap-scan:
+                description:
+                    - Enable/disable rogue AP detection.
+                choices:
+                    - disable
+                    - enable
+            ap-scan-passive:
+                description:
+                    - Enable/disable passive scanning. Enable means do not send probe request on any channels (default = disable).
+                choices:
+                    - enable
+                    - disable
+            asleap-attack:
+                description:
+                    - Enable/disable asleap attack detection (default = disable).
+                choices:
+                    - enable
+                    - disable
+            assoc-flood-thresh:
+                description:
+                    - The threshold value for association frame flooding.
+            assoc-flood-time:
+                description:
+                    - Number of seconds after which a station is considered not connected.
+            assoc-frame-flood:
+                description:
+                    - Enable/disable association frame flooding detection (default = disable).
+                choices:
+                    - enable
+                    - disable
+            auth-flood-thresh:
+                description:
+                    - The threshold value for authentication frame flooding.
+            auth-flood-time:
+                description:
+                    - Number of seconds after which a station is considered not connected.
+            auth-frame-flood:
+                description:
+                    - Enable/disable authentication frame flooding detection (default = disable).
+                choices:
+                    - enable
+                    - disable
+            comment:
+                description:
+                    - Comment.
+            deauth-broadcast:
+                description:
+                    - Enable/disable broadcasting de-authentication detection (default = disable).
+                choices:
+                    - enable
+                    - disable
+            deauth-unknown-src-thresh:
+                description:
+                    - "Threshold value per second to deauth unknown src for DoS attack (0: no limit)."
+            eapol-fail-flood:
+                description:
+                    - Enable/disable EAPOL-Failure flooding (to AP) detection (default = disable).
+                choices:
+                    - enable
+                    - disable
+            eapol-fail-intv:
+                description:
+                    - The detection interval for EAPOL-Failure flooding (1 - 3600 sec).
+            eapol-fail-thresh:
+                description:
+                    - The threshold value for EAPOL-Failure flooding in specified interval.
+            eapol-logoff-flood:
+                description:
+                    - Enable/disable EAPOL-Logoff flooding (to AP) detection (default = disable).
+                choices:
+                    - enable
+                    - disable
+            eapol-logoff-intv:
+                description:
+                    - The detection interval for EAPOL-Logoff flooding (1 - 3600 sec).
+            eapol-logoff-thresh:
+                description:
+                    - The threshold value for EAPOL-Logoff flooding in specified interval.
+            eapol-pre-fail-flood:
+                description:
+                    - Enable/disable premature EAPOL-Failure flooding (to STA) detection (default = disable).
+                choices:
+                    - enable
+                    - disable
+            eapol-pre-fail-intv:
+                description:
+                    - The detection interval for premature EAPOL-Failure flooding (1 - 3600 sec).
+            eapol-pre-fail-thresh:
+                description:
+                    - The threshold value for premature EAPOL-Failure flooding in specified interval.
+            eapol-pre-succ-flood:
+                description:
+                    - Enable/disable premature EAPOL-Success flooding (to STA) detection (default = disable).
+                choices:
+                    - enable
+                    - disable
+            eapol-pre-succ-intv:
+                description:
+                    - The detection interval for premature EAPOL-Success flooding (1 - 3600 sec).
+            eapol-pre-succ-thresh:
+                description:
+                    - The threshold value for premature EAPOL-Success flooding in specified interval.
+            eapol-start-flood:
+                description:
+                    - Enable/disable EAPOL-Start flooding (to AP) detection (default = disable).
+                choices:
+                    - enable
+                    - disable
+            eapol-start-intv:
+                description:
+                    - The detection interval for EAPOL-Start flooding (1 - 3600 sec).
+            eapol-start-thresh:
+                description:
+                    - The threshold value for EAPOL-Start flooding in specified interval.
+            eapol-succ-flood:
+                description:
+                    - Enable/disable EAPOL-Success flooding (to AP) detection (default = disable).
+                choices:
+                    - enable
+                    - disable
+            eapol-succ-intv:
+                description:
+                    - The detection interval for EAPOL-Success flooding (1 - 3600 sec).
+            eapol-succ-thresh:
+                description:
+                    - The threshold value for EAPOL-Success flooding in specified interval.
+            invalid-mac-oui:
+                description:
+                    - Enable/disable invalid MAC OUI detection.
+                choices:
+                    - enable
+                    - disable
+            long-duration-attack:
+                description:
+                    - Enable/disable long duration attack detection based on user configured threshold (default = disable).
+                choices:
+                    - enable
+                    - disable
+            long-duration-thresh:
+                description:
+                    - Threshold value for long duration attack detection (1000 - 32767 usec, default = 8200).
+            name:
+                description:
+                    - WIDS profile name.
+                required: true
+            null-ssid-probe-resp:
+                description:
+                    - Enable/disable null SSID probe response detection (default = disable).
+                choices:
+                    - enable
+                    - disable
+            sensor-mode:
+                description:
+                    - Scan WiFi nearby stations (default = disable).
+                choices:
+                    - disable
+                    - foreign
+                    - both
+            spoofed-deauth:
+                description:
+                    - Enable/disable spoofed de-authentication attack detection (default = disable).
+                choices:
+                    - enable
+                    - disable
+            weak-wep-iv:
+                description:
+                    - Enable/disable weak WEP IV (Initialization Vector) detection (default = disable).
+                choices:
+                    - enable
+                    - disable
+            wireless-bridge:
+                description:
+                    - Enable/disable wireless bridge detection (default = disable).
+                choices:
+                    - enable
+                    - disable
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+  tasks:
+  - name: Configure wireless intrusion detection system (WIDS) profiles.
+    fortios_wireless_controller_wids_profile:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      wireless_controller_wids_profile:
+        state: "present"
+        ap-auto-suppress: "enable"
+        ap-bgscan-disable-day: "sunday"
+        ap-bgscan-disable-end: "<your_own_value>"
+        ap-bgscan-disable-start: "<your_own_value>"
+        ap-bgscan-duration: "7"
+        ap-bgscan-idle: "8"
+        ap-bgscan-intv: "9"
+        ap-bgscan-period: "10"
+        ap-bgscan-report-intv: "11"
+        ap-fgscan-report-intv: "12"
+        ap-scan: "disable"
+        ap-scan-passive: "enable"
+        asleap-attack: "enable"
+        assoc-flood-thresh: "16"
+        assoc-flood-time: "17"
+        assoc-frame-flood: "enable"
+        auth-flood-thresh: "19"
+        auth-flood-time: "20"
+        auth-frame-flood: "enable"
+        comment: "Comment."
+        deauth-broadcast: "enable"
+        deauth-unknown-src-thresh: "24"
+        eapol-fail-flood: "enable"
+        eapol-fail-intv: "26"
+        eapol-fail-thresh: "27"
+        eapol-logoff-flood: "enable"
+        eapol-logoff-intv: "29"
+        eapol-logoff-thresh: "30"
+        eapol-pre-fail-flood: "enable"
+        eapol-pre-fail-intv: "32"
+        eapol-pre-fail-thresh: "33"
+        eapol-pre-succ-flood: "enable"
+        eapol-pre-succ-intv: "35"
+        eapol-pre-succ-thresh: "36"
+        eapol-start-flood: "enable"
+        eapol-start-intv: "38"
+        eapol-start-thresh: "39"
+        eapol-succ-flood: "enable"
+        eapol-succ-intv: "41"
+        eapol-succ-thresh: "42"
+        invalid-mac-oui: "enable"
+        long-duration-attack: "enable"
+        long-duration-thresh: "45"
+        name: "default_name_46"
+        null-ssid-probe-resp: "enable"
+        sensor-mode: "disable"
+        spoofed-deauth: "enable"
+        weak-wep-iv: "enable"
+        wireless-bridge: "enable"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password)
+
+
+def filter_wireless_controller_wids_profile_data(json):
+    option_list = ['ap-auto-suppress', 'ap-bgscan-disable-day', 'ap-bgscan-disable-end',
+                   'ap-bgscan-disable-start', 'ap-bgscan-duration', 'ap-bgscan-idle',
+                   'ap-bgscan-intv', 'ap-bgscan-period', 'ap-bgscan-report-intv',
+                   'ap-fgscan-report-intv', 'ap-scan', 'ap-scan-passive',
+                   'asleap-attack', 'assoc-flood-thresh', 'assoc-flood-time',
+                   'assoc-frame-flood', 'auth-flood-thresh', 'auth-flood-time',
+                   'auth-frame-flood', 'comment', 'deauth-broadcast',
+                   'deauth-unknown-src-thresh', 'eapol-fail-flood', 'eapol-fail-intv',
+                   'eapol-fail-thresh', 'eapol-logoff-flood', 'eapol-logoff-intv',
+                   'eapol-logoff-thresh', 'eapol-pre-fail-flood', 'eapol-pre-fail-intv',
+                   'eapol-pre-fail-thresh', 'eapol-pre-succ-flood', 'eapol-pre-succ-intv',
+                   'eapol-pre-succ-thresh', 'eapol-start-flood', 'eapol-start-intv',
+                   'eapol-start-thresh', 'eapol-succ-flood', 'eapol-succ-intv',
+                   'eapol-succ-thresh', 'invalid-mac-oui', 'long-duration-attack',
+                   'long-duration-thresh', 'name', 'null-ssid-probe-resp',
+                   'sensor-mode', 'spoofed-deauth', 'weak-wep-iv',
+                   'wireless-bridge']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def flatten_multilists_attributes(data):
+    multilist_attrs = []
+
+    for attr in multilist_attrs:
+        try:
+            path = "data['" + "']['".join(elem for elem in attr) + "']"
+            current_val = eval(path)
+            flattened_val = ' '.join(elem for elem in current_val)
+            exec(path + '= flattened_val')
+        except BaseException:
+            pass
+
+    return data
+
+
+def wireless_controller_wids_profile(data, fos):
+    vdom = data['vdom']
+    wireless_controller_wids_profile_data = data['wireless_controller_wids_profile']
+    flattened_data = flatten_multilists_attributes(wireless_controller_wids_profile_data)
+    filtered_data = filter_wireless_controller_wids_profile_data(flattened_data)
+    if wireless_controller_wids_profile_data['state'] == "present":
+        return fos.set('wireless-controller',
+                       'wids-profile',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif wireless_controller_wids_profile_data['state'] == "absent":
+        return fos.delete('wireless-controller',
+                          'wids-profile',
+                          mkey=filtered_data['name'],
+                          vdom=vdom)
+
+
+def fortios_wireless_controller(data, fos):
+    login(data, fos)
+
+    if data['wireless_controller_wids_profile']:
+        resp = wireless_controller_wids_profile(data, fos)
+
+    fos.logout()
+    return not resp['status'] == "success", resp['status'] == "success", resp
+
+
+def main():
+    fields = {
+        "host": {"required": True, "type": "str"},
+        "username": {"required": True, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "wireless_controller_wids_profile": {
+            "required": False, "type": "dict",
+            "options": {
+                "state": {"required": True, "type": "str",
+                          "choices": ["present", "absent"]},
+                "ap-auto-suppress": {"required": False, "type": "str",
+                                     "choices": ["enable", "disable"]},
+                "ap-bgscan-disable-day": {"required": False, "type": "str",
+                                          "choices": ["sunday", "monday", "tuesday",
+                                                      "wednesday", "thursday", "friday",
+                                                      "saturday"]},
+                "ap-bgscan-disable-end": {"required": False, "type": "str"},
+                "ap-bgscan-disable-start": {"required": False, "type": "str"},
+                "ap-bgscan-duration": {"required": False, "type": "int"},
+                "ap-bgscan-idle": {"required": False, "type": "int"},
+                "ap-bgscan-intv": {"required": False, "type": "int"},
+                "ap-bgscan-period": {"required": False, "type": "int"},
+                "ap-bgscan-report-intv": {"required": False, "type": "int"},
+                "ap-fgscan-report-intv": {"required": False, "type": "int"},
+                "ap-scan": {"required": False, "type": "str",
+                            "choices": ["disable", "enable"]},
+                "ap-scan-passive": {"required": False, "type": "str",
+                                    "choices": ["enable", "disable"]},
+                "asleap-attack": {"required": False, "type": "str",
+                                  "choices": ["enable", "disable"]},
+                "assoc-flood-thresh": {"required": False, "type": "int"},
+                "assoc-flood-time": {"required": False, "type": "int"},
+                "assoc-frame-flood": {"required": False, "type": "str",
+                                      "choices": ["enable", "disable"]},
+                "auth-flood-thresh": {"required": False, "type": "int"},
+                "auth-flood-time": {"required": False, "type": "int"},
+                "auth-frame-flood": {"required": False, "type": "str",
+                                     "choices": ["enable", "disable"]},
+                "comment": {"required": False, "type": "str"},
+                "deauth-broadcast": {"required": False, "type": "str",
+                                     "choices": ["enable", "disable"]},
+                "deauth-unknown-src-thresh": {"required": False, "type": "int"},
+                "eapol-fail-flood": {"required": False, "type": "str",
+                                     "choices": ["enable", "disable"]},
+                "eapol-fail-intv": {"required": False, "type": "int"},
+                "eapol-fail-thresh": {"required": False, "type": "int"},
+                "eapol-logoff-flood": {"required": False, "type": "str",
+                                       "choices": ["enable", "disable"]},
+                "eapol-logoff-intv": {"required": False, "type": "int"},
+                "eapol-logoff-thresh": {"required": False, "type": "int"},
+                "eapol-pre-fail-flood": {"required": False, "type": "str",
+                                         "choices": ["enable", "disable"]},
+                "eapol-pre-fail-intv": {"required": False, "type": "int"},
+                "eapol-pre-fail-thresh": {"required": False, "type": "int"},
+                "eapol-pre-succ-flood": {"required": False, "type": "str",
+                                         "choices": ["enable", "disable"]},
+                "eapol-pre-succ-intv": {"required": False, "type": "int"},
+                "eapol-pre-succ-thresh": {"required": False, "type": "int"},
+                "eapol-start-flood": {"required": False, "type": "str",
+                                      "choices": ["enable", "disable"]},
+                "eapol-start-intv": {"required": False, "type": "int"},
+                "eapol-start-thresh": {"required": False, "type": "int"},
+                "eapol-succ-flood": {"required": False, "type": "str",
+                                     "choices": ["enable", "disable"]},
+                "eapol-succ-intv": {"required": False, "type": "int"},
+                "eapol-succ-thresh": {"required": False, "type": "int"},
+                "invalid-mac-oui": {"required": False, "type": "str",
+                                    "choices": ["enable", "disable"]},
+                "long-duration-attack": {"required": False, "type": "str",
+                                         "choices": ["enable", "disable"]},
+                "long-duration-thresh": {"required": False, "type": "int"},
+                "name": {"required": True, "type": "str"},
+                "null-ssid-probe-resp": {"required": False, "type": "str",
+                                         "choices": ["enable", "disable"]},
+                "sensor-mode": {"required": False, "type": "str",
+                                "choices": ["disable", "foreign", "both"]},
+                "spoofed-deauth": {"required": False, "type": "str",
+                                   "choices": ["enable", "disable"]},
+                "weak-wep-iv": {"required": False, "type": "str",
+                                "choices": ["enable", "disable"]},
+                "wireless-bridge": {"required": False, "type": "str",
+                                    "choices": ["enable", "disable"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+    try:
+        from fortiosapi import FortiOSAPI
+    except ImportError:
+        module.fail_json(msg="fortiosapi module is required")
+
+    fos = FortiOSAPI()
+
+    is_error, has_changed, result = fortios_wireless_controller(module.params, fos)
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_wireless_controller_wtp.py
+++ b/lib/ansible/modules/network/fortios/fortios_wireless_controller_wtp.py
@@ -1,0 +1,1008 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_wireless_controller_wtp
+short_description: Configure Wireless Termination Points (WTPs), that is, FortiAPs or APs to be managed by FortiGate in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS by allowing the
+      user to set and modify wireless_controller feature and wtp category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.2
+version_added: "2.8"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+       description:
+            - FortiOS or FortiGate ip address.
+       required: true
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        required: true
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS
+              protocol
+        type: bool
+        default: true
+    wireless_controller_wtp:
+        description:
+            - Configure Wireless Termination Points (WTPs), that is, FortiAPs or APs to be managed by FortiGate.
+        default: null
+        suboptions:
+            state:
+                description:
+                    - Indicates whether to create or remove the object
+                choices:
+                    - present
+                    - absent
+            admin:
+                description:
+                    - Configure how the FortiGate operating as a wireless controller discovers and manages this WTP, AP or FortiAP.
+                choices:
+                    - discovered
+                    - disable
+                    - enable
+            allowaccess:
+                description:
+                    - Control management access to the managed WTP, FortiAP, or AP. Separate entries with a space.
+                choices:
+                    - telnet
+                    - http
+                    - https
+                    - ssh
+            bonjour-profile:
+                description:
+                    - Bonjour profile name. Source wireless-controller.bonjour-profile.name.
+            coordinate-enable:
+                description:
+                    - Enable/disable WTP coordinates (X,Y axis).
+                choices:
+                    - enable
+                    - disable
+            coordinate-latitude:
+                description:
+                    - WTP latitude coordinate.
+            coordinate-longitude:
+                description:
+                    - WTP longitude coordinate.
+            coordinate-x:
+                description:
+                    - X axis coordinate.
+            coordinate-y:
+                description:
+                    - Y axis coordinate.
+            image-download:
+                description:
+                    - Enable/disable WTP image download.
+                choices:
+                    - enable
+                    - disable
+            index:
+                description:
+                    - Index (0 - 4294967295).
+            ip-fragment-preventing:
+                description:
+                    - Method by which IP fragmentation is prevented for CAPWAP tunneled control and data packets (default = tcp-mss-adjust).
+                choices:
+                    - tcp-mss-adjust
+                    - icmp-unreachable
+            lan:
+                description:
+                    - WTP LAN port mapping.
+                suboptions:
+                    port-mode:
+                        description:
+                            - LAN port mode.
+                        choices:
+                            - offline
+                            - nat-to-wan
+                            - bridge-to-wan
+                            - bridge-to-ssid
+                    port-ssid:
+                        description:
+                            - Bridge LAN port to SSID. Source wireless-controller.vap.name.
+                    port1-mode:
+                        description:
+                            - LAN port 1 mode.
+                        choices:
+                            - offline
+                            - nat-to-wan
+                            - bridge-to-wan
+                            - bridge-to-ssid
+                    port1-ssid:
+                        description:
+                            - Bridge LAN port 1 to SSID. Source wireless-controller.vap.name.
+                    port2-mode:
+                        description:
+                            - LAN port 2 mode.
+                        choices:
+                            - offline
+                            - nat-to-wan
+                            - bridge-to-wan
+                            - bridge-to-ssid
+                    port2-ssid:
+                        description:
+                            - Bridge LAN port 2 to SSID. Source wireless-controller.vap.name.
+                    port3-mode:
+                        description:
+                            - LAN port 3 mode.
+                        choices:
+                            - offline
+                            - nat-to-wan
+                            - bridge-to-wan
+                            - bridge-to-ssid
+                    port3-ssid:
+                        description:
+                            - Bridge LAN port 3 to SSID. Source wireless-controller.vap.name.
+                    port4-mode:
+                        description:
+                            - LAN port 4 mode.
+                        choices:
+                            - offline
+                            - nat-to-wan
+                            - bridge-to-wan
+                            - bridge-to-ssid
+                    port4-ssid:
+                        description:
+                            - Bridge LAN port 4 to SSID. Source wireless-controller.vap.name.
+                    port5-mode:
+                        description:
+                            - LAN port 5 mode.
+                        choices:
+                            - offline
+                            - nat-to-wan
+                            - bridge-to-wan
+                            - bridge-to-ssid
+                    port5-ssid:
+                        description:
+                            - Bridge LAN port 5 to SSID. Source wireless-controller.vap.name.
+                    port6-mode:
+                        description:
+                            - LAN port 6 mode.
+                        choices:
+                            - offline
+                            - nat-to-wan
+                            - bridge-to-wan
+                            - bridge-to-ssid
+                    port6-ssid:
+                        description:
+                            - Bridge LAN port 6 to SSID. Source wireless-controller.vap.name.
+                    port7-mode:
+                        description:
+                            - LAN port 7 mode.
+                        choices:
+                            - offline
+                            - nat-to-wan
+                            - bridge-to-wan
+                            - bridge-to-ssid
+                    port7-ssid:
+                        description:
+                            - Bridge LAN port 7 to SSID. Source wireless-controller.vap.name.
+                    port8-mode:
+                        description:
+                            - LAN port 8 mode.
+                        choices:
+                            - offline
+                            - nat-to-wan
+                            - bridge-to-wan
+                            - bridge-to-ssid
+                    port8-ssid:
+                        description:
+                            - Bridge LAN port 8 to SSID. Source wireless-controller.vap.name.
+            led-state:
+                description:
+                    - Enable to allow the FortiAPs LEDs to light. Disable to keep the LEDs off. You may want to keep the LEDs off so they are not distracting
+                       in low light areas etc.
+                choices:
+                    - enable
+                    - disable
+            location:
+                description:
+                    - Field for describing the physical location of the WTP, AP or FortiAP.
+            login-passwd:
+                description:
+                    - Set the managed WTP, FortiAP, or AP's administrator password.
+            login-passwd-change:
+                description:
+                    - Change or reset the administrator password of a managed WTP, FortiAP or AP (yes, default, or no, default = no).
+                choices:
+                    - yes
+                    - default
+                    - no
+            mesh-bridge-enable:
+                description:
+                    - Enable/disable mesh Ethernet bridge when WTP is configured as a mesh branch/leaf AP.
+                choices:
+                    - default
+                    - enable
+                    - disable
+            name:
+                description:
+                    - WTP, AP or FortiAP configuration name.
+            override-allowaccess:
+                description:
+                    - Enable to override the WTP profile management access configuration.
+                choices:
+                    - enable
+                    - disable
+            override-ip-fragment:
+                description:
+                    - Enable/disable overriding the WTP profile IP fragment prevention setting.
+                choices:
+                    - enable
+                    - disable
+            override-lan:
+                description:
+                    - Enable to override the WTP profile LAN port setting.
+                choices:
+                    - enable
+                    - disable
+            override-led-state:
+                description:
+                    - Enable to override the profile LED state setting for this FortiAP. You must enable this option to use the led-state command to turn off
+                       the FortiAP's LEDs.
+                choices:
+                    - enable
+                    - disable
+            override-login-passwd-change:
+                description:
+                    - Enable to override the WTP profile login-password (administrator password) setting.
+                choices:
+                    - enable
+                    - disable
+            override-split-tunnel:
+                description:
+                    - Enable/disable overriding the WTP profile split tunneling setting.
+                choices:
+                    - enable
+                    - disable
+            override-wan-port-mode:
+                description:
+                    - Enable/disable overriding the wan-port-mode in the WTP profile.
+                choices:
+                    - enable
+                    - disable
+            radio-1:
+                description:
+                    - Configuration options for radio 1.
+                suboptions:
+                    auto-power-high:
+                        description:
+                            - Automatic transmission power high limit in decibels (dB) of the measured power referenced to one milliwatt (mW), or dBm (10 - 17
+                               dBm, default = 17).
+                    auto-power-level:
+                        description:
+                            - Enable/disable automatic power-level adjustment to prevent co-channel interference (default = enable).
+                        choices:
+                            - enable
+                            - disable
+                    auto-power-low:
+                        description:
+                            - Automatic transmission power low limit in dBm (the actual range of transmit power depends on the AP platform type).
+                    band:
+                        description:
+                            - WiFi band that Radio 1 operates on.
+                        choices:
+                            - 802.11a
+                            - 802.11b
+                            - 802.11g
+                            - 802.11n
+                            - 802.11n-5G
+                            - 802.11n,g-only
+                            - 802.11g-only
+                            - 802.11n-only
+                            - 802.11n-5G-only
+                            - 802.11ac
+                            - 802.11ac,n-only
+                            - 802.11ac-only
+                    channel:
+                        description:
+                            - Selected list of wireless radio channels.
+                        suboptions:
+                            chan:
+                                description:
+                                    - Channel number.
+                                required: true
+                    override-analysis:
+                        description:
+                            - Enable to override the WTP profile spectrum analysis configuration.
+                        choices:
+                            - enable
+                            - disable
+                    override-band:
+                        description:
+                            - Enable to override the WTP profile band setting.
+                        choices:
+                            - enable
+                            - disable
+                    override-channel:
+                        description:
+                            - Enable to override WTP profile channel settings.
+                        choices:
+                            - enable
+                            - disable
+                    override-txpower:
+                        description:
+                            - Enable to override the WTP profile power level configuration.
+                        choices:
+                            - enable
+                            - disable
+                    override-vaps:
+                        description:
+                            - Enable to override WTP profile Virtual Access Point (VAP) settings.
+                        choices:
+                            - enable
+                            - disable
+                    power-level:
+                        description:
+                            - Radio power level as a percentage of the maximum transmit power (0 - 100, default = 100).
+                    radio-id:
+                        description:
+                            - radio-id
+                    spectrum-analysis:
+                        description:
+                            - Enable/disable spectrum analysis to find interference that would negatively impact wireless performance.
+                        choices:
+                            - enable
+                            - disable
+                    vap-all:
+                        description:
+                            - Enable/disable the automatic inheritance of all Virtual Access Points (VAPs) (default = enable).
+                        choices:
+                            - enable
+                            - disable
+                    vaps:
+                        description:
+                            - Manually selected list of Virtual Access Points (VAPs).
+                        suboptions:
+                            name:
+                                description:
+                                    - Virtual Access Point (VAP) name. Source wireless-controller.vap-group.name wireless-controller.vap.name.
+                                required: true
+            radio-2:
+                description:
+                    - Configuration options for radio 2.
+                suboptions:
+                    auto-power-high:
+                        description:
+                            - Automatic transmission power high limit in decibels (dB) of the measured power referenced to one milliwatt (mW), or dBm (10 - 17
+                               dBm, default = 17).
+                    auto-power-level:
+                        description:
+                            - Enable/disable automatic power-level adjustment to prevent co-channel interference (default = enable).
+                        choices:
+                            - enable
+                            - disable
+                    auto-power-low:
+                        description:
+                            - Automatic transmission power low limit in dBm (the actual range of transmit power depends on the AP platform type).
+                    band:
+                        description:
+                            - WiFi band that Radio 1 operates on.
+                        choices:
+                            - 802.11a
+                            - 802.11b
+                            - 802.11g
+                            - 802.11n
+                            - 802.11n-5G
+                            - 802.11n,g-only
+                            - 802.11g-only
+                            - 802.11n-only
+                            - 802.11n-5G-only
+                            - 802.11ac
+                            - 802.11ac,n-only
+                            - 802.11ac-only
+                    channel:
+                        description:
+                            - Selected list of wireless radio channels.
+                        suboptions:
+                            chan:
+                                description:
+                                    - Channel number.
+                                required: true
+                    override-analysis:
+                        description:
+                            - Enable to override the WTP profile spectrum analysis configuration.
+                        choices:
+                            - enable
+                            - disable
+                    override-band:
+                        description:
+                            - Enable to override the WTP profile band setting.
+                        choices:
+                            - enable
+                            - disable
+                    override-channel:
+                        description:
+                            - Enable to override WTP profile channel settings.
+                        choices:
+                            - enable
+                            - disable
+                    override-txpower:
+                        description:
+                            - Enable to override the WTP profile power level configuration.
+                        choices:
+                            - enable
+                            - disable
+                    override-vaps:
+                        description:
+                            - Enable to override WTP profile Virtual Access Point (VAP) settings.
+                        choices:
+                            - enable
+                            - disable
+                    power-level:
+                        description:
+                            - Radio power level as a percentage of the maximum transmit power (0 - 100, default = 100).
+                    radio-id:
+                        description:
+                            - radio-id
+                    spectrum-analysis:
+                        description:
+                            - Enable/disable spectrum analysis to find interference that would negatively impact wireless performance.
+                        choices:
+                            - enable
+                            - disable
+                    vap-all:
+                        description:
+                            - Enable/disable the automatic inheritance of all Virtual Access Points (VAPs) (default = enable).
+                        choices:
+                            - enable
+                            - disable
+                    vaps:
+                        description:
+                            - Manually selected list of Virtual Access Points (VAPs).
+                        suboptions:
+                            name:
+                                description:
+                                    - Virtual Access Point (VAP) name. Source wireless-controller.vap-group.name wireless-controller.vap.name.
+                                required: true
+            split-tunneling-acl:
+                description:
+                    - Split tunneling ACL filter list.
+                suboptions:
+                    dest-ip:
+                        description:
+                            - Destination IP and mask for the split-tunneling subnet.
+                    id:
+                        description:
+                            - ID.
+                        required: true
+            split-tunneling-acl-local-ap-subnet:
+                description:
+                    - Enable/disable automatically adding local subnetwork of FortiAP to split-tunneling ACL (default = disable).
+                choices:
+                    - enable
+                    - disable
+            split-tunneling-acl-path:
+                description:
+                    - Split tunneling ACL path is local/tunnel.
+                choices:
+                    - tunnel
+                    - local
+            tun-mtu-downlink:
+                description:
+                    - Downlink tunnel MTU in octets. Set the value to either 0 (by default), 576, or 1500.
+            tun-mtu-uplink:
+                description:
+                    - Uplink tunnel maximum transmission unit (MTU) in octets (eight-bit bytes). Set the value to either 0 (by default), 576, or 1500.
+            wan-port-mode:
+                description:
+                    - Enable/disable using the FortiAP WAN port as a LAN port.
+                choices:
+                    - wan-lan
+                    - wan-only
+            wtp-id:
+                description:
+                    - WTP ID.
+                required: true
+            wtp-mode:
+                description:
+                    - WTP, AP, or FortiAP operating mode; normal (by default) or remote. A tunnel mode SSID can be assigned to an AP in normal mode but not
+                       remote mode, while a local-bridge mode SSID can be assigned to an AP in either normal mode or remote mode.
+                choices:
+                    - normal
+                    - remote
+            wtp-profile:
+                description:
+                    - WTP profile name to apply to this WTP, AP or FortiAP. Source wireless-controller.wtp-profile.name.
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+  tasks:
+  - name: Configure Wireless Termination Points (WTPs), that is, FortiAPs or APs to be managed by FortiGate.
+    fortios_wireless_controller_wtp:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      wireless_controller_wtp:
+        state: "present"
+        admin: "discovered"
+        allowaccess: "telnet"
+        bonjour-profile: "<your_own_value> (source wireless-controller.bonjour-profile.name)"
+        coordinate-enable: "enable"
+        coordinate-latitude: "<your_own_value>"
+        coordinate-longitude: "<your_own_value>"
+        coordinate-x: "<your_own_value>"
+        coordinate-y: "<your_own_value>"
+        image-download: "enable"
+        index: "12"
+        ip-fragment-preventing: "tcp-mss-adjust"
+        lan:
+            port-mode: "offline"
+            port-ssid: "<your_own_value> (source wireless-controller.vap.name)"
+            port1-mode: "offline"
+            port1-ssid: "<your_own_value> (source wireless-controller.vap.name)"
+            port2-mode: "offline"
+            port2-ssid: "<your_own_value> (source wireless-controller.vap.name)"
+            port3-mode: "offline"
+            port3-ssid: "<your_own_value> (source wireless-controller.vap.name)"
+            port4-mode: "offline"
+            port4-ssid: "<your_own_value> (source wireless-controller.vap.name)"
+            port5-mode: "offline"
+            port5-ssid: "<your_own_value> (source wireless-controller.vap.name)"
+            port6-mode: "offline"
+            port6-ssid: "<your_own_value> (source wireless-controller.vap.name)"
+            port7-mode: "offline"
+            port7-ssid: "<your_own_value> (source wireless-controller.vap.name)"
+            port8-mode: "offline"
+            port8-ssid: "<your_own_value> (source wireless-controller.vap.name)"
+        led-state: "enable"
+        location: "<your_own_value>"
+        login-passwd: "<your_own_value>"
+        login-passwd-change: "yes"
+        mesh-bridge-enable: "default"
+        name: "default_name_38"
+        override-allowaccess: "enable"
+        override-ip-fragment: "enable"
+        override-lan: "enable"
+        override-led-state: "enable"
+        override-login-passwd-change: "enable"
+        override-split-tunnel: "enable"
+        override-wan-port-mode: "enable"
+        radio-1:
+            auto-power-high: "47"
+            auto-power-level: "enable"
+            auto-power-low: "49"
+            band: "802.11a"
+            channel:
+             -
+                chan: "<your_own_value>"
+            override-analysis: "enable"
+            override-band: "enable"
+            override-channel: "enable"
+            override-txpower: "enable"
+            override-vaps: "enable"
+            power-level: "58"
+            radio-id: "59"
+            spectrum-analysis: "enable"
+            vap-all: "enable"
+            vaps:
+             -
+                name: "default_name_63 (source wireless-controller.vap-group.name wireless-controller.vap.name)"
+        radio-2:
+            auto-power-high: "65"
+            auto-power-level: "enable"
+            auto-power-low: "67"
+            band: "802.11a"
+            channel:
+             -
+                chan: "<your_own_value>"
+            override-analysis: "enable"
+            override-band: "enable"
+            override-channel: "enable"
+            override-txpower: "enable"
+            override-vaps: "enable"
+            power-level: "76"
+            radio-id: "77"
+            spectrum-analysis: "enable"
+            vap-all: "enable"
+            vaps:
+             -
+                name: "default_name_81 (source wireless-controller.vap-group.name wireless-controller.vap.name)"
+        split-tunneling-acl:
+         -
+            dest-ip: "<your_own_value>"
+            id:  "84"
+        split-tunneling-acl-local-ap-subnet: "enable"
+        split-tunneling-acl-path: "tunnel"
+        tun-mtu-downlink: "87"
+        tun-mtu-uplink: "88"
+        wan-port-mode: "wan-lan"
+        wtp-id: "<your_own_value>"
+        wtp-mode: "normal"
+        wtp-profile: "<your_own_value> (source wireless-controller.wtp-profile.name)"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password)
+
+
+def filter_wireless_controller_wtp_data(json):
+    option_list = ['admin', 'allowaccess', 'bonjour-profile',
+                   'coordinate-enable', 'coordinate-latitude', 'coordinate-longitude',
+                   'coordinate-x', 'coordinate-y', 'image-download',
+                   'index', 'ip-fragment-preventing', 'lan',
+                   'led-state', 'location', 'login-passwd',
+                   'login-passwd-change', 'mesh-bridge-enable', 'name',
+                   'override-allowaccess', 'override-ip-fragment', 'override-lan',
+                   'override-led-state', 'override-login-passwd-change', 'override-split-tunnel',
+                   'override-wan-port-mode', 'radio-1', 'radio-2',
+                   'split-tunneling-acl', 'split-tunneling-acl-local-ap-subnet', 'split-tunneling-acl-path',
+                   'tun-mtu-downlink', 'tun-mtu-uplink', 'wan-port-mode',
+                   'wtp-id', 'wtp-mode', 'wtp-profile']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def flatten_multilists_attributes(data):
+    multilist_attrs = []
+
+    for attr in multilist_attrs:
+        try:
+            path = "data['" + "']['".join(elem for elem in attr) + "']"
+            current_val = eval(path)
+            flattened_val = ' '.join(elem for elem in current_val)
+            exec(path + '= flattened_val')
+        except BaseException:
+            pass
+
+    return data
+
+
+def wireless_controller_wtp(data, fos):
+    vdom = data['vdom']
+    wireless_controller_wtp_data = data['wireless_controller_wtp']
+    flattened_data = flatten_multilists_attributes(wireless_controller_wtp_data)
+    filtered_data = filter_wireless_controller_wtp_data(flattened_data)
+    if wireless_controller_wtp_data['state'] == "present":
+        return fos.set('wireless-controller',
+                       'wtp',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif wireless_controller_wtp_data['state'] == "absent":
+        return fos.delete('wireless-controller',
+                          'wtp',
+                          mkey=filtered_data['wtp-id'],
+                          vdom=vdom)
+
+
+def fortios_wireless_controller(data, fos):
+    login(data, fos)
+
+    if data['wireless_controller_wtp']:
+        resp = wireless_controller_wtp(data, fos)
+
+    fos.logout()
+    return not resp['status'] == "success", resp['status'] == "success", resp
+
+
+def main():
+    fields = {
+        "host": {"required": True, "type": "str"},
+        "username": {"required": True, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "wireless_controller_wtp": {
+            "required": False, "type": "dict",
+            "options": {
+                "state": {"required": True, "type": "str",
+                          "choices": ["present", "absent"]},
+                "admin": {"required": False, "type": "str",
+                          "choices": ["discovered", "disable", "enable"]},
+                "allowaccess": {"required": False, "type": "str",
+                                "choices": ["telnet", "http", "https",
+                                            "ssh"]},
+                "bonjour-profile": {"required": False, "type": "str"},
+                "coordinate-enable": {"required": False, "type": "str",
+                                      "choices": ["enable", "disable"]},
+                "coordinate-latitude": {"required": False, "type": "str"},
+                "coordinate-longitude": {"required": False, "type": "str"},
+                "coordinate-x": {"required": False, "type": "str"},
+                "coordinate-y": {"required": False, "type": "str"},
+                "image-download": {"required": False, "type": "str",
+                                   "choices": ["enable", "disable"]},
+                "index": {"required": False, "type": "int"},
+                "ip-fragment-preventing": {"required": False, "type": "str",
+                                           "choices": ["tcp-mss-adjust", "icmp-unreachable"]},
+                "lan": {"required": False, "type": "dict",
+                        "options": {
+                            "port-mode": {"required": False, "type": "str",
+                                          "choices": ["offline", "nat-to-wan", "bridge-to-wan",
+                                                      "bridge-to-ssid"]},
+                            "port-ssid": {"required": False, "type": "str"},
+                            "port1-mode": {"required": False, "type": "str",
+                                           "choices": ["offline", "nat-to-wan", "bridge-to-wan",
+                                                       "bridge-to-ssid"]},
+                            "port1-ssid": {"required": False, "type": "str"},
+                            "port2-mode": {"required": False, "type": "str",
+                                           "choices": ["offline", "nat-to-wan", "bridge-to-wan",
+                                                       "bridge-to-ssid"]},
+                            "port2-ssid": {"required": False, "type": "str"},
+                            "port3-mode": {"required": False, "type": "str",
+                                           "choices": ["offline", "nat-to-wan", "bridge-to-wan",
+                                                       "bridge-to-ssid"]},
+                            "port3-ssid": {"required": False, "type": "str"},
+                            "port4-mode": {"required": False, "type": "str",
+                                           "choices": ["offline", "nat-to-wan", "bridge-to-wan",
+                                                       "bridge-to-ssid"]},
+                            "port4-ssid": {"required": False, "type": "str"},
+                            "port5-mode": {"required": False, "type": "str",
+                                           "choices": ["offline", "nat-to-wan", "bridge-to-wan",
+                                                       "bridge-to-ssid"]},
+                            "port5-ssid": {"required": False, "type": "str"},
+                            "port6-mode": {"required": False, "type": "str",
+                                           "choices": ["offline", "nat-to-wan", "bridge-to-wan",
+                                                       "bridge-to-ssid"]},
+                            "port6-ssid": {"required": False, "type": "str"},
+                            "port7-mode": {"required": False, "type": "str",
+                                           "choices": ["offline", "nat-to-wan", "bridge-to-wan",
+                                                       "bridge-to-ssid"]},
+                            "port7-ssid": {"required": False, "type": "str"},
+                            "port8-mode": {"required": False, "type": "str",
+                                           "choices": ["offline", "nat-to-wan", "bridge-to-wan",
+                                                       "bridge-to-ssid"]},
+                            "port8-ssid": {"required": False, "type": "str"}
+                        }},
+                "led-state": {"required": False, "type": "str",
+                              "choices": ["enable", "disable"]},
+                "location": {"required": False, "type": "str"},
+                "login-passwd": {"required": False, "type": "str"},
+                "login-passwd-change": {"required": False, "type": "str",
+                                        "choices": ["yes", "default", "no"]},
+                "mesh-bridge-enable": {"required": False, "type": "str",
+                                       "choices": ["default", "enable", "disable"]},
+                "name": {"required": False, "type": "str"},
+                "override-allowaccess": {"required": False, "type": "str",
+                                         "choices": ["enable", "disable"]},
+                "override-ip-fragment": {"required": False, "type": "str",
+                                         "choices": ["enable", "disable"]},
+                "override-lan": {"required": False, "type": "str",
+                                 "choices": ["enable", "disable"]},
+                "override-led-state": {"required": False, "type": "str",
+                                       "choices": ["enable", "disable"]},
+                "override-login-passwd-change": {"required": False, "type": "str",
+                                                 "choices": ["enable", "disable"]},
+                "override-split-tunnel": {"required": False, "type": "str",
+                                          "choices": ["enable", "disable"]},
+                "override-wan-port-mode": {"required": False, "type": "str",
+                                           "choices": ["enable", "disable"]},
+                "radio-1": {"required": False, "type": "dict",
+                            "options": {
+                                "auto-power-high": {"required": False, "type": "int"},
+                                "auto-power-level": {"required": False, "type": "str",
+                                                     "choices": ["enable", "disable"]},
+                                "auto-power-low": {"required": False, "type": "int"},
+                                "band": {"required": False, "type": "str",
+                                         "choices": ["802.11a", "802.11b", "802.11g",
+                                                     "802.11n", "802.11n-5G", "802.11n,g-only",
+                                                     "802.11g-only", "802.11n-only", "802.11n-5G-only",
+                                                     "802.11ac", "802.11ac,n-only", "802.11ac-only"]},
+                                "channel": {"required": False, "type": "list",
+                                            "options": {
+                                                "chan": {"required": True, "type": "str"}
+                                            }},
+                                "override-analysis": {"required": False, "type": "str",
+                                                      "choices": ["enable", "disable"]},
+                                "override-band": {"required": False, "type": "str",
+                                                  "choices": ["enable", "disable"]},
+                                "override-channel": {"required": False, "type": "str",
+                                                     "choices": ["enable", "disable"]},
+                                "override-txpower": {"required": False, "type": "str",
+                                                     "choices": ["enable", "disable"]},
+                                "override-vaps": {"required": False, "type": "str",
+                                                  "choices": ["enable", "disable"]},
+                                "power-level": {"required": False, "type": "int"},
+                                "radio-id": {"required": False, "type": "int"},
+                                "spectrum-analysis": {"required": False, "type": "str",
+                                                      "choices": ["enable", "disable"]},
+                                "vap-all": {"required": False, "type": "str",
+                                            "choices": ["enable", "disable"]},
+                                "vaps": {"required": False, "type": "list",
+                                         "options": {
+                                             "name": {"required": True, "type": "str"}
+                                         }}
+                            }},
+                "radio-2": {"required": False, "type": "dict",
+                            "options": {
+                                "auto-power-high": {"required": False, "type": "int"},
+                                "auto-power-level": {"required": False, "type": "str",
+                                                     "choices": ["enable", "disable"]},
+                                "auto-power-low": {"required": False, "type": "int"},
+                                "band": {"required": False, "type": "str",
+                                         "choices": ["802.11a", "802.11b", "802.11g",
+                                                     "802.11n", "802.11n-5G", "802.11n,g-only",
+                                                     "802.11g-only", "802.11n-only", "802.11n-5G-only",
+                                                     "802.11ac", "802.11ac,n-only", "802.11ac-only"]},
+                                "channel": {"required": False, "type": "list",
+                                            "options": {
+                                                "chan": {"required": True, "type": "str"}
+                                            }},
+                                "override-analysis": {"required": False, "type": "str",
+                                                      "choices": ["enable", "disable"]},
+                                "override-band": {"required": False, "type": "str",
+                                                  "choices": ["enable", "disable"]},
+                                "override-channel": {"required": False, "type": "str",
+                                                     "choices": ["enable", "disable"]},
+                                "override-txpower": {"required": False, "type": "str",
+                                                     "choices": ["enable", "disable"]},
+                                "override-vaps": {"required": False, "type": "str",
+                                                  "choices": ["enable", "disable"]},
+                                "power-level": {"required": False, "type": "int"},
+                                "radio-id": {"required": False, "type": "int"},
+                                "spectrum-analysis": {"required": False, "type": "str",
+                                                      "choices": ["enable", "disable"]},
+                                "vap-all": {"required": False, "type": "str",
+                                            "choices": ["enable", "disable"]},
+                                "vaps": {"required": False, "type": "list",
+                                         "options": {
+                                             "name": {"required": True, "type": "str"}
+                                         }}
+                            }},
+                "split-tunneling-acl": {"required": False, "type": "list",
+                                        "options": {
+                                            "dest-ip": {"required": False, "type": "str"},
+                                            "id": {"required": True, "type": "int"}
+                                        }},
+                "split-tunneling-acl-local-ap-subnet": {"required": False, "type": "str",
+                                                        "choices": ["enable", "disable"]},
+                "split-tunneling-acl-path": {"required": False, "type": "str",
+                                             "choices": ["tunnel", "local"]},
+                "tun-mtu-downlink": {"required": False, "type": "int"},
+                "tun-mtu-uplink": {"required": False, "type": "int"},
+                "wan-port-mode": {"required": False, "type": "str",
+                                  "choices": ["wan-lan", "wan-only"]},
+                "wtp-id": {"required": True, "type": "str"},
+                "wtp-mode": {"required": False, "type": "str",
+                             "choices": ["normal", "remote"]},
+                "wtp-profile": {"required": False, "type": "str"}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+    try:
+        from fortiosapi import FortiOSAPI
+    except ImportError:
+        module.fail_json(msg="fortiosapi module is required")
+
+    fos = FortiOSAPI()
+
+    is_error, has_changed, result = fortios_wireless_controller(module.params, fos)
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/plugins/callback/profile_tasks.py
+++ b/lib/ansible/plugins/callback/profile_tasks.py
@@ -171,6 +171,7 @@ class CallbackModule(CallbackBase):
         self._display.display(filled("", fchar="="))
 
         timestamp(self)
+        self.current = None
 
         results = self.stats.items()
 

--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -41,6 +41,7 @@ COMPAT_OPTIONS = (('display_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS),
                   ('show_custom_stats', C.SHOW_CUSTOM_STATS),
                   ('display_failed_stderr', False),)
 
+
 class CallbackModule(CallbackBase):
 
     '''

--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -20,7 +20,7 @@ DOCUMENTATION = '''
       - set as stdout in configuration
     options:
       show_only_changed:
-        description: Whether to display output from 'ok' task results
+        description: If true, do not show output from 'ok' task results
         default: False
         env:
           - name: UNIXY_SHOW_ONLY_CHANGED

--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -18,6 +18,15 @@ DOCUMENTATION = '''
       - default_callback
     requirements:
       - set as stdout in configuration
+    options:
+      show_only_changed:
+        description: Whether to display output from 'ok' task results
+        default: False
+        env:
+          - name: UNIXY_SHOW_ONLY_CHANGED
+        ini:
+          - section: callback_unixy
+            key: show_only_changed
 '''
 
 from os.path import basename
@@ -127,10 +136,13 @@ class CallbackModule(CallbackBase):
     def v2_runner_on_ok(self, result, msg="ok", display_color=C.COLOR_OK):
         self._preprocess_result(result)
 
+        show_only_changed = self.get_option('show_only_changed')
         result_was_changed = ('changed' in result._result and result._result['changed'])
         if result_was_changed:
             msg = "done"
             display_color = C.COLOR_CHANGED
+        elif show_only_changed:
+            return
 
         task_result = self._process_result_output(result, msg)
         self._display.display("  " + task_result, display_color)

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -1891,6 +1891,7 @@
     kernel_memory: 8M
     state: started
   register: kernel_memory_1
+  ignore_errors: yes
 
 - name: kernel_memory (idempotency)
   docker_container:
@@ -1900,6 +1901,7 @@
     kernel_memory: 8M
     state: started
   register: kernel_memory_2
+  ignore_errors: yes
 
 - name: kernel_memory (change)
   docker_container:
@@ -1910,6 +1912,7 @@
     state: started
     force_kill: yes
   register: kernel_memory_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -1917,12 +1920,14 @@
     state: absent
     force_kill: yes
   diff: no
+  ignore_errors: yes
 
 - assert:
     that:
     - kernel_memory_1 is changed
     - kernel_memory_2 is not changed
     - kernel_memory_3 is changed
+  when: kernel_memory_1 is not failed or 'kernel memory accounting disabled in this runc build' not in kernel_memory_1.msg
 
 ####################################################################
 ## kill_signal #####################################################

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -268,6 +268,19 @@
     that:
       - result is not changed
 
+- name: test checksum match in check mode
+  get_url:
+    url: 'https://{{ httpbin_host }}/get'
+    dest: '{{ remote_tmp_dir }}/test'
+    checksum: 'sha256:7036ede810fad2b5d2e7547ec703cae8da61edbba43c23f9d7203a0239b765c4.'
+  check_mode: True
+  register: result
+
+- name: Assert that check mode was green
+  assert:
+    that:
+      - result is not changed
+
 # https://github.com/ansible/ansible/issues/27617
 
 - name: set role facts

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -161,6 +161,7 @@ lib/ansible/modules/cloud/google/gcpubsub_facts.py E322
 lib/ansible/modules/cloud/google/gcpubsub_facts.py E324
 lib/ansible/modules/cloud/google/gcpubsub_facts.py E326
 lib/ansible/modules/cloud/google/gcspanner.py E322
+lib/ansible/modules/cloud/kubevirt/kubevirt_cdi_upload.py E203
 lib/ansible/modules/cloud/linode/linode.py E322
 lib/ansible/modules/cloud/linode/linode.py E324
 lib/ansible/modules/cloud/lxc/lxc_container.py E210


### PR DESCRIPTION
##### SUMMARY
This PR adds an option that, when set, will display task output only for
tasks that return a 'changed' (or failed) result.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
callback plugin unixy.py

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (unixy_show_only_changed d87e63cfe7) last updated 2018/10/09 23:41:39 (GMT -500)
  config file = /home/ally/.ansible.cfg
  configured module search path = [u'/home/ally/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ally/code/ansible/lib/ansible
  executable location = /home/ally/code/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```

##### ADDITIONAL INFORMATION

```
# Default behavior
Executing playbook test.yml

- localhost -
Gathering Facts...
  localhost ok
debug...
  localhost ok: {
    "changed": false,
    "msg": "Success."
} | msg: Success.
debug...
  localhost ok: {
    "ansible_hostname": "metis",
    "changed": false
}
command...
  localhost done | stdout:  23:35:51 up 23 days,  1:05, 27 users,  load average: 0.25, 0.11, 0.13

- Play recap -
  localhost                  : ok=4    changed=1    unreachable=0    failed=0

# with UNIXY_SHOW_ONLY_CHANGED=true
Executing playbook test.yml

- localhost -
Gathering Facts...
debug...
debug...
command...
  localhost done | stdout:  23:35:41 up 23 days,  1:05, 27 users,  load average: 0.20, 0.10, 0.13

- Play recap -
  localhost                  : ok=4    changed=1    unreachable=0    failed=0

```
