### PR TITLE
reboot: Add timeout in error to help troubleshooting

### DIFF
--- a/changelogs/fragments/reboot-show-timeout.yaml
+++ b/changelogs/fragments/reboot-show-timeout.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- reboot - Expose timeout value in error message

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -204,7 +204,7 @@ class ActionModule(ActionBase):
                 fail_count += 1
                 time.sleep(fail_sleep)
 
-        raise TimedOutException('Timed out waiting for %s' % (action_desc))
+        raise TimedOutException('Timed out waiting for %s (timeout=%s)' % (action_desc, reboot_timeout))
 
     def perform_reboot(self):
         display.debug("%s: rebooting server" % self._task.action)


### PR DESCRIPTION
##### SUMMARY
So we've been hit by **'Timed out waiting for boot_time check'** and it was
unclear what timeout was used for the boot_time check. By adding the
timeout value it is easier to understand the used value, and verify if a
change to the timeout is reflected in the output.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
reboot, win_reboot

##### ANSIBLE VERSION
v2.8