### PR TITLE
fix error checking if netns exists

### DIFF
--- a/lib/ansible/modules/net_tools/ip_netns.py
+++ b/lib/ansible/modules/net_tools/ip_netns.py
@@ -61,6 +61,7 @@ RETURN = '''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
 
 
 class Namespace(object):
@@ -77,9 +78,10 @@ class Namespace(object):
 
     def exists(self):
         '''Check if the namespace already exists'''
-        rtc, out, err = self._netns(['exec', self.name, 'ls'])
-        if rtc != 0:
-            self.module.fail_json(msg=err)
+        rc, out, err = self.module.run_command('ip netns list')
+        if rc != 0:
+            self.module.fail_json(msg=to_text(err))
+        return self.name in out
 
     def add(self):
         '''Create network namespace'''


### PR DESCRIPTION
This patch fixes an error that occurs when attempting to see if the
netns already exists on the remote device.  This change will now execute
`ip netns list` and check if the desired namespace is in the output.

Signed-off-by: Peter Sprygada <psprygada@ansible.com>

