### PR TITLE
add more consistent extension matching for inventory plugins

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -102,11 +102,11 @@ This method is used by Ansible to make a quick determination if the inventory so
         valid = False
         if super(InventoryModule, self).verify_file(path):
             # base class verifies that file exists and is readable by current user
-            if path.endswith(('.vbox.yaml', '.vbox.yml')):
+            if path.endswith(('virtualbox.yaml', 'virtualbox.yml', 'vbox.yaml', 'vbox.yml')):
                 valid = True
         return valid
 
-In this case, from the :ref:`virtualbox inventory plugin <virtualbox_inventory>`, we screen for specific file name patterns to avoid attempting to consume any valid yaml file. You can add any type of condition here, but the most common one is 'extension matching'
+In this case, from the :ref:`virtualbox inventory plugin <virtualbox_inventory>`, we screen for specific file name patterns to avoid attempting to consume any valid yaml file. You can add any type of condition here, but the most common one is 'extension matching'. If you implement extension matching for YAML configuration files the path suffix <plugin_name>.<yml|yaml> should be accepted. All valid extensions should be documented in the plugin description.
 
 Another example that actually does not use a 'file' but the inventory source string itself,
 from the :ref:`host list <host_list_inventory>` plugin:

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
         - constructed
     description:
         - Get inventory hosts from Amazon Web Services EC2.
-        - Uses a <name>.aws_ec2.yaml (or <name>.aws_ec2.yml) YAML configuration file.
+        - Uses a YAML configuration file that ends with aws_ec2.(yml|yaml).
     options:
         plugin:
             description: token that ensures this is a source file for the 'aws_ec2' plugin.
@@ -509,9 +509,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             :return the contents of the config file
         '''
         if super(InventoryModule, self).verify_file(path):
-            if path.endswith('.aws_ec2.yml') or path.endswith('.aws_ec2.yaml'):
+            if path.endswith(('aws_ec2.yml', 'aws_ec2.yaml')):
                 return True
-        display.debug("aws_ec2 inventory filename must end with '*.aws_ec2.yml' or '*.aws_ec2.yaml'")
+        display.debug("aws_ec2 inventory filename must end with 'aws_ec2.yml' or 'aws_ec2.yaml'")
         return False
 
     def _get_query_options(self, config_data):

--- a/lib/ansible/plugins/inventory/aws_rds.py
+++ b/lib/ansible/plugins/inventory/aws_rds.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
     short_description: rds instance source
     description:
         - Get instances and clusters from Amazon Web Services RDS.
-        - Uses a <name>.aws_rds.yaml (or <name>.aws_rds.yml) YAML configuration file.
+        - Uses a YAML configuration file that ends with aws_rds.(yml|yaml).
     options:
         boto_profile:
           description: The boto profile to use. The plugin will look for an instance role if no credentials
@@ -301,7 +301,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             :return the contents of the config file
         '''
         if super(InventoryModule, self).verify_file(path):
-            if path.endswith('.aws_rds.yml') or path.endswith('.aws_rds.yaml'):
+            if path.endswith(('aws_rds.yml', 'aws_rds.yaml')):
                 return True
         return False
 

--- a/lib/ansible/plugins/inventory/azure_rm.py
+++ b/lib/ansible/plugins/inventory/azure_rm.py
@@ -12,7 +12,7 @@ DOCUMENTATION = r'''
       - azure
     description:
         - Query VM details from Azure Resource Manager
-        - Requires a YAML configuration file whose name ends with '.azure_rm.yaml'
+        - Requires a YAML configuration file whose name ends with 'azure_rm.(yml|yaml)'
         - By default, sets C(ansible_host) to the first public IP address found (preferring the primary NIC). If no
           public IPs are found, the first private IP (also preferring the primary NIC). The default may be overridden
           via C(hostvar_expressions); see examples.
@@ -216,9 +216,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             :return the contents of the config file
         '''
         if super(InventoryModule, self).verify_file(path):
-            if re.match(r'.+\.azure_rm\.y(a)?ml$', path):
+            if re.match(r'.{0,}azure_rm\.y(a)?ml$', path):
                 return True
-        # display.debug("azure_rm inventory filename must match '*.azure_rm.yml' or '*.azure_rm.yaml'")
+        # display.debug("azure_rm inventory filename must end with 'azure_rm.yml' or 'azure_rm.yaml'")
         return False
 
     def parse(self, inventory, loader, path, cache=True):

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -100,7 +100,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
         valid = False
         if super(InventoryModule, self).verify_file(path):
