### PR TITLE
Fix mysql authentication errors

### DIFF
--- a/test/integration/targets/mysql_db/tasks/main.yml
+++ b/test/integration/targets/mysql_db/tasks/main.yml
@@ -18,13 +18,21 @@
 
 # ============================================================
 
+- name: remove database if it exists
+  command: >
+    mysql -sse "drop database {{db_name}};"
+  ignore_errors: True
+
 - name: make sure the test database is not there
   command: mysql {{db_name}}
   register: mysql_db_check
   failed_when: "'1049' not in mysql_db_check.stderr"
 
 - name: test state=present for a database name (expect changed=true)
-  mysql_db: name={{ db_name }} state=present
+  mysql_db:
+    name: '{{ db_name }}'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert output message that database exist
@@ -42,7 +50,10 @@
 
 # ============================================================
 - name: test state=absent for a database name (expect changed=true)
-  mysql_db: name={{ db_name }} state=absent
+  mysql_db:
+    name: '{{ db_name }}'
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert output message that database does not exist
@@ -60,7 +71,11 @@
 
 # ============================================================
 - name: test mysql_db encoding param not valid - issue 8075
-  mysql_db: name=datanotvalid state=present encoding=notvalid
+  mysql_db:
+    name: datanotvalid
+    state: present
+    encoding: notvalid
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
   ignore_errors: true
 
@@ -73,7 +88,11 @@
 
 # ============================================================
 - name: test mysql_db using a valid encoding utf8 (expect changed=true)
-  mysql_db: name=en{{ db_name }}  state=present encoding=utf8
+  mysql_db:
+    name: 'en{{ db_name }}'
+    state: present
+    encoding: utf8
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert output message created a database
@@ -87,11 +106,18 @@
   assert: { that: "'utf8' in result.stdout" }
 
 - name: remove database
-  mysql_db: name=en{{ db_name }} state=absent
+  mysql_db:
+    name: 'en{{ db_name }}'
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'
 
 # ============================================================
 - name: test mysql_db using valid encoding binary (expect changed=true)
-  mysql_db: name=en{{ db_name }}  state=present encoding=binary
+  mysql_db:
+    name: 'en{{ db_name }}'
+    state: present
+    encoding: binary
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert output message that database was created
@@ -105,14 +131,26 @@
   assert: { that: "'binary' in result.stdout" }
 
 - name: remove database
-  mysql_db: name=en{{ db_name }}  state=absent
+  mysql_db:
+    name: 'en{{ db_name }}'
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'
 
 # ============================================================
 - name: create user1 to access database dbuser1
-  mysql_user: name=user1 password=Hfd6fds^dfA8Ga priv=*.*:ALL state=present
+  mysql_user:
+    name: user1
+    password: 'Hfd6fds^dfA8Ga'
+    priv: '*.*:ALL'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: create database dbuser1 using user1
-  mysql_db: name={{ db_user1 }} state=present login_user=user1 login_password=Hfd6fds^dfA8Ga
+  mysql_db:
+    name: '{{ db_user1 }}'
+    state: present
+    login_user: user1
+    login_password: 'Hfd6fds^dfA8Ga'
   register: result
 
 - name: assert output message that database was created
@@ -127,10 +165,19 @@
 
 # ============================================================
 - name: create user2 to access database with privilege select only
-  mysql_user: name=user2 password=kjsfd&F7safjad priv=*.*:SELECT state=present
+  mysql_user:
+    name: user2
+    password: 'kjsfd&F7safjad'
+    priv: '*.*:SELECT'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: create database dbuser2 using user2 with no privilege to create (expect failed=true)
-  mysql_db: name={{ db_user2 }} state=present login_user=user2 login_password=kjsfd&F7safjad
+  mysql_db:
+    name: '{{ db_user2 }}'
+    state: present
+    login_user: user2
+    login_password: 'kjsfd&F7safjad'
   register: result
   ignore_errors: true
 
