### PR TITLE
dnf properly gpg check local packages based on param

### DIFF
--- a/changelogs/fragments/dnf-localgpgcheck.yaml
+++ b/changelogs/fragments/dnf-localgpgcheck.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "dnf properly honor disable_gpg_check for local (on local disk of remote node) package installation"

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -490,6 +490,7 @@ class DnfModule(YumDnf):
 
         # Set whether to check gpg signatures
         conf.gpgcheck = not disable_gpg_check
+        conf.localpkg_gpgcheck = not disable_gpg_check
 
         # Don't prompt for user confirmations
         conf.assumeyes = True


### PR DESCRIPTION
Fixes #43624

Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
properly gpg check local packages (on the local disk of the remote node) based on param provided by the user
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dnf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (bugfix/43624-dnf-localgpgcheck 807684ff8b) last updated 2018/10/22 17:22:32 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, Sep 21 2018, 23:26:48) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```

