### PR TITLE
postgresql_user: fix test errors on newer Fedora versions (#47166)

### DIFF
--- a/changelogs/fragments/postgresql_user-not-sup-error.yaml
+++ b/changelogs/fragments/postgresql_user-not-sup-error.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_user - create pretty error message when creating a user without an encrypted password on newer PostgreSQL versions

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -406,6 +406,8 @@ def user_alter(db_connection, module, user, password, role_attr_flags, encrypted
                 return changed
             else:
                 raise psycopg2.InternalError(e)
+        except psycopg2.NotSupportedError as e:
+            module.fail_json(msg=e.pgerror, exception=traceback.format_exc())
 
     elif no_password_changes and role_attr_flags != '':
         # Grab role information from pg_roles instead of pg_authid

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -186,17 +186,8 @@
 #
 # Create and destroy user, test 'password' and 'encrypted' parameters
 #
-- include: test_password.yml
-  vars:
-    encrypted: '{{ item.user_creation_encrypted_value }}'
-    db_password1: 'secretù' # use UTF-8
-  with_items:
-    - user_creation_encrypted_value: 'yes'
-    - user_creation_encrypted_value: 'no'
-
-# BYPASSRLS role attribute was introduced in PostgreSQL 9.5, so
-# we want to test atrribute management differently depending
-# on the version.
+# unencrypted values are not supported on newer versions
+# do not run the encrypted: no tests if on 10+
 - name: Get PostgreSQL version
   become_user: "{{ pg_user }}"
   become: True
@@ -207,6 +198,23 @@
   debug:
     msg: "{{ postgres_version_resp.stdout }}"
 
+- set_fact:
+    encryption_values:
+    - 'yes'
+
+- set_fact:
+    encryption_values: '{{ encryption_values }} + ["no"]'
+  when: postgres_version_resp.stdout is version('10', '<=')
+
+- include: test_password.yml
+  vars:
+    encrypted: '{{ item }}'
+    db_password1: 'secretù' # use UTF-8
+  loop: '{{ encryption_values }}'
+
+# BYPASSRLS role attribute was introduced in PostgreSQL 9.5, so
+# we want to test atrribute management differently depending
+# on the version.
 - set_fact:
     bypassrls_supported: "{{ postgres_version_resp.stdout is version('9.5.0', '>=') }}"
 
@@ -648,7 +656,7 @@
   postgresql_user:
     name: "{{ db_user1 }}"
     state: "present"
-    encrypted: 'no'
+    encrypted: 'yes'
     password: "password"
     role_attr_flags: "CREATEDB,LOGIN,CREATEROLE"
     login_user: "{{ pg_user }}"

--- a/test/integration/targets/postgresql/tasks/test_password.yml
+++ b/test/integration/targets/postgresql/tasks/test_password.yml
@@ -158,6 +158,11 @@
         <<: *parameters
         password: "md5{{ ('prefix2' ~ db_password1 ~ db_user1) | hash('md5')}}"
         encrypted: 'no'
+      register: change_pass_unencrypted
+      failed_when:
+      - change_pass_unencrypted is failed
+      # newer version of psycopg2 no longer supported unencrypted password, we ignore the error
+      - '"UNENCRYPTED PASSWORD is no longer supported" not in change_pass_unencrypted.msg'
 
     - <<: *changed
 


### PR DESCRIPTION
(cherry picked from commit dd46f953f6c88bc159c532b17e9b5c7e34f216bc)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/47166

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_user

##### ANSIBLE VERSION
```paste below
2.7
```