### PR TITLE
Remove deprecated os_server_actions alias

### DIFF
--- a/lib/ansible/modules/cloud/openstack/_os_server_actions.py
+++ b/lib/ansible/modules/cloud/openstack/_os_server_actions.py
@@ -1,1 +1,19 @@
-os_server_action.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['removed'],
+                    'supported_by': 'community'}
+
+
+from ansible.module_utils.common.removed import removed_module
+
+
+if __name__ == '__main__':
+    removed_module(removed_in='2.8')

--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -130,9 +130,6 @@ def main():
                            required_if=[('action', 'rebuild', ['image'])],
                            **module_kwargs)
 
-    if module._name == 'os_server_actions':
-        module.deprecate("The 'os_server_actions' module is being renamed 'os_server_action'", version=2.8)
-
     action = module.params['action']
     wait = module.params['wait']
     timeout = module.params['timeout']

--- a/test/sanity/ansible-doc/skip.txt
+++ b/test/sanity/ansible-doc/skip.txt
@@ -18,3 +18,4 @@ cs_nic
 ec2_remote_facts
 netscaler
 win_msi
+os_server_actions


### PR DESCRIPTION
##### SUMMARY
Remove deprecated os_server_actions alias. Fixes #44991

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/openstack/_os_server_actions.py
lib/ansible/modules/cloud/openstack/os_server_action.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```