### PR TITLE
Always use /proc/sys/kernel/random/boot_id to confirm reboot on Linux

### DIFF
--- a/changelogs/fragments/reboot-change-default-boot-command.yaml
+++ b/changelogs/fragments/reboot-change-default-boot-command.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - reboot - change default reboot time command to prevent hanging on certain systems (https://github.com/ansible/ansible/issues/46562)

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -35,7 +35,7 @@ class ActionModule(ActionBase):
     DEFAULT_PRE_REBOOT_DELAY = 0
     DEFAULT_POST_REBOOT_DELAY = 0
     DEFAULT_TEST_COMMAND = 'whoami'
-    DEFAULT_BOOT_TIME_COMMAND = 'who -b'
+    DEFAULT_BOOT_TIME_COMMAND = 'cat /proc/sys/kernel/random/boot_id'
     DEFAULT_REBOOT_MESSAGE = 'Reboot initiated by Ansible'
     DEFAULT_SHUTDOWN_COMMAND = 'shutdown'
     DEFAULT_SUDOABLE = True
@@ -43,16 +43,18 @@ class ActionModule(ActionBase):
     DEPRECATED_ARGS = {}
 
     BOOT_TIME_COMMANDS = {
-        'linux': 'cat /proc/sys/kernel/random/boot_id',
-        'openbsd': "/sbin/sysctl kern.boottime",
+        'openbsd': '/sbin/sysctl kern.boottime',
+        'freebsd': '/sbin/sysctl kern.boottime',
+        'sunos': 'who -b',
+        'darwin': 'who -b',
     }
 
     SHUTDOWN_COMMANDS = {
         'linux': DEFAULT_SHUTDOWN_COMMAND,
         'freebsd': DEFAULT_SHUTDOWN_COMMAND,
+        'openbsd': DEFAULT_SHUTDOWN_COMMAND,
         'sunos': '/usr/sbin/shutdown',
         'darwin': '/sbin/shutdown',
-        'openbsd': DEFAULT_SHUTDOWN_COMMAND,
     }
 
     SHUTDOWN_COMMAND_ARGS = {


### PR DESCRIPTION
##### SUMMARY
/proc/sys/kernel/random/boot_id is available since kernel 2.3.16 and
should be safe to rely on.

The previously used method by checking the system boot time using who -b
turned out to be unreliable: Some systems lacking an RTC report the Unix
epoch as boot time, but the code trying to detect that did't always
work.

Fixes #46562
Fixes #47371

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
reboot.py

##### ANSIBLE VERSION
```paste below
ansible 2.7.0
  config file = None
  configured module search path = [u'/home/stefan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/stefan/.local/venvs/ansible/lib/python2.7/site-packages/ansible
  executable location = /home/stefan/.local/bin/ansible
  python version = 2.7.14 (default, Oct 12 2017, 15:50:02) [GCC]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
