### PR TITLE
don't restrict disable_excludes choices incorrectly (#47453)

### DIFF
--- a/changelogs/fragments/dnfyum-disable-excludes.yaml
+++ b/changelogs/fragments/dnfyum-disable-excludes.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "dnf appropriately handles disable_excludes repoid argument"

--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -22,7 +22,7 @@ yumdnf_argument_spec = dict(
         autoremove=dict(type='bool', default=False),
         bugfix=dict(required=False, type='bool', default=False),
         conf_file=dict(type='str'),
-        disable_excludes=dict(type='str', default=None, choices=['all', 'main', 'repoid']),
+        disable_excludes=dict(type='str', default=None),
         disable_gpg_check=dict(type='bool', default=False),
         disable_plugin=dict(type='list', default=[]),
         disablerepo=dict(type='list', default=[]),

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -149,7 +149,6 @@ options:
       - If set to C(main), disable excludes defined in [main] in yum.conf.
       - If set to C(repoid), disable excludes defined for given repo id.
     required: false
-    choices: [ all, main, repoid ]
     version_added: "2.7"
   validate_certs:
     description:

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -183,7 +183,6 @@ options:
       - If set to C(main), disable excludes defined in [main] in yum.conf.
       - If set to C(repoid), disable excludes defined for given repo id.
     required: false
-    choices: [ all, main, repoid ]
     version_added: "2.7"
   download_only:
     description:


### PR DESCRIPTION

##### SUMMARY
Backport cherry-pick of https://github.com/ansible/ansible/pull/47453

don't restrict disable_excludes choices incorrectly

Fixes #47085

(cherry picked from commit 0e3e646189552950a9ae2e681a21554b2003d910)
Signed-off-by: Adam Miller <admiller@redhat.com>


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum
dnf

