### PR TITLE
openstack: drop some references to shade

### DIFF
--- a/lib/ansible/modules/cloud/openstack/README.md
+++ b/lib/ansible/modules/cloud/openstack/README.md
@@ -50,16 +50,14 @@ Libraries
 * All complex cloud interaction or interoperability code should be housed in
   the [openstacksdk](http://git.openstack.org/cgit/openstack/openstacksdk)
   library.
-* All OpenStack API interactions should happen via shade and not via
+* All OpenStack API interactions should happen via the openstacksdk and not via
   OpenStack Client libraries. The OpenStack Client libraries do no have end
-  users as a primary audience, they are for intra-server communication. The
-  python-openstacksdk is the future there, and shade will migrate to it when
-  its ready in a manner that is not noticeable to ansible users.
+  users as a primary audience, they are for intra-server communication.
 
 Testing
 -------
 
 * Integration testing is currently done in OpenStack's CI system in
-  http://git.openstack.org/cgit/openstack-infra/shade/tree/shade/tests/ansible
-* Testing in shade produces an obvious chicken-and-egg scenario. Work is under
+  https://git.openstack.org/cgit/openstack/openstacksdk/tree/openstack/tests/ansible
+* Testing in openstacksdk produces an obvious chicken-and-egg scenario. Work is under
   way to trigger from and report on PRs directly.

--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -625,11 +625,7 @@ def _check_security_groups(module, cloud, server):
         return changed, server
 
     module_security_groups = set(module.params['security_groups'])
-    # Workaround a bug in shade <= 1.20.0
-    if server.security_groups is not None:
-        server_security_groups = set(sg.name for sg in server.security_groups)
-    else:
-        server_security_groups = set()
+    server_security_groups = set(sg.name for sg in server.security_groups)
 
     add_sgs = module_security_groups - server_security_groups
     remove_sgs = server_security_groups - module_security_groups

--- a/lib/ansible/modules/cloud/openstack/os_server_metadata.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_metadata.py
@@ -44,7 +44,7 @@ options:
      required: false
 requirements:
     - "python >= 2.7"
-    - "shade"
+    - "openstack"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -172,7 +172,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             else:
                 config_files = None
 
-            # TODO(mordred) Integrate shade's logging with ansible's logging
+            # TODO(mordred) Integrate openstack's logging with ansible's logging
             sdk.enable_logging()
 
             cloud_inventory = sdk_inventory.OpenStackInventory(


### PR DESCRIPTION
shade is not used anymore by the `os_*` modules. This commit does some
clean up.

##### SUMMARY

PR ansible#40532 replaces `shade` library by `openstacksdk`. This commit clean
up some references to the old library. It's similiar to what has been
done in PR ansible#40784.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

openstack
docs

##### ANSIBLE VERSION

```paste below
2.8.0.dev0
```

##### ADDITIONAL INFORMATION

The patch does a minor clean up in `os_server.py` of a Shade specific work around.