### PR TITLE
support for targetGroupArn with load balancer

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -198,6 +198,10 @@ service:
             returned: always
             type: complex
             contains:
+                targetGroupArn:
+                    description: the name of the Elastic Load Balancing target group
+                    returned: always
+                    type: string
                 loadBalancerName:
                     description: the name
                     returned: always

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -522,6 +522,10 @@ def main():
                 clientToken = module.params['client_token']
                 loadBalancers = module.params['load_balancers']
 
+                for loadBalancer in loadBalancers:
+                    if 'containerPort' in loadBalancer:
+                        loadBalancer['containerPort'] = int(loadBalancer['containerPort'])
+
                 if update:
                     if (existing['loadBalancers'] or []) != loadBalancers:
                         module.fail_json(msg="It is not possible to update the load balancers of an existing service")
@@ -533,9 +537,6 @@ def main():
                                                           deploymentConfiguration,
                                                           network_configuration)
                 else:
-                    for loadBalancer in loadBalancers:
-                        if 'containerPort' in loadBalancer:
-                            loadBalancer['containerPort'] = int(loadBalancer['containerPort'])
                     # doesn't exist. create it.
                     try:
                         response = service_mgr.create_service(module.params['name'],


### PR DESCRIPTION
##### SUMMARY
Adding support for target group with load balancer, via ECS Service.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ecs_service

##### ANSIBLE VERSION
```
ansible 2.7.0
  python version = 2.7.10 (default, Oct  6 2017, 22:29:07) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```

##### ADDITIONAL INFORMATION
ECS Service can specify either loadBalancerName or targetGroupArn.
targetGroupArn can now be specified in this PR.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.create_service