### PR TITLE
Enable additional pylint rules and resolve issues found.

### DIFF
--- a/lib/ansible/module_utils/network/aos/aos.py
+++ b/lib/ansible/module_utils/network/aos/aos.py
@@ -69,7 +69,7 @@ def check_aos_version(module, min=False):
         import apstra.aosom
         AOS_PYEZ_VERSION = apstra.aosom.__version__
 
-        if not LooseVersion(AOS_PYEZ_VERSION) >= LooseVersion(min):
+        if LooseVersion(AOS_PYEZ_VERSION) < LooseVersion(min):
             module.fail_json(msg='aos-pyez >= %s is required for this module' % min)
 
     return True

--- a/lib/ansible/module_utils/network/junos/junos.py
+++ b/lib/ansible/module_utils/network/junos/junos.py
@@ -129,7 +129,7 @@ def load_configuration(module, candidate=None, action='merge', rollback=None, fo
         module.fail_json(msg='invalid action for format json')
     elif format in ('text', 'xml') and action not in ACTIONS:
         module.fail_json(msg='invalid action format %s' % format)
-    if action == 'set' and not format == 'text':
+    if action == 'set' and format != 'text':
         module.fail_json(msg='format must be text when action is set')
 
     conn = get_connection(module)

--- a/lib/ansible/modules/cloud/amazon/aws_kms.py
+++ b/lib/ansible/modules/cloud/amazon/aws_kms.py
@@ -209,7 +209,7 @@ def do_grant(kms, keyarn, role_arn, granttypes, mode='grant', dry_run=True, clea
     ret['new_policy'] = policy
     if dry_run:
         # true if changes > 0
-        ret['changed'] = (not len(changes_needed) == 0)
+        ret['changed'] = len(changes_needed) > 0
 
     return ret
 

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -363,7 +363,7 @@ def main():
     # The server could be in a changeing or error state.
     # Wait for one of the allowed states before doing anything.
     # If an allowed state can't be reached, this module fails.
-    if not server.info['state'] in ALLOWED_STATES:
+    if server.info['state'] not in ALLOWED_STATES:
         server.wait_for_state(ALLOWED_STATES)
     current_state = server.info['state']
 

--- a/lib/ansible/modules/cloud/misc/rhevm.py
+++ b/lib/ansible/modules/cloud/misc/rhevm.py
@@ -316,7 +316,6 @@ RHEV_UNAVAILABLE = 2
 RHEV_TYPE_OPTS = ['server', 'desktop', 'host']
 STATE_OPTS = ['ping', 'present', 'absent', 'up', 'down', 'restart', 'cd', 'info']
 
-global msg, changed, failed
 msg = []
 changed = False
 failed = False

--- a/lib/ansible/modules/cloud/pubnub/pubnub_blocks.py
+++ b/lib/ansible/modules/cloud/pubnub/pubnub_blocks.py
@@ -228,7 +228,7 @@ try:
     # Import PubNub BLOCKS client.
     from pubnub_blocks_client import User, Account, Owner, Application, Keyset
     from pubnub_blocks_client import Block, EventHandler
-    import pubnub_blocks_client.exceptions as exceptions
+    from pubnub_blocks_client import exceptions
     HAS_PUBNUB_BLOCKS_CLIENT = True
 except ImportError:
     HAS_PUBNUB_BLOCKS_CLIENT = False

--- a/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
@@ -376,7 +376,7 @@ def absent_strategy(compute_api, wished_server):
         return changed, {"status": "Server %s would be made absent." % target_server["id"]}
 
     # A server MUST be stopped to be deleted.
-    while not fetch_state(compute_api=compute_api, server=target_server) == "stopped":
+    while fetch_state(compute_api=compute_api, server=target_server) != "stopped":
         wait_to_complete_state_transition(compute_api=compute_api, server=target_server)
         response = stop_server(compute_api=compute_api, server=target_server)
 

--- a/lib/ansible/modules/database/proxysql/proxysql_scheduler.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_scheduler.py
@@ -370,7 +370,7 @@ def main():
 
     if proxysql_schedule.state == "present":
         try:
-            if not proxysql_schedule.check_schedule_config(cursor) > 0:
+            if proxysql_schedule.check_schedule_config(cursor) <= 0:
                 proxysql_schedule.create_schedule(module.check_mode,
                                                   result,
                                                   cursor)

--- a/lib/ansible/modules/network/fortimanager/fmgr_provisioning.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_provisioning.py
@@ -343,11 +343,11 @@ def main():
                                       module.params["minor_release"],
                                       module.params["patch_release"],
                                       module.params["adom"])
-        if not results[0] == 0:
+        if results[0] != 0:
             module.fail_json(msg="Create model failed", **results)
 
         results = update_flags(fmg, module.params["name"])
-        if not results[0] == 0:
+        if results[0] != 0:
             module.fail_json(msg="Update device flags failed", **results)
 
         # results = assign_dev_grp(fmg, 'Ansible', 'FGVM000000117992', 'root', 'root')
@@ -355,11 +355,11 @@ def main():
         #     module.fail_json(msg="Setting device group failed", **results)
 
         results = update_install_target(fmg, module.params["name"], module.params["policy_package"])
-        if not results[0] == 0:
+        if results[0] != 0:
             module.fail_json(msg="Adding device target to package failed", **results)
 
         results = install_pp(fmg, module.params["name"], module.params["policy_package"])
-        if not results[0] == 0:
+        if results[0] != 0:
             module.fail_json(msg="Installing policy package failed", **results)
 
         fmg.logout()

--- a/lib/ansible/modules/network/fortimanager/fmgr_script.py
+++ b/lib/ansible/modules/network/fortimanager/fmgr_script.py
@@ -249,18 +249,18 @@ def main():
         # if state is present (default), then add the script
         if state == "present":
             results = set_script(fmg, script_name, script_type, script_content, script_description, script_target, adom)
-            if not results[0] == 0:
+            if results[0] != 0:
                 if isinstance(results[1], list):
                     module.fail_json(msg="Adding Script Failed", **results)
                 else:
                     module.fail_json(msg="Adding Script Failed")
         elif state == "execute":
             results = execute_script(fmg, script_name, script_scope, script_package, adom, vdom)
-            if not results[0] == 0:
+            if results[0] != 0:
                 module.fail_json(msg="Script Execution Failed", **results)
         elif state == "delete":
             results = delete_script(fmg, script_name, adom)
-            if not results[0] == 0:
+            if results[0] != 0:
                 module.fail_json(msg="Script Deletion Failed", **results)
 
         fmg.logout()

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -483,7 +483,6 @@ FACT_SUBSETS = dict(
 
 VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())
 
-global warnings
 warnings = list()
 
 

--- a/lib/ansible/modules/network/routeros/routeros_facts.py
+++ b/lib/ansible/modules/network/routeros/routeros_facts.py
@@ -363,7 +363,6 @@ FACT_SUBSETS = dict(
 
 VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())
 
-global warnings
 warnings = list()
 
 

--- a/lib/ansible/modules/source_control/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab_user.py
@@ -247,7 +247,6 @@ class GitLabUser(object):
 
 
 def main():
-    global user_id
     module = AnsibleModule(
         argument_spec=dict(
             server_url=dict(required=True),

--- a/lib/ansible/modules/storage/netapp/_na_cdot_license.py
+++ b/lib/ansible/modules/storage/netapp/_na_cdot_license.py
@@ -264,11 +264,11 @@ class NetAppCDOTLicense(object):
                     codes.add_new_child('license-code-v2', str_value)
 
         # Remove requested licenses.
-        if not len(remove_list) == 0:
+        if len(remove_list) != 0:
             self.remove_licenses(remove_list)
 
         # Add requested licenses
-        if not len(codes.get_children()) == 0:
+        if len(codes.get_children()) != 0:
             license_add.add_child_elem(codes)
             try:
                 self.server.invoke_successfully(license_add,
@@ -284,7 +284,7 @@ class NetAppCDOTLicense(object):
         self.update_licenses()
         new_license_status = self.get_licensing_status()
 
-        if not license_status == new_license_status:
+        if license_status != new_license_status:
             changed = True
 
         self.module.exit_json(changed=changed)

--- a/lib/ansible/modules/storage/netapp/netapp_e_mgmt_interface.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_mgmt_interface.py
@@ -550,7 +550,7 @@ class MgmtInterface(object):
             url_address_info = socket.getaddrinfo(iface["address"], 8443)
             update_used_matching_address = any(info in url_address_info for info in address_info)
 
-        self._logger.info("update_used_matching_address: " + str(update_used_matching_address))
+        self._logger.info("update_used_matching_address: %s", update_used_matching_address)
 
         # Populate the body of the request and check for changes
         if self.enable_interface is not None:

--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -698,7 +698,7 @@ def main():
                 changed = True
 
     # no changes to env/job, but existing crontab needs a terminating newline
-    if not changed and not crontab.existing == '':
+    if not changed and crontab.existing != '':
         if not (crontab.existing.endswith('\r') or crontab.existing.endswith('\n')):
             changed = True
 

--- a/lib/ansible/utils/hashing.py
+++ b/lib/ansible/utils/hashing.py
@@ -24,7 +24,7 @@ import os
 # Note, sha1 is the only hash algorithm compatible with python2.4 and with
 # FIPS-140 mode (as of 11-2014)
 try:
-    from hashlib import sha1 as sha1
+    from hashlib import sha1
 except ImportError:
     from sha import sha as sha1
 

--- a/test/sanity/pylint/config/default
+++ b/test/sanity/pylint/config/default
@@ -105,7 +105,6 @@ disable=
     unexpected-keyword-arg,
     ungrouped-imports,
     unidiomatic-typecheck,
-    unneeded-not,
     unsubscriptable-object,
     unsupported-assignment-operation,
     unsupported-delete-operation,

--- a/test/sanity/pylint/config/default
+++ b/test/sanity/pylint/config/default
@@ -112,7 +112,6 @@ disable=
     unused-import,
     unused-variable,
     used-before-assignment,
-    useless-import-alias,
     useless-object-inheritance,
     useless-return,
     useless-super-delegation,

--- a/test/sanity/pylint/config/default
+++ b/test/sanity/pylint/config/default
@@ -36,7 +36,6 @@ disable=
     fixme,
     function-redefined,
     global-statement,
-    global-variable-not-assigned,
     global-variable-undefined,
     import-error,
     import-self,

--- a/test/sanity/pylint/config/default
+++ b/test/sanity/pylint/config/default
@@ -11,7 +11,6 @@ disable=
     bad-continuation,
     bad-indentation,
     bad-mcs-classmethod-argument,
-    bad-whitespace,
     bare-except,
     blacklisted-name,
     broad-except,

--- a/test/sanity/pylint/config/default
+++ b/test/sanity/pylint/config/default
@@ -18,7 +18,6 @@ disable=
     cell-var-from-loop,
     chained-comparison,
     comparison-with-callable,
-    comparison-with-itself,
     consider-iterating-dictionary,
     consider-merging-isinstance,
     consider-using-dict-comprehension,

--- a/test/sanity/pylint/config/default
+++ b/test/sanity/pylint/config/default
@@ -36,7 +36,6 @@ disable=
     expression-not-assigned,
     fixme,
     function-redefined,
-    global-at-module-level,
     global-statement,
     global-variable-not-assigned,
     global-variable-undefined,

--- a/test/sanity/pylint/config/default
+++ b/test/sanity/pylint/config/default
@@ -49,7 +49,6 @@ disable=
     line-too-long,
     literal-comparison,
     locally-disabled,
-    logging-not-lazy,
     method-hidden,
     misplaced-comparison-constant,
     missing-docstring,

--- a/test/units/module_utils/gcp/test_gcp_utils.py
+++ b/test/units/module_utils/gcp/test_gcp_utils.py
@@ -29,7 +29,7 @@ class GCPRequestDifferenceTestCase(unittest.TestCase):
             'test': 'original'
         }
         request = GcpRequest(value1)
-        self.assertEquals(request == request, True)
+        self.assertEquals(request, request)
 
     def test_simple_different(self):
         value1 = {
@@ -45,7 +45,7 @@ class GCPRequestDifferenceTestCase(unittest.TestCase):
         }
         request1 = GcpRequest(value1)
         request2 = GcpRequest(value2)
-        self.assertEquals(request1 == request2, False)
+        self.assertNotEquals(request1, request2)
         self.assertEquals(request1.difference(request2), difference)
 
     def test_nested_dictionaries_no_difference(self):
@@ -59,7 +59,7 @@ class GCPRequestDifferenceTestCase(unittest.TestCase):
             'test': 'original'
         }
         request = GcpRequest(value1)
-        self.assertEquals(request == request, True)
+        self.assertEquals(request, request)
 
     def test_nested_dictionaries_with_difference(self):
         value1 = {
@@ -90,7 +90,7 @@ class GCPRequestDifferenceTestCase(unittest.TestCase):
         }
         request1 = GcpRequest(value1)
         request2 = GcpRequest(value2)
-        self.assertEquals(request1 == request2, False)
+        self.assertNotEquals(request1, request2)
         self.assertEquals(request1.difference(request2), difference)
 
     def test_arrays_strings_no_difference(self):
@@ -101,7 +101,7 @@ class GCPRequestDifferenceTestCase(unittest.TestCase):
             ]
         }
         request = GcpRequest(value1)