@@ -149,7 +196,11 @@
 
 # ============================================================
 - name: delete database using user2 with no privilege to delete (expect failed=true)
-  mysql_db: name={{ db_user1 }} state=absent login_user=user2 login_password=kjsfd&F7safjad
+  mysql_db:
+    name: '{{ db_user1 }}'
+    state: absent
+    login_user: user2
+    login_password: 'kjsfd&F7safjad'
   register: result
   ignore_errors: true
 
@@ -168,7 +219,11 @@
 
 # ============================================================
 - name: delete database using user1 with all privilege to delete a database (expect changed=true)
-  mysql_db: name={{ db_user1 }} state=absent login_user=user1 login_password=Hfd6fds^dfA8Ga
+  mysql_db:
+    name: '{{ db_user1 }}'
+    state: absent
+    login_user: user1
+    login_password: 'Hfd6fds^dfA8Ga'
   register: result
   ignore_errors: true
 

--- a/test/integration/targets/mysql_db/tasks/state_dump_import.yml
+++ b/test/integration/targets/mysql_db/tasks/state_dump_import.yml
@@ -20,7 +20,10 @@
 - set_fact: db_file_name="{{tmp_dir}}/{{file}}"
 
 - name: state dump/import - create database
-  mysql_db: name={{ db_name }} state=present
+  mysql_db:
+    name: '{{ db_name }}'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: state dump/import - create table department
   command: mysql {{ db_name }} '-e create table department(id int, name varchar(100));'
@@ -44,6 +47,7 @@
     target: "{{ db_file_name }}"
     ignore_tables:
         - "{{ db_name }}.department"
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert successful completion of dump operation
@@ -55,10 +59,17 @@
   file: name={{ db_file_name }} state=file
 
 - name: state dump/import - remove database
-  mysql_db: name={{ db_name }} state=absent
+  mysql_db:
+    name: '{{ db_name }}'
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: test state=import to restore the database of type {{ format_type }} (expect changed=true)
-  mysql_db: name={{ db_name }} state=import target={{ db_file_name }}
+  mysql_db:
+    name: '{{ db_name }}'
+    state: import
+    target: '{{ db_file_name }}'
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: show the tables
@@ -71,7 +82,11 @@
        - "'department' not in result.stdout"
 
 - name: test state=dump to backup the database of type {{ format_type }} (expect changed=true)
-  mysql_db: name={{ db_name }} state=dump target={{ db_file_name }}
+  mysql_db:
+    name: '{{ db_name }}'
+    state: dump
+    target: '{{ db_file_name }}'
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert output message backup the database
@@ -91,7 +106,11 @@
   command: mysql {{ db_name }} "-e update employee set name='John Doe' where id=47;"
 
 - name: test state=import to restore the database of type {{ format_type }} (expect changed=true)
-  mysql_db: name={{ db_name }} state=import target={{ db_file_name }}
+  mysql_db:
+    name: '{{ db_name }}'
+    state: import
+    target: '{{ db_file_name }}'
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert output message restore the database
@@ -108,7 +127,10 @@
        - "'Joe Smith' in result.stdout"
 
 - name: remove database name
-  mysql_db: name={{ db_name }} state=absent
+  mysql_db:
+    name: '{{ db_name }}'
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: remove file name
   file: name={{ db_file_name }}  state=absent

--- a/test/integration/targets/mysql_user/tasks/create_user.yml
+++ b/test/integration/targets/mysql_user/tasks/create_user.yml
@@ -18,7 +18,11 @@
 
 # ============================================================
 - name: create mysql user {{user_name}}
-  mysql_user: name={{user_name}} password={{user_password}} state=present
+  mysql_user:
+    name: '{{user_name}}'
+    password: '{{user_password}}'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert output message mysql user was created

