### PR TITLE
_flatpak_command returns a str on python2 or python3

### DIFF
--- a/lib/ansible/modules/packaging/os/flatpak.py
+++ b/lib/ansible/modules/packaging/os/flatpak.py
@@ -203,7 +203,10 @@ def _flatpak_command(module, noop, command):
     result['stderr'] = stderr_data
     if result['rc'] != 0:
         module.fail_json(msg="Failed to execute flatpak command", **result)
-    return stdout_data
+    if isinstance(stdout_data, str):
+        return stdout_data
+    else:
+        return stdout_data.decode('utf-8')
 
 
 def main():

--- a/lib/ansible/modules/packaging/os/flatpak.py
+++ b/lib/ansible/modules/packaging/os/flatpak.py
@@ -127,6 +127,7 @@ stdout:
 import subprocess
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import _text
 
 
 def install_flat(module, binary, remote, name, method):
@@ -203,10 +204,7 @@ def _flatpak_command(module, noop, command):
     result['stderr'] = stderr_data
     if result['rc'] != 0:
         module.fail_json(msg="Failed to execute flatpak command", **result)
-    if isinstance(stdout_data, str):
-        return stdout_data
-    else:
-        return stdout_data.decode('utf-8')
+    return _text.to_native(stdout_data)
 
 
 def main():

--- a/lib/ansible/modules/packaging/os/flatpak_remote.py
+++ b/lib/ansible/modules/packaging/os/flatpak_remote.py
@@ -120,6 +120,7 @@ stdout:
 
 import subprocess
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import _text
 
 
 def add_remote(module, binary, name, flatpakrepo_url, method):
@@ -168,7 +169,7 @@ def _flatpak_command(module, noop, command):
     result['stderr'] = stderr_data
     if result['rc'] != 0:
         module.fail_json(msg="Failed to execute flatpak command", **result)
-    return stdout_data
+    return _text.to_native(stdout_data)
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/46995

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
flatpak

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (str-flatpack-out 7469172add) last updated 2018/10/12 20:06:16 (GMT -400)
  config file = None
  configured module search path = ['/home/jobevers/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jobevers/code/ansible/lib/ansible
  executable location = /home/jobevers/.local/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
