### PR TITLE
[stable-2.7] Don't use the task for a cache, return a special cache var (#47243)

### DIFF
--- a/changelogs/fragments/delegate_to_loop_hostvars.yaml
+++ b/changelogs/fragments/delegate_to_loop_hostvars.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- delegate_to - When templating ``delegate_to`` in a loop, don't use the task for a cache, return a special cache through ``get_vars`` allowing looping over a hostvar (https://github.com/ansible/ansible/issues/47207)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -210,7 +210,12 @@ class TaskExecutor:
 
         templar = Templar(loader=self._loader, shared_loader_obj=self._shared_loader_obj, variables=self._job_vars)
         items = None
-        if self._task.loop_with:
+        loop_cache = self._job_vars.get('_ansible_loop_cache')
+        if loop_cache is not None:
+            # _ansible_loop_cache may be set in `get_vars` when calculating `delegate_to`
+            # to avoid reprocessing the loop
+            items = loop_cache
+        elif self._task.loop_with:
             if self._task.loop_with in self._shared_loader_obj.lookup_loader:
                 fail = True
                 if self._task.loop_with == 'first_found':

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -9,4 +9,6 @@ ansible-playbook test_loop_control.yml -v "$@"
 
 ansible-playbook test_delegate_to_loop_randomness.yml -v "$@"
 
-ansible-playbook delegate_and_nolog.yml -v "$@"
+ansible-playbook delegate_and_nolog.yml -i ../../inventory -v "$@"
+
+ansible-playbook test_delegate_to_loop_caching.yml -i ../../inventory -v "$@"

--- a/test/integration/targets/delegate_to/test_delegate_to_loop_caching.yml
+++ b/test/integration/targets/delegate_to/test_delegate_to_loop_caching.yml
@@ -1,0 +1,45 @@
+- hosts: testhost,testhost2
+  gather_facts: false
+  vars:
+    delegate_to_host: "localhost"
+  tasks:
+    - set_fact:
+        gandalf:
+          shout: 'You shall not pass!'
+      when: inventory_hostname == 'testhost'
+
+    - set_fact:
+        gandalf:
+          speak: 'Run you fools!'
+      when: inventory_hostname == 'testhost2'
+
+    - name: works correctly
+      debug: var=item
+      delegate_to: localhost
+      with_dict: "{{ gandalf }}"
+      register: result1
+
+    - name: shows same item for all hosts
+      debug: var=item
+      delegate_to: "{{ delegate_to_host }}"
+      with_dict: "{{ gandalf }}"
+      register: result2
+
+    - debug:
+        var: result2.results[0].item.value
+
+    - assert:
+        that:
+          - result1.results[0].item.value == 'You shall not pass!'
+          - result2.results[0].item.value == 'You shall not pass!'
+      when: inventory_hostname == 'testhost'
+
+    - assert:
+        that:
+          - result1.results[0].item.value == 'Run you fools!'
+          - result2.results[0].item.value == 'Run you fools!'
+      when: inventory_hostname == 'testhost2'
+
+    - assert:
+        that:
+          - _ansible_loop_cache is undefined


### PR DESCRIPTION
[stable-2.7] Don't use the task for a cache, return a special cache var (#47243)

* Don't use task to cache loop results, use hostvars. Fixes #47207

* Avoid a race condition, supply _ansible_loop_cache through get_vars directly

* Add tests

* Add changelog fragment

* Remove unnecessary copy

* Remove unnecessary host from _get_delegated_vars signature.
(cherry picked from commit 77d32b8f5799b8a32f464a22e25b38e5ea4b260c)


Co-authored-by: Matt Martz <matt@sivel.net>