--- a/test/integration/targets/mysql_user/tasks/main.yml
+++ b/test/integration/targets/mysql_user/tasks/main.yml
@@ -33,7 +33,11 @@
 - include: create_user.yml user_name={{user_name_1}} user_password={{ user_password_1 }}
 
 - name: create mysql user that already exist (expect changed=false)
-  mysql_user: name={{user_name_1}} password={{user_password_1}} state=present
+  mysql_user:
+    name: '{{user_name_1}}'
+    password: '{{user_password_1}}'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert output message mysql user was not created
@@ -43,7 +47,11 @@
 # remove mysql user and verify user is removed from mysql database
 #
 - name: remove mysql user state=absent (expect changed=true)
-  mysql_user: name={{ user_name_1 }} password={{ user_password_1 }} state=absent
+  mysql_user:
+    name: '{{ user_name_1 }}'
+    password: '{{ user_password_1 }}'
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert output message mysql user was removed
@@ -55,7 +63,11 @@
 # remove mysql user that does not exist on mysql database
 #
 - name: remove mysql user that does not exist state=absent (expect changed=false)
-  mysql_user: name={{ user_name_1 }} password={{ user_password_1 }} state=absent
+  mysql_user:
+    name: '{{ user_name_1 }}'
+    password: '{{ user_password_1 }}'
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert output message mysql user that does not exist
@@ -67,7 +79,11 @@
 # Create user with no privileges and verify default privileges are assign
 #
 - name: create user with select privilege state=present (expect changed=true)
-  mysql_user: name={{ user_name_1 }} password={{ user_password_1 }} state=present
+  mysql_user:
+    name: '{{ user_name_1 }}'
+    password: '{{ user_password_1 }}'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - include: assert_user.yml user_name={{user_name_1}} priv=USAGE
@@ -80,7 +96,12 @@
 # Create user with select privileges and verify select privileges are assign
 #
 - name: create user with select privilege state=present (expect changed=true)
-  mysql_user: name={{ user_name_2 }} password={{ user_password_2 }} state=present priv=*.*:SELECT
+  mysql_user:
+    name: '{{ user_name_2 }}'
+    password: '{{ user_password_2 }}'
+    state: present
+    priv: '*.*:SELECT'
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - include: assert_user.yml user_name={{user_name_2}} priv=SELECT
@@ -93,7 +114,12 @@
 # Assert user has access to multiple databases
 #
 - name: give users access to multiple databases
-  mysql_user: name={{ item[0]  }} priv={{ item[1] }}.*:ALL append_privs=yes password={{ user_password_1 }}
+  mysql_user:
+    name: '{{ item[0] }}'
+    priv: '{{ item[1] }}.*:ALL'
+    append_privs: yes
+    password: '{{ user_password_1 }}'
+    login_unix_socket: '{{ mysql_socket }}'
   with_nested:
     - [ '{{ user_name_1 }}', '{{ user_name_2 }}']
     - "{{db_names}}"
@@ -119,7 +145,12 @@
 - include: remove_user.yml user_name={{user_name_2}} user_password={{ user_password_1 }}
 
 - name: give user access to database via wildcard
-  mysql_user: name={{ user_name_1 }} priv=%db.*:SELECT append_privs=yes password={{ user_password_1 }}
+  mysql_user:
+    name: '{{ user_name_1 }}'
+    priv: '%db.*:SELECT'
+    append_privs: yes
+    password: '{{ user_password_1 }}'
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: show grants access for user1 on multiple database
   command: mysql "-e SHOW GRANTS FOR '{{ user_name_1 }}'@'localhost';"
@@ -132,7 +163,12 @@
       - "'SELECT' in result.stdout"
 
 - name: change user access to database via wildcard
-  mysql_user: name={{ user_name_1 }} priv=%db.*:INSERT append_privs=yes password={{ user_password_1 }}
+  mysql_user:
+    name: '{{ user_name_1 }}'
+    priv: '%db.*:INSERT'
+    append_privs: yes
+    password: '{{ user_password_1 }}'
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: show grants access for user1 on multiple database
   command: mysql "-e SHOW GRANTS FOR '{{ user_name_1 }}'@'localhost';"

