### PR TITLE
Fix netconf module_utils dict changed size issue

### DIFF
--- a/lib/ansible/module_utils/network/netconf/netconf.py
+++ b/lib/ansible/module_utils/network/netconf/netconf.py
@@ -131,7 +131,7 @@ def sanitize_xml(data):
         # remove attributes
         attribute = element.attrib
         if attribute:
-            for key in attribute:
+            for key in list(attribute):
                 if key not in IGNORE_XML_ATTRIBUTE:
                     attribute.pop(key)
     return to_text(tostring(tree), errors='surrogate_then_replace').strip()


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #46755

Use list() to copy the keys of attribute dict
while iterating over attribute dict.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
junos_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
