### PR TITLE
[WIP] Allow caching inventory with database-backed cache plugins

### DIFF
--- a/lib/ansible/plugins/cache/memcached.py
+++ b/lib/ansible/plugins/cache/memcached.py
@@ -48,7 +48,6 @@ import time
 from multiprocessing import Lock
 from itertools import chain
 
-from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.module_utils.common._collections_compat import MutableSet
 from ansible.plugins.cache import BaseCacheModule
@@ -166,13 +165,14 @@ class CacheModuleKeys(MutableSet):
 class CacheModule(BaseCacheModule):
 
     def __init__(self, *args, **kwargs):
-        if C.CACHE_PLUGIN_CONNECTION:
-            connection = C.CACHE_PLUGIN_CONNECTION.split(',')
+        super(CacheModule, self).__init__(*args, **kwargs)
+        if self.get_option('_uri'):
+            connection = self.get_option('_uri')
         else:
             connection = ['127.0.0.1:11211']
 
-        self._timeout = C.CACHE_PLUGIN_TIMEOUT
-        self._prefix = C.CACHE_PLUGIN_PREFIX
+        self._timeout = self.get_option('_timeout')
+        self._prefix = self.get_option('_prefix')
         self._cache = {}
         self._db = ProxyClientPool(connection, debug=0)
         self._keys = CacheModuleKeys(self._db, self._db.get(CacheModuleKeys.PREFIX) or [])

--- a/lib/ansible/plugins/cache/mongodb.py
+++ b/lib/ansible/plugins/cache/mongodb.py
@@ -47,7 +47,6 @@ import datetime
 
 from contextlib import contextmanager
 
-from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.plugins.cache import BaseCacheModule
 
@@ -62,8 +61,10 @@ class CacheModule(BaseCacheModule):
     A caching module backed by mongodb.
     """
     def __init__(self, *args, **kwargs):
-        self._timeout = int(C.CACHE_PLUGIN_TIMEOUT)
-        self._prefix = C.CACHE_PLUGIN_PREFIX
+        super(CacheModule, self).__init__(*args, **kwargs)
+        self.cache_dir = self.get_option('_uri')
+        self._timeout = int(self.get_option('_timeout'))
+        self._prefix = self.get_option('_prefix')
         self._cache = {}
         self._managed_indexes = False
 
@@ -94,7 +95,7 @@ class CacheModule(BaseCacheModule):
         This is a context manager for opening and closing mongo connections as needed. This exists as to not create a global
         connection, due to pymongo not being fork safe (http://api.mongodb.com/python/current/faq.html#is-pymongo-fork-safe)
         '''
-        mongo = pymongo.MongoClient(C.CACHE_PLUGIN_CONNECTION)
+        mongo = pymongo.MongoClient(self.cache_dir)
         try:
             db = mongo.get_default_database()
         except pymongo.errors.ConfigurationError:

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -575,9 +575,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Generate inventory
         formatted_inventory = {}
         cache_needs_update = False
+
+        cache = cache and self.get_option('cache')
+
+        # if refresh_inventory/flush cache is used and user is using caching, update the cached inventory
+        cache_needs_update = not cache and self.get_option('cache')
         if cache:
             try:
-                results = self.cache.get(cache_key)
+                results = self._cache[cache_key]
             except KeyError:
                 # if cache expires or cache file doesn't exist
                 cache_needs_update = True
@@ -589,7 +594,5 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self._populate(results, hostnames)
             formatted_inventory = self._format_inventory(results, hostnames)
 
-        # If the cache has expired/doesn't exist or if refresh_inventory/flush cache is used
-        # when the user is using caching, update the cached inventory
-        if cache_needs_update or (not cache and self.get_option('cache')):
-            self.cache.set(cache_key, formatted_inventory)
+        if cache_needs_update:
+            self._cache[cache_key] = formatted_inventory

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -118,7 +118,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
         if not self.use_cache or url not in self._cache.get(self.cache_key, {}):
 
             if self.cache_key not in self._cache:
-                self._cache[self.cache_key] = {'url': ''}
+                self._cache[self.cache_key] = {url: ''}
 
             results = []
             s = self._get_session()
@@ -155,7 +155,9 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                     # get next page
                     params['page'] += 1
 
-            self._cache[self.cache_key][url] = results
+            # Set the cache if it is enabled or if the cache was refreshed
+            if self.use_cache or self.get_option('cache'):
+                self._cache[self.cache_key][url] = results
 
         return self._cache[self.cache_key][url]
 

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -344,17 +344,19 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         else:
             cache_key = None
 
-        cache_needs_update = False
-        if cache:
+        use_cache = cache and self.get_option('cache')
+        cache_needs_update = not use_cache and self.get_option('cache')  # refresh_inventory and --flush-cache should update the cache
+
+        if use_cache:
             try:
-                results = self.cache.get(cache_key)
+                results = self._cache[cache_key]
                 for project in results:
                     for zone in results[project]:
                         self._add_hosts(results[project][zone], config_data, False)
             except KeyError:
                 cache_needs_update = True
 
-        if not cache or cache_needs_update:
+        if not use_cache or cache_needs_update:
             cached_data = {}
             for project in projects:
                 cached_data[project] = {}
@@ -369,4 +371,4 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     cached_data[project][zone] = resp.get('items')
 
         if cache_needs_update:
-            self.cache.set(cache_key, cached_data)
+            self._cache.set(cache_key, cached_data)

--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -160,7 +160,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         source_data = None
         if cache:
             try:
-                source_data = self.cache.get(cache_key)
+                source_data = self._cache[cache_key]
             except KeyError:
                 pass
 
@@ -196,8 +196,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             source_data = cloud_inventory.list_hosts(
                 expand=expand_hostvars, fail_on_cloud_config=fail_on_errors)
 
-            if self.cache is not None:
-                self.cache.set(cache_key, source_data)
+            if self._cache is not None:
+                self._cache.set(cache_key, source_data)
 
         self._populate_from_source(source_data)
 

--- a/lib/ansible/plugins/inventory/virtualbox.py
+++ b/lib/ansible/plugins/inventory/virtualbox.py
@@ -226,13 +226,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self._consume_options(config_data)
 
         source_data = None
-        if cache:
-            cache = self.get_option('cache')
-
-        update_cache = False
+        cache = cache and self.get_option('cache')
+        update_cache = not cache and self.get_option('cache')
         if cache:
             try:
-                source_data = self.cache.get(cache_key)
+                source_data = self._cache[cache_key]
             except KeyError:
                 update_cache = True
 
@@ -262,4 +260,4 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         cacheable_results = self._populate_from_source(source_data, using_current_cache)
 
         if update_cache:
-            self.cache.set(cache_key, cacheable_results)
+            self._cache[cache_key] = cacheable_results

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -265,13 +265,12 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
         config_data = self._read_config_data(path)
 
         source_data = None
-        if cache:
-            cache = self.get_option('cache')
+        use_cache = cache and self.get_option('cache')
+        update_cache = not use_cache and self.get_option('cache')  # meta: refresh_inventory or --flush-cache may be used
 
-        update_cache = False
-        if cache:
+        if use_cache:
             try:
-                source_data = self.cache.get(cache_key)
+                source_data = self._cache[cache_key]
             except KeyError:
                 update_cache = True
 
@@ -283,11 +282,11 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
         if self.with_tags:
             self.rest_content = self._login_vapi()
 
-        using_current_cache = cache and not update_cache
+        using_current_cache = use_cache and not update_cache
         cacheable_results = self._populate_from_source(source_data, using_current_cache)
 
         if update_cache:
-            self.cache.set(cache_key, cacheable_results)
+            self._cache.set(cache_key, cacheable_results)
 
     def _populate_from_cache(self, source_data):
         """

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -392,6 +392,11 @@ class PluginLoader:
                 return None
 
         self._display_plugin_load(self.class_name, name, self._searched_paths, path, found_in_cache=found_in_cache, class_only=class_only)
