### PR TITLE
VMware: correct logic to pass ESXi SSL thumbprint

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -32,8 +32,8 @@ from ansible.module_utils.basic import env_fallback
 
 
 class TaskError(Exception):
-    def __init__(self, error_msg, host_thumbprint=None):
-        super(TaskError).__init__()
+    def __init__(self, *args, **kwargs):
+        super(TaskError, self).__init__(*args, **kwargs)
 
 
 def wait_for_task(task, max_backoff=64, timeout=3600):

--- a/lib/ansible/modules/cloud/vmware/vmware_host.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host.py
@@ -259,10 +259,14 @@ class VMwareHost(PyVmomi):
                 return success, result
             except TaskError as task_error_exception:
                 task_error = task_error_exception.args[0]
-                if self.esxi_ssl_thumbprint == '' and isinstance(task_error, vim.fault.SSLVerifyFault):
+                if len(task_error_exception.args) == 2:
+                    host_thumbprint = task_error_exception.args[1]
+                else:
+                    host_thumbprint = None
+                if self.esxi_ssl_thumbprint == '' and host_thumbprint:
                     # User has not specified SSL Thumbprint for ESXi host,
                     # try to grab it using SSLVerifyFault exception
-                    host_connect_spec.sslThumbprint = task_error.thumbprint
+                    host_connect_spec.sslThumbprint = host_thumbprint
                 else:
                     self.module.fail_json(msg="Failed to add host %s to vCenter: %s" % (self.esxi_hostname,
                                                                                         to_native(task_error)))


### PR DESCRIPTION
##### SUMMARY
Due to refactoring of task_error and wait_for_task method,
SSL thumbprint was lost in error message. This fixes the
retry mechanism of AddHost task.

Fixes: #47563

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/vmware.py
lib/ansible/modules/cloud/vmware/vmware_host.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8-devel
```