### PR TITLE
ansible-test: run win httptester with bypass policy

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -569,7 +569,8 @@ def command_windows_integration(args):
                 manage.upload("test/runner/setup/windows-httptester.ps1", watcher_path)
 
                 # need to use -Command as we cannot pass an array of values with -File
-                script = "powershell.exe -NoProfile -Command .\\%s -Hosts %s" % (watcher_path, ", ".join(HTTPTESTER_HOSTS))
+                script = "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command .\\%s -Hosts %s" \
+                         % (watcher_path, ", ".join(HTTPTESTER_HOSTS))
                 if args.verbosity > 3:
                     script += " -Verbose"
                 manage.ssh(script, options=ssh_options, force_pty=False)


### PR DESCRIPTION
##### SUMMARY
When running on Azure hosts the execution policy stops us from running the httptester script on Windows. This makes sure we explicitly set to bypass the execution policy.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```paste below
devel
```