### PR TITLE
s3_bucket: don't always call policy/requestPayment/versioning API

### DIFF
--- a/changelogs/fragments/s3_bucket_requester_pays_default_value.yaml
+++ b/changelogs/fragments/s3_bucket_requester_pays_default_value.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - s3_bucket - avoid failure when ``policy``, ``requestPayment``, ``tags`` or
+    ``versioning`` operations aren't supported by the endpoint and related
+    parameters aren't set


### PR DESCRIPTION
##### SUMMARY
don't call `policy`/`requestPayment`/`versioning` API when default value is used with parameters `policy`/`requester_pays`/`versioning`.

Fix the following error:
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_s3_bucket_payload_tfn8z6cy/__main__.py", line 181, in create_or_update_bucket
    requester_pays_status = get_bucket_request_payment(s3_client, name)
  File "/tmp/ansible_s3_bucket_payload_tfn8z6cy/ansible_s3_bucket_payload.zip/ansible/module_utils/cloud.py", line 150, in retry_func
    raise e
  File "/tmp/ansible_s3_bucket_payload_tfn8z6cy/ansible_s3_bucket_payload.zip/ansible/module_utils/cloud.py", line 140, in retry_func
    return f(*args, **kwargs)
  File "/tmp/ansible_s3_bucket_payload_tfn8z6cy/__main__.py", line 314, in get_bucket_request_payment
    return s3_client.get_bucket_request_payment(Bucket=bucket_name).get('Payer')
  File "$HOME/.venv/ansible/lib/python3.6/site-packages/botocore/client.py", line 310, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "$HOME/.venv/ansible/lib/python3.6/site-packages/botocore/client.py", line 599, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (NotImplemented) when calling the GetBucketRequestPayment operation: The requested resource is not implemented
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
s3_bucket

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION
With #46745, it allows to use `s3_bucket` with [Scaleway Object Storage](https://www.scaleway.com/object-storage/) (if you're willing to test these changes with the Scaleway service, there is currently a free public beta).