### PR TITLE
modules: network: ingate: Add module ig_revert_edit

### DIFF
--- a/lib/ansible/modules/network/ingate/ig_revert_edit.py
+++ b/lib/ansible/modules/network/ingate/ig_revert_edit.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2018, Ingate Systems AB
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: ig_revert_edit
+short_description: Reset the preliminary configuration on an Ingate SBC.
+description:
+  - Reset the preliminary configuration to the permanent configuration on an
+    Ingate SBC.
+version_added: 2.8
+extends_documentation_fragment: ingate
+author:
+  - Ingate Systems AB (@ingatesystems)
+'''
+
+EXAMPLES = '''
+- name: Revert to last known applied configuration
+  ig_revert_edit:
+    client:
+      version: v1
+      scheme: http
+      address: 192.168.1.1
+      username: alice
+      password: foobar
+'''
+
+RETURN = '''
+revert-edits:
+  description: A command status message
+  returned: success
+  type: complex
+  contains:
+    msg:
+      description: The command status message
+      returned: success
+      type: string
+      sample: reverted the configuration to the last applied configuration.
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.ingate.common import (ingate_argument_spec,
+                                                        ingate_create_client)
+
+try:
+    from ingate import ingatesdk
+    HAS_INGATESDK = True
+except ImportError:
+    HAS_INGATESDK = False
+
+
+def make_request(module):
+    # Create client and authenticate.
+    api_client = ingate_create_client(**module.params)
+
+    # Revert edits.
+    response = api_client.revert_edits()
+    return response
+
+
+def main():
+    argument_spec = ingate_argument_spec()
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=False)
+    if not HAS_INGATESDK:
+        module.fail_json(msg='The Ingate Python SDK module is required')
+
+    result = dict(changed=False)
+    try:
+        response = make_request(module)
+        result.update(response[0])
+        result['changed'] = True
+    except ingatesdk.SdkError as e:
+        module.fail_json(msg=str(e))
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/ingate/fixtures/test_ig_revert_edit.json
+++ b/test/units/modules/network/ingate/fixtures/test_ig_revert_edit.json
@@ -1,0 +1,7 @@
+[
+    {
+        "revert-edits": {
+            "msg": "reverted the configuration to the last applied configuration."
+        }
+    }
+]

--- a/test/units/modules/network/ingate/test_ig_revert_edit.py
+++ b/test/units/modules/network/ingate/test_ig_revert_edit.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2018, Ingate Systems AB
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+from units.compat.mock import patch
+from ansible.modules.network.ingate import ig_revert_edit
+from units.modules.utils import set_module_args
+from .ingate_module import TestIngateModule, load_fixture
+
+
+class TestRevertEditModule(TestIngateModule):
+
+    module = ig_revert_edit
+
+    def setUp(self):
+        super(TestRevertEditModule, self).setUp()
+
+        self.mock_make_request = patch('ansible.modules.network.ingate.'
+                                       'ig_revert_edit.make_request')
+        self.make_request = self.mock_make_request.start()
+        # ATM the Ingate Python SDK is not needed in this unit test.
+        self.module.HAS_INGATESDK = True
+
+    def tearDown(self):
+        super(TestRevertEditModule, self).tearDown()
+        self.mock_make_request.stop()
+
+    def load_fixtures(self, fixture=None):
+        self.make_request.side_effect = [load_fixture(fixture)]
+
+    def test_ig_revert_edit(self):
+        set_module_args(dict(
+            client=dict(
+                version='v1',
+                address='127.0.0.1',
+                scheme='http',
+                username='alice',
+                password='foobar'
+            )))
+        fixture = '%s.%s' % (os.path.basename(__file__).split('.')[0], 'json')
+        result = self.execute_module(changed=True, fixture=fixture)
+        self.assertTrue('revert-edits' in result)


### PR DESCRIPTION
##### SUMMARY
Add Ingate network module ig_revert_edit 

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
ig_revert_edit

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (add-module-ig-revert-edit ecddcebf95) last updated 2018/10/26 16:12:52 (GMT +200)
  config file = None
  configured module search path = [u'/home/erik/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /share/washi-users/erik/git/ansible/lib/ansible
  executable location = /share/washi-users/erik/git/ansible/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
