### PR TITLE
Adding headers to be returned for retrieved messages.

### DIFF
--- a/lib/ansible/plugins/lookup/rabbitmq.py
+++ b/lib/ansible/plugins/lookup/rabbitmq.py
@@ -88,6 +88,9 @@ RETURN = """
       routing_key:
         description: The routing_key on the message in the queue.
         type: str
+      headers:
+        description: The headers for the message returned from the queue.
+        type: dict
       json:
         description: If application/json is specified in content_type, json will be loaded into variables.
         type: dict
@@ -161,7 +164,8 @@ class LookupModule(LookupBase):
                                    'redelivered': method_frame.redelivered,
                                    'exchange': method_frame.exchange,
                                    'delivery_mode': properties.delivery_mode,
-                                   'content_type': properties.content_type
+                                   'content_type': properties.content_type,
+                                   'headers': properties.headers
                                    })
                 if properties.content_type == 'application/json':
                     try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Minor modification to return the headers from a message retrieved off a queue. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lookup/rabbitmq.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (lookup_rabbitmq_add_headers cab489b2b6) last updated 2018/10/20 22:19:08 (GMT +1100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/johni/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/johni/ansible/hacking/ansible/lib/ansible
  executable location = /home/johni/ansible/hacking/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Playbook:
```
---
- hosts: localhost
  gather_facts: no

  tasks:
    - name: Lookup queue
      set_fact:
        contents: "{{ lookup('rabbitmq', url='amqp://guest:guest@192.168.0.2:5672/%2F', queue='hello') }}"

    - debug:
        var: contents
```


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
PLAY [localhost] *******************************************************************************************************************************************************************************************

TASK [Lookup queue] ****************************************************************************************************************************************************************************************
ok: [localhost]

TASK [debug] ***********************************************************************************************************************************************************************************************
ok: [localhost] => {
    "contents": [
        {
            "content_type": null, 
            "delivery_mode": 1, 
            "delivery_tag": 1, 
            "exchange": "", 
            "headers": {
                "another_header_key": "another value", 
                "filename": "test"
            }, 
            "message_count": 0, 
            "msg": "blah blah blah", 
            "redelivered": false, 
            "routing_key": "hello"
        }
    ]
}

PLAY RECAP *************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0   

```

If no headers present:

```

PLAY [localhost] *******************************************************************************************************************************************************************************************

TASK [Lookup queue] ****************************************************************************************************************************************************************************************
ok: [localhost]

TASK [debug] ***********************************************************************************************************************************************************************************************
ok: [localhost] => {
    "contents": [
        {
            "content_type": null, 
            "delivery_mode": 1, 
            "delivery_tag": 1, 
            "exchange": "", 
            "headers": {}, 
            "message_count": 0, 
            "msg": "no headers", 
            "redelivered": false, 
            "routing_key": "hello"
        }
    ]
}

```