### PR TITLE
flatpak: Support parsing a list of packages. #41996

### DIFF
--- a/lib/ansible/modules/packaging/os/flatpak.py
+++ b/lib/ansible/modules/packaging/os/flatpak.py
@@ -125,10 +125,10 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-command:
-  description: The exact flatpak command that was executed
+commands:
+  description: The exact flatpak commands that were executed
   returned: When a flatpak command has been executed
-  type: str
+  type: list
   sample: "/usr/bin/flatpak install --user -y flathub org.gnome.Calculator"
 msg:
   description: Module error message
@@ -161,22 +161,29 @@ OUTDATED_FLATPAK_VERSION_ERROR_MESSAGE = "Unknown option --columns=application"
 
 
 def install_flat(module, binary, remote, name, method):
-    """Add a new flatpak."""
+    """Add one or more new flatpaks."""
     global result
-    apps = " ".join(name)
-    use_remote = True
+    no_remote_apps = []
+    remote_apps = []
 
     for app in name:
 
         if app.startswith('http://') or app.startswith('https://'):
-            use_remote = False
+            no_remote_apps.append(app)
+        else:
+            remote_apps.append(app)
 
-    if use_remote:
-        command = "{0} install --{1} -y {2} {3}".format(binary, method, remote, apps)
-    else:
+    if remote_apps:
+        apps = " ".join(remote_apps)
+        command = "{0} install --{1} -y {2} {3}".format(binary, method,
+                                                        remote, apps)
+        _flatpak_command(module, module.check_mode, command)
+
+    if no_remote_apps:
+        apps = " ".join(no_remote_apps)
         command = "{0} install --{1} -y {2}".format(binary, method, apps)
+        _flatpak_command(module, module.check_mode, command)
 
-    _flatpak_command(module, module.check_mode, command)
     result['changed'] = True
 
 

--- a/lib/ansible/modules/packaging/os/flatpak.py
+++ b/lib/ansible/modules/packaging/os/flatpak.py
@@ -3,6 +3,7 @@
 
 # Copyright: (c) 2017 John Kwiatkoski (@JayKayy) <jkwiat40@gmail.com>
 # Copyright: (c) 2018 Alexander Bethke (@oolongbrothers) <oolongbrothers@gmx.net>
+# Copyright: (c) 2019 Luke Short (@ekultails) <ekultails@gmail.com>
 # Copyright: (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 


### PR DESCRIPTION
##### SUMMARY
Package modules since Ansible 2.7 support using a list instead of a string. This adds support to the flatpak module to install and uninstall a list of packages.

Fixes #41996

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
flatpak module

##### ANSIBLE VERSION
2.8
