### PR TITLE
Fix google auth scoping for unscoped credentials

### DIFF
--- a/changelogs/fragments/46740-gcp-utils-credentials-scoping.yaml
+++ b/changelogs/fragments/46740-gcp-utils-credentials-scoping.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "gcp_utils - fix google auth scoping issue with application default credentials or google cloud engine credentials. Only scope credentials that can be scoped."

--- a/lib/ansible/module_utils/gcp_utils.py
+++ b/lib/ansible/module_utils/gcp_utils.py
@@ -103,8 +103,7 @@ class GcpSession(object):
             self.module.fail_json(msg=inst.message)
 
     def session(self):
-        return AuthorizedSession(
-            self._credentials().with_scopes(self.module.params['scopes']))
+        return AuthorizedSession(self._credentials())
 
     def _validate(self):
         if not HAS_REQUESTS:
@@ -126,11 +125,11 @@ class GcpSession(object):
     def _credentials(self):
         cred_type = self.module.params['auth_kind']
         if cred_type == 'application':
-            credentials, project_id = google.auth.default()
+            credentials, project_id = google.auth.default(scopes=self.module.params['scopes'])
             return credentials
         elif cred_type == 'serviceaccount':
             path = os.path.realpath(os.path.expanduser(self.module.params['service_account_file']))
-            return service_account.Credentials.from_service_account_file(path)
+            return service_account.Credentials.from_service_account_file(path).with_scopes(self.module.params['scopes'])
         elif cred_type == 'machineaccount':
             return google.auth.compute_engine.Credentials(
                 self.module.params['service_account_email'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes #46073.

When using Google Application Default of Machine Default credentials the Credentials object returned by `google.auth.default()` is not a `google.auth.credentials.Scope` descendant and will not have the `google.auth.credentials.Scope.with_scope()` attribute.

1. The code doc [explicitly mentions it](https://github.com/GoogleCloudPlatform/google-auth-library-python/blob/master/google/auth/compute_engine/credentials.py#L47) for `google.auth.compute_engine.Credentials` used by `auth_type: machineaccount`
2. For `google.auth.default()` used by `auth_type: application`, there is a [`scopes` parameter](https://github.com/GoogleCloudPlatform/google-auth-library-python/blob/master/google/auth/_default.py#L209) that [will only get applied if necessary](https://github.com/GoogleCloudPlatform/google-auth-library-python/blob/master/google/auth/_default.py#L296).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_compute inventory (module_utils)

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0.post0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/tpicariello/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/tpicariello/.pyenv/batcheval/local/lib/python2.7/site-packages/ansible
  executable location = /home/tpicariello/.pyenv/project/bin/ansible
  python version = 2.7.12 (default, Jul 18 2016, 15:02:52) [GCC 4.8.4]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Following the tutorial at https://docs.ansible.com/ansible/latest/scenario_guides/guide_gce.html#gce-dynamic-inventory
Using the following config:
```
plugin: gcp_compute
projects:
  - ...
filters:
auth_kind: application
```
Then calling `ansible-inventory --list -i <filename>.gcp.yml`
<!--- Paste verbatim command output below, e.g. before and after your change -->
Before fix:
```
 [WARNING]:  * Failed to parse
/home/my_user/ansible/inventory/test/dynamic-inventory.gcp.yml
with auto plugin: 'Credentials' object has no attribute 'with_scopes'
```

After fix:
```
{venv}/python2.7/site-packages/google/auth/_default.py:66: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK. We recommend that most server applications use service accounts instead. If your application continues to use end user credentials from Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error. For more information about service accounts, see https://cloud.google.com/docs/authentication/.
  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)
Parsed ansible/inventory/test/dynamic-inventory.gcp.yml inventory source with auto plugin
{
    "_meta": {
        "hostvars": {
            ...
```

Reopening #46479 on `devel` branch.