### PR TITLE
Enable pylint rules and fix exposed bugs.

### DIFF
--- a/lib/ansible/module_utils/compat/ipaddress.py
+++ b/lib/ansible/module_utils/compat/ipaddress.py
@@ -346,10 +346,7 @@ def _find_address_range(addresses):
 
     """
     it = iter(addresses)
-    try:
-        first = last = next(it)
-    except StopIteration:
-        return
+    first = last = next(it)  # pylint: disable=stop-iteration-return
     for ip in it:
         if ip._ip != last._ip + 1:
             yield first, last

--- a/lib/ansible/module_utils/compat/ipaddress.py
+++ b/lib/ansible/module_utils/compat/ipaddress.py
@@ -346,7 +346,10 @@ def _find_address_range(addresses):
 
     """
     it = iter(addresses)
-    first = last = next(it)
+    try:
+        first = last = next(it)
+    except StopIteration:
+        return
     for ip in it:
         if ip._ip != last._ip + 1:
             yield first, last

--- a/lib/ansible/module_utils/pycompat24.py
+++ b/lib/ansible/module_utils/pycompat24.py
@@ -81,7 +81,7 @@ except ImportError:
                 if node.name in _safe_names:
                     return _safe_names[node.name]
             elif isinstance(node, ast.UnarySub):
-                return -_convert(node.expr)
+                return -_convert(node.expr)  # pylint: disable=invalid-unary-operand-type
             raise ValueError('malformed string')
         return _convert(node_or_string)
 

--- a/lib/ansible/modules/clustering/consul_kv.py
+++ b/lib/ansible/modules/clustering/consul_kv.py
@@ -233,7 +233,7 @@ def set_value(module):
     value = module.params.get('value')
 
     if value is NOT_SET:
-        raise AssertionError('Cannot set value of "%s" to `NOT_SET`', (key, ))
+        raise AssertionError('Cannot set value of "%s" to `NOT_SET`' % key)
 
     index, changed = _has_value_changed(consul_api, key, value)
 

--- a/lib/ansible/modules/network/cnos/cnos_backup.py
+++ b/lib/ansible/modules/network/cnos/cnos_backup.py
@@ -213,7 +213,7 @@ def doConfigBackUp(module, prompt, answer):
     elif(protocol == "tftp"):
         command = "copy " + configType + " " + protocol + " " + protocol
         command = command + "://" + server + "/" + confPath
-        command = command + + " vrf management\n"
+        command = command + " vrf management\n"
         # cnos.debugOutput(command)
         tftp_cmd = [{'command': command, 'prompt': None, 'answer': None}]
         cmd.extend(tftp_cmd)

--- a/lib/ansible/modules/network/cnos/cnos_image.py
+++ b/lib/ansible/modules/network/cnos/cnos_image.py
@@ -175,7 +175,7 @@ def doImageDownload(module, prompt, answer):
     elif(protocol == "tftp"):
         command = "copy " + protocol + " " + protocol + "://" + server
         command = command + "/" + imgPath + " system-image " + imgType
-        command = command + + " vrf management"
+        command = command + " vrf management"
         prompt = ['Confirm download operation',
                   'Do you want to change that to the standby image']
         answer = ['y', 'y']

--- a/lib/ansible/modules/packaging/os/apt_repository.py
+++ b/lib/ansible/modules/packaging/os/apt_repository.py
@@ -184,7 +184,6 @@ class SourcesList(object):
             for n, valid, enabled, source, comment in sources:
                 if valid:
                     yield file, n, enabled, source, comment
-        raise StopIteration
 
     def _expand_path(self, filename):
         if '/' in filename:

--- a/lib/ansible/modules/storage/netapp/netapp_e_storagepool.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_storagepool.py
@@ -145,7 +145,10 @@ class GroupBy(object):
     def _grouper(self, tgtkey):
         while self.currkey == tgtkey:
             yield self.currvalue
-            self.currvalue = next(self.it)  # Exit on StopIteration
+            try:
+                self.currvalue = next(self.it)  # Exit on StopIteration
+            except StopIteration:
+                return
             self.currkey = self.keyfunc(self.currvalue)
 
 

--- a/test/sanity/pylint/config/default
+++ b/test/sanity/pylint/config/default
@@ -46,7 +46,6 @@ disable=
     invalid-envvar-default,
     invalid-name,
     invalid-sequence-index,
-    invalid-unary-operand-type,
     keyword-arg-before-vararg,
     len-as-condition,
     line-too-long,

--- a/test/sanity/pylint/config/default
+++ b/test/sanity/pylint/config/default
@@ -78,7 +78,6 @@ disable=
     relative-import,
     signature-differs,
     simplifiable-if-statement,
-    stop-iteration-return,
     subprocess-popen-preexec-fn,
     super-init-not-called,
     superfluous-parens,

--- a/test/sanity/pylint/config/default
+++ b/test/sanity/pylint/config/default
@@ -70,7 +70,6 @@ disable=
     pointless-string-statement,
     possibly-unused-variable,
     protected-access,
-    raising-format-tuple,
     redefined-argument-from-local,
     redefined-builtin,
     redefined-outer-name,


### PR DESCRIPTION
##### SUMMARY

Enable pylint rules and fix exposed bugs:

* invalid-unary-operand-type
* raising-format-tuple
* stop-iteration-return

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

various

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (pylint-bug-fixes a2fd4f2444) last updated 2018/10/17 10:06:27 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/matt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/matt/code/mattclay/ansible/lib/ansible
  executable location = /home/matt/code/mattclay/ansible/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```
