### PR TITLE
Handle non-ascii characters in foreman.py

### DIFF
--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -46,6 +46,8 @@ if LooseVersion(requests.__version__) < LooseVersion('1.1.0'):
 
 from requests.auth import HTTPBasicAuth
 
+from ansible.module_utils._text import to_text
+
 
 def json_format_dict(data, pretty=False):
     """Converts a dict to a JSON object and dumps it as a formatted string"""
@@ -285,20 +287,32 @@ class ForemanInventory(object):
             group = 'hostgroup'
             val = host.get('%s_title' % group) or host.get('%s_name' % group)
             if val:
-                safe_key = self.to_safe('%s%s_%s' % (self.group_prefix, group, val.lower()))
+                safe_key = self.to_safe('%s%s_%s' % (
+                    to_text(self.group_prefix),
+                    group,
+                    to_text(val).lower()
+                ))
                 self.inventory[safe_key].append(dns_name)
 
             # Create ansible groups for environment, location and organization
             for group in ['environment', 'location', 'organization']:
                 val = host.get('%s_name' % group)
                 if val:
-                    safe_key = self.to_safe('%s%s_%s' % (self.group_prefix, group, val.lower()))
+                    safe_key = self.to_safe('%s%s_%s' % (
+                        to_text(self.group_prefix),
+                        group,
+                        to_text(val).lower()
+                    ))
                     self.inventory[safe_key].append(dns_name)
 
             for group in ['lifecycle_environment', 'content_view']:
                 val = host.get('content_facet_attributes', {}).get('%s_name' % group)
                 if val:
-                    safe_key = self.to_safe('%s%s_%s' % (self.group_prefix, group, val.lower()))
+                    safe_key = self.to_safe('%s%s_%s' % (
+                        to_text(self.group_prefix),
+                        group,
+                        to_text(val).lower()
+                    ))
                     self.inventory[safe_key].append(dns_name)
 
             params = self._resolve_params(host_params)
@@ -307,7 +321,7 @@ class ForemanInventory(object):
             # attributes.
             groupby = dict()
             for k, v in params.items():
-                groupby[k] = self.to_safe(str(v))
+                groupby[k] = self.to_safe(to_text(v))
 
             # The name of the ansible groups is given by group_patterns:
             for pattern in self.group_patterns:

--- a/test/integration/targets/inventory_foreman_script/runme.sh
+++ b/test/integration/targets/inventory_foreman_script/runme.sh
@@ -6,6 +6,11 @@ export FOREMAN_HOST="${FOREMAN_HOST:-localhost}"
 export FOREMAN_PORT="${FOREMAN_PORT:-8080}"
 export FOREMAN_INI_PATH="${OUTPUT_DIR}/foreman.ini"
 
+
+############################################
+#   SMOKETEST WITH SIMPLE INI
+############################################
+
 cat > "$FOREMAN_INI_PATH" <<FOREMAN_INI
 [foreman]
 url = http://${FOREMAN_HOST}:${FOREMAN_PORT}
@@ -16,3 +21,29 @@ FOREMAN_INI
 
 # use ansible to validate the return data
 ansible-playbook -i foreman.sh test_foreman_inventory.yml --connection=local
+RC=$?
+if [[ $RC != 0 ]]; then
+    echo "foreman inventory script smoketest failed"
+    exit $RC
+fi
+
+############################################
+#   SMOKETEST WITH NON-ASCII INI
+############################################
+
+cat > "$FOREMAN_INI_PATH" <<FOREMAN_INI
+[foreman]
+url = http://${FOREMAN_HOST}:${FOREMAN_PORT}
+user = ansible-tester
+password = secure
+ssl_verify = False
+group_prefix = Ľuboš_
+FOREMAN_INI
+
+# use ansible to validate the return data
+ansible-playbook -i foreman.sh test_foreman_inventory.yml --connection=local
+RC=$?
+if [[ $RC != 0 ]]; then
+    echo "foreman inventory script non-ascii failed"
+    exit $RC
+fi


### PR DESCRIPTION
##### SUMMARY

Fixes #46438

```
# config
$ egrep ^group_prefix foreman.ini 
group_prefix = Ľuboš_
```

```
# Traceback
./foreman.py --refresh-cache
...
safe_key = self.to_safe('%s%s_%s' % (self.group_prefix, group, val.lower()))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc4 in position 0: ordinal not in range(128) 
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
foreman.py

##### ANSIBLE VERSION
```paste below
devel
```

