### PR TITLE
Fix nxos_ospf_vrf module auto-cost idempotency and module check mode

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
@@ -377,7 +377,7 @@ def main():
 
     warnings = list()
     check_args(module, warnings)
-    result = dict(changed=False, warnings=warnings)
+    result = dict(changed=False, commands=[], warnings=warnings)
 
     state = module.params['state']
     args = PARAM_TO_COMMAND_KEYMAP.keys()
@@ -405,15 +405,12 @@ def main():
     if state == 'absent' and existing:
         state_absent(module, existing, proposed, candidate)
 
-    if not module.check_mode and candidate:
-        candidate = candidate.items_text()
-        load_config(module, candidate)
-        result['changed'] = True
-        result['commands'] = candidate
-
-    else:
+    if candidate:
         candidate = candidate.items_text()
         result['commands'] = candidate
+        if not module.check_mode:
+            load_config(module, candidate)
+            result['changed'] = True
     module.exit_json(**result)
 
 

--- a/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
@@ -204,7 +204,7 @@ def get_existing(module, args):
             elif 'auto' in line:
                 cost = re.search(r'auto-cost reference-bandwidth (\d+) (\S+)', line).group(1)
                 if 'Gbps' in line:
-                    cost *= 1000
+                    cost = int(cost) * 1000
                 existing['auto_cost'] = str(cost)
             elif 'timers throttle lsa' in line:
                 tmp = re.search(r'timers throttle lsa (\S+) (\S+) (\S+)', line)
@@ -405,14 +405,15 @@ def main():
     if state == 'absent' and existing:
         state_absent(module, existing, proposed, candidate)
 
-    if candidate:
+    if not module.check_mode and candidate:
         candidate = candidate.items_text()
         load_config(module, candidate)
         result['changed'] = True
         result['commands'] = candidate
 
     else:
-        result['commands'] = []
+        candidate = candidate.items_text()
+        result['commands'] = candidate
     module.exit_json(**result)
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixing auto-cost not being idempotent and module check mode for nxos_ospf_vrf module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #43081

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_ospf_vrf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel 5cd1ba3477) last updated 2018/10/06 21:45:11 (GMT +000)
  config file = None
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This PR fixes #43081
Tested on 93180YC-EX running NXOS: version 7.0(3)I6(1)

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
