### PR TITLE
 docker_service: parse scale parameter correctly to 2.6

### DIFF
--- a/changelogs/fragments/45508-parse-docker-service-parameter.yaml
+++ b/changelogs/fragments/45508-parse-docker-service-parameter.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - docker_service - correctly parse string values for the `scale` parameter https://github.com/ansible/ansible/pull/45508


### PR DESCRIPTION
##### SUMMARY
Backporting https://github.com/ansible/ansible/pull/45508 to 2.6.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_service

##### ANSIBLE VERSION


##### ADDITIONAL INFORMATION
