### PR TITLE
[stable-2.7] get_url: Updates documentation for proper use of headers (#47242)

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -179,7 +179,9 @@ EXAMPLES = r'''
   get_url:
     url: http://example.com/path/file.conf
     dest: /etc/foo.conf
-    headers: 'key:value,key:value'
+    headers:
+      key1: one
+      key2: two
 
 - name: Download file with check (sha256)
   get_url:


### PR DESCRIPTION
* Fixes the example for headers in documentation

* remove whitespace

* missed a whitespace
(cherry picked from commit 3b5471a)


Co-authored-by: Nate Borener <33846287+borener@users.noreply.github.com>