### PR TITLE
Add porting guide note about inline vars on import/include_tasks

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -72,7 +72,7 @@ In Ansible 2.7 a new module argument named ``public`` was added to the ``include
 There is an important difference in the way that ``include_role`` (dynamic) will expose the role's variables, as opposed to ``import_role`` (static). ``import_role`` is a pre-processor, and the ``defaults`` and ``vars`` are evaluated at playbook parsing, making the variables available to tasks and roles listed at any point in the play. ``include_role`` is a conditional task, and the ``defaults`` and ``vars`` are evaluated at execution time, making the variables available to tasks and roles listed *after* the ``include_role`` task.
 
 include_tasks/import_tasks inline variables
-```````````````````````````````````````````
+-------------------------------------------
 
 As of Ansible 2.7, `include_tasks` and `import_tasks` can no longer accept inline variables. Instead of using inline variables, tasks should supply variables under the ``vars`` keyword.
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -71,6 +71,25 @@ In Ansible 2.7 a new module argument named ``public`` was added to the ``include
 
 There is an important difference in the way that ``include_role`` (dynamic) will expose the role's variables, as opposed to ``import_role`` (static). ``import_role`` is a pre-processor, and the ``defaults`` and ``vars`` are evaluated at playbook parsing, making the variables available to tasks and roles listed at any point in the play. ``include_role`` is a conditional task, and the ``defaults`` and ``vars`` are evaluated at execution time, making the variables available to tasks and roles listed *after* the ``include_role`` task.
 
+include_tasks/import_tasks inline variables
+```````````````````````````````````````````
+
+As of Ansible 2.7, `include_tasks` and `import_tasks` can no longer accept inline variables. Instead of using inline variables, tasks should supply variables under the ``vars`` keyword.
+
+**OLD** In Ansible 2.6 (and earlier) the following was valid syntax for specifying variables:
+
+.. code-block:: yaml
+
+    - include_tasks: include_me.yml variable=value
+
+**NEW** In Ansible 2.7 the task should be changed to use the ``vars`` keyword:
+
+.. code-block:: yaml
+
+    - include_tasks: include_me.yml
+      vars:
+        variable: value
+
 vars_prompt with unknown algorithms
 -----------------------------------
 


### PR DESCRIPTION
##### SUMMARY
Add porting guide note about inline vars on import/include_tasks. Fixes #47102
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME
docs/docsite/rst/porting_guides/porting_guide_2.7.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```