### PR TITLE
[Backport 2.7] VMware: Refactor disk logic

### DIFF
--- a/changelogs/fragments/38679-vmware_guest-refactor_disk_logic.yml
+++ b/changelogs/fragments/38679-vmware_guest-refactor_disk_logic.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Refactor virtual machine disk logic.

--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -125,3 +125,83 @@
     that:
       - "cdrom_vm.failed == false"
       - "cdrom_vm.changed == true"
+
+- name: Create VM with multiple disks and a CDROM - GitHub issue 38679
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    name: CDROM-Test-38679
+    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    cluster: "{{ clusterlist['json'][0] | basename }}"
+    resource_pool: Resources
+    guest_id: centos64Guest
+    hardware:
+      memory_mb: 512
+      num_cpus: 1
+      scsi: paravirtual
+    disk:
+    - size_mb: 128
+      type: thin
+      datastore: LocalDS_0
+    - size_mb: 128
+      type: thin
+      datastore: LocalDS_0
+    - size_mb: 128
+      type: thin
+      datastore: LocalDS_0
+    cdrom:
+      type: iso
+      iso_path: "[LocalDS_0] base.iso"
+  register: cdrom_vm
+
+- debug: var=cdrom_vm
+
+- name: assert the VM was created
+  assert:
+    that:
+      - "cdrom_vm.failed == false"
+      - "cdrom_vm.changed == true"
+
+# VCSIM fails with invalidspec exception but real vCenter PASS testcase
+# Commenting this testcase till the time
+#- name: Again create VM with multiple disks and a CDROM - GitHub issue 38679
+#  vmware_guest:
+#    validate_certs: False
+#    hostname: "{{ vcsim }}"
+#    username: "{{ vcsim_instance['json']['username'] }}"
+#    password: "{{ vcsim_instance['json']['password'] }}"
+#    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+#    name: CDROM-Test-38679
+#    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+#    cluster: "{{ clusterlist['json'][0] | basename }}"
+#    resource_pool: Resources
+#    guest_id: centos64Guest
+#    hardware:
+#      memory_mb: 512
+#      num_cpus: 1
+#      scsi: paravirtual
+#    disk:
+#    - size_mb: 128
+#      type: thin
+#      datastore: LocalDS_0
+#    - size_mb: 128
+#      type: thin
+#      datastore: LocalDS_0
+#    - size_mb: 128
+#      type: thin
+#      datastore: LocalDS_0
+#    cdrom:
+#      type: iso
+#      iso_path: "[LocalDS_0] base.iso"
+#  register: cdrom_vm
+
+#- debug: var=cdrom_vm
+
+#- name: assert the VM was created
+#  assert:
+#    that:
+#      - "cdrom_vm.failed == false"
+#      - "cdrom_vm.changed == false"


### PR DESCRIPTION
##### SUMMARY
* Refactoring related to network device
* Assign unique random temporary key while creating SCSI or/and IDE controller devices
* Add testcase for this change

Fixes: #38679

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit fd985db72d09852af9326fd7470fb75d98b254e8)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/38679-vmware_guest-refactor_disk_logic.yml
lib/ansible/modules/cloud/vmware/vmware_guest.py
test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
Stable-2.7
```