### PR TITLE
Fix markup: inline literal with spaces

### DIFF
--- a/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
+++ b/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
@@ -137,8 +137,8 @@ Gotchas
 -------
 
 While you can put just about anything into an unquoted scalar, there are some exceptions.
-A colon followed by a space (or newline) ``: `` is an indicator for a mapping.
-A space followed by the pound sign `` #`` starts a comment.
+A colon followed by a space (or newline) ``": "`` is an indicator for a mapping.
+A space followed by the pound sign ``" #"`` starts a comment.
 
 Because of this, the following is going to result in a YAML syntax error::
 


### PR DESCRIPTION
##### SUMMARY

According to the official documentation, and as seen in the current
HTML version for this document, leading and trailing spaces are not
allowed for inline literal text:

http://docutils.sourceforge.net/docs/user/rst/quickref.html#inline-markup
  2. The start-string must be immediately followed by non-whitespace.
  3. The end-string must be immediately preceded by non-whitespace.

This commit fixes the problem with a compromise: adding quotes around
the text. The quotes will appear in the HTML version. But at least it's
better than the current broken state :)


##### ISSUE TYPE
- Docs Pull Request

