### PR TITLE
Fix Issue:#47076 onyx_l2_interface parameter trunk_allowed_vlans trie…

### DIFF
--- a/lib/ansible/modules/network/onyx/onyx_l2_interface.py
+++ b/lib/ansible/modules/network/onyx/onyx_l2_interface.py
@@ -150,16 +150,28 @@ class OnyxL2InterfaceModule(BaseOnyxModule):
     @classmethod
     def get_allowed_vlans(cls, if_data):
         allowed_vlans = cls.get_config_attr(if_data, 'Allowed vlans')
+        interface_allwoed_vlans = []
         if allowed_vlans:
             vlans = allowed_vlans.split(',')
-            allowed_vlans = [int(vlan.strip()) for vlan in vlans]
-        return allowed_vlans
+            for vlan in vlans:
+                if '-' not in vlan:
+                    interface_allwoed_vlans.append(int(vlan))
+                else:
+                    vlan_range = vlan.split("-")
+                    min_number = int(vlan_range[0].strip())
+                    max_number = int(vlan_range[1].strip())
+                    vlan_list = range(min_number, max_number + 1)
+                    interface_allwoed_vlans.extend(vlan_list)
+        return interface_allwoed_vlans
 
     @classmethod
     def get_access_vlan(cls, if_data):
         access_vlan = cls.get_config_attr(if_data, 'Access vlan')
         if access_vlan:
-            return int(access_vlan)
+            try:
+                return int(access_vlan)
+            except ValueError:
+                return None
 
     def _create_switchport_data(self, if_name, if_data):
         if self._os_version >= self.ONYX_API_VERSION:
@@ -224,13 +236,13 @@ class OnyxL2InterfaceModule(BaseOnyxModule):
         if req_trunk_vlans:
             req_trunk_vlans = set(req_trunk_vlans)
         if req_mode != 'access' and curr_trunk_vlans != req_trunk_vlans:
-            removed_vlans = curr_trunk_vlans - req_trunk_vlans
-            for vlan_id in removed_vlans:
-                commands.append('switchport %s allowed-vlan remove %s' %
-                                (req_mode, vlan_id))
             added_vlans = req_trunk_vlans - curr_trunk_vlans
             for vlan_id in added_vlans:
                 commands.append('switchport %s allowed-vlan add %s' %
+                                (req_mode, vlan_id))
+            removed_vlans = curr_trunk_vlans - req_trunk_vlans
+            for vlan_id in removed_vlans:
+                commands.append('switchport %s allowed-vlan remove %s' %
                                 (req_mode, vlan_id))
 
         if commands:


### PR DESCRIPTION
…s to remove all existing vlans on a port

Signed-off-by: Anas Badaha <anasb@mellanox.com>

##### SUMMARY
Fixes #46468 #47076

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
module onyx_l2_interface parameter trunk_allowed_vlans

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0 
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /.autodirect/mtrswgwork/anasb/ansible_dev4/lib/ansible
  executable location = /.autodirect/mtrswgwork/anasb/ansible_dev4/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
