### PR TITLE
lineinfile file locking support

### DIFF
--- a/changelogs/fragments/30413-lineinfile-concurrence_issue.yaml
+++ b/changelogs/fragments/30413-lineinfile-concurrence_issue.yaml
@@ -1,3 +1,3 @@
 bugfixes:
 - "Fixed lineinfile concurrence issue with multiple delegation on same delegated host and same file"
-- "common.file.FileLocking now properly handles lock_timeout = None"
+- "common.file.FileLocking now properly handles lock_timeout = None and negative int"

--- a/changelogs/fragments/30413-lineinfile-concurrence_issue.yaml
+++ b/changelogs/fragments/30413-lineinfile-concurrence_issue.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- "Fixed lineinfile concurrence issue with multiple delegation on same delegated host and same file"
+- "common.file.FileLocking now properly handles lock_timeout = None"

--- a/changelogs/fragments/30413-lineinfile-concurrence_issue.yaml
+++ b/changelogs/fragments/30413-lineinfile-concurrence_issue.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-- "Fixed lineinfile concurrence issue with multiple delegation on same delegated host and same file"
+- "lineinfile now uses FileLock to prevent concurrency issues, fixes #30413"
 - "common.file.FileLocking now properly handles lock_timeout = None and negative int"

--- a/changelogs/fragments/30413-lineinfile-concurrence_issue.yaml
+++ b/changelogs/fragments/30413-lineinfile-concurrence_issue.yaml
@@ -1,3 +1,4 @@
 bugfixes:
 - "lineinfile now uses FileLock to prevent concurrency issues, fixes #30413"
 - "common.file.FileLocking now properly handles lock_timeout = None and negative int"
+- "common.file.FileLocking now locks the actual file instead of per-user lock files making locks global for processes that supports it"

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -151,8 +151,6 @@ class FileLock:
         :returns: True
         '''
         lock_path = os.path.join(tmpdir, 'ansible-{0}.lock'.format(os.path.basename(path)))
-        lock_path = lock_path.encode('utf-8')
-
         l_wait = 0.1
         r_exception = IOError
         if sys.version_info[0] == 3:

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -148,13 +148,13 @@ class FileLock:
             Default is None, wait indefinitely until lock is released.
         :returns: True
         '''
-        lock_path_b = to_bytes(path, errors='surrogate_or_strict')
+        b_lock_path = to_bytes(path, errors='surrogate_or_strict')
         l_wait = 0.1
         r_exception = IOError
         if sys.version_info[0] == 3:
             r_exception = BlockingIOError
 
-        self.lockfd = open(lock_path_b, 'ab')
+        self.lockfd = open(b_lock_path, 'ab')
 
         if lock_timeout is None or lock_timeout < 0:
             fcntl.flock(self.lockfd, fcntl.LOCK_EX)

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -151,21 +151,22 @@ class FileLock:
         :returns: True
         '''
         lock_path = os.path.join(tmpdir, 'ansible-{0}.lock'.format(os.path.basename(path)))
+        lock_path_b = to_bytes(lock_path, errors='surrogate_or_strict')
         l_wait = 0.1
         r_exception = IOError
         if sys.version_info[0] == 3:
             r_exception = BlockingIOError
 
-        self.lockfd = open(lock_path, 'w')
+        self.lockfd = open(lock_path_b, 'w')
 
         if lock_timeout is None or lock_timeout < 0:
             fcntl.flock(self.lockfd, fcntl.LOCK_EX)
-            os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
+            os.chmod(lock_path_b, stat.S_IWRITE | stat.S_IREAD)
             return True
 
         if lock_timeout == 0:
             fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
+            os.chmod(lock_path_b, stat.S_IWRITE | stat.S_IREAD)
             return True
 
         if lock_timeout > 0:
@@ -173,7 +174,7 @@ class FileLock:
             while e_secs < lock_timeout:
                 try:
                     fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                    os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
+                    os.chmod(lock_path_b, stat.S_IWRITE | stat.S_IREAD)
                     return True
                 except r_exception:
                     time.sleep(l_wait)

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -148,14 +148,13 @@ class FileLock:
             Default is None, wait indefinitely until lock is released.
         :returns: True
         '''
-        lock_path = path
-        lock_path_b = to_bytes(lock_path, errors='surrogate_or_strict')
+        lock_path_b = to_bytes(path, errors='surrogate_or_strict')
         l_wait = 0.1
         r_exception = IOError
         if sys.version_info[0] == 3:
             r_exception = BlockingIOError
 
-        self.lockfd = open(lock_path_b, 'a')
+        self.lockfd = open(lock_path_b, 'ab')
 
         if lock_timeout is None or lock_timeout < 0:
             fcntl.flock(self.lockfd, fcntl.LOCK_EX)

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -120,7 +120,7 @@ class LockTimeout(Exception):
 #       to not open or close the same file within the existing context.
 #       It is essential to reuse the returned file descriptor only.
 @contextmanager
-def open_locked(path, check_mode=False, lock_timeout=15):
+def open_locked(path, lock_timeout=15):
     '''
     Context managed for opening files with lock acquisition
 
@@ -132,16 +132,12 @@ def open_locked(path, check_mode=False, lock_timeout=15):
         Default is wait 15s.
     :returns: file descriptor
     '''
