### PR TITLE
[Backport 2.7] ec2_vol_facts: only access volume tags when set

### DIFF
--- a/changelogs/fragments/46800-ec2_vol_facts-handle-missing-tags.yml
+++ b/changelogs/fragments/46800-ec2_vol_facts-handle-missing-tags.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- Only access EC2 volume tags when set

--- a/lib/ansible/modules/cloud/amazon/ec2_vol_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vol_facts.py
@@ -92,7 +92,7 @@ def get_volume_info(volume, region):
             'status': attachment[0]["state"] if len(attachment) > 0 else None,
             'delete_on_termination': attachment[0]["delete_on_termination"] if len(attachment) > 0 else None
         },
-        'tags': boto3_tag_list_to_ansible_dict(volume['tags'])
+        'tags': boto3_tag_list_to_ansible_dict(volume['tags']) if "tags" in volume else None
     }
 
     return volume_info


### PR DESCRIPTION
(cherry picked from commit e744c838081cc2b3db308809d161f2c8393068d6)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #46800 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ec2_vol_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
2.7.0
```

##### ADDITIONAL INFORMATION
Backport fix to latest `stable-2.7`.
