### PR TITLE
[2.7] ios check_rc: Default to sending text of exception, not the whole exception (#47300)

### DIFF
--- a/changelogs/fragments/47300-ios-check_rc.yaml
+++ b/changelogs/fragments/47300-ios-check_rc.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix issue getting output from failed ios commands when ``check_rc=False``

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -291,7 +291,7 @@ class Cliconf(CliconfBase):
             except AnsibleConnectionFailure as e:
                 if check_rc:
                     raise
-                out = getattr(e, 'err', e)
+                out = getattr(e, 'err', to_text(e))
 
             responses.append(out)
 


### PR DESCRIPTION

##### SUMMARY

* Default to sending text of exception, not the whole exception
(cherry picked from commit 6a866a5)
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cliconf/ios

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```
