### PR TITLE
[Backport 2.6] VMware: Avoid misleading PyVmomi error if requests import fails

### DIFF
--- a/changelogs/fragments/47313-vmware_utils-handle_requests_import_error.yaml
+++ b/changelogs/fragments/47313-vmware_utils-handle_requests_import_error.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Avoid misleading PyVmomi error if requests import fails in vmware module utils.

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -14,6 +14,11 @@ import time
 try:
     # requests is required for exception handling of the ConnectionError
     import requests
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
+
+try:
     from pyVim import connect
     from pyVmomi import vim, vmodl
     HAS_PYVMOMI = True
@@ -736,6 +741,10 @@ class PyVmomi(object):
         """
         Constructor
         """
+        if not HAS_REQUESTS:
+            self.module.fail_json(msg="Unable to find 'requests' Python library which is required."
+                                      " Please install using 'pip install requests'")
+
         if not HAS_PYVMOMI:
             module.fail_json(msg='PyVmomi Python module required. Install using "pip install PyVmomi"')
 


### PR DESCRIPTION
##### SUMMARY
* Avoid misleading PyVmomi error if requests import fails

Requests is imported by the VMware module_utils as an external
dependency; however, because it is in a try/catch block containing the
imports for PyVmomi, if requests fails to import properly, Ansible will
instead complain about PyVmomi not being installed.

By moving the import outside of the try/catch block, if requests fails
to import, an error like the following will be returned:

    ImportError: No module named requests

This should result in less confusion.

* catch requests ImportError

Signed-off-by: Jim Gu <jim@jimgu.com>
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

(cherry picked from commit 99ee30768acce4f99137b58009ee14c24fef9937)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/47313-vmware_utils-handle_requests_import_error.yaml
lib/ansible/module_utils/vmware.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
Stable-2.6
```