### PR TITLE
Do not strip new lines in native jinja

### DIFF
--- a/changelogs/fragments/46743-fix-native-jinja-newlines.yaml
+++ b/changelogs/fragments/46743-fix-native-jinja-newlines.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - templar - Do not strip new lines in native jinja - https://github.com/ansible/ansible/issues/46743

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -621,10 +621,7 @@ class Templar:
 
         # For preserving the number of input newlines in the output (used
         # later in this method)
-        if not USE_JINJA2_NATIVE:
-            data_newlines = _count_newlines_from_end(data)
-        else:
-            data_newlines = None
+        data_newlines = _count_newlines_from_end(data)
 
         if fail_on_undefined is None:
             fail_on_undefined = self._fail_on_undefined_errors
@@ -690,7 +687,7 @@ class Templar:
                     display.debug("failing because of a type error, template data is: %s" % to_native(data))
                     raise AnsibleError("Unexpected templating type error occurred on (%s): %s" % (to_native(data), to_native(te)))
 
-            if USE_JINJA2_NATIVE:
+            if USE_JINJA2_NATIVE and not isinstance(res, string_types):
                 return res
 
             if preserve_trailing_newlines:

--- a/test/integration/targets/jinja2_native_types/runtests.yml
+++ b/test/integration/targets/jinja2_native_types/runtests.yml
@@ -46,4 +46,5 @@
             - import_tasks: test_dunder.yml
             - import_tasks: test_types.yml
             - import_tasks: test_none.yml
+            - import_tasks: test_template.yml
         when: is_native

--- a/test/integration/targets/jinja2_native_types/test_template.yml
+++ b/test/integration/targets/jinja2_native_types/test_template.yml
@@ -1,0 +1,26 @@
+- block:
+  - name: cast things to other things
+    template:
+      src: test_template_newlines.j2
+      dest: test_template_newlines.res
+
+  - name: Dump template file
+    stat:
+      path: test_template_newlines.j2
+      get_checksum: yes
+    register: template_stat
+
+  - name: Dump result file
+    stat:
+      path: test_template_newlines.res
+      get_checksum: yes
+    register: result_stat
+
+  - assert:
+      that:
+        - template_stat.stat.checksum == result_stat.stat.checksum
+  always:
+    - name: Clean up
+      file:
+        path: test_template_newlines.res
+        state: absent

--- a/test/integration/targets/jinja2_native_types/test_template.yml
+++ b/test/integration/targets/jinja2_native_types/test_template.yml
@@ -1,5 +1,5 @@
 - block:
-  - name: cast things to other things
+  - name: Template file with newlines
     template:
       src: test_template_newlines.j2
       dest: test_template_newlines.res
@@ -16,7 +16,8 @@
       get_checksum: yes
     register: result_stat
 
-  - assert:
+  - name: Check that number of newlines from original template are preserved
+    assert:
       that:
         - template_stat.stat.checksum == result_stat.stat.checksum
   always:

--- a/test/integration/targets/jinja2_native_types/test_template_newlines.j2
+++ b/test/integration/targets/jinja2_native_types/test_template_newlines.j2
@@ -1,0 +1,4 @@
+First line.
+
+
+


### PR DESCRIPTION
##### SUMMARY
Do not skip `preserve_trailing_newlines` if data is `string_types` in native jinja.
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/46743
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
templar

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
devel
```

##### ADDITIONAL INFORMATION