### PR TITLE
docker_volume: fix recreation test logic

### DIFF
--- a/changelogs/fragments/docker_volume-force-change-detection.yaml
+++ b/changelogs/fragments/docker_volume-force-change-detection.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_volume - fix ``force`` and change detection logic. If not both evaluated to ``True``, the volume was not recreated."

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -223,7 +223,7 @@ class DockerVolumeManager(object):
         if self.existing_volume:
             differences = self.has_different_config()
 
-        if differences and self.parameters.force:
+        if differences or self.parameters.force:
             self.remove_volume()
             self.existing_volume = None
 


### PR DESCRIPTION
##### SUMMARY
Fixes a bug in `docker_volume` which caused volumes to only be recreated if `force == yes` **and** configuration changed (instead of *or*).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_volume

##### ANSIBLE VERSION
```
2.7.1
```
