### PR TITLE
Fix mysql_db: ProgrammingError when using quotes #47051

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -120,6 +120,7 @@ from ansible.module_utils._text import to_native
 
 
 def db_exists(cursor, db):
+    db = db.replace("`", r"\`")
     res = cursor.execute("SHOW DATABASES LIKE %s", (db.replace("_", r"\_"),))
     return bool(res)
 


### PR DESCRIPTION
Update db_exists method to escape backticks

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Escapes backticks when determining if database exists

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #47051

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
mysql_db

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
  config file = /home/azielke/ansible/ansible.cfg
  configured module search path = [u'/home/azielke/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
