### PR TITLE
filesystem: fix test to work on newer Fedora

### DIFF
--- a/test/integration/targets/filesystem/defaults/main.yml
+++ b/test/integration/targets/filesystem/defaults/main.yml
@@ -15,7 +15,7 @@ tested_filesystems:
   ext3: {fssize: 10, grow: True}
   ext2: {fssize: 10, grow: True}
   xfs: {fssize: 20, grow: False}  # grow requires a mounted filesystem
-  btrfs: {fssize: 100, grow: False}  # grow not implemented
+  btrfs: {fssize: 150, grow: False}  # grow not implemented
   vfat: {fssize: 20, grow: True}
   ocfs2: {fssize: '{{ ocfs2_fssize }}', grow: False}  # grow not implemented
   f2fs: {fssize: '{{ f2fs_fssize|default(60) }}', grow: 'f2fs_version is version("1.10.0", ">=")'}


### PR DESCRIPTION
##### SUMMARY
The min filesize for btrfs has increased on newer kernels breaking our tests on these versions. Bump the size to fit the min size requirements.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
filesystem

##### ANSIBLE VERSION
```paste below
devel
```