### PR TITLE
Don't use the task for a cache, return a special cache var

### DIFF
--- a/changelogs/fragments/delegate_to_loop_hostvars.yaml
+++ b/changelogs/fragments/delegate_to_loop_hostvars.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- delegate_to - When templating ``delegate_to`` in a loop, don't use the task for a cache, return a special cache through ``get_vars`` allowing looping over a hostvar (https://github.com/ansible/ansible/issues/47207)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -4,6 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import copy
 import os
 import pty
 import time
@@ -210,7 +211,11 @@ class TaskExecutor:
 
         templar = Templar(loader=self._loader, shared_loader_obj=self._shared_loader_obj, variables=self._job_vars)
         items = None
-        if self._task.loop_with:
+        loop_cache = self._job_vars.get(self._host.name, {}).get('_ansible_loop_cache')
+        if loop_cache is not None:
+            items = copy.copy(loop_cache)
+            del self._job_vars[self._host.name]['_ansible_loop_cache']
+        elif self._task.loop_with:
             if self._task.loop_with in self._shared_loader_obj.lookup_loader:
                 fail = True
                 if self._task.loop_with == 'first_found':

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -211,10 +211,11 @@ class TaskExecutor:
 
         templar = Templar(loader=self._loader, shared_loader_obj=self._shared_loader_obj, variables=self._job_vars)
         items = None
-        loop_cache = self._job_vars.get(self._host.name, {}).get('_ansible_loop_cache')
+        loop_cache = self._job_vars.get('_ansible_loop_cache')
         if loop_cache is not None:
+            # _ansible_loop_cache may be set in `get_vars` when calculating `delegate_to`
+            # to avoid reprocessing the loop
             items = copy.copy(loop_cache)
-            del self._job_vars[self._host.name]['_ansible_loop_cache']
         elif self._task.loop_with:
             if self._task.loop_with in self._shared_loader_obj.lookup_loader:
                 fail = True

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -4,7 +4,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import copy
 import os
 import pty
 import time
@@ -215,7 +214,7 @@ class TaskExecutor:
         if loop_cache is not None:
             # _ansible_loop_cache may be set in `get_vars` when calculating `delegate_to`
             # to avoid reprocessing the loop
-            items = copy.copy(loop_cache)
+            items = loop_cache
         elif self._task.loop_with:
             if self._task.loop_with in self._shared_loader_obj.lookup_loader:
                 fail = True

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -430,7 +430,7 @@ class VariableManager:
         # if we have a task and we're delegating to another host, figure out the
         # variables for that host now so we don't have to rely on hostvars later
         if task and task.delegate_to is not None and include_delegate_to:
-            all_vars['ansible_delegated_vars'] = self._get_delegated_vars(play, task, host, all_vars)
+            all_vars['ansible_delegated_vars'], all_vars['_ansible_loop_cache'] = self._get_delegated_vars(play, task, host, all_vars)
 
         # 'vars' magic var
         if task or play:
@@ -594,14 +594,15 @@ class VariableManager:
                 include_hostvars=False,
             )
 
+        _ansible_loop_cache = None
         if has_loop and cache_items:
             # delegate_to templating produced a change, so we will cache the templated items
             # in a special private hostvar
             # this ensures that delegate_to+loop doesn't produce different results than TaskExecutor
             # which may reprocess the loop
-            self.set_host_variable(host, '_ansible_loop_cache', items)
+            _ansible_loop_cache = items
 
