### PR TITLE
WIP - upgrade Fedora test containers

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -8,123 +8,126 @@ matrix:
   exclude:
     - env: T=none
   include:
-    - env: T=sanity/1
-    - env: T=sanity/2
-    - env: T=sanity/3
-    - env: T=sanity/4
-
-    - env: T=units/2.6
-    - env: T=units/2.7
-    - env: T=units/3.5
-    - env: T=units/3.6
-    - env: T=units/3.7
-
-    - env: T=windows/2008/1
-    - env: T=windows/2008-R2/1
-    - env: T=windows/2012/1
-    - env: T=windows/2012-R2/1
-    - env: T=windows/2016/1
-
-    - env: T=windows/2008/2
-    - env: T=windows/2008-R2/2
-    - env: T=windows/2012/2
-    - env: T=windows/2012-R2/2
-    - env: T=windows/2016/2
-
-    - env: T=windows/2008/3
-    - env: T=windows/2008-R2/3
-    - env: T=windows/2012/3
-    - env: T=windows/2012-R2/3
-    - env: T=windows/2016/3
-
-    - env: T=windows/2008/4
-    - env: T=windows/2008-R2/4
-    - env: T=windows/2012/4
-    - env: T=windows/2012-R2/4
-    - env: T=windows/2016/4
-
-    - env: T=network
-
-    - env: T=osx/10.11/1
-    - env: T=rhel/7.6/1
-    - env: T=rhel/8.0/1
-    - env: T=freebsd/11.1/1
-    - env: T=linux/centos6/1
-    - env: T=linux/centos7/1
+#    - env: T=sanity/1
+#    - env: T=sanity/2
+#    - env: T=sanity/3
+#    - env: T=sanity/4
+#
+#    - env: T=units/2.6
+#    - env: T=units/2.7
+#    - env: T=units/3.5
+#    - env: T=units/3.6
+#    - env: T=units/3.7
+#
+#    - env: T=windows/2008/1
+#    - env: T=windows/2008-R2/1
+#    - env: T=windows/2012/1
+#    - env: T=windows/2012-R2/1
+#    - env: T=windows/2016/1
+#
+#    - env: T=windows/2008/2
+#    - env: T=windows/2008-R2/2
+#    - env: T=windows/2012/2
+#    - env: T=windows/2012-R2/2
+#    - env: T=windows/2016/2
+#
+#    - env: T=windows/2008/3
+#    - env: T=windows/2008-R2/3
+#    - env: T=windows/2012/3
+#    - env: T=windows/2012-R2/3
+#    - env: T=windows/2016/3
+#
+#    - env: T=windows/2008/4
+#    - env: T=windows/2008-R2/4
+#    - env: T=windows/2012/4
+#    - env: T=windows/2012-R2/4
+#    - env: T=windows/2016/4
+#
+#    - env: T=network
+#
+#    - env: T=osx/10.11/1
+#    - env: T=rhel/7.6/1
+#    - env: T=rhel/8.0/1
+#    - env: T=freebsd/11.1/1
+#    - env: T=linux/centos6/1
+#    - env: T=linux/centos7/1
     - env: T=linux/fedora25/1
     - env: T=linux/fedora28/1
-    - env: T=linux/opensuse42.3/1
-    - env: T=linux/ubuntu1404/1
-    - env: T=linux/ubuntu1604/1
-    - env: T=linux/ubuntu1604py3/1
-
-    - env: T=osx/10.11/2
-    - env: T=rhel/7.6/2
-    - env: T=rhel/8.0/2
-    - env: T=freebsd/11.1/2
-    - env: T=linux/centos6/2
-    - env: T=linux/centos7/2
+    - env: T=linux/fedora29/1
+#    - env: T=linux/opensuse42.3/1
+#    - env: T=linux/ubuntu1404/1
+#    - env: T=linux/ubuntu1604/1
+#    - env: T=linux/ubuntu1604py3/1
+#
+#    - env: T=osx/10.11/2
+#    - env: T=rhel/7.6/2
+#    - env: T=rhel/8.0/2
+#    - env: T=freebsd/11.1/2
+#    - env: T=linux/centos6/2
+#    - env: T=linux/centos7/2
     - env: T=linux/fedora25/2
     - env: T=linux/fedora28/2
-    - env: T=linux/opensuse42.3/2
-    - env: T=linux/ubuntu1404/2
-    - env: T=linux/ubuntu1604/2
-    - env: T=linux/ubuntu1604py3/2
-
-    - env: T=osx/10.11/3
-    - env: T=rhel/7.6/3
-    - env: T=rhel/8.0/3
-    - env: T=freebsd/11.1/3
-    - env: T=linux/centos6/3
-    - env: T=linux/centos7/3
+    - env: T=linux/fedora29/2
+#    - env: T=linux/opensuse42.3/2
+#    - env: T=linux/ubuntu1404/2
+#    - env: T=linux/ubuntu1604/2
+#    - env: T=linux/ubuntu1604py3/2
+#
+#    - env: T=osx/10.11/3
+#    - env: T=rhel/7.6/3
+#    - env: T=rhel/8.0/3
+#    - env: T=freebsd/11.1/3
+#    - env: T=linux/centos6/3
+#    - env: T=linux/centos7/3
     - env: T=linux/fedora25/3
     - env: T=linux/fedora28/3
