### PR TITLE
[stable-2.7] Fix exception when including tasks from handlers (#47307)

### DIFF
--- a/changelogs/fragments/47307-handler-include-task.yml
+++ b/changelogs/fragments/47307-handler-include-task.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "handlers - fix crash when handler task include tasks"

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -947,9 +947,12 @@ class StrategyBase:
                         iterator._play.handlers.append(block)
                         iterator.cache_block_tasks(block)
                         for task in block.block:
+                            task_name = task.get_name()
+                            display.debug("adding task '%s' included in handler '%s'" % (task_name, handler_name))
+                            self._notified_handlers[task._uuid] = included_file._hosts[:]
                             result = self._do_handler_run(
                                 handler=task,
-                                handler_name=task.get_name(),
+                                handler_name=task_name,
                                 iterator=iterator,
                                 play_context=play_context,
                                 notified_hosts=included_file._hosts[:],

--- a/test/integration/targets/handlers/runme.sh
+++ b/test/integration/targets/handlers/runme.sh
@@ -63,3 +63,6 @@ set +e
 result="$(ansible-playbook test_handlers_any_errors_fatal.yml -e output_dir=$output_dir -i inventory.handlers -v "$@" 2>&1)"
 set -e
 [ ! -f $output_dir/should_not_exist_B ] || (rm -f $output_dir/should_not_exist_B && exit 1)
+
+# https://github.com/ansible/ansible/issues/47287
+[ "$(ansible-playbook test_handlers_including_task.yml -i ../../inventory -v "$@" | egrep -o 'failed=[0-9]+')" = "failed=0" ]

--- a/test/integration/targets/handlers/test_handlers_including_task.yml
+++ b/test/integration/targets/handlers/test_handlers_including_task.yml
@@ -1,0 +1,16 @@
+---
+- name: Verify handler can include other tasks (#47287)
+  hosts: testhost
+  tasks:
+    - name: include a task from the tasks section
+      include_tasks: handlers.yml
+
+    - name: notify a handler
+      debug:
+        msg: notifying handler
+      changed_when: yes
+      notify: include a task from the handlers section
+
+  handlers:
+    - name: include a task from the handlers section
+      include_tasks: handlers.yml


### PR DESCRIPTION
Set _notified_handlers for the task's _uuid that is run as a handler

Fix #47287
(cherry picked from commit 6497049)


Co-authored-by: Pablo <pablorf.dev@outlook.com>