### PR TITLE
Use loop instead of obsolete with_items

### DIFF
--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -184,8 +184,8 @@ EXAMPLES = r'''
     device: /dev/sdb
     number: '{{ item.num }}'
     state: absent
-  loop: "{{ sdb_info.partitions }}"
-"""
+  loop: '{{ sdb_info.partitions }}'
+'''
 
 
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -184,9 +184,8 @@ EXAMPLES = r'''
     device: /dev/sdb
     number: '{{ item.num }}'
     state: absent
-  with_items:
-   - '{{ sdb_info.partitions }}'
-'''
+  loop: "{{ sdb_info.partitions }}"
+"""
 
 
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
##### SUMMARY
Use syntax loop instead of with_items in example of module parted

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
parted

##### ANSIBLE VERSION
ansible 2.5 upward