### PR TITLE
[stable-2.7] Revert "[stable-2.7] Handle sets differently than lists …

### DIFF
--- a/changelogs/fragments/unsafe-set-wrap.yaml
+++ b/changelogs/fragments/unsafe-set-wrap.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-- unsafe - Add special casing to sets, to support wrapping elements of sets correctly in Python 3 (https://github.com/ansible/ansible/issues/47372)

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -96,17 +96,11 @@ def _wrap_list(v):
     return v
 
 
-def _wrap_set(v):
-    return set(item if item is None else wrap_var(item) for item in v)
-
-
 def wrap_var(v):
     if isinstance(v, Mapping):
         v = _wrap_dict(v)
-    elif isinstance(v, MutableSequence):
+    elif isinstance(v, (MutableSequence, Set)):
         v = _wrap_list(v)
-    elif isinstance(v, Set):
-        v = _wrap_set(v)
     elif v is not None and not isinstance(v, AnsibleUnsafe):
         v = UnsafeProxy(v)
     return v

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -252,13 +252,3 @@
   loop: "{{ fake_var }}"
   register: result
   failed_when: result is not skipped
-
-# https://github.com/ansible/ansible/issues/47372
-- name: Loop unsafe list
-  debug:
-    var: item
-  with_items: "{{ things|map('string')|unique }}"
-  vars:
-    things:
-      - !unsafe foo
-      - !unsafe bar


### PR DESCRIPTION
…in wrap_var. Fixes #47372."

This reverts commit 0e933f76ba4edb0e06f0779f5fb4b0ea85191e8b.

The tests for this were broken on centos6 because jinja2 does not have
a map filter on that platform.  Tests need to be rewritten.
(cherry picked from commit ccabc2bff57992772cb91ae46bce405580a22c8a)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