+
+        # load plugin config data
+        if not found_in_cache:
+            self._load_config_defs(name, path)
+
         if not class_only:
             try:
                 obj = obj(*args, **kwargs)
@@ -401,10 +406,6 @@ class PluginLoader:
                     # fully implement the defined interface.
                     return None
                 raise
-
-        # load plugin config data
-        if not found_in_cache:
-            self._load_config_defs(name, path)
 
         self._update_object(obj, name, path)
         return obj

--- a/lib/ansible/utils/module_docs_fragments/inventory_cache.py
+++ b/lib/ansible/utils/module_docs_fragments/inventory_cache.py
@@ -20,27 +20,53 @@ options:
   cache_plugin:
     description:
       - Cache plugin to use for the inventory's source data.
+    default: memory
     env:
       - name: ANSIBLE_INVENTORY_CACHE_PLUGIN
+      - name: ANSIBLE_CACHE_PLUGIN
     ini:
       - section: inventory
         key: cache_plugin
-  cache_timeout:
+      - section: defaults
+        key: fact_caching
+  _timeout:
+    aliases:
+      - cache_timeout:
     description:
       - Cache duration in seconds
     default: 3600
     type: integer
     env:
       - name: ANSIBLE_INVENTORY_CACHE_TIMEOUT
+      - name: ANSIBLE_CACHE_PLUGIN_TIMEOUT
     ini:
       - section: inventory
         key: cache_timeout
-  cache_connection:
+      - section: defaults
+        key: fact_caching_timeout
+  _uri:
+    aliases:
+      - cache_connection:
     description:
       - Cache connection data or path, read cache plugin documentation for specifics.
     env:
       - name: ANSIBLE_INVENTORY_CACHE_CONNECTION
+      - name: ANSIBLE_CACHE_PLUGIN_CONNECTION
     ini:
       - section: inventory
         key: cache_connection
