### PR TITLE
Add check for timezone variable (windows customization), to check if value processed is 'int'

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -717,6 +717,22 @@ class PyVmomiDeviceHelper(object):
         mac_addr_regex = re.compile('[0-9a-f]{2}([-:])[0-9a-f]{2}(\\1[0-9a-f]{2}){4}$')
         return bool(mac_addr_regex.match(mac_addr))
 
+    def integer_value(self, input_value, name):
+        """
+        Function to return int value for given input, else return error
+        Args:
+            input_value: Input value to retrive int value from
+            name:  Name of the Input value (used to build error message)
+        Returns: (int) if integer value can be obtained, otherwise will send a error message.
+        """
+        if isinstance(input_value, int):
+            return input_value
+        elif isinstance(input_value, str) and input_value.isdigit():
+            return int(input_value)
+        else:
+            self.module.fail_json(msg='"%s" attribute should be an'
+                                  ' integer value.' % name)
+
 
 class PyVmomiCache(object):
     """ This class caches references to objects which are requested multiples times but not modified """
@@ -1515,10 +1531,9 @@ class PyVmomiHelper(PyVmomi):
 
             if 'timezone' in self.params['customization']:
                 # Check if timezone value is a int before proceeding.
-                if (self.params['customization']['timezone']).isdigit():
-                    ident.guiUnattended.timeZone = int(self.params['customization']['timezone'])
-                else:
-                    self.module.fail_json(msg="timezone attribute should be an integer value.")
+                ident.guiUnattended.timeZone = self.device_helper.integer_value(
+                    self.params['customization']['timezone'],
+                    'customization.timezone')
 
             ident.identification = vim.vm.customization.Identification()
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1517,6 +1517,8 @@ class PyVmomiHelper(PyVmomi):
                 # Check if timezone value is a int before proceeding.
                 if (self.params['customization']['timezone']).isdigit():
                     ident.guiUnattended.timeZone = int(self.params['customization']['timezone'])
+                else:
+                    self.module.fail_json(msg="timezone attribute should be an integer value.")
 
             ident.identification = vim.vm.customization.Identification()
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1514,7 +1514,9 @@ class PyVmomiHelper(PyVmomi):
                 ident.guiUnattended.autoLogonCount = self.params['customization'].get('autologoncount', 1)
 
             if 'timezone' in self.params['customization']:
-                ident.guiUnattended.timeZone = self.params['customization']['timezone']
+                # Check if timezone value is a int before proceeding.
+                if (self.params['customization']['timezone']).isdigit():
+                    ident.guiUnattended.timeZone = self.params['customization']['timezone']
 
             ident.identification = vim.vm.customization.Identification()
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1516,7 +1516,7 @@ class PyVmomiHelper(PyVmomi):
             if 'timezone' in self.params['customization']:
                 # Check if timezone value is a int before proceeding.
                 if (self.params['customization']['timezone']).isdigit():
-                    ident.guiUnattended.timeZone = self.params['customization']['timezone']
+                    ident.guiUnattended.timeZone = int(self.params['customization']['timezone'])
 
             ident.identification = vim.vm.customization.Identification()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Check to see if, Windows Customization, value of timezone consists only of digits, if yes, convert the digits to int value and then add it.

**Example:**
Previously, if a value _085_ was assigned
```- name: clone VM template (pyvmomi, deploy to cluster and provisioning network)
  vmware_guest:
    hostname: "{{ var_vcenter_host }}"
    cluster: "{{ var_vsphere_cluster }}"
    customization:
        hostname: "{{ var_vm_name }}"
        timezone: 085
    networks:
      - name: "{{ var_network_environment }}"
        ip: "{{ var_vm_ip }}"
    hardware:
      memory_mb: "{{ var_ram_in_mb }}"
      num_cpus: "{{ var_num_cpus }}"
    wait_for_ip_address: yes
    state: poweredon
```

Python Error:
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_RAb48_/ansible_module_vmware_guest.py", line 1981, in <module>
    main()
  File "/tmp/ansible_RAb48_/ansible_module_vmware_guest.py", line 1970, in main
    result = pyv.deploy_vm()
  File "/tmp/ansible_RAb48_/ansible_module_vmware_guest.py", line 1642, in deploy_vm
    self.customize_vm(vm_obj=vm_obj)
  File "/tmp/ansible_RAb48_/ansible_module_vmware_guest.py", line 1155, in customize_vm
    ident.guiUnattended.timeZone = self.params['customization']['timezone']
  File "/var/lib/awx/venv/ansible/lib/python2.7/site-packages/pyVmomi/VmomiSupport.py", line 537, in __setattr__
    CheckField(self._GetPropertyInfo(name), val)
  File "/var/lib/awx/venv/ansible/lib/python2.7/site-packages/pyVmomi/VmomiSupport.py", line 972, in CheckField
    % (info.name, info.type.__name__, valType.__name__))
TypeError: For "timeZone" expected type int, but got str
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (vmware_guest_timezone_check_integer_value 4dc8a7c) last updated 2018/10/16 17:50:45 (GMT +200)
  config file = None
  configured module search path = ['/home/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/Private/ansible/lib/ansible
  executable location = /home/user/Private/ansible/bin/ansible
```


