### PR TITLE
Fix AWS EC2 inventory plugin caching of groups

### DIFF
--- a/changelogs/fragments/46961_fix_aws_ec2_cache.yaml
+++ b/changelogs/fragments/46961_fix_aws_ec2_cache.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_ec2 - fixed issue where cache did not contain the computed groups

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -436,7 +436,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def _format_inventory(self):
         results = {'_meta': {'hostvars': {}}}
-        groups = self.inventory.get_groups_dict()
         for group in self.inventory.groups:
             hosts = self.inventory.groups[group].get_hosts()
             results[group] = {'hosts': map(lambda host: host.name, hosts)}

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -434,13 +434,17 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     self._populate_host_vars([host], hostvars.get(host, {}), group)
                 self.inventory.add_child('all', group)
 
-    def _format_inventory(self):
+    def _format_inventory(self, groups, hostnames):
         results = {'_meta': {'hostvars': {}}}
-        for group in self.inventory.groups:
-            hosts = self.inventory.groups[group].get_hosts()
-            results[group] = {'hosts': map(lambda host: host.name, hosts)}
-            for host in hosts:
-                results['_meta']['hostvars'][host.name] = host.vars
+        for group in groups:
+            results[group] = {'hosts': []}
+            for host in groups[group]:
+                hostname = self._get_hostname(host, hostnames)
+                if not hostname:
+                    continue
+                results[group]['hosts'].append(hostname)
+                h = self.inventory.get_host(hostname)
+                results['_meta']['hostvars'][h.name] = h.vars
         return results
 
     def _add_hosts(self, hosts, group, hostnames):
@@ -576,15 +580,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             except KeyError:
                 # if cache expires or cache file doesn't exist
                 cache_needs_update = True
-            else:
-                self._populate_from_source(results)
 
         if not cache or cache_needs_update:
             results = self._query(regions, filters, strict_permissions)
-            self._populate(results, hostnames)
+
+        self._populate(results, hostnames)
 
         # If the cache has expired/doesn't exist or if refresh_inventory/flush cache is used
         # when the user is using caching, update the cached inventory
         if cache_needs_update or (not cache and self.get_option('cache')):
-            formatted_inventory = self._format_inventory()
-            self.cache.set(cache_key, formatted_inventory)
+            self.cache.set(cache_key, results)

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -422,31 +422,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self._add_hosts(hosts=groups[group], group=group, hostnames=hostnames)
             self.inventory.add_child('all', group)
 
-    def _populate_from_source(self, source_data):
-        hostvars = source_data.pop('_meta', {}).get('hostvars', {})
-        for group in source_data:
-            if group == 'all':
-                continue
-            else:
-                self.inventory.add_group(group)
-                hosts = source_data[group].get('hosts', [])
-                for host in hosts:
-                    self._populate_host_vars([host], hostvars.get(host, {}), group)
-                self.inventory.add_child('all', group)
-
-    def _format_inventory(self, groups, hostnames):
-        results = {'_meta': {'hostvars': {}}}
-        for group in groups:
-            results[group] = {'hosts': []}
-            for host in groups[group]:
-                hostname = self._get_hostname(host, hostnames)
-                if not hostname:
-                    continue
-                results[group]['hosts'].append(hostname)
-                h = self.inventory.get_host(hostname)
-                results['_meta']['hostvars'][h.name] = h.vars
-        return results
-
     def _add_hosts(self, hosts, group, hostnames):
         '''
             :param hosts: a list of hosts to be added to a group


### PR DESCRIPTION
Cache the raw EC2 query results and re-run populate when using the cache.

##### SUMMARY
The AWS EC2 inventory plugin cache was using the raw EC2 query result as a source of groups rather than the actual groups inserted into the inventory. When using the cached details it then assumed that the cache was a complete source of inventory information, which meant that all the computed groups were lost.

I initially attempted to make the cache a more complete reflection of what was added to the inventory, but this led to inventory information from other sources leaking into the cache. Instead I now just cache the raw query results, and use the cache to avoid the need for querying the AWS APIs.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_ec2

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (fix-aws-ec2-caching 0d621b6f50) last updated 2018/10/12 14:34:25 (GMT +100)
  config file = /home/tw.com/jonathan.oddy/IdeaProjects/Ansible/ansible.cfg
  configured module search path = [u'/home/tw.com/jonathan.oddy/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/tw.com/jonathan.oddy/IdeaProjects/ansible/lib/ansible
  executable location = /home/tw.com/jonathan.oddy/IdeaProjects/ansible/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

