### PR TITLE
added missing references to aliases in azure_rm_sqlserver test

### DIFF
--- a/test/integration/targets/azure_rm_postgresqlserver/aliases
+++ b/test/integration/targets/azure_rm_postgresqlserver/aliases
@@ -4,3 +4,5 @@ shippable/azure/group8
 azure_rm_postgresqlserver_facts
 azure_rm_postgresqldatabase
 azure_rm_postgresqldatabase_facts
+azure_rm_postgresqlfirewallrule
+azure_rm_postgresqlfirewallrule_facts


### PR DESCRIPTION
##### SUMMARY
A few dependencies were missing

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_postgresqlserver
azure_rm_postgresqlfirewallrule
azure_rm_postgresqlfirewallrule_facts

##### ANSIBLE VERSION
2.7

##### ADDITIONAL INFORMATION

