### PR TITLE
WinRM/PSRP: Fix UTF-8 issue

### DIFF
--- a/changelogs/fragments/psrp-utf8.yaml
+++ b/changelogs/fragments/psrp-utf8.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- psrp - Fix issue when dealing with unicode values in the output for Python 2 - https://github.com/ansible/ansible/pull/46998

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -550,7 +550,7 @@ if ($bytes_read -gt 0) {
             # create our own output based on the properties if that is the
             # case+
             try:
-                output_msg = str(output)
+                output_msg = to_text(output)
             except TypeError:
                 if isinstance(output, GenericComplexObject):
                     obj_lines = output.property_sets


### PR DESCRIPTION
##### SUMMARY
This fixes the traceback below:
```
Using module file /opt/anvers/default/lib/ansible/modules/windows/win_shell.ps1
<192.168.0.53> PSRP: EXEC (via pipeline wrapper)
The full traceback is:
Traceback (most recent call last):
  File "/opt/anvers/default/lib/ansible/executor/task_executor.py", line 105, in run
    item_results = self._run_loop(items)
  File "/opt/anvers/default/lib/ansible/executor/task_executor.py", line 337, in _run_loop
    res = self._execute(variables=task_vars)
  File "/opt/anvers/default/lib/ansible/executor/task_executor.py", line 598, in _execute
    result = self._handler.run(task_vars=variables)
  File "/opt/anvers/default/lib/ansible/plugins/action/normal.py", line 46, in run
    result = merge_hash(result, self._execute_module(task_vars=task_vars, wrap_async=wrap_async))
  File "/opt/anvers/default/lib/ansible/plugins/action/__init__.py", line 870, in _execute_module
    res = self._low_level_execute_command(cmd, sudoable=sudoable, in_data=in_data)
  File "/opt/anvers/default/lib/ansible/plugins/action/__init__.py", line 985, in _low_level_execute_command
    rc, stdout, stderr = self._connection.exec_command(cmd, in_data=in_data, sudoable=sudoable)
  File "/opt/anvers/default/lib/ansible/plugins/connection/psrp.py", line 287, in exec_command
    rc, stdout, stderr = self._exec_psrp_script(script, in_data)
  File "/opt/anvers/default/lib/ansible/plugins/connection/psrp.py", line 528, in _exec_psrp_script
    rc, stdout, stderr = self._parse_pipeline_result(ps)
  File "/opt/anvers/default/lib/ansible/plugins/connection/psrp.py", line 553, in _parse_pipeline_result
    output_msg = str(output)
UnicodeEncodeError: 'ascii' codec can't encode character u'\ufffd' in position 102: ordinal not in range(128)

fatal: [computer28]: FAILED! => {
    "msg": "Unexpected failure during module execution.", 
    "stdout": ""
}
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
WinRM PSRP

##### ANSIBLE VERSION
v2.8