### PR TITLE
[WIP] validate-modules: Documentation bool

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_validate-modules.rst
@@ -126,6 +126,7 @@ Errors
   331       argument in argument_spec must be a dictionary/hash when used
   332       ``AnsibleModule`` schema validation error
   333       ``ANSIBLE_METADATA.status`` of deprecated or removed can't include other statuses
+  334       argument_spec defines type="str" but documentation defines as "bool"
 
   ..
 ---------   -------------------

--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -1206,6 +1206,13 @@ class ModuleValidator(Validator):
                     msg='argument_spec for "%s" defines type="bool" but documentation does not' % (arg,)
                 )
 
+            if 'type' not in data and doc_type == 'bool':
+                self.reporter.error(
+                    path=self.object_path,
+                    code=334,
+                    msg='argument_spec for "%s" defines type="str" but documentation defines as "bool"' % (arg,)
+                )
+
             # TODO: needs to recursively traverse suboptions
             doc_choices = []
             try:


### PR DESCRIPTION
##### SUMMARY
This check allows to catch cases where type of argument is str,
and documentation defines it as 'bool'

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/testing_validate-modules.rst
test/sanity/validate-modules/main.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8-devel
```