### PR TITLE
VMware: Add check mode support to vmware_vmkernel_facts

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel_facts.py
@@ -189,7 +189,8 @@ def main():
         argument_spec=argument_spec,
         required_one_of=[
             ['cluster_name', 'esxi_hostname'],
-        ]
+        ],
+        supports_check_mode=True
     )
 
     vmware_vmk_config = VmkernelFactsManager(module)

--- a/test/integration/targets/vmware_vmkernel_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vmkernel_facts/tasks/main.yml
@@ -45,7 +45,7 @@
 
 - debug: var=host1
 
-- name: Gather VNICs facts about all hosts in given cluster
+- name: Gather VMkernel facts about all hosts in given cluster
   vmware_vmkernel_facts:
     hostname: "{{ vcsim }}"
     username: "{{ user }}"
@@ -59,3 +59,19 @@
 - assert:
     that:
       - host_vmkernel.host_vmk_facts is defined
+
+- name: Gather VMkernel facts about all hosts in given cluster in check mode
+  vmware_vmkernel_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ user }}"
+    password: "{{ passwd }}"
+    esxi_hostname: "{{ host1 }}"
+    validate_certs: no
+  register: host_vmkernel_check_mode
+  check_mode: yes
+
+- debug: var=host_vmkernel
+
+- assert:
+    that:
+      - host_vmkernel_check_mode.host_vmk_facts is defined


### PR DESCRIPTION
##### SUMMARY
Add check mode support.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_vmkernel_facts

##### ANSIBLE VERSION
```
ansible 2.6.3
  config file = /root/ansible-vmware/ansible.cfg
  configured module search path = [u'/root/ansible-vmware/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
