### PR TITLE
ipa_config: support for group object classes configuration

### DIFF
--- a/lib/ansible/module_utils/ipa.py
+++ b/lib/ansible/module_utils/ipa.py
@@ -132,9 +132,9 @@ class IPAClient(object):
         data = dict(method=method)
 
         # TODO: We should probably handle this a little better.
-        if method in ('ping', 'config_show'):
+        if method == 'ping':
             data['params'] = [[], {}]
-        elif method == 'config_mod':
+        elif method in ('config_mod', 'config_show'):
             data['params'] = [[], item]
         else:
             data['params'] = [[name], item]

--- a/lib/ansible/modules/identity/ipa/ipa_config.py
+++ b/lib/ansible/modules/identity/ipa/ipa_config.py
@@ -25,6 +25,11 @@ options:
   ipadefaultemaildomain:
     description: Default e-mail domain for new users.
     aliases: ["emaildomain"]
+  ipagroupobjectclasses:
+    description: list of ipa group object classes
+    aliases: ["groupobjectclasses"]
+    type: list
+    version_added: "2.8"
 extends_documentation_fragment: ipa.documentation
 version_added: "2.7"
 '''
@@ -64,18 +69,28 @@ class ConfigIPAClient(IPAClient):
         super(ConfigIPAClient, self).__init__(module, host, port, protocol)
 
     def config_show(self):
-        return self._post_json(method='config_show', name=None)
+        return self._post_json(
+            method='config_show',
+            name=None,
+            item={'all': True}
+        )
 
     def config_mod(self, name, item):
         return self._post_json(method='config_mod', name=name, item=item)
 
 
-def get_config_dict(ipadefaultloginshell=None, ipadefaultemaildomain=None):
+def get_config_dict(
+    ipadefaultloginshell=None,
+    ipadefaultemaildomain=None,
+    ipagroupobjectclasses=None,
+):
     config = {}
     if ipadefaultloginshell is not None:
         config['ipadefaultloginshell'] = ipadefaultloginshell
     if ipadefaultemaildomain is not None:
         config['ipadefaultemaildomain'] = ipadefaultemaildomain
+    if ipagroupobjectclasses is not None:
+        config['ipagroupobjectclasses'] = ipagroupobjectclasses
 
     return config
 
@@ -110,6 +125,7 @@ def main():
     argument_spec.update(
         ipadefaultloginshell=dict(type='str', aliases=['loginshell']),
         ipadefaultemaildomain=dict(type='str', aliases=['emaildomain']),
+        ipagroupobjectclasses=dict(type='list', aliases=['groupobjectclasses'])
     )
 
     module = AnsibleModule(

--- a/lib/ansible/modules/identity/ipa/ipa_config.py
+++ b/lib/ansible/modules/identity/ipa/ipa_config.py
@@ -29,7 +29,7 @@ options:
     description: list of ipa group object classes
     aliases: ["groupobjectclasses"]
     type: list
-    version_added: "2.8"
+    version_added: "2.9"
 extends_documentation_fragment: ipa.documentation
 version_added: "2.7"
 '''

--- a/lib/ansible/modules/identity/ipa/ipa_config.py
+++ b/lib/ansible/modules/identity/ipa/ipa_config.py
@@ -48,6 +48,19 @@ EXAMPLES = '''
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
+
+# Ensure the group object classes are configured correctly.
+- ipa_config:
+    ipagroupobjectclasses:
+        - top
+        - groupofnames
+        - nestedgroup
+        - ipausergroup
+        - ipaobject
+        - groupOfUniqueNames
+    ipa_host: localhost
+    ipa_user: admin
+    ipa_pass: supersecret
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY
This PR provides configuration support for FreeIPA's global group object classes configuration.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ipa_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0
  config file = None
  configured module search path = [u'/Users/redact/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/redact/.pyenv/versions/2.7.15/envs/ansible/lib/python2.7/site-packages/ansible
  executable location = /Users/redact/.pyenv/versions/ansible/bin/ansible
  python version = 2.7.15 (default, May 29 2018, 20:16:38) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```

##### ADDITIONAL INFORMATION
N/A
