### PR TITLE
Fix ios_user not able to handle certain scenario

### DIFF
--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -164,6 +164,12 @@ EXAMPLES = """
       - name: ansibletest3
     view: network-admin
 
+- name: Add a user specifying password type
+  ios_user:
+    name: ansibletest4
+    configure_password: "{{ new_password }}"
+    password_type: password
+
 - name: Delete users with aggregate
   ios_user:
     aggregate:

--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -398,6 +398,7 @@ def map_params_to_obj(module):
 
     return objects
 
+
 def update_objects(want, have):
     updates = list()
     for entry in want:

--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -167,7 +167,7 @@ EXAMPLES = """
 - name: Add a user specifying password type
   ios_user:
     name: ansibletest4
-    configure_password: "{{ new_password }}"
+    configured_password: "{{ new_password }}"
     password_type: password
 
 - name: Delete users with aggregate

--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -66,6 +66,13 @@ options:
         the username is created.
     default: always
     choices: ['on_create', 'always']
+  password_type:
+    description:
+      - This argument determines whether a 'password' or 'secret' will be
+        configured.
+    default: secret
+    choices: ['secret', 'password']
+    version_added: "2.8"
   privilege:
     description:
       - The C(privilege) argument configures the privilege level of the
@@ -224,6 +231,7 @@ def map_obj_to_commands(updates, module):
     commands = list()
     state = module.params['state']
     update_password = module.params['update_password']
+    password_type = module.params['password_type']
 
     def needs_update(want, have, x):
         return want.get(x) and (want.get(x) != have.get(x))
@@ -261,7 +269,10 @@ def map_obj_to_commands(updates, module):
 
         if needs_update(want, have, 'configured_password'):
             if update_password == 'always' or not have:
-                add(commands, want, 'secret %s' % want['configured_password'])
+                if have and password_type != have['password_type']:
+                    module.fail_json(msg='Can not have both a user password and a user secret.' +
+                                         ' Please choose one or the other.')
+                add(commands, want, '%s %s' % (password_type, want['configured_password']))
 
         if needs_update(want, have, 'nopassword'):
             if want['nopassword']:
@@ -290,6 +301,13 @@ def parse_privilege(data):
         return int(match.group(1))
 
 
+def parse_password_type(data):
+    type = None
+    if data and data.split()[-3] in ['password', 'secret']:
+        type = data.split()[-3]
+    return type
+
+
 def map_config_to_obj(module):
     data = get_config(module, flags=['| section username'])
 
@@ -311,6 +329,7 @@ def map_config_to_obj(module):
             'state': 'present',
             'nopassword': 'nopassword' in cfg,
             'configured_password': None,
+            'password_type': parse_password_type(cfg),
             'sshkey': parse_sshkey(sshcfg),
             'privilege': parse_privilege(cfg),
             'view': parse_view(cfg)
@@ -373,7 +392,6 @@ def map_params_to_obj(module):
 
     return objects
 
-
 def update_objects(want, have):
     updates = list()
     for entry in want:
@@ -396,6 +414,7 @@ def main():
         configured_password=dict(no_log=True),
         nopassword=dict(type='bool'),
         update_password=dict(default='always', choices=['on_create', 'always']),
+        password_type=dict(default='secret', choices=['secret', 'password']),
 
         privilege=dict(type='int'),
         view=dict(aliases=['role']),

--- a/test/integration/targets/ios_user/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_user/tests/cli/basic.yaml
@@ -5,6 +5,8 @@
       - name: ansibletest1
       - name: ansibletest2
       - name: ansibletest3
+      - name: ansibletest4
+      - name: ansibletest5
     state: absent
     provider: "{{ cli }}"
 
@@ -66,12 +68,40 @@
       - 'result.changed == false'
       - 'result.commands | length == 0'
 
+- name: Create user with password_type (password)
+  ios_user:
+    name: ansibleuser4
+    password_type: password
+    configured_password: testpass
+    state: present
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == true'
+      - "'username ansibleuser4 password' in result.commands[0]"
+
+- name: Create user with password_type (secret)
+  ios_user:
+    name: ansibleuser5
+    password_type: secret
+    configured_password: testpass
+    state: present
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == true'
+      - "'username ansibleuser5 secret' in result.commands[0]"
+
 - name: tearDown
   ios_user:
     aggregate:
       - name: ansibletest1
       - name: ansibletest2
       - name: ansibletest3
+      - name: ansibletest4
+      - name: ansibletest5
     state: absent
     provider: "{{ cli }}"
   register: result


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #47575 
- Issue:
If the device already has a user configured with _password_ (not _secret_) and if we try to update it using a playbook, the module returns no errors, displays changed=True but nothing happens on the device. 
This is because, the module always attempts to configure _secret_ and not _password_, but since a user cannot have both _password_ and _secret_, if we run the command generated by the module directly on the device, it fails with the error message:
```
Can not have both a user password and a user secret. Please choose one or the other.
```
- This PR adds a new parameter `password_type` which can have two values, `secret` or `password`. The default is `secret`. Based on this value the appropriate type of password is configured.
- We also fetch the existing type of password from the device. While updating the password for an user, if the `password_type` for `want` doesn't match with `password_type` for `have`, we throw the exact error which the device throws in this scenario.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ios_user.py

##### ANSIBLE VERSION
```
devel
```