### PR TITLE
Fix yum/dnf lock file polling

### DIFF
--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -44,9 +44,7 @@ yumdnf_argument_spec = dict(
         update_cache=dict(type='bool', default=False, aliases=['expire-cache']),
         update_only=dict(required=False, default="no", type='bool'),
         validate_certs=dict(type='bool', default=True),
-        # this should not be needed, but exists as a failsafe
-        lock_poll=dict(type='int', default=-1),
-        lock_timeout=dict(type='int', default=10),
+        lock_timeout=dict(type='int', default=0),
     ),
     required_one_of=[['name', 'list', 'update_cache']],
     mutually_exclusive=[['name', 'list']],
@@ -88,7 +86,6 @@ class YumDnf(with_metaclass(ABCMeta, object)):
         self.update_only = self.module.params['update_only']
         self.update_cache = self.module.params['update_cache']
         self.validate_certs = self.module.params['validate_certs']
-        self.lock_poll = self.module.params['lock_poll']
         self.lock_timeout = self.module.params['lock_timeout']
 
         # It's possible someone passed a comma separated string since it used
@@ -103,14 +100,14 @@ class YumDnf(with_metaclass(ABCMeta, object)):
         self.lockfile = '/var/run/yum.pid'
 
     def wait_for_lock(self):
-        '''Poll until the lock is removed if interval is a positive number'''
-        if (os.path.isfile(self.lockfile) or glob.glob(self.lockfile)) and self.lock_timeout > 0:
-            for iteration in range(0, self.lock_timeout):
-                time.sleep(self.lock_poll)
-                if not os.path.isfile(self.lockfile) or not glob.glob(self.lockfile):
-                    break
-            if os.path.isfile(self.lockfile) or glob.glob(self.lockfile):
-                self.module.fail_json(msg='{0} lockfile was not released'.format(self.pkg_mgr_name))
+        '''Poll until the lock is removed if timeout is a positive number'''
+        if (os.path.isfile(self.lockfile) or glob.glob(self.lockfile)):
+            if self.lock_timeout > 0:
+                for iteration in range(0, self.lock_timeout):
+                    time.sleep(1)
+                    if not os.path.isfile(self.lockfile) and not glob.glob(self.lockfile):
+                        return
+            self.module.fail_json(msg='{0} lockfile is held by another process'.format(self.pkg_mgr_name))
 
     def listify_comma_sep_strings_in_list(self, some_list):
         """

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -176,20 +176,11 @@ options:
     default: "no"
     type: bool
     version_added: "2.7"
-  lock_poll:
-    description:
-      - Poll interval to wait for the dnf lockfile to be freed.
-      - "By default this is set to -1, if you set it to a positive integer it will enable to polling"
-    required: false
-    default: -1
-    type: int
-    version_added: "2.8"
   lock_timeout:
     description:
-      - Amount of time to wait for the dnf lockfile to be freed
-      - This should be set along with C(lock_poll) to enable the lockfile polling.
+      - Amount of time to wait for the dnf lockfile to be freed.
     required: false
-    default: 10
+    default: 0
     type: int
     version_added: "2.8"
 notes:

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -183,20 +183,11 @@ options:
     default: "no"
     type: bool
     version_added: "2.7"
-  lock_poll:
-    description:
-      - Poll interval to wait for the yum lockfile to be freed.
-      - "By default this is set to -1, if you set it to a positive integer it will enable to polling"
-    required: false
-    default: -1
-    type: int
-    version_added: "2.8"
   lock_timeout:
     description:
-      - Amount of time to wait for the yum lockfile to be freed
-      - This should be set along with C(lock_poll) to enable the lockfile polling.
+      - Amount of time to wait for the yum lockfile to be freed.
     required: false
-    default: 10
+    default: 0
     type: int
     version_added: "2.8"
 notes:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
#45359 attempted to improve lock file handling, but the default `lock_poll` of -1 resulted in calling `time.sleep(-1)`, which is invalid and throws an exception. The poorly-documented combination of `lock_timeout` and `lock_poll` is confusing in the first place and doesn't seem to provide much utility compared to just accepting a timeout in seconds, so I dropped `lock_poll` entirely.

Waiting for dnf's globbed lockfiles was also broken; the loop was exited as soon as os.path.isfile(self.lockfile) returned false, rather than checking both.

I set the `lock_timeout` default to 0, which seems to match the intent of the previous change but is a fairly major change to the behaviour of the yum module (which was to wait for the lockfile pretty much indefinitely). I don't know what the old expected behaviour of dnf was, but it's probably more appropriate to set a reasonable default timeout.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum
dnf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (detached HEAD 9cc9ca584a) last updated 2018/10/17 21:51:51 (GMT +000)
  config file = None
  configured module search path = [u'/home/zeke/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/zeke/git/ansible/lib/ansible
  executable location = /home/zeke/git/ansible/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```