### PR TITLE
s3_bucket: don't assume anything other than '*.amazonaws.com' is Walrus

### DIFF
--- a/changelogs/fragments/s3_bucket_walrus_endpoint.yaml
+++ b/changelogs/fragments/s3_bucket_walrus_endpoint.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "s3_bucket - Walrus users: ``s3_url`` must be a FQDN without scheme not path."

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -43,7 +43,9 @@ options:
       - The JSON policy as a string.
   s3_url:
     description:
-      - S3 URL endpoint for usage with Ceph, Eucalyptus and fakes3 etc. Otherwise assumes AWS.
+      - S3 URL endpoint for usage with Ceph, Eucalyptus and fakes3 etc.
+      - Assumes AWS if not specified.
+      - For Walrus, use FQDN of the endpoint without scheme nor path.
     aliases: [ S3_URL ]
   ceph:
     description:
@@ -483,17 +485,6 @@ def is_fakes3(s3_url):
         return False
 
 
-def is_walrus(s3_url):
-    """ Return True if it's Walrus endpoint, not S3
-
-    We assume anything other than *.amazonaws.com is Walrus"""
-    if s3_url is not None:
-        o = urlparse(s3_url)
-        return not o.hostname.endswith('amazonaws.com')
-    else:
-        return False
-
-
 def get_s3_client(module, aws_connect_kwargs, location, ceph, s3_url):
     if s3_url and ceph:  # TODO - test this
         ceph = urlparse(s3_url)
@@ -512,9 +503,6 @@ def get_s3_client(module, aws_connect_kwargs, location, ceph, s3_url):
         params = dict(module=module, conn_type='client', resource='s3', region=location,
                       endpoint="%s://%s:%s" % (protocol, fakes3.hostname, to_text(port)),
                       use_ssl=fakes3.scheme == 'fakes3s', **aws_connect_kwargs)
-    elif is_walrus(s3_url):
-        walrus = urlparse(s3_url).hostname
-        params = dict(module=module, conn_type='client', resource='s3', region=location, endpoint=walrus, **aws_connect_kwargs)
     else:
         params = dict(module=module, conn_type='client', resource='s3', region=location, endpoint=s3_url, **aws_connect_kwargs)
     return boto3_conn(**params)


### PR DESCRIPTION
##### SUMMARY

Don't assume anything other than `*.amazonaws.com` is Walrus, for example, `https://s3.nl-ams.scw.cloud` isn't Walrus.

Fix the error below when using [Scaleway object storage](https://www.scaleway.com/object-storage/):
```
 fatal: [localhost]: FAILED! => {"changed": false, "msg": "Couldn't connect to AWS: Invalid endpoint: s3.nl-ams.scw.cloud"}
```

When Walrus is used, `s3_url` parameter should be a FQDN.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
s3_bucket

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

<!--- ##### ADDITIONAL INFORMATION --->
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
