### PR TITLE
Use 4 nodes for sanity tests in CI.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -11,6 +11,7 @@ matrix:
     - env: T=sanity/1
     - env: T=sanity/2
     - env: T=sanity/3
+    - env: T=sanity/4
 
     - env: T=units/2.6
     - env: T=units/2.7

--- a/test/utils/shippable/sanity.sh
+++ b/test/utils/shippable/sanity.sh
@@ -17,8 +17,9 @@ fi
 
 case "${group}" in
     1) options=(--skip-test pylint --skip-test ansible-doc --skip-test docs-build) ;;
-    2) options=(--test pylint) ;;
-    3) options=(--test ansible-doc --test docs-build) ;;
+    2) options=(--test ansible-doc --test docs-build) ;;
+    3) options=(--test pylint --exclude test/units/ --exclude lib/ansible/module_utils/ --exclude lib/ansible/modules/network/) ;;
+    4) options=(--test pylint           test/units/           lib/ansible/module_utils/           lib/ansible/modules/network/) ;;
 esac
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
##### SUMMARY

Use 4 nodes for sanity tests in CI.

2nd attempt after fixing an ansible-test delegation issue which prevented --exclude from working.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

shippable.yml

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (sanity-split 258d8886ec) last updated 2018/10/15 14:06:56 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
