### PR TITLE
Fix consistency issue in grafana_dashboard module.

### DIFF
--- a/changelogs/fragments/47459_grafana_dashboard_consistency_fix.yaml
+++ b/changelogs/fragments/47459_grafana_dashboard_consistency_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix consistency issue in grafana_dashboard module where the module would detect absence of 'dashboard' key on dashboard create but not dashboard update.

--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -248,6 +248,10 @@ def grafana_create_dashboard(module, data):
     # test if dashboard already exists
     dashboard_exists, dashboard = grafana_dashboard_exists(module, data['grafana_url'], uid, headers=headers)
 
+    # Check that the dashboard JSON is nested under the 'dashboard' key
+    if 'dashboard' not in payload:
+        payload = {'dashboard': payload}
+
     result = {}
     if dashboard_exists is True:
         if dashboard == payload:
@@ -278,8 +282,6 @@ def grafana_create_dashboard(module, data):
                 raise GrafanaAPIException('Unable to update the dashboard %s : %s' % (uid, body['message']))
     else:
         # create
-        if 'dashboard' not in payload:
-            payload = {'dashboard': payload}
         r, info = fetch_url(module, '%s/api/dashboards/db' % data['grafana_url'], data=json.dumps(payload), headers=headers, method='POST')
         if info['status'] == 200:
             result['msg'] = "Dashboard %s created" % uid

--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -226,6 +226,10 @@ def grafana_create_dashboard(module, data):
     except Exception as e:
         raise GrafanaAPIException("Can't load json file %s" % to_native(e))
 
+    # Check that the dashboard JSON is nested under the 'dashboard' key
+    if 'dashboard' not in payload:
+        payload = {'dashboard': payload}
+
     # define http header
     headers = grafana_headers(module, data)
 
@@ -247,10 +251,6 @@ def grafana_create_dashboard(module, data):
 
     # test if dashboard already exists
     dashboard_exists, dashboard = grafana_dashboard_exists(module, data['grafana_url'], uid, headers=headers)
-
-    # Check that the dashboard JSON is nested under the 'dashboard' key
-    if 'dashboard' not in payload:
-        payload = {'dashboard': payload}
 
     result = {}
     if dashboard_exists is True:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Move check for 'dashboard' key to before the create/update if statement.
Before this check only happened in the 'create' section of the if statement.
This check makes it much easier to manage your dashboard JSON files and should be done for both create and update methods for consistency.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
grafana_dashboard

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.2
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

1. Create dashboard with raw dashboard JSON (no 'dashboard' key)
2. Update dashboard JSON
3. Run play again and it will fail

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
before:
[{"fieldNames":["Dashboard"],"classification":"RequiredError","message":"Required"}]

after:
... "failed": false, "changed": true ...
```
