### PR TITLE
IBM_Storage: Added a module to support adding and removing host ports.

### DIFF
--- a/lib/ansible/modules/storage/ibm/ibm_sa_host_ports.py
+++ b/lib/ansible/modules/storage/ibm/ibm_sa_host_ports.py
@@ -74,6 +74,9 @@ EXAMPLES = '''
     state: absent
 
 '''
+RETURN = '''
+'''
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ibm_sa_utils import (execute_pyxcli_command, connect_ssl,
                                                spectrum_accelerate_spec, is_pyxcli_installed)

--- a/lib/ansible/modules/storage/ibm/ibm_sa_host_ports.py
+++ b/lib/ansible/modules/storage/ibm/ibm_sa_host_ports.py
@@ -1,0 +1,124 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2018 IBM CORPORATION
+# Author(s): Tzur Eliyahu <tzure@il.ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: ibm_sa_host_ports
+short_description: Add host ports on an IBM Spectrum Accelerate storage array.
+version_added: "2.8"
+
+description:
+    - "This module adds ports to or removes them from the hosts
+        on IBM Spectrum Accelerate storage systems."
+
+options:
+    host:
+        description:
+            - Host name.
+        required: true
+    state:
+        description:
+            - Host ports state.
+        required: true
+        default: "present"
+        choices: [ "present", "absent" ]
+    iscsi_name:
+        description:
+            - iSCSI initiator name.
+        required: false
+    fcaddress:
+        description:
+            - Fiber channel address.
+        required: false
+    num_of_visible_targets:
+        description:
+            - Number of visible targets.
+        required: false
+
+extends_documentation_fragment:
+    - ibm_storage
+
+author:
+    - Tzur Eliyahu (tzure@il.ibm.com)
+'''
+
+EXAMPLES = '''
+- name: Add ports for host.
+  ibm_sa_host_ports:
+    host: test_host
+    iscsi_name: iqn.1994-05.com***
+    username: admin
+    password: secret
+    endpoints: hostdev-system
+    state: present
+
+- name: Remove ports for host.
+  ibm_sa_host_ports:
+    host: test_host
+    iscsi_name: iqn.1994-05.com***
+    username: admin
+    password: secret
+    endpoints: hostdev-system
+    state: absent
+
+'''
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ibm_sa_utils import (execute_pyxcli_command, connect_ssl,
+                                               spectrum_accelerate_spec, is_pyxcli_installed)
+
+
+def main():
+    argument_spec = spectrum_accelerate_spec()
+    argument_spec.update(
+        dict(
+            state=dict(default='present', choices=['present', 'absent']),
+            host=dict(required=True),
+            iscsi_name=dict(),
+            fcaddress=dict(),
+            num_of_visible_targets=dict()
+        )
+    )
+
+    module = AnsibleModule(argument_spec)
+    is_pyxcli_installed(module)
+
+    xcli_client = connect_ssl(module)
+    # required args
+    ports = None
+    try:
+        ports = xcli_client.cmd.host_list_ports(
+            host=module.params.get('host')).as_list
+    except Exception:
+        pass
+    state = module.params['state']
+    port_exists = False
+    ports = [port.get('port_name') for port in ports]
+
+    for port in ports:
+        if port in module.params.get('iscsi_name', "") or port in module.params.get('fcaddress', ""):
+            port_exists = True
+    state_changed = False
+    if state == 'present' and not port_exists:
+        state_changed = execute_pyxcli_command(
+            module, 'host_add_port', xcli_client)
+    if state == 'absent' and port_exists:
+        state_changed = execute_pyxcli_command(
+            module, 'host_remove_port', xcli_client)
+
+    module.exit_json(changed=state_changed)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
Added a module to support adding and removing host ports.
This module adds or removes host ports on the IBM Spectrum accelerate storage array

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ibm_sa_host_ports

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (add_ibm_storage_host_ports_module 4550ec22b5) last updated 2018/10/25 14:16:23 (GMT +300)
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
