### PR TITLE
Add runtime option to docker_container module

### DIFF
--- a/changelogs/fragments/47247-docker_container-add-runtime-option.yaml
+++ b/changelogs/fragments/47247-docker_container-add-runtime-option.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_container - Add runtime option."

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -2458,6 +2458,39 @@
     - restart_retries_3 is changed
 
 ####################################################################
+## runtime #########################################################
+####################################################################
+
+- name: runtime
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -v -c "sleep 10m"'
+    name: "{{ cname }}"
+    runtime: runc
+    state: started
+  register: runtime_1
+
+- name: runtime (idempotency)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -v -c "sleep 10m"'
+    name: "{{ cname }}"
+    runtime: runc
+    state: started
+  register: runtime_2
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    stop_timeout: 1
+
+- assert:
+    that:
+    - runtime_1 is changed
+    - runtime_2 is not changed
+
+####################################################################
 ## security_opts ###################################################
 ####################################################################
 


### PR DESCRIPTION
##### SUMMARY

Add support for --runtime option to docker_container module

It is based on #40695 and #40839.

Fixes #40694

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`docker_container`

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (docker_container_runtime_option f711387643) last updated 2018/10/17 13:38:08 (GMT -700)
  config file = /home/antoine/.ansible.cfg
  configured module search path = [u'/home/antoine/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/antoine/src/ansible/lib/ansible
  executable location = /home/antoine/src/ansible/venv/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

cc @felixfontein 