### PR TITLE
Update requirements for urllib3 for python 2.6.

### DIFF
--- a/test/integration/targets/uri/files/constraints.txt
+++ b/test/integration/targets/uri/files/constraints.txt
@@ -1,2 +1,0 @@
-cryptography < 2.2 ; python_version < "2.7" # cryptography 2.2+ requires python 2.7+
-pyopenssl < 18.0 ; python_version < "2.7" # pyopenssl 18.0+ requires python 2.7+

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -285,7 +285,7 @@
   pip:
     name: "{{ item }}"
     state: latest
-    extra_args: "-c {{ role_path }}/files/constraints.txt"
+    extra_args: "-c {{ role_path }}/../../../runner/requirements/constraints.txt"
   with_items:
     - urllib3
     - PyOpenSSL

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -1,5 +1,6 @@
 coverage >= 4.2, != 4.3.2 # features in 4.2+ required, avoid known bug in 4.3.2 on python 2.6
 cryptography < 2.2 ; python_version < '2.7' # cryptography 2.2 drops support for python 2.6
+urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 2.7 or later
 pywinrm >= 0.3.0 # message encryption support
 sphinx < 1.6 ; python_version < '2.7' # sphinx 1.6 and later require python 2.7 or later
 sphinx < 1.8 ; python_version >= '2.7' # sphinx 1.8 and later are currently incompatible with rstcheck 3.3


### PR DESCRIPTION
##### SUMMARY

Update requirements for urllib3 for python 2.6.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
uri integration test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (urllib3-fix 546231eecd) last updated 2018/10/16 13:32:10 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
