### PR TITLE
win_uri: use variable for httpbin host

### DIFF
--- a/test/integration/targets/win_uri/tasks/test.yml
+++ b/test/integration/targets/win_uri/tasks/test.yml
@@ -363,7 +363,7 @@
 
 - name: validate status codes as list of strings
   win_uri:
-    url: https://httpbin.org/status/202
+    url: https://{{httpbin_host}}/status/202
     status_code:
     - '202'
     - '418'
@@ -380,7 +380,7 @@
 
 - name: validate status codes as comma separated list
   win_uri:
-    url: https://httpbin.org/status/202
+    url: https://{{httpbin_host}}/status/202
     status_code: 202, 418
     method: POST
     body: foo


### PR DESCRIPTION
##### SUMMARY
Minor fix in the win_uri tests to use the common variable instead of hardcoding URL. This will fix up issues when moving towards the internal httptester container.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_uri

##### ANSIBLE VERSION
```paste below
devel
```