### PR TITLE
Backport pamd fixes to stable-2.7 (#47281) (#47133)

### DIFF
--- a/changelogs/fragments/47133-pamd_use_module_tmpdir.yml
+++ b/changelogs/fragments/47133-pamd_use_module_tmpdir.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- "pamd: use module.tmpdir for NamedTemporaryFile()
+   (see https://github.com/ansible/ansible/pull/47133 and https://github.com/ansible/ansible/issues/36954)" 

--- a/changelogs/fragments/47281-pamd-dont-delete-named_temporary_file_on_close.yaml
+++ b/changelogs/fragments/47281-pamd-dont-delete-named_temporary_file_on_close.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+- "pamd: add delete=False to NamedTemporaryFile() fixes OSError on module completion, and
+   removes print statement from module code.
+   (see https://github.com/ansible/ansible/pull/47281 and https://github.com/ansible/ansible/issues/47080)" 

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -776,9 +776,8 @@ def main():
         # First, create a backup if desired.
         if module.params['backup']:
             backupdest = module.backup_local(fname)
-            print("BACKUP DEST", backupdest)
         try:
-            temp_file = NamedTemporaryFile(mode='w')
+            temp_file = NamedTemporaryFile(mode='w', dir=module.tmpdir, delete=False)
             with open(temp_file.name, 'w') as fd:
                 fd.write(str(service))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of pamd module fixes in #47281 and #47133 

* add delete=False to NamedTemporaryFile and remove print statement from module

* add changelog fragment

* use module.tmpdir from (#47133) and add changelog fragment for it as well

(cherry picked from commit c67ab296bbbb90e7f701413fa793fc0cdbc4818a)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pamd

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
stable-2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
