### PR TITLE
[2.7] docker_network: add basic integration tests

### DIFF
--- a/test/integration/targets/docker_network/aliases
+++ b/test/integration/targets/docker_network/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group2
+skip/osx
+skip/freebsd
+destructive

--- a/test/integration/targets/docker_network/meta/main.yml
+++ b/test/integration/targets/docker_network/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_docker

--- a/test/integration/targets/docker_network/tasks/main.yml
+++ b/test/integration/targets/docker_network/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: Create random name prefix
+  set_fact:
+    name_prefix: "{{ 'ansible-test-%0x' % ((2**32) | random) }}"
+    cnames: []
+    dnetworks: []
+
+- debug:
+    msg: "Using name prefix {{ name_prefix }}"
+
+- block:
+  - include_tasks: run-test.yml
+    with_fileglob:
+    - "tests/*.yml"
+
+  always:
+  - name: "Make sure all containers are removed"
+    docker_container:
+      name: "{{ item }}"
+      state: absent
+      stop_timeout: 1
+    loop: "{{ cnames }}"
+  - name: "Make sure all networks are removed"
+    docker_network:
+      name: "{{ item }}"
+      state: absent
+      force: yes
+    loop: "{{ dnetworks }}"
+
+  # Skip for CentOS 6
+  when: ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6

--- a/test/integration/targets/docker_network/tasks/run-test.yml
+++ b/test/integration/targets/docker_network/tasks/run-test.yml
@@ -1,0 +1,3 @@
+---
+- name: "Loading tasks from {{ item }}"
+  include_tasks: "{{ item }}"

--- a/test/integration/targets/docker_network/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_network/tasks/tests/basic.yml
@@ -1,0 +1,117 @@
+---
+- name: Registering container and network names
+  set_fact:
+    cname_1: "{{ name_prefix ~ '-container-1' }}"
+    cname_2: "{{ name_prefix ~ '-container-2' }}"
+    cname_3: "{{ name_prefix ~ '-container-3' }}"
+    nname_1: "{{ name_prefix ~ '-network-1' }}"
+    nname_2: "{{ name_prefix ~ '-network-2' }}"
+- name: Registering container and network names
+  set_fact:
+    cnames: "{{ cnames }} + [cname_1, cname_2, cname_3]"
+    dnetworks: "{{ dnetworks }} + [nname_1, nname_2]"
+
+- name: Create containers
+  docker_container:
+    name: "{{ container_name }}"
+    image: hello-world
+    state: present
+  loop:
+  - "{{ cname_1 }}"
+  - "{{ cname_2 }}"
+  - "{{ cname_3 }}"
+  loop_control:
+    loop_var: container_name
+
+####################################################################
+
+- name: Create network
+  docker_network:
+    name: "{{ nname_1 }}"
+    state: present
+  register: networks_1
+
+- name: Connect network to containers 1 and 2
+  docker_network:
+    name: "{{ nname_1 }}"
+    state: present
+    connected:
+    - "{{ cname_1 }}"
+    - "{{ cname_2 }}"
+  register: networks_2
+
+- name: Connect network to containers 1 and 2 (idempotency)
+  docker_network:
+    name: "{{ nname_1 }}"
+    state: present
+    connected:
+    - "{{ cname_1 }}"
+    - "{{ cname_2 }}"
+  register: networks_2_idem
+
+- name: Connect network to container 3
+  docker_network:
+    name: "{{ nname_1 }}"
+    state: present
+    connected:
+    - "{{ cname_3 }}"
+    appends: yes
+  register: networks_3
+
+- name: Connect network to container 3 (idempotency)
+  docker_network:
+    name: "{{ nname_1 }}"
+    state: present
+    connected:
+    - "{{ cname_3 }}"
+    appends: yes
+  register: networks_3_idem
+
+- name: Disconnect network from container 1
+  docker_network:
+    name: "{{ nname_1 }}"
+    state: present
+    connected:
+    - "{{ cname_2 }}"
+    - "{{ cname_3 }}"
+  register: networks_4
+
+- name: Disconnect network from container 1 (idempotency)
+  docker_network:
+    name: "{{ nname_1 }}"
+    state: present
+    connected:
+    - "{{ cname_2 }}"
+    - "{{ cname_3 }}"
+  register: networks_4_idem
+
+- name: Cleanup
+  docker_network:
+    name: "{{ nname_1 }}"
+    state: absent
+
+# The idempotency tests do NOT work currently.
+
+- assert:
+    that:
+    - networks_1 is changed
+    - networks_2 is changed
+    # - networks_2_idem is not changed
+    - networks_3 is changed
+    # - networks_3_idem is not changed
+    - networks_4 is changed
+    # - networks_4_idem is not changed
+
+####################################################################
+
+- name: Delete containers
+  docker_container:
+    name: "{{ container_name }}"
+    state: absent
+    stop_timeout: 1
+  loop:
+  - "{{ cname_1 }}"
+  - "{{ cname_2 }}"
+  - "{{ cname_3 }}"
+  loop_control:
+    loop_var: container_name


### PR DESCRIPTION
##### SUMMARY
Backport of #46137: some basic integration tests for docker_network.

There's no changelog included since this is a purely internal thing which doesn't affect any of the code in the release. If I should still add a changelog I can do that, though.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_network

##### ANSIBLE VERSION
```
2.7.1
```
