### PR TITLE
Check if `enabled_snat` is set in modules arguments

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_router.py
+++ b/lib/ansible/modules/cloud/openstack/os_router.py
@@ -227,8 +227,10 @@ def _needs_update(cloud, module, router, network, internal_subnet_ids, internal_
     if router['admin_state_up'] != module.params['admin_state_up']:
         return True
     if router['external_gateway_info']:
-        if router['external_gateway_info'].get('enable_snat', True) != module.params['enable_snat']:
-            return True
+        # check if enable_snat is set in module params
+        if module.params['enable_snat'] is not None:
+            if router['external_gateway_info'].get('enable_snat', True) != module.params['enable_snat']:
+                return True
     if network:
         if not router['external_gateway_info']:
             return True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
If `enabled_snat` is not set at all in module arguments but Neutron
policy sets it by default in Openstack, then `os_router` will attempt to
recreate otherwise perfectly good router.

Follow up for https://github.com/ansible/ansible/issues/44432#issuecomment-428531031
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_router

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
$ ansible --version
ansible 2.7.0
  config file = /home/siemek/repos/baltig/WizDom/ci-peons-ansible/ansible.cfg
  configured module search path = ['/home/siemek/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/siemek/envs/ci-peons-ansible-jB3vWrrC/lib/python3.6/site-packages/ansible
  executable location = /home/siemek/envs/ci-peons-ansible-jB3vWrrC/bin/ansible
  python version = 3.6.7rc1 (default, Sep 27 2018, 09:51:25) [GCC 8.2.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
