### PR TITLE
 Do not filter out exception, warnings, deprecations on failure when using debug

### DIFF
--- a/changelogs/fragments/callback-keep-more-debug-keys.yml
+++ b/changelogs/fragments/callback-keep-more-debug-keys.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- callbacks - Do not filter out exception, warnings, deprecations on failure when using debug (https://github.com/ansible/ansible/issues/47576)

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -49,6 +49,9 @@ except ImportError:
 __all__ = ["CallbackBase"]
 
 
+_DEBUG_ALLOWED_KEYS = frozenset(('msg', 'exception', 'warnings', 'deprecations'))
+
+
 class CallbackBase(AnsiblePlugin):
 
     '''
@@ -234,11 +237,11 @@ class CallbackBase(AnsiblePlugin):
         ''' removes data from results for display '''
 
         # mostly controls that debug only outputs what it was meant to
-        if task_name in ['debug']:
+        if task_name == 'debug':
             if 'msg' in result:
                 # msg should be alone
                 for key in list(result.keys()):
-                    if key != 'msg' and not key.startswith('_'):
+                    if key not in _DEBUG_ALLOWED_KEYS and not key.startswith('_'):
                         result.pop(key)
             else:
                 # 'var' value as field, so eliminate others and what is left should be varname


### PR DESCRIPTION
##### SUMMARY
 Do not filter out exception, warnings, deprecations on failure when using debug. Fixes #47576

`warnings` and `deprecations` may not be needed, but I added them for potential future proofing.

This resolves a problem where a filter plugin raises an exception, which is caught by:

https://github.com/ansible/ansible/blob/77d32b8f5799b8a32f464a22e25b38e5ea4b260c/lib/ansible/executor/task_executor.py#L175-L177

This adds an `exception` key, which was previously removed, preventing the user from being able to see the exception.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```