### PR TITLE
Update netconf jumphost documentation

### DIFF
--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -452,8 +452,7 @@ Suggestions to resolve:
         provider: "{{ cli }}"
         timeout: 30
 
-For network_cli, 
-connection type (applicable from 2.7 onwards):
+For network_cli, netconf connection type (applicable from 2.7 onwards):
 
 .. FIXME: Detail error here
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -618,7 +618,6 @@ Enabling jump host setting
 
 
 Bastion/jump host with netconf connection can be enabled by:
-
  - Setting Ansible variable ``ansible_netconf_ssh_config`` either to ``True`` or custom ssh config file path
  - Setting environment variable ``ANSIBLE_NETCONF_SSH_CONFIG`` to ``True`` or custom ssh config file path
  - Setting ``ssh_config = 1`` or ``ssh_config = <ssh-file-path>`` under ``netconf_connection`` section

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -634,7 +634,11 @@ Example ssh config file (~/.ssh/config)
    HostName junos01
    User myuser
 
-   ProxyCommand ssh user@bastion01 nc %h %p %r
+   # Where host is listening for NETCONF on port 22
+   ProxyCommand ssh user@bastion01 nc %h %p
+   # Where host is listening for NETCONF on port 830
+   ProxyCommand ssh user@bastion01 nc %h 830
+
 
 Example Ansible inventory file
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -630,14 +630,19 @@ Example ssh config file (~/.ssh/config)
 
 .. code-block:: ini
 
-   Host junos01
-   HostName junos01
-   User myuser
+  Host jumphost
+    HostName jumphost.domain.name.com
+    User jumphost-user
+    IdentityFile "/path/to/ssh-key.pem"
+    Port 22
 
-   # Where host is listening for NETCONF on port 22
-   ProxyCommand ssh user@bastion01 nc %h %p
-   # Where host is listening for NETCONF on port 830
-   ProxyCommand ssh user@bastion01 nc %h 830
+  Host netconf-host
+    HostName netconf.host.domain.name.com
+    ProxyCommand ssh -W %h:%p jumphost
+
+  # Note: Due to the way that Paramiko reads the SSH Config file, if your NETCONF host uses port 830, you need to use the following instead.
+
+    ProxyCommand ssh -W %h:830 jumphost
 
 
 Example Ansible inventory file

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -452,7 +452,8 @@ Suggestions to resolve:
         provider: "{{ cli }}"
         timeout: 30
 
-For network_cli, netconf connection type (applicable from 2.7 onwards):
+For network_cli, 
+connection type (applicable from 2.7 onwards):
 
 .. FIXME: Detail error here
 
@@ -615,13 +616,16 @@ Using bastion/jump host with netconf connection
 Enabling jump host setting
 --------------------------
 
-Bastion/jump host with netconf connection can be enable using
-- Setting Ansible variable``ansible_netconf_ssh_config`` either to ``True`` or custom ssh config file path
-- Setting environment variable ``ANSIBLE_NETCONF_SSH_CONFIG`` to ``True`` or custom ssh config file path
-- Setting ``ssh_config = 1`` or ``ssh_config = <ssh-file-path>``under ``netconf_connection`` section
+
+Bastion/jump host with netconf connection can be enabled by:
+
+ - Setting Ansible variable ``ansible_netconf_ssh_config`` either to ``True`` or custom ssh config file path
+ - Setting environment variable ``ANSIBLE_NETCONF_SSH_CONFIG`` to ``True`` or custom ssh config file path
+ - Setting ``ssh_config = 1`` or ``ssh_config = <ssh-file-path>`` under ``netconf_connection`` section
 
 If the configuration variable is set to 1 the proxycommand and other ssh variables are read from
 default ssh config file (~/.ssh/config).
+
 If the configuration variable is set to file path the proxycommand and other ssh variables are read
 from the given custom ssh file path
 
@@ -636,14 +640,22 @@ Example ssh config file (~/.ssh/config)
     IdentityFile "/path/to/ssh-key.pem"
     Port 22
 
-  Host netconf-host
-    HostName netconf.host.domain.name.com
-    ProxyCommand ssh -W %h:%p jumphost
-
-  # Note: Due to the way that Paramiko reads the SSH Config file, if your NETCONF host uses port 830, you need to use the following instead.
-
+  # Note: Due to the way that Paramiko reads the SSH Config file, 
+  # you need to specify the NETCONF port that the host uses.
+  # i.e. It does not automatically use ansible_port
+  # As a result you need either:
+  
+  Host junos01
+    HostName junos01
+    ProxyCommand ssh -W %h:22 jumphost
+    
+  # OR
+  
+  Host junos01
+    HostName junos01
     ProxyCommand ssh -W %h:830 jumphost
-
+    
+  # Depending on the netconf port used.
 
 Example Ansible inventory file
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update documentation on how to use a jump host with the netconf connection type. 
This removes the requirement to have netcat installed on the jump host and caters for where the netconf host uses port 830 (instead of 22)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
network_debug_troubleshooting.rstnetwork_debug_troubleshooting.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.2
  config file = /home/markfarrell/Projects/epg-model-inventory/ansible.cfg
  configured module search path = [u'/home/markfarrell/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

ProxyCommand based on https://en.wikibooks.org/wiki/OpenSSH/Cookbook/Proxies_and_Jump_Hosts#Passing_Through_a_Gateway_Using_stdio_Forwarding_(Netcat_Mode)

When Paramiko loads the SSH config file it uses port 22 as the default port to replace %p (and not the port passed to ncclient manager when connecting.

As a result we have to specify the port that netconf uses rather than using %p (unless ncclient is fixed)
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
