### PR TITLE
psrp - fix unicode handling in Python 2 (#47461) - 2.7

### DIFF
--- a/changelogs/fragments/psrp-utf8-stdio.yaml
+++ b/changelogs/fragments/psrp-utf8-stdio.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- psrp - Fix UTF-8 output - https://github.com/ansible/ansible/pull/46998

--- a/changelogs/fragments/psrp-utf8.yaml
+++ b/changelogs/fragments/psrp-utf8.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- psrp - Fix issue when dealing with unicode values in the output for Python 2

--- a/test/integration/targets/connection_psrp/inventory.ini
+++ b/test/integration/targets/connection_psrp/inventory.ini
@@ -1,0 +1,3 @@
+[windows:vars]
+ansible_connection=psrp
+ansible_psrp_cert_validation=ignore

--- a/test/integration/targets/connection_psrp/runme.sh
+++ b/test/integration/targets/connection_psrp/runme.sh
@@ -2,14 +2,18 @@
 
 set -eux
 
-pip install pypsrp
+python.py -m pip install pypsrp
 cd ../connection
 
 INVENTORY=../../inventory.winrm ./test.sh \
+    -i ../connection_psrp/inventory.ini \
     -e target_hosts=winrm \
     -e action_prefix=win_ \
     -e local_tmp=/tmp/ansible-local \
     -e remote_tmp=c:/windows/temp/ansible-remote \
-    -e ansible_psrp_cert_validation=False \
-    -c psrp \
+    "$@"
+
+cd ../connection_psrp
+
+ansible-playbook -i ../../inventory.winrm -i inventory.ini tests.yml \
     "$@"

--- a/test/integration/targets/connection_psrp/tests.yml
+++ b/test/integration/targets/connection_psrp/tests.yml
@@ -1,0 +1,61 @@
+---
+# these are extra tests for psrp that aren't covered under test/integration/targets/connection/*
+- name: test out psrp specific tests
+  hosts: winrm
+  serial: 1
+  gather_facts: no
+
+  tasks:
+  - name: test complex objects in raw output
+    # until PyYAML is upgraded to 4.x we need to use the \U escape for a unicode codepoint
+    # and enclose in a quote to it translates the \U
+    raw: "
+      [PSCustomObject]@{string = 'string'};
+      [PSCustomObject]@{unicode = 'poo - \U0001F4A9'};
+      [PSCustomObject]@{integer = 1};
+      [PSCustomObject]@{list = @(1, 2)};
+      Get-Service -Name winrm;
+      Write-Output -InputObject 'string - \U0001F4A9';"
+    register: raw_out
+
+  - name: assert complex objects in raw output
+    assert:
+      that:
+      - raw_out.stdout_lines|count == 6
+      - "raw_out.stdout_lines[0] == 'string: string'"
+      - "raw_out.stdout_lines[1] == 'unicode: poo - \U0001F4A9'"
+      - "raw_out.stdout_lines[2] == 'integer: 1'"
+      - "raw_out.stdout_lines[3] == \"list: [1, 2]\""
+      - raw_out.stdout_lines[4] == "winrm"
+      - raw_out.stdout_lines[5] == "string - \U0001F4A9"
+
+  # Become only works on Server 2008 when running with basic auth, skip this host for now as it is too complicated to
+  # override the auth protocol in the tests.
+  - name: check if we running on Server 2008
+    win_shell: '[System.Environment]::OSVersion.Version -ge [Version]"6.1"'
+    register: os_version
+
+  - name: test out become with psrp
+    win_whoami:
+    when: os_version|bool
+    register: whoami_out
+    become: yes
+    become_method: runas
+    become_user: SYSTEM
+
+  - name: assert test out become with psrp
+    assert:
+      that:
+      - whoami_out.account.sid == "S-1-5-18"
+    when: os_version|bool
+
+  - name: test out async with psrp
+    win_shell: Start-Sleep -Seconds 2; Write-Output abc
+    async: 5
+    poll: 1
+    register: async_out
+
+  - name: assert est out async with psrp
+    assert:
+      that:
+      - async_out.stdout_lines == ["abc"]

--- a/test/integration/targets/connection_psrp/tests.yml
+++ b/test/integration/targets/connection_psrp/tests.yml
@@ -59,3 +59,27 @@
     assert:
       that:
       - async_out.stdout_lines == ["abc"]
+
+  - name: Output unicode characters from Powershell using PSRP
+    win_command: "powershell.exe -ExecutionPolicy ByPass -Command \"Write-Host '\U0001F4A9'\""
+    register: command_unicode_output
+
+  - name: Assert unicode output
+    assert:
+      that:
+      - command_unicode_output is changed
+      - command_unicode_output.rc == 0
+      - "command_unicode_output.stdout == '\U0001F4A9\n'"
+      - command_unicode_output.stderr == ''
+
+  - name: Output unicode characters from Powershell using PSRP
+    win_shell: "Write-Host '\U0001F4A9'"
+    register: shell_unicode_output
+
+  - name: Assert unicode output
+    assert:
+      that:
+      - shell_unicode_output is changed
+      - shell_unicode_output.rc == 0
+      - "shell_unicode_output.stdout == '\U0001F4A9\n'"
+      - shell_unicode_output.stderr == ''

--- a/test/integration/targets/win_module_utils/library/command_util_test.ps1
+++ b/test/integration/targets/win_module_utils/library/command_util_test.ps1
@@ -76,6 +76,12 @@ Assert-Equals -actual $actual.rc -expected 0
 Assert-Equals -actual $actual.stdout -expected "stdout `r`n"
 Assert-Equals -actual $actual.stderr -expected "stderr `r`n"
 
+$test_name = "Test UTF8 output from stdout stream"
+$actual = Run-Command -command "powershell.exe -ExecutionPolicy ByPass -Command `"Write-Host '💩'`""
+Assert-Equals -actual $actual.rc -expected 0
+Assert-Equals -actual $actual.stdout -expected "💩`n"
+Assert-Equals -actual $actual.stderr -expected ""
+
 $test_name = "test default environment variable"
 Set-Item -Path env:TESTENV -Value "test"
 $actual = Run-Command -command "cmd.exe /c set"


### PR DESCRIPTION
(cherry picked from commit f28b7c7ab1b58201977ee73644f113c1a32cba1b)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/47461

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
psrp

##### ANSIBLE VERSION
```paste below
2.7
```