### PR TITLE
hostname.py: Fix openSUSE distribution name

### DIFF
--- a/changelogs/fragments/suse_distro_names.yaml
+++ b/changelogs/fragments/suse_distro_names.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+    - Add code to detect correctly a host running openSUSE Tumbleweed
+    - Fix detection string for SUSE distribution variants like Leap and SLES (SUSE Enterprise Linux Server).

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -565,7 +565,7 @@ class FedoraHostname(Hostname):
 
 class SLESHostname(Hostname):
     platform = 'Linux'
-    distribution = 'Suse linux enterprise server '
+    distribution = 'Sles'
     try:
         distribution_version = get_distribution_version()
         # cast to float may raise ValueError on non SLES, we use float for a little more safety over int
@@ -579,7 +579,13 @@ class SLESHostname(Hostname):
 
 class OpenSUSEHostname(Hostname):
     platform = 'Linux'
-    distribution = 'Opensuse '
+    distribution = 'Opensuse leap'
+    strategy_class = SystemdStrategy
+
+
+class TumbleweedHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Opensuse tumbleweed'
     strategy_class = SystemdStrategy
 
 


### PR DESCRIPTION
Currently there is a problem to discover the distribution name by
python's platform.linux_distribution method used by Ansible's hostname modules
when running a playblook in openSUSE[1]. This method was deprecated
in python  3.5, and was already removed in the current developer version (3.8)[2]

There is a patch[3] being reviewed that would fix this problem by using
the distro package, which would return correctly the openSUSE string,
also avoiding the use of the deprecated python method in Ansible.

Using the distro package, the returned distribution string in a openSUSE system would
be 'openSUSE Leap', but currently Ansible is checking for 'Opensuse ' in hostname.py,
so this patch change the string to check for the correct value, making possible to use
the hostname module in a playbook for example.

1: https://bugzilla.suse.com/show_bug.cgi?id=997614
2: https://docs.python.org/3.7/library/platform.html#platform.linux_distribution
3: https://github.com/ansible/ansible/pull/35985

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`hostname.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
