### PR TITLE
ovirt_datacenter: Fix minor typos in variable naming

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_datacenter.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_datacenter.py
@@ -208,7 +208,7 @@ def main():
         auth = module.params.pop('auth')
         connection = create_connection(auth)
         data_centers_service = connection.system_service().data_centers_service()
-        clusters_module = DatacentersModule(
+        data_centers_module = DatacentersModule(
             connection=connection,
             module=module,
             service=data_centers_service,
@@ -216,9 +216,9 @@ def main():
 
         state = module.params['state']
         if state == 'present':
-            ret = clusters_module.create()
+            ret = data_centers_module.create()
         elif state == 'absent':
-            ret = clusters_module.remove(force=module.params['force'])
+            ret = data_centers_module.remove(force=module.params['force'])
 
         module.exit_json(**ret)
     except Exception as e:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
IHMO, the variable name `clusters_module` should be renamed as `data_centers_module`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ovirt_datacenter

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
devel
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
