### PR TITLE
enhance recv calls in network_cli

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -378,7 +378,7 @@ class Connection(NetworkConnectionBase):
         self._validate_timeout_value(buffer_read_timeout, "persistent_buffer_read_timeout")
 
         while True:
-            if self._ssh_shell.recv_ready() is False:
+            if not self._ssh_shell.recv_ready():
                 time.sleep(0.001)
                 continue
             if command_prompt_matched:

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -360,6 +360,15 @@ class Connection(NetworkConnectionBase):
                 display.debug("ssh connection has been closed successfully")
         super(Connection, self).close()
 
+    def receive_ssh_data(self, count, timeout):
+        if timeout:
+            start = time.time()
+            while not self._ssh_shell.recv_ready():
+                if time.time() - start >= timeout:
+                    raise AnsibleConnectionFailure("timeout waiting ssh data")
+                time.sleep(0.001)
+        return self._ssh_shell.recv(count)
+
     def receive(self, command=None, prompts=None, answer=None, newline=True, prompt_retry_check=False, check_all=False):
         '''
         Handles receiving of output from command
@@ -377,16 +386,14 @@ class Connection(NetworkConnectionBase):
         buffer_read_timeout = self.get_option('persistent_buffer_read_timeout')
         self._validate_timeout_value(buffer_read_timeout, "persistent_buffer_read_timeout")
 
-        while True:
-            if not self._ssh_shell.recv_ready():
-                time.sleep(0.001)
-                continue
+        receive_data_timeout = self._ssh_shell.gettimeout()
 
+        while True:
             if command_prompt_matched:
                 try:
                     signal.signal(signal.SIGALRM, self._handle_buffer_read_timeout)
                     signal.setitimer(signal.ITIMER_REAL, buffer_read_timeout)
-                    data = self._ssh_shell.recv(256)
+                    data = self.receive_ssh_data(256, receive_data_timeout)
                     signal.alarm(0)
                     # if data is still received on channel it indicates the prompt string
                     # is wrongly matched in between response chunks, continue to read
@@ -400,7 +407,7 @@ class Connection(NetworkConnectionBase):
                 except AnsibleCmdRespRecv:
                     return self._command_response
             else:
-                data = self._ssh_shell.recv(256)
+                data = self.receive_ssh_data(256, receive_data_timeout)
 
             # when a channel stream is closed, received data will be empty
             if not data:

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -360,16 +360,6 @@ class Connection(NetworkConnectionBase):
                 display.debug("ssh connection has been closed successfully")
         super(Connection, self).close()
 
-    def receive_ssh_data(self, count, timeout):
-        # a None timeout is a blocking call
-        if timeout is None or timeout > 0:
-            start = time.time()
-            while not self._ssh_shell.recv_ready():
-                if timeout is not None and time.time() - start >= timeout:
-                    raise AnsibleConnectionFailure("timeout waiting ouput from command")
-                time.sleep(0.001)
-        return self._ssh_shell.recv(count)
-
     def receive(self, command=None, prompts=None, answer=None, newline=True, prompt_retry_check=False, check_all=False):
         '''
         Handles receiving of output from command
@@ -387,14 +377,16 @@ class Connection(NetworkConnectionBase):
         buffer_read_timeout = self.get_option('persistent_buffer_read_timeout')
         self._validate_timeout_value(buffer_read_timeout, "persistent_buffer_read_timeout")
 
-        receive_data_timeout = self._ssh_shell.gettimeout()
-
         while True:
+            if not self._ssh_shell.recv_ready():
+                time.sleep(0.001)
+                continue
+
             if command_prompt_matched:
                 try:
                     signal.signal(signal.SIGALRM, self._handle_buffer_read_timeout)
                     signal.setitimer(signal.ITIMER_REAL, buffer_read_timeout)
-                    data = self.receive_ssh_data(256, receive_data_timeout)
+                    data = self._ssh_shell.recv(256)
                     signal.alarm(0)
                     # if data is still received on channel it indicates the prompt string
                     # is wrongly matched in between response chunks, continue to read
@@ -408,7 +400,7 @@ class Connection(NetworkConnectionBase):
                 except AnsibleCmdRespRecv:
                     return self._command_response
             else:
