### PR TITLE
DigitalOcean module deprecation

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -110,7 +110,7 @@ files:
     maintainers: $team_cloudstack
     labels: cloudstack
   $modules/cloud/digital_ocean/: BondAnthony
-  $modules/cloud/digital_ocean/digital_ocean.py: alukovenko
+  $modules/cloud/digital_ocean/_digital_ocean.py: alukovenko
   $modules/cloud/digital_ocean/digital_ocean_domain.py: alukovenko
   $modules/cloud/digital_ocean/digital_ocean_sshkey.py: alukovenko mgregson
   $modules/cloud/dimensiondata/dimensiondata_network.py: tintoy

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -105,6 +105,7 @@ The following modules will be removed in Ansible 2.12. Please update your playbo
 * ``foreman`` use <https://github.com/theforeman/foreman-ansible-modules> instead.
 * ``katello`` use <https://github.com/theforeman/foreman-ansible-modules> instead.
 * ``github_hooks`` use :ref:`github_webhook <github_webhook_module>` and :ref:`github_webhook_facts <github_webhook_facts_module>` instead.
+* ``digital_ocean`` use :ref `digital_ocean_droplet <digital_ocean_droplet_module>` instead.
 
 
 Noteworthy module changes
@@ -146,6 +147,9 @@ Noteworthy module changes
   changed if ``state: present``. Any playbooks that are using ``changed_when: no`` to mask this quirk can safely
   remove that workaround. To get the previous behavior when applying ``state: absent`` to a builtin kernel module,
   use ``failed_when: false`` or ``ignore_errors: true`` in your playbook.
+
+* The ``digital_ocean`` module has been deprecated in favor of modules that do not require external dependencies.
+  This allows for more flexibility and better module support.
 
 Plugins
 =======

--- a/lib/ansible/modules/cloud/digital_ocean/_digital_ocean.py
+++ b/lib/ansible/modules/cloud/digital_ocean/_digital_ocean.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 
@@ -17,6 +17,10 @@ DOCUMENTATION = '''
 ---
 module: digital_ocean
 short_description: Create/delete a droplet/SSH_key in DigitalOcean
+deprecated:
+  removed_in: '2.12'
+  why: Updated module to remove external dependency with increased functionality.
+  alternative: Use M(digital_ocean_droplet) instead.
 description:
      - Create/delete a droplet in DigitalOcean and optionally wait for it to be 'running', or deploy an SSH key.
 version_added: "1.3"
@@ -185,7 +189,7 @@ from distutils.version import LooseVersion
 
 try:
     # Imported as a dependency for dopy
-    import six
+    import ansible.module_utils.six
     HAS_SIX = True
 except ImportError:
     HAS_SIX = False

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -120,7 +120,7 @@ lib/ansible/modules/cloud/cloudstack/cs_vpn_connection.py E322
 lib/ansible/modules/cloud/cloudstack/cs_zone.py E322
 lib/ansible/modules/cloud/cloudstack/cs_zone.py E325
 lib/ansible/modules/cloud/cloudstack/cs_zone.py E326
-lib/ansible/modules/cloud/digital_ocean/digital_ocean.py E322
+lib/ansible/modules/cloud/digital_ocean/_digital_ocean.py E322
 lib/ansible/modules/cloud/digital_ocean/digital_ocean_floating_ip.py E322
 lib/ansible/modules/cloud/digital_ocean/digital_ocean_floating_ip.py E324
 lib/ansible/modules/cloud/digital_ocean/digital_ocean_floating_ip.py E325


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Deprecation of digital_ocean module in favor of digital_ocean_droplet. This migration completes removal of all external software dependencies from the digital_ocean modules.

This change can be merged after #33984

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/cloud/digital_ocean/digital_ocean.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (feature/dep-do-module ba8da1b9a1) last updated 2018/10/18 06:53:05 (GMT -400)
  config file = /Users/abond/Dev/github/ansible.cfg
  configured module search path = ['/Users/abond/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/abond/Dev/github/ansible/lib/ansible
  executable location = /Users/abond/Dev/github/ansible/bin/ansible
  python version = 3.7.0 (default, Jun 29 2018, 20:14:27) [Clang 9.0.0 (clang-900.0.39.2)]

```