### PR TITLE
Providing fix for #47083 in pamd.py

### DIFF
--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -509,6 +509,27 @@ class PamdService(object):
 
         changes = 0
         for current_rule in rules_to_find:
+            if new_type:
+                if(current_rule.rule_type != new_type):
+                    changes = 1
+                    current_rule.rule_type = new_type
+            if new_control:
+                if(current_rule.rule_control != new_control):
+                    changes = 1
+                    current_rule.rule_control = new_control
+            if new_path:
+                if(current_rule.rule_path != new_path):
+                    changes = 1
+                    current_rule.rule_path = new_path
+            if new_args:
+                for i, new_arg in enumerate(new_args):
+                    new_args[i] = new_arg.replace(" = ", "=")
+                if(current_rule.rule_args != new_args):
+                    changes = 1
+                    current_rule.rule_args = new_args
+
+        return changes
+        for current_rule in rules_to_find:
             rule_changed = False
             if new_type:
                 if(current_rule.rule_type is not new_type):

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -662,25 +662,24 @@ class PamdService(object):
             rule_args_k = set(rule_args_d.keys())
 
             # if there is nothing in common and neither set is empty
-            if ((no_eq_new_args.isdisjoint(no_eq_rule_args))
-            and (len(no_eq_new_args) is not 0)
-            and (len(no_eq_rule_args) is not 0)):
-                rule_changed = True
-                for new_arg in no_eq_new_args:
-                    no_eq_rule_args.add(new_arg)
+            if no_eq_new_args.isdisjoint(no_eq_rule_args):
+                if((len(no_eq_new_args) != 0) and (len(no_eq_rule_args) != 0)):
+                    rule_changed = True
+                    for new_arg in no_eq_new_args:
+                        no_eq_rule_args.add(new_arg)
             # else there's an intersection and possibly new args
             else:
                 real_new_no_eq_args = no_eq_new_args.difference(no_eq_rule_args)
                 for new_arg in real_new_no_eq_args:
                     no_eq_rule_args.add(new_arg)
 
-            # if there are only new args that are not the same as any current rule args and neither set is empty
-            if((new_args_k.isdisjoint(rule_args_k))
-            and (len(new_args_k) is not 0)
-            and (len(rule_args_k) is not 0)):
-                rule_changed = True
-                for key in new_args_k:
-                    rule_args_d[key] = new_args_d[key]
+            # if there are only new args that are not the same as
+            # any current rule args and neither set is empty
+            if new_args_k.isdisjoint(rule_args_k):
+                if((len(new_args_k) != 0) and (len(rule_args_k) != 0)):
+                    rule_changed = True
+                    for key in new_args_k:
+                        rule_args_d[key] = new_args_d[key]
             # else there's an intersection and possibly new args
             else:
                 # what args are in both new_args_d and rule_args_d

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -507,20 +507,32 @@ class PamdService(object):
         # Get a list of rules we want to change
         rules_to_find = self.get(rule_type, rule_control, rule_path)
 
+        changes = 0
         for current_rule in rules_to_find:
+            rule_changed = False
             if new_type:
-                current_rule.rule_type = new_type
+                if(current_rule.rule_type is not new_type):
+                    rule_changed = True
+                    current_rule.rule_type = new_type
             if new_control:
-                current_rule.rule_control = new_control
+                if(current_rule.rule_control is not new_control):
+                    rule_changed = True
+                    current_rule.rule_control = new_control
             if new_path:
-                current_rule.rule_path = new_path
+                if(current_rule.rule_path is not new_path):
+                    rule_changed = True
+                    current_rule.rule_path = new_path
             if new_args:
-                if isinstance(new_args, str):
-                    new_args = new_args.replace(" = ", "=")
-                    new_args = new_args.split(' ')
-                current_rule.rule_args = new_args
+                    if isinstance(new_args, str):
+                        new_args = new_args.replace(" = ", "=")
+                        new_args = new_args.split(' ')
+                    if(current_rule.rule_args is not new_args):
+                        rule_changed = True
+                        current_rule.rule_args = new_args
+            if rule_changed:
+                changes += 1
 
-        return len(rules_to_find)
+        return changes
 
     def insert_before(self, rule_type, rule_control, rule_path,
                       new_type=None, new_control=None, new_path=None, new_args=None):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For #47083 
pamd.update_rule() returned the number of rules matching the passed parameters, regardless of those rules changing or not.  This caused the report to be erroneous indicating there were [number_of_rules] changes, even if there was indeed no change to any of the matching rules.  To fix this, I simply checked if any parameters of a rule needed to be changed, if they were passed in, flipped a boolean if this was the case, then incremented a counter of changes after evaluating that rule if the boolean indicated a change.

For #47197
pamd.add_module_arguments() was checking entire strings in a list of 'param=value' strings and adding the argument if there was no match, creating duplicates of arguments which only had new values, instead of just changing the value. To solve this I created dictionaries of new arguments and current ones, added the arguments that didn't exist, and updated the values of the ones that did.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #47083
Fixes #47197

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pamd.py

@shepdelacreme can you test this please?

