### PR TITLE
Add support for "credentials" in the tower_job_template module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -49,7 +49,15 @@ options:
     credential:
       description:
         - Name of the credential to use for the job template.
+        - Mutually exclusive with 'credentials'.
       version_added: 2.7
+    credentials:
+      description:
+        - List of credentials to use for the job template.
+        - Mutually exclusive with 'credential'.
+      version_added: 2.8
+      type: list
+      default: []
     vault_credential:
       description:
         - Name of the vault credential to use for the job template.
@@ -259,6 +267,7 @@ def main():
         playbook=dict(required=True),
         credential=dict(default=''),
         vault_credential=dict(default=''),
+        credentials=dict(type='list', default=[]),
         forks=dict(type='int'),
         limit=dict(default=''),
         verbosity=dict(type='int', choices=[0, 1, 2, 3, 4], default=0),
@@ -286,7 +295,11 @@ def main():
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        mutually_exclusive=[('credential', 'credentials')]
+    )
 
     name = module.params.get('name')
     state = module.params.pop('state')

--- a/test/integration/targets/tower_job_template/tasks/main.yml
+++ b/test/integration/targets/tower_job_template/tasks/main.yml
@@ -4,6 +4,12 @@
     organization: Default
     kind: scm
 
+- name: Create a ssh noop credential
+  tower_credential:
+    name: noop
+    organization: Default
+    kind: ssh
+
 - name: Create a Demo Project
   tower_project:
     name: Job Template Test Project
@@ -52,3 +58,38 @@
 - assert:
     that:
       - "result is changed"
+
+- name: Create a Job Template with more than one credential
+  tower_job_template:
+    name: hello-worlds
+    project: Job Template Test Project
+    inventory: Demo Inventory
+    playbook: hello_world.yml
+    credentials:
+      - Demo Credential
+      - noop
+    job_type: run
+    state: present
+  register: result_credentials
+
+- assert:
+    that:
+      - "result_credentials is changed"
+
+- name: Create a Job Template with credential and credentials
+  ignore_errors: yes
+  tower_job_template:
+    name: goodby-world
+    project: Job Template Test Project
+    inventory: Demo Inventory
+    playbook: hello_world.yml
+    credential: Demo Credential
+    credentials:
+      - noop
+    job_type: run
+    state: present
+  register: result_exclusive
+
+- assert:
+    that:
+      - "result_exclusive is failed"


### PR DESCRIPTION
##### SUMMARY
Job templates might require more than one credential.
There's credential, vault_credential, machine_credential, etc.
"credentials" is a thing, let's support it.

Fixes: https://github.com/ansible/ansible/issues/43234

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tower_job_template

##### ANSIBLE VERSION
devel