### PR TITLE
Check correct return field for LXD API operations.

### DIFF
--- a/lib/ansible/module_utils/lxd.py
+++ b/lib/ansible/module_utils/lxd.py
@@ -93,7 +93,11 @@ class LXDClient(object):
         if resp_json['type'] == 'async':
             url = '{0}/wait'.format(resp_json['operation'])
             resp_json = self._send_request('GET', url)
-            if resp_json['status'] != 'Success':
+            if 'status' in resp_json.get('metadata')
+                status = resp_json['metadata']['status']
+            else:
+                status = resp_json.get('status', 'Failure')
+            if status != 'Success':
                 self._raise_err_from_json(resp_json)
         return resp_json
 

--- a/lib/ansible/module_utils/lxd.py
+++ b/lib/ansible/module_utils/lxd.py
@@ -93,7 +93,7 @@ class LXDClient(object):
         if resp_json['type'] == 'async':
             url = '{0}/wait'.format(resp_json['operation'])
             resp_json = self._send_request('GET', url)
-            if status in resp_json.get('metadata')
+            if 'status' in resp_json.get('metadata')
                 status = resp_json['metadata']['status']
             else:
                 status = resp_json.get('status', 'Failure')

--- a/lib/ansible/module_utils/lxd.py
+++ b/lib/ansible/module_utils/lxd.py
@@ -93,7 +93,7 @@ class LXDClient(object):
         if resp_json['type'] == 'async':
             url = '{0}/wait'.format(resp_json['operation'])
             resp_json = self._send_request('GET', url)
-            if 'status' in resp_json.get('metadata')
+            if status in resp_json.get('metadata')
                 status = resp_json['metadata']['status']
             else:
                 status = resp_json.get('status', 'Failure')

--- a/lib/ansible/module_utils/lxd.py
+++ b/lib/ansible/module_utils/lxd.py
@@ -93,7 +93,7 @@ class LXDClient(object):
         if resp_json['type'] == 'async':
             url = '{0}/wait'.format(resp_json['operation'])
             resp_json = self._send_request('GET', url)
-            if resp_json['metadata']['status'] != 'Success':
+            if resp_json['status'] != 'Success':
                 self._raise_err_from_json(resp_json)
         return resp_json
 

--- a/lib/ansible/module_utils/lxd.py
+++ b/lib/ansible/module_utils/lxd.py
@@ -93,7 +93,7 @@ class LXDClient(object):
         if resp_json['type'] == 'async':
             url = '{0}/wait'.format(resp_json['operation'])
             resp_json = self._send_request('GET', url)
-            if 'status' in resp_json.get('metadata')
+            if 'status' in resp_json.get('metadata'):
                 status = resp_json['metadata']['status']
             else:
                 status = resp_json.get('status', 'Failure')


### PR DESCRIPTION
##### SUMMARY
According to API documentation we should check "status" to find out when an operation is successful. "metadata" is generally empty.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lxd (module_utils)

##### ANSIBLE VERSION
```
ansible 2.7.0
  config file = /home/nafallo/.ansible.cfg
  configured module search path = [u'/home/nafallo/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
This made every lxd_container operation with "url" set fail until the container was started and no operations were required.

I have checked the API documentation against a handful of tags ranging from 2.0 to latest, in addition to the master, stable-2.0 and stable-3.0 branches.

Reference: https://github.com/lxc/lxd/blob/master/doc/rest-api.md