### PR TITLE
WinRM/PSRP: Ensure shell returns UTF-8 output

### DIFF
--- a/changelogs/fragments/psrp-utf8-stdio.yaml
+++ b/changelogs/fragments/psrp-utf8-stdio.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- psrp - Fix UTF-8 output - https://github.com/ansible/ansible/pull/46998
+

--- a/changelogs/fragments/psrp-utf8-stdio.yaml
+++ b/changelogs/fragments/psrp-utf8-stdio.yaml
@@ -1,3 +1,2 @@
 bugfixes:
 - psrp - Fix UTF-8 output - https://github.com/ansible/ansible/pull/46998
-

--- a/test/integration/targets/connection_psrp/tests.yml
+++ b/test/integration/targets/connection_psrp/tests.yml
@@ -59,3 +59,27 @@
     assert:
       that:
       - async_out.stdout_lines == ["abc"]
+
+  - name: Output unicode characters from Powershell using PSRP
+    win_command: powershell.exe -ExecutionPolicy ByPass -Command "Write-Host '\U0001F4A9'"
+    register: command_unicode_output
+
+  - name: Assert unicode output
+    assert:
+      that:
+      - command_unicode_output is changed
+      - command_unicode_output.rc == 0
+      - command_unicode_output.stdout == "\U0001F4A9\n"
+      - command_unicode_output.stderr == ''
+
+  - name: Output unicode characters from Powershell using PSRP
+    win_shell: Write-Host "\U0001F4A9"
+    register: shell_unicode_output
+
+  - name: Assert unicode output
+    assert:
+      that:
+      - shell_unicode_output is changed
+      - shell_unicode_output.rc == 0
+      - shell_unicode_output.stdout == "\U0001F4A9\n"
+      - shell_unicode_output.stderr == ''

--- a/test/integration/targets/connection_psrp/tests.yml
+++ b/test/integration/targets/connection_psrp/tests.yml
@@ -61,7 +61,7 @@
       - async_out.stdout_lines == ["abc"]
 
   - name: Output unicode characters from Powershell using PSRP
-    win_command: powershell.exe -ExecutionPolicy ByPass -Command "Write-Host '\U0001F4A9'"
+    win_command: "powershell.exe -ExecutionPolicy ByPass -Command \"Write-Host '\U0001F4A9'\""
     register: command_unicode_output
 
   - name: Assert unicode output
@@ -73,7 +73,7 @@
       - command_unicode_output.stderr == ''
 
   - name: Output unicode characters from Powershell using PSRP
-    win_shell: Write-Host "\U0001F4A9"
+    win_shell: "Write-Host '\U0001F4A9'"
     register: shell_unicode_output
 
   - name: Assert unicode output

--- a/test/integration/targets/connection_psrp/tests.yml
+++ b/test/integration/targets/connection_psrp/tests.yml
@@ -69,7 +69,7 @@
       that:
       - command_unicode_output is changed
       - command_unicode_output.rc == 0
-      - command_unicode_output.stdout == "\U0001F4A9\n"
+      - "command_unicode_output.stdout == '\U0001F4A9\n'"
       - command_unicode_output.stderr == ''
 
   - name: Output unicode characters from Powershell using PSRP
@@ -81,5 +81,5 @@
       that:
       - shell_unicode_output is changed
       - shell_unicode_output.rc == 0
-      - shell_unicode_output.stdout == "\U0001F4A9\n"
+      - "shell_unicode_output.stdout == '\U0001F4A9\n'"
       - shell_unicode_output.stderr == ''

--- a/test/integration/targets/win_module_utils/library/command_util_test.ps1
+++ b/test/integration/targets/win_module_utils/library/command_util_test.ps1
@@ -76,6 +76,12 @@ Assert-Equals -actual $actual.rc -expected 0
 Assert-Equals -actual $actual.stdout -expected "stdout `r`n"
 Assert-Equals -actual $actual.stderr -expected "stderr `r`n"
 
+$test_name = "Test UTF8 output from stdout stream"
+$actual = Run-Command -command "powershell.exe -ExecutionPolicy ByPass -Command `"Write-Host '💩'`""
+Assert-Equals -actual $actual.rc -expected 0
+Assert-Equals -actual $actual.stdout -expected "💩`n"
+Assert-Equals -actual $actual.stderr -expected ""
+
 $test_name = "test default environment variable"
 Set-Item -Path env:TESTENV -Value "test"
 $actual = Run-Command -command "cmd.exe /c set"


### PR DESCRIPTION
##### SUMMARY
This PR makes UTF-8 output work in PSRP shells.

This relates to #46998

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
WinRM/PSRP

##### ANSIBLE VERSION
v2.8