### PR TITLE
Update os_image.py

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -27,12 +27,12 @@ description:
 options:
    name:
      description:
-        - Name that has to be given to the image
+        - The name of the image when uploading - or the name/ID of the image if deleting
      required: true
    id:
      version_added: "2.4"
      description:
-        - The Id of the image
+        - The ID of the image when uploading an image
    checksum:
      version_added: "2.5"
      description:


### PR DESCRIPTION
The description of the `name` and `id` options are updated to highlight the fact that the `name` (which is required and leads to failures if several images exist with the same name) argument can also contain the image `id`.

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
