### PR TITLE
ovirt_vm: Fix issue in setting the custom_compatibility_version to NULL

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -790,14 +790,14 @@ class BaseModule(object):
         return entity
 
     def _get_major(self, full_version):
-        if full_version is None:
+        if full_version is None or full_version == "":
             return None
         if isinstance(full_version, otypes.Version):
             return int(full_version.major)
         return int(full_version.split('.')[0])
 
     def _get_minor(self, full_version):
-        if full_version is None:
+        if full_version is None or full_version == "":
             return None
         if isinstance(full_version, otypes.Version):
             return int(full_version.minor)

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -1146,7 +1146,7 @@ class VmsModule(BaseModule):
             custom_compatibility_version=otypes.Version(
                 major=self._get_major(self.param('custom_compatibility_version')),
                 minor=self._get_minor(self.param('custom_compatibility_version')),
-            ) if self.param('custom_compatibility_version') else None,
+            ) if self.param('custom_compatibility_version') is not None else None,
             description=self.param('description'),
             comment=self.param('comment'),
             time_zone=otypes.TimeZone(
@@ -1228,12 +1228,19 @@ class VmsModule(BaseModule):
                 return self.param('host') in [self._connection.follow_link(host).name for host in getattr(entity.placement_policy, 'hosts', None) or []]
             return True
 
+        def check_custom_compatibility_version():
+            if self.param('custom_compatibility_version') is not None:
+                return (self._get_minor(self.param('custom_compatibility_version')) == self._get_minor(entity.custom_compatibility_version) and
+                        self._get_major(self.param('custom_compatibility_version')) == self._get_major(entity.custom_compatibility_version))
+            return True
+
         cpu_mode = getattr(entity.cpu, 'mode')
         vm_display = entity.display
         return (
             check_cpu_pinning() and
             check_custom_properties() and
             check_host() and
+            check_custom_compatibility_version() and
             not self.param('cloud_init_persist') and
             not self.param('kernel_params_persist') and
             equal(self.param('cluster'), get_link_name(self._connection, entity.cluster)) and equal(convert_to_bytes(self.param('memory')), entity.memory) and
@@ -1252,8 +1259,6 @@ class VmsModule(BaseModule):
             equal(self.param('io_threads'), entity.io.threads) and
             equal(self.param('ballooning_enabled'), entity.memory_policy.ballooning) and
             equal(self.param('serial_console'), getattr(entity.console, 'enabled', None)) and
-            equal(self._get_minor(self.param('custom_compatibility_version')), self._get_minor(entity.custom_compatibility_version)) and
-            equal(self._get_major(self.param('custom_compatibility_version')), self._get_major(entity.custom_compatibility_version)) and
             equal(self.param('usb_support'), entity.usb.enabled) and
             equal(self.param('sso'), True if entity.sso.methods else False) and
             equal(self.param('quota_id'), getattr(entity.quota, 'id', None)) and


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently, there is no way to reset the custom_compatibility_version to
NULL. If we provide a empty string('') to custom_compatibility_version,
it will fail with error "IndexError: list index out of range" at _get_minor
function.

To reset the custom_compatibility_version, we have to pass None value to
types.Version. The PR fixes the same.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ovirt_vm module
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible --version
ansible 2.7.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]


```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
```
