### PR TITLE
[stable-2.5] Update requirements for urllib3 for python 2.6.

### DIFF
--- a/test/integration/targets/uri/files/constraints.txt
+++ b/test/integration/targets/uri/files/constraints.txt
@@ -1,2 +1,0 @@
-cryptography < 2.2 ; python_version < "2.7" # cryptography 2.2+ requires python 2.7+
-pyopenssl < 18.0 ; python_version < "2.7" # pyopenssl 18.0+ requires python 2.7+

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -285,7 +285,7 @@
   pip:
     name: "{{ item }}"
     state: latest
-    extra_args: "-c {{ role_path }}/files/constraints.txt"
+    extra_args: "-c {{ role_path }}/../../../runner/requirements/constraints.txt"
   with_items:
     - urllib3
     - PyOpenSSL

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -1,5 +1,6 @@
 coverage >= 4.2, != 4.3.2 # features in 4.2+ required, avoid known bug in 4.3.2 on python 2.6
 cryptography < 2.2 ; python_version < '2.7' # cryptography 2.2 drops support for python 2.6
+urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 2.7 or later
 pywinrm >= 0.3.0 # message encryption support
 astroid == 1.5.3 ; python_version >= '3.5' # newer versions of astroid require newer versions of pylint to avoid bugs
 pylint == 1.7.4 ; python_version >= '3.5' # versions before 1.7.1 hang or fail to install on python 3.x


### PR DESCRIPTION
##### SUMMARY

Update requirements for urllib3 for python 2.6.

(cherry picked from commit d048785640a4a7677e2a123cbd92105875c1ba5a)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
uri integration test

##### ANSIBLE VERSION

2.5