### PR TITLE
Add Alibaba to RedHat family list.

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -421,7 +421,7 @@ class Distribution(object):
     # keep keys in sync with Conditionals page of docs
     OS_FAMILY_MAP = {'RedHat': ['RedHat', 'Fedora', 'CentOS', 'Scientific', 'SLC',
                                 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS',
-                                'OEL', 'Amazon', 'Virtuozzo', 'XenServer'],
+                                'OEL', 'Amazon', 'Virtuozzo', 'XenServer', 'Alibaba'],
                      'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon',
                                 'Linux Mint', 'SteamOS', 'Devuan'],
                      'Suse': ['SuSE', 'SLES', 'SLED', 'openSUSE', 'openSUSE Tumbleweed',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ansible should identify Alibaba image as RedHat based, not as 'Alibaba' - for Alicloud machines.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
distribution.py changed

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (alicloud_alibaba_is_redhat_based cbabd7bf8e) last updated 2018/10/11 11:45:58 (GMT -500)
  config file = /Users/Alb0t/.ansible.cfg
  configured module search path = [u'/Users/Alb0t/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/Alb0t/code/ansible/lib/ansible
  executable location = /Users/Alb0t/code/ansible/bin/ansible
  python version = 2.7.15 (default, Oct  2 2018, 11:47:18) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

```
[root@aliyun~]# cat /etc/*release*
Alibaba Cloud Enterprise Linux Server release 17.01.2 (Golden Toad)
Alibaba Cloud Enterprise Linux Server release 17.01.2 (Golden Toad)
cat: /etc/lsb-release.d: Is a directory
NAME="Alibaba Cloud Enterprise Linux Server"
VERSION="17.01 (Golden Toad)"
ID="alinux"
ID_LIKE="rhel fedora centos"
VERSION_ID="17.01"
PRETTY_NAME="Alibaba Cloud Enterprise Linux Server 17.01 (Golden Toad)"
ANSI_COLOR="0;31"
HOME_URL="https://www.aliyun.com/"

Alibaba Cloud Enterprise Linux Server release 17.01.2 (Golden Toad)
Alibaba Cloud Enterprise Linux Server release 17.01.2 (Golden Toad)
[root@aliyun ~]# lsb_release -a
LSB Version:    :core-4.1-amd64:core-4.1-noarch
Distributor ID: AlibabaCloudEnterpriseServer
Description:    Alibaba Cloud Enterprise Linux Server release 17.01.2 (Golden Toad)
Release:        17.01.2
Codename:       GoldenToad```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Before: 
$ ansible -i alicloud.inv all -m setup -u root|grep os_fam
        "ansible_os_family": "Alibaba", 
        "ansible_os_family": "Alibaba",

After:
$ ansible -i alicloud.inv all -m setup -u root|grep os_fam
        "ansible_os_family": "RedHat", 
        "ansible_os_family": "RedHat", 
```
