### PR TITLE
[docker_network] add ipv6 support

### DIFF
--- a/changelogs/fragments/35370-add_support_for_docker_network_internal_flag.yaml
+++ b/changelogs/fragments/35370-add_support_for_docker_network_internal_flag.yaml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
   - "docker_network - ``internal`` is now used to set the ``Internal`` property of the docker network during creation."
-  - "docker_network - Minimum docker-py version increased from ``1.8.0`` to ``1.9.0``."

--- a/changelogs/fragments/47492-docker_network-add-ipv6-support.yaml
+++ b/changelogs/fragments/47492-docker_network-add-ipv6-support.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+  - "docker_network - Add support for ipv6 networks."
+  - "docker_network - Minimum docker-py version increased from ``1.9.0`` to ``1.10.0``."
+deprecated_features:
+  - "docker_network - Deprecate ``ipam_options`` in favour of ``ipam_config``."

--- a/changelogs/fragments/47492-docker_network-add-ipv6-support.yaml
+++ b/changelogs/fragments/47492-docker_network-add-ipv6-support.yaml
@@ -1,5 +1,5 @@
 minor_changes:
-  - "docker_network - Add support for ipv6 networks."
+  - "docker_network - Add support for IPv6 networks."
   - "docker_network - Minimum docker-py version increased from ``1.9.0`` to ``1.10.0``."
   - "docker_network - Minimum docker server version increased from ``1.9.0`` to ``1.10.0``."
 deprecated_features:

--- a/changelogs/fragments/47492-docker_network-add-ipv6-support.yaml
+++ b/changelogs/fragments/47492-docker_network-add-ipv6-support.yaml
@@ -1,5 +1,6 @@
 minor_changes:
   - "docker_network - Add support for ipv6 networks."
   - "docker_network - Minimum docker-py version increased from ``1.9.0`` to ``1.10.0``."
+  - "docker_network - Minimum docker server version increased from ``1.9.0`` to ``1.10.0``."
 deprecated_features:
   - "docker_network - Deprecate ``ipam_options`` in favour of ``ipam_config``."

--- a/changelogs/fragments/47492-docker_network-add-ipv6-support.yaml
+++ b/changelogs/fragments/47492-docker_network-add-ipv6-support.yaml
@@ -1,6 +1,4 @@
 minor_changes:
   - "docker_network - Add support for IPv6 networks."
-  - "docker_network - Minimum docker-py version increased from ``1.9.0`` to ``1.10.0``."
-  - "docker_network - Minimum docker server version increased from ``1.9.0`` to ``1.10.0``."
 deprecated_features:
   - "docker_network - Deprecate ``ipam_options`` in favour of ``ipam_config``."

--- a/changelogs/fragments/47492-docker_network-add-ipv6-support.yaml
+++ b/changelogs/fragments/47492-docker_network-add-ipv6-support.yaml
@@ -1,3 +1,4 @@
+---
 minor_changes:
   - "docker_network - Add support for IPv6 networks."
 deprecated_features:

--- a/changelogs/fragments/docker_network-requirements.yaml
+++ b/changelogs/fragments/docker_network-requirements.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "docker_network - Minimum docker-py version increased from ``1.8.0`` to ``1.10.0``."
+  - "docker_network - Minimum docker server version increased from ``1.9.0`` to ``1.10.0``."

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -346,7 +346,7 @@ class DockerNetworkManager(object):
                             different = True
                             differences.append('ipam_config[%s].%s' % (idx, key))
 
