### PR TITLE
Add support to urls util for special characters in proxy username and password

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -51,6 +51,7 @@ except ImportError:
 import ansible.module_utils.six.moves.http_cookiejar as cookiejar
 import ansible.module_utils.six.moves.urllib.request as urllib_request
 import ansible.module_utils.six.moves.urllib.error as urllib_error
+import ansible.module_utils.six.moves.urllib.parse.unquote as urllib_parse_unquote
 
 from ansible.module_utils.six import PY3
 
@@ -744,7 +745,7 @@ class SSLValidationHandler(urllib_request.BaseHandler):
                 if proxy_parts.get('scheme') == 'http':
                     s.sendall(to_bytes(self.CONNECT_COMMAND % (self.hostname, self.port), errors='surrogate_or_strict'))
                     if proxy_parts.get('username'):
-                        credentials = "%s:%s" % (proxy_parts.get('username', ''), proxy_parts.get('password', ''))
+                        credentials = "%s:%s" % (urllib_parse_unquote(proxy_parts.get('username', '')), urllib_parse_unquote(proxy_parts.get('password', '')))
                         s.sendall(b'Proxy-Authorization: Basic %s\r\n' % base64.b64encode(to_bytes(credentials, errors='surrogate_or_strict')).strip())
                     s.sendall(b'\r\n')
                     connect_result = b""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When using any module which uses `ansible.module_utils.urls` and your username or password for proxy contain special characters like '#' you will get the following error:

```
fatal: [some_machine]: FAILED! => {"changed": false, "msg": "Connection to proxy failed"}
```

More detailed error log reveals that error happened in `ansible.module_utils.urls`:
```
The full traceback is:
  File "/tmp/ansible_jg073rku/ansible_modlib.zip/ansible/module_utils/urls.py", line 1058, in fetch_url
    client_key=client_key, cookies=cookies)
  File "/tmp/ansible_jg073rku/ansible_modlib.zip/ansible/module_utils/urls.py", line 961, in open_url
    r = urllib_request.urlopen(*urlopen_args)
  File "/usr/lib/python3.6/urllib/request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.6/urllib/request.py", line 524, in open
    req = meth(req)
  File "/tmp/ansible_jg073rku/ansible_modlib.zip/ansible/module_utils/urls.py", line 753, in http_request
    self.validate_proxy_response(connect_result)
  File "/tmp/ansible_jg073rku/ansible_modlib.zip/ansible/module_utils/urls.py", line 676, in validate_proxy_response
    raise ProxyError('Connection to proxy failed')

fatal: [some_machine]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "data": null,
            "file": null,
            "id": null,
            "key": null,
            "keyring": null,
            "keyserver": null,
            "state": "present",
            "url": "https://pkg.jenkins.io/debian-stable/jenkins.io.key",
            "validate_certs": true
        }
    },
    "msg": "Connection to proxy failed"
}
```
In my case it was authentication error, because base64 encoded credentials were wrong.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.module_utils.urls

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.5
  config file = /home/user/ansible/ansible.cfg
  configured module search path = ['/home/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.5 (default, Apr  1 2018, 05:46:30) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
For example, `apt_key` module uses `ansible.module_utils.urls` to download key file. Note the "%23" special character here.
```
- name: Add Jenkins apt repository key.
  environment:
    http_proxy: "http://SA0001user:password%23SpecialCharacter@proxy.corporation.com:3128"
  apt_key:
    url: "https://pkg.jenkins.io/debian-stable/jenkins.io.key"
    state: present
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```paste below
fatal: [some_machine]: FAILED! => {"changed": false, "msg": "Connection to proxy failed"}
```

After
```paste below
changed: [some_machine]
```