-        self.assertEquals(request == request, True)
+        self.assertEquals(request, request)
 
     def test_arrays_strings_with_difference(self):
         value1 = {
@@ -124,7 +124,7 @@ class GCPRequestDifferenceTestCase(unittest.TestCase):
         }
         request1 = GcpRequest(value1)
         request2 = GcpRequest(value2)
-        self.assertEquals(request1 == request2, False)
+        self.assertNotEquals(request1, request2)
         self.assertEquals(request1.difference(request2), difference)
 
     def test_arrays_dicts_with_no_difference(self):
@@ -140,7 +140,7 @@ class GCPRequestDifferenceTestCase(unittest.TestCase):
             ]
         }
         request = GcpRequest(value1)
-        self.assertEquals(request == request, True)
+        self.assertEquals(request, request)
 
     def test_arrays_dicts_with_difference(self):
         value1 = {
@@ -172,5 +172,5 @@ class GCPRequestDifferenceTestCase(unittest.TestCase):
         }
         request1 = GcpRequest(value1)
         request2 = GcpRequest(value2)
-        self.assertEquals(request1 == request2, False)
+        self.assertNotEquals(request1, request2)
         self.assertEquals(request1.difference(request2), difference)

--- a/test/units/modules/cloud/amazon/test_aws_api_gateway.py
+++ b/test/units/modules/cloud/amazon/test_aws_api_gateway.py
@@ -31,7 +31,7 @@ if not HAS_BOTO3:
     pytestmark = pytest.mark.skip("test_api_gateway.py requires the `boto3` and `botocore` modules")
 
 import ansible.modules.cloud.amazon.aws_api_gateway as agw
