### PR TITLE
filesystem: fix test to work on newer Fedora 2.5 (#47176)

### DIFF
--- a/test/integration/targets/filesystem/defaults/main.yml
+++ b/test/integration/targets/filesystem/defaults/main.yml
@@ -4,7 +4,7 @@ tested_filesystems:
   #   grow: True if resizefs is supported
   # Other minimal sizes:
   # - XFS: 20Mo
-  # - Btrfs: 100Mo (50Mo when "--metadata single" is used)
+  # - Btrfs: 150Mo (50Mo when "--metadata single" is used and 100Mb when on newer Fedora versions)
   ext4: {fssize: 10, grow: True}
   ext4dev: {fssize: 10, grow: True}
   ext3: {fssize: 10, grow: True}

--- a/test/integration/targets/filesystem/defaults/main.yml
+++ b/test/integration/targets/filesystem/defaults/main.yml
@@ -10,6 +10,6 @@ tested_filesystems:
   ext3: {fssize: 10, grow: True}
   ext2: {fssize: 10, grow: True}
   xfs: {fssize: 20, grow: False}  # grow requires a mounted filesystem
-  btrfs: {fssize: 100, grow: False}  # grow not implemented
+  btrfs: {fssize: 150, grow: False}  # grow not implemented
   vfat: {fssize: 20, grow: True}
   # untested: lvm, requires a block device


### PR DESCRIPTION
(cherry picked from commit ae5aeb9a67c65490b6e93ddae63c6ef2aa575f24)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/47176

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
filesystem

##### ANSIBLE VERSION
```paste below
2.5
```