### PR TITLE
Revert "WinRM/PSRP: Fix UTF-8 issue (#46998)"

### DIFF
--- a/changelogs/fragments/psrp-utf8.yaml
+++ b/changelogs/fragments/psrp-utf8.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-- psrp - Fix issue when dealing with unicode values in the output for Python 2 - https://github.com/ansible/ansible/pull/46998

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -557,7 +557,7 @@ if ($bytes_read -gt 0) {
             # create our own output based on the properties if that is the
             # case+
             try:
-                output_msg = to_text(output)
+                output_msg = str(output)
             except TypeError:
                 if isinstance(output, GenericComplexObject):
                     obj_lines = output.property_sets


### PR DESCRIPTION
This reverts commit 1bb674034f78260d1cbe42b35c05cc462471a6f5.

##### SUMMARY
Reverts https://github.com/ansible/ansible/pull/46998 based on feedback from @abadger

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
psrp

##### ANSIBLE VERSION
```paste below
devel
```