-        if self.parameters.enable_ipv6 is not None and self.parameters.enable_ipv6 != net['EnableIPv6']:
+        if self.parameters.enable_ipv6 is not None and self.parameters.enable_ipv6 != net.get('EnableIPv6', False):
             different = True
             differences.append('enable_ipv6')
 

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -191,7 +191,7 @@ EXAMPLES = '''
 
 - name: Delete a network, disconnecting all containers
   docker_network:
-    name: network_four
+    name: network_one
     state: absent
     force: yes
 '''

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -256,7 +256,7 @@ def get_ip_version(cidr):
     :return: ``ipv4`` or ``ipv6``
     :rtype: str
     """
-    cidr_ipv4 = re.compile(r'^([0-9]{1,3}\.){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|3[0-2]))?$')
+    cidr_ipv4 = re.compile(r'^([0-9]{1,3}\.){3}[0-9]{1,3}/([0-9]|[1-2][0-9]|3[0-2])$')
     if cidr_ipv4.match(cidr):
         return 'ipv4'
     return 'ipv6'

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -173,6 +173,9 @@ EXAMPLES = '''
       - subnet: 172.3.27.0/24
         gateway: 172.3.27.2
         iprange: 172.3.27.0/26
+        aux_addresses:
+          host1: 172.3.27.3
+          host2: 172.3.27.4
 - name: Create a network with IPv6 IPAM config
   docker_network:
     name: network_ipv6_one

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -173,15 +173,14 @@ EXAMPLES = '''
       - subnet: 172.3.27.0/24
         gateway: 172.3.27.1
         iprange: 192.168.1.0/24
-
-- name: Create a network with ipv6 IPAM config
+- name: Create a network with IPv6 IPAM config
   docker_network:
     name: network_ipv6_one
     enable_ipv6: yes
     ipam_config:
       - subnet: fdd1:ac8c:0557:7ce1::/64
 
-- name: Create a network with ipv6 and custom ipv4 IPAM config
+- name: Create a network with IPv6 and custom IPv4 IPAM config
   docker_network:
     name: network_ipv6_two
     enable_ipv6: true

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -126,7 +126,7 @@ author:
 
 requirements:
     - "python >= 2.6"
-    - "docker-py >= 1.9.0"
+    - "docker-py >= 1.10.0"
     - "Please note that the L(docker-py,https://pypi.org/project/docker-py/) Python
        module has been superseded by L(docker,https://pypi.org/project/docker/)
        (see L(here,https://github.com/docker/docker-py/issues/1310) for details).
@@ -135,7 +135,7 @@ requirements:
        be installed at the same time. Also note that when both modules are installed
        and one of them is uninstalled, the other might no longer function and a
        reinstall of it is required."
-    - "The docker server >= 1.9.0"
+    - "The docker server >= 1.10.0"
 '''
 
 EXAMPLES = '''
@@ -478,7 +478,7 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         min_docker_version='1.10.0'
-        # "The docker server >= 1.9.0"
+        # "The docker server >= 1.10.0"
     )
 
     cm = DockerNetworkManager(client)

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -84,7 +84,7 @@ options:
   ipam_config:
     version_added: 2.8
     description:
-      - List of IPAM config blocks. Consult 
+      - List of IPAM config blocks. Consult
         L(Docker docs, https://docs.docker.com/compose/compose-file/compose-file-v2/#ipam) for valid options and values.
     type: list
     default: null
@@ -177,6 +177,7 @@ EXAMPLES = '''
         aux_addresses:
           host1: 172.3.27.3
           host2: 172.3.27.4
+
 - name: Create a network with IPv6 IPAM config
   docker_network:
     name: network_ipv6_one

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -77,7 +77,7 @@ options:
   ipam_options:
     description:
       - Dictionary of IPAM options.
-      - Deprecated in 2.8, will be removed in 2.12. Use parameter ``ipam_config`` instead. In Docker 1.10.0, IPAM 
+      - Deprecated in 2.8, will be removed in 2.12. Use parameter ``ipam_config`` instead. In Docker 1.10.0, IPAM
         options were introduced (see L(here,https://github.com/moby/moby/pull/17316)). This module parameter addresses
         the IPAM config not the newly introduced IPAM options.
 

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -87,7 +87,7 @@ options:
       - List of IPAM config blocks. Consult 
         L(Docker docs, https://docs.docker.com/compose/compose-file/compose-file-v2/#ipam) for valid options and values.
     type: list
-    default: []
+    default: null
     required: false
 
   state:
@@ -321,7 +321,7 @@ class DockerNetworkManager(object):
                 different = True
                 differences.append('ipam_driver')
 
-        if self.parameters.ipam_config:
+        if self.parameters.ipam_config is not None and self.parameters.ipam_config:
             if not net.get('IPAM') or not net['IPAM']['Config']:
                 different = True
                 differences.append('ipam_config')
@@ -473,7 +473,7 @@ def main():
         appends=dict(type='bool', default=False, aliases=['incremental']),
         ipam_driver=dict(type='str', default=None),
         ipam_options=dict(type='dict', default={}, removed_in_version='2.12'),
-        ipam_config=dict(type='list', elements='dict', default=[]),
+        ipam_config=dict(type='list', elements='dict', default=None),
         enable_ipv6=dict(type='bool', default=None),
         internal=dict(type='bool', default=None),
         debug=dict(type='bool', default=False)

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -171,8 +171,8 @@ EXAMPLES = '''
     name: network_three
     ipam_config:
       - subnet: 172.3.27.0/24
-        gateway: 172.3.27.1
-        iprange: 192.168.1.0/24
+        gateway: 172.3.27.2
+        iprange: 172.3.27.0/26
 - name: Create a network with IPv6 IPAM config
   docker_network:
     name: network_ipv6_one

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -274,10 +274,8 @@ class DockerNetworkManager(object):
         if not self.parameters.connected and self.existing_network:
             self.parameters.connected = container_names_in_network(self.existing_network)
 
-        if self.parameters.ipam_options and self.parameters.ipam_config:
-            self.client.fail("Only one of `ipam_options` and `ipam_config` can be defined.")
-        elif self.parameters.ipam_options:
-            self.parameters.ipam_config.append(self.parameters.ipam_options)
+        if self.parameters.ipam_options:
+            self.parameters.ipam_config = [self.parameters.ipam_options]
 
         state = self.parameters.state
         if state == 'present':
@@ -477,8 +475,13 @@ def main():
         debug=dict(type='bool', default=False)
     )
 
+    mutually_exclusive = [
+        ('ipam_config', 'ipam_options')
+    ]
+
     client = AnsibleDockerClient(
         argument_spec=argument_spec,
+        mutually_exclusive=mutually_exclusive,
         supports_check_mode=True,
         min_docker_version='1.10.0'
         # "The docker server >= 1.10.0"

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -84,7 +84,8 @@ options:
   ipam_config:
     version_added: 2.8
     description:
-      - List of IPAM config blocks. Consult docker docs for valid options and values.
+      - List of IPAM config blocks. Consult 
+        L(Docker docs, https://docs.docker.com/compose/compose-file/compose-file-v2/#ipam) for valid options and values.
     type: list
     default: []
     required: false

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -77,12 +77,9 @@ options:
   ipam_options:
     description:
       - Dictionary of IPAM options.
-    deprecated:
-      removed_in: "2.12"
-      alternative: ipam_config
-      why: >
-        Ipam options were introduced in Docker 1.10.0 (see L(here,https://github.com/moby/moby/pull/17316)). This
-        module parameter addresses the ipam config not the newly introduced ipam options.
+      - Deprecated in 2.8, will be removed in 2.12. Use parameter ``ipam_config`` instead. In Docker 1.10.0, IPAM 
+        options were introduced (see L(here,https://github.com/moby/moby/pull/17316)). This module parameter addresses
+        the IPAM config not the newly introduced IPAM options.
 
   ipam_config:
     version_added: 2.8
@@ -467,7 +464,7 @@ def main():
         force=dict(type='bool', default=False),
         appends=dict(type='bool', default=False, aliases=['incremental']),
         ipam_driver=dict(type='str', default=None),
-        ipam_options=dict(type='dict', default={}),
+        ipam_options=dict(type='dict', default={}, removed_in_version='2.12'),
         ipam_config=dict(type='list', elements='dict', default=[]),
         enable_ipv6=dict(type='bool', default=None),
         internal=dict(type='bool', default=None),

--- a/test/integration/targets/docker_network/tasks/tests/ipam.yml
+++ b/test/integration/targets/docker_network/tasks/tests/ipam.yml
@@ -26,7 +26,7 @@
 - assert:
     that:
       - network is failed
-      - network.msg == "Only one of `ipam_options` and `ipam_config` can be defined."
+      - "network.msg == 'parameters are mutually exclusive: ipam_config, ipam_options'"
 
 - name: Create network with deprecated custom IPAM config
   docker_network:

--- a/test/integration/targets/docker_network/tasks/tests/ipam.yml
+++ b/test/integration/targets/docker_network/tasks/tests/ipam.yml
@@ -67,29 +67,35 @@
       - subnet: 172.3.27.0/24
         gateway: 172.3.27.2
         iprange: 172.3.27.0/26
+        aux_addresses:
+          host1: 172.3.27.3
+          host2: 172.3.27.4
   register: network
 
 - assert:
     that:
       - network is changed
 
-- name: Change subnet, gateway and iprange of network with custom IPAM config
+- name: Change subnet, gateway, iprange and auxiliary addresses of network with custom IPAM config
   docker_network:
     name: "{{ nname_ipam_1 }}"
     ipam_config:
       - subnet: 172.3.28.0/24
         gateway: 172.3.28.2
         iprange: 172.3.28.0/26
+        aux_addresses:
+          host1: 172.3.28.3
   register: network
   diff: yes
 
 - assert:
     that:
       - network is changed
-      - network['diff'] | length == 3
+      - network['diff'] | length == 4
       - '"ipam_config[0].subnet" in network["diff"]'
       - '"ipam_config[0].gateway" in network["diff"]'
       - '"ipam_config[0].iprange" in network["diff"]'
+      - '"ipam_config[0].aux_addresses" in network["diff"]'
 
 - name: Remove gateway and iprange of network with custom IPAM config
   docker_network:

--- a/test/integration/targets/docker_network/tasks/tests/ipam.yml
+++ b/test/integration/targets/docker_network/tasks/tests/ipam.yml
@@ -100,7 +100,7 @@
 
 #################### network-ipam-2 ####################
 
-- name: Create network with ipv6 IPAM config
+- name: Create network with IPv6 IPAM config
   docker_network:
     name: "{{ nname_ipam_2 }}"
     enable_ipv6: yes
@@ -112,7 +112,7 @@
     that:
       - network is changed
 
-- name: Change subnet of network with ipv6 IPAM config
+- name: Change subnet of network with IPv6 IPAM config
   docker_network:
     name: "{{ nname_ipam_2 }}"
     enable_ipv6: yes
@@ -130,7 +130,7 @@
 
 #################### network-ipam-3 ####################
 
-- name: Create network with ipv6 and custom ipv4 IPAM config
+- name: Create network with IPv6 and custom IPv4 IPAM config
   docker_network:
     name: "{{ nname_ipam_3 }}"
     enable_ipv6: yes
@@ -143,7 +143,7 @@
     that:
       - network is changed
 
-- name: Change subnet order of network with ipv6 and custom ipv4 IPAM config
+- name: Change subnet order of network with IPv6 and custom IPv4 IPAM config
   docker_network:
     name: "{{ nname_ipam_3 }}"
     enable_ipv6: yes
@@ -156,7 +156,7 @@
     that:
       - network is not changed
 
-- name: Remove ipv6 from network with custom ipv4 and ipv6 IPAM config
+- name: Remove IPv6 from network with custom IPv4 and IPv6 IPAM config
   docker_network:
     name: "{{ nname_ipam_3 }}"
     enable_ipv6: no

--- a/test/integration/targets/docker_network/tasks/tests/ipam.yml
+++ b/test/integration/targets/docker_network/tasks/tests/ipam.yml
@@ -1,13 +1,57 @@
 ---
 - name: Registering network names
   set_fact:
+    nname_ipam_0: "{{ name_prefix ~ '-network-ipam-0' }}"
     nname_ipam_1: "{{ name_prefix ~ '-network-ipam-1' }}"
     nname_ipam_2: "{{ name_prefix ~ '-network-ipam-2' }}"
     nname_ipam_3: "{{ name_prefix ~ '-network-ipam-3' }}"
 
 - name: Registering network names
   set_fact:
-    dnetworks: "{{ dnetworks }} + [nname_ipam_1, nname_ipam_2, nname_ipam_3]"
+    dnetworks: "{{ dnetworks }} + [nname_ipam_0, nname_ipam_1, nname_ipam_2, nname_ipam_3]"
+
+
+#################### network-ipam-0 deprecated ####################
+
+- name: Create network with ipam_config and deprecated ipam_options
+  docker_network:
+    name: "{{ nname_ipam_0 }}"
+    ipam_options:
+      subnet: 172.3.29.0/24
+    ipam_config:
+      - subnet: 172.3.29.0/24
+  register: network
+  ignore_errors: yes
+
+- assert:
+    that:
+      - network is failed
+      - network.msg == "Only one of `ipam_options` and `ipam_config` can be defined."
+
+- name: Create network with deprecated custom IPAM config
+  docker_network:
+    name: "{{ nname_ipam_0 }}"
+    ipam_options:
+      subnet: 172.3.29.0/24
+  register: network
+
+- assert:
+    that:
+      - network is changed
+
+- name: Change subnet of network with deprecated custom IPAM config
+  docker_network:
+    name: "{{ nname_ipam_0 }}"
+    ipam_options:
+      subnet: 172.3.30.0/24
+  register: network
+  diff: yes
+
+- assert:
+    that:
+      - network is changed
+      - network['diff'] | length == 1
+      - network['diff'][0] == "ipam_config[0].subnet"
 
 
 #################### network-ipam-1 ####################

--- a/test/integration/targets/docker_network/tasks/tests/ipam.yml
+++ b/test/integration/targets/docker_network/tasks/tests/ipam.yml
@@ -143,6 +143,20 @@
       - network['diff'] | length == 1
       - network['diff'][0] == "ipam_config[0].subnet"
 
+- name: Change subnet of network with IPv6 IPAM config
+  docker_network:
+    name: "{{ nname_ipam_2 }}"
+    enable_ipv6: yes
+    ipam_config:
+      - subnet: "fdd1:ac8c:0557:7ce1::"
+  register: network
+  ignore_errors: yes
+
+- assert:
+    that:
+      - network is failed
+      - "network.msg == '\"fdd1:ac8c:0557:7ce1::\" is not a valid CIDR'"
+
 - name: Cleanup network with IPv6 IPAM config
   docker_network:
     name: "{{ nname_ipam_2 }}"

--- a/test/integration/targets/docker_network/tasks/tests/ipam.yml
+++ b/test/integration/targets/docker_network/tasks/tests/ipam.yml
@@ -53,6 +53,11 @@
       - network['diff'] | length == 1
       - network['diff'][0] == "ipam_config[0].subnet"
 
+- name: Cleanup network with ipam_config and deprecated ipam_options
+  docker_network:
+    name: "{{ nname_ipam_0 }}"
+    state: absent
+
 
 #################### network-ipam-1 ####################
 - name: Create network with custom IPAM config
@@ -97,6 +102,11 @@
     that:
       - network is not changed
 
+- name: Cleanup network with custom IPAM config
+  docker_network:
+    name: "{{ nname_ipam_1 }}"
+    state: absent
+
 
 #################### network-ipam-2 ####################
 
@@ -126,6 +136,11 @@
       - network is changed
       - network['diff'] | length == 1
       - network['diff'][0] == "ipam_config[0].subnet"
+
+- name: Cleanup network with IPv6 IPAM config
+  docker_network:
+    name: "{{ nname_ipam_2 }}"
+    state: absent
 
 
 #################### network-ipam-3 ####################
@@ -170,3 +185,8 @@
       - network is changed
       - network['diff'] | length == 1
       - network['diff'][0] == "enable_ipv6"
+
+- name: Cleanup network with IPv6 and custom IPv4 IPAM config
+  docker_network:
+    name: "{{ nname_ipam_3 }}"
+    state: absent

--- a/test/integration/targets/docker_network/tasks/tests/ipam.yml
+++ b/test/integration/targets/docker_network/tasks/tests/ipam.yml
@@ -65,8 +65,8 @@
     name: "{{ nname_ipam_1 }}"
     ipam_config:
       - subnet: 172.3.27.0/24
-        gateway: 172.3.27.1
-        iprange: 192.168.1.0/24
+        gateway: 172.3.27.2
+        iprange: 172.3.27.0/26
   register: network
 
 - assert:
@@ -78,8 +78,8 @@
     name: "{{ nname_ipam_1 }}"
     ipam_config:
       - subnet: 172.3.28.0/24
-        gateway: 172.3.28.1
-        iprange: 192.168.2.0/24
+        gateway: 172.3.28.2
+        iprange: 172.3.28.0/26
   register: network
   diff: yes
 

--- a/test/integration/targets/docker_network/tasks/tests/ipam_config.yml
+++ b/test/integration/targets/docker_network/tasks/tests/ipam_config.yml
@@ -1,0 +1,128 @@
+---
+- name: Registering network names
+  set_fact:
+    nname_ipam_1: "{{ name_prefix ~ '-network-ipam-1' }}"
+    nname_ipam_2: "{{ name_prefix ~ '-network-ipam-2' }}"
+    nname_ipam_3: "{{ name_prefix ~ '-network-ipam-3' }}"
+
+- name: Registering network names
+  set_fact:
+    dnetworks: "{{ dnetworks }} + [nname_ipam_1, nname_ipam_2, nname_ipam_3]"
+
+
+#################### network-ipam-1 ####################
+- name: Create network with custom IPAM config
+  docker_network:
+    name: "{{ nname_ipam_1 }}"
+    ipam_config:
+      - subnet: 172.3.27.0/24
+        gateway: 172.3.27.1
+        iprange: 192.168.1.0/24
+  register: network
+
+- assert:
+    that:
+      - network is changed
+
+- name: Change subnet, gateway and iprange of network with custom IPAM config
+  docker_network:
+    name: "{{ nname_ipam_1 }}"
+    ipam_config:
+      - subnet: 172.3.28.0/24
+        gateway: 172.3.28.1
+        iprange: 192.168.2.0/24
+  register: network
+  diff: yes
+
+- assert:
+    that:
+      - network is changed
+      - network['diff'] | length == 3
+      - '"ipam_config[0].subnet" in network["diff"]'
+      - '"ipam_config[0].gateway" in network["diff"]'
+      - '"ipam_config[0].iprange" in network["diff"]'
+
+- name: Remove gateway and iprange of network with custom IPAM config
+  docker_network:
+    name: "{{ nname_ipam_1 }}"
+    ipam_config:
+      - subnet: 172.3.28.0/24
+  register: network
+
+- assert:
+    that:
+      - network is not changed
+
+
+#################### network-ipam-2 ####################
+
+- name: Create network with ipv6 IPAM config
+  docker_network:
+    name: "{{ nname_ipam_2 }}"
+    enable_ipv6: yes
+    ipam_config:
+      - subnet: fdd1:ac8c:0557:7ce0::/64
+  register: network
+
+- assert:
+    that:
+      - network is changed
+
+- name: Change subnet of network with ipv6 IPAM config
+  docker_network:
+    name: "{{ nname_ipam_2 }}"
+    enable_ipv6: yes
+    ipam_config:
+      - subnet: fdd1:ac8c:0557:7ce1::/64
+  register: network
+  diff: yes
+
+- assert:
+    that:
+      - network is changed
+      - network['diff'] | length == 1
+      - network['diff'][0] == "ipam_config[0].subnet"
+
+
+#################### network-ipam-3 ####################
+
+- name: Create network with ipv6 and custom ipv4 IPAM config
+  docker_network:
+    name: "{{ nname_ipam_3 }}"
+    enable_ipv6: yes
+    ipam_config:
+      - subnet: 172.4.27.0/24
+      - subnet: fdd1:ac8c:0557:7ce2::/64
+  register: network
+
+- assert:
+    that:
+      - network is changed
+
+- name: Change subnet order of network with ipv6 and custom ipv4 IPAM config
+  docker_network:
+    name: "{{ nname_ipam_3 }}"
+    enable_ipv6: yes
+    ipam_config:
+      - subnet: fdd1:ac8c:0557:7ce2::/64
+      - subnet: 172.4.27.0/24
+  register: network
+
+- assert:
+    that:
+      - network is not changed
+
+- name: Remove ipv6 from network with custom ipv4 and ipv6 IPAM config
+  docker_network:
+    name: "{{ nname_ipam_3 }}"
+    enable_ipv6: no
+    ipam_config:
+      - subnet: 172.4.27.0/24
+  register: network
+  diff: yes
+
+- assert:
+    that:
+      - network is changed
+      - network['diff'] | length == 1
+      - network['diff'][0] == "enable_ipv6"

--- a/test/units/modules/cloud/docker/test_docker_network.py
+++ b/test/units/modules/cloud/docker/test_docker_network.py
@@ -1,4 +1,9 @@
-import unittest
+import sys
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 from ansible.modules.cloud.docker.docker_network import get_ip_version
 

--- a/test/units/modules/cloud/docker/test_docker_network.py
+++ b/test/units/modules/cloud/docker/test_docker_network.py
@@ -1,38 +1,27 @@
-import sys
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+"""Unit tests for docker_network."""
+import pytest
 
 from ansible.modules.cloud.docker.docker_network import get_ip_version
 
 
-class TestDockerNetwork(unittest.TestCase):
-    """Unit tests for docker_network."""
+@pytest.mark.parametrize("cidr,expected", [
+    ('192.168.0.1/16', 'ipv4'),
+    ('192.168.0.1/24', 'ipv4'),
+    ('192.168.0.1/32', 'ipv4'),
+    ('fdd1:ac8c:0557:7ce2::/64', 'ipv6'),
+    ('fdd1:ac8c:0557:7ce2::/128', 'ipv6'),
+])
+def test_get_ip_version_positives(cidr, expected):
+    assert get_ip_version(cidr) == expected
 
-    def test_get_ip_version(self):
-        """Ensure get_ip_version correctly identifies IP version of a CIDR string."""
 
-        self.assertEqual(get_ip_version('192.168.0.1/16'), 'ipv4')
-        self.assertEqual(get_ip_version('192.168.0.1/24'), 'ipv4')
-        self.assertEqual(get_ip_version('192.168.0.1/32'), 'ipv4')
-
-        self.assertEqual(get_ip_version('fdd1:ac8c:0557:7ce2::/64'), 'ipv6')
-        self.assertEqual(get_ip_version('fdd1:ac8c:0557:7ce2::/128'), 'ipv6')
-
-        with self.assertRaises(ValueError) as e:
-            get_ip_version('192.168.0.1')
-        self.assertEqual('"192.168.0.1" is not a valid CIDR', str(e.exception))
-
-        with self.assertRaises(ValueError) as e:
-            get_ip_version('192.168.0.1/34')
-        self.assertEqual('"192.168.0.1/34" is not a valid CIDR', str(e.exception))
-
-        with self.assertRaises(ValueError) as e:
-            get_ip_version('192.168.0.1/asd')
-        self.assertEqual('"192.168.0.1/asd" is not a valid CIDR', str(e.exception))
-
-        with self.assertRaises(ValueError) as e:
-            get_ip_version('fdd1:ac8c:0557:7ce2::')
-        self.assertEqual('"fdd1:ac8c:0557:7ce2::" is not a valid CIDR', str(e.exception))
+@pytest.mark.parametrize("cidr", [
+    '192.168.0.1',
+    '192.168.0.1/34',
+    '192.168.0.1/asd',
+    'fdd1:ac8c:0557:7ce2::',
+])
+def test_get_ip_version_negatives(cidr):
+    with pytest.raises(ValueError) as e:
+        get_ip_version(cidr)
+    assert '"{0}" is not a valid CIDR'.format(cidr) == str(e.value)

--- a/test/units/modules/cloud/docker/test_docker_network.py
+++ b/test/units/modules/cloud/docker/test_docker_network.py
@@ -1,0 +1,23 @@
+import unittest
+
+from ansible.modules.cloud.docker.docker_network import get_ip_version
+
+
+class TestDockerNetwork(unittest.TestCase):
+    """Unit tests for docker_network."""
+
+    def test_get_ip_version(self):
+        """Ensure get_ip_version correctly identifies IP version of a valid CIDR."""
+
+        self.assertEqual(get_ip_version('192.168.0.1/16'), 'ipv4')
+        self.assertEqual(get_ip_version('192.168.0.1/24'), 'ipv4')
+        self.assertEqual(get_ip_version('192.168.0.1/32'), 'ipv4')
+
+        self.assertEqual(get_ip_version('fdd1:ac8c:0557:7ce2::/64'), 'ipv6')
+        self.assertEqual(get_ip_version('fdd1:ac8c:0557:7ce2::/128'), 'ipv6')
+
+        # not valid IPv4 or IPv6 subnet resulting in default 'ipv6'
+        self.assertEqual(get_ip_version('192.168.0.1'), 'ipv6')
+        self.assertEqual(get_ip_version('192.168.0.1/34'), 'ipv6')
+        self.assertEqual(get_ip_version('192.168.0.1/asd'), 'ipv6')
+        self.assertEqual(get_ip_version('fdd1:ac8c:0557:7ce2::'), 'ipv6')

--- a/test/units/modules/cloud/docker/test_docker_network.py
+++ b/test/units/modules/cloud/docker/test_docker_network.py
@@ -7,7 +7,7 @@ class TestDockerNetwork(unittest.TestCase):
     """Unit tests for docker_network."""
 
     def test_get_ip_version(self):
-        """Ensure get_ip_version correctly identifies IP version of a valid CIDR."""
+        """Ensure get_ip_version correctly identifies IP version of a CIDR string."""
 
         self.assertEqual(get_ip_version('192.168.0.1/16'), 'ipv4')
         self.assertEqual(get_ip_version('192.168.0.1/24'), 'ipv4')
@@ -16,8 +16,18 @@ class TestDockerNetwork(unittest.TestCase):
         self.assertEqual(get_ip_version('fdd1:ac8c:0557:7ce2::/64'), 'ipv6')
         self.assertEqual(get_ip_version('fdd1:ac8c:0557:7ce2::/128'), 'ipv6')
 
-        # not valid IPv4 or IPv6 subnet resulting in default 'ipv6'
-        self.assertEqual(get_ip_version('192.168.0.1'), 'ipv6')
-        self.assertEqual(get_ip_version('192.168.0.1/34'), 'ipv6')
-        self.assertEqual(get_ip_version('192.168.0.1/asd'), 'ipv6')
-        self.assertEqual(get_ip_version('fdd1:ac8c:0557:7ce2::'), 'ipv6')
+        with self.assertRaises(ValueError) as e:
+            get_ip_version('192.168.0.1')
+        self.assertEqual('"192.168.0.1" is not a valid CIDR', str(e.exception))
+
+        with self.assertRaises(ValueError) as e:
+            get_ip_version('192.168.0.1/34')
+        self.assertEqual('"192.168.0.1/34" is not a valid CIDR', str(e.exception))
+
+        with self.assertRaises(ValueError) as e:
+            get_ip_version('192.168.0.1/asd')
+        self.assertEqual('"192.168.0.1/asd" is not a valid CIDR', str(e.exception))
+
+        with self.assertRaises(ValueError) as e:
+            get_ip_version('fdd1:ac8c:0557:7ce2::')
+        self.assertEqual('"fdd1:ac8c:0557:7ce2::" is not a valid CIDR', str(e.exception))


### PR DESCRIPTION
##### SUMMARY
This PR enables support for IPv6 networks and allows defining IPv6 IPAM config blocks. The configuration options are based on the existing docker-compose documentation https://docs.docker.com/compose/compose-file/compose-file-v2/#ipam .

So far, the parameter for IPAM config was named `ipam_options` but in recent docker versions, this is called `ipam_config` (see link above). Here is the example from the docker-compose docs:
```
ipam:
  driver: default
  config:
    - subnet: 172.28.0.0/16
      ip_range: 172.28.5.0/24
      gateway: 172.28.5.254
      aux_addresses:
        host1: 172.28.1.5
        host2: 172.28.1.6
        host3: 172.28.1.7
  options:
    foo: bar
    baz: "0"
```
So I changed the parameter name `ipam_options` to `ipam_config`. I also created a branch (https://github.com/smueller18/ansible/tree/docker_network_ipam_options) that handles the new parameter `ipam_options` well, but this change requires docker >= 2.0.0, so I cannot create a pull request for that change until support for docker-py and python 2.6 is dropped.

Fixes #34855

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_network

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/sm/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/sm/git/github/smueller18/ansible/venv/lib/python3.7/site-packages/ansible-2.8.0.dev0-py3.7.egg/ansible
  executable location = /home/sm/git/github/smueller18/ansible/venv/bin/ansible
  python version = 3.7.0 (default, Aug 30 2018, 22:41:14) [GCC 7.3.0]
```