--- a/test/integration/targets/mysql_user/tasks/remove_user.yml
+++ b/test/integration/targets/mysql_user/tasks/remove_user.yml
@@ -18,7 +18,11 @@
 
 # ============================================================
 - name: remove mysql user {{user_name}}
-  mysql_user: name={{user_name}} password={{user_password}} state=absent
+  mysql_user:
+    name: '{{user_name}}'
+    password: '{{user_password}}'
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert output message mysql user was removed
@@ -26,17 +30,29 @@
 
 # ============================================================
 - name: create blank mysql user to be removed later
-  mysql_user: name="" state=present password='KJFDY&D*Sfuydsgf'
+  mysql_user:
+    name: ""
+    state: present
+    password: 'KJFDY&D*Sfuydsgf'
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: remove blank mysql user with hosts=all (expect changed)
-  mysql_user: user="" host_all=true state=absent
+  mysql_user:
+    user: ""
+    host_all: true
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert changed is true for removing all blank users
   assert: { that: "result.changed == true" }
 
 - name: remove blank mysql user with hosts=all (expect ok)
-  mysql_user: user="" host_all=true state=absent
+  mysql_user:
+    user: ""
+    host_all: true
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert changed is true for removing all blank users

--- a/test/integration/targets/mysql_user/tasks/test_privs.yml
+++ b/test/integration/targets/mysql_user/tasks/test_privs.yml
@@ -18,14 +18,25 @@
 
 # ============================================================
 - name: create user with basic select privileges
-  mysql_user: name={{ user_name_2 }} password={{ user_password_2 }} priv=*.*:SELECT state=present
+  mysql_user:
+    name: '{{ user_name_2 }}'
+    password: '{{ user_password_2 }}'
+    priv: '*.*:SELECT'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
   when: current_append_privs ==  "yes"
 
 - include: assert_user.yml user_name={{user_name_2}} priv='SELECT'
   when: current_append_privs ==  "yes"
  
 - name: create user with current privileges (expect changed=true)
-  mysql_user: name={{ user_name_2 }} password={{ user_password_2 }} priv=*.*:{{current_privilege}} append_privs={{current_append_privs}} state=present
+  mysql_user:
+    name: '{{ user_name_2 }}'
+    password: '{{ user_password_2 }}'
+    priv: '*.*:{{current_privilege}}'
+    append_privs: '{{current_append_privs}}'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: assert output message for current privileges 
@@ -44,7 +55,11 @@
   when: current_append_privs ==  "yes"
 
 - name: create database using user current privileges
-  mysql_db: name={{ db_name }} state=present login_user={{ user_name_2 }} login_password={{ user_password_2 }}
+  mysql_db:
+    name: '{{ db_name }}'
+    state: present
+    login_user: '{{ user_name_2 }}'
+    login_password: '{{ user_password_2 }}'
   ignore_errors: true 
 
 - name: run command to test that database was not created
@@ -56,14 +71,24 @@
 
 # ============================================================
 - name: Add privs to a specific table (expect changed)
-  mysql_user: name={{ user_name_2 }} password={{ user_password_2 }} priv=jmainguy.jmainguy:ALL state=present
+  mysql_user:
+    name: '{{ user_name_2 }}'
+    password: '{{ user_password_2 }}'
+    priv: 'jmainguy.jmainguy:ALL'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: Assert that priv changed
   assert: { that: "result.changed == true" }
 
 - name: Add privs to a specific table (expect ok)
-  mysql_user: name={{ user_name_2 }} password={{ user_password_2 }} priv=jmainguy.jmainguy:ALL state=present
+  mysql_user:
+    name: '{{ user_name_2 }}'
+    password: '{{ user_password_2 }}'
+    priv: 'jmainguy.jmainguy:ALL'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - name: Assert that priv did not change
@@ -71,18 +96,35 @@
 
 # ============================================================
 - name: update user with all privileges 
