### PR TITLE
Fixed test mode of aws ec2_instance module

### DIFF
--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/block_devices.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/block_devices.yml
@@ -32,3 +32,45 @@
     - in_test_vpc.instances[0].block_device_mappings[0]
     - in_test_vpc.instances[0].block_device_mappings[1]
     - in_test_vpc.instances[0].block_device_mappings[1].device_name == '/dev/sdb'
+
+- name: New instance with an extra block device(check mode)
+  ec2_instance:
+    name: "{{ resource_prefix }}-test-ebs-vols-checkmode"
+    image_id: "{{ ec2_ami_image[aws_region] }}"
+    vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+    volumes:
+    - device_name: /dev/sda1
+      ebs:
+        delete_on_termination: true
+    - device_name: /dev/sdb
+      ebs:
+        volume_size: 20
+        delete_on_termination: true
+        volume_type: standard
+    tags:
+      TestId: "{{ resource_prefix }}"
+    instance_type: t2.micro
+    <<: *aws_connection_info
+  check_mode: yes
+
+- name: "fact presented ec2 instance"
+  ec2_instance_facts:
+    filters:
+      "tag:Name": "{{ resource_prefix }}-test-ebs-vols"
+      "instance-state-name": "running"
+    <<: *aws_connection_info
+  register: presented_instance_fact
+
+- name: "fact checkmode ec2 instance"
+  ec2_instance_facts:
+    filters:
+      "tag:Name": "{{ resource_prefix }}-test-ebs-vols-checkmode"
+      "instance-state-name": "running"
+    <<: *aws_connection_info
+  register: checkmode_instance_fact
+
+- name: "Confirm whether the check mode is working normally."
+  assert:
+    that:
+      - "{{ presented_instance_fact.instances | length }} > 0"
+      - "{{ checkmode_instance_fact.instances | length }} == 0"

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/checkmode_tests.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/checkmode_tests.yml
@@ -185,4 +185,3 @@
       until: removed is not failed
       ignore_errors: yes
       retries: 10
