### PR TITLE
Add Support of healthcheck in docker_container module

### DIFF
--- a/changelogs/fragments/46772-docker_container-healthcheck.yaml
+++ b/changelogs/fragments/46772-docker_container-healthcheck.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_container - Added support for healthcheck."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -688,6 +688,15 @@ EXAMPLES = '''
       timeout: 10s
       retries: 3
       start_period: 30s
+
+- name: Remove healthcheck from container
+  docker_container:
+    name: nginx-proxy
+    image: nginx:1.13
+    state: started
+    healthcheck:
+      # The "NONE" check needs to be specified
+      test: ["NONE"]
 '''
 
 RETURN = '''
@@ -948,7 +957,7 @@ class TaskParameters(DockerBaseClass):
         self.ulimits = self._parse_ulimits()
         self.sysctls = self._parse_sysctls()
         self.log_config = self._parse_log_config()
-        self.healthcheck = self._parse_healthcheck()
+        self.healthcheck, self.disable_healthcheck = self._parse_healthcheck()
         self.exp_links = None
         self.volume_binds = self._get_volume_binds(self.volumes)
 
@@ -1370,7 +1379,7 @@ class TaskParameters(DockerBaseClass):
         Return dictionary of healthcheck parameters
         '''
         if (not self.healthcheck) or (not self.healthcheck.get('test')):
-            return None
+            return None, None
 
         result = dict()
 
@@ -1393,8 +1402,24 @@ class TaskParameters(DockerBaseClass):
                         result[key] = time
                 elif self.healthcheck.get(value):
                     result[key] = self.healthcheck.get(value)
+                    if key == 'test':
+                        if isinstance(result[key], (tuple, list)):
+                            result[key] = [str(e) for e in result[key]]
+                        else:
+                            result[key] = str(result[key])
+                    elif key == 'retries':
+                        try:
+                            result[key] = int(result[key])
+                        except Exception as e:
+                            self.fail('Cannot parse number of retries for healthcheck. '
+                                      'Expected an integer, got "{0}".'.format(result[key]))
 
-        return result
+        if result['test'] == ['NONE']:
+            # If the user explicitly disables the healthcheck, return None
+            # as the healthcheck object, and set disable_healthcheck to True
+            return None, True
+
+        return result, False
 
     def _convert_duration_to_nanosecond(self, time_str):
         '''
@@ -1676,7 +1701,8 @@ class Container(DockerBaseClass):
             volumes_from=host_config.get('VolumesFrom'),
             working_dir=config.get('WorkingDir'),
             publish_all_ports=host_config.get('PublishAllPorts'),
-            expected_healthcheck=(config.get('Healthcheck') or dict())
+            expected_healthcheck=config.get('Healthcheck'),
+            disable_healthcheck=(not config.get('Healthcheck') or config.get('Healthcheck').get('Test') == ['NONE']),
         )
         if self.parameters.restart_policy:
             config_mapping['restart_retries'] = restart_policy.get('MaximumRetryCount')
@@ -2486,6 +2512,7 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
         # Add implicit options
         comparisons['publish_all_ports'] = dict(type='value', comparison='strict', name='published_ports')
         comparisons['expected_ports'] = dict(type='dict', comparison=comparisons['published_ports']['comparison'], name='expected_ports')
+        comparisons['disable_healthcheck'] = dict(type='value', comparison='ignore' if comparisons['healthcheck']['comparison'] == 'ignore' else 'strict', name='disable_healthcheck')
         # Check legacy values
         if self.module.params['ignore_image'] and comparisons['image']['comparison'] != 'ignore':
             self.module.warn('The ignore_image option has been overridden by the comparisons option!')

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1406,7 +1406,7 @@ class TaskParameters(DockerBaseClass):
                         if isinstance(result[key], (tuple, list)):
                             result[key] = [str(e) for e in result[key]]
                         else:
-                            result[key] = str(result[key])
+                            result[key] = ["CMD-SHELL", str(result[key])]
                     elif key == 'retries':
                         try:
                             result[key] = int(result[key])

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2570,8 +2570,7 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
 
         healthcheck_supported = LooseVersion(docker_version) >= LooseVersion('2.0')
         if self.module.params.get("healthcheck") and not healthcheck_supported:
-            self.module.warn("docker or docker-py version is %s. Minimum version required is 2.0 to set healthcheck option. "
-                             "healthcheck is ignored." % (docker_version,))
+            self.fail("docker or docker-py version is %s. Minimum version required is 2.0 to set healthcheck option." % (docker_version,))
 
         self.HAS_INIT_OPT = init_supported
         self.HAS_UTS_MODE_OPT = uts_mode_supported

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2512,7 +2512,9 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
         # Add implicit options
         comparisons['publish_all_ports'] = dict(type='value', comparison='strict', name='published_ports')
         comparisons['expected_ports'] = dict(type='dict', comparison=comparisons['published_ports']['comparison'], name='expected_ports')