-  mysql_user: name={{ user_name_2 }} password={{ user_password_2 }} priv=*.*:ALL state=present
+  mysql_user:
+    name: '{{ user_name_2 }}'
+    password: '{{ user_password_2 }}'
+    priv: '*.*:ALL'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
 
 - include: assert_user.yml user_name={{user_name_2}} priv='ALL PRIVILEGES'
 
 - name: create database using user
-  mysql_db: name={{ db_name }} state=present login_user={{ user_name_2 }} login_password={{ user_password_2 }}
+  mysql_db:
+    name: '{{ db_name }}'
+    state: present
+    login_user: '{{ user_name_2 }}'
+    login_password: '{{ user_password_2 }}'
 
 - name: run command to test database was created using user new privileges
   command: mysql "-e SHOW CREATE DATABASE {{ db_name }};" 
 
 - name: drop database using user
-  mysql_db: name={{ db_name }} state=absent login_user={{ user_name_2 }} login_password={{ user_password_2 }}
+  mysql_db:
+    name: '{{ db_name }}'
+    state: absent
+    login_user: '{{ user_name_2 }}'
+    login_password: '{{ user_password_2 }}'
 
 - name: remove username
-  mysql_user: name={{ user_name_2 }} password={{ user_password_2 }} state=absent
+  mysql_user:
+    name: '{{ user_name_2 }}'
+    password: '{{ user_password_2 }}'
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'

--- a/test/integration/targets/mysql_user/tasks/user_password_update_test.yml
+++ b/test/integration/targets/mysql_user/tasks/user_password_update_test.yml
@@ -21,10 +21,20 @@
 # Assert the user password is updated and old password can no longer be used.
 #
 - name: create user1 state=present with a password 
-  mysql_user: name={{ user_name_1 }} password={{ user_password_1 }} priv=*.*:ALL state=present
+  mysql_user:
+    name: '{{ user_name_1 }}'
+    password: '{{ user_password_1 }}'
+    priv: '*.*:ALL'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: create user2 state=present with a password 
-  mysql_user: name={{ user_name_2 }} password={{ user_password_2 }} priv=*.*:ALL state=present
+  mysql_user:
+    name: '{{ user_name_2 }}'
+    password: '{{ user_password_2 }}'
+    priv: '*.*:ALL'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: store user2 grants with old password (mysql 5.7.6 and newer)
   command: mysql "-e SHOW CREATE USER '{{ user_name_2 }}'@'localhost';"
@@ -38,16 +48,25 @@
 
 # FIXME: not sure why this is failing, but it looks like it should expect changed=true
 #- name: update user2 state=present with same password (expect changed=false)
-#  mysql_user: name={{ user_name_2 }} password={{ user_password_2 }} priv=*.*:ALL state=present
+#  mysql_user:
+#    name: '{{ user_name_2 }}'
+#    password: '{{ user_password_2 }}'
+#    priv: '*.*:ALL'
+#    state: present
+#    login_unix_socket: '{{ mysql_socket }}'
 #  register: result
 #
 #- name: assert output user2 was not updated 
 #  assert: { that: "result.changed == false" }
 
 - include: assert_user.yml user_name={{user_name_2}} priv='ALL PRIVILEGES'
- 
+
 - name: update user2 state=present with a new password (expect changed=true)
-  mysql_user: name={{ user_name_2 }} password={{ user_password_1 }} state=present
+  mysql_user:
+    name: '{{ user_name_2 }}'
+    password: '{{ user_password_1 }}'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - include: assert_user.yml user_name={{user_name_2}} priv='ALL PRIVILEGES'
@@ -71,7 +90,11 @@
   when: user_password_new_create is failed
 
 - name: create database using user2 and old password
