### PR TITLE
Use kubeconfig if either context or kubeconfig is set

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -148,7 +148,7 @@ class K8sAnsibleMixin(object):
         if auth_set('username', 'password', 'host') or auth_set('api_key', 'host'):
             # We have enough in the parameters to authenticate, no need to load incluster or kubeconfig
             pass
-        elif auth_set('kubeconfig', 'context'):
+        elif auth_set('kubeconfig') or auth_set('context'):
             kubernetes.config.load_kube_config(auth.get('kubeconfig'), auth.get('context'))
         else:
             # First try to do incluster config, then kubeconfig


### PR DESCRIPTION
##### SUMMARY

kubeconfig should be loaded if *either* or both of context
or kubeconfig is set (this allows picking a context and default
kubeconfig or picking a kubeconfig with default context)

Fixes #47149

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
k8s

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel acda7bae5f) last updated 2018/10/20 12:58:54 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.15 (default, Oct  2 2018, 11:47:18) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.2)]
```

##### ADDITIONAL INFORMATION
Should be backported to 2.7