### PR TITLE
NetApp bugfix for na_ontap_snapmirror

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_snapmirror.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_snapmirror.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
-                    'supported_by': 'community'}
+                    'supported_by': 'certified'}
 
 
 DOCUMENTATION = '''


### PR DESCRIPTION
##### SUMMARY
These are bug fixes for na_ontap_snapmirror for our internal stories (909, and 963)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- na_ontap_snapmirror

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0.a1.post0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/jenkins/workspace/ansible-playbooks_master-G4Z7YDNWRBYEXYJXQYF7JFYEUHU5W7D3MEYPILJ5JRUED6LGLCRQ/ansible/lib/ansible
  executable location = /tmp/jenkins/workspace/ansible-playbooks_master-G4Z7YDNWRBYEXYJXQYF7JFYEUHU5W7D3MEYPILJ5JRUED6LGLCRQ/ansible/bin/ansible
  python version = 2.7.5 (default, Feb 20 2018, 09:19:12) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
