### PR TITLE
cloud/ovirt: Add retry mechanism support for deactivating storage domain (#47550)

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -26,6 +26,7 @@ from abc import ABCMeta, abstractmethod
 from datetime import datetime
 from distutils.version import LooseVersion
 
+from ansible.module_utils.cloud import CloudRetry
 from ansible.module_utils.common._collections_compat import Mapping
 
 try:
@@ -802,3 +803,32 @@ class BaseModule(object):
         if isinstance(full_version, otypes.Version):
             return int(full_version.minor)
         return int(full_version.split('.')[1])
+
+
+def _sdk4_error_maybe():
+    """
+    Allow for ovirtsdk4 not being installed.
+    """
+    if HAS_SDK:
+        return sdk.Error
+    return type(None)
+
+
+class OvirtRetry(CloudRetry):
+    base_class = _sdk4_error_maybe()
+
+    @staticmethod
+    def status_code_from_exception(error):
+        return error.code
+
+    @staticmethod
+    def found(response_code, catch_extra_error_codes=None):
+        # This is a list of error codes to retry.
+        retry_on = [
+            # HTTP status: Conflict
+            409,
+        ]
+        if catch_extra_error_codes:
+            retry_on.extend(catch_extra_error_codes)
+
+        return response_code in retry_on

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domain.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domain.py
@@ -311,6 +311,7 @@ from ansible.module_utils.ovirt import (
     equal,
     get_entity,
     get_id_by_name,
+    OvirtRetry,
     ovirt_full_argument_spec,
     search_by_name,
     search_by_attributes,
@@ -676,7 +677,10 @@ def main():
         elif state == 'maintenance':
             sd_id = storage_domains_module.create()['id']
             storage_domains_module.post_create_check(sd_id)
-            ret = storage_domains_module.action(
+
+            ret = OvirtRetry.backoff(tries=5, delay=1, backoff=2)(
+                storage_domains_module.action
+            )(
                 action='deactivate',
                 action_condition=lambda s: s.status == sdstate.ACTIVE,
                 wait_condition=lambda s: s.status == sdstate.MAINTENANCE,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In oVirt engine, async tasks related to a storage domain may still be running **for a while** after the state of the storage domain has became to `active`, which is the root cause of issue #47550 . This pull request adds retrying mechanism when encountering a `409` error to deactivate a storage domain. The implementation will try the best to guarantee the `deactivate` action to succeed, which makes the module more robust.

Changes proposed in this pr:
* Add a new `OvirtRetry` class definition to make retry mechanism available to all oVirt modules.
* Retries with exponential backoff strategy when failed to performing `deactivate` a storage domain action. Current strategy is to make a `deactivate` action with a maximum of 5 tries at delays: `[1s, 2s, 4s, 8s, 16s]`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #47550 . 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_storage_domain

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
devel
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Follow the steps mentioned in #47550 .

<!--- Paste verbatim command output below, e.g. before and after your change -->
After changes the playbook is successfully applied and the state of storage domain is `active`. Also note that some additional retrying logs below are also recorded.
```paste below
Oct 24 00:27:56 localhost ansible-ovirt_storage_domain: Fault reason is "Operation Failed". Fault detail is "[Cannot deactivate Storage while there are running tasks on this Storage.#012-Please wait until tasks will finish and try again.]". HTTP response code is 409.: Retrying in 1 seconds...
Oct 24 00:27:57 localhost ansible-ovirt_storage_domain: Fault reason is "Operation Failed". Fault detail is "[Cannot deactivate Storage while there are running tasks on this Storage.#012-Please wait until tasks will finish and try again.]". HTTP response code is 409.: Retrying in 2 seconds...
Oct 24 00:28:00 localhost ansible-ovirt_storage_domain: Fault reason is "Operation Failed". Fault detail is "[Cannot deactivate Storage while there are running tasks on this Storage.#012-Please wait until tasks will finish and try again.]". HTTP response code is 409.: Retrying in 4 seconds...
```
