### PR TITLE
VMware: Add lacp option in vmware_dvswitch module

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -48,6 +48,7 @@ options:
         description:
             - Add the LACP configuration
         required: True
+        version_added: 2.8
     uplink_quantity:
         description:
             - Quantity of uplink per ESXi host added to the switch

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -48,7 +48,6 @@ options:
         description:
             - Add the LACP configuration
         required: True
-        version_added: 2.8
     uplink_quantity:
         description:
             - Quantity of uplink per ESXi host added to the switch
@@ -209,7 +208,7 @@ def main():
     argument_spec.update(dict(datacenter_name=dict(required=True, type='str'),
                               switch_name=dict(required=True, type='str'),
                               mtu=dict(required=True, type='int'),
-                              lacp=dict(required=True, type='str'),
+                              lacp=dict(required=False, type='str'),
                               switch_version=dict(type='str'),
                               uplink_quantity=dict(required=True, type='int'),
                               discovery_proto=dict(required=True, choices=['cdp', 'lldp'], type='str'),

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -44,6 +44,11 @@ options:
         description:
             - The switch maximum transmission unit
         required: True
+    lacp:
+        description:
+            - Add the LACP configuration
+        required: True
+        version_added: 2.8
     uplink_quantity:
         description:
             - Quantity of uplink per ESXi host added to the switch
@@ -83,6 +88,7 @@ EXAMPLES = '''
     switch_name: dvSwitch
     switch_version: 6.0.0
     mtu: 9000
+    lacp: singleLag
     uplink_quantity: 2
     discovery_proto: lldp
     discovery_operation: both
@@ -115,6 +121,7 @@ class VMwareDVSwitch(object):
         self.switch_version = self.module.params['switch_version']
         self.datacenter_name = self.module.params['datacenter_name']
         self.mtu = self.module.params['mtu']
+        self.lacp = self.module.params['lacp']
         self.uplink_quantity = self.module.params['uplink_quantity']
         self.discovery_proto = self.module.params['discovery_proto']
         self.discovery_operation = self.module.params['discovery_operation']
@@ -153,6 +160,7 @@ class VMwareDVSwitch(object):
 
         spec.configSpec.name = self.switch_name
         spec.configSpec.maxMtu = self.mtu
+        spec.configSpec.lacpApiVersion = self.lacp
         spec.configSpec.linkDiscoveryProtocolConfig.protocol = self.discovery_proto
         spec.configSpec.linkDiscoveryProtocolConfig.operation = self.discovery_operation
         spec.productInfo = vim.dvs.ProductSpec()
@@ -201,6 +209,7 @@ def main():
     argument_spec.update(dict(datacenter_name=dict(required=True, type='str'),
                               switch_name=dict(required=True, type='str'),
                               mtu=dict(required=True, type='int'),
+                              lacp=dict(required=True, type='str'),
                               switch_version=dict(type='str'),
                               uplink_quantity=dict(required=True, type='int'),
                               discovery_proto=dict(required=True, choices=['cdp', 'lldp'], type='str'),


### PR DESCRIPTION
##### SUMMARY
When vmware dvswitch is created on vCenter 6.5. LACP option is not visible. 
Improvement of vmware_dvswitch module to enable LACP with vCenter 6.5 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_dvswitch

##### ANSIBLE VERSION
ansible --version
ansible 2.7.0

##### ADDITIONAL INFORMATION
add LACP option to configure on playbook. 
  tasks:
  - name: Create DVSWITCH
    vmware_dvswitch:
      hostname: '{{ vcenter_hostname }}'
      username: '{{ vcenter_username }}'
      password: '{{ vcenter_password }}'
      validate_certs: no
      datacenter_name: Datacenter
      switch_name: DVSWITCH_ANSIBLE_LACP
      switch_version: 6.5.0
      mtu: 9000
    '''  lacp: multipleLag '''
      uplink_quantity: 2
      discovery_proto: lldp
      discovery_operation: both
      state: present
    delegate_to: localhost

Tested and validated with vCenter 6.5  