-

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/checkmode_tests.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/checkmode_tests.yml
@@ -1,0 +1,188 @@
+- name: set connection information for all tasks
+  set_fact:
+    aws_connection_info: &aws_connection_info
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token }}"
+      region: "{{ aws_region }}"
+  no_log: true
+
+- block:
+    - name: Make basic instance
+      ec2_instance:
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        image_id: "{{ ec2_ami_image[aws_region] }}"
+        security_groups: "{{ sg.group_id }}"
+        instance_type: t2.micro
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        volumes:
+        - device_name: /dev/sda1
+          ebs:
+            delete_on_termination: true
+        <<: *aws_connection_info
+      register: instance_creation
+
+    - name: Make basic instance(check mode)
+      ec2_instance:
+        name: "{{ resource_prefix }}-checkmode-comparison-checkmode"
+        image_id: "{{ ec2_ami_image[aws_region] }}"
+        security_groups: "{{ sg.group_id }}"
+        instance_type: t2.micro
+        vpc_subnet_id: "{{ testing_subnet_c.subnet.id }}"
+        volumes:
+        - device_name: /dev/sda1
+          ebs:
+            delete_on_termination: true
+        <<: *aws_connection_info
+      check_mode: yes
+
+    - name: fact presented ec2 instance
+      ec2_instance_facts:
+        filters:
+          "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
+          "instance-state-name": "running"
+        <<: *aws_connection_info
+      register: presented_instance_fact
+
+    - name: fact checkmode ec2 instance
+      ec2_instance_facts:
+        filters:
+          "tag:Name": "{{ resource_prefix }}-checkmode-comparison-checkmode"
+          "instance-state-name": "running"
+        <<: *aws_connection_info
+      register: checkmode_instance_fact
+
+    - name: Confirm whether the check mode is working normally.
+      assert:
+        that:
+          - "{{ presented_instance_fact.instances | length }} > 0"
+          - "{{ checkmode_instance_fact.instances | length }} == 0"
+
+    - name: Stop instance in check mode.
+      ec2_instance:
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        state: stopped
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        <<: *aws_connection_info
+      check_mode: yes
+
+    - name: fact ec2 instance
+      ec2_instance_facts:
+        filters:
+          "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
+        <<: *aws_connection_info
+      register: confirm_checkmode_stopinstance_fact
+
+    - name: Verify that it was not stopped.
+      assert:
+        that:
+          - '"{{ confirm_checkmode_stopinstance_fact.instances[0].state.name }}" != "stopped"'
+
+    - name: Stop instance in normaly.
+      ec2_instance:
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        state: stopped
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        <<: *aws_connection_info
+      
+    - name: fact stopped ec2 instance
+      ec2_instance_facts:
+        filters:
+          "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
+        <<: *aws_connection_info
+      register: confirm_stopinstance_fact
+
+    - name: Verify that it was stopped.
+      assert:
+        that:
+          - '"{{ confirm_stopinstance_fact.instances[0].state.name }}" == "stopped"'
+
+    - name: Running instance in check mode.
+      ec2_instance:
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        state: running
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        <<: *aws_connection_info
+      check_mode: yes
+      
+    - name: fact ec2 instance
+      ec2_instance_facts:
+        filters:
+          "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
+        <<: *aws_connection_info
+      register: confirm_checkmode_runninginstance_fact
+      
+    - name: Verify that it was not running.
+      assert:
+        that:
+          - '"{{ confirm_checkmode_runninginstance_fact.instances[0].state.name }}" != "running"'
+
+    - name: Running instance in normaly.
+      ec2_instance:
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        state: running
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        <<: *aws_connection_info
+          
+    - name: fact ec2 instance.
+      ec2_instance_facts:
+        filters:
+          "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
+        <<: *aws_connection_info
+      register: confirm_runninginstance_fact
+
+    - name: Verify that it was running.
+      assert:
+        that:
+          - '"{{ confirm_runninginstance_fact.instances[0].state.name }}" == "running"'
+
+    - name: Terminate instance in check mode.
+      ec2_instance:
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        state: absent
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        <<: *aws_connection_info
+      check_mode: yes
+
+    - name: fact ec2 instance
+      ec2_instance_facts:
+        filters:
+          "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
+        <<: *aws_connection_info
+      register: confirm_checkmode_terminatedinstance_fact
+      
+    - name: Verify that it was not terminated,
+      assert:
+        that:
+          - '"{{ confirm_checkmode_terminatedinstance_fact.instances[0].state.name }}" != "terminated"'
+
+    - name: Terminate instance in check mode.
+      ec2_instance:
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        state: absent
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        <<: *aws_connection_info
+
+    - name: fact ec2 instance
+      ec2_instance_facts:
+        filters:
+          "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
+        <<: *aws_connection_info
+      register: confirm_terminatedinstance_fact
+      
+    - name: Verify that it was terminated,
+      assert:
+        that:
+          - '"{{ confirm_terminatedinstance_fact.instances[0].state.name }}" == "terminated"'
+        
+  always:
+    - name: Terminate instance
+      ec2:
+        instance_ids: "{{ basic_instance.instance_ids }}"
+        state: absent
+        <<: *aws_connection_info
+      register: removed
+      until: removed is not failed
+      ignore_errors: yes
+      retries: 10
+

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/cpu_options.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/cpu_options.yml
@@ -58,3 +58,44 @@
     that:
       - cpu_options_update is success
       - cpu_options_update is not changed
+
+- name: create c4.large instance with cpu_options(check mode)
+  ec2_instance:
+    name: "{{ resource_prefix }}-test-c4large-1-threads-per-core-checkmode"
+    image_id: "{{ ec2_ami_image[aws_region] }}"
+    tags:
+      TestId: "{{ resource_prefix }}"
+    vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+    instance_type: c4.large
+    cpu_options:
+        core_count: 1
+        threads_per_core: 1
+    volumes:
+    - device_name: /dev/sda1
+      ebs:
+        delete_on_termination: true
+    <<: *aws_connection_info
+  check_mode: yes
+
+- name: "fact presented ec2 instance"
+  ec2_instance_facts:
+    filters:
+      "tag:Name": "{{ resource_prefix }}-test-c4large-1-threads-per-core"
+      "instance-state-name": "running"
+    <<: *aws_connection_info
+  register: presented_instance_fact
+
+- name: "fact checkmode ec2 instance"
+  ec2_instance_facts:
+    filters:
+      "tag:Name": "{{ resource_prefix }}-test-c4large-1-threads-per-core-checkmode"
+      "instance-state-name": "running"
+    <<: *aws_connection_info
+  register: checkmode_instance_fact
+
+- name: "Confirm existence of instance id."
+  assert:
+    that:
+      - "{{ presented_instance_fact.instances | length }} > 0"
+      - "{{ checkmode_instance_fact.instances | length }} == 0"
+

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/cpu_options.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/cpu_options.yml
@@ -98,4 +98,3 @@
     that:
       - "{{ presented_instance_fact.instances | length }} > 0"
       - "{{ checkmode_instance_fact.instances | length }} == 0"
-

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/default_vpc_tests.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/default_vpc_tests.yml
@@ -20,6 +20,44 @@
         delete_on_termination: true
     <<: *aws_connection_info
   register: in_default_vpc
