### PR TITLE
ecs_service - fix containerPort type before comparison

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -516,7 +516,12 @@ def main():
 
                 role = module.params['role']
                 clientToken = module.params['client_token']
-                loadBalancers = module.params['load_balancers']
+
+                loadBalancers = []
+                for loadBalancer in module.params['load_balancers']:
+                    if 'containerPort' in loadBalancer:
+                        loadBalancer['containerPort'] = int(loadBalancer['containerPort'])
+                    loadBalancers.append(loadBalancer)
 
                 if update:
                     if (existing['loadBalancers'] or []) != loadBalancers:
@@ -529,10 +534,6 @@ def main():
                                                           deploymentConfiguration,
                                                           network_configuration)
                 else:
-                    for loadBalancer in loadBalancers:
-                        if 'containerPort' in loadBalancer:
-                            loadBalancer['containerPort'] = int(loadBalancer['containerPort'])
-                    # doesn't exist. create it.
                     try:
                         response = service_mgr.create_service(module.params['name'],
                                                               module.params['cluster'],


### PR DESCRIPTION
##### SUMMARY

The configuration of `containerPort` of the `load_balancers` parameter in the `ecs_service` module can be defined as integer or as an integer in a string, for example when interpolating integer variables via jinja2. In the second case the value from ansible and the one coming from aws does not match because of their type. When a `ecs_service` needs to be updated it fails due to wrongly detecting differences there.

This PR fixes that by converting the values coming from ansible into integers before comparing them with the values provided by aws.
 
Fixes #39215

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ecs_service

##### ANSIBLE VERSION
```
devel
```

##### ADDITIONAL INFORMATION
Changing from:
```
containerPort: 3000
```
To:
```
containerPort: "3000"
```
Resulted in:
```paste below
fatal: [localhost]: FAILED! => {"changed": false, "msg": "It is not possible to update the load balancers of an existing service"}
```

Now:
```
ok: [localhost]
```
