### PR TITLE
ovirt_storage_domain: Improve logic for state controlling.

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domain.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domain.py
@@ -565,6 +565,13 @@ def control_state(sd_module):
         return
 
     sd_service = sd_module._service.service(sd.id)
+
+    # In the case of no status returned, it's an attached storage domain.
+    # Redetermine the corresponding serivce and entity:
+    if sd.status is None:
+        sd_service = sd_module._attached_sd_service(sd)
+        sd = get_entity(sd_service)
+
     if sd.status == sdstate.LOCKED:
         wait(
             service=sd_service,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Now the returned `status` attribute of a storage domain for state controlling is always be a `None` value when the storage domain is attached to a datacenter, which makes the `control_state` function not works as expected.

This is because for an **attached** storage domain, the `status` attribute is not included in the response of invoking `system_service().storage_domains_service().storage_domain_service(sd_id).get()`. While we need to use `system_service().data_centers_service().data_center_service(dc_id).storage_domains_service().storage_domain_service(sd_id).get()` instead.

Changes in this PR are looking for the correct `status` along with the corresponding `service` and the function will work properly.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ovirt_storage_domain

##### ANSIBLE VERSION
```paste below
devel
```

