### PR TITLE
don't restrict disable_excludes choices incorrectly

### DIFF
--- a/changelogs/fragments/dnfyum-disable-excludes.yaml
+++ b/changelogs/fragments/dnfyum-disable-excludes.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "dnf appropriately handles disable_excludes repoid argument"

--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -24,7 +24,7 @@ yumdnf_argument_spec = dict(
         autoremove=dict(type='bool', default=False),
         bugfix=dict(required=False, type='bool', default=False),
         conf_file=dict(type='str'),
-        disable_excludes=dict(type='str', default=None, choices=['all', 'main', 'repoid']),
+        disable_excludes=dict(type='str', default=None),
         disable_gpg_check=dict(type='bool', default=False),
         disable_plugin=dict(type='list', default=[]),
         disablerepo=dict(type='list', default=[]),

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -142,7 +142,6 @@ options:
       - If set to C(all), disables all excludes.
       - If set to C(main), disable excludes defined in [main] in yum.conf.
       - If set to C(repoid), disable excludes defined for given repo id.
-    choices: [ all, main, repoid ]
     version_added: "2.7"
   validate_certs:
     description:

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -175,7 +175,6 @@ options:
       - If set to C(all), disables all excludes.
       - If set to C(main), disable excludes defined in [main] in yum.conf.
       - If set to C(repoid), disable excludes defined for given repo id.
-    choices: [ all, main, repoid ]
     version_added: "2.7"
   download_only:
     description:


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #47085

The `choices` option should not have been set for the `disable_excludes` parameter in the `yum` and `dnf` argument spec because it incorrectly restricts the input possibilities.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum
dnf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (bugfix/47085-yumdnf-disable-excludes 31c1e2adf8) last updated 2018/10/22 16:27:17 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, Sep 21 2018, 23:26:48) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]

```

