### PR TITLE
Fix documentation

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_image_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_image_facts.py
@@ -20,7 +20,7 @@ author: "Davide Agnello (@dagnello)"
 description:
     - Retrieve facts about a image image from OpenStack.
 notes:
-    - Facts are placed in the C(openstack) variable.
+    - Facts are placed in the C(openstack_image) variable.
 requirements:
     - "python >= 2.7"
     - "openstacksdk"


### PR DESCRIPTION
The result variable is `openstack_image` and not `openstack` as incorrectly stated in the description.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
