### PR TITLE
Backport PR fix to resolve bug 46671, which now handles checking for Nonetype connection prompt

### DIFF
--- a/changelogs/fragments/ios_nonetype_connection_prompt.yaml
+++ b/changelogs/fragments/ios_nonetype_connection_prompt.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - To resolve code exception for Nonetype connection prompt.
+    (https://github.com/ansible/ansible/pull/46677)

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -58,7 +58,8 @@ class TerminalModule(TerminalBase):
             raise AnsibleConnectionFailure('unable to set terminal parameters')
 
     def on_become(self, passwd=None):
-        if self._get_prompt().endswith(b'#'):
+        conn_prompt = self._get_prompt()
+        if not conn_prompt or conn_prompt.endswith(b'#'):
             return
 
         cmd = {u'command': u'enable'}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This Backport PR resolves bug #46671 where the exception is thrown in case of Nonetype connection prompt
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/plugins/terminal/ios.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
(Backport and cherry picked from commit: 9ddceaf78df13c134a52426bd81b089cec17ead5) 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