-            if path.endswith('.foreman.yaml') or path.endswith('.foreman.yml'):
+            if path.endswith(('foreman.yaml', 'foreman.yml')):
                 valid = True
         return valid
 

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
         - inventory_cache
     description:
         - Get inventory hosts from Google Cloud Platform GCE.
-        - Uses a <name>.gcp.yaml (or <name>.gcp.yml) YAML configuration file.
+        - Uses a YAML configuration file that ends with gcp_compute.(yml|yaml) or gcp.(yml|yaml).
     options:
         plugin:
             description: token that ensures this is a source file for the 'gcp_compute' plugin.
@@ -120,9 +120,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             :return the contents of the config file
         '''
         if super(InventoryModule, self).verify_file(path):
-            if path.endswith('.gcp.yml') or path.endswith('.gcp.yaml'):
+            if path.endswith(('gcp.yml', 'gcp.yaml')):
                 return True
-            elif path.endswith('.gcp_compute.yml') or path.endswith('.gcp_compute.yaml'):
+            elif path.endswith(('gcp_compute.yml', 'gcp_compute.yaml')):
                 return True
         return False
 
@@ -317,8 +317,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         super(InventoryModule, self).parse(inventory, loader, path)
 
         config_data = {}
-        if self.verify_file(path):
-            config_data = self._read_config_data(path)
+        config_data = self._read_config_data(path)
 
         # get user specifications
         if 'zones' in config_data:

--- a/lib/ansible/plugins/inventory/linode.py
+++ b/lib/ansible/plugins/inventory/linode.py
@@ -16,7 +16,7 @@ DOCUMENTATION = r'''
         - linode_api4 >= 2.0.0
     description:
         - Reads inventories from the Linode API v4.
-        - Uses a C(<name>.linode.yaml) (or C(<name>.linode.yml)) YAML configuration file.
+        - Uses a YAML configuration file that ends with linode.(yml|yaml).
         - Linode labels are used by default as the hostnames.
         - The inventory groups are built from groups and not tags.
     options:
@@ -186,7 +186,7 @@ class InventoryModule(BaseInventoryPlugin):
     def verify_file(self, path):
         """Verify the Linode configuration file."""
         if super(InventoryModule, self).verify_file(path):
-            endings = ('.linode.yaml', '.linode.yml')
+            endings = ('linode.yaml', 'linode.yml')
             if any((path.endswith(ending) for ending in endings)):
                 return True
         return False

--- a/lib/ansible/plugins/inventory/tower.py
+++ b/lib/ansible/plugins/inventory/tower.py
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
     description:
         - Reads inventories from Ansible Tower.
         - Supports reading configuration from both YAML config file and environment variables.
-        - If reading from the YAML file, the file name must end with tower_inventory.(yml|yaml),
+        - If reading from the YAML file, the file name must end with tower.(yml|yaml) or tower_inventory.(yml|yaml),
           the path in the command would be /path/to/tower_inventory.(yml|yaml). If some arguments in the config file
           are missing, this plugin will try to fill in missing arguments by reading from environment variables.
         - If reading configurations from environment variables, the path in the command must be @tower_inventory.
@@ -143,7 +143,7 @@ class InventoryModule(BaseInventoryPlugin):
             self.no_config_file_supplied = True
             return True
         elif super(InventoryModule, self).verify_file(path):
-            return path.endswith('tower_inventory.yml') or path.endswith('tower_inventory.yaml')
+            return path.endswith(('tower_inventory.yml', 'tower_inventory.yaml', 'tower.yml', 'tower.yaml'))
         else:
             return False
 

--- a/lib/ansible/plugins/inventory/virtualbox.py
+++ b/lib/ansible/plugins/inventory/virtualbox.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
     short_description: virtualbox inventory source
     description:
         - Get inventory hosts from the local virtualbox installation.
-        - Uses a <name>.vbox.yaml (or .vbox.yml) YAML configuration file.
+        - Uses a YAML configuration file that ends with virtualbox.(yml|yaml) or vbox.(yml|yaml).
         - The inventory_hostname is always the 'Name' of the virtualbox instance.
     extends_documentation_fragment:
       - constructed
@@ -210,7 +210,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         valid = False
         if super(InventoryModule, self).verify_file(path):
-            if path.endswith(('.vbox.yaml', '.vbox.yml')):
+            if path.endswith(('virtualbox.yaml', 'virtualbox.yml', 'vbox.yaml', 'vbox.yml')):
                 valid = True
         return valid
 


### PR DESCRIPTION
##### SUMMARY
Add more consistent extension matching for inventory plugins that support YAML configuration files. Document the expectation that `plugin_name.(yml|yaml)` should be an accepted extension. This is backwards compatible.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
Inventory plugins

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
```

