### PR TITLE
Add constraints to pip install in setup_docker.

### DIFF
--- a/test/integration/targets/setup_docker/tasks/main.yml
+++ b/test/integration/targets/setup_docker/tasks/main.yml
@@ -16,3 +16,4 @@
       pip:
         state: present
         name: 'docker{{ extra_packages }}'
+        extra_args: "-c {{ role_path }}/../../../runner/requirements/constraints.txt"


### PR DESCRIPTION
##### SUMMARY

Add constraints to pip install in setup_docker.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

setup_docker integration test target

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (ci-fix 29ffb29c58) last updated 2018/10/18 10:04:52 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
