### PR TITLE
junos terminal: add simple unit tests

### DIFF
--- a/lib/ansible/plugins/terminal/junos.py
+++ b/lib/ansible/plugins/terminal/junos.py
@@ -49,7 +49,7 @@ class TerminalModule(TerminalBase):
             prompt = self._get_prompt()
             if prompt.strip().endswith(b'%'):
                 display.vvv('starting cli', self._connection._play_context.remote_addr)
-                self._exec_cli_command('cli')
+                self._exec_cli_command(b'cli')
             for c in (b'set cli timestamp disable', b'set cli screen-length 0', b'set cli screen-width 1024'):
                 self._exec_cli_command(c)
         except AnsibleConnectionFailure:

--- a/test/units/plugins/terminal/test_junos.py
+++ b/test/units/plugins/terminal/test_junos.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2018, Fran Fitzpatrick <francis.x.fitzpatrick@gmail.com> fxfitz
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from mock import call, MagicMock
+import pytest
+
+from ansible.errors import AnsibleConnectionFailure
+from ansible.plugins.terminal import junos
+
+
+@pytest.fixture
+def junos_terminal():
+    mock_connection = MagicMock()
+    return junos.TerminalModule(mock_connection)
+
+
+def test_on_open_shell_sets_terminal_parameters(junos_terminal):
+    expected_calls = [
+        call(b'set cli timestamp disable'),
+        call(b'set cli screen-length 0'),
+        call(b'set cli screen-width 1024'),
+    ]
+    junos_terminal._exec_cli_command = MagicMock()
+    junos_terminal._get_prompt = MagicMock()
+
+    junos_terminal._get_prompt.return_value = b'user@localhost >'
+    junos_terminal.on_open_shell()
+    junos_terminal._exec_cli_command.assert_has_calls(expected_calls)
+
+
+def test_on_open_shell_enters_cli_if_root_prompt(junos_terminal):
+    expected_calls = [
+        call(b'cli'),
+        call(b'set cli timestamp disable'),
+        call(b'set cli screen-length 0'),
+        call(b'set cli screen-width 1024'),
+    ]
+    junos_terminal._exec_cli_command = MagicMock()
+    junos_terminal._get_prompt = MagicMock()
+
+    junos_terminal._connection.get_prompt.return_value = b'root@localhost%'
+    junos_terminal.on_open_shell()
+    junos_terminal._exec_cli_command.assert_has_calls(expected_calls)
+
+
+def test_on_open_shell_raises_problem_setting_terminal_config(junos_terminal):
+    junos_terminal._connection.exec_command.side_effect = AnsibleConnectionFailure
+    with pytest.raises(AnsibleConnectionFailure) as exc:
+        junos_terminal.on_open_shell()
+
+    assert 'unable to set terminal parameters' in str(exc)


### PR DESCRIPTION
##### SUMMARY
This PR is meant to add some initial, basic unit tests for the JunOS terminal. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
junos

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (fix_junos_terminal_regex e7513034df) last updated 2018/10/15 17:28:21 (GMT -500)
  config file = None
  configured module search path = ['/Users/redact/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/redact/dev/ansible/lib/ansible
  executable location = /Users/redact/.pyenv/versions/3.6.5/bin/ansible
  python version = 3.6.5 (default, May 29 2018, 20:18:53) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```

##### ADDITIONAL INFORMATION
N/A
