### PR TITLE
ovirt_vm: Check next_run configuration update if exist

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -1160,6 +1160,13 @@ class VmsModule(BaseModule):
         )
 
     def update_check(self, entity):
+        res = self._update_check(entity)
+        if entity.next_run_configuration_exists:
+            res = res and self._update_check(self._service.service(entity.id).get(next_run=True))
+
+        return res
+
+    def _update_check(self, entity):
         def check_cpu_pinning():
             if self.param('cpu_pinning'):
                 current = []
@@ -1206,7 +1213,7 @@ class VmsModule(BaseModule):
             equal(self.param('smartcard_enabled'), getattr(vm_display, 'smartcard_enabled', False)) and
             equal(self.param('io_threads'), entity.io.threads) and
             equal(self.param('ballooning_enabled'), entity.memory_policy.ballooning) and
-            equal(self.param('serial_console'), entity.console.enabled) and
+            equal(self.param('serial_console'), getattr(entity.console, 'enabled', None)) and
             equal(self._get_minor(self.param('custom_compatibility_version')), self._get_minor(entity.custom_compatibility_version)) and
             equal(self._get_major(self.param('custom_compatibility_version')), self._get_major(entity.custom_compatibility_version)) and
             equal(self.param('usb_support'), entity.usb.enabled) and


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the update check method so it now check also the next_run
configuration of the virtual machine if it exists.

So if previously the VM was updated with new parameters, and then reset
back, the module didn't set the parameters to be set back in next_run.
This PR fixes it so the next run configuration is set back with proper
parameters.

Signed-off-by: Ondra Machacek <omachace@redhat.com>
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1639894

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_vm

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7.0
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
