### PR TITLE
[Backport 2.7] Fix iterator to list conversion in ldap_entry module

### DIFF
--- a/changelogs/fragments/45417-ldap_entry-list_conversion.yml
+++ b/changelogs/fragments/45417-ldap_entry-list_conversion.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix iterator to list conversion in ldap_entry module.

--- a/lib/ansible/modules/net_tools/ldap/ldap_entry.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_entry.py
@@ -145,7 +145,7 @@ class LdapEntry(LdapGeneric):
                 attrs[name] = []
 
             if isinstance(value, list):
-                attrs[name] = [map(to_bytes, value)]
+                attrs[name] = list(map(to_bytes, value))
             else:
                 attrs[name].append(to_bytes(value))
 


### PR DESCRIPTION
##### SUMMARY
Fixes #45417

(cherry picked from commit 7a747341fbfef9c5d47588945cd018fc5697af0d)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/45417-ldap_entry-list_conversion.yml
lib/ansible/modules/net_tools/ldap/ldap_entry.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
Stable-2.7
```