### PR TITLE
Fix in confirmed_commit capability in netconf_config modules (#46964)

### DIFF
--- a/changelogs/fragments/netconf_config_comfirm_commit_fix.yaml
+++ b/changelogs/fragments/netconf_config_comfirm_commit_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- netconf_config - Fix in confirmed_commit capability in netconf_config modules  (https://github.com/ansible/ansible/pull/46778)

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -123,7 +123,7 @@ options:
   commit:
     description:
       - This boolean flag controls if the configuration changes should be committed or not after editing the
-        candidate datastore. This oprion is supported only if remote Netconf server supports :candidate
+        candidate datastore. This option is supported only if remote Netconf server supports :candidate
         capability. If the value is set to I(False) commit won't be issued after edit-config operation
         and user needs to handle commit or discard-changes explicitly.
     type: bool
@@ -305,8 +305,8 @@ def main():
     if confirm_commit and not operations.get('supports_confirm_commit', False):
         module.fail_json(msg='confirm commit is not supported by Netconf server')
 
-    if confirm_commit or (confirm > 0) and not operations.get('supports_confirm_commit', False):
-        module.fail_json(msg='confirm commit is not supported by this netconf server')
+    if (confirm > 0) and not operations.get('supports_confirm_commit', False):
+        module.fail_json(msg='confirm commit is not supported by this netconf server, given confirm timeout: %d' % confirm)
 
     if validate and not operations.get('supports_validate', False):
         module.fail_json(msg='validate is not supported by this netconf server')
@@ -323,6 +323,7 @@ def main():
 
     result = {'changed': False, 'server_capabilities': capabilities.get('server_capabilities', [])}
     before = None
+    after = None
     locked = False
     try:
         if module.params['backup']:
@@ -362,15 +363,20 @@ def main():
                 'error_option': module.params['error_option'],
                 'format': module.params['format'],
             }
+
             conn.edit_config(**kwargs)
+
             if supports_commit and module.params['commit']:
+                after = to_text(conn.get_config(source='candidate'), errors='surrogate_then_replace').strip()
                 if not module.check_mode:
-                    timeout = confirm if confirm > 0 else None
-                    conn.commit(confirmed=confirm_commit, timeout=timeout)
+                    confirm_timeout = confirm if confirm > 0 else None
+                    confirmed_commit = True if confirm_timeout else False
+                    conn.commit(confirmed=confirmed_commit, timeout=confirm_timeout)
                 else:
                     conn.discard_changes()
 
-            after = to_text(conn.get_config(source='running'), errors='surrogate_then_replace').strip()
+            if after is None:
+                after = to_text(conn.get_config(source='running'), errors='surrogate_then_replace').strip()
 
             sanitized_before = sanitize_xml(before)
             sanitized_after = sanitize_xml(after)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #46804

*  If confirm value is greater than zero or confirm_commit option is set and confirmed-commit
    capability is not supported but Netconf server only in that case fail the module

* Update confirm-commit flag

* Minor changes

Merged to devel https://github.com/ansible/ansible/pull/46964
(cherry picked from commit 5394638047d9c11681ff7573e64d8b0a9c22f645)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
