### PR TITLE
[WIP] [POC] Ignore reserved keywords when querying action_loader and module_loader

### DIFF
--- a/changelogs/fragments/ignore-keywords-plugin-loader.yaml
+++ b/changelogs/fragments/ignore-keywords-plugin-loader.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Task Parsing - Ignore reserved keywords when checking the action_loader and module_loader to improve performance and ignore files that shadow the name of a module (https://github.com/ansible/ansible/pull/47564)

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -291,7 +291,7 @@ class ModuleArgsParser:
 
         # walk the input dictionary to see we recognize a module name
         for (item, value) in iteritems(self._task_ds):
-            if not is_reserved_name(item) and (item in BUILTIN_TASKS or action_loader.has_plugin(item, collection_list=self._collection_list) or \
+            if not is_reserved_name(item) and (item in BUILTIN_TASKS or action_loader.has_plugin(item, collection_list=self._collection_list) or
                     module_loader.has_plugin(item, collection_list=self._collection_list)):
                 # finding more than one module name is a problem
                 if action is not None:

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -292,7 +292,7 @@ class ModuleArgsParser:
         # walk the input dictionary to see we recognize a module name
         for (item, value) in iteritems(self._task_ds):
             if not is_reserved_name(item) and (item in BUILTIN_TASKS or action_loader.has_plugin(item, collection_list=self._collection_list) or
-                    module_loader.has_plugin(item, collection_list=self._collection_list)):
+                                               module_loader.has_plugin(item, collection_list=self._collection_list)):
                 # finding more than one module name is a problem
                 if action is not None:
                     raise AnsibleParserError("conflicting action statements: %s, %s" % (action, item), obj=self._task_ds)

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -367,7 +367,7 @@ class PluginLoader:
 
         return to_text(found_files[0])
 
-    def _find_plugin(self, name, mod_type='', ignore_deprecated=False, check_aliases=False, collection_list=None):
+    def find_plugin(self, name, mod_type='', ignore_deprecated=False, check_aliases=False, collection_list=None):
         ''' Find a plugin named name '''
 
         global _PLUGIN_FILTERS
@@ -488,20 +488,6 @@ class PluginLoader:
                 return pull_cache[alias_name]
 
         return None
-
-    def find_plugin(self, name, mod_type='', ignore_deprecated=False, check_aliases=False, collection_list=None):
-        ''' Find a plugin named name '''
-
-        # Import here to avoid circular import
-        from ansible.vars.reserved import is_reserved_name
-
-        plugin = self._find_plugin(name, mod_type=mod_type, ignore_deprecated=ignore_deprecated, check_aliases=check_aliases, collection_list=collection_list)
-        if plugin and self.package == 'ansible.modules' and name not in ('gather_facts',) and is_reserved_name(name):
-            raise AnsibleError(
-                'Module "%s" shadows the name of a reserved keyword. Please rename or remove this module. Found at %s' % (name, plugin)
-            )
-
-        return plugin
 
     def has_plugin(self, name, collection_list=None):
         ''' Checks if a plugin named name exists '''

--- a/test/integration/targets/shadowed_module/runme.sh
+++ b/test/integration/targets/shadowed_module/runme.sh
@@ -2,12 +2,8 @@
 
 set -ux
 
-OUT=$(ansible-playbook playbook.yml -i inventory -e @../../integration_config.yml "$@" 2>&1 | grep 'ERROR! Module "tags" shadows the name of a reserved keyword.')
-
-if [[ -z "$OUT" ]]; then
-    echo "Fake tags module did not cause error"
-    exit 1
-fi
+# Modules that shadow keywords are ignored, this should succeed without issue
+ansible-playbook playbook.yml -i inventory -e @../../integration_config.yml "$@"
 
 # This playbook calls a lookup which shadows a keyword.
 # This is an ok situation, and should not error

--- a/test/units/playbook/test_block.py
+++ b/test/units/playbook/test_block.py
@@ -54,9 +54,9 @@ class TestBlock(unittest.TestCase):
 
     def test_load_block_with_tasks(self):
         ds = dict(
-            block=[dict(action='block')],
-            rescue=[dict(action='rescue')],
-            always=[dict(action='always')],
+            block=[dict(action='ping')],
+            rescue=[dict(action='ping')],
+            always=[dict(action='ping')],
             # otherwise=[dict(action='otherwise')],
         )
         b = Block.load(ds)
@@ -78,9 +78,9 @@ class TestBlock(unittest.TestCase):
 
     def test_deserialize(self):
         ds = dict(
-            block=[dict(action='block')],
-            rescue=[dict(action='rescue')],
-            always=[dict(action='always')],
+            block=[dict(action='ping')],
+            rescue=[dict(action='ping')],
+            always=[dict(action='ping')],
         )
         b = Block.load(ds)
         data = dict(parent=ds, parent_type='Block')


### PR DESCRIPTION
##### SUMMARY
Ignore reserved keywords when querying action_loader and module_loader

This does 2 things for us:

1. Improves performance by querying PluginLoader fewer times
1. Removes special casing from the PluginLoader to catch shadowed module names

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/parsing/mod_args.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```