### PR TITLE
ansible-test: httptester for Windows 2.5

### DIFF
--- a/test/integration/targets/prepare_http_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_http_tests/tasks/main.yml
@@ -3,6 +3,11 @@
 - set_fact:
     has_httptester: "{{ lookup('env', 'HTTPTESTER') != '' }}"
 
+- name: make sure we have the ansible_os_family and ansible_distribution_version facts
+  setup:
+    gather_subset: distribution
+  when: ansible_facts == {}
+
 # If we are running with access to a httptester container, grab it's cacert and install it
 - block:
     # Override hostname defaults with httptester linked names
@@ -22,6 +27,16 @@
       get_url:
         url: "http://ansible.http.tests/{{ item }}"
         dest: "{{ output_dir }}/{{ item }}"
+      when: ansible_os_family != 'Windows'
+      with_items:
+        - client.pem
+        - client.key
+
+    - name: Windows - Get client cert/key
+      win_get_url:
+        url: http://ansible.http.tests/{{ item }}
+        dest: '{{ win_output_dir }}\{{ item }}'
+      when: ansible_os_family == 'Windows'
       with_items:
         - client.pem
         - client.key
@@ -38,6 +53,12 @@
         dest: "/usr/local/share/ca-certificates/ansible.crt"
       when: ansible_os_family == 'Debian'
 
+    - name: Windows - Retrieve test cacert
+      win_get_url:
+        url: http://ansible.http.tests/cacert.pem
+        dest: '{{ win_output_dir }}\cacert.pem'
+      when: ansible_os_family == 'Windows'
+
     - name: Redhat - Update ca trust
       command: update-ca-trust extract
       when: ansible_os_family == 'RedHat'
@@ -45,6 +66,14 @@
     - name: Debian/Suse - Update ca certificates
       command: update-ca-certificates
       when: ansible_os_family == 'Debian' or ansible_os_family == 'Suse'
+
+    - name: Windows - Update ca trust
+      win_certificate_store:
+        path: '{{ win_output_dir }}\cacert.pem'
+        state: present
+        store_location: LocalMachine
+        store_name: Root
+      when: ansible_os_family == 'Windows'
 
     - name: FreeBSD - Retrieve test cacert
       get_url:
@@ -68,4 +97,7 @@
       command: /usr/local/opt/openssl/bin/c_rehash
       when: ansible_os_family == 'Darwin'
 
-  when: has_httptester|bool
+  when:
+  - has_httptester|bool
+  # skip the setup if running on Windows Server 2008 as httptester is not available
+  - ansible_os_family != 'Windows' or (ansible_os_family == 'Windows' and not ansible_distribution_version.startswith("6.0."))

--- a/test/integration/targets/win_uri/aliases
+++ b/test/integration/targets/win_uri/aliases
@@ -1,3 +1,3 @@
 shippable/windows/group3
-unstable
+needs/httptester
 skip/windows/2008  # httptester requires SSH which doesn't work with 2008

--- a/test/integration/targets/win_uri/aliases
+++ b/test/integration/targets/win_uri/aliases
@@ -1,2 +1,3 @@
 shippable/windows/group3
 unstable
+skip/windows/2008  # httptester requires SSH which doesn't work with 2008

--- a/test/integration/targets/win_uri/defaults/main.yml
+++ b/test/integration/targets/win_uri/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-test_uri_path: C:\ansible\win_uri
-httpbin_host: httpbin.org
+test_uri_path: '{{ win_output_dir }}\win_uri'

--- a/test/integration/targets/win_uri/meta/main.yml
+++ b/test/integration/targets/win_uri/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+- prepare_win_tests
+- prepare_http_tests

--- a/test/integration/targets/win_uri/tasks/test.yml
+++ b/test/integration/targets/win_uri/tasks/test.yml
@@ -363,7 +363,7 @@
 
 - name: validate status codes as list of strings
   win_uri:
-    url: https://httpbin.org/status/202
+    url: https://{{httpbin_host}}/status/202
     status_code:
     - '202'
     - '418'
@@ -380,7 +380,7 @@
 
 - name: validate status codes as comma separated list
   win_uri:
-    url: https://httpbin.org/status/202
+    url: https://{{httpbin_host}}/status/202
     status_code: 202, 418
     method: POST
     body: foo

--- a/test/runner/lib/cli.py
+++ b/test/runner/lib/cli.py
@@ -333,6 +333,7 @@ def parse_args():
                                      config=WindowsIntegrationConfig)
 
     add_extra_docker_options(windows_integration, integration=False)
