### PR TITLE
ansible-doc: list types of plugin available

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -89,7 +89,8 @@ class DocCLI(CLI):
         self.parser.add_option("-j", "--json", action="store_true", default=False, dest='json_dump',
                                help='**For internal testing only** Dump json metadata for all plugins.')
         self.parser.add_option("-t", "--type", action="store", default='module', dest='type', type='choice',
-                               help='Choose which plugin type (defaults to "module")',
+                               help='Choose which plugin type (defaults to "module"). '
+                                    'Available plugin types are : {0}'.format(C.DOCUMENTABLE_PLUGINS),
                                choices=C.DOCUMENTABLE_PLUGINS)
         super(DocCLI, self).parse()
 


### PR DESCRIPTION
##### SUMMARY
This fix allows user to view types of plugin available in
ansible-doc command.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/cli/doc.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8-devel
```
