### PR TITLE
Ensure that k8s_facts always returns resources key (#46733)

### DIFF
--- a/changelogs/fragments/k8s_facts_fix.yaml
+++ b/changelogs/fragments/k8s_facts_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- k8s_facts now returns a resources key in all situations

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -204,7 +204,7 @@ class K8sAnsibleMixin(object):
                                   label_selector=','.join(label_selectors),
                                   field_selector=','.join(field_selectors)).to_dict()
         except openshift.dynamic.exceptions.NotFoundError:
-            return dict(items=[])
+            return dict(resources=[])
 
         if 'items' in result:
             return dict(resources=result['items'])

--- a/test/integration/targets/k8s/playbooks/roles/k8s/tasks/main.yml
+++ b/test/integration/targets/k8s/playbooks/roles/k8s/tasks/main.yml
@@ -15,6 +15,19 @@
       debug:
         var: output
 
+    - name: k8s_facts works with empty resources
+      k8s_facts:
+        kind: Deployment
+        namespace: testing
+        api_version: extensions/v1beta1
+      register: k8s_facts
+
+    - name: assert that k8s_facts is in correct format
+      assert:
+        that:
+          - "'resources' in k8s_facts"
+          - not k8s_facts.resources
+
     - name: Create a service
       k8s:
         state: present
@@ -85,7 +98,7 @@
       k8s:
         state: present
         inline: &deployment
-          apiVersion: apps/v1beta1
+          apiVersion: extensions/v1beta1
           kind: Deployment
           metadata:
             name: elastic


### PR DESCRIPTION
##### SUMMARY

Fix bug returning `items` key if NotFound exception is hit

(cherry picked from commit b772485d97168722c241aca13906ab016b332cdd)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
k8s_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
stable-2.7
```