-import ansible.module_utils.aws.core as core
+from ansible.module_utils.aws import core
 
 
 exit_return_dict = {}

--- a/test/units/modules/cloud/amazon/test_kinesis_stream.py
+++ b/test/units/modules/cloud/amazon/test_kinesis_stream.py
@@ -4,7 +4,7 @@ import unittest
 boto3 = pytest.importorskip("boto3")
 botocore = pytest.importorskip("botocore")
 
-import ansible.modules.cloud.amazon.kinesis_stream as kinesis_stream
+from ansible.modules.cloud.amazon import kinesis_stream
 
 aws_region = 'us-west-2'
 

--- a/test/units/modules/cloud/amazon/test_lambda_policy.py
+++ b/test/units/modules/cloud/amazon/test_lambda_policy.py
@@ -31,7 +31,7 @@ if not HAS_BOTO3:
     pytestmark = pytest.mark.skip("test_api_gateway.py requires the `boto3` and `botocore` modules")
 
 # these are here cause ... boto!
-import ansible.modules.cloud.amazon.lambda_policy as lambda_policy
+from ansible.modules.cloud.amazon import lambda_policy
 from ansible.modules.cloud.amazon.lambda_policy import setup_module_object
 try:
     from botocore.exceptions import ClientError

--- a/test/units/modules/cloud/openstack/test_os_server.py
+++ b/test/units/modules/cloud/openstack/test_os_server.py
@@ -35,7 +35,7 @@ def params_from_doc(func):
     return cfg[0]['os_server']
 
 
