### PR TITLE
2.7: adds 'success_msg' to valid args for assert module (#47030)

### DIFF
--- a/changelogs/fragments/47030-assert-add-success_msg-to-valid-args.yaml
+++ b/changelogs/fragments/47030-assert-add-success_msg-to-valid-args.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - assert - add 'success_msg' to valid args (https://github.com/ansible/ansible/pull/47030)

--- a/lib/ansible/plugins/action/assert.py
+++ b/lib/ansible/plugins/action/assert.py
@@ -27,7 +27,7 @@ class ActionModule(ActionBase):
     ''' Fail with custom message '''
 
     TRANSFERS_FILES = False
-    _VALID_ARGS = frozenset(('fail_msg', 'msg', 'that'))
+    _VALID_ARGS = frozenset(('fail_msg', 'msg', 'success_msg', 'that'))
 
     def run(self, tmp=None, task_vars=None):
         if task_vars is None:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Backport of https://github.com/ansible/ansible/pull/47030

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
assert

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION