### PR TITLE
Clearer error logging in passwordstore lookup

### DIFF
--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -194,7 +194,7 @@ class LookupModule(LookupBase):
                 else:
                     return False
             else:
-                raise AnsibleError(e)
+                raise AnsibleError('exit code {0} while running {1}. Error output: {2}'.format(e.returncode, e.cmd, e.output))
         return True
 
     def get_newpass(self):
@@ -216,7 +216,7 @@ class LookupModule(LookupBase):
         try:
             check_output2(['pass', 'insert', '-f', '-m', self.passname], input=msg)
         except (subprocess.CalledProcessError) as e:
-            raise AnsibleError(e)
+            raise AnsibleError('exit code {0} while running {1}. Error output: {2}'.format(e.returncode, e.cmd, e.output))
         return newpass
 
     def generate_password(self):
@@ -228,7 +228,7 @@ class LookupModule(LookupBase):
         try:
             check_output2(['pass', 'insert', '-f', '-m', self.passname], input=msg)
         except (subprocess.CalledProcessError) as e:
-            raise AnsibleError(e)
+            raise AnsibleError('exit code {0} while running {1}. Error output: {2}'.format(e.returncode, e.cmd, e.output))
         return newpass
 
     def get_passresult(self):


### PR DESCRIPTION
##### SUMMARY
There are many reasons why password store would return exit code 1. Just search for "exit 1" in https://git.zx2c4.com/password-store/tree/src/password-store.sh. This change creates clearer error messages, so one can see what is actually wrong.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lookup passwordstore

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```ansible 2.7.0
  config file = /Users/sylviavanos/ansible.cfg
  configured module search path = [u'/Users/sylviavanos/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jul 23 2018, 21:27:06) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before:
```
fatal: [testhost-01]: FAILED! => {
    "changed": false,
    "msg": "AnsibleError: An unhandled exception occurred while templating '{{ test_pass }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while templating '{{ lookup(\"passwordstore\", \"{{ test_passwordstore_path }}/test create={{ not ansible_check_mode }}\") }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while running the lookup plugin 'passwordstore'. Error was a <class 'ansible.errors.AnsibleError'>, original message: command ['pass', 'insert', '-f', '-m', u'testpath/test']. returned non-zero exit status 1"
}
```

after:
```
fatal: [testhost-01]: FAILED! => {
    "changed": false,
    "msg": "AnsibleError: An unhandled exception occurred while templating '{{ test_pass }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while templating '{{ lookup(\"passwordstore\", \"{{ test_passwordstore_path }}/test create={{ not ansible_check_mode }}\") }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while running the lookup plugin 'passwordstore'. Error was a <class 'ansible.errors.AnsibleError'>, original message: exit code 1 while running ['pass', 'insert', '-f', '-m', u'testpath/test']. Error output: Enter contents of testpath/test and press Ctrl+D when finished:\n\ngpg: ABCDEF0123456789: There is no assurance this key belongs to the named user\ngpg: [stdin]: encryption failed: Unusable public key\nPassword encryption aborted.\n"
}
```