### PR TITLE
Detect the socket path after starting the service. Fixes #47582

### DIFF
--- a/test/integration/targets/setup_mysql_db/tasks/main.yml
+++ b/test/integration/targets/setup_mysql_db/tasks/main.yml
@@ -37,15 +37,6 @@
         - 'default{{ python_suffix }}.yml'
       paths: '../vars'
 
-- name: Detect socket path
-  shell: >
-          echo "show variables like 'socket'\G" | mysql | grep 'Value: ' | sed 's/[ ]\+Value: //'
-  register: _socket_path
-
-- name: Set socket path
-  set_fact:
-    mysql_socket: '{{ _socket_path["stdout"] }}'
-
 - name: install mysqldb_test rpm dependencies
   yum: name={{ item }} state=latest
   with_items: "{{mysql_packages}}"
@@ -82,3 +73,12 @@
 
 - name: start mysql_db service if not running
   service: name={{ mysql_service }} state=started
+
+- name: Detect socket path
+  shell: >
+          echo "show variables like 'socket'\G" | mysql | grep 'Value: ' | sed 's/[ ]\+Value: //'
+  register: _socket_path
+
+- name: Set socket path
+  set_fact:
+    mysql_socket: '{{ _socket_path["stdout"] }}'


### PR DESCRIPTION
##### SUMMARY
Detect the socket path after starting the service. Fixes #47582

On Debian based systems the daemon starts during package install.  On Red Hat based, it does not.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/setup_mysql_db/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```