### PR TITLE
Test  and account for TZ adjust with fake_hwclock. Fixes #47371

### DIFF
--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -114,7 +114,8 @@ class ActionModule(ActionBase):
         # launched by systemd, the update of utmp/wtmp is not done correctly.
         # Fall back to using uptime -s for those systems.
         # https://github.com/systemd/systemd/issues/6057
-        if '1970-01-01 00:00' in command_result['stdout']:
+        # if '1970-01-01 00:00' in command_result['stdout']:
+        if int(''.join(c for c in command_result['stdout'] if c.isdigit())[:4]) <= 1970:
             stdout += command_result['stdout']
             stderr += command_result['stderr']
             command_result = self._low_level_execute_command('uptime -s', sudoable=self.DEFAULT_SUDOABLE)

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -115,7 +115,7 @@ class ActionModule(ActionBase):
         # Fall back to using uptime -s for those systems.
         # https://github.com/systemd/systemd/issues/6057
         # if '1970-01-01 00:00' in command_result['stdout']:
-        if int(''.join(c for c in command_result['stdout'] if c.isdigit())[:4]) <= 1970:
+        if command_result['stdout'] and (int(''.join(c for c in command_result['stdout'] if c.isdigit())[:4]) <= 1970):
             stdout += command_result['stdout']
             stderr += command_result['stderr']
             command_result = self._low_level_execute_command('uptime -s', sudoable=self.DEFAULT_SUDOABLE)


### PR DESCRIPTION
##### SUMMARY
Fixes #47371 

Extracts the first four digits from `who -b` stdout, converts to int(), and tests if <= 1970 (module then calls `uptime` instead).  

No timezone is more than +/-12h from UNIX epoch, so this will catch all cases where fake_hwclock is setting the wrong time on wtmp.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
reboot

##### ANSIBLE VERSION
```paste below
ansible 2.7.0
  config file = /home/cerebus/.ansible.cfg
  configured module search path = ['/home/cerebus/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/cerebus/.local/lib/python3.6/site-packages/ansible
  executable location = /home/cerebus/.local/bin/ansible
  python version = 3.6.6 (default, Sep 12 2018, 18:26:19) [GCC 8.0.1 20180414 (experimental) [trunk revision 259383]]
```
