### PR TITLE
Fix an issue retrieving some types of 1Password items.

### DIFF
--- a/changelogs/fragments/47213-onepassword_facts_fix_password_lookup.yaml
+++ b/changelogs/fragments/47213-onepassword_facts_fix_password_lookup.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - onepassword_facts - Fix an issue looking up some 1Password items which have a 'password' attribute alongside the 'fields' attribute, not inside it.

--- a/lib/ansible/modules/identity/onepassword_facts.py
+++ b/lib/ansible/modules/identity/onepassword_facts.py
@@ -192,20 +192,28 @@ class OnePasswordFacts(object):
 
         else:
             # This is not a document, let's try to find the requested field
-            if section_title is None:
-                for field_data in data['details'].get('fields', []):
-                    if field_data.get('name').lower() == field_name.lower():
-                        return {field_name: field_data.get('value', '')}
 
-            # Not found it yet, so now lets see if there are any sections defined
-            # and search through those for the field. If a section was given, we skip
-            # any non-matching sections, otherwise we search them all until we find the field.
-            for section_data in data['details'].get('sections', []):
-                if section_title is not None and section_title.lower() != section_data['title'].lower():
-                    continue
-                for field_data in section_data.get('fields', []):
-                    if field_data.get('t').lower() == field_name.lower():
-                        return {field_name: field_data.get('v', '')}
+            # Some types of 1Password items have a 'password' field directly alongside the 'fields' attribute,
+            # not inside it, so we need to check there first.
+            if (field_name in data['details']):
+                return {field_name: data['details'][field_name]}
+
+            # Otherwise we continue looking inside the 'fields' attribute for the specified field.
+            else:
+                if section_title is None:
+                    for field_data in data['details'].get('fields', []):
+                        if field_data.get('name').lower() == field_name.lower():
+                            return {field_name: field_data.get('value', '')}
+
+                # Not found it yet, so now lets see if there are any sections defined
+                # and search through those for the field. If a section was given, we skip
+                # any non-matching sections, otherwise we search them all until we find the field.
+                for section_data in data['details'].get('sections', []):
+                    if section_title is not None and section_title.lower() != section_data['title'].lower():
+                        continue
+                    for field_data in section_data.get('fields', []):
+                        if field_data.get('t').lower() == field_name.lower():
+                            return {field_name: field_data.get('v', '')}
 
         # We will get here if the field could not be found in any section and the item wasn't a document to be downloaded.
         optional_section_title = '' if section_title is None else " in the section '%s'" % section_title


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Some types of 1Password items have a `password` field alongside the `fields` attribute, not inside it, so we need to check there as well.

This slightly modifies the `_parse_field()` method to look for the requested field (or `password` by default) alongside the `fields` attribute, before continuing with the regular search logic.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
onepassword_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
  config file = None
  configured module search path = [u'/Users/ryan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/ryan/code/rylon-ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.15 (default, Sep 24 2018, 12:35:10) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.10.44.2)]
```