-  mysql_db: name={{ db_name }} state=present login_user={{ user_name_2 }} login_password={{ user_password_2 }}
+  mysql_db:
+    name: '{{ db_name }}'
+    state: present
+    login_user: '{{ user_name_2 }}'
+    login_password: '{{ user_password_2 }}'
   ignore_errors: true 
   register: result
 
@@ -82,21 +105,32 @@
        - "result.failed == true"
 
 - name: create database using user2 and new password
-  mysql_db: name={{ db_name }} state=present login_user={{ user_name_2 }} login_password={{ user_password_1 }}
+  mysql_db:
+    name: '{{ db_name }}'
+    state: present
+    login_user: '{{ user_name_2 }}'
+    login_password: '{{ user_password_1 }}'
   register: result
 
 - name: assert output message that database is created with new password
   assert: { that: "result.changed == true" }
 
 - name: remove database
-  mysql_db: name={{ db_name }} state=absent
+  mysql_db:
+    name: '{{ db_name }}'
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'
 
 - include: remove_user.yml user_name={{user_name_1}} user_password={{ user_password_1 }}
 
 - include: remove_user.yml user_name={{user_name_2}} user_password={{ user_password_1 }}
 
 - name: Create user with Fdt8fd^34ds using hash. (expect changed=true)
-  mysql_user: name=jmainguy password='*0cb5b86f23fdc24db19a29b8854eb860cbc47793' encrypted=yes
+  mysql_user:
+    name: jmainguy
+    password: '*0cb5b86f23fdc24db19a29b8854eb860cbc47793'
+    encrypted: yes
+    login_unix_socket: '{{ mysql_socket }}'
   register: encrypt_result
 
 - name: Check that the module made a change
@@ -105,7 +139,10 @@
       - "encrypt_result.changed == True"
 
 - name: See if the password needs to be updated. (expect changed=false)
-  mysql_user: name=jmainguy password='Fdt8fd^34ds'
+  mysql_user:
+    name: jmainguy
+    password: 'Fdt8fd^34ds'
+    login_unix_socket: '{{ mysql_socket }}'
   register: plain_result
 
 - name: Check that the module did not change the password
@@ -114,4 +151,6 @@
       - "plain_result.changed == False"
 
 - name: Remove user (cleanup)
-  mysql_user: name=jmainguy state=absent
+  mysql_user:
+    name: jmainguy
+    state: absent

--- a/test/integration/targets/mysql_variables/tasks/main.yml
+++ b/test/integration/targets/mysql_variables/tasks/main.yml
@@ -22,7 +22,9 @@
 - set_fact: set_name='version'
 
 - name: read mysql variables (expect changed=false)
-  mysql_variables: variable={{set_name}}
+  mysql_variables:
+    variable: '{{set_name}}'
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - include: assert_var_output.yml changed=false output={{result}} var_name={{set_name}}
@@ -35,10 +37,16 @@
      set_value: 'ON'
 
 - name: set mysql variable
-  mysql_variables: variable={{set_name}} value={{set_value}}
+  mysql_variables:
+    variable: '{{set_name}}'
+    value: '{{set_value}}'
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: update mysql variable to same value (expect changed=false)
-  mysql_variables: variable={{set_name}} value={{set_value}}
+  mysql_variables:
+    variable: '{{set_name}}'
+    value: '{{set_value}}'
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - include: assert_var.yml changed=false output={{result}} var_name={{set_name}} var_value={{set_value}}
@@ -51,10 +59,16 @@
      set_value: '300'
 
 - name: set mysql variable to a temp value
-  mysql_variables: variable={{set_name}} value='200'
+  mysql_variables:
+    variable: '{{set_name}}'
+    value: '200'
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: update mysql variable value (expect changed=true)
-  mysql_variables: variable={{set_name}} value={{set_value}}
+  mysql_variables:
+    variable: '{{set_name}}'
+    value: '{{set_value}}'
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - include: assert_var.yml changed=true output={{result}} var_name={{set_name}} var_value='{{set_value}}'
@@ -67,10 +81,16 @@
      set_value: "400"
 
 - name: set mysql variable to a temp value
