### PR TITLE
ovirt_vm: Fix initialization of cloud init

### DIFF
--- a/changelogs/fragments/ovirt_vm__Fix_initialization_of_cloud_init.yaml
+++ b/changelogs/fragments/ovirt_vm__Fix_initialization_of_cloud_init.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ovirt_vm - Fix initialization of cloud init (https://github.com/ansible/ansible/pull/47354).

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -2034,8 +2034,8 @@ def main():
                     ),
                     wait_condition=lambda vm: vm.status == otypes.VmStatus.UP,
                     # Start action kwargs:
-                    use_cloud_init=not module.params.get('cloud_init_persist') and module.params.get('cloud_init') is not None,
-                    use_sysprep=not module.params.get('cloud_init_persist') and module.params.get('sysprep') is not None,
+                    use_cloud_init=True if not module.params.get('cloud_init_persist') and module.params.get('cloud_init') is not None else None,
+                    use_sysprep=True if not module.params.get('cloud_init_persist') and module.params.get('sysprep') is not None else None,
                     vm=otypes.Vm(
                         placement_policy=otypes.VmPlacementPolicy(
                             hosts=[otypes.Host(name=module.params['host'])]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of: https://github.com/ansible/ansible/pull/47348
Fixes: https://github.com/ansible/ansible/issues/45900

This PR fixes the case when the cloud_init_persist was used, but we
still sent use_cloud_init=False, which is in oVirt API evaluated as not
to use cloud_init in first VM execution. This patch is changing it to
send just None, instead of False.

Signed-off-by: Ondra Machacek <omachace@redhat.com>

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_vm

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7.0
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