+
+- name: Make instance in a default subnet of the VPC(check mode)
+  ec2_instance:
+    name: "{{ resource_prefix }}-test-default-vpc-checkmode"
+    image_id: "{{ ec2_ami_image[aws_region] }}"
+    tags:
+      TestId: "{{ resource_prefix }}"
+    security_groups: "{{ sg.group_id }}"
+    instance_type: t2.micro
+    volumes:
+    - device_name: /dev/sda1
+      ebs:
+        delete_on_termination: true
+    <<: *aws_connection_info
+  check_mode: yes
+
+- name: "fact presented ec2 instance"
+  ec2_instance_facts:
+    filters:
+      "tag:Name": "{{ resource_prefix }}-test-default-vpc"
+      "instance-state-name": "running"
+    <<: *aws_connection_info
+  register: presented_instance_fact
+
+- name: "fact checkmode ec2 instance"
+  ec2_instance_facts:
+    filters:
+      "tag:Name": "{{ resource_prefix }}-test-default-vpc-checkmode"
+      "instance-state-name": "running"
+    <<: *aws_connection_info
+  register: checkmode_instance_fact
+
+- name: "Confirm whether the check mode is working normally."
+  assert:
+    that:
+      - "{{ presented_instance_fact.instances | length }} > 0"
+      - "{{ checkmode_instance_fact.instances | length }} == 0"
+
 - name: Terminate instance
   ec2:
     instance_ids: "{{ in_default_vpc.instance_ids }}"

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/external_resource_attach.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/external_resource_attach.yml
@@ -21,6 +21,13 @@
       - "{{ sg.group_id }}"
     <<: *aws_connection_info
   register: eni_b
+- ec2_eni:
+    delete_on_termination: true
+    subnet_id: "{{ testing_subnet_b.subnet.id }}"
+    security_groups:
+      - "{{ sg.group_id }}"
+    <<: *aws_connection_info
+  register: eni_c
 
 - ec2_key:
     name: "{{ resource_prefix }}_test_key"
@@ -63,6 +70,47 @@
     instance_type: t2.micro
     <<: *aws_connection_info
 
+- name: Make instance in the testing subnet created in the test VPC(check mode)
+  ec2_instance:
+    name: "{{ resource_prefix }}-test-eni-vpc-checkmode"
+    key_name: "{{ resource_prefix }}_test_key"
+    network:
+      interfaces:
+        - id: "{{ eni_c.interface.id }}"
+    image_id: "{{ ec2_ami_image[aws_region] }}"
+    availability_zone: '{{ aws_region }}b'
+    tags:
+      TestId: "{{ resource_prefix }}"
+    volumes:
+    - device_name: /dev/sda1
+      ebs:
+        delete_on_termination: true
+    instance_type: t2.micro
+    <<: *aws_connection_info
+  check_mode: yes
+
+- name: "fact presented ec2 instance"
+  ec2_instance_facts:
+    filters:
+      "tag:Name": "{{ resource_prefix }}-test-eni-vpc"
+      "instance-state-name": "running"
+    <<: *aws_connection_info
+  register: presented_instance_fact
+
+- name: "fact checkmode ec2 instance"
+  ec2_instance_facts:
+    filters:
+      "tag:Name": "{{ resource_prefix }}-test-eni-vpc-checkmode"
+      "instance-state-name": "running"
+    <<: *aws_connection_info
+  register: checkmode_instance_fact
+
+- name: "Confirm existence of instance id."
+  assert:
+    that:
+      - "{{ presented_instance_fact.instances | length }} > 0"
+      - "{{ checkmode_instance_fact.instances | length }} == 0"
+
 - name: Terminate instance
   ec2_instance:
     filters:
@@ -94,3 +142,4 @@
   with_items:
     - "{{ eni_a.interface.id }}"
     - "{{ eni_b.interface.id }}"
+    - "{{ eni_c.interface.id }}"

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/iam_instance_role.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/iam_instance_role.yml
@@ -48,6 +48,42 @@
         that:
           - 'instance_with_role.instances[0].iam_instance_profile.arn == iam_role.arn.replace(":role/", ":instance-profile/")'
 
