### PR TITLE
Fix prompt mismatch issue for ios

### DIFF
--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -665,9 +665,9 @@ Intermittent failure while using ``network_cli`` connection type
 ----------------------------------------------------------------
 
 If the command prompt received in response is not matched correctly within
-``network_cli`` connection plugin the task might fail intermittently with stacktarce
-or truncated response or with error message ``operation requires privilege escalation``.
-Startin 2.7.1 a new buffer read timer is added to ensure prompts are matched properly
+``network_cli`` connection plugin the task might fail intermittently with truncated
+response or with error message ``operation requires privilege escalation``.
+Starting 2.7.1 a new buffer read timer is added to ensure prompts are matched properly
 and complete response is send in output. The timer default value is 0.2 seconds and
 can be adjusted per task basis or can be set globally in seconds.
 
@@ -683,7 +683,7 @@ Example Per task timer setting
       ansible_buffer_read_timeout: 2
 
 
-To make this a global, add the following to your ``ansible.cfg`` file:
+To make this a global setting, add the following to your ``ansible.cfg`` file:
 
 .. code-block:: ini
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -665,11 +665,11 @@ Intermittent failure while using ``network_cli`` connection type
 ----------------------------------------------------------------
 
 If the command prompt received in response is not matched correctly within
-``network_cli`` connection plugin the task might fail intermittently with truncated
-response or with error message ``operation requires privilege escalation``.
-Starting 2.7.1 a new buffer read timer is added to ensure prompts are matched properly
-and complete response is send in output. The timer default value is 0.2 seconds and
-can be adjusted per task basis or can be set globally in seconds.
+the ``network_cli`` connection plugin the task might fail intermittently with truncated
+response or with the error message ``operation requires privilege escalation``.
+Starting in 2.7.1 a new buffer read timer is added to ensure prompts are matched properly
+and a complete response is send in output. The timer default value is 0.2 seconds and
+can be adjusted on a per task basis or can be set globally in seconds.
 
 Example Per task timer setting
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -656,3 +656,36 @@ Example Ansible inventory file
    This is done to prevent secrets from leaking out, for example in ``ps`` output.
 
    We recommend using SSH Keys, and if needed an ssh-agent, rather than passwords, where ever possible.
+
+Miscellaneous Issues
+====================
+
+
+Intermittent failure while using ``network_cli`` connection type
+----------------------------------------------------------------
+
+If the command prompt received in response is not matched correctly within
+``network_cli`` connection plugin the task might fail intermittently with stacktarce
+or truncated response or with error message ``operation requires privilege escalation``.
+Startin 2.7.1 a new buffer read timer is added to ensure prompts are matched properly
+and complete response is send in output. The timer default value is 0.2 seconds and
+can be adjusted per task basis or can be set globally in seconds.
+
+Example Per task timer setting
+
+.. code-block:: yaml
+
+  - name: gather ios facts
+    ios_facts:
+      gather_subset: all
+    register: result
+    vars:
+      ansible_buffer_read_timeout: 2
+
+
+To make this a global, add the following to your ``ansible.cfg`` file:
+
+.. code-block:: ini
+
+   [persistent_connection]
+   buffer_read_timeout = 2

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -689,3 +689,5 @@ To make this a global setting, add the following to your ``ansible.cfg`` file:
 
    [persistent_connection]
    buffer_read_timeout = 2
+
+This timer delay per command executed on remote host can be disabled by setting the value to zero.

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -162,7 +162,7 @@ options:
     description:
       - Configures, in seconds, the amount of time to wait for the data to be read
         from Paramiko channel after the command prompt is matched. This timeout
-        value ensure that command prompt matched is correct and there is no more data
+        value ensures that command prompt matched is correct and there is no more data
         left to be received from remote host.
     default: 0.1
     ini:

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -158,13 +158,13 @@ options:
     vars:
       - name: ansible_command_timeout
   persistent_buffer_read_timeout:
-    type: int
+    type: float
     description:
       - Configures, in seconds, the amount of time to wait for the data to be read
         from Paramiko channel after the command prompt is matched. This timeout
         value ensure that command prompt matched is correct and there is no more data
         left to be received from remote host.
-    default: 1
+    default: 0.1
     ini:
       - section: persistent_connection
         key: buffer_read_timeout
@@ -375,10 +375,9 @@ class Connection(NetworkConnectionBase):
             if command_prompt_matched:
                 try:
                     signal.signal(signal.SIGALRM, self._handle_buffer_read_timeout)
-                    signal.alarm(self.get_option('persistent_buffer_read_timeout'))
+                    signal.setitimer(signal.ITIMER_REAL, self.get_option('persistent_buffer_read_timeout'))
                     data = self._ssh_shell.recv(256)
                     signal.alarm(0)
-
                     # if data is still received on channel it indicates the prompt string
                     # is wrongly matched in between response chunks, continue to read
                     # remaining response.

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -544,6 +544,6 @@ class Connection(NetworkConnectionBase):
 
         return False
 
-    def _validate_timeout_value(timeout, timer_name):
+    def _validate_timeout_value(self, timeout, timer_name):
         if timeout <= 0:
-         raise AnsibleConnectionFailure("'%s' timer value is invalid: %s, value should be greater than zero." % (timer_name, timeout))
+            raise AnsibleConnectionFailure("'%s' timer value '%s' is invalid, value should be greater than zero." % (timer_name, timeout))

--- a/test/units/plugins/connection/test_network_cli.py
+++ b/test/units/plugins/connection/test_network_cli.py
@@ -21,6 +21,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
+import time
 import json
 
 from io import StringIO
@@ -28,6 +29,7 @@ from io import StringIO
 from units.compat import unittest
 from units.compat.mock import patch, MagicMock
 
+from ansible.module_utils._text import to_text
 from ansible.errors import AnsibleConnectionFailure
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
@@ -131,15 +133,14 @@ class TestConnectionClass(unittest.TestCase):
         device#
         """
 
-        mock__shell.recv.return_value = response
-
+        mock__shell.recv.side_effect = [response, None]
         output = conn.send(b'command', None, None, None)
 
         mock__shell.sendall.assert_called_with(b'command\r')
-        self.assertEqual(output, 'command response')
+        self.assertEqual(to_text(conn._command_response), 'command response')
 
         mock__shell.reset_mock()
-        mock__shell.recv.return_value = b"ERROR: error message device#"
+        mock__shell.recv.side_effect = [b"ERROR: error message device#"]
 
         with self.assertRaises(AnsibleConnectionFailure) as exc:
             conn.send(b'command', None, None, None)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #40884 #44463 #46082

~~*  Check if the last matched prompt in the response~~
~~is the same as that of the current prompt. This will ensure
   any misinterpreted prompt that is matched in between response is ignored.~~
~~*  To get around command that will result in the prompt change~~
~~example `configure` add a window count check which ensures
   above check is not passed in such scenario's.~~

*  If the command prompt is matched check if data is
   still pending to be read from the buffer.
*  This fix adds a new timer `buffer_read_timeout`
   which will be triggered after the command prompt
   is matched and data is attempted to be read from the channel.
   If no data is present on the channel the timer will expire and 
   the response we be returned to the calling function. If data is
   present it will continue to process the response.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
network_cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
