### PR TITLE
azure_rm_cdnprofile: Add 'standard_microsoft' to sku

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_cdnprofile.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_cdnprofile.py
@@ -41,6 +41,7 @@ options:
             - custom_verizon
             - standard_akamai
             - standard_chinacdn
+            - standard_microsoft
     state:
         description:
             - Assert the state of the CDN profile. Use C(present) to create or update a CDN profile and C(absent) to delete it.
@@ -126,7 +127,7 @@ class AzureRMCdnprofile(AzureRMModuleBase):
             ),
             sku=dict(
                 type='str',
-                choices=['standard_verizon', 'premium_verizon', 'custom_verizon', 'standard_akamai', 'standard_chinacdn']
+                choices=['standard_verizon', 'premium_verizon', 'custom_verizon', 'standard_akamai', 'standard_chinacdn', 'standard_microsoft']
             )
         )
 


### PR DESCRIPTION
##### SUMMARY
The azure_rm_cdnprofile module was missing a valid sku 'standard_microsoft'.  Added it to the list of valid choices.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_cdnprofile

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
It was not possible to deploy using the 'standard_microsoft' sku previously.  This addition allows this.