### PR TITLE
VMware: enhancement - add timeout parameter for vmware module vsphere_copy

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vsphere_copy.py
+++ b/lib/ansible/modules/cloud/vmware/vsphere_copy.py
@@ -58,6 +58,11 @@ options:
         set to C(no) when no other option exists.
     default: 'yes'
     type: bool
+  timeout:
+    description:
+      - The timeout in seconds for the upload to the datastore.
+    default: 10
+    type: int
 
 notes:
   - "This module ought to be run from a system that can access vCenter directly and has the file to transfer.
@@ -126,6 +131,7 @@ def main():
             datastore=dict(required=True),
             dest=dict(required=True, aliases=['path']),
             validate_certs=dict(default=True, type='bool'),
+            timeout=dict(default=10, type='int')
         ),
         # Implementing check-mode using HEAD is impossible, since size/date is not 100% reliable
         supports_check_mode=False,
@@ -139,6 +145,7 @@ def main():
     datastore = module.params.get('datastore')
     dest = module.params.get('dest')
     validate_certs = module.params.get('validate_certs')
+    timeout = module.params.get('timeout')
 
     fd = open(src, "rb")
     atexit.register(fd.close)
@@ -155,7 +162,7 @@ def main():
     }
 
     try:
-        r = open_url(url, data=data, headers=headers, method='PUT',
+        r = open_url(url, data=data, headers=headers, method='PUT', timeout=timeout,
                      url_username=login, url_password=password, validate_certs=validate_certs,
                      force_basic_auth=True)
     except socket.error as e:

--- a/lib/ansible/modules/cloud/vmware/vsphere_copy.py
+++ b/lib/ansible/modules/cloud/vmware/vsphere_copy.py
@@ -63,6 +63,7 @@ options:
       - The timeout in seconds for the upload to the datastore.
     default: 10
     type: int
+    version_added: "2.8"
 
 notes:
   - "This module ought to be run from a system that can access vCenter directly and has the file to transfer.


### PR DESCRIPTION
##### SUMMARY
This add the new optional 'timeout' parameter to the vsphere_copy module.

The default timeout value is 10 seconds, but this can't be configured. Now users have the option to select a higher (or lower) timeout. This can be especially useful when uploading large files (like ISO's).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Module - vsphere_copy.py

##### ANSIBLE VERSION
Affects the latest version of Ansible
```
ansible 2.3.1.0
  config file = None
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug 29 2016, 10:12:21) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

```
