### PR TITLE
win httptester: add wait for endpoint in case it is still coming up 2.7 (#47326)

### DIFF
--- a/test/integration/targets/prepare_http_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_http_tests/tasks/main.yml
@@ -13,6 +13,17 @@
     # Override hostname defaults with httptester linked names
     - include_vars: httptester.yml
 
+    # Server 2008 R2 uses a 3rd party program to foward the ports and it may
+    # not be ready straight away, we give it at least 5 minutes before
+    # conceding defeat
+    - name: make sure the port forwarder is active - Windows
+      win_wait_for:
+        host: ansible.http.tests
+        port: 80
+        state: started
+        timeout: 300
+      when: ansible_os_family == 'Windows'
+
     - name: RedHat - Enable the dynamic CA configuration feature
       command: update-ca-trust force-enable
       when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
(cherry picked from commit c0546b41331c6928e0d118be2711a382b6a9fefd)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/47326

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```paste below
2.7
```