### PR TITLE
Disable update behavior until properly fixed

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_compute_instance.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_instance.py
@@ -910,9 +910,11 @@ def main():
 
     if fetch:
         if state == 'present':
-            if is_different(module, fetch):
-                fetch = update(module, self_link(module), kind)
-                changed = True
+            pass
+            # TODO: fix update beheavior (issue #46531)
+            # if is_different(module, fetch):
+            #     fetch = update(module, self_link(module), kind)
+            #     changed = True
         else:
             delete(module, self_link(module), kind)
             fetch = {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is a temporary fix for #46531

When using the `gcp_compute_instance`, the update method tries to use `PUT` on the google cloud engine instance API which is not supported.
There are a couple of methods to update parameters that can be updated after launch and they should be called individually. 
Because the API endpoint return a `404` status code, the module does not return the current instance (i.e: IPs) which prevents using them in following tasks. By preventing the broken update to happen in the first place it keeps the data from the initial fetch, allowing the next tasks to use them.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_compute_instance

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0.post0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/tpicariello/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/tpicariello/.pyenv/project/local/lib/python2.7/site-packages/ansible
  executable location = /home/tpicariello/.pyenv/project/bin/ansible
  python version = 2.7.12 (default, Jul 18 2016, 15:02:52) [GCC 4.8.4]

```
