### PR TITLE
Netbox inventory: Fix NoneType issue if query_filters is not in netbox_inventory.yml

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -60,27 +60,22 @@ DOCUMENTATION = '''
 EXAMPLES = '''
 # netbox_inventory.yml file in YAML format
 # Example command line: ansible-inventory -v --list -i netbox_inventory.yml
-
 plugin: netbox
 api_endpoint: http://localhost:8000
 group_by:
   - device_roles
 query_filters:
   - role: network-edge-router
-
 # Query filters are passed directly as an argument to the fetching queries.
 # You can repeat tags in the query string.
-
 query_filters:
   - role: server
   - tag: web
   - tag: production
-
 # See the NetBox documentation at https://netbox.readthedocs.io/en/latest/api/overview/
 # the query_filters work as a logical **OR**
 #
 # Prefix any custom fields with cf_ and pass the field value with the regular NetBox query string
-
 query_filters:
   - cf_foo: bar
 '''
@@ -309,8 +304,9 @@ class InventoryModule(BaseInventoryPlugin):
 
     def refresh_url(self):
         query_parameters = [("limit", 0)]
-        query_parameters.extend(filter(lambda x: x,
-                                       map(self.validate_query_parameters, self.query_filters)))
+        if self.query_filters:
+            query_parameters.extend(filter(lambda x: x,
+                                           map(self.validate_query_parameters, self.query_filters)))
         self.device_url = self.api_endpoint + "/api/dcim/devices/" + "?" + urlencode(query_parameters)
 
     def fetch_hosts(self):

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -60,22 +60,27 @@ DOCUMENTATION = '''
 EXAMPLES = '''
 # netbox_inventory.yml file in YAML format
 # Example command line: ansible-inventory -v --list -i netbox_inventory.yml
+
 plugin: netbox
 api_endpoint: http://localhost:8000
 group_by:
   - device_roles
 query_filters:
   - role: network-edge-router
+
 # Query filters are passed directly as an argument to the fetching queries.
 # You can repeat tags in the query string.
+
 query_filters:
   - role: server
   - tag: web
   - tag: production
+
 # See the NetBox documentation at https://netbox.readthedocs.io/en/latest/api/overview/
 # the query_filters work as a logical **OR**
 #
 # Prefix any custom fields with cf_ and pass the field value with the regular NetBox query string
+
 query_filters:
   - cf_foo: bar
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes an issue with seeing the following error when `query_filters:` is not defined in netbox_inventory.yml
` [WARNING]:  * Failed to parse /home/myohman/netbox_inventory.yml with netbox plugin: 'NoneType' object is not iterable`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netbox
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (netbox_inv_url_fix b530afe456) last updated 2018/10/10 22:43:26 (GMT -400)
  config file = /home/myohman/ansible.cfg
  configured module search path = ['/home/myohman/clonedrepos']
  ansible python module location = /home/myohman/ansible/lib/ansible
  executable location = /home/myohman/ansible/bin/ansible
  python version = 3.6.5 (default, Apr 10 2018, 17:08:37) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Do not have `query_filters:` defined at all in netbox_inventory.yml
```
---

plugin: netbox
api_endpoint: http://netbox-demo.org
token: faketoken
group_by:
  - device_roles
```
