### PR TITLE
pagerduty_alert: fix IndexError exception

### DIFF
--- a/lib/ansible/modules/monitoring/pagerduty_alert.py
+++ b/lib/ansible/modules/monitoring/pagerduty_alert.py
@@ -153,11 +153,17 @@ def check(module, name, state, service_id, integration_key, api_key, incident_ke
     if info['status'] != 200:
         module.fail_json(msg="failed to check current incident status."
                              "Reason: %s" % info['msg'])
-    json_out = json.loads(response.read())["incidents"][0]
 
-    if state != json_out["status"]:
-        return json_out, True
-    return json_out, False
+    incidents = json.loads(response.read())["incidents"]
+
+    if len(incidents) == 0 and state in ('acknowledged', 'resolved'):
+        return "No corresponding incident", False
+    elif len(incidents) == 0:
+        return "No corresponding incident", True
+    elif state != incidents[0]["status"]:
+        return incidents[0], True
+
+    return incidents[0], False
 
 
 def send_event(module, service_key, event_type, desc,

--- a/lib/ansible/modules/monitoring/pagerduty_alert.py
+++ b/lib/ansible/modules/monitoring/pagerduty_alert.py
@@ -155,11 +155,12 @@ def check(module, name, state, service_id, integration_key, api_key, incident_ke
                              "Reason: %s" % info['msg'])
 
     incidents = json.loads(response.read())["incidents"]
+    msg = "No corresponding incident"
 
-    if len(incidents) == 0 and state in ('acknowledged', 'resolved'):
-        return "No corresponding incident", False
-    elif len(incidents) == 0:
-        return "No corresponding incident", True
+    if len(incidents) == 0:
+        if state in ('acknowledged', 'resolved'):
+            return msg, False
+        return msg, True
     elif state != incidents[0]["status"]:
         return incidents[0], True
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #46765 

This fixes the IndexError Exception in case the PagerDuty api returns an empty list of incidents.

I attempted to follow the [documentation](https://docs.ansible.com/ansible/2.6/modules/pagerduty_alert_module.html) to determine whether to set the `changed` state to true or false.
Since `acknowledged` and `resolved` events are ignored if no corresponding events are found, I decided to return `changed: false` for those in case no previous incident exists.

I also set `No corresponding incident` as result in such a case, but I wasn't quite sure what would be best here. Maybe empty dict would be better ? 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pagerduty_alert

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.7.0
  config file = /home/oceyral/dev/COMPANY/PROJECT_NAME/ansible.cfg
  configured module search path = ['/home/oceyral/dev/COMPANY/PROJECT_NAME/library']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.0 (default, Sep 15 2018, 19:13:07) [GCC 8.2.1 20180831]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
The full traceback is:
Traceback (most recent call last):
  File "<stdin>", line 113, in <module>
  File "<stdin>", line 105, in _ansiballz_main
  File "<stdin>", line 48, in invoke_module
  File "/tmp/ansible_pagerduty_alert_payload_7fEBxg/__main__.py", line 248, in <module>
  File "/tmp/ansible_pagerduty_alert_payload_7fEBxg/__main__.py", line 238, in main
  File "/tmp/ansible_pagerduty_alert_payload_7fEBxg/__main__.py", line 156, in check
IndexError: list index out of range

fatal: [HOSTNAME]: FAILED! => {
    "changed": false, 
    "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 113, in <module>\n  File \"<stdin>\", line 105, in _ansiballz_main\n  File \"<stdin>\", line 48, in invoke_module\n  File \"/tmp/ansible_pagerduty_alert_payload_7fEBxg/__main__.py\", line 248, in <module>\n  File \"/tmp/ansible_pagerduty_alert_payload_7fEBxg/__main__.py\", line 238, in main\n  File \"/tmp/ansible_pagerduty_alert_payload_7fEBxg/__main__.py\", line 156, in check\nIndexError: list index out of range\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", 
    "rc": 1
}
```

After:
```
ok: [HOSTNAME] => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "api_key": "API_KEY",                                                                                                                                                                                                
            "client": null, 
            "client_url": null,                                                                                                                                                                                                               
            "desc": "description",  
            "incident_key": "HOSTNAME incident key", 
            "integration_key": "PAGERDUTY_INTEGRATION_KEY", 
            "name": "hello",                                                                                                                                                                                                                
            "service_id": "PAGERDUTY_SERVICE_ID", 
            "service_key": null, 
            "state": "resolved"
        }
    }, 
    "result": "No corresponding incident"
}
```