### PR TITLE
removes docs/api dir from .gitignore and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,6 @@ docs/man/man3/*
 *.sublime-project
 *.sublime-workspace
 # docsite stuff...
-docs/api/_build/
-docs/api/rst/
 docs/docsite/_build
 docs/docsite/*.html
 docs/docsite/htmlout

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,6 @@ clean:
 	rm -f AUTHORS.TXT
 	@echo "Cleaning up docsite"
 	$(MAKE) -C docs/docsite clean
-	$(MAKE) -C docs/api clean
 
 .PHONY: python
 python:
@@ -402,4 +401,3 @@ alldocs: docs webdocs
 
 version:
 	@echo $(VERSION)
-

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -66,17 +66,15 @@ clean:
 	find . -type f \( -name "*~" -or -name "#*" \) -delete
 	find . -type f \( -name "*.swp" \) -delete
 	@echo "Cleaning up generated rst"
-	-rm rst/cli/ansible-*.rst
-	-rm rst/cli/ansible.rst
-	-rm rst/modules/*_by_category.rst
-	-rm rst/modules/list_of_*.rst
-	-rm rst/modules/*_maintained.rst
-	-rm rst/modules/*_module.rst
-	-rm rst/modules/*_plugin.rst
-	-rm rst/playbooks_directives.rst
-	-rm rst/plugins/*/*.rst
-	-rm rst/reference_appendices/config.rst
-	-rm rst/reference_appendices/playbooks_keywords.rst
+	-rm -f rst/modules/*_by_category.rst
+	-rm -f rst/modules/list_of_*.rst
+	-rm -f rst/modules/*_maintained.rst
+	-rm -f rst/modules/*_module.rst
+	-rm -f rst/modules/*_plugin.rst
+	-rm -f rst/playbooks_directives.rst
+	-rm -f rst/plugins/*/*.rst
+	-rm -f rst/reference_appendices/config.rst
+	-rm -f rst/reference_appendices/playbooks_keywords.rst
 
 .PHONY: docs clean
 

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -66,15 +66,15 @@ clean:
 	find . -type f \( -name "*~" -or -name "#*" \) -delete
 	find . -type f \( -name "*.swp" \) -delete
 	@echo "Cleaning up generated rst"
-	-rm -f rst/modules/*_by_category.rst
-	-rm -f rst/modules/list_of_*.rst
-	-rm -f rst/modules/*_maintained.rst
-	-rm -f rst/modules/*_module.rst
-	-rm -f rst/modules/*_plugin.rst
-	-rm -f rst/playbooks_directives.rst
-	-rm -f rst/plugins/*/*.rst
-	-rm -f rst/reference_appendices/config.rst
-	-rm -f rst/reference_appendices/playbooks_keywords.rst
+	rm -f rst/modules/*_by_category.rst
+	rm -f rst/modules/list_of_*.rst
+	rm -f rst/modules/*_maintained.rst
+	rm -f rst/modules/*_module.rst
+	rm -f rst/modules/*_plugin.rst
+	rm -f rst/playbooks_directives.rst
+	rm -f rst/plugins/*/*.rst
+	rm -f rst/reference_appendices/config.rst
+	rm -f rst/reference_appendices/playbooks_keywords.rst
 
 .PHONY: docs clean
 


### PR DESCRIPTION
##### SUMMARY
Repairs the docs build by removing references to the `docs/api` directory, which has not existed since we merged #46663. 

Thanks to @mattclay for finding the issue.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ANSIBLE VERSION
2.8 
