### PR TITLE
Block module ansible imports outside module_utils.

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_autoscale.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_autoscale.py
@@ -326,6 +326,7 @@ state:
 '''  # NOQA
 
 from ansible.module_utils.azure_rm_common import AzureRMModuleBase, format_resource_id
+from ansible.module_utils._text import to_native
 from datetime import timedelta
 
 try:
@@ -333,12 +334,12 @@ try:
     from msrestazure.azure_exceptions import CloudError
     from azure.mgmt.monitor.models import WebhookNotification, EmailNotification, AutoscaleNotification, RecurrentSchedule, MetricTrigger, \
         ScaleAction, AutoscaleSettingResource, AutoscaleProfile, ScaleCapacity, TimeWindow, Recurrence, ScaleRule
-    from ansible.module_utils._text import to_native
 except ImportError:
     # This is handled in azure_rm_common
     pass
 
 
+# duplicated in azure_rm_autoscale_facts
 def timedelta_to_minutes(time):
     if not time:
         return 0

--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
@@ -145,6 +145,7 @@ except ImportError:
     pass
 
 
+# duplicated in azure_rm_managed_disk_facts
 def managed_disk_to_dict(managed_disk):
     create_data = managed_disk.creation_data
     return dict(

--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk_facts.py
@@ -79,10 +79,27 @@ from ansible.module_utils.azure_rm_common import AzureRMModuleBase
 
 try:
     from msrestazure.azure_exceptions import CloudError
-    from ansible.modules.cloud.azure.azure_rm_managed_disk import managed_disk_to_dict
 except:
     # handled in azure_rm_common
     pass
+
+
+# duplicated in azure_rm_managed_disk
+def managed_disk_to_dict(managed_disk):
+    create_data = managed_disk.creation_data
+    return dict(
+        id=managed_disk.id,
+        name=managed_disk.name,
+        location=managed_disk.location,
+        tags=managed_disk.tags,
+        create_option=create_data.create_option.value.lower(),
+        source_uri=create_data.source_uri,
+        source_resource_uri=create_data.source_resource_id,
+        disk_size_gb=managed_disk.disk_size_gb,
+        os_type=managed_disk.os_type.value if managed_disk.os_type else None,
+        storage_account_type=managed_disk.sku.name.value if managed_disk.sku else None,
+        managed_by=managed_disk.managed_by
+    )
 
 
 class AzureRMManagedDiskFacts(AzureRMModuleBase):


### PR DESCRIPTION
##### SUMMARY

Block module ansible imports outside module_utils.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

blacklist pylint plugin

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (at-blacklist-ansible bd204254c9) last updated 2018/10/11 16:23:58 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
