### PR TITLE
lambda: fix unboundLocalError in lambda

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -554,6 +554,7 @@ def main():
                                               'SecurityGroupIds': vpc_security_group_ids}})
 
         # Finally try to create function
+        current_version = None
         try:
             if not check_mode:
                 response = client.create_function(**func_kwargs)


### PR DESCRIPTION
##### SUMMARY
This fix initializes current_version to None so that
module proceeds in check mode.

Fixes: #46654

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/lambda.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8-devel
```