### PR TITLE
influxdb_user: Fixed default password behavior

### DIFF
--- a/lib/ansible/modules/database/influxdb/influxdb_user.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_user.py
@@ -158,7 +158,7 @@ def main():
 
     state = module.params['state']
     user_name = module.params['user_name']
-    user_password = module.params['user_password']
+    user_password = module.params['user_password'] or ''
     admin = module.params['admin']
     influxdb = influx.InfluxDb(module)
     client = influxdb.connect_to_influxdb()


### PR DESCRIPTION
##### SUMMARY
Fixes #47039

Sets the default password value to an empty string, instead of None.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
influxdb_user

##### ANSIBLE VERSION
devel branch