### PR TITLE
powershell: add ability to ignore specific warnings in C# Add-Type

### DIFF
--- a/test/integration/targets/win_module_utils/library/add_type_test.ps1
+++ b/test/integration/targets/win_module_utils/library/add_type_test.ps1
@@ -183,5 +183,26 @@ Add-CSharpType -References $reference_1, $reference_2
 $actual = [Namespace6.Class6]::GetString()
 Assert-Equals -actual $actual -expected "Hello World"
 
+$ignored_warning = @'
+using System;
+
+//NoWarn -Name CS0219
+
+namespace Namespace7
+{
+    public class Class7
+    {
+        public static string GetString()
+        {
+            string a = "";
+            return "abc";
+        }
+    }
+}
+'@
+Add-CSharpType -References $ignored_warning
+$actual = [Namespace7.Class7]::GetString()
+Assert-Equals -actual $actual -expected "abc"
+
 $result.res = "success"
 Exit-Json -obj $result


### PR DESCRIPTION
##### SUMMARY
Adds the ability to specify individual warnings to ignore on compilation with `//NoWarn -Name CS...`, this gives the code the ability to ignore known warnings without having the caller explicitly ignore all warnings.

Also fixes an issue in PSCore where a referenced assembly would fail to be loaded.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module_utils/powershell/Ansible.ModuleUtils.AddType.psm1

##### ANSIBLE VERSION
```paste below
devel
```