### PR TITLE
Fixed #47505: Type error in openssl_certificate

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -618,11 +618,11 @@ class OwnCACertificate(Certificate):
             cert = crypto.X509()
             cert.set_serial_number(self.serial_number)
             if self.notBefore:
-                cert.set_notBefore(self.notBefore.encode())
+                cert.set_notBefore(to_bytes(self.notBefore))
             else:
                 cert.gmtime_adj_notBefore(0)
             if self.notAfter:
-                cert.set_notAfter(self.notAfter.encode())
+                cert.set_notAfter(to_bytes(self.notAfter))
             else:
                 # If no NotAfter specified, expire in
                 # 10 years. 315360000 is 10 years in seconds.

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -521,11 +521,11 @@ class SelfSignedCertificate(Certificate):
             cert = crypto.X509()
             cert.set_serial_number(self.serial_number)
             if self.notBefore:
-                cert.set_notBefore(self.notBefore.encode())
+                cert.set_notBefore(to_bytes(self.notBefore))
             else:
                 cert.gmtime_adj_notBefore(0)
             if self.notAfter:
-                cert.set_notAfter(self.notAfter.encode())
+                cert.set_notAfter(to_bytes(self.notAfter))
             else:
                 # If no NotAfter specified, expire in
                 # 10 years. 315360000 is 10 years in seconds.

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -521,11 +521,11 @@ class SelfSignedCertificate(Certificate):
             cert = crypto.X509()
             cert.set_serial_number(self.serial_number)
             if self.notBefore:
-                cert.set_notBefore(self.notBefore)
+                cert.set_notBefore(self.notBefore.encode())
             else:
                 cert.gmtime_adj_notBefore(0)
             if self.notAfter:
-                cert.set_notAfter(self.notAfter)
+                cert.set_notAfter(self.notAfter.encode())
             else:
                 # If no NotAfter specified, expire in
                 # 10 years. 315360000 is 10 years in seconds.

--- a/test/integration/targets/openssl_certificate/tasks/ownca.yml
+++ b/test/integration/targets/openssl_certificate/tasks/ownca.yml
@@ -116,4 +116,15 @@
     issuer:
       commonName: Example CA
 
+- name: Create ownca certificate with notBefore and notAfter
+  openssl_certificate:
+    provider: ownca
+    ownca_not_before: 20181023133742Z
+    ownca_not_after: 20191023133742Z
+    path: "{{ output_dir }}/ownca_cert3.pem"
+    csr_path: "{{ output_dir }}/csr.csr"
+    privatekey_path: "{{ output_dir }}/privatekey3.pem"
+    ownca_path: '{{ output_dir }}/ca_cert.pem'
+    ownca_privatekey_path: '{{ output_dir }}/ca_privatekey.pem'
+      
 - import_tasks: ../tests/validate_ownca.yml

--- a/test/integration/targets/openssl_certificate/tasks/selfsigned.yml
+++ b/test/integration/targets/openssl_certificate/tasks/selfsigned.yml
@@ -114,4 +114,24 @@
       - ipsecUser
       - biometricInfo
 
+- name: Create private key 3
+  openssl_privatekey:
+    path: "{{ output_dir }}/privatekey3.pem"
+
+- name: Create CSR 3
+  openssl_csr:
+    subject:
+      CN: www.example.com
+    privatekey_path: "{{ output_dir }}/privatekey3.pem"
+    path: "{{ output_dir }}/csr3.pem"
+        
+- name: Create certificate3 with notBefore and notAfter
+  openssl_certificate:
+    provider: selfsigned
+    selfsigned_not_before: 20181023133742Z
+    selfsigned_not_after: 20191023133742Z
+    path: "{{ output_dir }}/cert3.pem"
+    csr_path: "{{ output_dir }}/csr3.pem"
+    privatekey_path: "{{ output_dir }}/privatekey3.pem"
+        
 - import_tasks: ../tests/validate_selfsigned.yml

--- a/test/integration/targets/openssl_certificate/tests/validate_ownca.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate_ownca.yml
@@ -47,3 +47,21 @@
   assert:
     that:
       - ownca_cert2_modulus.stdout == privatekey2_modulus.stdout
