### PR TITLE
Integration tests: use {{ ansible_python.executable }} instead of python

### DIFF
--- a/test/integration/targets/certificate_complete_chain/tasks/main.yml
+++ b/test/integration/targets/certificate_complete_chain/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: register cryptography version
-  command: python -c 'import cryptography; print(cryptography.__version__)'
+  command: "{{ ansible_python.executable }} -c 'import cryptography; print(cryptography.__version__)'"
   register: cryptography_version
 
 - block:

--- a/test/integration/targets/lookup_hashi_vault/playbooks/test_lookup_hashi_vault.yml
+++ b/test/integration/targets/lookup_hashi_vault/playbooks/test_lookup_hashi_vault.yml
@@ -1,7 +1,7 @@
 - hosts: testhost
   tasks:
     - name: register pyOpenSSL version
-      command: python -c 'import OpenSSL; print(OpenSSL.__version__)'
+      command: "{{ ansible_python.executable }} -c 'import OpenSSL; print(OpenSSL.__version__)'"
       register: pyopenssl_version
 
     - name: Test lookup hashi_vault

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -256,11 +256,11 @@
     extra_args: --user --upgrade --root {{ output_dir }}/pip_root
 
 - name: register python_site_lib
-  command: 'python -c "import site; print(site.USER_SITE)"'
+  command: '{{ ansible_python.executable }} -c "import site; print(site.USER_SITE)"'
   register: pip_python_site_lib
 
 - name: register python_user_base
-  command: 'python -c "import site; print(site.USER_BASE)"'
+  command: '{{ ansible_python.executable }} -c "import site; print(site.USER_BASE)"'
   register: pip_python_user_base
 
 - name: run test module

--- a/test/integration/targets/setup_acme/tasks/main.yml
+++ b/test/integration/targets/setup_acme/tasks/main.yml
@@ -4,7 +4,7 @@
   register: openssl_version
 
 - name: register cryptography version
-  command: python -c 'import cryptography; print(cryptography.__version__)'
+  command: "{{ ansible_python.executable }} -c 'import cryptography; print(cryptography.__version__)'"
   register: cryptography_version
 
 - debug: msg="ACME test container IP is {{ acme_host }}; OpenSSL version is {{ openssl_version.stdout }}; cryptography version is {{ cryptography_version.stdout }}"

--- a/test/integration/targets/setup_openssl/tasks/main.yml
+++ b/test/integration/targets/setup_openssl/tasks/main.yml
@@ -21,7 +21,7 @@
   when:  ansible_os_family == 'Darwin'
 
 - name: register pyOpenSSL version
-  command: python -c 'import OpenSSL; print(OpenSSL.__version__)'
+  command: "{{ ansible_python.executable }} -c 'import OpenSSL; print(OpenSSL.__version__)'"
   register: pyopenssl_version
 
 - name: register openssl version
@@ -29,5 +29,5 @@
   register: openssl_version
 
 - name: register cryptography version
-  command: python -c 'import cryptography; print(cryptography.__version__)'
+  command: "{{ ansible_python.executable }} -c 'import cryptography; print(cryptography.__version__)'"
   register: cryptography_version

--- a/test/integration/targets/sts_assume_role/tasks/main.yml
+++ b/test/integration/targets/sts_assume_role/tasks/main.yml
@@ -16,7 +16,7 @@
           print(response['Account'])
 
     - name: get the aws account id
-      command: python "{{ output_dir }}/sts.py"
+      command: "{{ ansible_python.executable }} '{{ output_dir }}/sts.py'"
       environment:
         AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
         AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"


### PR DESCRIPTION
##### SUMMARY
@mattclay wrote [here](https://github.com/ansible/ansible/pull/38792#issuecomment-431080938) that role-based integration tests should not directly use `command: python ...`, but use `{{ ansible_python.executable }}` instead to determine the correct Python interpreter.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
certificate_complete_chain
hashi_vault
pip
sts_assume_role
test/integration/targets/setup_acme/tasks/main.yml
test/integration/targets/setup_openssl/tasks/main.yml

##### ANSIBLE VERSION
```
2.8.0
```