-  mysql_variables: variable={{set_name}} value="200"
+  mysql_variables:
+    variable: '{{set_name}}'
+    value: "200"
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: update mysql variable value (expect changed=true)
-  mysql_variables: variable={{set_name}} value={{set_value}}
+  mysql_variables:
+    variable: '{{set_name}}'
+    value: '{{set_value}}'
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - include: assert_var.yml changed=true output={{result}} var_name={{set_name}} var_value='{{set_value}}'
@@ -83,10 +103,16 @@
      set_value: 500
 
 - name: set mysql variable to a temp value
-  mysql_variables: variable={{set_name}} value=200
+  mysql_variables:
+    variable: '{{set_name}}'
+    value: 200
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: update mysql variable value (expect changed=true)
-  mysql_variables: variable={{set_name}} value={{set_value}}
+  mysql_variables:
+    variable: '{{set_name}}'
+    value: '{{set_value}}'
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
 
 - include: assert_var.yml changed=true output={{result}} var_name={{set_name}} var_value='{{set_value}}'
@@ -95,7 +121,10 @@
 # Verify mysql_variable successfully updates a variable using an expression (e.g. 1024*4)
 #
 - name: set mysql variable value to an expression
-  mysql_variables: variable=max_tmp_tables value="1024*4"
+  mysql_variables:
+    variable: max_tmp_tables
+    value: "1024*4"
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
   ignore_errors: true
 
@@ -105,7 +134,10 @@
 # Verify mysql_variable fails when setting an incorrect value (out of range)
 #
 - name: set mysql variable value to a number out of range
-  mysql_variables: variable=max_tmp_tables value=-1
+  mysql_variables:
+    variable: max_tmp_tables
+    value: -1
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
   ignore_errors: true
 
@@ -115,7 +147,10 @@
 # Verify mysql_variable fails when setting an incorrect value (incorrect type)
 #
 - name: set mysql variable value to a non-valid value number
-  mysql_variables: variable=max_tmp_tables value=TEST
+  mysql_variables:
+    variable: max_tmp_tables
+    value: TEST
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
   ignore_errors: true
 
@@ -125,7 +160,10 @@
 # Verify mysql_variable fails when setting an unknown variable
 #
 - name: set a non mysql variable
-  mysql_variables: variable=my_sql_variable value=ON
+  mysql_variables:
+    variable: my_sql_variable
+    value: ON
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
   ignore_errors: true
 
@@ -135,7 +173,10 @@
 # Verify mysql_variable fails when setting a read-only variable
 #
 - name: set value of a read only mysql variable
-  mysql_variables: variable=character_set_system value=utf16
+  mysql_variables:
+    variable: character_set_system
+    value: utf16
+    login_unix_socket: '{{ mysql_socket }}'
   register: result
   ignore_errors: true
 
@@ -145,24 +186,40 @@
 # Verify mysql_variable works with the login_user and login_password parameters
 #
 - name: create mysql user
-  mysql_user: name={{user}} password={{password}} state=present priv=*.*:ALL
+  mysql_user:
+    name: '{{user}}'
+    password: '{{password}}'
+    state: present
+    priv: '*.*:ALL'
+    login_unix_socket: '{{ mysql_socket }}'
 
 - set_fact:
      set_name: wait_timeout
      set_value: 77
 
 - name: query mysql_variable using login_user and password_password
-  mysql_variables: variable={{set_name}} login_user={{user}} login_password={{password}}
+  mysql_variables:
+    variable: '{{set_name}}'
+    login_user: '{{user}}'
+    login_password: '{{password}}'
   register: result
 
 - include: assert_var_output.yml changed=false output={{result}} var_name={{set_name}}
 
 - name: set mysql variable to temp value using user login and password (expect changed=true)
