### PR TITLE
Added config-context in hostvars

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -198,6 +198,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             "device_roles": self.extract_device_role,
             "platforms": self.extract_platform,
             "device_types": self.extract_device_type,
+            "config_contexts": self.extract_config_contexts,
             "manufacturers": self.extract_manufacturer
         }
 
@@ -243,6 +244,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def extract_device_role(self, host):
         try:
             return [self.device_roles_lookup[host["device_role"]["id"]]]
+        except Exception:
+            return
+
+    def extract_config_contexts(self, host):
+        try:
+            url = urljoin(self.api_endpoint, "/api/dcim/devices/" + str(host["id"]))
+            device_lookup = self._fetch_information(url)
+            return device_lookup["config_context"]
         except Exception:
             return
 

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -198,7 +198,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             "device_roles": self.extract_device_role,
             "platforms": self.extract_platform,
             "device_types": self.extract_device_type,
-            "config_contexts": self.extract_config_contexts,
+            "config_context": self.extract_config_context,
             "manufacturers": self.extract_manufacturer
         }
 
@@ -247,11 +247,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         except Exception:
             return
 
-    def extract_config_contexts(self, host):
+    def extract_config_context(self, host):
         try:
             url = urljoin(self.api_endpoint, "/api/dcim/devices/" + str(host["id"]))
             device_lookup = self._fetch_information(url)
-            return device_lookup["config_context"]
+            return [device_lookup["config_context"]]
         except Exception:
             return
 


### PR DESCRIPTION
##### SUMMARY
config-context addition in hostvars in netbox dynamic inventory
Fixed #47391

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
config-context in hostvars in netbox dynamic inventory

##### ANSIBLE VERSION
```
ansible 2.6.5
  config file = /User/ansible.cfg
  configured module search path = [u'/User/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Sep  5 2018, 14:52:04) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
Before change
```
ansible-inventory -vvv -i netbox_inventory.yml --host random
ansible-inventory 2.6.5
  config file = /User/ansible.cfg
  configured module search path = [u'/User/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible-inventory
  python version = 2.7.15 (default, Sep  5 2018, 14:52:04) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
Using /User/ansible.cfg as config file
Fetching: http://localhost:8000/api/dcim/sites/?limit=0
Fetching: http://localhost:8000/api/dcim/regions/?limit=0
Fetching: http://localhost:8000/api/tenancy/tenants/?limit=0
Fetching: http://localhost:8000/api/dcim/racks/?limit=0
Fetching: http://localhost:8000/api/dcim/device-roles/?limit=0
Fetching: http://localhost:8000/api/dcim/device-types/?limit=0
Fetching: http://localhost:8000/api/dcim/manufacturers/?limit=0
Fetching: http://localhost:8000/api/dcim/devices/?limit=0&role=aci-ipn
Fetching: http://localhost:8000/api/virtualization/virtual-machines/?limit=0&role=aci-ipn
Parsed /User/netbox_inventory.yml inventory source with netbox plugin
{
    "device_roles": [
        "ACI IPN"
    ],
    "device_types": [
        "random"
    ],
    "manufacturers": [
        "Cisco"
    ],
    "racks": [
        "abc"
    ],
    "sites": [
        "abc"
    ],
    "tenants": [
        "xyz"
    ]
}
```

After change
```
ansible-inventory -vvv -i netbox_inventory.yml --host random
ansible-inventory 2.6.5
  config file = /User/ansible.cfg
  configured module search path = [u'/User/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible-inventory
  python version = 2.7.15 (default, Sep  5 2018, 14:52:04) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
Using /User/ansible.cfg as config file
Fetching: http://localhost:8000/api/dcim/sites/?limit=0
Fetching: http://localhost:8000/api/dcim/regions/?limit=0
Fetching: http://localhost:8000/api/tenancy/tenants/?limit=0
Fetching: http://localhost:8000/api/dcim/racks/?limit=0
Fetching: http://localhost:8000/api/dcim/device-roles/?limit=0
Fetching: http://localhost:8000/api/dcim/device-types/?limit=0
Fetching: http://localhost:8000/api/dcim/manufacturers/?limit=0
Fetching: http://localhost:8000/api/dcim/devices/?limit=0&role=aci-ipn
Fetching: http://localhost:8000/api/virtualization/virtual-machines/?limit=0&role=aci-ipn
Parsed /User/netbox_inventory.yml inventory source with netbox plugin
{
    "config_contexts": {
        "cc": {
            "net": {
                "vpn_asn": 66000
            }
        }
    },
    "device_roles": [
        "ACI IPN"
    ],
    "device_types": [
        "random"
    ],
    "manufacturers": [
        "Cisco"
    ],
    "racks": [
        "abc"
    ],
    "sites": [
        "abc"
    ],
    "tenants": [
        "xyz"
    ]
}
```
