### PR TITLE
Adding full list of supported devices

### DIFF
--- a/test/integration/targets/cnos_vlag/README.md
+++ b/test/integration/targets/cnos_vlag/README.md
@@ -36,7 +36,7 @@ Variable | Description
 `ansible_ssh_pass` | Specifies the password used to log into the switch
 `enablePassword` | Configures the password used to enter Global Configuration command mode on the switch (this is an optional parameter)
 `hostname` | Searches the hosts file at */etc/ansible/hosts* and identifies the IP address of the switch on which the role is going to be applied
-`deviceType` | Specifies the type of device from where the configuration will be backed up (**g8272_cnos** - G8272, **g8296_cnos** - G8296)
+`deviceType` | Specifies the type of device from where the configuration will be backed up (**g8272_cnos** - G8272, **g8296_cnos** - G8296, **g8332_cnos** - G8332, **NE10032** - NE10032, **NE1072T** - NE1072T, **NE1032** - NE1032, **NE1032T** - NE1032T, **NE2572** - NE2572, **NE0152T** - NE0152T)
 
 The values of the variables used need to be modified to fit the specific scenario in which you are deploying the solution. To change the values of the variables, you need to visits the *vars* directory of each role and edit the *main.yml* file located there. The values stored in this file will be used by Ansible when the template is executed.
 


### PR DESCRIPTION
##### SUMMARY
Adding all device types that has been supported for the module cnos_vlag. This is updated for rest all roles but for this role it has been missed out.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
test/integration/targets/cnos_vlag_sample/README.md

##### ANSIBLE VERSION
ansible 2.8.0.dev0 (devel e2b9c36080) last updated 2018/10/12 13:58:41 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ansible/sheru/ansible/lib/ansible
  executable location = /home/ansible/sheru/ansible/bin/ansible
  python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]

##### ADDITIONAL INFORMATION
None