### PR TITLE
Add vmware dvswitch lacp option

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -48,6 +48,7 @@ options:
         description:
             - Add the LACP configuration
         required: True
+        version_added: 2.8
     uplink_quantity:
         description:
             - Quantity of uplink per ESXi host added to the switch

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -44,7 +44,7 @@ options:
         description:
             - The switch maximum transmission unit
         required: True
-    lacp: 
+    lacp:
         description:
             - Add the LACP configuration
         required: True

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -44,6 +44,10 @@ options:
         description:
             - The switch maximum transmission unit
         required: True
+    lacp: 
+        description:
+            - Add the LACP configuration
+        required: True
     uplink_quantity:
         description:
             - Quantity of uplink per ESXi host added to the switch

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -83,6 +83,7 @@ EXAMPLES = '''
     switch_name: dvSwitch
     switch_version: 6.0.0
     mtu: 9000
+    lacp: singleLag
     uplink_quantity: 2
     discovery_proto: lldp
     discovery_operation: both
@@ -115,6 +116,7 @@ class VMwareDVSwitch(object):
         self.switch_version = self.module.params['switch_version']
         self.datacenter_name = self.module.params['datacenter_name']
         self.mtu = self.module.params['mtu']
+        self.lacp = self.module.params['lacp']
         self.uplink_quantity = self.module.params['uplink_quantity']
         self.discovery_proto = self.module.params['discovery_proto']
         self.discovery_operation = self.module.params['discovery_operation']
@@ -153,6 +155,7 @@ class VMwareDVSwitch(object):
 
         spec.configSpec.name = self.switch_name
         spec.configSpec.maxMtu = self.mtu
+        spec.configSpec.lacpApiVersion = self.lacp
         spec.configSpec.linkDiscoveryProtocolConfig.protocol = self.discovery_proto
         spec.configSpec.linkDiscoveryProtocolConfig.operation = self.discovery_operation
         spec.productInfo = vim.dvs.ProductSpec()
@@ -201,6 +204,7 @@ def main():
     argument_spec.update(dict(datacenter_name=dict(required=True, type='str'),
                               switch_name=dict(required=True, type='str'),
                               mtu=dict(required=True, type='int'),
+                              lacp=dict(required=True, type='str'),
                               switch_version=dict(type='str'),
                               uplink_quantity=dict(required=True, type='int'),
                               discovery_proto=dict(required=True, choices=['cdp', 'lldp'], type='str'),


### PR DESCRIPTION
##### SUMMARY
I have changed the python file for the modules vmware_dvswitch in order to add the LACP support. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
modules/cloud/vmware/vmware_dvswitch.py 

##### ANSIBLE VERSION
Ansible version 2.7 

##### ADDITIONAL INFORMATION
Tested and validated on vCenter 6.5. 
