### PR TITLE
Display output for loops on 'ok' result

### DIFF
--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -109,6 +109,14 @@ class CallbackModule(CallbackBase):
 
         self._display.display(msg)
 
+    def v2_runner_on_skipped(self, result, ignore_errors=False):
+        self._preprocess_result(result)
+        display_color = C.COLOR_SKIP
+        msg = "skipped"
+
+        task_result = self._process_result_output(result, msg)
+        self._display.display("  " + task_result, display_color)
+
     def v2_runner_on_failed(self, result, ignore_errors=False):
         self._preprocess_result(result)
         display_color = C.COLOR_ERROR
@@ -127,6 +135,9 @@ class CallbackModule(CallbackBase):
 
         task_result = self._process_result_output(result, msg)
         self._display.display("  " + task_result, display_color)
+
+    def v2_runner_item_on_skipped(self, result):
+        self.v2_runner_on_skipped(result)
 
     def v2_runner_item_on_failed(self, result):
         self.v2_runner_on_failed(result)

--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -131,6 +131,9 @@ class CallbackModule(CallbackBase):
     def v2_runner_item_on_failed(self, result):
         self.v2_runner_on_failed(result)
 
+    def v2_runner_item_on_ok(self, result):
+        self.v2_runner_on_ok(result)
+
     def v2_runner_on_unreachable(self, result):
         msg = "unreachable"
         display_color = C.COLOR_UNREACHABLE


### PR DESCRIPTION
##### SUMMARY
Fixes #47059

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
callback plugin unixy.py

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (47059_no_output_on_loops 74295328a2) last updated 2018/10/16 18:44:09 (GMT -500)
  config file = /home/ally/.ansible.cfg
  configured module search path = [u'/home/ally/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ally/code/ansible/lib/ansible
  executable location = /home/ally/code/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```

##### ADDITIONAL INFORMATION
```
# Before

command...
  localhost done
command...

# After

command...
  localhost done | stdout: foo
  localhost done | stdout: bar
  localhost done | stdout: baz
  localhost done | stdout: qux
  localhost done
command...
  localhost skipped

```
