### PR TITLE
Add shorthand debugger method to recreate the task from the original ds

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_debugger.rst
+++ b/docs/docsite/rst/user_guide/playbooks_debugger.rst
@@ -246,7 +246,7 @@ Then the task runs again with new ``task_vars``.
 .. _update_task_command:
 
 u(pdate_task)
-```````````
+`````````````
 
 This command re-creates the task from the original task data structure, and templates with updated ``task_vars``
 

--- a/docs/docsite/rst/user_guide/playbooks_debugger.rst
+++ b/docs/docsite/rst/user_guide/playbooks_debugger.rst
@@ -248,6 +248,8 @@ Then the task runs again with new ``task_vars``.
 u(pdate_task)
 `````````````
 
+.. versionadded:: 2.8
+
 This command re-creates the task from the original task data structure, and templates with updated ``task_vars``
 
 See the above documentation for :ref:`update_vars_command` for an example of use.

--- a/docs/docsite/rst/user_guide/playbooks_debugger.rst
+++ b/docs/docsite/rst/user_guide/playbooks_debugger.rst
@@ -235,12 +235,22 @@ Let's use the same playbook above, but fix ``task_vars`` instead of args::
     [192.0.2.10] TASK: install package (debug)> task_vars['pkg_name'] = 'bash'
     [192.0.2.10] TASK: install package (debug)> p task_vars['pkg_name']
     'bash'
+    [192.0.2.10] TASK: install package (debug)> update_task
     [192.0.2.10] TASK: install package (debug)> redo
 
 Then the task runs again with new ``task_vars``.
 
 .. note::
     In 2.5 this was updated from ``vars`` to ``task_vars`` to not conflict with the ``vars()`` python function.
+
+.. _update_task_command:
+
+u(pdate_task)
+```````````
+
+This command re-creates the task from the original task data structure, and templates with updated ``task_vars``
+
+See the above documentation for :ref:`update_vars_command` for an example of use.
 
 .. _redo_command:
 

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1197,6 +1197,16 @@ class Debugger(cmd.Cmd):
 
     do_r = do_redo
 
+    def do_update_task(self, args):
+        """Recreate the task from ``task._ds``, and template with updated ``task_vars``"""
+        templar = Templar(None, shared_loader_obj=None, variables=self.scope['task_vars'])
+        task = self.scope['task']
+        task = task.load_data(task._ds)
+        task.post_validate(templar)
+        self.scope['task'] = task
+
+    do_u = do_update_task
+
     def evaluate(self, args):
         try:
             return eval(args, globals(), self.scope)


### PR DESCRIPTION
##### SUMMARY
Add shorthand debugger method to recreate the task from the original ds, and re-template. Fixes #46321

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/strategy/__init__.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```