### PR TITLE
postgresql_ext: Allow creating extension in a specific schema

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -28,6 +28,10 @@ options:
     description:
       - name of the database to add or remove the extension to/from
     required: true
+  schema:
+    description:
+      - name of the schema to add the extension to
+    version_added: "2.8"
   login_user:
     description:
       - The username used to authenticate with
@@ -100,9 +104,12 @@ def ext_delete(cursor, ext):
         return False
 
 
-def ext_create(cursor, ext):
+def ext_create(cursor, ext, schema):
     if not ext_exists(cursor, ext):
-        query = 'CREATE EXTENSION "%s"' % ext
+        query_fragments = ['CREATE EXTENSION "%s"' % ext]
+        if schema:
+            query_fragments.append(' WITH SCHEMA "%s"' % schema)
+        query = ''.join(query_fragments)
         cursor.execute(query)
         return True
     else:
@@ -122,6 +129,7 @@ def main():
             port=dict(default="5432"),
             db=dict(required=True),
             ext=dict(required=True, aliases=['name']),
+            schema=dict(default=""),
             state=dict(default="present", choices=["absent", "present"]),
         ),
         supports_check_mode=True
@@ -132,6 +140,7 @@ def main():
 
     db = module.params["db"]
     ext = module.params["ext"]
+    schema = module.params["schema"]
     state = module.params["state"]
     changed = False
 
@@ -171,7 +180,7 @@ def main():
                 changed = ext_delete(cursor, ext)
 
             elif state == "present":
-                changed = ext_create(cursor, ext)
+                changed = ext_create(cursor, ext, schema)
     except NotSupportedError as e:
         module.fail_json(msg=to_native(e), exception=traceback.format_exc())
     except Exception as e:

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -66,6 +66,7 @@ EXAMPLES = '''
 - postgresql_ext:
     name: postgis
     db: acme
+    schema: extensions
 '''
 import traceback
 

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -107,10 +107,9 @@ def ext_delete(cursor, ext):
 
 def ext_create(cursor, ext, schema):
     if not ext_exists(cursor, ext):
-        query_fragments = ['CREATE EXTENSION "%s"' % ext]
+        query = 'CREATE EXTENSION "%s"' % ext
         if schema:
-            query_fragments.append(' WITH SCHEMA "%s"' % schema)
-        query = ''.join(query_fragments)
+            query += ' WITH SCHEMA "%s"' % schema
         cursor.execute(query)
         return True
     else:


### PR DESCRIPTION
##### SUMMARY
Currently, the `postgresql_ext` module creates extensions in the public schema. This PR adds support for creating extensions in a specific schema.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
postgresql_ext

##### ANSIBLE VERSION
```paste below
ansible 2.8.0.dev0 (devel 9de8744702) last updated 2018/10/18 17:16:09 (GMT +550)
  config file = None
  configured module search path = [u'/Users/prashant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/prashant/git/ansible/lib/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 16:44:14) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION
Example:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- postgresql_ext:
    name: postgis
    db: test
    schema: extensions
```
