### PR TITLE
VMware: Improve vmware_portgroup_facts module

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_portgroup_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_portgroup_facts.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
+# Copyright: (c) 2018, Christian Kotte <christian.kotte@gmx.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -16,18 +17,27 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = r'''
 ---
 module: vmware_portgroup_facts
-short_description: Gathers facts about an ESXi host's portgroup configuration
+short_description: Gathers facts about an ESXi host's Port Group configuration
 description:
-- This module can be used to gather facts about an ESXi host's portgroup configuration when ESXi hostname or Cluster name is given.
+- This module can be used to gather facts about an ESXi host's Port Group configuration when ESXi hostname or Cluster name is given.
 version_added: '2.6'
 author:
 - Abhijeet Kasurde (@Akasurde)
+- Christian Kotte (@ckotte)
 notes:
 - Tested on vSphere 6.5
+- The C(vswitch_name) property is deprecated starting from Ansible v2.12
 requirements:
 - python >= 2.6
 - PyVmomi
 options:
+  policies:
+    description:
+    - Gather facts about Security, Traffic Shaping, as well as Teaming and failover.
+    - The property C(ts) stands for Traffic Shaping and C(lb) for Load Balancing.
+    type: bool
+    default: false
+    version_added: 2.8
   cluster_name:
     description:
     - Name of the cluster.