+
+- name: Validate owncal certificate3 (test - notBefore)
+  shell: 'openssl x509 -noout -in {{ output_dir }}/ownca_cert3.pem -text | grep "Not Before" | sed "s/.*: \(.*\) .*/\1/g"'
+  register: ownca_cert3_notBefore
+
+- name: Validate ownca certificate3 (test - notAfter)
+  shell: 'openssl x509 -noout -in {{ output_dir }}/ownca_cert3.pem -text | grep "Not After" | sed "s/.*: \(.*\) .*/\1/g"'
+  register: ownca_cert3_notAfter
+
+- name: Validate ownca certificate3 (assert - notBefore)
+  assert:
+    that:
+      - ownca_cert3_notBefore.stdout == 'Oct 23 13:37:42 2018'
+
+- name: Validate ownca certificate3 (assert - notAfter)
+  assert:
+    that:
+      - ownca_cert3_notAfter.stdout == 'Oct 23 13:37:42 2019'

--- a/test/integration/targets/openssl_certificate/tests/validate_selfsigned.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate_selfsigned.yml
@@ -50,3 +50,21 @@
   assert:
     that:
       - cert2_modulus.stdout == privatekey2_modulus.stdout
+
+- name: Validate certificate3 (test - notBefore)
+  shell: 'openssl x509 -noout -in {{ output_dir }}/cert3.pem -text | grep "Not Before" | sed "s/.*: \(.*\) .*/\1/g"'
+  register: cert3_notBefore
+
+- name: Validate certificate3 (test - notAfter)
+  shell: 'openssl x509 -noout -in {{ output_dir }}/cert3.pem -text | grep "Not After" | sed "s/.*: \(.*\) .*/\1/g"'
+  register: cert3_notAfter
+
+- name: Validate certificate3 (assert - notBefore)
+  assert:
+    that:
+      - cert3_notBefore.stdout == 'Oct 23 13:37:42 2018'
+
+- name: Validate certificate3 (assert - notAfter)
+  assert:
+    that:
+      - cert3_notAfter.stdout == 'Oct 23 13:37:42 2019'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #47505: openssl_certificate: selfsigned_not_before and selfsigned_not_after raise a TypeError

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openssl_certificate

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/sebastian/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.1 (default, Oct 22 2018, 10:41:28) [GCC 8.2.1 20180831]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

pyOpenSSL's OpenSSL.crypto.X509 class expects the argument passed to `set_notBefore` and
`set_notAfter` to be of type `bytes`, rather than `str`.  This PR adds the necessary `.encode()` function
calls where they were missing.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```paste below
TASK [Create self-signed certificate] *************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "/home/sebastian/.ansible/tmp/ansible-tmp-1540299378.342488-272722201934548/AnsiballZ_openssl_certificate.py:17: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses\n  import imp\nTraceback (most recent call last):\n  File \"/home/sebastian/.ansible/tmp/ansible-tmp-1540299378.342488-272722201934548/AnsiballZ_openssl_certificate.py\", line 113, in <module>\n    _ansiballz_main()\n  File \"/home/sebastian/.ansible/tmp/ansible-tmp-1540299378.342488-272722201934548/AnsiballZ_openssl_certificate.py\", line 105, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/sebastian/.ansible/tmp/ansible-tmp-1540299378.342488-272722201934548/AnsiballZ_openssl_certificate.py\", line 48, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/usr/lib/python3.7/imp.py\", line 234, in load_module\n    return load_source(name, filename, file)\n  File \"/usr/lib/python3.7/imp.py\", line 169, in load_source\n    module = _exec(spec, sys.modules[name])\n  File \"<frozen importlib._bootstrap>\", line 630, in _exec\n  File \"<frozen importlib._bootstrap_external>\", line 728, in exec_module\n  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\n  File \"/tmp/ansible_openssl_certificate_payload_20vtys0b/__main__.py\", line 1091, in <module>\n  File \"/tmp/ansible_openssl_certificate_payload_20vtys0b/__main__.py\", line 1070, in main\n  File \"/tmp/ansible_openssl_certificate_payload_20vtys0b/__main__.py\", line 524, in generate\n  File \"/usr/lib/python3.7/site-packages/OpenSSL/crypto.py\", line 1391, in set_notBefore\n    return self._set_boundary_time(_lib.X509_get_notBefore, when)\n  File \"/usr/lib/python3.7/site-packages/OpenSSL/crypto.py\", line 1378, in _set_boundary_time\n    return _set_asn1_time(which(self._x509), when)\n  File \"/usr/lib/python3.7/site-packages/OpenSSL/crypto.py\", line 157, in _set_asn1_time\n    raise TypeError(\"when must be a byte string\")\nTypeError: when must be a byte string\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```
After:
```paste below
TASK [Create self-signed certificate] *************************************************************************************************
changed: [localhost]
```