-  mysql_variables: variable={{set_name}} value=20 login_user={{user}} login_password={{password}}
+  mysql_variables:
+    variable: '{{set_name}}'
+    value: 20
+    login_user: '{{user}}'
+    login_password: '{{password}}'
   register: result
 
 - name: update mysql variable value using user login and password (expect changed=true)
-  mysql_variables: variable={{set_name}} value={{set_value}} login_user={{user}} login_password={{password}}
+  mysql_variables:
+    variable: '{{set_name}}'
+    value: '{{set_value}}'
+    login_user: '{{user}}'
+    login_password: '{{password}}'
   register: result
 
 - include: assert_var.yml changed=true output={{result}} var_name={{set_name}} var_value='{{set_value}}'
@@ -175,28 +232,43 @@
      set_value: 10
 
 - name: query mysql_variable using incorrect login_password
-  mysql_variables: variable={{set_name}} login_user={{user}} login_password=wrongpassword
+  mysql_variables:
+    variable: '{{set_name}}'
+    login_user: '{{user}}'
+    login_password: 'wrongpassword'
   register: result
   ignore_errors: true
 
 - include: assert_fail_msg.yml output={{result}}  msg='unable to connect to database'
 
 - name: update mysql variable value using incorrect login_password (expect failed=true)
-  mysql_variables: variable={{set_name}} value={{set_value}} login_user={{user}} login_password='this is an incorrect password'
+  mysql_variables:
+    variable: '{{set_name}}'
+    value: '{{set_value}}'
+    login_user: '{{user}}'
+    login_password: 'this is an incorrect password'
+  register: result
+  ignore_errors: true
+
+- include: assert_fail_msg.yml output={{result}}  msg='unable to connect to database'
+
+#============================================================
+# Verify mysql_variable fails with an incorrect login_host parameter
+#
+- name: query mysql_variable using incorrect login_host
+  mysql_variables:
+    variable: wait_timeout
+    login_host: '12.0.0.9'
+    login_user: '{{user}}'
+    login_password: '{{password}}'
+    connect_timeout: 5
   register: result
   ignore_errors: true
 
 - include: assert_fail_msg.yml output={{result}}  msg='unable to connect to database'
 
 - name: remove mysql_user {{user}}
-  mysql_user: name={{user}} state=absent
-
-#============================================================
-# Verify mysql_variable fails with an incorrect login_host parameter
-#
-- name: query mysql_variable using incorrect login_host
-  mysql_variables: variable=wait_timeout login_host=12.0.0.9 connect_timeout=5
-  register: result
-  ignore_errors: true
-
-- include: assert_fail_msg.yml output={{result}}  msg='unable to connect to database'
+  mysql_user:
+    name: '{{user}}'
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'

--- a/test/integration/targets/setup_mysql_db/tasks/main.yml
+++ b/test/integration/targets/setup_mysql_db/tasks/main.yml
@@ -37,6 +37,15 @@
         - 'default{{ python_suffix }}.yml'
       paths: '../vars'
 
+- name: Detect socket path
+  shell: >
+          echo "show variables like 'socket'\G" | mysql | grep 'Value: ' | sed 's/[ ]\+Value: //'
+  register: _socket_path
+
+- name: Set socket path
+  set_fact:
+    mysql_socket: '{{ _socket_path["stdout"] }}'
+
 - name: install mysqldb_test rpm dependencies
   yum: name={{ item }} state=latest
   with_items: "{{mysql_packages}}"


### PR DESCRIPTION
The mysql-server package on Ubuntu16.04 was recently updated to disallow
unauthenticated root user login over tcp/ip.  This, coupled with pymysql
using tcp/ip whenever host and port is specified causes us to fail to
connect to the database when testing Python3 on Ubuntu16.04.

The fix is to use the unix socket instead.

(cherry picked from commit 62bb3dcfa3cbfc76a6cbf0ebea4acbeac776a27c)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
various mysql

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7.1
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
