### PR TITLE
docker_image: allow to delete image by ID

### DIFF
--- a/changelogs/fragments/47393-docker_image-id.yaml
+++ b/changelogs/fragments/47393-docker_image-id.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_image - Allow to use image ID instead of image name for deleting images."

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -250,7 +250,9 @@ image:
 import os
 import re
 
-from ansible.module_utils.docker_common import HAS_DOCKER_PY_2, HAS_DOCKER_PY_3, AnsibleDockerClient, DockerBaseClass
+from ansible.module_utils.docker_common import (
+    HAS_DOCKER_PY_2, HAS_DOCKER_PY_3, AnsibleDockerClient, DockerBaseClass, is_image_name_id,
+)
 from ansible.module_utils._text import to_native
 
 try:
@@ -293,10 +295,11 @@ class ImageManager(DockerBaseClass):
         self.buildargs = parameters.get('buildargs')
 
         # If name contains a tag, it takes precedence over tag parameter.
-        repo, repo_tag = parse_repository_tag(self.name)
-        if repo_tag:
-            self.name = repo
-            self.tag = repo_tag
+        if not is_image_name_id(self.name):
+            repo, repo_tag = parse_repository_tag(self.name)
+            if repo_tag:
+                self.name = repo
+                self.tag = repo_tag
 
         if self.state in ['present', 'build']:
             self.present()
@@ -363,11 +366,14 @@ class ImageManager(DockerBaseClass):
 
         :return None
         '''
-        image = self.client.find_image(self.name, self.tag)
-        if image:
-            name = self.name
+        name = self.name
+        if is_image_name_id(name):
+            image = self.client.find_image_by_id(name)
+        else:
+            image = self.client.find_image(name, self.tag)
             if self.tag:
                 name = "%s:%s" % (self.name, self.tag)
+        if image:
             if not self.check_mode:
                 try:
                     self.client.remove_image(name, force=self.force)


### PR DESCRIPTION
##### SUMMARY
Allow to specify a docker image by ID for `state == absent`. This is (to my knowledge) the only case where specifying an image ID makes sense, as image IDs cannot be used to pull or build an image. (If you simply want to make sure that an image by this ID is there, use `docker_image_facts` together with `fail`.)

Fixes #29462, supersedes #25764.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_image

##### ANSIBLE VERSION
```
2.8.0
```
