### PR TITLE
Fix ansible-test custom docker image traceback.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1478,7 +1478,7 @@ def get_integration_docker_filter(args, targets):
 
     python_version = 2  # images are expected to default to python 2 unless otherwise specified
 
-    python_version = int(get_docker_completion().get(args.docker_raw).get('python', str(python_version)))
+    python_version = int(get_docker_completion().get(args.docker_raw, {}).get('python', str(python_version)))
 
     if args.python:  # specifying a numeric --python option overrides the default python
         if args.python.startswith('3'):


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test custom docker image traceback.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (at-tb-fix 3c081b83b0) last updated 2018/10/11 09:40:31 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
