### PR TITLE
[2.6] Fixes #33045: get existing containers in a network via inspect_network (Rebased #33048)

### DIFF
--- a/changelogs/fragments/43997-docker_network-inspect.yaml
+++ b/changelogs/fragments/43997-docker_network-inspect.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_network - fixes idempotency issues (https://github.com/ansible/ansible/issues/33045) and name substring issue (https://github.com/ansible/ansible/issues/32926)."

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -161,6 +161,7 @@ from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseCl
 
 try:
     from docker import utils
+    from docker.errors import NotFound
     if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:
         from docker.types import IPAMPool, IPAMConfig
 except:
@@ -215,14 +216,10 @@ class DockerNetworkManager(object):
             self.absent()
 
     def get_existing_network(self):
-        networks = self.client.networks(names=[self.parameters.network_name])
-        # check if a user is trying to find network by its Id
-        if not networks:
-            networks = self.client.networks(ids=[self.parameters.network_name])
-        if not networks:
+        try:
+            return self.client.inspect_network(self.parameters.network_name)
+        except NotFound:
             return None
-        else:
-            return networks[0]
 
     def has_different_config(self, net):
         '''


### PR DESCRIPTION
##### SUMMARY
Backport of #43997: fixes issues with idempotency of docker_network and problem with network names being substrings of other network names.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_network

##### ANSIBLE VERSION
```
2.6.6
```
