### PR TITLE
WinRM/PSRP: Add support for unreachable

### DIFF
--- a/changelogs/fragments/windows-psrp-unreachable.yaml
+++ b/changelogs/fragments/windows-psrp-unreachable.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-- Windows/PSRP - Ensure that a connection timeout results in host being unreachable
+- Windows/PSRP - Ensure that a connection timeout or connection error results in host being unreachable

--- a/changelogs/fragments/windows-psrp-unreachable.yaml
+++ b/changelogs/fragments/windows-psrp-unreachable.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Windows/PSRP - Ensure that a connection timeout results in host being unreachable

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -166,6 +166,7 @@ from ansible.plugins.connection import ConnectionBase
 from ansible.plugins.shell.powershell import _common_args
 from ansible.utils.hashing import secure_hash
 from ansible.utils.path import makedirs_safe
+from requests.exceptions import ConnectTimeout
 
 HAS_PYPSRP = True
 PYPSRP_IMP_ERR = None
@@ -243,6 +244,12 @@ class Connection(ConnectionBase):
                     "psrp connection failure during runspace open: %s"
                     % to_native(e)
                 )
+            except ConnectTimeout as e:
+                raise AnsibleConnectionFailure(
+                    "Failed to connect to the host via PSRP: %s"
+                    % to_native(e)
+                )
+
             self._connected = True
         return self
 

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -176,7 +176,7 @@ try:
     from pypsrp.powershell import PowerShell, RunspacePool
     from pypsrp.shell import Process, SignalCode, WinRS
     from pypsrp.wsman import WSMan, AUTH_KWARGS
-    from requests.exceptions import ConnectTimeout
+    from requests.exceptions import ConnectionError, ConnectTimeout
 except ImportError as err:
     HAS_PYPSRP = False
     PYPSRP_IMP_ERR = err
@@ -244,7 +244,7 @@ class Connection(ConnectionBase):
                     "psrp connection failure during runspace open: %s"
                     % to_native(e)
                 )
-            except ConnectTimeout as e:
+            except (ConnectionError, ConnectTimeout) as e:
                 raise AnsibleConnectionFailure(
                     "Failed to connect to the host via PSRP: %s"
                     % to_native(e)

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -166,7 +166,6 @@ from ansible.plugins.connection import ConnectionBase
 from ansible.plugins.shell.powershell import _common_args
 from ansible.utils.hashing import secure_hash
 from ansible.utils.path import makedirs_safe
-from requests.exceptions import ConnectTimeout
 
 HAS_PYPSRP = True
 PYPSRP_IMP_ERR = None
@@ -177,6 +176,7 @@ try:
     from pypsrp.powershell import PowerShell, RunspacePool
     from pypsrp.shell import Process, SignalCode, WinRS
     from pypsrp.wsman import WSMan, AUTH_KWARGS
+    from requests.exceptions import ConnectTimeout
 except ImportError as err:
     HAS_PYPSRP = False
     PYPSRP_IMP_ERR = err


### PR DESCRIPTION
##### SUMMARY
Currently PSRP connection always fail, even if the system is not
reachable. This PR fixes this.

**Before:**
```
[dag@moria ansible.git]$ ansible -m win_ping -i 1.2.3.4, 1.2.3.4 -e 'ansible_connection=psrp'
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ConnectTimeout: HTTPSConnectionPool(host='1.2.3.4', port=5986): Max retries exceeded with url: /wsman (Caused by ConnectTimeoutError(<urllib3.connection.VerifiedHTTPSConnection object at 0x7f6ec0ceaed0>, 'Connection to 1.2.3.4 timed out. (connect timeout=30)'))
1.2.3.4 | FAILED! => {
    "msg": "Unexpected failure during module execution.", 
    "stdout": ""
}
```
**After:**
```
[dag@moria ansible.git]$ ansible -m win_ping -i 1.2.3.4, 1.2.3.4 -e 'ansible_connection=psrp'
1.2.3.4 | UNREACHABLE! => {
    "changed": false, 
    "msg": "Failed to connect to the host via PSRP: HTTPSConnectionPool(host='1.2.3.4', port=5986): Max retries exceeded with url: /wsman (Caused by ConnectTimeoutError(<urllib3.connection.VerifiedHTTPSConnection object at 0x7f3516025e50>, 'Connection to 1.2.3.4 timed out. (connect timeout=30)'))", 
    "unreachable": true
}
```

This is the output when using SSH as connection:
```
[dag@moria ansible.git]$ ansible -m ping -i 1.2.3.4, 1.2.3.4
1.2.3.4 | UNREACHABLE! => {
    "changed": false, 
    "msg": "Failed to connect to the host via ssh: ssh: connect to host 1.2.3.4 port 22: Connection timed out\r\n", 
    "unreachable": true
}
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
WinRM/PSRP

##### ANSIBLE VERSION
v2.8