### PR TITLE
yum module properly check for None config_file (#46641)

### DIFF
--- a/changelogs/fragments/yum_bugfux_conf_file_none_type.yml
+++ b/changelogs/fragments/yum_bugfux_conf_file_none_type.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Fix yum module to properly check for empty conf_file value

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1317,8 +1317,8 @@ class YumModule(YumDnf):
         if self.conf_file and os.path.exists(self.conf_file):
             self.yum_basecmd += ['-c', self.conf_file]
 
-        if repoq:
-            repoq += ['-c', self.conf_file]
+            if repoq:
+                repoq += ['-c', self.conf_file]
 
         if self.skip_broken:
             self.yum_basecmd.extend(['--skip-broken'])

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -110,6 +110,15 @@
     that:
         - "yum_result is successful"
 
+- name: install sos with state latest in check mode with config file param
+  yum: name=sos state=latest conf_file=/etc/yum.conf
+  check_mode: true
+  register: yum_result
+- name: verify install sos with state latest in check mode with config file param
+  assert:
+    that:
+        - "yum_result is changed"
+
 - name: install sos with state latest in check mode
   yum: name=sos state=latest
   check_mode: true
@@ -134,6 +143,15 @@
   assert:
     that:
         - "not yum_result is changed"
+
+- name: install sos with state latest idempotence with config file param
+  yum: name=sos state=latest
+  register: yum_result
+- name: verify install sos with state latest idempotence with config file param
+  assert:
+    that:
+        - "not yum_result is changed"
+
 
 # Multiple packages
 - name: uninstall sos and bc


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
* yum module properly check for None config_file
* add conf_file test cases to yum integration tests

Fixes #46485
Fixes #46603 

Backport of https://github.com/ansible/ansible/pull/46641

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0.post0 (backport/2.7/pr/46641 0c4568a88d) last updated 2018/10/11 10:16:42 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, Sep 21 2018, 23:26:48) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```
