### PR TITLE
Use kubeconfig if either context or kubeconfig is set (#47373)

### DIFF
--- a/changelogs/fragments/k8s_auth_kubeconfig.yml
+++ b/changelogs/fragments/k8s_auth_kubeconfig.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - k8s - allow kubeconfig or context to be set without the other

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -152,7 +152,7 @@ class K8sAnsibleMixin(object):
         if auth_set('username', 'password', 'host') or auth_set('api_key', 'host'):
             # We have enough in the parameters to authenticate, no need to load incluster or kubeconfig
             pass
-        elif auth_set('kubeconfig', 'context'):
+        elif auth_set('kubeconfig') or auth_set('context'):
             kubernetes.config.load_kube_config(auth.get('kubeconfig'), auth.get('context'))
         else:
             # First try to do incluster config, then kubeconfig


### PR DESCRIPTION
##### SUMMARY

kubeconfig should be loaded if *either* or both of context
or kubeconfig is set (this allows picking a context and default
kubeconfig or picking a kubeconfig with default context)

Fixes #47149

(cherry picked from commit 00ccad97642dd125c196e0336c79bac0a5250316)


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
k8s

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
stable-2.7
```
