### PR TITLE
adding additional example and clarification

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -42,9 +42,10 @@ options:
     organization:
       description:
         - Organization that should own the credential.
+      required: True
     kind:
       description:
-        - Type of credential being added.
+        - Type of credential being added.  The ssh choice refers to a Tower Machine credential.
       required: True
       choices: ["ssh", "vault", "net", "scm", "aws", "vmware", "satellite6", "cloudforms", "gce", "azure_rm", "openstack", "rhv", "insights", "tower"]
     host:
@@ -118,6 +119,7 @@ EXAMPLES = '''
     name: Team Name
     description: Team Description
     organization: test-org
+    kind: ssh
     state: present
     tower_config_file: "~/tower_cli.cfg"
 
@@ -131,6 +133,18 @@ EXAMPLES = '''
     password: secret
     ssh_key_data: "{{ lookup('file', '/tmp/id_rsa') }}"
     ssh_key_unlock: "passphrase"
+
+- name: Add Credential Into Tower
+  tower_credential:
+    name: Workshop Credential
+    ssh_key_data: "/home/{{ansible_user}}/.ssh/aws-private.pem"
+    kind: ssh
+    organization: Default
+    tower_username: admin
+    tower_password: ansible
+    tower_host: https://localhost
+  run_once: true
+  delegate_to: localhost
 '''
 
 import os


### PR DESCRIPTION
##### SUMMARY
The kind: paramter is missing from the original example (which won't actually work).  The organization needs to be listed as required (if you don't list it, you will get an error).  Also adding additional example using the tower_username and tower_password method.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
tower_credential 

##### ANSIBLE VERSION
```paste below
[student1@ansible networking-workshop]$ ansible --version
ansible 2.7.0
  config file = /home/student1/.ansible.cfg
  configured module search path = [u'/home/student1/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May 31 2018, 09:41:32) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
N/A, just trying to improve documentation
