### PR TITLE
[2.7] zabbix_host: backport of #46521

### DIFF
--- a/changelogs/fragments/46521-zabbix_host-fix-link-template-error.yml
+++ b/changelogs/fragments/46521-zabbix_host-fix-link-template-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "zabbix_host - module was failing when zabbix host was updated with new interface and template depending on that interface at the same time"

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -814,12 +814,12 @@ def main():
                                          description, host_name, inventory_mode, inventory_zabbix,
                                          tls_accept, tls_psk_identity, tls_psk, tls_issuer, tls_subject, tls_connect,
                                          ipmi_authtype, ipmi_privilege, ipmi_username, ipmi_password):
-                host.link_or_clear_template(host_id, template_ids, tls_connect, tls_accept, tls_psk_identity,
-                                            tls_psk, tls_issuer, tls_subject, ipmi_authtype, ipmi_privilege,
-                                            ipmi_username, ipmi_password)
                 host.update_host(host_name, group_ids, status, host_id,
                                  interfaces, exist_interfaces, proxy_id, visible_name, description, tls_connect, tls_accept,
                                  tls_psk_identity, tls_psk, tls_issuer, tls_subject, ipmi_authtype, ipmi_privilege, ipmi_username, ipmi_password)
+                host.link_or_clear_template(host_id, template_ids, tls_connect, tls_accept, tls_psk_identity,
+                                            tls_psk, tls_issuer, tls_subject, ipmi_authtype, ipmi_privilege,
+                                            ipmi_username, ipmi_password)
                 host.update_inventory_mode(host_id, inventory_mode)
                 host.update_inventory_zabbix(host_id, inventory_zabbix)
 


### PR DESCRIPTION
##### SUMMARY
Backport of #46521 - fixed issue preventing user from updating zabbix host with both new interface and template depending on that interface at the same time.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
zabbix_host

##### ANSIBLE VERSION
```
ansible 2.7.0.post0 (backport/2.7/46521 62cd784e25) last updated 2018/10/23 08:25:00 (GMT +200)
```
