### PR TITLE
Fix Junos Prompt Regex to Properly Match

### DIFF
--- a/lib/ansible/plugins/terminal/junos.py
+++ b/lib/ansible/plugins/terminal/junos.py
@@ -36,7 +36,7 @@ except ImportError:
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$|%"),
+        re.compile(br"[\r\n]?[\w@+\-\.:\/\[\]]+[>#%] ?$"),
     ]
 
     terminal_stderr_re = [


### PR DESCRIPTION
##### SUMMARY
The current JunOS terminal's stdout regex is incorrectly causing it to match whenever a percent sign is encountered.

~~My co-worker and I cannot figure out why the percent was in the original regex in the first place, but we're assuming there's a reason and we just don't know it.  So in the meantime, we've just removed the percent, and we're hoping someone with some insight can tell us why it was there in the first place and we'll modify the regex hopefully cover all edge cases.~~

It appears the percent sign was originally added in #22536 to handle the situation of root logging in, giving a prompt of `root@somehost%`.  However, instead the percent sign just matches on any percent sign in the output.

Fixes #46082

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
junos

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (fix_junos_terminal_regex e7513034df) last updated 2018/10/15 17:28:21 (GMT -500)
  config file = None
  configured module search path = ['/Users/redact/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/redact/dev/ansible/lib/ansible
  executable location = /Users/redact/.pyenv/versions/3.6.5/bin/ansible
  python version = 3.6.5 (default, May 29 2018, 20:18:53) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```

##### ADDITIONAL INFORMATION
Running `junos_config` with any command that will have a % in it will demonstrate this.
