### PR TITLE
[stable-2.7] Fix from sivel for ansible-doc

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -136,9 +136,9 @@ class DocCLI(CLI):
             plugin_data = {}
             for plugin_type in C.DOCUMENTABLE_PLUGINS:
                 plugin_data[plugin_type] = dict()
-                plugin_names = self.get_all_plugins_of_type(plugin_type, loader)
+                plugin_names = self.get_all_plugins_of_type(plugin_type)
                 for plugin_name in plugin_names:
-                    plugin_info = self.get_plugin_metadata(plugin_type, plugin_name, loader)
+                    plugin_info = self.get_plugin_metadata(plugin_type, plugin_name)
                     if plugin_info is not None:
                         plugin_data[plugin_type][plugin_name] = plugin_info
 
@@ -162,7 +162,8 @@ class DocCLI(CLI):
 
         return 0
 
-    def get_all_plugins_of_type(self, plugin_type, loader):
+    def get_all_plugins_of_type(self, plugin_type):
+        loader = getattr(plugin_loader, '%s_loader' % plugin_type)
         plugin_list = set()
         paths = loader._get_paths()
         for path in paths:
@@ -170,8 +171,9 @@ class DocCLI(CLI):
             plugin_list.update(plugins_to_add)
         return sorted(set(plugin_list))
 
-    def get_plugin_metadata(self, plugin_type, plugin_name, loader):
+    def get_plugin_metadata(self, plugin_type, plugin_name):
         # if the plugin lives in a non-python file (eg, win_X.ps1), require the corresponding python file for docs
+        loader = getattr(plugin_loader, '%s_loader' % plugin_type)
         filename = loader.find_plugin(plugin_name, mod_type='.py', ignore_deprecated=True, check_aliases=True)
         if filename is None:
             raise AnsibleError("unable to load {0} plugin named {1} ".format(plugin_type, plugin_name))

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -106,7 +106,7 @@ DEFAULT_SU_PASS = None
 # FIXME: expand to other plugins, but never doc fragments
 CONFIGURABLE_PLUGINS = ('cache', 'callback', 'connection', 'inventory', 'lookup', 'shell', 'cliconf', 'httpapi')
 # NOTE: always update the docs/docsite/Makefile to match
-DOCUMENTABLE_PLUGINS = CONFIGURABLE_PLUGINS + ('module', 'strategy', 'vars')
+DOCUMENTABLE_PLUGINS = ('cache', 'callback', 'connection', 'inventory', 'lookup', 'shell', 'module', 'strategy', 'vars')
 IGNORE_FILES = ("COPYING", "CONTRIBUTING", "LICENSE", "README", "VERSION", "GUIDELINES")  # ignore during module search
 INTERNAL_RESULT_KEYS = ('add_host', 'add_group')
 LOCALHOST = ('127.0.0.1', 'localhost', '::1')


### PR DESCRIPTION
* Major slow down due to using the wrong loader for plugin_types
* traceback due to adding httpapi and cliconf plugins to the plugins we
allow ansible-doc to process
(cherry picked from commit e5a245d)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7.0
```
