### PR TITLE
Correct wording in k8s module description

### DIFF
--- a/lib/ansible/modules/clustering/k8s/k8s.py
+++ b/lib/ansible/modules/clustering/k8s/k8s.py
@@ -43,7 +43,7 @@ extends_documentation_fragment:
 options:
   merge_type:
     description:
-    - Whether to override the default patch merge approach with a specific type. By the default, the strategic
+    - Whether to override the default patch merge approach with a specific type. By default, the strategic
       merge will typically be used.
     - For example, Custom Resource Definitions typically aren't updatable by the usual strategic merge. You may
       want to use C(merge) if you see "strategic merge patch format is not supported"


### PR DESCRIPTION
##### SUMMARY
Just a simple wording fix.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
modules/clustering/k8s/k8s

##### ANSIBLE VERSION
```
ansible 2.7.0
  config file = None
  configured module search path = [u'/home/mmazur/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mmazur/.local/lib/python2.7/site-packages/ansible
  executable location = /home/mmazur/.local/bin/ansible
  python version = 2.7.15 (default, Sep 21 2018, 23:28:06) [GCC 8.2.1 20180801 (Red Hat 8.2.1-2)]
```