-    if check_mode:
-        b_path = to_bytes(path, errors='surrogate_or_strict')
-        fd = open(b_path, 'rb+')
-    else:
-        fd = lock(path, check_mode, lock_timeout)
+    fd = lock(path, lock_timeout)
     yield fd
     fd.close()
 
 
-def lock(path, check_mode=False, lock_timeout=15):
+def lock(path, lock_timeout=15):
     '''
     Set lock on given path via fcntl.flock(), note that using
     locks does not guarantee exclusiveness unless all accessing

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -57,12 +57,7 @@ PERMS_RE = re.compile(r'[^rwxXstugo]')
 _PERM_BITS = 0o7777          # file mode permission bits
 _EXEC_PERM_BITS = 0o0111     # execute permission bits
 _DEFAULT_PERM = 0o0666       # default file permission bits
-
-# Ensure we use flock on e.g. FreeBSD, MacOSX and Solaris
-if sys.platform.startswith('linux'):
-    filelock = fcntl.lockf
-else:
-    filelock = fcntl.flock
+filelock = fcntl.lockf
 
 
 def is_executable(path):
@@ -139,8 +134,8 @@ def open_locked(path, lock_timeout=15):
 
 def lock(path, lock_timeout=15):
     '''
-    Set lock on given path via fcntl.lockf() (on linux) and fcntl.flock() on bsd's,
-    note that using locks does not guarantee exclusiveness unless all accessing
+    Set lock on given path via fcntl.lockf() (on linux), note that using 
+    locks does not guarantee exclusiveness unless all accessing
     processes honor locks.
 
     :kw path: Path (file) to lock

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -183,7 +183,6 @@ class FileLock:
             self.lockfd.close()
             raise LockTimeout('{0} sec'.format(lock_timeout))
 
-
     def unlock(self):
         '''
         Make sure lock file is available for everyone and Unlock the file descriptor

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -116,16 +116,16 @@ class LockTimeout(Exception):
 
 class FileLock:
     '''
-    Currently FileLock is implemented via fcntl.flock on a lock file, however this
-    behaviour may change in the future. Avoid mixing lock types fcntl.flock,
-    fcntl.flock and module_utils.common.file.FileLock as it will certainly cause
-    unwanted and/or unexpected behaviour
+    Currently FileLock is implemented via fcntl.flock however this behaviour
+    may change in the future. Avoid mixing lock types fcntl.flock, fcntl.lockf
+    and module_utils.common.file.FileLock as it will certainly cause unwanted
+    and/or unexpected behaviour
     '''
     def __init__(self):
         self.lockfd = None
 
     @contextmanager
-    def lock_file(self, path, lock_timeout=None):
+    def lock_file(self, path, lock_timeout=15):
         '''
         Context for lock acquisition
         '''
@@ -135,7 +135,7 @@ class FileLock:
         finally:
             self.unlock()
 
-    def set_lock(self, path, lock_timeout=None):
+    def set_lock(self, path, lock_timeout=15):
         '''
         Set lock on given path via fcntl.flock(), note that using
         locks does not guarantee exclusiveness unless all accessing
@@ -145,7 +145,8 @@ class FileLock:
         :kw lock_timeout:
             Wait n seconds for lock acquisition, fail if timeout is reached.
             0 = Do not wait, fail if lock cannot be acquired immediately,
-            Default is None, wait indefinitely until lock is released.
+            Less than 0 or None = wait indefinitely until lock is released
+            Default is wait 15s.
         :returns: True
         '''
         b_lock_path = to_bytes(path, errors='surrogate_or_strict')

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -134,7 +134,7 @@ def open_locked(path, lock_timeout=15):
 
 def lock(path, lock_timeout=15):
     '''
-    Set lock on given path via fcntl.lockf() (on linux), note that using 
+    Set lock on given path via fcntl.lockf() (on linux), note that using
     locks does not guarantee exclusiveness unless all accessing
     processes honor locks.
 

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -151,6 +151,9 @@ class FileLock:
         b_lock_path = to_bytes(path, errors='surrogate_or_strict')
         l_wait = 0.1
         r_exception = IOError
+        if not os.path.exists(b_lock_path):
+            raise IOError('{0} does not exist'.format(path))
+
         if sys.version_info[0] == 3:
             r_exception = BlockingIOError
 

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -116,8 +116,8 @@ class LockTimeout(Exception):
 
 class FileLock:
     '''
-    Currently FileLock is implemented via fcntl.flock on a lock file, however this
-    behaviour may change in the future. Avoid mixing lock types fcntl.flock,
+    Currently FileLock is implemented via fcntl.lockf on a lock file, however this
+    behaviour may change in the future. Avoid mixing lock types fcntl.lockf,
     fcntl.lockf and module_utils.common.file.FileLock as it will certainly cause
     unwanted and/or unexpected behaviour
     '''
