### PR TITLE
[stable-2.7] Handle sets differently than lists in wrap_var. Fixes #47372

### DIFF
--- a/changelogs/fragments/unsafe-set-wrap.yaml
+++ b/changelogs/fragments/unsafe-set-wrap.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- unsafe - Add special casing to sets, to support wrapping elements of sets correctly in Python 3 (https://github.com/ansible/ansible/issues/47372)

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -96,11 +96,17 @@ def _wrap_list(v):
     return v
 
 
+def _wrap_set(v):
+    return set(item if item is None else wrap_var(item) for item in v)
+
+
 def wrap_var(v):
     if isinstance(v, Mapping):
         v = _wrap_dict(v)
-    elif isinstance(v, (MutableSequence, Set)):
+    elif isinstance(v, MutableSequence):
         v = _wrap_list(v)
+    elif isinstance(v, Set):
+        v = _wrap_set(v)
     elif v is not None and not isinstance(v, AnsibleUnsafe):
         v = UnsafeProxy(v)
     return v

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -252,3 +252,13 @@
   loop: "{{ fake_var }}"
   register: result
   failed_when: result is not skipped
+
+# https://github.com/ansible/ansible/issues/47372
+- name: Loop unsafe list
+  debug:
+    var: item
+  with_items: "{{ things|map('string')|unique }}"
+  vars:
+    things:
+      - !unsafe foo
+      - !unsafe bar


### PR DESCRIPTION
(cherry picked from commit c58de75f385dcfcef0531fc7c0cbb13bfdef0e83)

Co-authored-by: Matt Martz <matt@sivel.net>