### PR TITLE
Locate prtdiag even when absent from /usr/bin (#44113)

### DIFF
--- a/changelogs/fragments/solaris-prtdiag-path.yaml
+++ b/changelogs/fragments/solaris-prtdiag-path.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Hardware fact gathering now completes on Solaris 8.  Previously, it aborted with error `Argument 'args' to run_command must be list or string`.

--- a/lib/ansible/module_utils/facts/hardware/sunos.py
+++ b/lib/ansible/module_utils/facts/hardware/sunos.py
@@ -168,8 +168,13 @@ class SunOSHardware(Hardware):
     def get_dmi_facts(self):
         dmi_facts = {}
 
-        uname_path = self.module.get_bin_path("prtdiag")
-        rc, out, err = self.module.run_command(uname_path)
+        # On Solaris 8 the prtdiag wrapper is absent from /usr/sbin,
+        # but that's okay, because we know where to find the real thing:
+        rc, platform, err = self.module.run_command('/usr/bin/uname -i')
+        platform_sbin = '/usr/platform/' + platform.rstrip() + '/sbin'
+
+        prtdiag_path = self.module.get_bin_path("prtdiag", opt_dirs=[platform_sbin])
+        rc, out, err = self.module.run_command(prtdiag_path)
         """
         rc returns 1
         """


### PR DESCRIPTION
##### SUMMARY
This is a backport of pull request #44113 to the 2.7 branch.

On Solaris 8, the `prtdiag` wrapper is absent from `/usr/sbin`, so we must find the real thing ourselves. This prevents fact collection from aborting.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Hardware facts.