### PR TITLE
Module portinstall: use_packages is a bool

### DIFF
--- a/lib/ansible/modules/packaging/os/portinstall.py
+++ b/lib/ansible/modules/packaging/os/portinstall.py
@@ -163,7 +163,7 @@ def install_packages(module, packages, use_packages):
             module.run_command("pkg install -y portupgrade")
         portinstall_path = module.get_bin_path('portinstall', True)
 
-    if use_packages == "yes":
+    if use_packages:
         portinstall_params = "--use-packages"
     else:
         portinstall_params = ""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The portinstall module checks if `use_packages == "yes"`, but `AnsibleModule` actually converts the `use_packages` argument to a `bool`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
portinstall

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.4
  config file = None
  configured module search path = ['/Users/overhack/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/ansible
  executable location = /opt/local/Library/Frameworks/Python.framework/Versions/3.6/bin/ansible
  python version = 3.6.6 (default, Jun 28 2018, 05:43:53) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
There's no change in Ansible command output, but the portinstall module fails to add the `--use-packages` option to the `portinstall` command line, causing every package/port specified (and all its dependencies) to be built from source. After this change, the option is correctly added to the command line.