+    - name: Make instance with an instance_role(check mode)
+      ec2_instance:
+        name: "{{ resource_prefix }}-test-instance-role-checkmode"
+        image_id: "{{ ec2_ami_image[aws_region] }}"
+        security_groups: "{{ sg.group_id }}"
+        instance_type: t2.micro
+        instance_role: "{{ resource_prefix }}-test-policy"
+        volumes:
+        - device_name: /dev/sda1
+          ebs:
+            delete_on_termination: true
+        <<: *aws_connection_info
+      check_mode: yes
+
+    - name: "fact presented ec2 instance"
+      ec2_instance_facts:
+        filters:
+          "tag:Name": "{{ resource_prefix }}-test-instance-role"
+          "instance-state-name": "running"
+        <<: *aws_connection_info
+      register: presented_instance_fact
+
+    - name: "fact checkmode ec2 instance"
+      ec2_instance_facts:
+        filters:
+          "tag:Name": "{{ resource_prefix }}-test-instance-role-checkmode"
+          "instance-state-name": "running"
+        <<: *aws_connection_info
+      register: checkmode_instance_fact
+
+    - name: "Confirm whether the check mode is working normally."
+      assert:
+        that:
+          - "{{ presented_instance_fact.instances | length }} > 0"
+          - "{{ checkmode_instance_fact.instances | length }} == 0"
+
     - name: Update instance with new instance_role
       ec2_instance:
         name: "{{ resource_prefix }}-test-instance-role"

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/main.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/main.yml
@@ -96,6 +96,7 @@
     - include_tasks: block_devices.yml
     - include_tasks: default_vpc_tests.yml
     - include_tasks: iam_instance_role.yml
+    - include_tasks: checkmode_tests.yml
 
 
     # ============================================================

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/tags_and_vpc_settings.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/tags_and_vpc_settings.yml
@@ -29,6 +29,29 @@
     <<: *aws_connection_info
   register: in_test_vpc
 
+- name: Make instance in the testing subnet created in the test VPC(check mode)
+  ec2_instance:
+    name: "{{ resource_prefix }}-test-basic-vpc-create-checkmode"
+    image_id: "{{ ec2_ami_image[aws_region] }}"
+    user_data: |
+      #cloud-config
+      package_upgrade: true
+      package_update: true
+    tags:
+      TestId: "{{ resource_prefix }}"
+      Something: else
+    security_groups: "{{ sg.group_id }}"
+    network:
+      source_dest_check: false
+    vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+    instance_type: t2.micro
+    volumes:
+    - device_name: /dev/sda1
+      ebs:
+        delete_on_termination: true
+    <<: *aws_connection_info
+  check_mode: yes
+
 - name: Try to re-make the instance, hopefully this shows changed=False
   ec2_instance:
     name: "{{ resource_prefix }}-test-basic-vpc-create"
@@ -54,6 +77,28 @@
 - name: check that source_dest_check was set to false
   assert:
     that: 'not remake_in_test_vpc.instances[0].source_dest_check'
+
+- name: "fact presented ec2 instance"
+  ec2_instance_facts:
+    filters:
+      "tag:Name": "{{ resource_prefix }}-test-basic-vpc-create"
+      "instance-state-name": "running"
+    <<: *aws_connection_info
+  register: presented_instance_fact
+
+- name: "fact checkmode ec2 instance"
+  ec2_instance_facts:
+    filters:
+      "tag:Name": "{{ resource_prefix }}-test-basic-vpc-create-checkmode"
+      "instance-state-name": "running"
+    <<: *aws_connection_info
+  register: checkmode_instance_fact
+
+- name: "Confirm whether the check mode is working normally."
+  assert:
+    that:
+      - "{{ presented_instance_fact.instances | length }} > 0"
+      - "{{ checkmode_instance_fact.instances | length }} == 0"
 
 - name: Alter it by adding tags
   ec2_instance:

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/termination_protection.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/termination_protection.yml
@@ -22,6 +22,46 @@
         delete_on_termination: true
     <<: *aws_connection_info
   register: in_test_vpc
+
+- name: Make termination-protected instance in the testing subnet created in the test VPC(check mode)
+  ec2_instance:
+    name: "{{ resource_prefix }}-test-protected-instance-in-vpc-checkmode"
+    image_id: "{{ ec2_ami_image[aws_region] }}"
+    tags:
+      TestId: "{{ resource_prefix }}"
+    security_groups: "{{ sg.group_id }}"
+    vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+    termination_protection: true
+    instance_type: t2.micro
+    volumes:
+    - device_name: /dev/sda1
+      ebs:
+        delete_on_termination: true
+    <<: *aws_connection_info
+  check_mode: yes
+
+- name: "fact presented ec2 instance"
+  ec2_instance_facts:
+    filters:
+      "tag:Name": "{{ resource_prefix }}-test-protected-instance-in-vpc"
+      "instance-state-name": "running"
+    <<: *aws_connection_info
+  register: presented_instance_fact
+
+- name: "fact checkmode ec2 instance"
+  ec2_instance_facts:
+    filters:
+      "tag:Name": "{{ resource_prefix }}-test-protected-instance-in-vpc-checkmode"
+      "instance-state-name": "running"
+    <<: *aws_connection_info
+  register: checkmode_instance_fact
+
+- name: "Confirm whether the check mode is working normally."
+  assert:
+    that:
+      - "{{ presented_instance_fact.instances | length }} > 0"
+      - "{{ checkmode_instance_fact.instances | length }} == 0"
+
 - name: Try to terminate the instance
   ec2_instance:
     state: absent


