### PR TITLE
[2.7] docker_* modules: unify docker module version checks

### DIFF
--- a/changelogs/fragments/47046-docker-versions.yaml
+++ b/changelogs/fragments/47046-docker-versions.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "The docker_* modules more uniformly check versions of docker-py/docker and (if necessary) the docker API."

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -183,7 +183,7 @@ class AnsibleDockerClient(Client):
             required_together=required_together_params,
             required_if=required_if)
 
-        NEEDS_DOCKER_PY2 = (LooseVersion(min_docker_version) < LooseVersion('2.0'))
+        NEEDS_DOCKER_PY2 = (LooseVersion(min_docker_version) >= LooseVersion('2.0.0'))
 
         if HAS_DOCKER_MODELS and HAS_DOCKER_SSLADAPTER:
             self.fail("Cannot have both the docker-py and docker python modules installed together as they use the same namespace and "

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2308,7 +2308,8 @@ def main():
     client = AnsibleDockerClientContainer(
         argument_spec=argument_spec,
         required_if=required_if,
-        supports_check_mode=True
+        supports_check_mode=True,
+        min_docker_api_version='1.20',
     )
 
     cm = ContainerManager(client)

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -597,6 +597,7 @@ def main():
     client = AnsibleDockerClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        min_docker_api_version='1.20',
     )
 
     results = dict(

--- a/lib/ansible/modules/cloud/docker/docker_image_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_image_facts.py
@@ -227,7 +227,8 @@ def main():
 
     client = AnsibleDockerClient(
         argument_spec=argument_spec,
-        supports_check_mode=True
+        supports_check_mode=True,
+        min_docker_api_version='1.20',
     )
 
     results = dict(

--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -311,7 +311,8 @@ def main():
     client = AnsibleDockerClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_if=required_if
+        required_if=required_if,
+        min_docker_api_version='1.20',
     )
 
     results = dict(

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -163,7 +163,7 @@ try:
     from docker import utils
     if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:
         from docker.types import IPAMPool, IPAMConfig
-except:
+except Exception as dummy:
     # missing docker-py handled in ansible.module_utils.docker_common
     pass
 
@@ -384,6 +384,7 @@ def main():
     client = AnsibleDockerClient(
         argument_spec=argument_spec,
         supports_check_mode=True
+        # "The docker server >= 1.9.0"
     )
 
     cm = DockerNetworkManager(client)

--- a/lib/ansible/modules/cloud/docker/docker_secret.py
+++ b/lib/ansible/modules/cloud/docker/docker_secret.py
@@ -272,7 +272,9 @@ def main():
     client = AnsibleDockerClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_if=required_if
+        required_if=required_if,
+        min_docker_version='2.1.0',
+        min_docker_api_version='1.25',
     )
 
     results = dict(

--- a/lib/ansible/modules/cloud/docker/docker_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_service.py
@@ -1053,7 +1053,8 @@ def main():
     client = AnsibleDockerClient(
         argument_spec=argument_spec,
         mutually_exclusive=mutually_exclusive,
-        supports_check_mode=True
+        supports_check_mode=True,
+        min_docker_api_version='1.20',
     )
 
     result = ContainerManager(client).exec_module()

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -508,7 +508,9 @@ def main():
     client = AnsibleDockerClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_if=required_if
+        required_if=required_if,
+        min_docker_version='2.6.0',
+        min_docker_api_version='1.35',
     )
 
     results = dict(

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -277,6 +277,10 @@ extends_documentation_fragment:
 - docker
 requirements:
 - "docker-py >= 2.0"
+- "Please note that the L(docker-py,https://pypi.org/project/docker-py/) Python
+   module has been superseded by L(docker,https://pypi.org/project/docker/)
+   (see L(here,https://github.com/docker/docker-py/issues/1310) for details).
+   Version 2.1.0 or newer is only available with the C(docker) module."
 '''
 
 RETURN = '''
@@ -462,13 +466,7 @@ try:
     from distutils.version import LooseVersion
     from docker import utils
     from docker import types
-    from docker import __version__ as docker_version
-    if LooseVersion(docker_version) >= LooseVersion('2.0.0'):
-        from docker.types import Ulimit, LogConfig
-        HAS_DOCKER_PY_2 = True
-    else:
-        from docker.utils.types import Ulimit, LogConfig
-except:
+except Exception as dummy:
     # missing docker-py handled in ansible.module_utils.docker
     pass
 
@@ -839,7 +837,7 @@ class DockerService(DockerBaseClass):
             network_id = None
             try:
                 network_id = filter(lambda n: n['name'] == network_name, docker_networks)[0]['id']
-            except:
+            except Exception as dummy:
                 pass
             if network_id:
                 networks.append({'Target': network_id})
@@ -1159,14 +1157,9 @@ def main():
     client = AnsibleDockerClient(
         argument_spec=argument_spec,
         required_if=required_if,
-        supports_check_mode=True
+        supports_check_mode=True,
+        min_docker_version='2.0.0',
     )
-
-    if not HAS_DOCKER_PY_2:
-        client.module.fail_json(
-            msg=("docker python library version is %s. " +
-                 "this module requires version 2.0.0 or greater")
-            % docker_version)
 
     dsm = DockerServiceManager(client)
     msg, changed, rebuilt, changes, facts = dsm.run()

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -254,7 +254,9 @@ def main():
 
     client = AnsibleDockerClient(
         argument_spec=argument_spec,
-        supports_check_mode=True
+        supports_check_mode=True,
+        min_docker_version='1.10.0',
+        # "The docker server >= 1.9.0"
     )
 
     cm = DockerVolumeManager(client)


### PR DESCRIPTION
##### SUMMARY
Backport of #47046 and #47274 to `stable-2.7`: unifies docker module version checks.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/docker_common.py
docker_container
docker_image
docker_image_facts
docker_login
docker_network
docker_secret
docker_service
docker_swarm
docker_swarm_service
docker_volume

##### ANSIBLE VERSION
```
2.7.1
```
