### PR TITLE
Handle sets differently than lists in wrap_var

### DIFF
--- a/changelogs/fragments/unsafe-set-wrap.yaml
+++ b/changelogs/fragments/unsafe-set-wrap.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- unsafe - Add special casing to sets, to support wrapping elements of sets correctly in Python 3 (https://github.com/ansible/ansible/issues/47372)

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -95,11 +95,17 @@ def _wrap_list(v):
     return v
 
 
+def _wrap_set(v):
+    return set(item if item is None else wrap_var(item) for item in v)
+
+
 def wrap_var(v):
     if isinstance(v, Mapping):
         v = _wrap_dict(v)
-    elif isinstance(v, (MutableSequence, Set)):
+    elif isinstance(v, MutableSequence):
         v = _wrap_list(v)
+    elif isinstance(v, Set):
+        v = _wrap_set(v)
     elif v is not None and not isinstance(v, AnsibleUnsafe):
         v = UnsafeProxy(v)
     return v

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -258,3 +258,13 @@
   loop: []
   register: literal_empty_list
   failed_when: literal_empty_list is not skipped
+
+# https://github.com/ansible/ansible/issues/47372
+- name: Loop unsafe list
+  debug:
+    var: item
+  with_items: "{{ things|map('string')|unique }}"
+  vars:
+    things:
+      - !unsafe foo
+      - !unsafe bar


### PR DESCRIPTION
##### SUMMARY
Handle sets differently than lists in wrap_var. Fixes #47372 

This resolves a Python3 bug.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/unsafe_proxy.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```