### PR TITLE
Fix netbox url with urljoin

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -355,11 +355,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         if self.query_filters:
             query_parameters.extend(filter(lambda x: x,
                                            map(self.validate_query_parameters, self.query_filters)))
-        self.device_url = self.api_endpoint + "/api/dcim/devices/" + "?" + urlencode(query_parameters)
-        self.virtual_machines_url = "".join([self.api_endpoint,
-                                             "/api/virtualization/virtual-machines/",
-                                             "?",
-                                             urlencode(query_parameters)])
+        self.device_url = urljoin(self.api_endpoint,
+                                  "/api/dcim/devices/?" + urlencode(query_parameters))
+        self.virtual_machines_url = urljoin(self.api_endpoint,
+                                            "/api/virtualization/virtual-machines/?" + urlencode(query_parameters))
 
     def fetch_hosts(self):
         return chain(


### PR DESCRIPTION
##### SUMMARY

Fixes #46705

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- netbox_inventory

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (fix_netbox_urljoin ee056ad547) last updated 2018/10/26 12:32:11 (GMT +200)
  config file = None
  configured module search path = [u'/Users/sieben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sieben/workspace/ansible/lib/ansible
  executable location = /Users/sieben/workspace/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```