### PR TITLE
allow 'ignore_missing' for fileglob lookups

### DIFF
--- a/changelogs/fragments/47344-ignore_missing_fileglob.yml
+++ b/changelogs/fragments/47344-ignore_missing_fileglob.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - fileglob - add 'ignore_missing' to suppress 'Unable to find...' warnings

--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -15,6 +15,11 @@ DOCUMENTATION = """
       _terms:
         description: path(s) of files to read
         required: True
+      ignore_missing:
+        description: Flag to control whether or not no matches found return a warning
+        type: boolean
+        default: False
+        version_added: "2.14"
     notes:
       - Patterns are only supported on files, not directory/paths.
       - See R(Ansible task paths,playbook_task_paths) to understand how file lookup occurs with paths.
@@ -59,12 +64,14 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
 
+        self.set_options(direct=kwargs)
+
         ret = []
         for term in terms:
             term_file = os.path.basename(term)
             found_paths = []
             if term_file != term:
-                found_paths.append(self.find_file_in_search_path(variables, 'files', os.path.dirname(term)))
+                found_paths.append(self.find_file_in_search_path(variables, 'files', os.path.dirname(term), ignore_missing=self.get_option('ignore_missing')))
             else:
                 # no dir, just file, so use paths and 'files' paths instead
                 if 'ansible_search_path' in variables:

--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -19,7 +19,7 @@ DOCUMENTATION = """
         description: Flag to control whether or not no matches found return a warning
         type: boolean
         default: False
-        version_added: "2.14"
+        version_added: "2.18"
     notes:
       - Patterns are only supported on files, not directory/paths.
       - See R(Ansible task paths,playbook_task_paths) to understand how file lookup occurs with paths.

--- a/test/integration/targets/lookup_fileglob/non_existent/play.yml
+++ b/test/integration/targets/lookup_fileglob/non_existent/play.yml
@@ -4,3 +4,22 @@
     - name: fileglob should be empty
       assert:
         that: q("fileglob", seed) | length == 0
+
+    - name: Test ignore_missing
+      vars:
+        query_with_warnings: "query('fileglob', 'missing/file')"
+        query_without_warnings: "query('fileglob', 'missing/file', ignore_missing=true)"
+        warning: "Unable to find 'missing' in expected paths"
+      block:
+        - name: Test a warning is given for a missing path
+          command: ansible localhost -m debug -a msg="{{ '{{' + query_with_warnings + '}}' }}"
+          register: warn_for_missing
+
+        - name: Test ignoring the warning
+          command: ansible localhost -m debug -a msg="{{ '{{' + query_without_warnings + '}}' }}"
+          register: ignore_missing
+
+        - assert:
+            that:
+              - warning in warn_for_missing.stderr
+              - warning not in ignore_missing.stderr


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There are situations where it's useful to hide the `Unable to find ... in expected paths (use -vvvvv to see paths)` message. This PR adds the ability to pass `ignore_missing` to the `fileglob` plugin. See below for example.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`fileglob`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (fileglob-ignore_missing e0389d0aab) last updated 2018/10/19 10:44:40 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/phil/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/phil/projects/3rdparty/ansible/lib/ansible
  executable location = /home/phil/projects/3rdparty/ansible/bin/ansible
  python version = 2.7.15 (default, Sep 21 2018, 23:26:48) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
echo -e "foo\nbar\nbaz" > inventory
for f in foo baz; do install -D /dev/null files/${f}/iptables; done
cat > test.yml <<EOF
---
- hosts: all
  gather_facts: no
  tasks:
    - name: "without ignore_missing"
      debug: var=item
      loop: '{{lookup("fileglob",
        "files/"+inventory_hostname+"/iptables",
        wantlist=true)}}'
    - name: "with ignore_missing"
      debug: var=item
      loop: '{{lookup("fileglob",
        "files/"+inventory_hostname+"/iptables",
        wantlist=true, ignore_missing=true)}}'
...
EOF
ansible-playbook -i inventory test.yml 
```
output:
```
PLAY [all] ********************************************************************************

TASK [without ignore_missing] *************************************************************
 [WARNING]: Unable to find 'files/bar' in expected paths (use -vvvvv to see paths)

ok: [foo] => (item=/home/phil/projects/3rdparty/ansible/tmp/files/foo/iptables) => {
    "item": "/home/phil/projects/3rdparty/ansible/tmp/files/foo/iptables"
}
ok: [baz] => (item=/home/phil/projects/3rdparty/ansible/tmp/files/baz/iptables) => {
    "item": "/home/phil/projects/3rdparty/ansible/tmp/files/baz/iptables"
}

TASK [with ignore_missing] ****************************************************************
ok: [foo] => (item=/home/phil/projects/3rdparty/ansible/tmp/files/foo/iptables) => {
    "item": "/home/phil/projects/3rdparty/ansible/tmp/files/foo/iptables"
}
ok: [baz] => (item=/home/phil/projects/3rdparty/ansible/tmp/files/baz/iptables) => {
    "item": "/home/phil/projects/3rdparty/ansible/tmp/files/baz/iptables"
}

PLAY RECAP ********************************************************************************
bar                        : ok=0    changed=0    unreachable=0    failed=0    skipped=2   
baz                        : ok=2    changed=0    unreachable=0    failed=0    skipped=0
foo                        : ok=2    changed=0    unreachable=0    failed=0    skipped=0
```