-        comparisons['disable_healthcheck'] = dict(type='value', comparison='ignore' if comparisons['healthcheck']['comparison'] == 'ignore' else 'strict', name='disable_healthcheck')
+        comparisons['disable_healthcheck'] = dict(type='value',
+                                                  comparison='ignore' if comparisons['healthcheck']['comparison'] == 'ignore' else 'strict',
+                                                  name='disable_healthcheck')
         # Check legacy values
         if self.module.params['ignore_image'] and comparisons['image']['comparison'] != 'ignore':
             self.module.warn('The ignore_image option has been overridden by the comparisons option!')

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1441,7 +1441,7 @@ class TaskParameters(DockerBaseClass):
                 time_params[name] = int(value)
 
         time = timedelta(**time_params)
-        time_in_nanoseconds = (time.seconds * 1000000 + time.microseconds) * 1000
+        time_in_nanoseconds = int(time.total_seconds() * 1000000000)
 
         return time_in_nanoseconds
 

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -1134,6 +1134,99 @@
     - groups_4 is changed
 
 ####################################################################
+## healthcheck #####################################################
+####################################################################
+
+- name: healthcheck
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    healthcheck:
+      test:
+      - CMD
+      - sleep
+      - 1
+      timeout: 2s
+      interval: 0h0m2s3ms4us
+      retries: 2
+    stop_timeout: 1
+  register: healthcheck_1
+
+- name: healthcheck (idempotency)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    healthcheck:
+      test:
+      - CMD
+      - sleep
+      - 1
+      timeout: 2s
+      interval: 0h0m2s3ms4us
+      retries: 2
+    stop_timeout: 1
+  register: healthcheck_2
+
+- name: healthcheck (changed)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    healthcheck:
+      test:
+      - CMD
+      - sleep
+      - 1
+      timeout: 3s
+      interval: 0h1m2s3ms4us
+      retries: 3
+    stop_timeout: 1
+  register: healthcheck_3
+
+- name: healthcheck (disabled)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    healthcheck:
+      test:
+      - NONE
+    stop_timeout: 1
+  register: healthcheck_4
+
+- name: healthcheck (disabled, idempotency)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    healthcheck:
+      test:
+      - NONE
+    stop_timeout: 1
+  register: healthcheck_5
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    stop_timeout: 1
+
+- assert:
+    that:
+    - healthcheck_1 is changed
+    - healthcheck_2 is not changed
+    - healthcheck_3 is changed
+    - healthcheck_4 is changed
+    - healthcheck_5 is not changed
+
+####################################################################
 ## hostname ########################################################
 ####################################################################
 

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -1188,6 +1188,15 @@
     stop_timeout: 1
   register: healthcheck_3
 
+- name: healthcheck (no change)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    stop_timeout: 1
+  register: healthcheck_4
+
 - name: healthcheck (disabled)
   docker_container:
     image: alpine:3.8
@@ -1198,7 +1207,7 @@
       test:
       - NONE
     stop_timeout: 1
-  register: healthcheck_4
+  register: healthcheck_5
 
 - name: healthcheck (disabled, idempotency)
   docker_container:
@@ -1210,7 +1219,7 @@
       test:
       - NONE
     stop_timeout: 1
-  register: healthcheck_5
+  register: healthcheck_6
 
 - name: cleanup
   docker_container:
@@ -1223,8 +1232,9 @@
     - healthcheck_1 is changed
     - healthcheck_2 is not changed
     - healthcheck_3 is changed
-    - healthcheck_4 is changed
-    - healthcheck_5 is not changed
+    - healthcheck_4 is not changed
+    - healthcheck_5 is changed
+    - healthcheck_6 is not changed
 
 ####################################################################
 ## hostname ########################################################

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -1221,6 +1221,28 @@
     stop_timeout: 1
   register: healthcheck_6
 
+- name: healthcheck (string in healthcheck test, changed)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    healthcheck:
+      test: "sleep 1"
+    stop_timeout: 1
+  register: healthcheck_7
+
+- name: healthcheck (string in healthcheck test, idempotency)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    healthcheck:
+      test: "sleep 1"
+    stop_timeout: 1
+  register: healthcheck_8
+
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
@@ -1235,6 +1257,8 @@
     - healthcheck_4 is not changed
     - healthcheck_5 is changed
     - healthcheck_6 is not changed
+    - healthcheck_7 is changed
+    - healthcheck_8 is not changed
 
 ####################################################################
 ## hostname ########################################################


### PR DESCRIPTION
Now container can be started with healthcheck enabled

##### SUMMARY
Fixes #33622

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (docker-healthcheck-fix-33622 71d323d402) last updated 2018/10/10 20:45:20 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/akshay/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/akshay/source/ansible/lib/ansible
  executable location = /home/akshay/source/ansible/bin/ansible
  python version = 3.6.6 (default, Jul 19 2018, 14:25:17) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Container started with healtcheck enabled using docker_container module.

    - name: Run nginx docker container
      docker_container:
        name: nginx-example1
        image: nginx:1.13
        state: started
        healthcheck:
          test: ["CMD-SHELL", "curl --fail http://nginx.host.com || exit 1"]
          interval: 5m
          timeout: 3s
          retries: 3
          start_period: 0s

```paste below
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                            PORTS               NAMES
841853243dbe        nginx:1.13          "nginx -g 'daemon of…"   2 minutes ago       Up 2 minutes (health: starting)   80/tcp              nginx-example1
```
