### PR TITLE
Fix problem where pip module cannot accept multiple extras

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -292,11 +292,16 @@ def _recover_package_name(names):
     # reconstruct the names
     name_parts = []
     package_names = []
+    in_brackets = False
     for name in names:
-        if _is_package_name(name):
+        if _is_package_name(name) and not in_brackets:
             if name_parts:
                 package_names.append(",".join(name_parts))
             name_parts = []
+        if name.find("[") != -1:
+            in_brackets = True
+        if in_brackets and name.find("]") != -1:
+            in_brackets = False
         name_parts.append(name)
     package_names.append(",".join(name_parts))
     return package_names
@@ -639,7 +644,7 @@ def main():
                             "Please keep the version specifier, but remove the 'version' argument."
                     )
                 # if the version specifier is provided by version, append that into the package
-                packages[0] = Package(packages[0].package_name, version)
+                packages[0] = Package(to_native(packages[0]), version)
 
         if module.params['editable']:
             args_list = []  # used if extra_args is not used at all

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -503,6 +503,7 @@ class Package:
             # old pkg_resource will replace 'setuptools' with 'distribute' when it already installed
             if self._requirement.project_name == "distribute":
                 self.package_name = "setuptools"
+                self._requirement.project_name = "setuptools"
             else:
                 self.package_name = self._requirement.project_name
             self._plain_package = True

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -298,9 +298,9 @@ def _recover_package_name(names):
             if name_parts:
                 package_names.append(",".join(name_parts))
             name_parts = []
-        if name.find("[") != -1:
+        if "[" in name:
             in_brackets = True
-        if in_brackets and name.find("]") != -1:
+        if in_brackets and "]" in name:
             in_brackets = False
         name_parts.append(name)
     package_names.append(",".join(name_parts))

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -470,6 +470,10 @@
   assert:
     that: "version13 is failed"
 
+- name: try install package with setuptools extras
+  pip:
+    name: "{{pip_test_package}}[dev,test]"
+
 - name: clean up
   pip:
     name: "{{ pip_test_packages }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix this, don't split a comma if the comma is between brackets.
Origin:
```["packageA[extraA,extraB,extraC]"]``` will become ```["packageA[extraA","extraB","extraC]"]```
Now the comma inside brackets will be ignored:
```["packageA[extraA,extraB,extraC]"]``` => ```["packageA[extraA,extraB,extraC]"]```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix #46519 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pip module
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (iss_46519 34345d15a0) last updated 2018/10/12 01:44:33 (GMT +000)
  config file = None
  configured module search path = [u'/home/ec2-user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ec2-user/ansible/lib/ansible
  executable location = /home/ec2-user/ansible/bin/ansible
  python version = 2.7.5 (default, May 31 2018, 09:41:32) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```
