### PR TITLE
Avoid undefined names by initializing variables

### DIFF
--- a/lib/ansible/module_utils/api.py
+++ b/lib/ansible/module_utils/api.py
@@ -107,11 +107,11 @@ def retry(retries=None, retry_pause=1):
         retry_count = 0
 
         def retried(*args, **kwargs):
+            global retry_count
             if retries is not None:
                 ret = None
                 while True:
-                    # pylint doesn't understand this is a closure
-                    retry_count += 1  # pylint: disable=undefined-variable
+                    retry_count += 1
                     if retry_count >= retries:
                         raise Exception("Retry limit exceeded: %d" % retries)
                     try:

--- a/lib/ansible/modules/network/dellos9/dellos9_facts.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_facts.py
@@ -370,6 +370,7 @@ class Interfaces(FactsBase):
         return parsed
 
     def parse_mgmt_interfaces(self, data):
+        key = None
         parsed = dict()
         interface_start = True
         for line in data.split('\n'):
@@ -387,6 +388,7 @@ class Interfaces(FactsBase):
         return parsed
 
     def parse_vlan_interfaces(self, data):
+        key = None
         parsed = dict()
         interface_start = True
         line_before_end = False
@@ -410,6 +412,7 @@ class Interfaces(FactsBase):
         return parsed
 
     def parse_ipv6_interfaces(self, data):
+        key = None
         parsed = dict()
         for line in data.split('\n'):
             if len(line) == 0:

--- a/lib/ansible/modules/network/ironware/ironware_facts.py
+++ b/lib/ansible/modules/network/ironware/ironware_facts.py
@@ -266,6 +266,7 @@ class MPLS(FactsBase):
             self.facts['mpls_vpls'] = self.populate_vpls(data)
 
     def parse_mpls(self, data):
+        key = None
         parsed = dict()
         for line in data.split('\n'):
             if not line:
@@ -506,6 +507,7 @@ class Interfaces(FactsBase):
         return facts
 
     def parse_interfaces(self, data):
+        key = None
         parsed = dict()
         for line in data.split('\n'):
             if not line:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Linters properly complain about _undefined names_ when code access variables before they have defined.  These changes include two approaches to help linters (and humans) to understand and relax about these undefined names:
* The __key__ fixes add a __key = None__ statement at the top of the function.
* The __retry_count__ fix adds a __global retry_count__ statement at the top of the function which allows tests to pass on both PyLint and flake8 without any linter directives.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* module_utils
* modules/network

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
* https://github.com/ansible/ansible

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
[flake8](http://flake8.pycqa.org) testing of https://github.com/ansible/ansible on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lib/ansible/module_utils/api.py:114:21: F823 local variable 'retry_count' (defined in enclosing scope on line 107) referenced before assignment
                    retry_count += 1  # pylint: disable=undefined-variable
                    ^
./lib/ansible/modules/network/dellos9/dellos9_facts.py:379:24: F821 undefined name 'key'
                parsed[key] += '\n%s' % line
                       ^
./lib/ansible/modules/network/dellos9/dellos9_facts.py:399:24: F821 undefined name 'key'
                parsed[key] += '\n%s' % line
                       ^
./lib/ansible/modules/network/dellos9/dellos9_facts.py:403:24: F821 undefined name 'key'
                parsed[key] += '\n%s' % line
                       ^
./lib/ansible/modules/network/dellos9/dellos9_facts.py:418:24: F821 undefined name 'key'
                parsed[key] += '\n%s' % line
                       ^
./lib/ansible/modules/network/ironware/ironware_facts.py:274:24: F821 undefined name 'key'
                parsed[key] += '\n%s' % line
                       ^
./lib/ansible/modules/network/ironware/ironware_facts.py:514:24: F821 undefined name 'key'
                parsed[key] += '\n%s' % line
                       ^
6    F821 undefined name 'key'
1     F823 local variable 'retry_count' (defined in enclosing scope on line 107) referenced before assignment
6
```