-                data = self.receive_ssh_data(256, receive_data_timeout)
+                data = self._ssh_shell.recv(256)
 
             # when a channel stream is closed, received data will be empty
             if not data:

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -360,6 +360,16 @@ class Connection(NetworkConnectionBase):
                 display.debug("ssh connection has been closed successfully")
         super(Connection, self).close()
 
+    def receive_ssh_data(self, count, timeout):
+        # a None timeout is a blocking call
+        if timeout is None or timeout > 0:
+            start = time.time()
+            while not self._ssh_shell.recv_ready():
+                if timeout is not None and time.time() - start >= timeout:
+                    raise AnsibleConnectionFailure("timeout waiting ouput from command")
+                time.sleep(0.001)
+        return self._ssh_shell.recv(count)
+
     def receive(self, command=None, prompts=None, answer=None, newline=True, prompt_retry_check=False, check_all=False):
         '''
         Handles receiving of output from command
@@ -377,15 +387,14 @@ class Connection(NetworkConnectionBase):
         buffer_read_timeout = self.get_option('persistent_buffer_read_timeout')
         self._validate_timeout_value(buffer_read_timeout, "persistent_buffer_read_timeout")
 
+        receive_data_timeout = self._ssh_shell.gettimeout()
+
         while True:
-            if not self._ssh_shell.recv_ready():
-                time.sleep(0.001)
-                continue
             if command_prompt_matched:
                 try:
                     signal.signal(signal.SIGALRM, self._handle_buffer_read_timeout)
                     signal.setitimer(signal.ITIMER_REAL, buffer_read_timeout)
-                    data = self._ssh_shell.recv(256)
+                    data = self.receive_ssh_data(256, receive_data_timeout)
                     signal.alarm(0)
                     # if data is still received on channel it indicates the prompt string
                     # is wrongly matched in between response chunks, continue to read
@@ -399,7 +408,7 @@ class Connection(NetworkConnectionBase):
                 except AnsibleCmdRespRecv:
                     return self._command_response
             else:
-                data = self._ssh_shell.recv(256)
+                data = self.receive_ssh_data(256, receive_data_timeout)
 
             # when a channel stream is closed, received data will be empty
             if not data:

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -361,11 +361,13 @@ class Connection(NetworkConnectionBase):
         super(Connection, self).close()
 
     def receive_ssh_data(self, count, timeout):
-        start = time.time()
-        while timeout and self._ssh_shell.recv_ready() is False:
-            if time.time() - start >= timeout:
-                raise AnsibleConnectionFailure("timeout waiting ouput from command")
-            time.sleep(0.001)
+        # a None timeout is a blocking call
+        if timeout is None or timeout > 0:
+            start = time.time()
+            while self._ssh_shell.recv_ready() is False:
+                if timeout is not None and time.time() - start >= timeout:
+                    raise AnsibleConnectionFailure("timeout waiting ouput from command")
+                time.sleep(0.001)
         return self._ssh_shell.recv(count)
 
     def receive(self, command=None, prompts=None, answer=None, newline=True, prompt_retry_check=False, check_all=False):

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -392,7 +392,7 @@ class Connection(NetworkConnectionBase):
                 try:
                     signal.signal(signal.SIGALRM, self._handle_buffer_read_timeout)
                     signal.setitimer(signal.ITIMER_REAL, buffer_read_timeout)
-                    data = receive_ssh_data(256, receive_data_timeout)
+                    data = self.receive_ssh_data(256, receive_data_timeout)
                     signal.alarm(0)
                     # if data is still received on channel it indicates the prompt string
                     # is wrongly matched in between response chunks, continue to read
@@ -406,7 +406,7 @@ class Connection(NetworkConnectionBase):
                 except AnsibleCmdRespRecv:
                     return self._command_response
             else:
-                data = receive_ssh_data(256, receive_data_timeout)
+                data = self.receive_ssh_data(256, receive_data_timeout)
 
             # when a channel stream is closed, received data will be empty
             if not data:

--- a/test/units/plugins/connection/test_network_cli.py
+++ b/test/units/plugins/connection/test_network_cli.py
@@ -126,7 +126,6 @@ class TestConnectionClass(unittest.TestCase):
 
         mock__shell = MagicMock()
         conn._ssh_shell = mock__shell
-        conn._ssh_shell.gettimeout.return_value = 10
         conn._ssh_shell.recv_ready.return_value = True
 
         response = b"""device#command

--- a/test/units/plugins/connection/test_network_cli.py
+++ b/test/units/plugins/connection/test_network_cli.py
@@ -127,6 +127,7 @@ class TestConnectionClass(unittest.TestCase):
         mock__shell = MagicMock()
         conn._ssh_shell = mock__shell
         conn._ssh_shell.recv_ready.return_value = True
+        conn._ssh_shell.gettimeout.return_value = 10
 
         response = b"""device#command
         command response

--- a/test/units/plugins/connection/test_network_cli.py
+++ b/test/units/plugins/connection/test_network_cli.py
@@ -126,6 +126,8 @@ class TestConnectionClass(unittest.TestCase):
 
         mock__shell = MagicMock()
         conn._ssh_shell = mock__shell
+        conn._ssh_shell.gettimeout.return_value = 10
+        conn._ssh_shell.recv_ready.return_value = True
 
         response = b"""device#command
         command response


### PR DESCRIPTION
##### SUMMARY
There is a potential ~25ms unneeded average overhead for each call to paramiko's Channel.recv.
Internally, paramiko's recv uses a wait call to be signaled that data is available.
wait calls sleep in a loop with a value that starts at 1ms and doubles to a max of 50ms each time. wait loops until timeout is reached or signal received.
Looping on Channel.recv_ready before calling recv in network_cli should allow to remove that ~25ms unneeded average overhead, because recv_ready just locks the buffer and checks if there is data in it.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
network_cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0
```

##### ADDITIONAL INFORMATION
I have used the following code to benchmark. It's a kind of ssh ping (meaning it just sends empty commands):
```
def main():
    """ main entry point for module execution
    """
    element_spec = dict(
        cmd_run=dict(type='int', default=1),
        cmd_count=dict(type='int', default=100)
    )

    module = AnsibleModule(argument_spec=element_spec)
    result = {'changed': False}

    commands=[]
    for i in range(0, module.params['cmd_count']):
        commands.append(' ')

    result['time'] = {}
    total = 0
    total_count = 0
    for i in range(0, module.params['cmd_run']):
        start = time.time() * 1000
        run_commands(module, commands, check_rc=False)
        end = time.time() * 1000

        result['time'][str(i)]= int(round(end - start))
        total = total + end - start
        total_count += module.params['cmd_count']

    result['time']['total'] = int(round(total))
    result['time']['count'] = total_count
    result['time']['avg'] = round(total / total_count, 2)

    module.exit_json(**result)


if __name__ == '__main__':
    main()
```

it gives an improvement of about 20ms per call in my environnement, quite near what was expected.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Results without PR:
```paste below
ok: [sw-test-1] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "cmd_count": 100,
            "cmd_run": 20
        }
    },
    "time": {
        "0": 5344,
        "1": 5289,
        "10": 5322,
        "11": 5280,
        "12": 5379,
        "13": 5221,
        "14": 5231,
        "15": 5274,
        "16": 5381,
        "17": 5279,
        "18": 5384,
        "19": 4927,
        "2": 5286,
        "3": 5279,
        "4": 5230,
        "5": 5230,
        "6": 5235,
        "7": 5279,
        "8": 5275,
        "9": 5476,
        "avg": 52.8,
        "count": 2000,
        "total": 105602
    }
}
```

And results with PR:
```paste below
ok: [sw-test-1] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "cmd_count": 100,
            "cmd_run": 20
        }
    },
    "time": {
        "0": 4176,
        "1": 4041,
        "10": 3110,
        "11": 3072,
        "12": 3129,
        "13": 3050,
        "14": 3061,
        "15": 3090,
        "16": 3230,
        "17": 3290,
        "18": 3331,
        "19": 3330,
        "2": 3389,
        "3": 3151,
        "4": 3040,
        "5": 3100,
        "6": 3063,
        "7": 3008,
        "8": 3080,
        "9": 3040,
        "avg": 32.39,
        "count": 2000,
        "total": 64779
    }
}
```