### PR TITLE
Adds option for passing files to instance

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -737,6 +737,7 @@ def main():
     boot_volume = module.params['boot_volume']
     flavor = module.params['flavor']
     flavor_ram = module.params['flavor_ram']
+    files = module.params['files']
 
     if state == 'present':
         if not (image or boot_volume):

--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -108,6 +108,13 @@ options:
         - Whether to boot the server with config drive enabled
      type: bool
      default: 'no'
+   files:
+     description:
+        - Files to insert into the instance.
+          Equivalent of files= option in nova boot for personality
+     required: false
+     default: null
+     version_added: "2.8"
    userdata:
      description:
         - Opaque blob of data which is made available to the instance
@@ -391,6 +398,20 @@ EXAMPLES = '''
         name: abcdef01-2345-6789-0abc-def0123456789
         state: absent
 
+# Creates a new instance and passes a file via config-drive option
+- name: launch a virtual-router instance
+  hosts: localhost
+  task:
+    - name: launch instance
+      os_server:
+        name: csr1kv
+        image: csr1kv
+        flavor: csr1000v.small
+        nics:
+          - net-id: 34605f38-e52a-25d2-b6ec-754a13ffb723
+        config_drive: true
+        files: iosxe_config.txt="{{ lookup('template', 'files/day0.j2') }}
+        state: present
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -505,6 +526,7 @@ def _create_server(module, cloud):
         security_groups=module.params['security_groups'],
         userdata=module.params['userdata'],
         config_drive=module.params['config_drive'],
+        files=module.params['files'],
     )
     for optional_param in (
             'key_name', 'availability_zone', 'network',
@@ -680,6 +702,7 @@ def main():
         meta=dict(default=None, type='raw'),
         userdata=dict(default=None, aliases=['user_data']),
         config_drive=dict(default=False, type='bool'),
+        files=dict(default=[], type='dict'),
         auto_ip=dict(default=True, type='bool', aliases=['auto_floating_ip', 'public_ip']),
         floating_ips=dict(default=None, type='list'),
         floating_ip_pools=dict(default=None, type='list'),


### PR DESCRIPTION
##### SUMMARY
Fixes #22244 by adding files options to os_server.py module to allow files to be passed to instance when config-drive option is present.

Supersedes #22449
Supersedes #23201 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
os_server.py

##### ANSIBLE VERSION
```
ansible 2.6.4
  config file = None
  configured module search path = [u'/Users/lurueda/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
```

##### ADDITIONAL INFORMATION