-        return delegated_host_vars
+        return delegated_host_vars, _ansible_loop_cache
 
     def clear_facts(self, hostname):
         '''

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -430,7 +430,7 @@ class VariableManager:
         # if we have a task and we're delegating to another host, figure out the
         # variables for that host now so we don't have to rely on hostvars later
         if task and task.delegate_to is not None and include_delegate_to:
-            all_vars['ansible_delegated_vars'], all_vars['_ansible_loop_cache'] = self._get_delegated_vars(play, task, host, all_vars)
+            all_vars['ansible_delegated_vars'], all_vars['_ansible_loop_cache'] = self._get_delegated_vars(play, task, all_vars)
 
         # 'vars' magic var
         if task or play:
@@ -486,7 +486,7 @@ class VariableManager:
 
         return variables
 
-    def _get_delegated_vars(self, play, task, host, existing_variables):
+    def _get_delegated_vars(self, play, task, existing_variables):
         if not hasattr(task, 'loop'):
             # This "task" is not a Task, so we need to skip it
             return {}

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -430,7 +430,7 @@ class VariableManager:
         # if we have a task and we're delegating to another host, figure out the
         # variables for that host now so we don't have to rely on hostvars later
         if task and task.delegate_to is not None and include_delegate_to:
-            all_vars['ansible_delegated_vars'] = self._get_delegated_vars(play, task, all_vars)
+            all_vars['ansible_delegated_vars'] = self._get_delegated_vars(play, task, host, all_vars)
 
         # 'vars' magic var
         if task or play:
@@ -486,7 +486,7 @@ class VariableManager:
 
         return variables
 
-    def _get_delegated_vars(self, play, task, existing_variables):
+    def _get_delegated_vars(self, play, task, host, existing_variables):
         if not hasattr(task, 'loop'):
             # This "task" is not a Task, so we need to skip it
             return {}
@@ -595,13 +595,11 @@ class VariableManager:
             )
 
         if has_loop and cache_items:
-            # delegate_to templating produced a change, update task.loop with templated items,
+            # delegate_to templating produced a change, so we will cache the templated items
+            # in a special private hostvar
             # this ensures that delegate_to+loop doesn't produce different results than TaskExecutor
             # which may reprocess the loop
-            # Set loop_with to None, so we don't do extra unexpected processing on the cached items later
-            # in TaskExecutor
-            task.loop_with = None
-            task.loop = items
+            self.set_host_variable(host, '_ansible_loop_cache', items)
 
         return delegated_host_vars
 

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -9,6 +9,8 @@ ansible-playbook test_loop_control.yml -v "$@"
 
 ansible-playbook test_delegate_to_loop_randomness.yml -v "$@"
 
-ansible-playbook delegate_and_nolog.yml -v "$@"
+ansible-playbook delegate_and_nolog.yml -i ../../inventory -v "$@"
 
-ansible-playbook delegate_facts_block.yml -v "$@"
+ansible-playbook delegate_facts_block.yml -i ../../inventory -v "$@"
+
+ansible-playbook test_delegate_to_loop_caching.yml -i ../../inventory -v "$@"

--- a/test/integration/targets/delegate_to/test_delegate_to_loop_caching.yml
+++ b/test/integration/targets/delegate_to/test_delegate_to_loop_caching.yml
@@ -1,0 +1,45 @@
+- hosts: testhost,testhost2
+  gather_facts: false
+  vars:
+    delegate_to_host: "localhost"
+  tasks:
+    - set_fact:
+        gandalf:
+          shout: 'You shall not pass!'
+      when: inventory_hostname == 'testhost'
+
+    - set_fact:
+        gandalf:
+          speak: 'Run you fools!'
+      when: inventory_hostname == 'testhost2'
+
+    - name: works correctly
+      debug: var=item
+      delegate_to: localhost
+      with_dict: "{{ gandalf }}"
+      register: result1
+
+    - name: shows same item for all hosts
+      debug: var=item
+      delegate_to: "{{ delegate_to_host }}"
+      with_dict: "{{ gandalf }}"
+      register: result2
+
+    - debug:
+        var: result2.results[0].item.value
+
+    - assert:
+        that:
+          - result1.results[0].item.value == 'You shall not pass!'
+          - result2.results[0].item.value == 'You shall not pass!'
+      when: inventory_hostname == 'testhost'
+
+    - assert:
+        that:
+          - result1.results[0].item.value == 'Run you fools!'
+          - result2.results[0].item.value == 'Run you fools!'
+      when: inventory_hostname == 'testhost2'
+
+    - assert:
+        that:
+          - _ansible_loop_cache is undefined


### PR DESCRIPTION
##### SUMMARY

This PR addresses an issue where looping over a hostvar, with a templated `delegate_to` would create a loop cache on the task for the last host in the loop.  Fixes #47207 

The original problem that was being solved was the following:

```
- command: whoami
  delegate_to: "{{ item }}"
  with_random_choice: "{{ ansible_play_hosts }}"
```

Because we process the loop in `VariableManager._get_delegated_vars` and in `TaskExecutor._get_loop_items` that loop could produce different results, causing `ansible_delegated_vars` to not exist for the host later selected in `TaskExecutor._get_loop_items`

We solved that by caching the resultant loop as `task.loop`.  The problem with that is when the variable being looped is different per host.

This fix allows the original case to work, as well as the case of:

```
- command: whoami
  delegate_to: "{{ item }}"
  loop: "{{ some_per_host_list }}"
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_executor.py
lib/ansible/vars/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
2.8
```

##### ADDITIONAL INFORMATION
Also, not mentioned above is that an inventory was supplied to some other tests that were skipping as a result of the inventory not matching.