### PR TITLE
Don't fail on unable to set terminal width on ios

### DIFF
--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -25,12 +25,9 @@ import re
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text, to_bytes
 from ansible.plugins.terminal import TerminalBase
+from ansible.utils.display import Display
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+display = Display()
 
 
 class TerminalModule(TerminalBase):

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -26,6 +26,12 @@ from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text, to_bytes
 from ansible.plugins.terminal import TerminalBase
 
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
 
 class TerminalModule(TerminalBase):
 
@@ -52,10 +58,14 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            for cmd in (b'terminal length 0', b'terminal width 512'):
-                self._exec_cli_command(cmd)
+            self._exec_cli_command(b'terminal length 0')
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')
+
+        try:
+            self._exec_cli_command(b'terminal width 512')
+        except AnsibleConnectionFailure:
+            display.display('WARNING: Unable to set terminal width, command responses may be truncated')
 
     def on_become(self, passwd=None):
         if self._get_prompt().endswith(b'#'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Also fixes #46185
Fixes #39106

I'm not happy with this, I'd rather be able to use `display.warning` and pretend nothing unusual is happening.

What I would like to see is a way for `ansible-connection` to return `messages` as a list of tuples of `(level, message)` so executor can redirect them properly (and not uniformly at `vvv`), but we can get them after being rendered to stdout, so this seems like it would require extensive work in display.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```