### PR TITLE
[stable-2.7] Ensure we don't overwrite roles from include/import_role when loading the play (#47512)

### DIFF
--- a/changelogs/fragments/no-overwrite-roles.yaml
+++ b/changelogs/fragments/no-overwrite-roles.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- roles - Ensure that we don't overwrite roles that have been registered (from imports) while parsing roles under the roles header (https://github.com/ansible/ansible/issues/47454)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -195,7 +195,12 @@ class Play(Base, Taggable, Become):
         roles = []
         for ri in role_includes:
             roles.append(Role.load(ri, play=self))
-        return roles
+
+        return self._extend_value(
+            self.roles,
+            roles,
+            prepend=True
+        )
 
     def _load_vars_prompt(self, attr, ds):
         new_ds = preprocess_vars(ds)

--- a/test/integration/targets/include_import/public_exposure/no_overwrite_roles.yml
+++ b/test/integration/targets/include_import/public_exposure/no_overwrite_roles.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  gather_facts: false
+  roles:
+    - call_import

--- a/test/integration/targets/include_import/public_exposure/roles/call_import/tasks/main.yml
+++ b/test/integration/targets/include_import/public_exposure/roles/call_import/tasks/main.yml
@@ -1,0 +1,6 @@
+- import_role:
+    name: regular
+
+- assert:
+    that:
+      - regular_defaults_var is defined

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -82,3 +82,4 @@ test "$(grep -c '"item=foo"' test_include_dupe_loop.out)" = 3
 
 ansible-playbook public_exposure/playbook.yml -i ../../inventory "$@"
 ansible-playbook public_exposure/no_bleeding.yml -i ../../inventory "$@"
+ansible-playbook public_exposure/no_overwrite_roles.yml -i ../../inventory "$@"


### PR DESCRIPTION
* Ensure we don't overwrite roles from include/import_role when loading the play. Fixes #47454

* Add changelog fragment
(cherry picked from commit d5e4f37)


Co-authored-by: Matt Martz <matt@sivel.net>