### PR TITLE
feat: support postgres 10 in azure_rm_postgresqlserver

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
@@ -56,7 +56,7 @@ options:
     version:
         description:
             - Server version.
-        choices: ['9.5', '9.6']
+        choices: ['9.5', '9.6', '10']
     enforce_ssl:
         description:
             - Enable SSL enforcement.
@@ -114,7 +114,7 @@ id:
     sample: /subscriptions/12345678-1234-1234-1234-123412341234/resourceGroups/samplerg/providers/Microsoft.DBforPostgreSQL/servers/mysqlsrv1b6dd89593
 version:
     description:
-        - 'Server version. Possible values include: C(9.5), C(9.6)'
+        - 'Server version. Possible values include: C(9.5), C(9.6), C(10)'
     returned: always
     type: str
     sample: 9.6
@@ -173,7 +173,7 @@ class AzureRMServers(AzureRMModuleBase):
             ),
             version=dict(
                 type='str',
-                choices=['9.5', '9.6']
+                choices=['9.5', '9.6', '10']
             ),
             enforce_ssl=dict(
                 type='bool',


### PR DESCRIPTION
##### SUMMARY
Add support to Azure Postgres 10.x (see [azure official docs](https://docs.microsoft.com/lv-lv/azure//postgresql/concepts-supported-versions)).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm_postgresqlserver

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.7.0
  config file = None
  configured module search path = [u'/Users/xyz/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jul 23 2018, 21:31:33) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION

See azure portal screenshot

<img width="296" alt="screen shot 2018-10-13 at 11 08 08" src="https://user-images.githubusercontent.com/673420/46904058-e41d7f00-cede-11e8-8cb0-439f12dc6325.png">
