### PR TITLE
icinga2_host: fix use_proxy option

### DIFF
--- a/icinga2_host-47671-fix-use_proxy.yaml
+++ b/icinga2_host-47671-fix-use_proxy.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- icinga2_host - fixed the issue with not working ``use_proxy`` option of the module.

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -134,13 +134,16 @@ from ansible.module_utils.urls import fetch_url, url_argument_spec
 class icinga2_api:
     module = None
 
+    def __init__(self, module):
+        self.module = module
+
     def call_url(self, path, data='', method='GET'):
         headers = {
             'Accept': 'application/json',
             'X-HTTP-Method-Override': method,
         }
         url = self.module.params.get("url") + "/" + path
-        rsp, info = fetch_url(module=self.module, url=url, data=data, headers=headers, method=method)
+        rsp, info = fetch_url(module=self.module, url=url, data=data, headers=headers, method=method, use_proxy=self.module.params['use_proxy'])
         body = ''
         if rsp:
             body = json.loads(rsp.read())
@@ -248,8 +251,7 @@ def main():
     variables = module.params["variables"]
 
     try:
-        icinga = icinga2_api()
-        icinga.module = module
+        icinga = icinga2_api(module=module)
         icinga.check_connection()
     except Exception as e:
         module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % (e))


### PR DESCRIPTION
##### SUMMARY
icinga2_host uses standard set of url parameters including use_proxy, which is documented as an paramter to this module. However, parameter is not passed to fetch_url resulting in proxy beeing used all the time (when defined in environment)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
icinga2_host

##### ANSIBLE VERSION
```
ansible 2.6.6
  config file = /home/cinek/.ansible.cfg
  configured module search path = [u'/home/cinek/ansible/lib/ansible/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]


