### PR TITLE
Update some cliconf plugins

### DIFF
--- a/lib/ansible/plugins/cliconf/aireos.py
+++ b/lib/ansible/plugins/cliconf/aireos.py
@@ -24,7 +24,7 @@ import json
 
 from itertools import chain
 
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils._text import to_text
 from ansible.module_utils.network.common.utils import to_list
 from ansible.plugins.cliconf import CliconfBase, enable_mode
 
@@ -69,8 +69,8 @@ class Cliconf(CliconfBase):
         for cmd in chain([b'config'], to_list(command), [b'end']):
             self.send_command(cmd)
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, output=None, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/lib/ansible/plugins/cliconf/aireos.py
+++ b/lib/ansible/plugins/cliconf/aireos.py
@@ -69,7 +69,7 @@ class Cliconf(CliconfBase):
         for cmd in chain([b'config'], to_list(command), [b'end']):
             self.send_command(cmd)
 
-    def get(self, command, prompt=None, answer=None, sendonly=False, output=None, check_all=False):
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):

--- a/lib/ansible/plugins/cliconf/aruba.py
+++ b/lib/ansible/plugins/cliconf/aruba.py
@@ -70,8 +70,8 @@ class Cliconf(CliconfBase):
         for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
             self.send_command(cmd)
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/lib/ansible/plugins/cliconf/asa.py
+++ b/lib/ansible/plugins/cliconf/asa.py
@@ -67,8 +67,8 @@ class Cliconf(CliconfBase):
         for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
             self.send_command(cmd)
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/lib/ansible/plugins/cliconf/ce.py
+++ b/lib/ansible/plugins/cliconf/ce.py
@@ -82,8 +82,8 @@ class Cliconf(CliconfBase):
             results.append(self.send_command(command, prompt, answer, False, newline))
         return results[1:-1]
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/lib/ansible/plugins/cliconf/cnos.py
+++ b/lib/ansible/plugins/cliconf/cnos.py
@@ -81,7 +81,7 @@ class Cliconf(CliconfBase):
             self.send_command(cmd)
 
     def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/lib/ansible/plugins/cliconf/dellos10.py
+++ b/lib/ansible/plugins/cliconf/dellos10.py
@@ -71,8 +71,8 @@ class Cliconf(CliconfBase):
         for cmd in chain(['configure terminal'], to_list(command), ['end']):
             self.send_command(to_bytes(cmd))
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/lib/ansible/plugins/cliconf/dellos6.py
+++ b/lib/ansible/plugins/cliconf/dellos6.py
@@ -71,8 +71,8 @@ class Cliconf(CliconfBase):
         for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
             self.send_command(cmd)
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/lib/ansible/plugins/cliconf/dellos9.py
+++ b/lib/ansible/plugins/cliconf/dellos9.py
@@ -71,8 +71,8 @@ class Cliconf(CliconfBase):
         for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
             self.send_command(cmd)
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/lib/ansible/plugins/cliconf/edgeos.py
+++ b/lib/ansible/plugins/cliconf/edgeos.py
@@ -45,8 +45,8 @@ class Cliconf(CliconfBase):
         for cmd in chain(['configure'], to_list(candidate)):
             self.send_command(cmd)
 
-    def get(self, command=None, prompt=None, answer=None, sendonly=False, output=None):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, output=None, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def commit(self, comment=None):
         if comment:

--- a/lib/ansible/plugins/cliconf/edgeos.py
+++ b/lib/ansible/plugins/cliconf/edgeos.py
@@ -45,7 +45,7 @@ class Cliconf(CliconfBase):
         for cmd in chain(['configure'], to_list(candidate)):
             self.send_command(cmd)
 
-    def get(self, command, prompt=None, answer=None, sendonly=False, output=None, check_all=False):
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
         return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def commit(self, comment=None):

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -67,8 +67,8 @@ class Cliconf(CliconfBase):
         for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
             self.send_command(cmd)
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/lib/ansible/plugins/cliconf/exos.py
+++ b/lib/ansible/plugins/cliconf/exos.py
@@ -87,8 +87,8 @@ class Cliconf(CliconfBase):
             self.send_command(to_bytes(command), to_bytes(prompt), to_bytes(answer),
                               False, newline)
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_device_operations(self):
         return {

--- a/lib/ansible/plugins/cliconf/ironware.py
+++ b/lib/ansible/plugins/cliconf/ironware.py
@@ -70,8 +70,8 @@ class Cliconf(CliconfBase):
         for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
             self.send_command(cmd)
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/lib/ansible/plugins/cliconf/nos.py
+++ b/lib/ansible/plugins/cliconf/nos.py
@@ -95,8 +95,8 @@ class Cliconf(CliconfBase):
         resp['response'] = results
         return resp
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/lib/ansible/plugins/cliconf/onyx.py
+++ b/lib/ansible/plugins/cliconf/onyx.py
@@ -59,8 +59,8 @@ class Cliconf(CliconfBase):
         for cmd in chain([b'configure terminal'], to_list(command), [b'exit']):
             self.send_command(cmd)
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/lib/ansible/plugins/cliconf/routeros.py
+++ b/lib/ansible/plugins/cliconf/routeros.py
@@ -67,8 +67,8 @@ class Cliconf(CliconfBase):
     def edit_config(self, command):
         return
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/lib/ansible/plugins/cliconf/slxos.py
+++ b/lib/ansible/plugins/cliconf/slxos.py
@@ -87,8 +87,8 @@ class Cliconf(CliconfBase):
 
             self.send_command(command, prompt, answer, False, newline)
 
-    def get(self, command, prompt=None, answer=None, sendonly=False):
-        return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_capabilities(self):
         result = {}

--- a/lib/ansible/plugins/cliconf/voss.py
+++ b/lib/ansible/plugins/cliconf/voss.py
@@ -142,13 +142,8 @@ class Cliconf(CliconfBase):
         resp['response'] = results
         return resp
 
-    def get(self, command=None, prompt=None, answer=None, sendonly=False, output=None):
-        if not command:
-            raise ValueError('must provide value of command to execute')
-        if output:
-            raise ValueError("'output' value %s is not supported for get" % output)
-
-        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly)
+    def get(self, command, prompt=None, answer=None, sendonly=False, check_all=False):
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, check_all=check_all)
 
     def get_device_info(self):
         device_info = {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Exposes network_cli functionality to more platform cliconf plugins. 

Query: Most of these options pass straight through to network_cli. Would a `**kwargs` for those options be acceptable, in order to reduce work on cliconf plugins?

Fixes #47143

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cliconf/aireos
cliconf/edgeos
many more

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```