-    - env: T=linux/opensuse42.3/3
-    - env: T=linux/ubuntu1404/3
-    - env: T=linux/ubuntu1604/3
-    - env: T=linux/ubuntu1604py3/3
-
-    - env: T=aws/2.7/1
-    - env: T=aws/3.6/1
-
-    - env: T=aws/2.7/2
-    - env: T=aws/3.6/2
-
-    - env: T=azure/2.7/1
-    - env: T=azure/3.6/1
-
-    - env: T=azure/2.7/2
-    - env: T=azure/3.6/2
-
-    - env: T=azure/2.7/3
-    - env: T=azure/3.6/3
-
-    - env: T=azure/2.7/4
-    - env: T=azure/3.6/4
-
-    - env: T=azure/2.7/5
-    - env: T=azure/3.6/5
-
-    - env: T=azure/2.7/6
-    - env: T=azure/3.6/6
-
-    - env: T=azure/2.7/7
-    - env: T=azure/3.6/7
-
-    - env: T=azure/2.7/8
-    - env: T=azure/3.6/8
-
-    - env: T=vcenter/2.7/1
-    - env: T=vcenter/3.6/1
-
-    - env: T=cs/2.7/1
-    - env: T=cs/3.6/1
-
-    - env: T=tower/2.7/1
-    - env: T=tower/3.6/1
-
-    - env: T=cloud/2.7/1
-    - env: T=cloud/3.6/1
+    - env: T=linux/fedora29/3
+#    - env: T=linux/opensuse42.3/3
+#    - env: T=linux/ubuntu1404/3
+#    - env: T=linux/ubuntu1604/3
+#    - env: T=linux/ubuntu1604py3/3
+#
+#    - env: T=aws/2.7/1
+#    - env: T=aws/3.6/1
+#
+#    - env: T=aws/2.7/2
+#    - env: T=aws/3.6/2
+#
+#    - env: T=azure/2.7/1
+#    - env: T=azure/3.6/1
+#
+#    - env: T=azure/2.7/2
+#    - env: T=azure/3.6/2
+#
+#    - env: T=azure/2.7/3
+#    - env: T=azure/3.6/3
+#
+#    - env: T=azure/2.7/4
+#    - env: T=azure/3.6/4
+#
+#    - env: T=azure/2.7/5
+#    - env: T=azure/3.6/5
+#
+#    - env: T=azure/2.7/6
+#    - env: T=azure/3.6/6
+#
+#    - env: T=azure/2.7/7
+#    - env: T=azure/3.6/7
+#
+#    - env: T=azure/2.7/8
+#    - env: T=azure/3.6/8
+#
+#    - env: T=vcenter/2.7/1
+#    - env: T=vcenter/3.6/1
+#
+#    - env: T=cs/2.7/1
+#    - env: T=cs/3.6/1
+#
+#    - env: T=tower/2.7/1
+#    - env: T=tower/3.6/1
+#
+#    - env: T=cloud/2.7/1
+#    - env: T=cloud/3.6/1
 branches:
   except:
     - "*-patch-*"

--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -3,6 +3,7 @@ centos6 name=quay.io/ansible/centos6-test-container:1.4.0 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.4.0 seccomp=unconfined
 fedora25 name=quay.io/ansible/fedora25-test-container:1.4.0 seccomp=unconfined
 fedora28 name=quay.io/ansible/fedora28-test-container:1.5.0
+fedora29 name=quay.io/ansible/fedora29-test-container:1.5.0 python=3
 opensuse42.3 name=quay.io/ansible/opensuse42.3-test-container:1.4.0 seccomp=unconfined
 ubuntu1404 name=quay.io/ansible/ubuntu1404-test-container:1.4.0 seccomp=unconfined
 ubuntu1604 name=quay.io/ansible/ubuntu1604-test-container:1.4.0 seccomp=unconfined

--- a/test/utils/shippable/linux.sh
+++ b/test/utils/shippable/linux.sh
@@ -15,4 +15,4 @@ fi
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
-    --docker "${image}"
+    --docker "${image}" --continue-on-error


### PR DESCRIPTION
##### SUMMARY
Now that Shippable has been upgraded, let's try out the new Fedora containers. This swaps Fedora 24 to Fedora 28 (Python 2) and Fedora 25 to Fedora 29 (Python 3).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```paste below
devel
```