### PR TITLE
Add more detailed documentation on how to use multiple inventories

### DIFF
--- a/docs/docsite/README.md
+++ b/docs/docsite/README.md
@@ -5,7 +5,7 @@ This project hosts the source behind [docs.ansible.com](https://docs.ansible.com
 
 Contributions to the documentation are welcome. To make changes, submit a pull request that changes the reStructuredText files in the `rst/` directory only, and the core team can do a docs build and push the static files.
 
-If you wish to verify output from the markup such as link references, you may install sphinx and build the documentation by running `make webdocs` from the `ansible/docsite` directory.
+If you wish to verify output from the markup such as link references, you may install sphinx and build the documentation by running `make webdocs` from the `ansible/docs/docsite` directory.
 
 To include module documentation you'll need to run `make webdocs` at the top level of the repository. The generated html files are in `docsite/htmlout/`.
 

--- a/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
@@ -317,13 +317,13 @@ Other inventory scripts
 
 You can find all included inventory scripts in the `contrib/inventory directory <https://github.com/ansible/ansible/tree/devel/contrib/inventory>`_. General usage is similar across all inventory scripts. You can also :ref:`write your own inventory script <developing_inventory>`.
 
-.. _using_multiple_sources_with_dynamic:
+.. _using_multiple_sources:
 
 Using Inventory Directories and Multiple Inventory Sources
 ==========================================================
 
 If the location given to ``-i`` in Ansible is a directory (or as so configured in ``ansible.cfg``), Ansible can use multiple inventory sources
-at the same time.  When doing so, it is possible to mix both dynamic and statically managed inventory sources in the same ansible run.  Instant
+at the same time.  When doing so, it is possible to mix both dynamic and statically managed inventory sources in the same ansible run. Instant
 hybrid cloud!
 
 In an inventory directory, executable files will be treated as dynamic inventory sources and most other files as static sources. Files which end with any of the following will be ignored::
@@ -332,7 +332,7 @@ In an inventory directory, executable files will be treated as dynamic inventory
 
 You can replace this list with your own selection by configuring an ``inventory_ignore_extensions`` list in ansible.cfg, or setting the :envvar:`ANSIBLE_INVENTORY_IGNORE` environment variable. The value in either case should be a comma-separated list of patterns, as shown above.
 
-Any ``group_vars`` and ``host_vars`` subdirectories in an inventory directory will be interpreted as expected, making inventory directories a powerful way to organize different sets of configurations. See :ref:`using_multiple_inventory_sources` for more information.
+Any ``group_vars`` and ``host_vars`` subdirectories in an inventory directory will be interpreted as expected, making inventory directories a powerful way to organize different sets of configurations.
 
 .. _static_groups_of_dynamic:
 

--- a/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
@@ -332,7 +332,7 @@ In an inventory directory, executable files will be treated as dynamic inventory
 
 You can replace this list with your own selection by configuring an ``inventory_ignore_extensions`` list in ansible.cfg, or setting the :envvar:`ANSIBLE_INVENTORY_IGNORE` environment variable. The value in either case should be a comma-separated list of patterns, as shown above.
 
-Any ``group_vars`` and ``host_vars`` subdirectories in an inventory directory will be interpreted as expected, making inventory directories a powerful way to organize different sets of configurations.
+Any ``group_vars`` and ``host_vars`` subdirectories in an inventory directory will be interpreted as expected, making inventory directories a powerful way to organize different sets of configurations. See :ref:`using_multiple_inventory_sources` for more information.
 
 .. _static_groups_of_dynamic:
 

--- a/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
@@ -317,7 +317,7 @@ Other inventory scripts
 
 You can find all included inventory scripts in the `contrib/inventory directory <https://github.com/ansible/ansible/tree/devel/contrib/inventory>`_. General usage is similar across all inventory scripts. You can also :ref:`write your own inventory script <developing_inventory>`.
 
-.. _using_multiple_sources:
+.. _using_multiple_sources_with_dynamic:
 
 Using Inventory Directories and Multiple Inventory Sources
 ==========================================================
@@ -332,7 +332,7 @@ In an inventory directory, executable files will be treated as dynamic inventory
 
 You can replace this list with your own selection by configuring an ``inventory_ignore_extensions`` list in ansible.cfg, or setting the :envvar:`ANSIBLE_INVENTORY_IGNORE` environment variable. The value in either case should be a comma-separated list of patterns, as shown above.
 
-Any ``group_vars`` and ``host_vars`` subdirectories in an inventory directory will be interpreted as expected, making inventory directories a powerful way to organize different sets of configurations.
+Any ``group_vars`` and ``host_vars`` subdirectories in an inventory directory will be interpreted as expected, making inventory directories a powerful way to organize different sets of configurations. See :ref:`using_multiple_inventory_sources` for more information.
 
 .. _static_groups_of_dynamic:
 

--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -15,7 +15,7 @@ You can specify a different inventory file using the ``-i <path>`` option on the
 
 Not only is this inventory configurable, but you can also use multiple inventory files at the same time and
 pull inventory from dynamic or cloud sources or different formats (YAML, ini, etc), as described in :ref:`intro_dynamic_inventory`.
-Introduced in version 2.4, Ansible has inventory plugins to make this flexible and customizable.
+Introduced in version 2.4, Ansible has :ref:`inventory_plugins` to make this flexible and customizable.
 
 .. _inventoryformat:
 
@@ -505,17 +505,18 @@ Here is an example of how to instantly deploy to created containers::
 .. note:: If you're reading the docs from the beginning, this may be the first example you've seen of an Ansible playbook. This is not an inventory file.
           Playbooks will be covered in great detail later in the docs.
 
-.. _using_multiple_inventory_directories:
+.. _using_multiple_inventory_sources:
 
-Using multiple inventory directories
-++++++++++++++++++++++++++++++++++++
+Using multiple inventory sources
+++++++++++++++++++++++++++++++++
 
-You can use multiple inventory directories if you want to target multiple environments or reuse common
-groups and variables across multiple environments. The targeted inventories are merged and run just like
+You can use multiple inventory sources if you want to target multiple environments, multiple inventory source types
+or reuse common groups and variables across multiple environments. The sources are merged and run just like
 only one inventory was given. One inventory can depend on groups or group variables of another inventory.
 Variable defined in the last inventory wins in precedence in accordance with :ref:`ansible_variable_precedence`.
 
-In this example we have two different environments: production and staging. Both have some
+In the following example the inventory sources are directories but could be any of the supported inventory plugins
+or dynamic inventory scripts. In the example we have two different environments: production and staging. Both have some
 common variables and groups but may also have some own environment specific configurations.
 To avoid copy pasting the commmon groups and variables the following directory layout is created::
 
@@ -577,6 +578,22 @@ You can target these inventories like this (note the order of the inventory para
     ansible-playbook example.yml -i inventories/common -i inventories/production
 
 It is also possible to configure :envvar:`ANSIBLE_INVENTORY` to use multiple inventories.
+
+**Aggregating inventory sources with a directory**
+
+You can combine multiple inventory sources under a directory. As an example the following inventory
+combines an inventory plugin source, a dynamic inventory script, and files with static hosts and groups::
+
+    inventory/
+      01-openstack.yml          # configure inventory plugin to get hosts from Openstack cloud
+      02-dynamic-inventory.py   # add additional hosts with dynamic inventory script
+      03-static-inventory       # add static hosts
+      04-static-groups          # define static groups using groups from earlier inventory sources as children
+      group_vars/
+        all.yml                 # assign variables to all hosts
+
+The inventories are parsed in alphabetical order so number prefixes are used to make sure
+the parsing order is correct. For more details about inventory plugins see :ref:`inventory_plugins`.
 
 .. seealso::
 

--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -505,12 +505,12 @@ Here is an example of how to instantly deploy to created containers::
 .. note:: If you're reading the docs from the beginning, this may be the first example you've seen of an Ansible playbook. This is not an inventory file.
           Playbooks will be covered in great detail later in the docs.
 
-.. _using_multiple_inventory_sources:
+.. _using_multiple_inventory_directories:
 
-Using multiple inventory sources
-++++++++++++++++++++++++++++++++
+Using multiple inventory directories
+++++++++++++++++++++++++++++++++++++
 
-You can use multiple inventory sources if you want to target multiple environments or reuse common
+You can use multiple inventory directories if you want to target multiple environments or reuse common
 groups and variables across multiple environments. The targeted inventories are merged and run just like
 only one inventory was given. One inventory can depend on groups or group variables of another inventory.
 Variable defined in the last inventory wins in precedence in accordance with :ref:`ansible_variable_precedence`.
@@ -577,8 +577,6 @@ You can target these inventories like this (note the order of the inventory para
     ansible-playbook example.yml -i inventories/common -i inventories/production
 
 It is also possible to configure :envvar:`ANSIBLE_INVENTORY` to use multiple inventories.
-
-Multiple inventory sources can be useful with dynamic inventories :ref:`using_multiple_sources_with_dynamic`.
 
 .. seealso::
 

--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -361,7 +361,7 @@ Using multiple inventory sources
 ================================
 
 As an advanced use case you can target multiple inventory sources (directories, dynamic inventory scripts 
-or files supported by inventory plugins) at same time by giving multiple inventory parameters from command 
+or files supported by inventory plugins) at the same time by giving multiple inventory parameters from the command 
 line or by configuring :envvar:`ANSIBLE_INVENTORY`. This can be useful when you want to target normally 
 separate environments, like staging and production, at the same time for a specific action.
 
@@ -372,14 +372,14 @@ Target two sources from the command line like this::
 Keep in mind that if there are variable conflicts in the inventories, they are resolved according
 to the rules described in :ref:`how_we_merge` and :ref:`ansible_variable_precedence`.
 The merging order is controlled by the order of the inventory source parameters.
-If `[all:vars]` in staging inventory defines `myvar = 1`, but production inventory defines `myvar = 2`,
-the playbook will be run with `myvar = 2`. The result would be reversed if the playbook was run with
-`-i production -i staging`.
+If ``[all:vars]`` in staging inventory defines ``myvar = 1``, but production inventory defines ``myvar = 2``,
+the playbook will be run with ``myvar = 2``. The result would be reversed if the playbook was run with
+``-i production -i staging``.
 
 **Aggregating inventory sources with a directory**
 
 You can also create an inventory by combining multiple inventory sources and source types under a directory.
-This can be useful for combining static and dynamic hosts and manage them as one inventory.
+This can be useful for combining static and dynamic hosts and managing them as one inventory.
 The following inventory combines an inventory plugin source, a dynamic inventory script,
 and a file with static hosts::
 
@@ -397,7 +397,7 @@ You can target this inventory directory simply like this::
 It can be useful to control the merging order of the inventory sources if there's variable
 conflicts or group of groups dependencies to the other inventory sources. The inventories
 are merged in alphabetical order according to the filenames so the result can
-be controller by adding prefixes to the files::
+be controlled by adding prefixes to the files::
 
     inventory/
       01-openstack.yml          # configure inventory plugin to get hosts from Openstack cloud
@@ -406,8 +406,8 @@ be controller by adding prefixes to the files::
       group_vars/
         all.yml                 # assign variables to all hosts
 
-If the openstack inventory source defines `myvar = 1` for the group `all`, dynamic inventory source defines `myvar = 2`,
-and `03-static-inventory` defines `myvar = 3`, the playbook will be run with `myvar = 3`.
+If ``01-openstack.yml`` defines ``myvar = 1`` for the group ``all``, ``02-dynamic-inventory.py`` defines ``myvar = 2``,
+and ``03-static-inventory`` defines ``myvar = 3``, the playbook will be run with ``myvar = 3``.
 
 For more details on inventory plugins and dynamic inventory scripts see :ref:`inventory_plugins` and :ref:`intro_dynamic_inventory`.
 


### PR DESCRIPTION
##### SUMMARY

Add a separate section on how to use multiple inventory directories with an example.

~~The documentation on multiple inventories was a bit hard to find as it was located only in the dynamic inventory documentation page. In addition that section doesn't have many details on how multiple inventories actually work.~~

This seems to be an undocumented feature related to "multiple sources" described in *Working with dynamic inventory*. Multiple sources documentation talks about using a directory and having multiple different inventory sources inside the directory. The new documented use case is different as it uses multiple inventory directories to promote DRY principle. The new documentation is in line with the comments in #36600 by @bcoca.

Using multiple directories is a bit cumbersome because you need to use multiple `-i` parameters but with `ansible.cfg` or `ANSIBLE_INVENTORY` it's manageable. 

I understand if this is not a feature you want to promote in the docs, it resolved some issues for me so I thought that I'll try documenting it. 

Comments appreciated :)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
documentation

##### ANSIBLE VERSION
Tested the example with 2.7. Should also work at least with 2.6.
```
ansible 2.7.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
N/A