### PR TITLE
ovirt_vm: Fix issue in SSO option

### DIFF
--- a/changelogs/fragments/ovirt_vm_fix_issue_in_SSO_option.yaml
+++ b/changelogs/fragments/ovirt_vm_fix_issue_in_SSO_option.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ovirt_vm - Fix issue in SSO option (https://github.com/ansible/ansible/pull/47312).

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -1031,7 +1031,7 @@ class VmsModule(BaseModule):
                 otypes.Sso(
                     methods=[otypes.Method(id=otypes.SsoMethod.GUEST_AGENT)] if self.param('sso') else []
                 )
-            ),
+            ) if self.param('sso') is not None else None,
             quota=otypes.Quota(id=self._module.params.get('quota_id')) if self.param('quota_id') is not None else None,
             high_availability=otypes.HighAvailability(
                 enabled=self.param('high_availability'),


### PR DESCRIPTION
Currently the module will disable the SSO if we didn't pass any
value for SSO option. The PR fixes the same.

Signed-off-by: Ondra Machacek <omachace@redhat.com>

Bacport of: https://github.com/ansible/ansible/pull/47312