-class FakeCloud (object):
+class FakeCloud(object):
     ports = [
         {'name': 'port1', 'id': '1234'},
         {'name': 'port2', 'id': '4321'},

--- a/test/units/modules/network/cloudvision/test_cv_server_provision.py
+++ b/test/units/modules/network/cloudvision/test_cv_server_provision.py
@@ -20,7 +20,7 @@ import sys
 sys.modules['cvprac'] = Mock()
 sys.modules['cvprac.cvp_client'] = Mock()
 sys.modules['cvprac.cvp_client_errors'] = Mock()
-import ansible.modules.network.cloudvision.cv_server_provision as cv_server_provision
+from ansible.modules.network.cloudvision import cv_server_provision
 
 
 class MockException(BaseException):

--- a/test/units/modules/network/radware/test_vdirect_commit.py
+++ b/test/units/modules/network/radware/test_vdirect_commit.py
@@ -48,7 +48,7 @@ MODULE_RESULT = {"msg": "Requested actions were successfully performed on all de
 
 
 @patch('vdirect_client.rest_client.RestClient')
-class RestClient ():
+class RestClient:
     def __init__(self, vdirect_ip=None, vdirect_user=None, vdirect_password=None, wait=None,
                  secondary_vdirect_ip=None, https_port=None, http_port=None,
                  timeout=None, https=None, strict_http_results=None,
@@ -56,7 +56,7 @@ class RestClient ():
         pass
 
 
-class DeviceMock ():
+class DeviceMock:
 
     def __init__(self, name, client):
         self.name = name

--- a/test/units/modules/network/radware/test_vdirect_file.py
+++ b/test/units/modules/network/radware/test_vdirect_file.py
@@ -35,7 +35,7 @@ NONE_PARAMS = {'vdirect_ip': None, 'vdirect_user': None, 'vdirect_password': Non
 
 
 @patch('vdirect_client.rest_client.RestClient')
-class RestClient ():
+class RestClient:
     def __init__(self, vdirect_ip=None, vdirect_user=None, vdirect_password=None, wait=None,
                  secondary_vdirect_ip=None, https_port=None, http_port=None,
                  timeout=None, https=None, strict_http_results=None,
@@ -44,7 +44,7 @@ class RestClient ():
 
 
 @patch('vdirect_client.rest_client.Template')
-class Template ():
+class Template:
     create_from_source_result = None
     upload_source_result = None
 
@@ -67,7 +67,7 @@ class Template ():
 
 
 @patch('vdirect_client.rest_client.WorkflowTemplate')
-class WorkflowTemplate ():
+class WorkflowTemplate:
     create_template_from_archive_result = None
     update_archive_result = None
 

--- a/test/units/modules/network/radware/test_vdirect_runnable.py
+++ b/test/units/modules/network/radware/test_vdirect_runnable.py
@@ -47,7 +47,7 @@ MODULE_RESULT = {"msg": "Configuration template run completed.", "parameters": {
 
 
 @patch('vdirect_client.rest_client.RestClient')
-class RestClient ():
+class RestClient:
     def __init__(self, vdirect_ip=None, vdirect_user=None, vdirect_password=None, wait=None,
                  secondary_vdirect_ip=None, https_port=None, http_port=None,
                  timeout=None, https=None, strict_http_results=None,
@@ -56,7 +56,7 @@ class RestClient ():
 
 
 @patch('vdirect_client.rest_client.Runnable')
-class Runnable ():
+class Runnable:
     available_actions_result = None
     action_info_result = None
     runnable_objects_result = None

--- a/test/units/modules/system/test_known_hosts.py
+++ b/test/units/modules/system/test_known_hosts.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-import ansible.module_utils.basic as basic
+from ansible.module_utils import basic
 
 from units.compat import unittest
 from ansible.module_utils._text import to_bytes

--- a/test/units/plugins/lookup/test_aws_ssm.py
+++ b/test/units/plugins/lookup/test_aws_ssm.py
@@ -24,7 +24,7 @@ from copy import copy
 
 from ansible.errors import AnsibleError
 
-import ansible.plugins.lookup.aws_ssm as aws_ssm
+from ansible.plugins.lookup import aws_ssm
 
 try:
     import boto3


### PR DESCRIPTION
##### SUMMARY

Enable additional pylint rules and resolve issues found:

* unneeded-not
* global-at-module-level
* useless-import-alias
* bad-whitespace
* global-variable-not-assigned
* logging-not-lazy
* comparison-with-itself

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

various

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (pylint-enable-rules 1bcc6d42dc) last updated 2018/10/17 10:12:19 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/matt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/matt/code/mattclay/ansible/lib/ansible
  executable location = /home/matt/code/mattclay/ansible/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```
