### PR TITLE
[stable-2.7] Add porting guide note about inline vars on import/include_tasks (#47121)

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -71,6 +71,25 @@ In Ansible 2.7 a new module argument named ``public`` was added to the ``include
 
 There is an important difference in the way that ``include_role`` (dynamic) will expose the role's variables, as opposed to ``import_role`` (static). ``import_role`` is a pre-processor, and the ``defaults`` and ``vars`` are evaluated at playbook parsing, making the variables available to tasks and roles listed at any point in the play. ``include_role`` is a conditional task, and the ``defaults`` and ``vars`` are evaluated at execution time, making the variables available to tasks and roles listed *after* the ``include_role`` task.
 
+include_tasks/import_tasks inline variables
+-------------------------------------------
+
+As of Ansible 2.7, `include_tasks` and `import_tasks` can no longer accept inline variables. Instead of using inline variables, tasks should supply variables under the ``vars`` keyword.
+
+**OLD** In Ansible 2.6 (and earlier) the following was valid syntax for specifying variables:
+
+.. code-block:: yaml
+
+    - include_tasks: include_me.yml variable=value
+
+**NEW** In Ansible 2.7 the task should be changed to use the ``vars`` keyword:
+
+.. code-block:: yaml
+
+    - include_tasks: include_me.yml
+      vars:
+        variable: value
+
 vars_prompt with unknown algorithms
 -----------------------------------
 


### PR DESCRIPTION
* Add porting guide note about inline vars. Fixes #47102
(cherry picked from commit abe6477)


Co-authored-by: Matt Martz <matt@sivel.net>