### PR TITLE
elasticsearch_plugin: fix module argument to be boolean

### DIFF
--- a/changelogs/fragments/47134-elasticsearch_plugin-fix_param_type.yml
+++ b/changelogs/fragments/47134-elasticsearch_plugin-fix_param_type.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "fix elasticsearch_plugin force to be bool (https://github.com/ansible/ansible/pull/47134)"

--- a/lib/ansible/modules/database/misc/elasticsearch_plugin.py
+++ b/lib/ansible/modules/database/misc/elasticsearch_plugin.py
@@ -61,6 +61,7 @@ options:
         description:
             - "Force batch mode when installing plugins. This is only necessary if a plugin requires additional permissions and console detection fails."
         default: False
+        type: bool
         version_added: "2.7"
     plugin_bin:
         description:
@@ -256,7 +257,7 @@ def main():
             src=dict(default=None),
             url=dict(default=None),
             timeout=dict(default="1m"),
-            force=dict(default=False),
+            force=dict(type='bool', default=False),
             plugin_bin=dict(type="path"),
             plugin_dir=dict(default="/usr/share/elasticsearch/plugins/", type="path"),
             proxy_host=dict(default=None),


### PR DESCRIPTION
##### SUMMARY
Fixes wrong argument type - 'False' is True....


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modules/elasticsearch_plugin

##### ANSIBLE VERSION
Having troubles with Ansible since 2.6