### PR TITLE
Ignore empty result of rabbitmqctl list_parameters

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_parameter.py
+++ b/lib/ansible/modules/messaging/rabbitmq_parameter.py
@@ -82,7 +82,7 @@ class RabbitMqParameter(object):
         return list()
 
     def get(self):
-        parameters = self._exec(['list_parameters', '-p', self.vhost], True)
+        parameters = [param for param in self._exec(['list_parameters', '-p', self.vhost], True) if param.strip()]
 
         for param_item in parameters:
             component, name, value = param_item.split('\t')


### PR DESCRIPTION

##### SUMMARY
Fixes: #37066

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/messaging/rabbitmq_parameter.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8-devel
```