### PR TITLE
ldap_attr bugfix

### DIFF
--- a/lib/ansible/modules/net_tools/ldap/ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attr.py
@@ -178,7 +178,7 @@ class LdapAttr(LdapGeneric):
             self.values = [to_bytes(self.module.params['values'])]
 
     def add(self):
-        values_to_add = filter(self._is_value_absent, self.values)
+        values_to_add = list(filter(self._is_value_absent, self.values))
 
         if len(values_to_add) > 0:
             modlist = [(ldap.MOD_ADD, self.name, values_to_add)]
@@ -188,7 +188,7 @@ class LdapAttr(LdapGeneric):
         return modlist
 
     def delete(self):
-        values_to_delete = filter(self._is_value_present, self.values)
+        values_to_delete = list(filter(self._is_value_present, self.values))
 
         if len(values_to_delete) > 0:
             modlist = [(ldap.MOD_DELETE, self.name, values_to_delete)]


### PR DESCRIPTION
##### SUMMARY
Adding a value to an attribute or removing a value from an attribute of a LDAP entry throws the exception `TypeError: object of type 'filter' has no len()`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ldap_attr

##### ANSIBLE VERSION
```
2.7
```
