### PR TITLE
mail: fixed STARTTLS module working with python 3.7.0

### DIFF
--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -264,8 +264,8 @@ def main():
     try:
         if secure != 'never':
             try:
-                smtp = smtplib.SMTP_SSL(host=host, timeout=timeout)
-                code, smtpmessage = smtp.connect(host, port=port)
+                smtp = smtplib.SMTP_SSL(host=host, port=port, timeout=timeout)
+                code, smtpmessage = smtp.connect(host, port)
                 secure_state = True
             except ssl.SSLError as e:
                 if secure == 'always':
@@ -275,8 +275,8 @@ def main():
                 pass
 
         if not secure_state:
-            smtp = smtplib.SMTP(timeout=timeout)
-            code, smtpmessage = smtp.connect(host, port=port)
+            smtp = smtplib.SMTP(host=host, port=port, timeout=timeout)
+            code, smtpmessage = smtp.connect(host, port)
 
     except smtplib.SMTPException as e:
         module.fail_json(rc=1, msg='Unable to Connect %s:%s: %s' % (host, port, to_native(e)), exception=traceback.format_exc())


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

#44552 was fixed module working with `SSL`.
This PR also fixed module working with `STARTTLS`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

mail

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
  config file = /home/k0ste/.ansible.cfg
  configured module search path = ['/home/k0ste/ansible/my_modules', '/home/k0ste/ceph-ansible/library']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.0 (default, Sep 15 2018, 19:13:07) [GCC 8.2.1 20180831]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

After backport to 2.7 should resolve #46673.