@@ -137,7 +137,7 @@ class FileLock:
 
     def set_lock(self, path, lock_timeout=None):
         '''
-        Set lock on given path via fcntl.flock(), note that using
+        Set lock on given path via fcntl.lockf(), note that using
         locks does not guarantee exclusiveness unless all accessing
         processes honor locks.
 
@@ -157,18 +157,18 @@ class FileLock:
         self.lockfd = open(lock_path_b, 'ab')
 
         if lock_timeout is None or lock_timeout < 0:
-            fcntl.flock(self.lockfd, fcntl.LOCK_EX)
+            fcntl.lockf(self.lockfd, fcntl.LOCK_EX)
             return True
 
         if lock_timeout == 0:
-            fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.lockf(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             return True
 
         if lock_timeout > 0:
             e_secs = 0
             while e_secs < lock_timeout:
                 try:
-                    fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    fcntl.lockf(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                     return True
                 except r_exception:
                     time.sleep(l_wait)
@@ -189,7 +189,7 @@ class FileLock:
             return True
 
         try:
-            fcntl.flock(self.lockfd, fcntl.LOCK_UN)
+            fcntl.lockf(self.lockfd, fcntl.LOCK_UN)
             self.lockfd.close()
         except ValueError:  # file wasn't opened, let context manager fail gracefully
             pass

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -163,7 +163,7 @@ class FileLock:
             os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
             return True
 
-        if lock_timeout:
+        if lock_timeout > 0:
             e_secs = 0
             while e_secs < lock_timeout:
                 try:

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -116,9 +116,9 @@ class LockTimeout(Exception):
 
 class FileLock:
     '''
-    Currently FileLock is implemented via fcntl.lockf on a lock file, however this
-    behaviour may change in the future. Avoid mixing lock types fcntl.lockf,
-    fcntl.lockf and module_utils.common.file.FileLock as it will certainly cause
+    Currently FileLock is implemented via fcntl.flock on a lock file, however this
+    behaviour may change in the future. Avoid mixing lock types fcntl.flock,
+    fcntl.flock and module_utils.common.file.FileLock as it will certainly cause
     unwanted and/or unexpected behaviour
     '''
     def __init__(self):
@@ -137,7 +137,7 @@ class FileLock:
 
     def set_lock(self, path, lock_timeout=None):
         '''
-        Set lock on given path via fcntl.lockf(), note that using
+        Set lock on given path via fcntl.flock(), note that using
         locks does not guarantee exclusiveness unless all accessing
         processes honor locks.
 
@@ -157,18 +157,18 @@ class FileLock:
         self.lockfd = open(lock_path_b, 'ab')
 
         if lock_timeout is None or lock_timeout < 0:
-            fcntl.lockf(self.lockfd, fcntl.LOCK_EX)
+            fcntl.flock(self.lockfd, fcntl.LOCK_EX)
             return True
 
         if lock_timeout == 0:
