### PR TITLE
pamd: allow leading dash and always end with newline

### DIFF
--- a/changelogs/fragments/47420-pamd_dashes_and_file_newlines.yml
+++ b/changelogs/fragments/47420-pamd_dashes_and_file_newlines.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- "pamd: allow leading dash per pamd config spec and always end file with newline
+   (see https://github.com/ansible/ansible/pull/47420 and https://github.com/ansible/ansible/issues/47418)" 

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -775,7 +775,7 @@ def main():
         try:
             temp_file = NamedTemporaryFile(mode='w', dir=module.tmpdir, delete=False)
             with open(temp_file.name, 'w') as fd:
-                fd.write(str(service))
+                fd.write(str(service) + '\n')
 
         except IOError:
             module.fail_json(msg='Unable to create temporary \

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -277,11 +277,12 @@ from tempfile import NamedTemporaryFile
 from datetime import datetime
 
 
-RULE_REGEX = re.compile(r"""(?P<rule_type>auth|account|session|password)\s+
+RULE_REGEX = re.compile(r"""(?P<rule_type>-?(auth|account|session|password))\s+
                         (?P<control>\[.*\]|\S*)\s+
                         (?P<path>\S*)\s?
                         (?P<args>.*)""", re.X)
 
+VALID_TYPES = ['account', '-account', 'auth', '-auth', 'password', '-password', 'session', '-session']
 
 class PamdLine(object):
 
@@ -334,7 +335,6 @@ class PamdInclude(PamdLine):
 
 class PamdRule(PamdLine):
 
-    valid_types = ['account', 'auth', 'password', 'session']
     valid_simple_controls = ['required', 'requisite', 'sufficient', 'optional', 'include', 'substack', 'definitive']
     valid_control_values = ['success', 'open_err', 'symbol_err', 'service_err', 'system_err', 'buf_err',
                             'perm_denied', 'auth_err', 'cred_insufficient', 'authinfo_unavail', 'user_unknown',
@@ -422,7 +422,7 @@ class PamdRule(PamdLine):
 
     def validate(self):
         # Validate the rule type
-        if self.rule_type not in PamdRule.valid_types:
+        if self.rule_type not in VALID_TYPES:
             return False, "Rule type, " + self.rule_type + ", is not valid in rule " + self.line
         # Validate the rule control
         if isinstance(self._control, str) and self.rule_control not in PamdRule.valid_simple_controls:
@@ -694,14 +694,10 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(required=True, type='str'),
-            type=dict(required=True,
-                      choices=['account', 'auth',
-                               'password', 'session']),
+            type=dict(required=True, choices=VALID_TYPES),
             control=dict(required=True, type='str'),
             module_path=dict(required=True, type='str'),
-            new_type=dict(required=False,
-                          choices=['account', 'auth',
-                                   'password', 'session']),
+            new_type=dict(required=False, choices=VALID_TYPES),
             new_control=dict(required=False, type='str'),
             new_module_path=dict(required=False, type='str'),
             module_arguments=dict(required=False, type='list'),

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -284,6 +284,7 @@ RULE_REGEX = re.compile(r"""(?P<rule_type>-?(auth|account|session|password))\s+
 
 VALID_TYPES = ['account', '-account', 'auth', '-auth', 'password', '-password', 'session', '-session']
 
+
 class PamdLine(object):
 
     def __init__(self, line):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update the regex to account for leading dashes that are allowed in the pamd config file spec. See #47418 for more info.

Also created a VALID_TYPES constant to use throughout the module with all allowed types and their dash permutations. 
`['account', '-account', 'auth', '-auth', 'password', '-password', 'session', '-session']`

Fixes #47418 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pamd

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.5
  config file = /Users/me/.ansible.cfg
  configured module search path = ['/Users/me/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/me/.virtualenvs/ansible/lib/python3.6/site-packages/ansible
  executable location = /Users/me/.virtualenvs/ansible/bin/ansible
  python version = 3.6.6 (default, Jul 21 2018, 22:49:24) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

Also tested with `2.7.0` and `devel`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See #47418 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
