### PR TITLE
ipaddr filter - return a network address when given an address with /32 subnet

### DIFF
--- a/changelogs/fragments/47539-fix-netaddr-network.yaml
+++ b/changelogs/fragments/47539-fix-netaddr-network.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ipaddr - fix issue where network address was blank for 0-size networks (https://github.com/ansible/ansible/issues/17872)

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -249,8 +249,7 @@ def _netmask_query(v):
 
 def _network_query(v):
     '''Return the network of a given IP or subnet'''
-    if v.size > 1:
-        return str(v.network)
+    return str(v.network)
 
 
 def _network_id_query(v):

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -38,15 +38,14 @@ class TestIpFilter(unittest.TestCase):
         self.assertEqual(ipaddr(address, 'netmask'), '255.255.255.255')
 
     def test_network(self):
-        # Unfixable in current state
-        # address = '1.12.1.34/32'
-        # self.assertEqual(ipaddr(address, 'network'), '1.12.1.34')
-        # address = '1.12.1.34/255.255.255.255'
-        # self.assertEqual(ipaddr(address, 'network'), '1.12.1.34')
-        # address = '1.12.1.34'
-        # self.assertEqual(ipaddr(address, 'network'), '1.12.1.34')
-        # address = '1.12.1.35/31'
-        # self.assertEqual(ipaddr(address, 'network'), '1.12.1.34')
+        address = '1.12.1.34/32'
+        self.assertEqual(ipaddr(address, 'network'), '1.12.1.34')
+        address = '1.12.1.34/255.255.255.255'
+        self.assertEqual(ipaddr(address, 'network'), '1.12.1.34')
+        address = '1.12.1.34'
+        self.assertEqual(ipaddr(address, 'network'), '1.12.1.34')
+        address = '1.12.1.35/31'
+        self.assertEqual(ipaddr(address, 'network'), '1.12.1.34')
         address = '1.12.1.34/24'
         self.assertEqual(ipaddr(address, 'network'), '1.12.1.0')
 


### PR DESCRIPTION
##### SUMMARY
Fixes #17872  
Even if the size of a network is 0, it should have a network address.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ipaddr filter

##### ADDITIONAL INFORMATION
Same change as PR #17627 (fixed #17624), for a different function.

There are other size checks in the `_foo_query` functions in this file. It would be worth considering what good those are doing, and perhaps removing more/all of them.