### PR TITLE
refresh_inventory doc typo

### DIFF
--- a/lib/ansible/modules/utilities/helper/meta.py
+++ b/lib/ansible/modules/utilities/helper/meta.py
@@ -60,7 +60,7 @@ EXAMPLES = '''
   cloud_guest:            # this is fake module
     name: newhost
     state: present
-- name: Refresh inventory to ensure new instaces exist in inventory
+- name: Refresh inventory to ensure new instances exist in inventory
   meta: refresh_inventory
 
 - name: Clear gathered facts from all currently targeted hosts


### PR DESCRIPTION
Fix typo in example for usage of refresh_inventory meta task

##### SUMMARY
Fix typo in example for usage of refresh_inventory meta task

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
meta

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (devel 6f9c6071e5) last updated 2018/10/21 12:33:52 (GMT -700)
  config file = None
  configured module search path = [u'/Users/panisset/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/panisset/Desktop/ansible/lib/ansible
  executable location = /Users/panisset/Desktop/ansible/bin/ansible
  python version = 2.7.15 (default, Oct  2 2018, 11:47:18) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.2)]
```

##### ADDITIONAL INFORMATION
N/A
