### PR TITLE
[2.7] docker_container: warn if ipvX_address is used for networks but not supported by docker-py

### DIFF
--- a/changelogs/fragments/47395-docker_container-ipvX_address.yaml
+++ b/changelogs/fragments/47395-docker_container-ipvX_address.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - fail if ``ipv4_address`` or ``ipv6_address`` is used with a too old docker-py version."


### PR DESCRIPTION
##### SUMMARY
Backport of #47395: warn if `ipv4_address` or `ipv6_address` is used for a network but not supported by docker-py.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.7.1
```
