### PR TITLE
ansible-test: add retry for Windows httptester download 2.7 (#47334)

### DIFF
--- a/test/integration/targets/prepare_http_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_http_tests/tasks/main.yml
@@ -47,6 +47,10 @@
       win_get_url:
         url: http://ansible.http.tests/{{ item }}
         dest: '{{ win_output_dir }}\{{ item }}'
+      register: win_download
+      # Server 2008 R2 is slightly slower, we attempt 5 retries
+      retries: 5
+      until: win_download is successful
       when: ansible_os_family == 'Windows'
       with_items:
         - client.pem


### PR DESCRIPTION
(cherry picked from commit e6a327fb8201124e3875325b28e7e7f698a9f5c1)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/47334

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```paste below
2.7
```