### PR TITLE
ovirt_host_network: check for empty user_opts (#46695)

### DIFF
--- a/changelogs/fragments/ovirt_host_network_check_for_empty_user_opts.yaml
+++ b/changelogs/fragments/ovirt_host_network_check_for_empty_user_opts.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ovirt_host_network - check for empty user_opts (https://github.com/ansible/ansible/pull/47283).

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -221,7 +221,8 @@ def get_bond_options(mode, usr_opts):
     )
 
     opts_dict = DEFAULT_MODE_OPTS.get(mode, {})
-    opts_dict.update(**usr_opts)
+    if usr_opts is not None:
+        opts_dict.update(**usr_opts)
 
     options.extend(
         [otypes.Option(name=opt, value=value)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With no bond.options given, the get_bond_options function gets called with usr_opts defaulting to None which results in a TypeError when opts_dict is update()'ed with NoneType.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_host_network

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
