### PR TITLE
VMware: Avoid misleading PyVmomi error if requests import fails

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -12,9 +12,10 @@ import ssl
 import time
 from random import randint
 
+# requests is required for exception handling of the ConnectionError
+import requests
+
 try:
-    # requests is required for exception handling of the ConnectionError
-    import requests
     from pyVim import connect
     from pyVmomi import vim, vmodl
     HAS_PYVMOMI = True

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -12,8 +12,12 @@ import ssl
 import time
 from random import randint
 
-# requests is required for exception handling of the ConnectionError
-import requests
+try:
+    # requests is required for exception handling of the ConnectionError
+    import requests
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
 
 try:
     from pyVim import connect
@@ -778,6 +782,10 @@ class PyVmomi(object):
         """
         Constructor
         """
+        if not HAS_REQUESTS:
+            self.module.fail_json(msg="Unable to find 'requests' Python library which is required."
+                                      " Please install using 'pip install requests'")
+
         if not HAS_PYVMOMI:
             module.fail_json(msg='PyVmomi Python module required. Install using "pip install PyVmomi"')
 


### PR DESCRIPTION
##### SUMMARY
Requests is imported by the VMware module_utils as an external
dependency; however, because it is in a try/catch block containing the
imports for PyVmomi, if requests fails to import properly, Ansible will
instead complain about PyVmomi not being installed.

By moving the import outside of the try/catch block, if requests fails
to import, an error like the following will be returned:

    ImportError: No module named requests

This should result in less confusion.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
module_utils/vmware.py