### PR TITLE
add note about named tasks in blocks

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/user_guide/playbooks_blocks.rst
@@ -11,26 +11,11 @@ Blocks allow for logical grouping of tasks and in play error handling. Most of w
   tasks:
     - name: Install, configure, and start Apache
       block:
-<<<<<<< HEAD
-        - yum:
-            name: "{{ item }}"
-            state: installed
-          loop:
-            - httpd
-            - memcached
-        - template:
-            src: templates/src.j2
-            dest: /etc/foo.conf
-        - service:
-            name: bar
-            state: started
-            enabled: True
-=======
       - name: install httpd and memcached
         yum:
           name: "{{ item }}"
           state: installed
-        with_items:
+        loop:
           - httpd
           - memcached
       - name: apply the foo config template
@@ -42,7 +27,6 @@ Blocks allow for logical grouping of tasks and in play error handling. Most of w
           name: bar
           state: started
           enabled: True
->>>>>>> adds names to tasks within example block, removes 2nd example
       when: ansible_facts['distribution'] == 'CentOS'
       become: true
       become_user: root

--- a/docs/docsite/rst/user_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/user_guide/playbooks_blocks.rst
@@ -33,6 +33,38 @@ In the example above, each of the 3 tasks will be executed after appending the `
 and evaluating it in the task's context. Also they inherit the privilege escalation directives enabling "become to root"
 for all the enclosed tasks.
 
+
+You may also define the tasks inside of a block with their own names, just as
+you can outside of a block, for added output about the tasks being executed when
+you run the playbook.
+
+.. code-block:: YAML
+ :emphasize-lines: 3
+ :caption: Block example with named tasks inside the block
+
+
+  tasks:
+    - name: Install Apache
+      block:
+        - name: install httpd and memcached
+          yum:
+            name:
+               - httpd
+               - memcached
+            state: installed
+        - name: apply the foo config template
+          template:
+            src: templates/src.j2
+            dest: /etc/foo.conf
+        - name: start service bar and enable it
+          service:
+            name: bar
+            state: started
+            enabled: True
+      when: ansible_facts['distribution'] == 'CentOS'
+      become: true
+      become_user: root
+
 .. versionadded:: 2.3
 
     The ``name:`` keyword for ``block:`` was added in Ansible 2.3.

--- a/docs/docsite/rst/user_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/user_guide/playbooks_blocks.rst
@@ -6,12 +6,12 @@ Blocks allow for logical grouping of tasks and in play error handling. Most of w
 
 .. code-block:: YAML
  :emphasize-lines: 3
- :caption: Block example
-
+ :caption: Block example with named tasks inside the block
 
   tasks:
-    - name: Install Apache
+    - name: Install, configure, and start Apache
       block:
+<<<<<<< HEAD
         - yum:
             name: "{{ item }}"
             state: installed
@@ -25,6 +25,24 @@ Blocks allow for logical grouping of tasks and in play error handling. Most of w
             name: bar
             state: started
             enabled: True
+=======
+      - name: install httpd and memcached
+        yum:
+          name: "{{ item }}"
+          state: installed
+        with_items:
+          - httpd
+          - memcached
+      - name: apply the foo config template
+        template:
+          src: templates/src.j2
+          dest: /etc/foo.conf
+      - name: start service bar and enable it
+        service:
+          name: bar
+          state: started
+          enabled: True
+>>>>>>> adds names to tasks within example block, removes 2nd example
       when: ansible_facts['distribution'] == 'CentOS'
       become: true
       become_user: root
@@ -33,41 +51,7 @@ In the example above, each of the 3 tasks will be executed after appending the `
 and evaluating it in the task's context. Also they inherit the privilege escalation directives enabling "become to root"
 for all the enclosed tasks.
 
-
-You may also define the tasks inside of a block with their own names, just as
-you can outside of a block, for added output about the tasks being executed when
-you run the playbook.
-
-.. code-block:: YAML
- :emphasize-lines: 3
- :caption: Block example with named tasks inside the block
-
-
-  tasks:
-    - name: Install Apache
-      block:
-        - name: install httpd and memcached
-          yum:
-            name:
-               - httpd
-               - memcached
-            state: installed
-        - name: apply the foo config template
-          template:
-            src: templates/src.j2
-            dest: /etc/foo.conf
-        - name: start service bar and enable it
-          service:
-            name: bar
-            state: started
-            enabled: True
-      when: ansible_facts['distribution'] == 'CentOS'
-      become: true
-      become_user: root
-
-.. versionadded:: 2.3
-
-    The ``name:`` keyword for ``block:`` was added in Ansible 2.3.
+Names for tasks within blocks have been available since Ansible 2.3. We recommend using names in all tasks, within blocks or elsewhere, for better visibility into the tasks being executed when you run the playbook.
 
 .. _block_error_handling:
 
@@ -191,6 +175,3 @@ ansible_failed_result
        Have a question?  Stop by the google group!
    `irc.freenode.net <http://irc.freenode.net>`_
        #ansible IRC chat channel
-
-
-


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add note and example showing names tasks inside a block
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (docs/blocks c4585058d4) last updated 2018/10/12 14:47:28 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, Sep 21 2018, 23:26:48) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```
