### PR TITLE
add old usages to network cluster

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_network.py
@@ -215,9 +215,9 @@ class ClusterNetworksModule(BaseModule):
         self._network_id = network_id
         self._cluster_network = cluster_network
         self._old_usages = []
-        self._cluster_network_service = get_entity(self._service.network_service(network_id))
-        if self._cluster_network_service is not None:
-            self._old_usages = self._cluster_network_service.usages
+        self._cluster_network_entity = get_entity(self._service.network_service(network_id))
+        if self._cluster_network_entity is not None:
+            self._old_usages = self._cluster_network_entity.usages
 
     def build_entity(self):
         return otypes.Network(

--- a/lib/ansible/modules/cloud/ovirt/ovirt_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_network.py
@@ -213,6 +213,7 @@ class ClusterNetworksModule(BaseModule):
         super(ClusterNetworksModule, self).__init__(*args, **kwargs)
         self._network_id = network_id
         self._cluster_network = cluster_network
+        self._old_usages = self._service.network_service(network_id).get().usages
 
     def build_entity(self):
         return otypes.Network(
@@ -220,11 +221,12 @@ class ClusterNetworksModule(BaseModule):
             name=self._module.params['name'],
             required=self._cluster_network.get('required'),
             display=self._cluster_network.get('display'),
-            usages=[
+            usages=list(set([
                 otypes.NetworkUsage(usage)
                 for usage in ['display', 'gluster', 'migration']
                 if self._cluster_network.get(usage, False)
-            ] if (
+            ] + self._old_usages))
+            if (
                 self._cluster_network.get('display') is not None or
                 self._cluster_network.get('gluster') is not None or
                 self._cluster_network.get('migration') is not None

--- a/lib/ansible/modules/cloud/ovirt/ovirt_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_network.py
@@ -146,6 +146,7 @@ from ansible.module_utils.ovirt import (
     search_by_name,
     get_id_by_name,
     get_dict_of_struct,
+    get_entity
 )
 
 
@@ -213,7 +214,10 @@ class ClusterNetworksModule(BaseModule):
         super(ClusterNetworksModule, self).__init__(*args, **kwargs)
         self._network_id = network_id
         self._cluster_network = cluster_network
-        self._old_usages = self._service.network_service(network_id).get().usages
+        self._old_usages = []
+        self._cluster_network_service = get_entity(self._service.network_service(network_id))
+        if self._cluster_network_service is not None:
+            self._old_usages = self._cluster_network_service.usages
 
     def build_entity(self):
         return otypes.Network(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
add old usages to network cluster
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #35286

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mnecas/Desktop/Projects/Redhat/ansible/lib/ansible/modules/cloud/ovirt']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, Sep 21 2018, 23:26:48) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
                                                                                                                  
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
