### PR TITLE
Docs: No need to follow up on backport PRs

### DIFF
--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -34,14 +34,17 @@ After the pull request submitted to Ansible for the ``devel`` branch is
 accepted and merged, the following instructions will help you create a
 pull request to backport the change to a previous stable branch.
 
+We do **not** backport features.
+
 .. note::
 
-    * These instructions assume that ``stable-2.5`` is the targeted release
-      branch for the backport.
-    * These instructions assume that ``https://github.com/ansible/ansible.git``
-      is configured as a ``git remote`` named ``upstream``. If you do not use
+   These instructions assume that:
+
+    * ``stable-2.7`` is the targeted release branch for the backport
+    * ``https://github.com/ansible/ansible.git`` is configured as a
+      ``git remote`` named ``upstream``. If you do not use
       a ``git remote`` named ``upstream``, adjust the instructions accordingly.
-    * These instructions assume that ``https://github.com/<yourgithubaccount>/ansible.git``
+    * ``https://github.com/<yourgithubaccount>/ansible.git``
       is configured as a ``git remote`` named ``origin``. If you do not use
       a ``git remote`` named ``origin``, adjust the instructions accordingly.
 
@@ -50,7 +53,7 @@ pull request to backport the change to a previous stable branch.
    ::
 
        git fetch upstream
-       git checkout -b backport/2.5/[PR_NUMBER_FROM_DEVEL] upstream/stable-2.5
+       git checkout -b backport/2.7/[PR_NUMBER_FROM_DEVEL] upstream/stable-2.7
 
 #. Cherry pick the relevant commit SHA from the devel branch into your feature
    branch, handling merge conflicts as necessary:
@@ -65,18 +68,18 @@ pull request to backport the change to a previous stable branch.
 
    ::
 
-       git push origin backport/2.5/[PR_NUMBER_FROM_DEVEL]
+       git push origin backport/2.7/[PR_NUMBER_FROM_DEVEL]
 
-#. Submit the pull request for ``backport/2.5/[PR_NUMBER_FROM_DEVEL]``
-   against the ``stable-2.5`` branch
+#. Submit the pull request for ``backport/2.7/[PR_NUMBER_FROM_DEVEL]``
+   against the ``stable-2.7`` branch
 
-#. The backport PR will be merged by the Release Manager in the lead up to the next
-   next release. There isn't any need to follow up. Just ensure that the automated
+#. The Release Manager will decide whether to merge the backport PR before
+   the next minor release. There isn't any need to follow up. Just ensure that the automated
    tests (CI) are green.
 
 .. note::
 
-    The choice to use ``backport/2.5/[PR_NUMBER_FROM_DEVEL]`` as the
+    The choice to use ``backport/2.7/[PR_NUMBER_FROM_DEVEL]`` as the
     name for the feature branch is somewhat arbitrary, but conveys meaning
     about the purpose of that branch. It is not required to use this format,
     but it can be helpful, especially when making multiple backport PRs for

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -4,7 +4,8 @@
 The Ansible Development Process
 *******************************
 
-.. contents:: Topics
+.. contents::
+   :local:
 
 This section discusses how the Ansible development and triage process works.
 
@@ -35,20 +36,14 @@ pull request to backport the change to a previous stable branch.
 
 .. note::
 
-    These instructions assume that ``stable-2.5`` is the targeted release
-    branch for the backport.
-
-.. note::
-
-    These instructions assume that ``https://github.com/ansible/ansible.git``
-    is configured as a ``git remote`` named ``upstream``. If you do not use
-    a ``git remote`` named ``upstream``, adjust the instructions accordingly.
-
-.. note::
-
-   These instructions assume that ``https://github.com/<yourgithubaccount>/ansible.git``
-   is configured as a ``git remote`` named ``origin``. If you do not use
-   a ``git remote`` named ``origin``, adjust the instructions accordingly.
+    * These instructions assume that ``stable-2.5`` is the targeted release
+      branch for the backport.
+    * These instructions assume that ``https://github.com/ansible/ansible.git``
+      is configured as a ``git remote`` named ``upstream``. If you do not use
+      a ``git remote`` named ``upstream``, adjust the instructions accordingly.
+    * These instructions assume that ``https://github.com/<yourgithubaccount>/ansible.git``
+      is configured as a ``git remote`` named ``origin``. If you do not use
+      a ``git remote`` named ``origin``, adjust the instructions accordingly.
 
 #. Prepare your devel, stable, and feature branches:
 
@@ -74,6 +69,10 @@ pull request to backport the change to a previous stable branch.
 
 #. Submit the pull request for ``backport/2.5/[PR_NUMBER_FROM_DEVEL]``
    against the ``stable-2.5`` branch
+
+#. The backport PR will be merged by the Release Manager in the lead up to the next
+   next release. There isn't any need to follow up. Just ensure that the automated
+   tests (CI) are green.
 
 .. note::
 


### PR DESCRIPTION
##### SUMMARY
@vladimir-mencl-eresearch pointed out in https://github.com/ansible/ansible/pull/46245#issuecomment-432831071 that it backports appeared `stale`. So we could clarify that no action is needed.

In the future `ansibullbot` will give clearer messages on Backport PRs, though not there yet.

This PR also tidy up `notes` section into a single box with a bullet point list, rather than three boxes

Found as part of https://github.com/ansible/community/issues/353

##### ISSUE TYPE
- Docs Pull Request