### PR DESCRIPTION
##### SUMMARY
Fixed test mode of aws ec2_instance module

<!--- Describe the change below, including rationale and design decisions -->
In the ec2_instance module, there was a problem to be executed regardless of the test mode.
With this PR, I will fix the problem and add the test code.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Related
https://github.com/ansible/ansible/issues/46611

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
$ ansible --version
ansible 2.8.0.dev0 (aws_ec2_instance-fix_checkmode 7d2f8c2cb9) last updated 2018/10/11 01:14:49 (GMT +900)
  config file = None
  configured module search path = ['/home/cahlchang/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/cahlchang/git/ansible/lib/ansible
  executable location = /home/cahlchang/git/ansible/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

This code is testing the behavior of check mode.
https://github.com/ansible/ansible/commit/7d2f8c2cb99b1e91dd7c1478e04ce1c9fc58fe7f

In the ec2_instance module, the test was unsupported, and the integration test could not be executed.
Therefore, I ran the Playbook manually and tested.
https://github.com/ansible/ansible/blob/0c22c0cefb0c08d5bc10b72484749a5282ee220b/test/integration/targets/ec2_instance/aliases#L1-L2

* integration  test
```paste below
$ ansible-test integration ec2_instance
WARNING: Excluding tests marked "unsupported" which require --allow-unsupported or prefixing with "unsupported/": ec2_instance
WARNING: All targets skipped.

$ ansible-test sanity --test validate-modules ec2_instance
Sanity check using validate-modules
WARNING: Cannot perform module comparison against the base branch. Base branch not detected when running locally.
WARNING: Reviewing previous 1 warning(s):
WARNING: Cannot perform module comparison against the base branch. Base branch not detected when running locally.
```

* runme script

The runme script did not work due to version relation of boto3.
I think that it is necessary to fix the version of boto3.
However, I am removing it from correspondence so as to make the problem simple.

https://github.com/ansible/ansible/blob/0c22c0cefb0c08d5bc10b72484749a5282ee220b/test/integration/targets/ec2_instance/runme.sh#L19
```
+ python -m pip install 'botocore<1.10.16' boto3
Collecting botocore<1.10.16
  Using cached https://files.pythonhosted.org/packages/3e/a2/4eddf990705eccdda115d8e9e7c20fa21615704ed0806fc9eba6c2fcaad5/botocore-1.10.15-py2.py3-none-any.whl
Requirement already satisfied: boto3 in /home/cahlchang/.local/lib/python3.5/site-packages (1.7.45)
Requirement already satisfied: python-dateutil<3.0.0,>=2.1; python_version >= "2.7" in /home/cahlchang/.local/lib/python3.5/site-packages (from botocore<1.10.16) (2.7.3)
Requirement already satisfied: jmespath<1.0.0,>=0.7.1 in /home/cahlchang/.local/lib/python3.5/site-packages (from botocore<1.10.16) (0.9.3)
Requirement already satisfied: docutils>=0.10 in /home/cahlchang/.local/lib/python3.5/site-packages (from botocore<1.10.16) (0.14)
Requirement already satisfied: s3transfer<0.2.0,>=0.1.10 in /home/cahlchang/.local/lib/python3.5/site-packages (from boto3) (0.1.13)
Requirement already satisfied: six>=1.5 in /home/cahlchang/.local/lib/python3.5/site-packages (from python-dateutil<3.0.0,>=2.1; python_version >= "2.7"->botocore<1.10.16) (1.11.0)
awscli 1.15.58 has requirement botocore==1.10.57, but you'll have botocore 1.10.15 which is incompatible.
boto3 1.7.45 has requirement botocore<1.11.0,>=1.10.45, but you'll have botocore 1.10.15 which is incompatible.
```

Run manually.
```
ansible-playbook --extra-vars="@test/integration/cloud-config-aws.yml" ./test/integration/targets/ec2_instance/playbooks/full_test.yml
# test result... all passed.
```

This code also passes pep8 test.
```paste below
$ ansible-test sanity --test pep8 ec2_instance
Sanity check using pep8
```