### PR TITLE
Invalid options for assert: success_msg

### DIFF
--- a/lib/ansible/plugins/action/assert.py
+++ b/lib/ansible/plugins/action/assert.py
@@ -27,7 +27,7 @@ class ActionModule(ActionBase):
     ''' Fail with custom message '''
 
     TRANSFERS_FILES = False
-    _VALID_ARGS = frozenset(('fail_msg', 'msg', 'that'))
+    _VALID_ARGS = frozenset(('fail_msg', 'msg', 'success_msg', 'that'))
 
     def run(self, tmp=None, task_vars=None):
         if task_vars is None:


### PR DESCRIPTION
<!--- Verify first that your issue is not already reported on GitHub -->
<!--- Also test if the latest release and devel branch are affected too -->
<!--- Complete *all* sections as described, this form is processed automatically -->

##### SUMMARY

With Ansible 2.7, the assert module was enhanced with the success message. See module documentation at https://docs.ansible.com/ansible/2.7/modules/assert_module.html. The below example task fails with the error: **Invalid options for assert: success_msg**
```yaml
- name: after version 2.7 both 'msg' and 'fail_msg' can customize failing assertion message
  assert:
    that:
      - "my_param <= 100"
      - "my_param >= 0"
    fail_msg: "'my_param' must be between 0 and 100"
    success_msg: "'my_param' is between 0 and 100"
```

##### ISSUE TYPE
- Bug Report

##### COMPONENT NAME
assert

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
```

##### STEPS TO REPRODUCE
<!--- Describe exactly how to reproduce the problem, using a minimal test-case -->

<!--- Paste example playbooks or commands between quotes below -->
```yaml
- name: after version 2.7 both 'msg' and 'fail_msg' can customize failing assertion message
  assert:
    that:
      - "my_param <= 100"
      - "my_param >= 0"
    fail_msg: "'my_param' must be between 0 and 100"
    success_msg: "'my_param' is between 0 and 100"
```

<!--- HINT: You can paste gist.github.com links for larger files -->

##### EXPECTED RESULTS
<!--- Describe what you expected to happen when running the steps above -->
It should accept the `success_msg` parameter

##### ACTUAL RESULTS
<!--- Describe what actually happened. If possible run with extra verbosity (-vvvv) -->

<!--- Paste verbatim command output between quotes -->
```paste below
fatal: [hostname]: FAILED! => changed=false 
  msg: 'Invalid options for assert: success_msg'
```