### PR TITLE
[stable-2.6] Detect the socket path after starting the service. Fixes…

### DIFF
--- a/test/integration/targets/setup_mysql_db/tasks/main.yml
+++ b/test/integration/targets/setup_mysql_db/tasks/main.yml
@@ -37,15 +37,6 @@
         - 'default{{ python_suffix }}.yml'
       paths: '../vars'
 
-- name: Detect socket path
-  shell: >
-          echo "show variables like 'socket'\G" | mysql | grep 'Value: ' | sed 's/[ ]\+Value: //'
-  register: _socket_path
-
-- name: Set socket path
-  set_fact:
-    mysql_socket: '{{ _socket_path["stdout"] }}'
-
 - name: install mysqldb_test rpm dependencies
   yum: name={{ item }} state=latest
   with_items: "{{mysql_packages}}"
@@ -82,3 +73,12 @@
 
 - name: start mysql_db service if not running
   service: name={{ mysql_service }} state=started
+
+- name: Detect socket path
+  shell: >
+          echo "show variables like 'socket'\G" | mysql | grep 'Value: ' | sed 's/[ ]\+Value: //'
+  register: _socket_path
+
+- name: Set socket path
+  set_fact:
+    mysql_socket: '{{ _socket_path["stdout"] }}'


### PR DESCRIPTION
… #47582

(cherry picked from commit 10e129e)

Co-authored-by: Matt Martz <matt@sivel.net>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_db integration tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6
```
