### PR TITLE
Doc: k8s_raw_module fixing typo K8S_AUTH_HOST -> K8S_AUTH_KEY_FILE

### DIFF
--- a/lib/ansible/plugins/inventory/k8s.py
+++ b/lib/ansible/plugins/inventory/k8s.py
@@ -63,7 +63,7 @@ DOCUMENTATION = '''
                 environment variable.
           key_file:
               description:
-              - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_HOST
+              - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_KEY_FILE
                 environment variable.
           ssl_ca_cert:
               description:

--- a/lib/ansible/plugins/inventory/openshift.py
+++ b/lib/ansible/plugins/inventory/openshift.py
@@ -63,7 +63,7 @@ DOCUMENTATION = '''
                 environment variable.
           key_file:
               description:
-              - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_HOST
+              - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_KEY_FILE
                 environment variable.
           ssl_ca_cert:
               description:

--- a/lib/ansible/plugins/lookup/k8s.py
+++ b/lib/ansible/plugins/lookup/k8s.py
@@ -105,7 +105,7 @@ DOCUMENTATION = """
           variable.
       key_file:
         description:
-        - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_HOST environment
+        - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_KEY_FILE environment
           variable.
       ssl_ca_cert:
         description:

--- a/lib/ansible/utils/module_docs_fragments/k8s_auth_options.py
+++ b/lib/ansible/utils/module_docs_fragments/k8s_auth_options.py
@@ -52,7 +52,7 @@ options:
       variable.
   key_file:
     description:
-    - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_HOST environment
+    - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_KEY_FILE environment
       variable.
   ssl_ca_cert:
     description:


### PR DESCRIPTION
##### SUMMARY

The current doc of k8s_raw_module contain a copy paste of the env var name :

```
host   :
Provide a URL for accessing the API. Can also be specified via K8S_AUTH_HOST environment variable.
key_file  : Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_HOST environment variable.
```

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

k8s_raw_module doc

##### ANSIBLE VERSION
```
2.5
```

##### ADDITIONAL INFORMATION
