### PR TITLE
params.get preserves k8s module invocation

### DIFF
--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -54,11 +54,11 @@ class KubernetesRawModule(KubernetesAnsibleModule):
                                          supports_check_mode=True,
                                          **kwargs)
 
-        self.kind = self.params.pop('kind')
-        self.api_version = self.params.pop('api_version')
-        self.name = self.params.pop('name')
-        self.namespace = self.params.pop('namespace')
-        resource_definition = self.params.pop('resource_definition')
+        self.kind = self.params.get('kind')
+        self.api_version = self.params.get('api_version')
+        self.name = self.params.get('name')
+        self.namespace = self.params.get('namespace')
+        resource_definition = self.params.get('resource_definition')
         if resource_definition:
             if isinstance(resource_definition, string_types):
                 try:
@@ -69,7 +69,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
                 self.resource_definitions = resource_definition
             else:
                 self.resource_definitions = [resource_definition]
-        src = self.params.pop('src')
+        src = self.params.get('src')
         if src:
             self.resource_definitions = self.load_resource_definitions(src)
 


### PR DESCRIPTION
##### SUMMARY
Using params.get rather than params.pop preserves the
original module invocation for more useful output under
more verbose output modes.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
k8s

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel 581b6aed2e) last updated 2018/10/23 08:41:23 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/opensource/ansible/lib/ansible
  executable location = /Users/will/src/opensource/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
