### PR TITLE
Remove get_exception from the remainder of the modules

### DIFF
--- a/changelogs/fragments/code-cleanup-no-get-exception.yaml
+++ b/changelogs/fragments/code-cleanup-no-get-exception.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Cleaned up module code to remove all calls to the deprecated get_exception() function

--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -108,9 +108,10 @@ remote_file:
 
 import re
 import os
+import sys
 import time
 from xml.etree import ElementTree
-from ansible.module_utils.basic import get_exception, AnsibleModule
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, run_commands, get_nc_config
 
 try:
@@ -155,7 +156,7 @@ def get_cli_exception(exc=None):
 
     msg = list()
     if not exc:
-        exc = get_exception()
+        exc = sys.exc_info[1]
     if exc:
         errs = str(exc).split("\r\n")
         for err in errs:

--- a/lib/ansible/modules/network/panos/panos_dag_tags.py
+++ b/lib/ansible/modules/network/panos/panos_dag_tags.py
@@ -100,8 +100,6 @@ RETURN = '''
 # Default return values
 '''
 
-from ansible.module_utils.basic import AnsibleModule, get_exception
-
 try:
     from pandevice import base
     from pandevice import firewall
@@ -113,6 +111,9 @@ try:
     HAS_LIB = True
 except ImportError:
     HAS_LIB = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
 
 
 def get_devicegroup(device, devicegroup):
@@ -128,10 +129,7 @@ def register_ip_to_tag_map(device, ip_addresses, tag):
     exc = None
     try:
         device.userid.register(ip_addresses, tag)
-    except PanXapiError:
-        exc = get_exception()
-
-    if exc:
+    except PanXapiError as exc:
         return False, exc
 
     return True, exc
@@ -142,10 +140,7 @@ def get_all_address_group_mapping(device):
     ret = None
     try:
         ret = device.userid.get_registered_ip()
-    except PanXapiError:
-        exc = get_exception()
-
-    if exc:
+    except PanXapiError as exc:
         return False, exc
 
     return ret, exc
@@ -155,10 +150,7 @@ def delete_address_from_mapping(device, ip_address, tags):
     exc = None
     try:
         ret = device.userid.unregister(ip_address, tags)
-    except PanXapiError:
-        exc = get_exception()
-
-    if exc:
+    except PanXapiError as exc:
         return False, exc
 
     return True, exc
@@ -224,9 +216,8 @@ def main():
     if commit:
         try:
             device.commit(sync=True)
-        except PanXapiError:
-            exc = get_exception()
-            module.fail_json(msg=exc)
+        except PanXapiError as exc:
+            module.fail_json(msg=to_native(exc))
 
     module.exit_json(changed=True, msg=result)
 

--- a/lib/ansible/modules/network/panos/panos_match_rule.py
+++ b/lib/ansible/modules/network/panos/panos_match_rule.py
@@ -181,7 +181,6 @@ RETURN = '''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.basic import get_exception
 
 try:
     from pan.xapi import PanXapiError
@@ -358,8 +357,7 @@ def main():
     # Submit the op command with the appropriate test string
     try:
         response = device.op(cmd=test_string, vsys=vsys_id)
-    except PanXapiError:
-        exc = get_exception()
+    except PanXapiError as exc:
         module.fail_json(msg=exc.message)
 
     if response.find('result/rules').__len__() == 1:

--- a/lib/ansible/modules/network/panos/panos_op.py
+++ b/lib/ansible/modules/network/panos/panos_op.py
@@ -90,7 +90,6 @@ stdout_xml:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.basic import get_exception
 
 try:
     import pan.xapi
@@ -133,9 +132,7 @@ def main():
     try:
         xml_output = device.op(cmd, xml=True)
         changed = True
-    except PanXapiError:
-        exc = get_exception()
-
+    except PanXapiError as exc:
         if 'non NULL value' in exc.message:
             # rewrap and call again
             cmd_array = cmd.split()
@@ -145,8 +142,7 @@ def main():
             try:
                 xml_output = device.op(cmd2, xml=True)
                 changed = True
-            except PanXapiError:
-                exc = get_exception()
+            except PanXapiError as exc:
                 module.fail_json(msg=exc.message)
 
     obj_dict = xmltodict.parse(xml_output)

--- a/lib/ansible/modules/system/sefcontext.py
+++ b/lib/ansible/modules/system/sefcontext.py
@@ -97,7 +97,6 @@ RETURN = r'''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils._text import to_native
 
 try:
@@ -193,8 +192,7 @@ def semanage_fcontext_modify(module, result, target, ftype, setype, do_reload, s
                 prepared_diff += '# Addition to semanage file context mappings\n'
                 prepared_diff += '+%s      %s      %s:%s:%s:%s\n' % (target, ftype, seuser, 'object_r', setype, serange)
 
-    except Exception:
-        e = get_exception()
+    except Exception as e:
         module.fail_json(msg="%s: %s\n" % (e.__class__.__name__, to_native(e)))
 
     if module._diff and prepared_diff:
@@ -225,8 +223,7 @@ def semanage_fcontext_delete(module, result, target, ftype, do_reload, sestore='
                 prepared_diff += '# Deletion to semanage file context mappings\n'
                 prepared_diff += '-%s      %s      %s:%s:%s:%s\n' % (target, ftype, exists[0], exists[1], exists[2], exists[3])
 
-    except Exception:
-        e = get_exception()
+    except Exception as e:
         module.fail_json(msg="%s: %s\n" % (e.__class__.__name__, to_native(e)))
 
     if module._diff and prepared_diff:

--- a/test/sanity/code-smell/no-get-exception.py
+++ b/test/sanity/code-smell/no-get-exception.py
@@ -9,13 +9,6 @@ def main():
     skip = set([
         'test/sanity/code-smell/%s' % os.path.basename(__file__),
         'lib/ansible/module_utils/pycompat24.py',
-        'lib/ansible/module_utils/six/__init__.py',
-        # the following files should be fixed and removed from this list
-        'lib/ansible/modules/network/cloudengine/ce_file_copy.py',
-        'lib/ansible/modules/network/panos/panos_dag_tags.py',
-        'lib/ansible/modules/network/panos/panos_match_rule.py',
-        'lib/ansible/modules/network/panos/panos_op.py',
-        'lib/ansible/modules/system/sefcontext.py',
     ])
 
     basic_allow_once = True


### PR DESCRIPTION
##### SUMMARY
We no longer need to use get_exception() and we want to deprecate it eventually.  First step is to remove all uses of it in our code.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
devel
```

##### ADDITIONAL INFORMATION
This removes the last of the get_exception() calls from modules.