### PR TITLE
network.py filter_plugin typo fix

### DIFF
--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -388,11 +388,11 @@ def hash_salt(password):
         return split_password[2]
 
 
-def comp_type5(unencrypted_password, encrypted_password, return_orginal=False):
+def comp_type5(unencrypted_password, encrypted_password, return_original=False):
 
     salt = hash_salt(encrypted_password)
     if type5_pw(unencrypted_password, salt) == encrypted_password:
-        if return_orginal is True:
+        if return_original is True:
             return encrypted_password
         else:
             return True


### PR DESCRIPTION
##### SUMMARY
changed return_orginal to return_original in /lib/ansible/plugins/filter/network.py

##### ISSUE TYPE
spelling error in source code

##### COMPONENT NAME
/lib/ansible/plugins/filter/network.py

##### ANSIBLE VERSION
current devel

##### ADDITIONAL INFORMATION
This is a trivial fix for a spelling error.  Nothing was updated feature wise.
