### PR TITLE
Correct usage of sorted() in mongodb_user

### DIFF
--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -320,7 +320,7 @@ def check_if_roles_changed(uinfo, roles, db_name):
     roles_as_list_of_dict = make_sure_roles_are_a_list_of_dict(roles, db_name)
     uinfo_roles = uinfo.get('roles', [])
 
-    if sorted(roles_as_list_of_dict,key=itemgetter('db')) == sorted(uinfo_roles,key=itemgetter('db')):
+    if sorted(roles_as_list_of_dict, key=itemgetter('db')) == sorted(uinfo_roles, key=itemgetter('db')):
         return False
     return True
 

--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -178,6 +178,7 @@ import os
 import ssl as ssl_lib
 import traceback
 from distutils.version import LooseVersion
+from operator import itemgetter
 
 try:
     from pymongo.errors import ConnectionFailure
@@ -319,7 +320,7 @@ def check_if_roles_changed(uinfo, roles, db_name):
     roles_as_list_of_dict = make_sure_roles_are_a_list_of_dict(roles, db_name)
     uinfo_roles = uinfo.get('roles', [])
 
-    if sorted(roles_as_list_of_dict) == sorted(uinfo_roles):
+    if sorted(roles_as_list_of_dict,key=itemgetter('db')) == sorted(uinfo_roles,key=itemgetter('db')):
         return False
     return True
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`sorted()` (or `list.sort()`) can't be called on a `list` of `dict` without supplying a `key` parameter. This is explained really well in the Python [Sorting HOWTO](https://docs.python.org/3.6/howto/sorting.html#key-functions).

Examples showing how this module fails before this change are in issue #46791, which this PR fixes.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
mongodb_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.4
  config file = /Users/user/Dev/ansible-site/ansible.cfg
  configured module search path = ['/Users/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/ansible
  executable location = /opt/local/Library/Frameworks/Python.framework/Versions/3.6/bin/ansible
  python version = 3.6.6 (default, Jun 28 2018, 05:43:53) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See issue #46791.
<!--- Paste verbatim command output below, e.g. before and after your change -->
