### PR TITLE
added in method to handle new and old cisco aireos login methods

### DIFF
--- a/lib/ansible/plugins/terminal/aireos.py
+++ b/lib/ansible/plugins/terminal/aireos.py
@@ -53,4 +53,7 @@ class TerminalModule(TerminalBase):
             for cmd in commands:
                 self._exec_cli_command(cmd)
         except AnsibleConnectionFailure:
-            raise AnsibleConnectionFailure('unable to set terminal parameters')
+            try:
+                self._exec_cli_command(b'config paging disable')
+            except AnsibleConnectionFailure:
+                raise AnsibleConnectionFailure('unable to set terminal parameters')


### PR DESCRIPTION
##### SUMMARY
Cisco AireOS 8.6+ changed the ssh login method, breaking previous ansible modules.  /plugins/terminal/aireos.py updated to handle new and old ssh processes.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
/plugins/terminal/aireos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
No playbook changes necessary.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
