### PR TITLE
Fix vmware_inventory unit tests so they run.

### DIFF
--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -10,6 +10,7 @@ pytest
 pytest-mock
 pytest-xdist
 python-memcached
+pyvmomi
 pyyaml
 redis
 requests

--- a/test/units/contrib/inventory/test_vmware_inventory.py
+++ b/test/units/contrib/inventory/test_vmware_inventory.py
@@ -1,31 +1,9 @@
 import json
 import os
-import pickle
-import unittest
+import pytest
 import sys
-from nose.plugins.skip import SkipTest
 
-
-try:
-    from pyVmomi import vim, vmodl
-except ImportError:
-    raise SkipTest("test_vmware_inventory.py requires the python module 'pyVmomi'")
-
-try:
-    from vmware_inventory import VMWareInventory
-except ImportError:
-    raise SkipTest("test_vmware_inventory.py requires the python module 'vmware_inventory'")
-
-# contrib's dirstruct doesn't contain __init__.py files
-checkout_path = os.path.dirname(__file__)
-checkout_path = checkout_path.replace('/test/units/contrib/inventory', '')
-inventory_dir = os.path.join(checkout_path, 'contrib', 'inventory')
-sys.path.append(os.path.abspath(inventory_dir))
-
-# cleanup so that nose's path is not polluted with other inv scripts
-sys.path.remove(os.path.abspath(inventory_dir))
-
-BASICINVENTORY = {
+BASIC_INVENTORY = {
     'all': {
         'hosts': ['foo', 'bar']
     },
@@ -46,85 +24,79 @@ class FakeArgs(object):
     list = True
 
 
-class TestVMWareInventory(unittest.TestCase):
+@pytest.fixture
+def vmware_inventory():
+    inventory_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'contrib', 'inventory'))
 
-    def test_host_info_returns_single_host(self):
-        vmw = VMWareInventory(load=False)
-        vmw.inventory = BASICINVENTORY
-        foo = vmw.get_host_info('foo')
-        bar = vmw.get_host_info('bar')
-        assert foo == {'hostname': 'foo'}
-        assert bar == {'hostname': 'bar'}
+    sys.path.append(inventory_dir)
 
-    def test_show_returns_serializable_data(self):
-        fakeargs = FakeArgs()
-        vmw = VMWareInventory(load=False)
-        vmw.args = fakeargs
-        vmw.inventory = BASICINVENTORY
-        showdata = vmw.show()
-        serializable = False
+    try:
+        import vmware_inventory
+    except BaseException as ex:
+        pytest.skip(ex)
+    finally:
+        sys.path.remove(inventory_dir)
 
-        try:
-            json.loads(showdata)
-            serializable = True
-        except:
-            pass
-        assert serializable
-        # import epdb; epdb.st()
+    return vmware_inventory
 
-    def test_show_list_returns_serializable_data(self):
-        fakeargs = FakeArgs()
-        vmw = VMWareInventory(load=False)
-        vmw.args = fakeargs
-        vmw.args.list = True
-        vmw.inventory = BASICINVENTORY
-        showdata = vmw.show()
-        serializable = False
 
-        try:
-            json.loads(showdata)
-            serializable = True
-        except:
-            pass
-        assert serializable
-        # import epdb; epdb.st()
+def test_host_info_returns_single_host(vmware_inventory):
+    vmw = vmware_inventory.VMWareInventory(load=False)
+    vmw.inventory = BASIC_INVENTORY
+    foo = vmw.get_host_info('foo')
+    bar = vmw.get_host_info('bar')
+    assert foo == {'hostname': 'foo'}
+    assert bar == {'hostname': 'bar'}
 
-    def test_show_list_returns_all_data(self):
-        fakeargs = FakeArgs()
-        vmw = VMWareInventory(load=False)
-        vmw.args = fakeargs
-        vmw.args.list = True
-        vmw.inventory = BASICINVENTORY
-        showdata = vmw.show()
-        expected = json.dumps(BASICINVENTORY, indent=2)
-        assert showdata == expected
 
-    def test_show_host_returns_serializable_data(self):
-        fakeargs = FakeArgs()
-        vmw = VMWareInventory(load=False)
-        vmw.args = fakeargs
-        vmw.args.host = 'foo'
-        vmw.inventory = BASICINVENTORY
-        showdata = vmw.show()
-        serializable = False
+def test_show_returns_serializable_data(vmware_inventory):
+    fakeargs = FakeArgs()
+    vmw = vmware_inventory.VMWareInventory(load=False)
+    vmw.args = fakeargs
+    vmw.inventory = BASIC_INVENTORY
+    showdata = vmw.show()
+    json.loads(showdata)
 
-        try:
-            json.loads(showdata)
-            serializable = True
-        except:
-            pass
-        assert serializable
-        # import epdb; epdb.st()
 
-    def test_show_host_returns_just_host(self):
-        fakeargs = FakeArgs()
-        vmw = VMWareInventory(load=False)
-        vmw.args = fakeargs
-        vmw.args.list = False
-        vmw.args.host = 'foo'
-        vmw.inventory = BASICINVENTORY
-        showdata = vmw.show()
-        expected = BASICINVENTORY['_meta']['hostvars']['foo']
-        expected = json.dumps(expected, indent=2)
-        # import epdb; epdb.st()
-        assert showdata == expected
+def test_show_list_returns_serializable_data(vmware_inventory):
+    fakeargs = FakeArgs()
+    vmw = vmware_inventory.VMWareInventory(load=False)
+    vmw.args = fakeargs
+    vmw.args.list = True
+    vmw.inventory = BASIC_INVENTORY
+    showdata = vmw.show()
+    json.loads(showdata)
+
+
+def test_show_list_returns_all_data(vmware_inventory):
+    fakeargs = FakeArgs()
+    vmw = vmware_inventory.VMWareInventory(load=False)
+    vmw.args = fakeargs
+    vmw.args.list = True
+    vmw.inventory = BASIC_INVENTORY
+    showdata = vmw.show()
+    expected = json.dumps(BASIC_INVENTORY, indent=2)
+    assert showdata == expected
+
+
+def test_show_host_returns_serializable_data(vmware_inventory):
+    fakeargs = FakeArgs()
+    vmw = vmware_inventory.VMWareInventory(load=False)
+    vmw.args = fakeargs
+    vmw.args.host = 'foo'
+    vmw.inventory = BASIC_INVENTORY
+    showdata = vmw.show()
+    json.loads(showdata)
+
+
+def test_show_host_returns_just_host(vmware_inventory):
+    fakeargs = FakeArgs()
+    vmw = vmware_inventory.VMWareInventory(load=False)
+    vmw.args = fakeargs
+    vmw.args.list = False
+    vmw.args.host = 'foo'
+    vmw.inventory = BASIC_INVENTORY
+    showdata = vmw.show()
+    expected = BASIC_INVENTORY['_meta']['hostvars']['foo']
+    expected = json.dumps(expected, indent=2)
+    assert showdata == expected


### PR DESCRIPTION
##### SUMMARY

Fix vmware_inventory unit tests so they run.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

vmware_inventory unit tests

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (units-fix 798fa26db4) last updated 2018/10/09 22:27:46 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
