### PR TITLE
option [others] of get_url is unnecessary

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -154,9 +154,7 @@ options:
         client authentication. If C(client_cert) contains both the certificate
         and key, this option is not required.
     version_added: '2.4'
-  others:
-    description:
-      - all arguments accepted by the M(file) module also work here
+
 # informational: requirements for nodes
 extends_documentation_fragment:
     - files

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -154,6 +154,7 @@ options:
         client authentication. If C(client_cert) contains both the certificate
         and key, this option is not required.
     version_added: '2.4'
+
 # informational: requirements for nodes
 extends_documentation_fragment:
     - files

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -154,7 +154,6 @@ options:
         client authentication. If C(client_cert) contains both the certificate
         and key, this option is not required.
     version_added: '2.4'
-
 # informational: requirements for nodes
 extends_documentation_fragment:
     - files

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -609,7 +609,6 @@ lib/ansible/modules/monitoring/sensu_client.py E324
 lib/ansible/modules/monitoring/sensu_handler.py E326
 lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py E317
 lib/ansible/modules/net_tools/basics/get_url.py E322
-lib/ansible/modules/net_tools/basics/get_url.py E323
 lib/ansible/modules/net_tools/basics/get_url.py E324
 lib/ansible/modules/net_tools/basics/slurp.py E322
 lib/ansible/modules/net_tools/basics/uri.py E322


### PR DESCRIPTION
##### SUMMARY

 issue #44238

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
get_url

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
all
```

