### PR TITLE
Fix versions in module.deprecate call to align with module deprecation

### DIFF
--- a/lib/ansible/modules/network/panos/_panos_nat_policy.py
+++ b/lib/ansible/modules/network/panos/_panos_nat_policy.py
@@ -272,7 +272,7 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
 
     if module._name == 'panos_nat_policy':
-        module.deprecate("The 'panos_nat_policy' module is being renamed 'panos_nat_rule'", version=2.8)
+        module.deprecate("The 'panos_nat_policy' module is being renamed 'panos_nat_rule'", version=2.9)
 
     if not HAS_LIB:
         module.fail_json(msg='pan-python is required for this module')

--- a/lib/ansible/modules/network/panos/_panos_security_policy.py
+++ b/lib/ansible/modules/network/panos/_panos_security_policy.py
@@ -414,7 +414,7 @@ def main():
                            required_one_of=[['api_key', 'password']])
 
     if module._name == 'panos_security_policy':
-        module.deprecate("The 'panos_security_policy' module is being renamed 'panos_security_rule'", version=2.8)
+        module.deprecate("The 'panos_security_policy' module is being renamed 'panos_security_rule'", version=2.9)
 
     if not HAS_LIB:
         module.fail_json(msg='Missing required pan-python and pandevice modules.')


### PR DESCRIPTION
##### SUMMARY
Fix versions in module.deprecate call to align with module deprecation. Fixes #45035 #45034

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/panos/_panos_nat_policy.py
lib/ansible/modules/network/panos/_panos_security_policy.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```