### PR TITLE
 ovirt_vm: Fix issue in setting the custom_compatibility_version to NULL

### DIFF
--- a/changelogs/fragments/ovirt_vm_fix_issue_in_setting_the_custom_compatibility_version_to_NULL.yaml
+++ b/changelogs/fragments/ovirt_vm_fix_issue_in_setting_the_custom_compatibility_version_to_NULL.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ovirt_vm - Fix issue in setting the custom_compatibility_version to NULL (https://github.com/ansible/ansible/pull/47388).

--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -789,14 +789,14 @@ class BaseModule(object):
         return entity
 
     def _get_major(self, full_version):
-        if full_version is None:
+        if full_version is None or full_version == "":
             return None
         if isinstance(full_version, otypes.Version):
             return int(full_version.major)
         return int(full_version.split('.')[0])
 
     def _get_minor(self, full_version):
-        if full_version is None:
+        if full_version is None or full_version == "":
             return None
         if isinstance(full_version, otypes.Version):
             return int(full_version.minor)


### PR DESCRIPTION
Currently there is no way to reset the custom_compatibility_version to
NULL. If we provide a empty string('') to custom_compatibility_version,
it will fail with error "IndexError: list index out of range" at _get_minor
function.

To reset the custom_compatibility_version, we have to pass None value to
types.Version. The PR fixes the same.

Signed-off-by: Ondra Machacek <omachace@redhat.com>

Backport of: https://github.com/ansible/ansible/pull/47388