### PR TITLE
Ecs service module health check settings

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -403,7 +403,7 @@ class EcsServiceManager:
             role=role,
             deploymentConfiguration=deployment_configuration,
             placementConstraints=placement_constraints,
-            placementStrategy=placement_strategy,
+            placementStrategy=placement_strategy
         )
         if network_configuration:
             params['networkConfiguration'] = network_configuration
@@ -421,7 +421,7 @@ class EcsServiceManager:
             service=service_name,
             taskDefinition=task_definition,
             desiredCount=desired_count,
-            deploymentConfiguration=deployment_configuration,
+            deploymentConfiguration=deployment_configuration
         )
         if network_configuration:
             params['networkConfiguration'] = network_configuration

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -312,7 +312,6 @@ DEPLOYMENT_CONFIGURATION_TYPE_MAP = {
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import ec2_argument_spec
 from ansible.module_utils.ec2 import snake_dict_to_camel_dict, map_complex_type, get_ec2_security_group_ids_from_names
-from distutils.version import LooseVersion
 
 try:
     import botocore
@@ -453,12 +452,13 @@ class EcsServiceManager:
         # There doesn't seem to be a nice way to inspect botocore to look
         # for attributes (and networkConfiguration is not an explicit argument
         # to e.g. ecs.run_task, it's just passed as a keyword argument)
-        return LooseVersion(botocore.__version__) >= LooseVersion('1.7.44')
+        return self.module.botocore_at_least('1.7.44')
 
     def health_check_setable(self, params):
         load_balancers = params.get('loadBalancers', [])
         # check if botocore (and thus boto3) is new enough for using the healthCheckGracePeriodSeconds parameter
-        return len(load_balancers) > 0  and LooseVersion(botocore.__version__) >= LooseVersion('1.9.0')
+        return len(load_balancers) > 0 and self.module.botocore_at_least('1.9.0')
+
 
 def main():
     argument_spec = ec2_argument_spec()

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -121,7 +121,6 @@ options:
         required: false
         version_added: 2.7
         choices: ["EC2", "FARGATE"]
-
     health_check_grace_period_seconds:
         description:
           - Seconds to wait before health checking the freshly added/updated services. This option requires botocore >= 1.9.0.

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -406,7 +406,7 @@ class EcsServiceManager:
             params['networkConfiguration'] = network_configuration
         if launch_type:
             params['launchType'] = launch_type
-        if self.health_check_setable(params):
+        if self.health_check_setable(params) and health_check_grace_period_seconds is not None:
             params['healthCheckGracePeriodSeconds'] = health_check_grace_period_seconds
         response = self.ecs.create_service(**params)
         return self.jsonize(response['service'])

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -125,7 +125,6 @@ options:
         description:
           - Seconds to wait before health checking the freshly added/updated services. This option requires botocore >= 1.9.0.
         required: false
-        default: 30
         version_added: 2.8
 extends_documentation_fragment:
     - aws
@@ -482,7 +481,7 @@ def main():
             assign_public_ip=dict(type='bool'),
         )),
         launch_type=dict(required=False, choices=['EC2', 'FARGATE']),
-        health_check_grace_period_seconds=dict(required=False, type='int', default=30)
+        health_check_grace_period_seconds=dict(required=False, type='int')
     ))
 
     module = AnsibleAWSModule(argument_spec=argument_spec,

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -123,7 +123,7 @@ options:
         choices: ["EC2", "FARGATE"]
     health_check_grace_period_seconds:
         description:
-          - Seconds to wait before health checking the freshly added/updated services. This option requires botocore >= 1.9.0.
+          - Seconds to wait before health checking the freshly added/updated services. This option requires botocore >= 1.8.20.
         required: false
         version_added: 2.8
 extends_documentation_fragment:
@@ -456,7 +456,7 @@ class EcsServiceManager:
     def health_check_setable(self, params):
         load_balancers = params.get('loadBalancers', [])
         # check if botocore (and thus boto3) is new enough for using the healthCheckGracePeriodSeconds parameter
-        return len(load_balancers) > 0 and self.module.botocore_at_least('1.9.0')
+        return len(load_balancers) > 0 and self.module.botocore_at_least('1.8.20')
 
 
 def main():

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/defaults/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/defaults/main.yml
@@ -27,6 +27,7 @@ ecs_service_placement_strategy:
 ecs_task_container_port: 8080
 ecs_target_group_name: "{{ resource_prefix[:28] }}-tg"
 ecs_load_balancer_name: "{{ resource_prefix[:29] }}-lb"
+ecs_service_health_check_grace_period: 60
 ecs_fargate_task_containers:
 - name: "{{ ecs_task_name }}"
   image: "{{ ecs_task_image_path }}"

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
@@ -281,7 +281,7 @@
         desired_count: 1
         deployment_configuration: "{{ ecs_service_deployment_configuration }}"
         placement_strategy: "{{ ecs_service_placement_strategy }}"
-        health_check_grace_period_seconds: 60
+        health_check_grace_period_seconds: "{{ ecs_service_health_check_grace_period }}"
         load_balancers:
           - targetGroupArn: "{{ elb_target_group_instance.target_group_arn }}"
             containerName: "{{ ecs_task_name }}"

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
@@ -232,6 +232,7 @@
         desired_count: 1
         deployment_configuration: "{{ ecs_service_deployment_configuration }}"
         placement_strategy: "{{ ecs_service_placement_strategy }}"
+        health_check_grace_period_seconds: "{{ ecs_service_health_check_grace_period }}"
         load_balancers:
           - targetGroupArn: "{{ elb_target_group_instance.target_group_arn }}"
             containerName: "{{ ecs_task_name }}"
@@ -254,6 +255,7 @@
         desired_count: 1
         deployment_configuration: "{{ ecs_service_deployment_configuration }}"
         placement_strategy: "{{ ecs_service_placement_strategy }}"
+        health_check_grace_period_seconds: "{{ ecs_service_health_check_grace_period }}"
         load_balancers:
           - targetGroupArn: "{{ elb_target_group_instance.target_group_arn }}"
             containerName: "{{ ecs_task_name }}"
@@ -279,6 +281,7 @@
         desired_count: 1
         deployment_configuration: "{{ ecs_service_deployment_configuration }}"
         placement_strategy: "{{ ecs_service_placement_strategy }}"
+        health_check_grace_period_seconds: 60
         load_balancers:
           - targetGroupArn: "{{ elb_target_group_instance.target_group_arn }}"
             containerName: "{{ ecs_task_name }}"


### PR DESCRIPTION
##### SUMMARY
Added health check grace period to ecs_service module. New attempt after closing this PR way back:
https://github.com/ansible/ansible/pull/39289 and none of the other PRs got merged.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module ecs_service.py

##### ADDITIONAL INFORMATION

Added backwards compatibility this time with a check for the botocore version. Also makes sure the healthCheckGracePeriodSeconds param is only applied when loadbalancers are configured (as creation otherwise fails). Added some initial tests.
