### PR TITLE
Gentoo installation no longer requires a workaround.

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -194,12 +194,6 @@ To install the newest version, you may need to unmask the ansible package prior 
 
     $ echo 'app-admin/ansible' >> /etc/portage/package.accept_keywords
 
-.. note::
-
-    The current default Python slot on Gentoo is version 3.4.  Ansible needs Python-3.5 or higher so
-    you will need to `:ref:`bootstrap <managed_node_requirements>` a compatible version onto the
-    machines.
-
 Latest Releases via pkg (FreeBSD)
 +++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
##### SUMMARY
The default Python version has been 3.6 since June 2018 and was 3.5 before then. Ansible supports Python 3.5 and above. This PR removes the workaround from the installation documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Installation documentation

##### ANSIBLE VERSION
2.8

##### ADDITIONAL INFORMATION
https://wiki.gentoo.org/wiki/Project:Python/PYTHON_TARGETS
