### PR TITLE
ovirt_host_pm: Fix to powermanagement module (#47659)

### DIFF
--- a/changelogs/fragments/ovirt_host_pm_bug_fixes_for_power_management.yaml
+++ b/changelogs/fragments/ovirt_host_pm_bug_fixes_for_power_management.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ovirt_host_pm - Bug fixes for power management (https://github.com/ansible/ansible/pull/47659).

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_pm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_pm.py
@@ -144,7 +144,13 @@ class HostModule(BaseModule):
 
 class HostPmModule(BaseModule):
 
+    def pre_create(self, entity):
+        # Save the entity, so we know if Agent already existed
+        self.entity = entity
+
     def build_entity(self):
+        last = next((s for s in sorted([a.order for a in self._service.list()])), 0)
+        order = self.param('order') if self.param('order') is not None else self.entity.order if self.entity else last + 1
         return otypes.Agent(
             address=self._module.params['address'],
             encrypt_options=self._module.params['encrypt_options'],
@@ -158,14 +164,23 @@ class HostPmModule(BaseModule):
             port=self._module.params['port'],
             type=self._module.params['type'],
             username=self._module.params['username'],
-            order=self._module.params.get('order', 100),
+            order=order,
         )
 
     def update_check(self, entity):
+        def check_options():
+            if self.param('options'):
+                current = []
+                if entity.options:
+                    current = [(opt.name, str(opt.value)) for opt in entity.options]
+                passed = [(k, str(v)) for k, v in self.param('options').items()]
+                return sorted(current) == sorted(passed)
+            return True
+
         return (
+            check_options() and
             equal(self._module.params.get('address'), entity.address) and
             equal(self._module.params.get('encrypt_options'), entity.encrypt_options) and
-            equal(self._module.params.get('password'), entity.password) and
             equal(self._module.params.get('username'), entity.username) and
             equal(self._module.params.get('port'), entity.port) and
             equal(self._module.params.get('type'), entity.type) and


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ovirt_host_pm: Fix to powermanagement module
    
    This PR is fixing following issues:
    
     1) Don't try to check password.
     2) Check options.
     3) Order wasn't adding at the end, as doc says.

backport of #47659

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_host_pm

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7.1
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
