### PR TITLE
Ensure that an empty literal list with loop skips the task

### DIFF
--- a/changelogs/fragments/loop-empty-literal-list.yaml
+++ b/changelogs/fragments/loop-empty-literal-list.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- loop - Do not evaluate a empty literal list ``[]`` as falsy, it should instead cause the task to skip ()

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -236,7 +236,7 @@ class TaskExecutor:
             else:
                 raise AnsibleError("Unexpected failure in finding the lookup named '%s' in the available lookup plugins" % self._task.loop_with)
 
-        elif self._task.loop:
+        elif self._task.loop is not None:
             items = templar.template(self._task.loop)
             if not isinstance(items, list):
                 raise AnsibleError(

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -252,3 +252,9 @@
   loop: "{{ fake_var }}"
   register: result
   failed_when: result is not skipped
+
+- name: Loop on literal empty list
+  debug:
+  loop: []
+  register: literal_empty_list
+  failed_when: literal_empty_list is not skipped


### PR DESCRIPTION
##### SUMMARY
Ensure that an empty literal list with loop skips the task

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_executor.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6
2.7
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```