+    add_httptester_options(windows_integration, argparse)
 
     windows_integration.add_argument('--windows',
                                      metavar='VERSION',

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -569,7 +569,8 @@ def command_windows_integration(args):
                 manage.upload("test/runner/setup/windows-httptester.ps1", watcher_path)
 
                 # need to use -Command as we cannot pass an array of values with -File
-                script = "powershell.exe -NoProfile -Command .\\%s -Hosts %s" % (watcher_path, ", ".join(HTTPTESTER_HOSTS))
+                script = "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command .\\%s -Hosts %s" \
+                         % (watcher_path, ", ".join(HTTPTESTER_HOSTS))
                 if args.verbosity > 3:
                     script += " -Verbose"
                 manage.ssh(script, options=ssh_options, force_pty=False)

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1406,6 +1406,40 @@ def common_integration_filter(args, targets, exclude):
             display.warning('Excluding tests marked "%s" which require --allow-unstable or prefixing with "unstable/": %s'
                             % (skip.rstrip('/'), ', '.join(skipped)))
 
+    # only skip a Windows test if using --windows and all the --windows versions are defined in the aliases as skip/windows/%s
+    if isinstance(args, WindowsIntegrationConfig) and args.windows:
+        all_skipped = []
+        not_skipped = []
+
+        for target in targets:
+            if "skip/windows/" not in target.aliases:
+                continue
+
+            skip_valid = []
+            skip_missing = []
+            for version in args.windows:
+                if "skip/windows/%s/" % version in target.aliases:
+                    skip_valid.append(version)
+                else:
+                    skip_missing.append(version)
+
+            if skip_missing and skip_valid:
+                not_skipped.append((target.name, skip_valid, skip_missing))
+            elif skip_valid:
+                all_skipped.append(target.name)
+
+        if all_skipped:
+            exclude.extend(all_skipped)
+            skip_aliases = ["skip/windows/%s/" % w for w in args.windows]
+            display.warning('Excluding tests marked "%s" which are set to skip with --windows %s: %s'
+                            % ('", "'.join(skip_aliases), ', '.join(args.windows), ', '.join(all_skipped)))
+
+        if not_skipped:
+            for target, skip_valid, skip_missing in not_skipped:
+                # warn when failing to skip due to lack of support for skipping only some versions
+                display.warning('Including test "%s" which was marked to skip for --windows %s but not %s.'
+                                % (target, ', '.join(skip_valid), ', '.join(skip_missing)))
+
 
 def get_integration_local_filter(args, targets):
     """

--- a/test/runner/setup/windows-httptester.ps1
+++ b/test/runner/setup/windows-httptester.ps1
@@ -1,0 +1,227 @@
+<#
+.SYNOPSIS
+Designed to set a Windows host to connect to the httptester container running
+on the Ansible host. This will setup the Windows host file and forward the
+local ports to use this connection. This will continue to run in the background
+until the script is deleted.
+
+Run this with SSH with the -R arguments to foward ports 8080 and 8443 to the
+httptester container.
+
+.PARAMETER Hosts
+A list of hostnames to add to the Windows hosts file for the httptester
+container.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true, Position=0)][String[]]$Hosts
+)
+
+$ProgressPreference = "SilentlyContinue"
+$ErrorActionPreference = "Stop"
+$os_version = [Version](Get-Item -Path "$env:SystemRoot\System32\kernel32.dll").VersionInfo.ProductVersion
+Write-Verbose -Message "Configuring HTTP Tester on Windows $os_version for '$($Hosts -join "', '")'"
+
+Function Get-PmapperRuleBytes {
+    <#
+    .SYNOPSIS
+    Create the byte values that configures a rule in the PMapper configuration
+    file. This isn't really documented but because PMapper is only used for
+    Server 2008 R2 we will stick to 1 version and just live with the legacy
+    work for now.
+
+    .PARAMETER ListenPort
+    The port to listen on localhost, this will be forwarded to the host defined
+    by ConnectAddress and ConnectPort.
+
+    .PARAMETER ConnectAddress
+    The hostname or IP to map the traffic to.
+
+    .PARAMETER ConnectPort
+    This port of ConnectAddress to map the traffic to.
+    #>
+    param(
+        [Parameter(Mandatory=$true)][UInt16]$ListenPort,
+        [Parameter(Mandatory=$true)][String]$ConnectAddress,
+        [Parameter(Mandatory=$true)][Int]$ConnectPort
+    )
+
+    $connect_field = "$($ConnectAddress):$ConnectPort"
+    $connect_bytes = [System.Text.Encoding]::ASCII.GetBytes($connect_field)
+    $data_length = [byte]($connect_bytes.Length + 6) # size of payload minus header, length, and footer
+    $port_bytes = [System.BitConverter]::GetBytes($ListenPort)
+
+    $payload = [System.Collections.Generic.List`1[Byte]]@()
+    $payload.Add([byte]16) > $null # header is \x10, means Configure Mapping rule
+    $payload.Add($data_length) > $null
+    $payload.AddRange($connect_bytes)
+    $payload.AddRange($port_bytes)
+    $payload.AddRange([byte[]]@(0, 0)) # 2 extra bytes of padding
+    $payload.Add([byte]0) > $null # 0 is TCP, 1 is UDP
+    $payload.Add([byte]0) > $null # 0 is Any, 1 is Internet
+    $payload.Add([byte]31) > $null # footer is \x1f, means end of Configure Mapping rule
+
+    return ,$payload.ToArray()
+}
+
+Write-Verbose -Message "Adding host file entries"
+$hosts_file = "$env:SystemRoot\System32\drivers\etc\hosts"
+$hosts_file_lines = [System.IO.File]::ReadAllLines($hosts_file)
+$changed = $false
+foreach ($httptester_host in $Hosts) {
+    $host_line = "127.0.0.1 $httptester_host # ansible-test httptester"
+    if ($host_line -notin $hosts_file_lines) {
+        $hosts_file_lines += $host_line
+        $changed = $true
+    }
+}
+if ($changed) {
+    Write-Verbose -Message "Host file is missing entries, adding missing entries"
+    [System.IO.File]::WriteAllLines($hosts_file, $hosts_file_lines)
+}
+
+# forward ports
+$forwarded_ports = @{
+    80 = 8080
+    443 = 8443
+}
+if ($os_version -ge [Version]"6.2") {
+    Write-Verbose -Message "Using netsh to configure forwarded ports"
+    foreach ($forwarded_port in $forwarded_ports.GetEnumerator()) {
+        $port_set = netsh interface portproxy show v4tov4 | `
+            Where-Object { $_ -match "127.0.0.1\s*$($forwarded_port.Key)\s*127.0.0.1\s*$($forwarded_port.Value)" }
+
+        if (-not $port_set) {
+            Write-Verbose -Message "Adding netsh portproxy rule for $($forwarded_port.Key) -> $($forwarded_port.Value)"
+            $add_args = @(
+                "interface",
+                "portproxy",
+                "add",
+                "v4tov4",
+                "listenaddress=127.0.0.1",
+                "listenport=$($forwarded_port.Key)",
+                "connectaddress=127.0.0.1",
+                "connectport=$($forwarded_port.Value)"
+            )
+            $null = netsh $add_args 2>&1
+        }
+    }
+} else {
+    Write-Verbose -Message "Using Port Mapper to configure forwarded ports"
+    # netsh interface portproxy doesn't work on local addresses in older
+    # versions of Windows. Use custom application Port Mapper to acheive the
+    # same outcome
+    # http://www.analogx.com/contents/download/Network/pmapper/Freeware.htm
+    $s3_url = "https://s3.amazonaws.com/ansible-ci-files/ansible-test/pmapper-1.04.exe"
+
+    # download the Port Mapper executable to a temporary directory
+    $pmapper_folder = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.IO.Path]::GetRandomFileName())
+    $pmapper_exe = Join-Path -Path $pmapper_folder -ChildPath pmapper.exe
+    $pmapper_config = Join-Path -Path $pmapper_folder -ChildPath pmapper.dat
+    New-Item -Path $pmapper_folder -ItemType Directory > $null
+
+    $stop = $false
+    do {
+        try {
+            Write-Verbose -Message "Attempting download of '$s3_url'"
+            (New-Object -TypeName System.Net.WebClient).DownloadFile($s3_url, $pmapper_exe)
+            $stop = $true
+        } catch { Start-Sleep -Second 5 }
+    } until ($stop)
+
+    # create the Port Mapper rule file that contains our forwarded ports
+    $fs = [System.IO.File]::Create($pmapper_config)
+    try {
+        foreach ($forwarded_port in $forwarded_ports.GetEnumerator()) {
+            Write-Verbose -Message "Creating forwarded port rule for $($forwarded_port.Key) -> $($forwarded_port.Value)"
+            $pmapper_rule = Get-PmapperRuleBytes -ListenPort $forwarded_port.Key -ConnectAddress 127.0.0.1 -ConnectPort $forwarded_port.Value
+            $fs.Write($pmapper_rule, 0, $pmapper_rule.Length)
+        }
+    } finally {
+        $fs.Close()
+    }
+
+    Write-Verbose -Message "Starting Port Mapper '$pmapper_exe' in the background"
+    $start_args = @{
+        CommandLine = $pmapper_exe
+        CurrentDirectory = $pmapper_folder
+    }
+    $res = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments $start_args
+    if ($res.ReturnValue -ne 0) {
+        $error_msg = switch($res.ReturnValue) {
+            2 { "Access denied" }
+            3 { "Insufficient privilege" }
+            8 { "Unknown failure" }
+            9 { "Path not found" }
+            21 { "Invalid parameter" }
+            default { "Undefined Error: $($res.ReturnValue)" }
+        }
+        Write-Error -Message "Failed to start pmapper: $error_msg"
+    }
+    $pmapper_pid = $res.ProcessId
+    Write-Verbose -Message "Port Mapper PID: $pmapper_pid"
+}
+
+Write-Verbose -Message "Wait for current script at '$PSCommandPath' to be deleted before running cleanup"
+$fsw = New-Object -TypeName System.IO.FileSystemWatcher
+$fsw.Path = Split-Path -Path $PSCommandPath -Parent
+$fsw.Filter = Split-Path -Path $PSCommandPath -Leaf
+$fsw.WaitForChanged([System.IO.WatcherChangeTypes]::Deleted, 3600000) > $null
+Write-Verbose -Message "Script delete or timeout reached, cleaning up Windows httptester artifacts"
+
+Write-Verbose -Message "Cleanup host file entries"
+$hosts_file_lines = [System.IO.File]::ReadAllLines($hosts_file)
+$new_lines = [System.Collections.ArrayList]@()
+$changed = $false
+foreach ($host_line in $hosts_file_lines) {
+    if ($host_line.EndsWith("# ansible-test httptester")) {
+        $changed = $true
+        continue
+    }
+    $new_lines.Add($host_line) > $null
+}
+if ($changed) {
+    Write-Verbose -Message "Host file has extra entries, removing extra entries"
+    [System.IO.File]::WriteAllLines($hosts_file, $new_lines)
+}
+
+if ($os_version -ge [Version]"6.2") {
+    Write-Verbose -Message "Cleanup of forwarded port configured in netsh"
+    foreach ($forwarded_port in $forwarded_ports.GetEnumerator()) {
+        $port_set = netsh interface portproxy show v4tov4 | `
+            Where-Object { $_ -match "127.0.0.1\s*$($forwarded_port.Key)\s*127.0.0.1\s*$($forwarded_port.Value)" }
+
+        if ($port_set) {
+            Write-Verbose -Message "Removing netsh portproxy rule for $($forwarded_port.Key) -> $($forwarded_port.Value)"
+            $delete_args = @(
+                "interface",
+                "portproxy",
+                "delete",
+                "v4tov4",
+                "listenaddress=127.0.0.1",
+                "listenport=$($forwarded_port.Key)"
+            )
+            $null = netsh $delete_args 2>&1
+        }
+    }
+} else {
+    Write-Verbose -Message "Stopping Port Mapper executable based on pid $pmapper_pid"
+    Stop-Process -Id $pmapper_pid -Force
+
+    # the process may not stop straight away, try multiple times to delete the Port Mapper folder
+    $attempts = 1
+    do {
+        try {
+            Write-Verbose -Message "Cleanup temporary files for Port Mapper at '$pmapper_folder' - Attempt: $attempts"
+            Remove-Item -Path $pmapper_folder -Force -Recurse
+            break
+        } catch {
+            Write-Verbose -Message "Cleanup temporary files for Port Mapper failed, waiting 5 seconds before trying again:$($_ | Out-String)"
+            if ($attempts -ge 5) {
+                break
+            }
+            $attempts += 1
+            Start-Sleep -Second 5
+        }
+    } until ($true)
+}


### PR DESCRIPTION
##### SUMMARY
Backports;

* https://github.com/ansible/ansible/pull/46606 - httptester integration for Windows tests
* https://github.com/ansible/ansible/pull/46845 - skip/windows/ support on aliases
* https://github.com/ansible/ansible/pull/46734 - cleanup of win_uri tests to use var instead of hardcoded URL
* https://github.com/ansible/ansible/pull/47090 - support Azure hosts with httptester
* https://github.com/ansible/ansible/pull/47100 - run httptester setup on each target

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```paste below
2.5
```