### PR TITLE
ansible-test: add retry for Windows httptester download

### DIFF
--- a/test/integration/targets/prepare_http_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_http_tests/tasks/main.yml
@@ -36,6 +36,10 @@
       win_get_url:
         url: http://ansible.http.tests/{{ item }}
         dest: '{{ win_output_dir }}\{{ item }}'
+      register: win_download
+      # Server 2008 R2 is slightly slower, we attempt 5 retries
+      retries: 5
+      until: win_download is successful
       when: ansible_os_family == 'Windows'
       with_items:
         - client.pem


### PR DESCRIPTION
##### SUMMARY
In a continuation of https://github.com/ansible/ansible/pull/47326, this is an attempt to stabilize Server 2008 R2 with httptester.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```paste below
devel
```