### PR TITLE
ansible-test: add skip/windows/... alias to skip tests on specific Windows versions

### DIFF
--- a/test/integration/targets/win_uri/aliases
+++ b/test/integration/targets/win_uri/aliases
@@ -1,2 +1,3 @@
 shippable/windows/group3
 unstable
+skip/windows/2008  # httptester requires SSH which doesn't work with 2008

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1423,18 +1423,18 @@ def common_integration_filter(args, targets, exclude):
                 else:
                     skip_missing.append(version)
 
-            if len(skip_missing) > 0 and len(skip_valid) > 0:
+            if skip_missing and skip_valid:
                 not_skipped.append((target.name, skip_valid, skip_missing))
-            elif len(skip_valid) > 0:
+            elif skip_valid:
                 all_skipped.append(target.name)
 
-        if len(all_skipped) > 0:
+        if all_skipped:
             exclude.extend(all_skipped)
             skip_aliases = ["skip/windows/%s/" % w for w in args.windows]
             display.warning('Excluding tests marked "%s" which are set to skip with --windows %s: %s'
                             % ('", "'.join(skip_aliases), ', '.join(args.windows), ', '.join(all_skipped)))
 
-        if len(not_skipped) > 0:
+        if not_skipped:
             for target, skip_valid, skip_missing in not_skipped:
                 display.warning('The test "%s" was marked to skip for the Windows version(s) "%s" but not "%s"; running for all targets'
                                 % (target, '", "'.join(skip_valid), '", "'.join(skip_missing)))

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1412,7 +1412,8 @@ def common_integration_filter(args, targets, exclude):
             skipped = [target.name for target in targets if skip in target.aliases]
             if skipped:
                 exclude.extend(skipped)
-                display.warning('Excluding tests marked "%s" which are set to skip --windows %s' % (skip.rstrip('/'), window))
+                display.warning('Excluding tests marked "%s" which are set to skip --windows %s: %s'
+                                % (skip.rstrip('/'), window, ', '.join(skipped)))
 
 
 def get_integration_local_filter(args, targets):

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1436,8 +1436,9 @@ def common_integration_filter(args, targets, exclude):
 
         if not_skipped:
             for target, skip_valid, skip_missing in not_skipped:
-                display.warning('The test "%s" was marked to skip for the Windows version(s) "%s" but not "%s"; running for all targets'
-                                % (target, '", "'.join(skip_valid), '", "'.join(skip_missing)))
+                # warn when failing to skip due to lack of support for skipping only some versions
+                display.warning('Including test "%s" which was marked to skip for --windows %s but not %s.'
+                                % (target, ', '.join(skip_valid), ', '.join(skip_missing)))
 
 
 def get_integration_local_filter(args, targets):

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1406,6 +1406,14 @@ def common_integration_filter(args, targets, exclude):
             display.warning('Excluding tests marked "%s" which require --allow-unstable or prefixing with "unstable/": %s'
                             % (skip.rstrip('/'), ', '.join(skipped)))
 
+    if args.windows:
+        for window in args.windows:
+            skip = 'skip/windows/%s/' % window
+            skipped = [target.name for target in targets if skip in target.aliases]
+            if skipped:
+                exclude.extend(skipped)
+                display.warning('Excluding tests marked "%s" which are set to skip --windows %s' % (skip.rstrip('/'), window))
+
 
 def get_integration_local_filter(args, targets):
     """

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1407,7 +1407,7 @@ def common_integration_filter(args, targets, exclude):
                             % (skip.rstrip('/'), ', '.join(skipped)))
 
     # only skip a Windows test if using --windows and all the --windows versions are defined in the aliases as skip/windows/%s
-    if args.windows:
+    if isinstance(args, WindowsIntegrationConfig) and args.windows:
         all_skipped = []
         not_skipped = []
 


### PR DESCRIPTION
##### SUMMARY
Add the ability to specify a skip for specific Windows versions on ansible-test aliases. This is useful for https://github.com/ansible/ansible/pull/46606 to skip older hosts that don't support those features or even tests that require newer hosts.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```paste below
devel
```