### PR TITLE
Bug fix for purefb_fs to stop incorrect filesystem eradication

### DIFF
--- a/lib/ansible/modules/storage/purestorage/purefb_fs.py
+++ b/lib/ansible/modules/storage/purestorage/purefb_fs.py
@@ -329,7 +329,7 @@ def main():
         modify_fs(module, blade)
     elif state == 'absent' and fs and not fs.destroyed:
         delete_fs(module, blade)
-    elif state == 'absent' and fs and fs.destroyed:
+    elif state == 'absent' and fs and fs.destroyed and module.params['eradicate']:
         eradicate_fs(module, blade)
     elif state == 'absent' and not fs:
         module.exit_json(changed=False)


### PR DESCRIPTION
##### SUMMARY
Bug fix to stop erasure of filesystem when it has already been deleted but the eradicate flag is not set to true

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modules/storage/purestorage/purefb_fs.py

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```