### PR TITLE
manage levels for 'multiple included lists' (#46359)

### DIFF
--- a/changelogs/fragments/fix_flatten.yml
+++ b/changelogs/fragments/fix_flatten.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - fix flatten to properly handle multiple lists in lists https://github.com/ansible/ansible/issues/46343

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -463,8 +463,8 @@ def flatten(mylist, levels=None):
             if levels is None:
                 ret.extend(flatten(element))
             elif levels >= 1:
-                levels = int(levels) - 1
-                ret.extend(flatten(element, levels=levels))
+                # decrement as we go down the stack
+                ret.extend(flatten(element, levels=(int(levels) - 1)))
             else:
                 ret.append(element)
         else:


### PR DESCRIPTION
* manage levels for 'multiple included lists'

fixes #46343

(cherry picked from commit 80d977bac65768bdd5cd675b9d1794640749431a)
(cherry picked from commit ef6637895301842ff0a62f35ef1a6e517af60e39)

>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
flatten
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6
```
