### PR TITLE
[stable-2.7] Use the copied and merged task for calculating task vars in the free strategy. Fixes #47024 (#47060)

### DIFF
--- a/changelogs/fragments/free-strategy-include-var-tags.yaml
+++ b/changelogs/fragments/free-strategy-include-var-tags.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- dynamic includes - Use the copied and merged task for calculating task vars in the free strategy (https://github.com/ansible/ansible/issues/47024)

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -237,7 +237,7 @@ class StrategyModule(StrategyBase):
                         continue
 
                     for new_block in new_blocks:
-                        task_vars = self._variable_manager.get_vars(play=iterator._play, task=included_file._task)
+                        task_vars = self._variable_manager.get_vars(play=iterator._play, task=new_block._parent)
                         final_block = new_block.filter_tagged_tasks(play_context, task_vars)
                         for host in hosts_left:
                             if host in included_file._hosts:


### PR DESCRIPTION
(cherry picked from commit c3d5779)


Co-authored-by: Matt Martz <matt@sivel.net>