@@ -64,31 +74,35 @@ hosts_portgroup_facts:
     returned: on success
     type: dict
     sample: {
-        "10.76.33.208": [
+        "esx01": [
             {
-                "forged_transmits": false,
-                "mac_changes": false,
-                "name": "VM Network",
-                "promiscuous_mode": false,
+                "failback": true,
+                "failover_active": ["vmnic0", "vmnic1"],
+                "failover_standby": [],
+                "failure_detection": "link_status_only",
+                "lb": "loadbalance_srcid",
+                "notify": true,
+                "portgroup": "Management Network",
+                "security": [false, false, false],
+                "ts": "No override",
                 "vlan_id": 0,
+                "vswitch": "vSwitch0",
                 "vswitch_name": "vSwitch0"
             },
             {
-                "forged_transmits": false,
-                "mac_changes": false,
-                "name": "Management Network",
-                "promiscuous_mode": false,
-                "vlan_id": 0,
-                "vswitch_name": "vSwitch0"
-            },
-            {
-                "forged_transmits": false,
-                "mac_changes": false,
-                "name": "pg0001",
-                "promiscuous_mode": false,
-                "vlan_id": 0,
-                "vswitch_name": "vSwitch001"
-            },
+                "failback": true,
+                "failover_active": ["vmnic2"],
+                "failover_standby": ["vmnic3"],
+                "failure_detection": "No override",
+                "lb": "No override",
+                "notify": true,
+                "portgroup": "vMotion",
+                "security": [false, false, false],
+                "ts": "No override",
+                "vlan_id": 33,
+                "vswitch": "vSwitch1",
+                "vswitch_name": "vSwitch1"
+            }
         ]
     }
 '''
@@ -98,54 +112,112 @@ from ansible.module_utils.vmware import vmware_argument_spec, PyVmomi
 
 
 class PortgroupFactsManager(PyVmomi):
+    """Class to manage Port Group facts"""
     def __init__(self, module):
         super(PortgroupFactsManager, self).__init__(module)
         cluster_name = self.params.get('cluster_name', None)
         esxi_host_name = self.params.get('esxi_hostname', None)
         self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
+        if not self.hosts:
+            self.module.fail_json(msg="Failed to find host system.")
+        self.policies = self.params.get('policies')
 
     @staticmethod
-    def normalize_pg_info(portgroup_obj):
+    def normalize_pg_info(portgroup_obj, policy_facts):
+        """Create Port Group information"""
         pg_info_dict = dict()
-        pg_info_dict['name'] = portgroup_obj.spec.name
-        vlan_id = 'N/A'
-        if portgroup_obj.spec.vlanId:
-            vlan_id = portgroup_obj.spec.vlanId
-        pg_info_dict['vlan_id'] = vlan_id
-        switch_name = 'N/A'
-        if portgroup_obj.spec.vswitchName:
-            switch_name = portgroup_obj.spec.vswitchName
-        pg_info_dict['vswitch_name'] = switch_name
+        spec = portgroup_obj.spec
+        pg_info_dict['portgroup'] = spec.name
+        pg_info_dict['vlan_id'] = spec.vlanId
+        # NOTE: the property vswitch_name is deprecated starting from Ansible v2.12
+        pg_info_dict['vswitch_name'] = spec.vswitchName
+        pg_info_dict['vswitch'] = spec.vswitchName
 
-        # Network Policy related facts
-        pg_info_dict['promiscuous_mode'] = bool(portgroup_obj.spec.policy.security.allowPromiscuous)
-        pg_info_dict['mac_changes'] = bool(portgroup_obj.spec.policy.security.macChanges)
-        pg_info_dict['forged_transmits'] = bool(portgroup_obj.spec.policy.security.forgedTransmits)
+        if policy_facts:
+            # Security facts
+            if spec.policy.security:
+                promiscuous_mode = spec.policy.security.allowPromiscuous
+                mac_changes = spec.policy.security.macChanges
+                forged_transmits = spec.policy.security.forgedTransmits
+                pg_info_dict['security'] = (
+                    ["No override" if promiscuous_mode is None else promiscuous_mode,
+                     "No override" if mac_changes is None else mac_changes,
+                     "No override" if forged_transmits is None else forged_transmits]
+                )
+            else:
+                pg_info_dict['security'] = ["No override", "No override", "No override"]
+
+            # Traffic Shaping facts
+            if spec.policy.shapingPolicy and spec.policy.shapingPolicy.enabled is not None:
+                pg_info_dict['ts'] = portgroup_obj.spec.policy.shapingPolicy.enabled
+            else:
+                pg_info_dict['ts'] = "No override"
+
+            # Teaming and failover facts
+            if spec.policy.nicTeaming:
+                if spec.policy.nicTeaming.policy is None:
+                    pg_info_dict['lb'] = "No override"
+                else:
+                    pg_info_dict['lb'] = spec.policy.nicTeaming.policy
+                if spec.policy.nicTeaming.notifySwitches is None:
+                    pg_info_dict['notify'] = "No override"
+                else:
+                    pg_info_dict['notify'] = spec.policy.nicTeaming.notifySwitches
+                if spec.policy.nicTeaming.rollingOrder is None:
+                    pg_info_dict['failback'] = "No override"
+                else:
+                    pg_info_dict['failback'] = not spec.policy.nicTeaming.rollingOrder
+                if spec.policy.nicTeaming.nicOrder is None:
+                    pg_info_dict['failover_active'] = "No override"
+                    pg_info_dict['failover_standby'] = "No override"
+                else:
+                    pg_info_dict['failover_active'] = spec.policy.nicTeaming.nicOrder.activeNic
+                    pg_info_dict['failover_standby'] = spec.policy.nicTeaming.nicOrder.standbyNic
+                if spec.policy.nicTeaming.failureCriteria and spec.policy.nicTeaming.failureCriteria.checkBeacon is None:
+                    pg_info_dict['failure_detection'] = "No override"
+                else:
+                    if spec.policy.nicTeaming.failureCriteria.checkBeacon:
+                        pg_info_dict['failure_detection'] = "beacon_probing"
+                    else:
+                        pg_info_dict['failure_detection'] = "link_status_only"
+            else:
+                pg_info_dict['lb'] = "No override"
+                pg_info_dict['notify'] = "No override"
+                pg_info_dict['failback'] = "No override"
+                pg_info_dict['failover_active'] = "No override"
+                pg_info_dict['failover_standby'] = "No override"
+                pg_info_dict['failure_detection'] = "No override"
 
         return pg_info_dict
 
     def gather_host_portgroup_facts(self):
+        """Gather Port Group facts per ESXi host"""
         hosts_pg_facts = dict()
         for host in self.hosts:
             pgs = host.config.network.portgroup
             hosts_pg_facts[host.name] = []
-            for pg in pgs:
-                hosts_pg_facts[host.name].append(self.normalize_pg_info(portgroup_obj=pg))
+            for portgroup in pgs:
+                hosts_pg_facts[host.name].append(
+                    self.normalize_pg_info(portgroup_obj=portgroup, policy_facts=self.policies)
+                )
         return hosts_pg_facts
 
 
 def main():
+    """Main"""
     argument_spec = vmware_argument_spec()
     argument_spec.update(
         cluster_name=dict(type='str', required=False),
         esxi_hostname=dict(type='str', required=False),
+        policies=dict(type='bool', required=False, default=False),
     )
 
     module = AnsibleModule(
         argument_spec=argument_spec,
         required_one_of=[
             ['cluster_name', 'esxi_hostname'],
-        ]
+        ],
+        supports_check_mode=True
     )
 
     host_pg_mgr = PortgroupFactsManager(module)

--- a/test/integration/targets/vmware_portgroup_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_portgroup_facts/tasks/main.yml
@@ -67,7 +67,7 @@
       - "not portgroup_0001_results.changed"
       - "portgroup_0001_results.hosts_portgroup_facts is defined"
 
-- name: Gather firewall facts for ESXi host
+- name: Gather portgroup facts for an ESXi host
   vmware_portgroup_facts:
     hostname: "{{ vcsim }}"
     username: "{{ vcsim_instance.json.username }}"
@@ -80,3 +80,34 @@
     that:
       - "not portgroup_0002_results.changed"
       - "portgroup_0002_results.hosts_portgroup_facts is defined"
+
+- name: Gather all portgroup facts for an ESXi host
+  vmware_portgroup_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    esxi_hostname: "{{ host1 }}"
+    policies: true
+  register: portgroup_0003_results
+
+- assert:
+    that:
+      - "not portgroup_0003_results.changed"
+      - "portgroup_0003_results.hosts_portgroup_facts is defined"
+
+- name: Gather all portgroup facts for an ESXi host in check mode
+  vmware_portgroup_facts:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance.json.username }}"
+    password: "{{ vcsim_instance.json.password }}"
+    validate_certs: no
+    esxi_hostname: "{{ host1 }}"
+    policies: true
+  register: portgroup_0004_results
+  check_mode: yes
+
+- assert:
+    that:
+      - "not portgroup_0004_results.changed"
+      - "portgroup_0004_results.hosts_portgroup_facts is defined"


### PR DESCRIPTION
##### SUMMARY
- Add check mode support
- Output policy settings
- Implement proper override handling

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_portgroup_facts

##### ANSIBLE VERSION
```
ansible 2.6.3
  config file = /root/ansible-vmware/ansible.cfg
  configured module search path = [u'/root/ansible-vmware/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
