### PR TITLE
Fix password lookup for FIPS

### DIFF
--- a/changelogs/fragments/fix-password-lookup-on-fips.yaml
+++ b/changelogs/fragments/fix-password-lookup-on-fips.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+- 'Fix the password lookup when run from a FIPS enabled system.  FIPS forbids
+  the use of md5 but we can use sha1 instead.
+  https://github.com/ansible/ansible/issues/47297'

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -268,7 +268,7 @@ def _get_lock(b_path):
     """Get the lock for writing password file."""
     first_process = False
     b_pathdir = os.path.dirname(b_path)
-    lockfile_name = to_bytes("%s.ansible_lockfile" % hashlib.md5(b_path).hexdigest())
+    lockfile_name = to_bytes("%s.ansible_lockfile" % hashlib.sha1(b_path).hexdigest())
     lockfile = os.path.join(b_pathdir, lockfile_name)
     if not os.path.exists(lockfile) and b_path != to_bytes('/dev/null'):
         try:


### PR DESCRIPTION
Password lookup relies on MD5 to create lock file which fails on a FIPS enabled system. Appears to affect 2.7 and devel.

Fixes #47297

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/lookup/password.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
devel and 2.7
```
