### PR TITLE
[2.7] escape default prompt detection in telnet action plugin (#46573)

### DIFF
--- a/changelogs/fragments/telent-prompt-fix.yaml
+++ b/changelogs/fragments/telent-prompt-fix.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- Fix an issue with the default telnet prompt handling. The value needs to be
+  escaped otherwise it does not work when converted to bytes.

--- a/lib/ansible/plugins/action/telnet.py
+++ b/lib/ansible/plugins/action/telnet.py
@@ -51,7 +51,7 @@ class ActionModule(ActionBase):
 
             login_prompt = self._task.args.get('login_prompt', "login: ")
             password_prompt = self._task.args.get('password_prompt', "Password: ")
-            prompts = self._task.args.get('prompts', ["$ "])
+            prompts = self._task.args.get('prompts', ["\\$ "])
             commands = self._task.args.get('command') or self._task.args.get('commands')
 
             if isinstance(commands, text_type):


### PR DESCRIPTION
This change fixes an issue with the default prompt handling.  The value
needs to be escaped otherwise it does not work when converted to bytes.
(cherry picked from commit 9180d2c)

Co-authored-by: Peter Sprygada <privateip@users.noreply.github.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/action/telnet

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```