### PR TITLE
TEMP HACK: Avoid overloading codecov.io

### DIFF
--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -86,7 +86,8 @@ function cleanup
         cp -a test/results/reports/coverage=*.xml shippable/codecoverage/
 
         # upload coverage report to codecov.io only when using complete on-demand coverage
-        if [ "${COVERAGE}" ] && [ "${CHANGED}" == "" ]; then
+        # HACK: Only upload certain results to codecov to avoid overloading it
+        if [ "${COVERAGE}" ] && [ "${CHANGED}" == "" ] && [[ "$T" =~ /1$ ]] ; then
             for file in test/results/reports/coverage=*.xml; do
                 flags="${file##*/coverage=}"
                 flags="${flags%.xml}"


### PR DESCRIPTION
##### SUMMARY
Without this patch we are overloading codecov.io by uploading 90+ tests.

As a workaround limit uploading to only "Group 1"

Will be removed/updated based on codecov.io's support team

##### ISSUE TYPE
- Bugfix Pull Request
