### PR TITLE
Ensure that k8s_facts always returns resources key

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -189,7 +189,7 @@ class K8sAnsibleMixin(object):
                                   label_selector=','.join(label_selectors),
                                   field_selector=','.join(field_selectors)).to_dict()
         except openshift.dynamic.exceptions.NotFoundError:
-            return dict(items=[])
+            return dict(resources=[])
 
         if 'items' in result:
             return dict(resources=result['items'])

--- a/test/integration/targets/k8s/playbooks/roles/k8s/tasks/main.yml
+++ b/test/integration/targets/k8s/playbooks/roles/k8s/tasks/main.yml
@@ -15,6 +15,19 @@
       debug:
         var: output
 
+    - name: k8s_facts works with empty resources
+      k8s_facts:
+        kind: Deployment
+        namespace: testing
+        api_version: extensions/v1beta1
+      register: k8s_facts
+
+    - name: assert that k8s_facts is in correct format
+      assert:
+        that:
+          - "'resources' in k8s_facts"
+          - not k8s_facts.resources
+
     - name: Create a service
       k8s:
         state: present
@@ -85,7 +98,7 @@
       k8s:
         state: present
         inline: &deployment
-          apiVersion: apps/v1beta1
+          apiVersion: extensions/v1beta1
           kind: Deployment
           metadata:
             name: elastic


### PR DESCRIPTION
##### SUMMARY
Fix bug returning `items` key if NotFound exception is hit

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
k8s_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel 0785656344) last updated 2018/10/10 16:34:16 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/opensource/ansible/lib/ansible
  executable location = /Users/will/src/opensource/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
Will need back porting to 2.7
