### PR TITLE
Fix os_router ignores enable_snat: no (#45921)

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_router.py
+++ b/lib/ansible/modules/cloud/openstack/os_router.py
@@ -317,7 +317,7 @@ def _build_kwargs(cloud, module, router, network):
     if network:
         kwargs['ext_gateway_net_id'] = network['id']
         # can't send enable_snat unless we have a network
-        if module.params['enable_snat']:
+        if module.params.get('enable_snat') is not None:
             kwargs['enable_snat'] = module.params['enable_snat']
 
     if module.params['external_fixed_ips']:


### PR DESCRIPTION
If enable_snat is False, this should be used to build the
request, because the default value in the OpenStack Networking
API is True.

Fixes the issue #45915.

(cherry picked from commit 452a4ab78118966189eeedbd3523bf6559f061b2)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
