### PR TITLE
Fix syntax error for Python 2.6

### DIFF
--- a/lib/ansible/modules/clustering/consul.py
+++ b/lib/ansible/modules/clustering/consul.py
@@ -475,7 +475,7 @@ class ConsulCheck(object):
         if duration:
             duration_units = ['ns', 'us', 'ms', 's', 'm', 'h']
             if not any((duration.endswith(suffix) for suffix in duration_units)):
-                duration = "{}s".format(duration)
+                duration = "{0}s".format(duration)
         return duration
 
     def register(self, consul_api):

--- a/test/sanity/pylint/ignore.txt
+++ b/test/sanity/pylint/ignore.txt
@@ -28,7 +28,6 @@ lib/ansible/modules/cloud/webfaction/webfaction_db.py ansible-format-automatic-s
 lib/ansible/modules/cloud/webfaction/webfaction_domain.py ansible-format-automatic-specification
 lib/ansible/modules/cloud/webfaction/webfaction_mailbox.py ansible-format-automatic-specification
 lib/ansible/modules/cloud/webfaction/webfaction_site.py ansible-format-automatic-specification
-lib/ansible/modules/clustering/consul.py ansible-format-automatic-specification
 lib/ansible/modules/monitoring/grafana_plugin.py ansible-format-automatic-specification
 lib/ansible/modules/net_tools/dnsmadeeasy.py ansible-format-automatic-specification
 lib/ansible/modules/net_tools/ipinfoio_facts.py ansible-format-automatic-specification


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes Syntax error for Consul module in Python 2.6
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/clustering/consul.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.5.1
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Fixes line 478 of consul.py for Python 2.6

$ python
Python 2.6.6 (r266:84292, Aug 18 2016, 08:36:59) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-17)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> duration = 5
>>> "{}s".format(duration)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: zero length field name in format
>>> "{0}s".format(duration)
'5s'
```