-            fcntl.lockf(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             return True
 
         if lock_timeout > 0:
             e_secs = 0
             while e_secs < lock_timeout:
                 try:
-                    fcntl.lockf(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                     return True
                 except r_exception:
                     time.sleep(l_wait)
@@ -189,7 +189,7 @@ class FileLock:
             return True
 
         try:
-            fcntl.lockf(self.lockfd, fcntl.LOCK_UN)
+            fcntl.flock(self.lockfd, fcntl.LOCK_UN)
             self.lockfd.close()
         except ValueError:  # file wasn't opened, let context manager fail gracefully
             pass

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -158,7 +158,7 @@ class FileLock:
 
         self.lockfd = open(lock_path, 'w')
 
-        if lock_timeout <= 0:
+        if lock_timeout == 0:
             fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
             return True

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -151,6 +151,8 @@ class FileLock:
         :returns: True
         '''
         lock_path = os.path.join(tmpdir, 'ansible-{0}.lock'.format(os.path.basename(path)))
+        lock_path = lock_path.encode('utf-8')
+
         l_wait = 0.1
         r_exception = IOError
         if sys.version_info[0] == 3:

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -130,6 +130,7 @@ def open_locked(path, lock_timeout=15):
     fd = lock(path, lock_timeout)
     yield fd
 
+
 def lock(path, lock_timeout=15):
     '''
     Set lock on given path via fcntl.flock(), note that using

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -129,6 +129,7 @@ def open_locked(path, lock_timeout=15):
     '''
     fd = lock(path, lock_timeout)
     yield fd
+    fd.close()
 
 
 def lock(path, lock_timeout=15):

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -160,24 +160,22 @@ def lock(path, lock_timeout=15):
         raise IOError('{0} does not exist'.format(path))
 
     if lock_timeout is None or lock_timeout < 0:
-        fd = open(b_path, 'rb+')
+        fd = open(b_path, 'ab+')
         filelock(fd, fcntl.LOCK_EX)
         return fd
 
     if lock_timeout >= 0:
         total_wait = 0
         while total_wait <= lock_timeout:
-            fd = open(b_path, 'rb+')
+            fd = open(b_path, 'ab+')
             try:
                 filelock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 return fd
             except lock_exception:
-                fd.close()
                 time.sleep(wait)
                 total_wait += wait
                 continue
 
-        fd.close()
         raise LockTimeout('Waited {0} seconds for lock on {1}'.format(total_wait, path))
 
 

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -158,6 +158,11 @@ class FileLock:
 
         self.lockfd = open(lock_path, 'w')
 
+        if lock_timeout is None or lock_timeout < 0:
+            fcntl.flock(self.lockfd, fcntl.LOCK_EX)
+            os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
+            return True
+
         if lock_timeout == 0:
             fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
@@ -178,10 +183,6 @@ class FileLock:
             self.lockfd.close()
             raise LockTimeout('{0} sec'.format(lock_timeout))
 
-        fcntl.flock(self.lockfd, fcntl.LOCK_EX)
-        os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
-
-        return True
 
     def unlock(self):
         '''

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -57,12 +57,7 @@ PERMS_RE = re.compile(r'[^rwxXstugo]')
 _PERM_BITS = 0o7777          # file mode permission bits
 _EXEC_PERM_BITS = 0o0111     # execute permission bits
 _DEFAULT_PERM = 0o0666       # default file permission bits
-
-if sys.platform.startswith('linux'):
-    filelock = fcntl.lockf
-else:
-    filelock = fcntl.flock
-
+filelock = fcntl.flock
 
 def is_executable(path):
     # This function's signature needs to be repeated
@@ -141,7 +136,9 @@ def lock(path, lock_timeout=15):
     '''
     Set lock on given path via fcntl.flock(), note that using
     locks does not guarantee exclusiveness unless all accessing
-    processes honor locks.
+    processes honor locks. Currently locking is implemented using
+    fcntl.flock, which may have issues on NFS with older Linux kernels
+    (< 2.6.5). Currently only tested for Linux.
 
     :kw path: Path (file) to lock
     :kw lock_timeout:

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -64,6 +64,7 @@ if sys.platform.startswith('linux'):
 else:
     filelock = fcntl.flock
 
+
 def is_executable(path):
     # This function's signature needs to be repeated
     # as the first line of its docstring.

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -125,48 +125,44 @@ class FileLock:
         self.lockfd = None
 
     @contextmanager
-    def lock_file(self, path, tmpdir, lock_timeout=None):
+    def lock_file(self, path, lock_timeout=None):
         '''
         Context for lock acquisition
         '''
         try:
-            self.set_lock(path, tmpdir, lock_timeout)
+            self.set_lock(path, lock_timeout)
             yield
         finally:
             self.unlock()
 
-    def set_lock(self, path, tmpdir, lock_timeout=None):
+    def set_lock(self, path, lock_timeout=None):
         '''
-        Create a lock file based on path with flock to prevent other processes
-        using given path.
-        Please note that currently file locking only works when it's executed by
-        the same user, I.E single user scenarios
+        Set lock on given path via fcntl.flock(), note that using
+        locks does not guarantee exclusiveness unless all accessing
+        processes honor locks.
 
         :kw path: Path (file) to lock
-        :kw tmpdir: Path where to place the temporary .lock file
         :kw lock_timeout:
             Wait n seconds for lock acquisition, fail if timeout is reached.
             0 = Do not wait, fail if lock cannot be acquired immediately,
             Default is None, wait indefinitely until lock is released.
         :returns: True
         '''
-        lock_path = os.path.join(tmpdir, 'ansible-{0}.lock'.format(os.path.basename(path)))
+        lock_path = path
         lock_path_b = to_bytes(lock_path, errors='surrogate_or_strict')
         l_wait = 0.1
         r_exception = IOError
         if sys.version_info[0] == 3:
             r_exception = BlockingIOError
 
-        self.lockfd = open(lock_path_b, 'w')
+        self.lockfd = open(lock_path_b, 'a')
 
         if lock_timeout is None or lock_timeout < 0:
             fcntl.flock(self.lockfd, fcntl.LOCK_EX)
-            os.chmod(lock_path_b, stat.S_IWRITE | stat.S_IREAD)
             return True
 
         if lock_timeout == 0:
             fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            os.chmod(lock_path_b, stat.S_IWRITE | stat.S_IREAD)
             return True
 
         if lock_timeout > 0:
@@ -174,7 +170,6 @@ class FileLock:
             while e_secs < lock_timeout:
                 try:
                     fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                    os.chmod(lock_path_b, stat.S_IWRITE | stat.S_IREAD)
                     return True
                 except r_exception:
                     time.sleep(l_wait)

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -114,7 +114,7 @@ class LockTimeout(Exception):
     pass
 
 
-class FileLock():
+class FileLock:
     '''
     Currently FileLock is implemented via fcntl.flock on a lock file, however this
     behaviour may change in the future. Avoid mixing lock types fcntl.flock,

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -63,6 +63,7 @@ if sys.platform.startswith('linux'):
 else:
     filelock = fcntl.flock
 
+
 def is_executable(path):
     # This function's signature needs to be repeated
     # as the first line of its docstring.

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -114,7 +114,7 @@ class LockTimeout(Exception):
     pass
 
 
-class FileLock:
+class FileLock():
     '''
     Currently FileLock is implemented via fcntl.flock on a lock file, however this
     behaviour may change in the future. Avoid mixing lock types fcntl.flock,

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -59,6 +59,7 @@ _EXEC_PERM_BITS = 0o0111     # execute permission bits
 _DEFAULT_PERM = 0o0666       # default file permission bits
 filelock = fcntl.flock
 
+
 def is_executable(path):
     # This function's signature needs to be repeated
     # as the first line of its docstring.

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -127,11 +127,13 @@ options:
       - Lock file while editing to prevent access to file from other concurrent lineinfile processes
     type: bool
     default: 'no'
+    version_added: "2.8"
   lock_timeout:
     description:
       - amount of time in seconds to wait for a lock before giving up
     type: int
-    default: 'None'
+    default: -1
+    version_added: "2.8"
 notes:
   - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
 seealso:
@@ -217,6 +219,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import b
 from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.common.file import FileLock
+
 
 def write_changes(module, b_lines, dest):
 
@@ -494,7 +497,7 @@ def main():
             firstmatch=dict(type='bool', default=False),
             validate=dict(type='str'),
             lock=dict(default=False, type='bool'),
-            lock_timeout=dict(default=None, type='int')
+            lock_timeout=dict(default=-1, type='int')
         ),
         mutually_exclusive=[['insertbefore', 'insertafter']],
         add_file_common_args=True,
@@ -552,6 +555,7 @@ def main():
 
     if module.lock:
         flock.unlock()
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -274,8 +274,10 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
         else:
             with open(b_dest, 'rb') as f:
                 b_lines = f.readlines()
-
-        msg, changed, b_modified_lines = _present_data_manipulator(b_lines, regexp, line, insertafter,
+        # Create a copy of the list to avoid modifying in _present_data_manipulator,
+        # resulting in an incorrect diff
+        b_lines_orig = b_lines[:]
+        msg, changed, b_modified_lines = _present_data_manipulator(b_lines_orig, regexp, line, insertafter,
                                                                    insertbefore, backrefs, firstmatch)
         if not os.path.exists(b_dest):
             diff['before'] = to_native(b('').join(b_lines))
@@ -286,8 +288,10 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
     else:
         with open_locked(b_dest) as f:
             b_lines = f.readlines()
-
-            msg, changed, b_modified_lines = _present_data_manipulator(b_lines, regexp, line, insertafter,
+            # Create a copy of the list to avoid modifying in _present_data_manipulator,
+            # resulting in an incorrect diff
+            b_lines_orig = b_lines[:]
+            msg, changed, b_modified_lines = _present_data_manipulator(b_lines_orig, regexp, line, insertafter,
                                                                        insertbefore, backrefs, firstmatch)
 
             if changed:

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -523,14 +523,14 @@ def main():
         if ins_bef is None and ins_aft is None:
             ins_aft = 'EOF'
 
-        with flock.lock_file(path, tempfile.gettempdir()):
+        with flock.lock_file(path):
             present(module, path, regexp, line,
                     ins_aft, ins_bef, create, backup, backrefs, firstmatch)
     else:
         if regexp is None and line is None:
             module.fail_json(msg='one of line or regexp is required with state=absent')
 
-        with flock.lock_file(path, tempfile.gettempdir()):
+        with flock.lock_file(path):
             absent(module, path, regexp, line, backup)
 
 

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -122,6 +122,9 @@ options:
   others:
      description:
        - All arguments accepted by the M(file) module also work here.
+extends_documentation_fragment:
+    - files
+    - validate
 notes:
   - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
 seealso:

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -204,7 +204,7 @@ import tempfile
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.file import FileLock
+from ansible.module_utils.common.file import open_locked
 from ansible.module_utils.six import b
 from ansible.module_utils._text import to_bytes, to_native
 
@@ -254,7 +254,6 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
     attr_diff = {}
     b_dest = to_bytes(dest, errors='surrogate_or_strict')
     backupdest = ''
-    flock = FileLock()
 
     if not os.path.exists(b_dest):
         if not create:
@@ -285,9 +284,8 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
 
         msg, changed = check_file_attrs(module, changed, msg, attr_diff)
     else:
-        with flock.lock_file(dest):
-            with open(b_dest, 'rb') as f:
-                b_lines = f.readlines()
+        with open_locked(b_dest) as f:
+            b_lines = f.readlines()
 
             msg, changed, b_modified_lines = _present_data_manipulator(b_lines, regexp, line, insertafter,
                                                                        insertbefore, backrefs, firstmatch)
@@ -438,7 +436,6 @@ def absent(module, dest, regexp, line, backup):
             'before_header': '{0} (content)'.format(dest),
             'after_header': '{0} (content)'.format(dest)}
     attr_diff = {}
-    flock = FileLock()
     b_dest = to_bytes(dest, errors='surrogate_or_strict')
     backupdest = ''
 
@@ -457,9 +454,8 @@ def absent(module, dest, regexp, line, backup):
         return msg, changed, found, backupdest, diff
 
     else:
-        with flock.lock_file(dest):
-            with open(b_dest, 'rb') as f:
-                b_lines = f.readlines()
+        with open_locked(b_dest) as f:
+            b_lines = f.readlines()
 
             msg, changed, b_modified_lines = _absent_data_manipulator(b_lines, regexp, line)
             if changed:

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -483,7 +483,7 @@ def main():
             create=dict(type='bool', default=False),
             backup=dict(type='bool', default=False),
             firstmatch=dict(default=False, type='bool'),
-            validate=dict(type='str')
+            validate=dict(type='str'),
         ),
         mutually_exclusive=[['insertbefore', 'insertafter']],
         add_file_common_args=True,

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -262,15 +262,15 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
 
     if module.check_mode:
         _present_data_manipulator(module, dest, regexp, line, insertafter, insertbefore,
-                                backup, backrefs, firstmatch)
+                                  backup, backrefs, firstmatch)
 
     with flock.lock_file(dest):
         _present_data_manipulator(module, dest, regexp, line, insertafter, insertbefore,
-                                backup, backrefs, firstmatch)
+                                  backup, backrefs, firstmatch)
 
 
 def _present_data_manipulator(module, dest, regexp, line, insertafter, insertbefore,
-                            backup, backrefs, firstmatch):
+                              backup, backrefs, firstmatch):
 
     diff = {'before': '',
             'after': '',

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -204,9 +204,9 @@ import tempfile
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.file import FileLock
 from ansible.module_utils.six import b
 from ansible.module_utils._text import to_bytes, to_native
-from ansible.module_utils.common.file import FileLock
 
 
 def write_changes(module, b_lines, dest):
@@ -523,14 +523,14 @@ def main():
         if ins_bef is None and ins_aft is None:
             ins_aft = 'EOF'
 
-        with flock.lock_file(path, module.tmpdir):
+        with flock.lock_file(path, tempfile.gettempdir()):
             present(module, path, regexp, line,
                     ins_aft, ins_bef, create, backup, backrefs, firstmatch)
     else:
         if regexp is None and line is None:
             module.fail_json(msg='one of line or regexp is required with state=absent')
 
-        with flock.lock_file(path, module.tmpdir):
+        with flock.lock_file(path, tempfile.gettempdir()):
             absent(module, path, regexp, line, backup)
 
 

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -267,9 +267,6 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
                 os.makedirs(b_destpath)
             except Exception as e:
                 module.fail_json(msg='Error creating {0} Error code: {1} Error description: {2}'.format(b_destpath, e[0], e[1]))
-        # destination must exist to be able to lock it
-        if not module.check_mode:
-            open(b_dest, 'ab').close()
 
     if module.check_mode:
         if create:

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -540,7 +540,7 @@ def main():
             ins_aft = 'EOF'
 
         if lock:
-            flock.set_lock(path, tempfile.gettempdir(), lock_timeout)
+            flock.set_lock(path, module.tmpdir, lock_timeout)
 
         present(module, path, regexp, line,
                 ins_aft, ins_bef, create, backup, backrefs, firstmatch)
@@ -549,7 +549,7 @@ def main():
             module.fail_json(msg='one of line or regexp is required with state=absent')
 
         if lock:
-            flock.set_lock(path, tempfile.gettempdir(), lock_timeout)
+            flock.set_lock(path, module.tmpdir, lock_timeout)
 
         absent(module, path, regexp, line, backup)
 

--- a/lib/ansible/modules/system/known_hosts.py
+++ b/lib/ansible/modules/system/known_hosts.py
@@ -84,7 +84,7 @@ import re
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.file import FileLock
+from ansible.module_utils.common.file import lock
 from ansible.module_utils._text import to_bytes, to_native
 
 

--- a/test/integration/targets/file_lock/aliases
+++ b/test/integration/targets/file_lock/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group2

--- a/test/integration/targets/file_lock/aliases
+++ b/test/integration/targets/file_lock/aliases
@@ -1,1 +1,3 @@
 shippable/posix/group2
+skip/freebsd
+skip/osx

--- a/test/integration/targets/file_lock/inventory
+++ b/test/integration/targets/file_lock/inventory
@@ -1,2 +1,2 @@
 [lockhosts]
-lockhost[0:20] ansible_connection=local
+lockhost[00:99] ansible_connection=local

--- a/test/integration/targets/file_lock/inventory
+++ b/test/integration/targets/file_lock/inventory
@@ -1,0 +1,2 @@
+[lockhosts]
+lockhost[0:20] ansible_connection=local

--- a/test/integration/targets/file_lock/inventory
+++ b/test/integration/targets/file_lock/inventory
@@ -1,2 +1,2 @@
 [lockhosts]
-lockhost[00:99] ansible_connection=local
+lockhost[00:99] ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/file_lock/runme.sh
+++ b/test/integration/targets/file_lock/runme.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ansible-playbook test_filelock.yml -i inventory --forks 10 -v "$@"
+ansible-playbook test_filelock_timeout.yml -i inventory -v "$@"

--- a/test/integration/targets/file_lock/runme.sh
+++ b/test/integration/targets/file_lock/runme.sh
@@ -2,5 +2,5 @@
 
 set -eux
 
-ansible-playbook test_filelock.yml -i inventory --forks 10 -v "$@"
+ansible-playbook test_filelock.yml -i inventory --forks 100 -v "$@"
 ansible-playbook test_filelock_timeout.yml -i inventory -v "$@"

--- a/test/integration/targets/file_lock/test_filelock.yml
+++ b/test/integration/targets/file_lock/test_filelock.yml
@@ -1,36 +1,45 @@
 ---
 - hosts: lockhosts
-  gather_facts: false
-  become: true
+  gather_facts: no
   vars:
-    testfile: ~/ansible_testing/lock.test
+    lockfile: ~/ansible_testing/lock.test
   tasks:
-  - name: write inventory_hostname to testfile
+  - name: Remove lockfile
+    file:
+      path: '{{ lockfile }}'
+      state: absent
+    run_once: yes
+
+  - name: Write inventory_hostname to lockfile concurrently
     lineinfile:
-      path: "{{ testfile }}"
-      line: "{{ inventory_hostname }}"
-      create: true
+      path: '{{ lockfile }}'
+      line: '{{ inventory_hostname }}'
+      create: yes
       state: present
-    async: 60
-    poll: 0
-    register: write_waiter
 
-  - name: wait for write jobs to finish
-    async_status:
-      jid: "{{ write_waiter.ansible_job_id }}"
-    register: write_job_result
-    until: write_job_result.finished
-    retries: 60
+  - debug:
+      msg: File {{ lockfile }} has {{ lines|length }} lines for {{ ansible_play_batch|length }} instances
+    vars:
+      lines: "{{ lookup('file', lockfile).split('\n') }}"
+    run_once: yes
 
-  - name: check testfile for inventory_hostname entries
+  - name: Assert we get the expected number of lines
+    assert:
+      that:
+      - lines|length == ansible_play_batch|length
+    vars:
+      lines: "{{ lookup('file', lockfile).split('\n') }}"
+    run_once: yes
+
+  - name: Check lockfile for inventory_hostname entries
     lineinfile:
-      path: "{{ testfile }}"
-      line: "{{ inventory_hostname }}"
+      path: '{{ lockfile }}'
+      line: '{{ inventory_hostname }}'
       state: present
     register: check_lockfile
 
-  - name: assert locking results
+  - name: Assert locking results
     assert:
       that:
-        - check_lockfile is not changed
-        - check_lockfile is not failed
+      - check_lockfile is not changed
+      - check_lockfile is not failed

--- a/test/integration/targets/file_lock/test_filelock.yml
+++ b/test/integration/targets/file_lock/test_filelock.yml
@@ -1,0 +1,36 @@
+---
+- hosts: lockhosts
+  gather_facts: false
+  become: true
+  vars:
+    testfile: ~/ansible_testing/lock.test
+  tasks:
+  - name: write inventory_hostname to testfile
+    lineinfile:
+      path: "{{ testfile }}"
+      line: "{{ inventory_hostname }}"
+      create: true
+      state: present
+    async: 60
+    poll: 0
+    register: write_waiter
+
+  - name: wait for write jobs to finish
+    async_status:
+      jid: "{{ write_waiter.ansible_job_id }}"
+    register: write_job_result
+    until: write_job_result.finished
+    retries: 60
+
+  - name: check testfile for inventory_hostname entries
+    lineinfile:
+      path: "{{ testfile }}"
+      line: "{{ inventory_hostname }}"
+      state: present
+    register: check_lockfile
+
+  - name: assert locking results
+    assert:
+      that:
+        - check_lockfile is not changed
+        - check_lockfile is not failed

--- a/test/integration/targets/file_lock/test_filelock_timeout.yml
+++ b/test/integration/targets/file_lock/test_filelock_timeout.yml
@@ -17,7 +17,7 @@
       state: present
       create: yes
 
-  - name: Lock lockfile with lockf and sleep 20s
+  - name: Lock lockfile and sleep 20s
     command: python
     args:
       stdin: |

--- a/test/integration/targets/file_lock/test_filelock_timeout.yml
+++ b/test/integration/targets/file_lock/test_filelock_timeout.yml
@@ -1,0 +1,51 @@
+---
+- hosts: lockhost0
+  vars:
+    testfile: ~/ansible_testing/locked.file
+  gather_facts: false
+  tasks:
+  - name: create /tmp/locked.file
+    lineinfile:
+      line: "{{ inventory_hostname }}"
+      path: "{{ testfile }}"
+      state: present
+      create: true
+
+  - name: lock testfile with flock and sleep 20s
+    command: flock -x {{ testfile }} -c "sleep 20"
+    async: 60
+    poll: 0
+    register: flock_waiter
+
+  - name: remove inventory_hostname line from testfile
+    lineinfile:
+      path: "{{ testfile }}"
+      line: "{{ inventory_hostname }}"
+      state: absent
+    ignore_errors: true
+    register: rm_line
+
+  - name: assert that removal of inventory_hostname from testfile failed
+    assert:
+      that:
+        - rm_line is failed
+
+  - name: wait for flock job to finish
+    async_status:
+      jid: "{{ flock_waiter.ansible_job_id }}"
+    register: job_result
+    until: job_result.finished
+    retries: 30
+
+  - name: inventory_hostname in testfile
+    lineinfile:
+      path: "{{ testfile }}"
+      line: "{{ inventory_hostname }}"
+      state: present
+    register: check_line
+
+  - name: assert that testfile is unchanged
+    assert:
+      that:
+        - check_line is not changed
+        - check_line is not failed

--- a/test/integration/targets/file_lock/test_filelock_timeout.yml
+++ b/test/integration/targets/file_lock/test_filelock_timeout.yml
@@ -1,50 +1,62 @@
 ---
-- hosts: lockhost0
+- hosts: lockhost00
   vars:
-    testfile: ~/ansible_testing/locked.file
-  gather_facts: false
+    lockfile: ~/ansible_testing/lock_timeout.test
+  gather_facts: no
   tasks:
-  - name: create /tmp/locked.file
-    lineinfile:
-      line: "{{ inventory_hostname }}"
-      path: "{{ testfile }}"
-      state: present
-      create: true
+  - name: Remove lockfile
+    file:
+      path: '{{ lockfile }}'
+      state: absent
+    run_once: yes
 
-  - name: lock testfile with flock and sleep 20s
-    command: flock -x {{ testfile }} -c "sleep 20"
+  - name: Create lockfile
+    lineinfile:
+      line: '{{ inventory_hostname }}'
+      path: '{{ lockfile }}'
+      state: present
+      create: yes
+
+  - name: Lock lockfile with lockf and sleep 20s
+    command: python
+    args:
+      stdin: |
+        import time
+        from ansible.module_utils.common.file import open_locked
+        with open_locked('{{ lockfile | expanduser }}') as fd:
+            time.sleep(20)
     async: 60
     poll: 0
     register: flock_waiter
 
-  - name: remove inventory_hostname line from testfile
+  - name: Remove inventory_hostname line from lockfile
     lineinfile:
-      path: "{{ testfile }}"
-      line: "{{ inventory_hostname }}"
+      path: '{{ lockfile }}'
+      line: '{{ inventory_hostname }}'
       state: absent
-    ignore_errors: true
+    ignore_errors: yes
     register: rm_line
 
-  - name: assert that removal of inventory_hostname from testfile failed
+  - name: Assert that removal of inventory_hostname from lockfile failed
     assert:
       that:
         - rm_line is failed
 
-  - name: wait for flock job to finish
+  - name: Wait for flock job to finish
     async_status:
-      jid: "{{ flock_waiter.ansible_job_id }}"
+      jid: '{{ flock_waiter.ansible_job_id }}'
     register: job_result
     until: job_result.finished
     retries: 30
 
-  - name: inventory_hostname in testfile
+  - name: Inventory_hostname in lockfile
     lineinfile:
-      path: "{{ testfile }}"
-      line: "{{ inventory_hostname }}"
+      path: '{{ lockfile }}'
+      line: '{{ inventory_hostname }}'
       state: present
     register: check_line
 
-  - name: assert that testfile is unchanged
+  - name: Assert that lockfile is unchanged
     assert:
       that:
         - check_line is not changed

--- a/test/integration/targets/lineinfile/tasks/main.yml
+++ b/test/integration/targets/lineinfile/tasks/main.yml
@@ -53,6 +53,7 @@
       - result2 is not changed
       - result1.msg == 'line added'
       - result1.backup != ''
+      - result1.diff[0].before != result2.diff[0].after
 
 - name: stat the backup file
   stat:

--- a/test/integration/targets/lineinfile/tasks/main.yml
+++ b/test/integration/targets/lineinfile/tasks/main.yml
@@ -818,3 +818,31 @@
       The regular expression is an empty string, which will match every line in the file.
       This may have unintended consequences, such as replacing the last line in the file rather than appending.
       If this is desired, use '^' to match every line in the file and avoid this warning.
+
+- name: deploy the test file for lineinfile
+  copy:
+    src: test.txt
+    dest: "{{ output_dir }}/test.txt"
+  register: result
+
+- name: assert that the test file was deployed
+  assert:
+    that:
+      - result is changed
+      - "result.checksum == '5feac65e442c91f557fc90069ce6efc4d346ab51'"
+      - "result.state == 'file'"
+
+- name: insert a line at the beginning of the file, using file lock
+  lineinfile:
+    dest: "{{ output_dir }}/test.txt"
+    state: present
+    line: "New line at the beginning"
+    insertbefore: "BOF"
+    lock: yes
+  register: result1
+
+- name: assert that the line was inserted at the head of the file
+  assert:
+    that:
+      - result1 is changed
+      - result1.msg == 'line added'

--- a/test/integration/targets/lineinfile/tasks/main.yml
+++ b/test/integration/targets/lineinfile/tasks/main.yml
@@ -818,31 +818,3 @@
       The regular expression is an empty string, which will match every line in the file.
       This may have unintended consequences, such as replacing the last line in the file rather than appending.
       If this is desired, use '^' to match every line in the file and avoid this warning.
-
-- name: deploy the test file for lineinfile
-  copy:
-    src: test.txt
-    dest: "{{ output_dir }}/test.txt"
-  register: result
-
-- name: assert that the test file was deployed
-  assert:
-    that:
-      - result is changed
-      - "result.checksum == '5feac65e442c91f557fc90069ce6efc4d346ab51'"
-      - "result.state == 'file'"
-
-- name: insert a line at the beginning of the file, using file lock
-  lineinfile:
-    dest: "{{ output_dir }}/test.txt"
-    state: present
-    line: "New line at the beginning"
-    insertbefore: "BOF"
-    lock: yes
-  register: result1
-
-- name: assert that the line was inserted at the head of the file
-  assert:
-    that:
-      - result1 is changed
-      - result1.msg == 'line added'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added support for file locking through common.file.FileLock (fixes #30413). Also fixed issue where FileLock.set_lock in module_utils/common/file.py didn't properly handle the default value None
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lineinfile
module_utils/common/file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (fix-30413 2455b96cc1) last updated 2018/10/19 00:04:07 (GMT +200)
  config file = None
  configured module search path = ['/home/acalm/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/acalm/venv/ansible/lib/python3.6/site-packages/ansible
  executable location = /home/acalm/venv/ansible/bin/ansible
  python version = 3.6.5 (default, Apr 20 2018, 08:08:06) [GCC 6.4.0]
```

##### ADDITIONAL INFORMATION
N/A
