### PR TITLE
VMware: Python3 migrations for vmware_inventory.py

### DIFF
--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -153,7 +153,7 @@ class VMWareInventory(object):
             try:
                 text = str(text)
             except UnicodeEncodeError:
-                text = text.encode('ascii', 'ignore')
+                text = text.encode('utf-8')
             print('%s %s' % (datetime.datetime.now(), text))
 
     def show(self):
@@ -187,14 +187,14 @@ class VMWareInventory(object):
 
     def write_to_cache(self, data):
         ''' Dump inventory to json file '''
-        with open(self.cache_path_cache, 'wb') as f:
-            f.write(json.dumps(data))
+        with open(self.cache_path_cache, 'w') as f:
+            f.write(json.dumps(data, indent=2))
 
     def get_inventory_from_cache(self):
         ''' Read in jsonified inventory '''
 
         jdata = None
-        with open(self.cache_path_cache, 'rb') as f:
+        with open(self.cache_path_cache, 'r') as f:
             jdata = f.read()
         return json.loads(jdata)
 
@@ -391,7 +391,7 @@ class VMWareInventory(object):
             instances = [x for x in instances if x.name == self.args.host]
 
         instance_tuples = []
-        for instance in sorted(instances):
+        for instance in instances:
             if self.guest_props:
                 ifacts = self.facts_from_proplist(instance)
             else:
@@ -693,7 +693,7 @@ class VMWareInventory(object):
             if vobj.isalnum():
                 rdata = vobj
             else:
-                rdata = vobj.decode('ascii', 'ignore')
+                rdata = vobj.encode('utf-8').decode('utf-8')
         elif issubclass(type(vobj), bool) or isinstance(vobj, bool):
             rdata = vobj
         elif issubclass(type(vobj), integer_types) or isinstance(vobj, integer_types):

--- a/test/integration/targets/vmware_inventory/aliases
+++ b/test/integration/targets/vmware_inventory/aliases
@@ -1,6 +1,5 @@
 shippable/vcenter/group1
 cloud/vcenter
-skip/python3
 destructive
 needs/file/contrib/inventory/vmware_inventory.py
 needs/file/contrib/inventory/vmware_inventory.ini


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Python3 str/byte migrations for vmware_inventory.py
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #46727
+ pretty print json cache file

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_inventory.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
  config file = /home/rowina/git/edigits-automation/ansible.cfg
  configured module search path = ['/home/rowina/git/edigits-automation/library/modules', '/home/rowina/git/edigits-automation/library']
  ansible python module location = /home/rowina/.local/share/virtualenvs/edigits-automation-81VDfJQh/lib/python3.5/site-packages/ansible
  executable location = /home/rowina/.local/share/virtualenvs/edigits-automation-81VDfJQh/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```

Also tested backwards compatibility with python 2.7
```
ansible 2.7.0
  config file = /home/rowina/git/edigits-automation-auto-501/ansible.cfg
  configured module search path = [u'/home/rowina/git/edigits-automation-auto-501/library/modules', u'/home/rowina/git/edigits-automation-auto-501/library']
  ansible python module location = /home/rowina/.local/share/virtualenvs/edigits-automation-auto-501-kNR9ozQR/local/lib/python2.7/site-packages/ansible
  executable location = /home/rowina/.local/share/virtualenvs/edigits-automation-auto-501-kNR9ozQR/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
./vmware_inventory.py --list --debug --refresh

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```paste below
Traceback (most recent call last):
  File "./vmware_inventory.py", line 772, in <module>
    print(VMWareInventory().show())
  File "./vmware_inventory.py", line 145, in __init__
    self.do_api_calls_update_cache()
  File "./vmware_inventory.py", line 184, in do_api_calls_update_cache
    self.inventory = self.instances_to_inventory(self.get_instances())
  File "./vmware_inventory.py", line 351, in get_instances
    return self._get_instances(kwargs)
  File "./vmware_inventory.py", line 393, in _get_instances
    for instance in sorted(instances):
TypeError: unorderable types: vim.VirtualMachine() < vim.VirtualMachine()
```

After:
Receive json of groups and hostvars