### PR TITLE
ovirt_vm: Check next_run configuration update if exist

### DIFF
--- a/changelogs/fragments/ovirt_vm_check_next_run_configuration_update_if_exist.yaml
+++ b/changelogs/fragments/ovirt_vm_check_next_run_configuration_update_if_exist.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ovirt_vm - Check next_run configuration update if exist (https://github.com/ansible/ansible/pull/47282/).

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -1146,6 +1146,13 @@ class VmsModule(BaseModule):
         )
 
     def update_check(self, entity):
+        res = self._update_check(entity)
+        if entity.next_run_configuration_exists:
+            res = res and self._update_check(self._service.service(entity.id).get(next_run=True))
+
+        return res
+
+    def _update_check(self, entity):
         def check_cpu_pinning():
             if self.param('cpu_pinning'):
                 current = []


### PR DESCRIPTION
Backport of https://github.com/ansible/ansible/pull/47280

This PR fixes the update check method so it now check also the next_run
configuration of the virtual machine if it exists.

So if previously the VM was updated with new parameters, and then reset
back, the module didn't set the parameters to be set back in next_run.
This PR fixes it so the next run configuration is set back with proper
parameters.

Signed-off-by: Ondra Machacek <omachace@redhat.com>
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1639894
Signed-off-by: Ondra Machacek <omachace@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
