### PR TITLE
Check docker.py version

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -221,7 +221,7 @@ try:
     from docker.errors import APIError
     from docker import __version__ as docker_py_version
     MINIMUM_DOCKER_PY_VERSION = '2.6.0'
-        
+
 except ImportError:
     # missing docker-py handled in ansible.module_utils.docker_common
     pass
@@ -232,11 +232,11 @@ from ansible.module_utils._text import to_native
 
 class TaskParameters(DockerBaseClass):
     def __init__(self, client):
-        
+
         if LooseVersion(docker_py_version) < LooseVersion(MINIMUM_DOCKER_PY_VERSION):
             client.fail("Found docker.py version %s. Minimum required version is %s. "
-                             "Upgrade docker.py to a min version of %s." %
-                             (docker_py_version, MINIMUM_DOCKER_PY_VERSION, MINIMUM_DOCKER_PY_VERSION))
+                        "Upgrade docker.py to a min version of %s." %
+                        (docker_py_version, MINIMUM_DOCKER_PY_VERSION, MINIMUM_DOCKER_PY_VERSION))
 
         super(TaskParameters, self).__init__()
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -216,8 +216,12 @@ actions:
 
 import json
 from time import sleep
+from distutils.version import LooseVersion
 try:
     from docker.errors import APIError
+    from docker import __version__ as docker_py_version
+    MINIMUM_DOCKER_PY_VERSION = '2.6.0'
+        
 except ImportError:
     # missing docker-py handled in ansible.module_utils.docker_common
     pass
@@ -228,6 +232,12 @@ from ansible.module_utils._text import to_native
 
 class TaskParameters(DockerBaseClass):
     def __init__(self, client):
+        
+        if LooseVersion(docker_py_version) < LooseVersion(MINIMUM_DOCKER_PY_VERSION):
+            client.fail("Found docker.py version %s. Minimum required version is %s. "
+                             "Upgrade docker.py to a min version of %s." %
+                             (docker_py_version, MINIMUM_DOCKER_PY_VERSION, MINIMUM_DOCKER_PY_VERSION))
+
         super(TaskParameters, self).__init__()
 
         self.state = None


### PR DESCRIPTION
##### SUMMARY
Test **docker.py** version to check version is `>= 2.6.0`
Fix issue #45683 

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request


##### COMPONENT NAME
docker_swarm.py

##### ANSIBLE VERSION
```
ansible 2.6.4
  config file = /root/.ansible.cfg
  configured module search path = [u'/root/ansible/core/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, Aug 16 2018, 14:17:09) [GCC 6.4.0]
```

##### ADDITIONAL INFORMATION
