### PR TITLE
An earlier optimization of ansible-doc -l caused failures.

### DIFF
--- a/changelogs/fragments/plugin-docs-list-fix.yaml
+++ b/changelogs/fragments/plugin-docs-list-fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- 'Fixed an issue with ansible-doc -l failing when parsing some plugin documentation.'

--- a/lib/ansible/parsing/plugin_docs.py
+++ b/lib/ansible/parsing/plugin_docs.py
@@ -104,7 +104,7 @@ def read_docstub(filename):
             elif capturing and not line.startswith(indent_detection):
                 break
 
-            elif line.lstrip().startswith('short_description: '):
+            elif line.lstrip().startswith('short_description:'):
                 capturing = True
                 # Detect that the short_description continues on the next line if it's indented more
                 # than short_description itself.


### PR DESCRIPTION
The optimization quickly searches the plugin code for short_description
fields and then uses that in the -l output.  The searching was a bit too
naive and ended up pulling out malformed yaml.  This caused those
plugins to be omitted from the list of plugins of that type with
a warning that their documentation strings were wrong.

This change makes the documentation parser aware that the documentation
string could have a relative indent for all of its fields which makes it
robust in the face of this particular problem.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-doc

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
devel 2.7.0 stable-2.6
```

##### ADDITIONAL INFORMATION
This should be backported to 2.7 and 2.6 as well.

Need to have a new sanity test that checks the output of ansible-doc -l  to prevent this from regressing.  Opened a ticket to track that.