### PR TITLE
Add constraint for requests on python 2.6. (#47306)

### DIFF
--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -15,6 +15,7 @@ idna < 2.6 # requests requires idna < 2.6, but cryptography will cause the lates
 paramiko < 2.4.0 ; python_version < '2.7' # paramiko 2.4.0 drops support for python 2.6
 pytest < 3.3.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 2.6
 ntlm-auth >= 1.0.6 # message encryption support
+requests < 2.20.0 ; python_version < '2.7' # requests 2.20.0 drops support for python 2.6
 requests-ntlm >= 1.1.0 # message encryption support
 requests-credssp >= 0.1.0 # message encryption support
 voluptuous >= 0.11.0 # Schema recursion via Self


### PR DESCRIPTION
##### SUMMARY

Add constraint for requests on python 2.6. (#47306)

(cherry picked from commit f74f7b03736a4b600e85ccad090f941595b47f6b)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test constraints

##### ANSIBLE VERSION

```
ansible 2.5.10 (bp-2.5 69967b6cfd) last updated 2018/10/18 13:31:18 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
