### PR TITLE
mail: Fix regression when sending mail without SSL (v2.7)

### DIFF
--- a/changelogs/fragments/mail-fix-regression.yaml
+++ b/changelogs/fragments/mail-fix-regression.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- mail - Fix regression when sending mail without TLS/SSL

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -255,6 +255,8 @@ def main():
                 if secure == 'always':
                     module.fail_json(rc=1, msg='Unable to start an encrypted session to %s:%s: %s' %
                                                (host, port, to_native(e)), exception=traceback.format_exc())
+            except:
+                pass
 
         if not secure_state:
             smtp = smtplib.SMTP(timeout=timeout)


### PR DESCRIPTION
##### SUMMARY
When this module was refactored in #37098 the non-SSL use-case was broken.

The main cause is that we have no way to do integration tests for testing SMTP.

This is a back-port to v2.7 of #46403
This fixes #46673

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mail

##### ANSIBLE VERSION
v2.7