### PR TITLE
Fix bug with json callback plugin serialization

### DIFF
--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -30,7 +30,6 @@ DOCUMENTATION = '''
 '''
 
 import datetime
-import json
 
 from functools import partial
 
@@ -114,7 +113,7 @@ class CallbackModule(CallbackBase):
             'global_custom_stats': global_custom_stats,
         }
 
-        self._display.display(json.dumps(output, indent=4, sort_keys=True))
+        self._display.display(self._dump_results(output, indent=4, sort_keys=True))
 
     def _record_task_result(self, on_info, result, **kwargs):
         """This function is used as a partial to add failed/skipped info in a single method"""


### PR DESCRIPTION
##### SUMMARY
Swaps out stock python JSON encoder for the base class's dumping method.

Fixes https://github.com/ansible/ansible/issues/46957

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/json.py

##### ANSIBLE VERSION
```paste below
ansible 2.8.0.dev0
  config file = None
  configured module search path = [u'/Users/alancoding/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible
  executable location = /Users/alancoding/.virtualenvs/ansible/bin/ansible
  python version = 2.7.11 (default, Oct 17 2016, 14:59:40) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```

##### ADDITIONAL INFORMATION
Demo of fix, following steps outlined in issue:

```paste below
ANSIBLE_STDOUT_CALLBACK=json ansible-playbook -i localhost, include_vars/vault_vars.yml --vault-id=alan@prompt -vvv
ansible-playbook 2.8.0.dev0
  config file = None
  configured module search path = [u'/Users/alancoding/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible
  executable location = /Users/alancoding/.virtualenvs/ansible/bin/ansible-playbook
  python version = 2.7.11 (default, Oct 17 2016, 14:59:40) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
No config file found; using defaults
Vault password (alan): 
Parsed localhost, inventory source with host_list plugin
1 plays in include_vars/vault_vars.yml
META: ran handlers
META: ran handlers
META: ran handlers
{
    "custom_stats": {}, 
    "global_custom_stats": {}, 
    "plays": [
        {
            "play": {
                "duration": {
                    "end": "2018-10-12T13:02:00.802364Z", 
                    "start": "2018-10-12T13:02:00.507589Z"
                }, 
                "id": "a0999b12-fe9b-5a5e-8114-000000000006", 
                "name": "Include vault vars"
            }, 
            "tasks": [
                {
                    "hosts": {
                        "localhost": {
                            "_ansible_no_log": false, 
                            "action": "include_vars", 
                            "ansible_facts": {
                                "spoiler_text": "people run into some space aliens\nand they end up fighting them"
                            }, 
                            "ansible_included_var_files": [
                                "/Users/alancoding/Documents/repos/utility-playbooks/include_vars/stuff.yml"
                            ], 
                            "changed": false
                        }
                    }, 
                    "task": {
                        "duration": {
                            "end": "2018-10-12T13:02:00.587428Z", 
                            "start": "2018-10-12T13:02:00.519785Z"
                        }, 
                        "id": "a0999b12-fe9b-5a5e-8114-000000000008", 
                        "name": "Include contents from whole-file encrypted vars"
                    }
                }, 
                {
                    "hosts": {
                        "localhost": {
                            "_ansible_no_log": false, 
                            "_ansible_verbose_always": true, 
                            "action": "debug", 
                            "changed": false, 
                            "spoiler_text": "people run into some space aliens\nand they end up fighting them"
                        }
                    }, 
                    "task": {
                        "duration": {
                            "end": "2018-10-12T13:02:00.625156Z", 
                            "start": "2018-10-12T13:02:00.592252Z"
                        }, 
                        "id": "a0999b12-fe9b-5a5e-8114-000000000009", 
                        "name": "debug var from whole-file encrypted stuff"
                    }
                }, 
                {
                    "hosts": {
                        "localhost": {
                            "_ansible_no_log": false, 
                            "action": "include_vars", 
                            "ansible_facts": {
                                "spoiler_text": {
                                    "__ansible_vault": "$ANSIBLE_VAULT;1.2;AES256;alan\n36386366323637343336383236333964643463626232663931323932616365616263646434356166\n6533313834316664626239396336326333643163353433340a623537336431313534393531663464\n65316639396361316664373732366438636638336439636166643832626432646231313633396666\n6435326436663766370a663466633064376161336439303166353139326335313665363030363437\n66643364343863366365343964343764316231373638633633303265363763613836313435313266\n31326665373432376461623162353038643935346633643862646632346532396263356135376431\n613262626339313336643338653330613164\n"
                                }
                            }, 
                            "ansible_included_var_files": [
                                "/Users/alancoding/Documents/repos/utility-playbooks/include_vars/thing.yml"
                            ], 
                            "changed": false
                        }
                    }, 
                    "task": {
                        "duration": {
                            "end": "2018-10-12T13:02:00.662181Z", 
                            "start": "2018-10-12T13:02:00.629443Z"
                        }, 
                        "id": "a0999b12-fe9b-5a5e-8114-00000000000a", 
                        "name": "Include contents from single-variable encrypted vars"
                    }
                }, 
                {
                    "hosts": {
                        "localhost": {
                            "_ansible_no_log": false, 
                            "_ansible_verbose_always": true, 
                            "action": "debug", 
                            "changed": false, 
                            "spoiler_text": "people run into some space aliens and they end up fighting them"
                        }
                    }, 
                    "task": {
                        "duration": {
                            "end": "2018-10-12T13:02:00.730376Z", 
                            "start": "2018-10-12T13:02:00.666312Z"
                        }, 
                        "id": "a0999b12-fe9b-5a5e-8114-00000000000b", 
                        "name": "debug var from single var encrypted value"
                    }
                }, 
                {
                    "hosts": {
                        "localhost": {
                            "_ansible_no_log": false, 
                            "action": "set_fact", 
                            "ansible_facts": {
                                "bar": "people run into some space aliens and they end up fighting them"
                            }, 
                            "changed": false
                        }
                    }, 
                    "task": {
                        "duration": {
                            "end": "2018-10-12T13:02:00.802364Z", 
                            "start": "2018-10-12T13:02:00.735972Z"
                        }, 
                        "id": "a0999b12-fe9b-5a5e-8114-00000000000c", 
                        "name": "set fact with spoiler_text"
                    }
                }
            ]
        }
    ], 
    "stats": {
        "localhost": {
            "changed": 0, 
            "failures": 0, 
            "ok": 5, 
            "skipped": 0, 
            "unreachable": 0
        }
    }
}
```

Note, this supports the new feature to not print in-line vaulted variables. See `spoiler_text` in encrypted form above.

This probably needs integration tests.