### PR TITLE
2.7: yum/dnf: fail when space separated string of names (#47109)

### DIFF
--- a/changelogs/fragments/47109-fail-space-separated-string-pkgs.yaml
+++ b/changelogs/fragments/47109-fail-space-separated-string-pkgs.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - yum/dnf: fail when space separated string of names (https://github.com/ansible/ansible/pull/47109)
+  - yum/dnf - fail when space separated string of names (https://github.com/ansible/ansible/pull/47109)

--- a/changelogs/fragments/47109-fail-space-separated-string-pkgs.yaml
+++ b/changelogs/fragments/47109-fail-space-separated-string-pkgs.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - yum/dnf: fail when space separated string of names (https://github.com/ansible/ansible/pull/47109)

--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -92,6 +92,15 @@ class YumDnf(with_metaclass(ABCMeta, object)):
         self.enablerepo = self.listify_comma_sep_strings_in_list(self.enablerepo)
         self.exclude = self.listify_comma_sep_strings_in_list(self.exclude)
 
+        # Fail if someone passed a space separated string
+        # https://github.com/ansible/ansible/issues/46301
+        if any((' ' in name and '@' not in name for name in self.names)):
+            module.fail_json(
+                msg='It appears that a space separated string of packages was passed in '
+                    'as an argument. To operate on several packages, pass a comma separated '
+                    'string of packages or a list of packages.'
+            )
+
     def listify_comma_sep_strings_in_list(self, some_list):
         """
         method to accept a list of strings as the parameter, find any strings

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -26,9 +26,10 @@ description:
 options:
   name:
     description:
-      - "A list of package names, or package specifier with version, like C(name-1.0)
+      - "A package name or package specifier with version, like C(name-1.0).
         When using state=latest, this can be '*' which means run: dnf -y update.
-        You can also pass a url or a local path to a rpm file."
+        You can also pass a url or a local path to a rpm file.
+        To operate on several packages this can accept a comma separated string of packages or a list of packages."
     required: true
     aliases:
         - pkg

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -40,7 +40,7 @@ options:
         See the C(allow_downgrade) documentation for caveats with downgrading packages.
       - When using state=latest, this can be C('*') which means run C(yum -y update).
       - You can also pass a url or a local path to a rpm file (using state=present).
-        To operate on several packages this can accept a comma separated list of packages or (as of 2.0) a list of packages.
+        To operate on several packages this can accept a comma separated string of packages or (as of 2.0) a list of packages.
     aliases: [ pkg ]
   exclude:
     description:


### PR DESCRIPTION
* yum/dnf: fail when space separated string of names

* Groups allow spaces in names

(cherry picked from commit e8b6864e21b52c6f9684c935d7363583d8e2598a)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/47109
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum
dnf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
