### PR TITLE
ansible-test: swap 2.5 to use AWS and not Azure

### DIFF
--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -70,13 +70,10 @@ class AnsibleCoreCI(object):
                 'junos',
                 'ios',
                 'tower',
+                'rhel',
             ),
             azure=(
                 'azure',
-                'rhel',
-                'windows/2012',
-                'windows/2012-R2',
-                'windows/2016',
             ),
             parallels=(
                 'osx',


### PR DESCRIPTION
##### SUMMARY
stable-2.5 was still using Azure instead of AWS for the tests, move to AWS to keep things aligned.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```paste below
2.5
```