### PR TITLE
get_url: Updates documentation for proper use of headers

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -180,7 +180,7 @@ EXAMPLES = r'''
   get_url:
     url: http://example.com/path/file.conf
     dest: /etc/foo.conf
-    headers: 
+    headers:
       key1: one 
       key2: two
 

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -180,7 +180,9 @@ EXAMPLES = r'''
   get_url:
     url: http://example.com/path/file.conf
     dest: /etc/foo.conf
-    headers: 'key:value,key:value'
+    headers: 
+      key1: one 
+      key2: two
 
 - name: Download file with check (sha256)
   get_url:

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -181,7 +181,7 @@ EXAMPLES = r'''
     url: http://example.com/path/file.conf
     dest: /etc/foo.conf
     headers:
-      key1: one 
+      key1: one
       key2: two
 
 - name: Download file with check (sha256)


### PR DESCRIPTION
##### SUMMARY
Went to remove the deprecation warning for headers we were receiving after the upgrade to 2.7.  The proper syntax to accomplish the task was not in the examples.  Removed outdated example and replaced with updated format.  

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
get_url

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.7.0
  config file = /cyclops-ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, Aug 22 2018, 13:28:29) [GCC 6.3.0]
```

##### ADDITIONAL INFORMATION
N/A
