### PR TITLE
Backport: junos terminal regex prompt fix to v2.6

### DIFF
--- a/changelogs/fragments/47096-junos-terminal-regex-fix.yml
+++ b/changelogs/fragments/47096-junos-terminal-regex-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - junos - fix terminal prompt regex (https://github.com/ansible/ansible/pull/47096)

--- a/lib/ansible/plugins/terminal/junos.py
+++ b/lib/ansible/plugins/terminal/junos.py
@@ -36,7 +36,7 @@ except ImportError:
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$|%"),
+        re.compile(br"[\r\n]?[\w@+\-\.:\/\[\]]+[>#%] ?$"),
     ]
 
     terminal_stderr_re = [


### PR DESCRIPTION
##### SUMMARY
Backporting #47096 into v2.6.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
junos

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.6.5.post0 (backport/2.6/47096 85b161065e) last updated 2018/10/17 10:12:01 (GMT -500)
  config file = None
  configured module search path = [u'/Users/fxfitz/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/fxfitz/dev/ansible/lib/ansible
  executable location = /Users/fxfitz/.pyenv/versions/ansible/bin/ansible
  python version = 2.7.15 (default, May 29 2018, 20:16:38) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```

##### ADDITIONAL INFORMATION
N/A
