### PR TITLE
pamd: add delete=False to NamedTemporaryFile()

### DIFF
--- a/changelogs/fragments/47281-pamd-dont-delete-named_temporary_file_on_close.yaml
+++ b/changelogs/fragments/47281-pamd-dont-delete-named_temporary_file_on_close.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+- "pamd: add delete=False to NamedTemporaryFile() fixes OSError on module completion, and
+   removes print statement from module code.
+   (see https://github.com/ansible/ansible/pull/47281 and https://github.com/ansible/ansible/issues/47080)" 

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -776,9 +776,8 @@ def main():
         # First, create a backup if desired.
         if module.params['backup']:
             backupdest = module.backup_local(fname)
-            print("BACKUP DEST", backupdest)
         try:
-            temp_file = NamedTemporaryFile(mode='w', dir=module.tmpdir)
+            temp_file = NamedTemporaryFile(mode='w', dir=module.tmpdir, delete=False)
             with open(temp_file.name, 'w') as fd:
                 fd.write(str(service))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Need to set delete=False on NamedTemporaryFile() or the file will be deleted after its closed which causes an issue. Fixes #47080 

Also removes errant print statement in the module.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pamd

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (pamd_47080_fix c6c5d072ed) last updated 2018/10/18 08:18:34 (GMT -400)
  config file = /Users/me/.ansible.cfg
  configured module search path = ['/Users/me/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/me/devel/shep-ansible/lib/ansible
  executable location = /Users/me/devel/shep-ansible/bin/ansible
  python version = 3.6.6 (default, Jul 21 2018, 22:49:24) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```