### PR TITLE
aix_facts: statvfs works on AIX too so make use of it

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/aix.py
+++ b/lib/ansible/module_utils/facts/hardware/aix.py
@@ -19,6 +19,7 @@ __metaclass__ = type
 import re
 
 from ansible.module_utils.facts.hardware.base import Hardware, HardwareCollector
+from ansible.module_utils.facts.utils import get_mount_size
 
 
 class AIXHardware(Hardware):
@@ -175,6 +176,9 @@ class AIXHardware(Hardware):
         mount_facts = {}
 
         mount_facts['mounts'] = []
+
+        mounts = []
+
         # AIX does not have mtab but mount command is only source of info (or to use
         # api calls to get same info)
         mount_path = self.module.get_bin_path('mount')
@@ -185,11 +189,13 @@ class AIXHardware(Hardware):
                 if len(fields) != 0 and fields[0] != 'node' and fields[0][0] != '-' and re.match('^/.*|^[a-zA-Z].*|^[0-9].*', fields[0]):
                     if re.match('^/', fields[0]):
                         # normal mount
-                        mount_facts['mounts'].append({'mount': fields[1],
-                                                      'device': fields[0],
-                                                      'fstype': fields[2],
-                                                      'options': fields[6],
-                                                      'time': '%s %s %s' % (fields[3], fields[4], fields[5])})
+                        mount = fields[1]
+                        mount_info = {'mount': mount,
+                                      'device': fields[0],
+                                      'fstype': fields[2],
+                                      'options': fields[6],
+                                      'time': '%s %s %s' % (fields[3], fields[4], fields[5])}
+                        mount_info.update(get_mount_size(mount))
                     else:
                         # nfs or cifs based mount
                         # in case of nfs if no mount options are provided on command line
@@ -197,11 +203,16 @@ class AIXHardware(Hardware):
                         if len(fields) < 8:
                             fields.append("")
 
-                        mount_facts['mounts'].append({'mount': fields[2],
-                                                      'device': '%s:%s' % (fields[0], fields[1]),
-                                                      'fstype': fields[3],
-                                                      'options': fields[7],
-                                                      'time': '%s %s %s' % (fields[4], fields[5], fields[6])})
+                        mount_info = {'mount': fields[2],
+                                      'device': '%s:%s' % (fields[0], fields[1]),
+                                      'fstype': fields[3],
+                                      'options': fields[7],
+                                      'time': '%s %s %s' % (fields[4], fields[5], fields[6])}
+
+                    mounts.append(mount_info)
+
+        mount_facts['mounts'] = mounts
+
         return mount_facts
 
     def get_device_facts(self):


### PR DESCRIPTION
##### SUMMARY
This enables Ansible to gather filesystem sizes on AIX.

On Linux these facts are gathered by function get_mount_size that uses os.statvfs.
Since AIX has the statvfs system call too, we can make use of that.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- module_utils/facts/hardware/aix.py

##### ADDITIONAL INFORMATION

```
        "ansible_mounts": [
            {
                "device": "/dev/hd4",
                "fstype": "jfs2",
                "mount": "/",
                "options": "rw,log=/dev/hd8",
                "time": "Mar 17 13:28"
            },
```

With patch:
```
        "ansible_mounts": [
            {
                "block_available": 210984,
                "block_size": 4096,
                "block_total": 327680,
                "block_used": 116696,
                "device": "/dev/hd4",
                "fstype": "jfs2",
                "inode_available": 188816,
                "inode_total": 201845,
                "inode_used": 13029,
                "mount": "/",
                "options": "rw,log=/dev/hd8",
                "size_available": 864190464,
                "size_total": 1342177280,
                "time": "Mar 17 13:28"
            },
```