### PR TITLE
PSRP: Add read_timeout connection parameters

### DIFF
--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -562,7 +562,8 @@ if ($bytes_read -gt 0) {
         if hasattr(pypsrp, 'FEATURES') and 'wsman_read_timeout' in pypsrp.FEATURES:
             self._psrp_conn_kwargs['read_timeout'] = self._psrp_read_timeout
         elif self._psrp_read_timeout:
-            display.debug("Installed pypsrp version does not support 'read_timeout', using 'connection_timeout' instead.")
+            display.warning("ansible_psrp_read_timeout is unsupported by the current psrp version installed, "
+                            "using ansible_psrp_connection_timeout value for read_timeout instead.")
 
         # Check if PSRP version supports newer reconnection_retries argument (needs pypsrp 0.3.0+)
         if hasattr(pypsrp, 'FEATURES') and 'wsman_reconnections' in pypsrp.FEATURES:
@@ -570,9 +571,9 @@ if ($bytes_read -gt 0) {
             self._psrp_conn_kwargs['reconnection_backoff'] = self._psrp_reconnection_backoff
         else:
             if self._psrp_reconnection_retries:
-                display.debug("Installed pypsrp version does not support 'reconnection_retries'.")
+                display.warning("ansible_psrp_reconnection_retries is unsupported by the current psrp version installed.")
             if self._psrp_reconnection_backoff:
-                display.debug("Installed pypsrp version does not support 'reconnection_backoff'.")
+                display.warning("ansible_psrp_reconnection_backoff is unsupported by the current psrp version installed.")
 
         # add in the extra args that were set
         for arg in extra_args.intersection(supported_args):

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -94,6 +94,16 @@ options:
     vars:
     - name: ansible_psrp_connection_timeout
     default: 30
+  read_timeout:
+    description:
+    - The read timeout for receiving data from the remote host.
+    - This value must always be greater than I(operation_timeout).
+    - This option requires pypsrp >= 0.3.
+    - This is measured in seconds.
+    vars:
+    - name: ansible_psrp_read_timeout
+    default: 30
+    version_added: '2.8'
   reconnection_retries:
     description:
     - The number of retries on connection errors.
@@ -514,7 +524,8 @@ if ($bytes_read -gt 0) {
         else:
             self._psrp_cert_validation = True
 
-        self._psrp_connection_timeout = int(self.get_option('connection_timeout'))
+        self._psrp_connection_timeout = self.get_option('connection_timeout')  # Can be None
+        self._psrp_read_timeout = self.get_option('read_timeout')  # Can be None
         self._psrp_message_encryption = self.get_option('message_encryption')
         self._psrp_proxy = self.get_option('proxy')
         self._psrp_ignore_proxy = boolean(self.get_option('ignore_proxy'))
@@ -546,6 +557,12 @@ if ($bytes_read -gt 0) {
             max_envelope_size=self._psrp_max_envelope_size,
             operation_timeout=self._psrp_operation_timeout,
         )
+
+        # Check if PSRP version supports newer read_timeout argument (needs pypsrp 0.3.0+)
+        if hasattr(pypsrp, 'FEATURES') and 'wsman_read_timeout' in pypsrp.FEATURES:
+            self._psrp_conn_kwargs['read_timeout'] = self._psrp_read_timeout
+        elif self._psrp_read_timeout:
+            display.debug("Installed pypsrp version does not support 'read_timeout', using 'connection_timeout' instead.")
 
         # Check if PSRP version supports newer reconnection_retries argument (needs pypsrp 0.3.0+)
         if hasattr(pypsrp, 'FEATURES') and 'wsman_reconnections' in pypsrp.FEATURES:

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -561,7 +561,7 @@ if ($bytes_read -gt 0) {
         # Check if PSRP version supports newer read_timeout argument (needs pypsrp 0.3.0+)
         if hasattr(pypsrp, 'FEATURES') and 'wsman_read_timeout' in pypsrp.FEATURES:
             self._psrp_conn_kwargs['read_timeout'] = self._psrp_read_timeout
-        elif self._psrp_read_timeout:
+        elif self._psrp_read_timeout is not None:
             display.warning("ansible_psrp_read_timeout is unsupported by the current psrp version installed, "
                             "using ansible_psrp_connection_timeout value for read_timeout instead.")
 
@@ -570,9 +570,9 @@ if ($bytes_read -gt 0) {
             self._psrp_conn_kwargs['reconnection_retries'] = self._psrp_reconnection_retries
             self._psrp_conn_kwargs['reconnection_backoff'] = self._psrp_reconnection_backoff
         else:
-            if self._psrp_reconnection_retries:
+            if self._psrp_reconnection_retries is not None:
                 display.warning("ansible_psrp_reconnection_retries is unsupported by the current psrp version installed.")
-            if self._psrp_reconnection_backoff:
+            if self._psrp_reconnection_backoff is not None:
                 display.warning("ansible_psrp_reconnection_backoff is unsupported by the current psrp version installed.")
 
         # add in the extra args that were set


### PR DESCRIPTION
##### SUMMARY
This PR adds read_timeout parameters for PSRP.
The WinRM variant is in #49701.

This PR requires https://github.com/jborean93/pypsrp/pull/13

This relates to #46108

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
WinRM/PSRP