+      - section: defaults
+        key: fact_caching_connection
+  _prefix:
+    description:
+      - Prefix to use for cache plugin files/tables
+    default: ansible_inventory_
+    env:
+      - name: ANSIBLE_INVENTORY_CACHE_PLUGIN_PREFIX
+      - name: ANSIBLE_CACHE_PLUGIN_PREFIX
+    ini:
+      - section: inventory
+        key: cache_prefix
+      - section: default
+        key: fact_caching_prefix
 """

--- a/test/integration/targets/inventory_foreman/inspect_cache.yml
+++ b/test/integration/targets/inventory_foreman/inspect_cache.yml
@@ -1,0 +1,31 @@
+---
+- hosts: localhost
+  vars:
+    foreman_stub_host: "{{ lookup('env', 'FOREMAN_HOST') }}"
+    foreman_stub_port: "{{ lookup('env', 'FOREMAN_PORT') }}"
+    foreman_stub_api_path: /api/v2
+    cached_hosts_key: "http://{{ foreman_stub_host }}:{{ foreman_stub_port }}{{ foreman_stub_api_path }}/hosts"
+  tasks:
+    - name: verify a cache file was created
+      find:
+        path:
+          - ./foreman_cache
+      register: matching_files
+
+    - assert:
+        that:
+          - matching_files.matched == 1
+    - name: read the cached inventory
+      set_fact:
+        contents: "{{ lookup('file', matching_files.files.0.path) }}"
+    
+    - name: extract all the host names
+      set_fact:
+        cached_hosts: "{{ contents[cached_hosts_key] | json_query('[*].name') }}"
+
+    - assert:
+        that:
+          "'{{ item }}' in cached_hosts"
+      loop:
+        - "v6.example-780.com"
+        - "c4.j1.y5.example-487.com"

--- a/test/integration/targets/inventory_foreman/runme.sh
+++ b/test/integration/targets/inventory_foreman/runme.sh
@@ -9,6 +9,11 @@ export FOREMAN_HOST="${FOREMAN_HOST:-localhost}"
 export FOREMAN_PORT="${FOREMAN_PORT:-8080}"
 FOREMAN_CONFIG=test-config.foreman.yaml
 
+# Set inventory caching environment variables to populate a jsonfile cache
+export ANSIBLE_INVENTORY_CACHE=True
+export ANSIBLE_INVENTORY_CACHE_PLUGIN=jsonfile
+export ANSIBLE_INVENTORY_CACHE_CONNECTION=./foreman_cache
+
 # flag for checking whether cleanup has already fired
 _is_clean=
 
@@ -33,3 +38,7 @@ validate_certs: False
 FOREMAN_YAML
 
 ansible-playbook test_foreman_inventory.yml --connection=local "$@"
+ansible-playbook inspect_cache.yml --connection=local "$@"
+
+# remove inventory cache
+rm -r ./foreman_cache

--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -24,6 +24,7 @@ from ansible.errors import AnsibleError
 from ansible.plugins.cache import FactCache
 from ansible.plugins.cache.base import BaseCacheModule
 from ansible.plugins.cache.memory import CacheModule as MemoryCache
+from ansible.plugins.loader import cache_loader
 
 HAVE_MEMCACHED = True
 try:
@@ -114,11 +115,14 @@ class TestAbstractClass(unittest.TestCase):
 
     @unittest.skipUnless(HAVE_MEMCACHED, 'python-memcached module not installed')
     def test_memcached_cachemodule(self):
-        self.assertIsInstance(MemcachedCache(), MemcachedCache)
+        # Load plugin so config defs are instantiated
+        self.assertIsInstance(cache_loader.get('memcached'), MemcachedCache)
 
     def test_memory_cachemodule(self):
         self.assertIsInstance(MemoryCache(), MemoryCache)
 
     @unittest.skipUnless(HAVE_REDIS, 'Redis python module not installed')
     def test_redis_cachemodule(self):
-        self.assertIsInstance(RedisCache(), RedisCache)
+        # Load plugin so config defs are instantiated
+        # The _uri option is required for the redis plugin
+        self.assertIsInstance(cache_loader.get('redis', **{'_uri': '127.0.0.1:6379:1'}), RedisCache)


### PR DESCRIPTION
##### SUMMARY
This is more invasive than what I was initially doing in #40105, so I closed it to preserve history instead of force pushing to the same branch.

* Fix inventory plugins to use self._cache instead of self.cache, using foreman as standard (also fixed bugs in foreman)
* Use a CacheObject class to access inventory cache like a dictionary.
    * "Like a dictionary" because it acts like a dict but is a recursive dict object. This is needed so setting self._cache['thecachekey']['arbitrarilynestedkeys'] = 'something' also is reflected in the cache stored with the plugin (compare that with self._cache['thecachekey'] = {'arbitrarilynestedkeys': 'something'} which will always use the self._cache `__setitem__`)

FactCache should be replaced with CacheObject easily, but it unearthed some issues.
This may need to be optimized - I need to test with a massive inventory.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/cache/__init__.py`
`lib/ansible/plugins/inventory/__init__.py`
Cache plugins
Inventory plugins

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
```