### PR TITLE
Add helper function to return helpful import error msg

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -59,22 +59,29 @@ Importing and using shared code
 * Use shared code whenever possible - don't reinvent the wheel. Ansible offers the ``AnsibleModule`` common Python code, plus :ref:`utilities <appendix_module_utilities>` for many common use cases and patterns.
 * Import ``ansible.module_utils`` code in the same place as you import other libraries.
 * Do NOT use wildcards (*) for importing other python modules; instead, list the function(s) you are importing (for example, ``from some.other_python_module.basic import otherFunction``).
-* Import custom packages in ``try``/``except`` and handle them with ``fail_json()`` in ``main()``. For example:
+* Import custom packages in ``try``/``except``, capture any import errors, and handle them with ``fail_json()`` in ``main()``. For example:
 
 	.. code-block:: python
 
+	    import traceback
+
+	    from ansible.basic import missing_required_lib
+
+	    LIB_IMP_ERR = None
 	    try:
 	        import foo
-	        HAS_LIB=True
+	        HAS_LIB = True
 	    except:
-	        HAS_LIB=False
+	        HAS_LIB = False
+	        LIB_IMP_ERR = traceback.format_exc()
 
-  Then in main(), just after the argspec, do
+  Then in ``main()``, just after the argspec, do
 
 	.. code-block:: python
 
 		if not HAS_LIB:
-		    module.fail_json(msg='The foo Python module is required')
+		    module.fail_json(msg=missing_required_lib("foo"),
+		                     exception=LIB_IMP_ERR)
 
   And document the dependency in the ``requirements`` section of your module's :ref:`documentation_block`.
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -785,6 +785,12 @@ def jsonify(data, **kwargs):
     raise UnicodeError('Invalid unicode encoding encountered')
 
 
+def missing_required_lib(library):
+    hostname = platform.node()
+    return "Failed to import the required Python library (%s) on %s's Python %s. Please read module documentation " \
+           "and install in the appropriate location." % (library, hostname, sys.executable)
+
+
 class AnsibleFallbackNotFound(Exception):
     pass
 

--- a/lib/ansible/modules/commands/psexec.py
+++ b/lib/ansible/modules/commands/psexec.py
@@ -321,10 +321,9 @@ rc:
   sample: 0
 '''
 
-import sys
 import traceback
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_bytes, to_text
 
 PYPSEXEC_IMP_ERR = None
@@ -407,9 +406,7 @@ def main():
                              'running as System: process_username, '
                              'process_password')
     if not HAS_PYPSEXEC:
-        module.fail_json(msg="The pypsexec Python module is required to be "
-                             "installed for the Python environment at '%s'"
-                             % sys.executable,
+        module.fail_json(msg=missing_required_lib("pypsexec"),
                          exception=PYPSEXEC_IMP_ERR)
 
     hostname = module.params['hostname']
@@ -443,11 +440,8 @@ def main():
 
     if connection_username is None or connection_password is None and \
             not HAS_KERBEROS:
-        module.fail_json(msg="The gssapi Python module with the GGF extension "
-                             "used for kerberos auth is required to be "
-                             "installed for the Python environment at '%s'"
-                             % sys.executable,
-                         exception=KERBEROS_IMP_ERR)
+        module.fail_json(msg=missing_required_lib("gssapi"),
+                         execption=KERBEROS_IMP_ERR)
 
     win_client = client.Client(server=hostname, username=connection_username,
                                password=connection_password, port=port,


### PR DESCRIPTION
##### SUMMARY
Return a prettier error msg to use when failing to import a required Python library. This will include the Python that is involved and the hostname to clear up any ambiguities when failing to import a Python library.

Supersedes https://github.com/ansible/ansible/pull/41793
Supersedes https://github.com/ansible/ansible/pull/38379

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
basic.py

##### ANSIBLE VERSION
```paste below
devel
```

##### ADDITIONAL INFORMATION
An example output with this change is now

```
# with no v's
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ModuleNotFoundError: No module named 'pypsexec'
fatal: [2016 -> localhost]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (pypsexec) on jborean-osx's Python /Users/jborean/venvs/ansible-py37/bin/python. Please read module documentation and install in the appropriate location."}

# with 3+ v's
The full traceback is:
Traceback (most recent call last):
  File "/var/folders/83/v33q_n515ps10nvlrpmd4x000000gn/T/ansible_psexec_payload_79ha7qpc/__main__.py", line 332, in <module>
    from pypsexec import client
ModuleNotFoundError: No module named 'pypsexec'

fatal: [2016 -> localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "arguments": "Write-Output abc",
            "asynchronous": false,
            "connection_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "connection_timeout": 60,
            "connection_username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "encrypt": true,
            "executable": "powershell.exe",
            "hostname": "server2016.domain.local",
            "integrity_level": "default",
            "interactive": false,
            "interactive_session": 0,
            "load_profile": true,
            "port": 445,
            "priority": "normal",
            "process_password": null,
            "process_timeout": 0,
            "process_username": null,
            "show_ui_on_logon_screen": false,
            "stdin": null,
            "working_directory": "C:\\Windows\\System32"
        }
    },
    "msg": "Failed to import the required Python library (pypsexec) on jborean-osx's Python /Users/jborean/venvs/ansible-py37/bin/python. Please read module documentation and install in the appropriate location."                                                                     
}
```