### PR TITLE
Fix for - Unable to create postgresql RDS Instance

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -189,6 +189,7 @@ def copy_image(module, ec2):
         if module.params.get('wait'):
             delay = 15
             max_attempts = module.params.get('wait_timeout') // delay
+            image_id = image['ImageId']
             ec2.get_waiter('image_available').wait(
                 ImageIds=[image_id],
                 WaiterConfig={'Delay': delay, 'MaxAttempts': max_attempts}

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -207,6 +207,7 @@ options:
           - license-included
           - bring-your-own-license
           - general-public-license
+          - postgresql-license
     master_user_password:
         description:
           - An 8-41 character password for the master database user. The password can contain any printable ASCII character
@@ -1038,7 +1039,7 @@ def main():
         force_failover=dict(type='bool'),
         iops=dict(type='int'),
         kms_key_id=dict(),
-        license_model=dict(choices=['license-included', 'bring-your-own-license', 'general-public-license']),
+        license_model=dict(choices=['license-included', 'bring-your-own-license', 'general-public-license', 'postgresql-license']),
         master_user_password=dict(aliases=['password'], no_log=True),
         master_username=dict(aliases=['username']),
         monitoring_interval=dict(type='int'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding postgresql-license as an allowed choice for license_model.  Current implementation does not allow for creation of a postgresql RDS instance postgresql-license is not an allowed choice.

Fixes #47405
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rds_instance.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
  config file = /home/jjohnston/ansible.cfg
  configured module search path = [u'/opt/GIT/gitcentral/Ansible/custom_modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May 31 2018, 09:41:32) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When creating a PostgreSQL RDS instance with the rds_instance.py module, use any of the currently allowed license_models and described in the documentation and you will get an error that you must use postgresql-license as the license_model from boto.  If you do use postgresql-license, you will get an error from Ansible module rds_instance.py that it is not allowed.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
When using postgresql-license as the license_model you get this error:

fatal: [localhost]: FAILED! => changed=false
  msg: 'value of license_model must be one of: license-included, bring-your-own-license, general-public-license, got: postgresql-license'

When using any of the three allowed license models: 'license-included', 'bring-your-own-license', 'general-public-license', you get this error:

An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ClientError: An error occurred (InvalidParameterCombination) when calling the ModifyDBInstance operation: The bring-your-own-license LicenseModel cannot be used for this configuration
```
