### PR TITLE
docker_container: warn if ipvX_address is used for networks but not supported by docker-py

### DIFF
--- a/changelogs/fragments/47395-docker_container-ipvX_address.yaml
+++ b/changelogs/fragments/47395-docker_container-ipvX_address.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - fail if ``ipv4_address`` or ``ipv6_address`` is used with a too old docker-py version."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2428,6 +2428,16 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
                 self.module.warn("docker API version is %s. Minimum version required is 1.25 to set or "
                                  "update the container's stop_timeout configuration." % (docker_api_version,))
 
+        ipvX_address_supported = LooseVersion(docker_version) >= LooseVersion('1.9')
+        if not ipvX_address_supported:
+            ipvX_address_used = False
+            for network in self.module.params.get("networks", []):
+                if 'ipv4_address' in network or 'ipv6_address' in network:
+                    ipvX_address_used = True
+            if ipvX_address_used:
+                self.fail("docker or docker-py version is %s. Minimum version required is 1.9 to use "
+                          "ipv4_address or ipv6_address in networks." % (docker_version,))
+
         runtime_supported = LooseVersion(docker_api_version) >= LooseVersion('1.12')
         if self.module.params.get("runtime") and not runtime_supported:
             self.fail('docker API version is %s. Minimum version required is 1.12 to set runtime option.' % (docker_api_version,))

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2154,12 +2154,10 @@ class ContainerManager(DockerBaseClass):
                         self.fail("Error disconnecting container from network %s - %s" % (diff['parameter']['name'],
                                                                                           str(exc)))
             # connect to the network
-            params = dict(
-                ipv4_address=diff['parameter'].get('ipv4_address', None),
-                ipv6_address=diff['parameter'].get('ipv6_address', None),
-                links=diff['parameter'].get('links', None),
-                aliases=diff['parameter'].get('aliases', None)
-            )
+            params = dict()
+            for para in ('ipv4_address', 'ipv6_address', 'links', 'aliases'):
+                if diff['parameter'].get(para):
+                    params[para] = diff['parameter'][para]
             self.results['actions'].append(dict(added_to_network=diff['parameter']['name'], network_parameters=params))
             if not self.check_mode:
                 try:


### PR DESCRIPTION
##### SUMMARY
Fixes #29608.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.8.0
```
