### PR TITLE
Add missing self._supports_async to uri action plugin

### DIFF
--- a/changelogs/fragments/uri-supports-async.yaml
+++ b/changelogs/fragments/uri-supports-async.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- uri - Ensure the ``uri`` module supports async (https://github.com/ansible/ansible/issues/47660)

--- a/lib/ansible/plugins/action/uri.py
+++ b/lib/ansible/plugins/action/uri.py
@@ -53,9 +53,10 @@ class ActionModule(ActionBase):
                 )
             )
 
-            result.update(self._execute_module('uri', module_args=new_module_args, task_vars=task_vars))
+            result.update(self._execute_module('uri', module_args=new_module_args, task_vars=task_vars, wrap_async=self._task.async_val))
         except AnsibleAction as e:
             result.update(e.result)
         finally:
-            self._remove_tmp_path(self._connection._shell.tmpdir)
+            if not self._task.async_val:
+                self._remove_tmp_path(self._connection._shell.tmpdir)
         return result

--- a/lib/ansible/plugins/action/uri.py
+++ b/lib/ansible/plugins/action/uri.py
@@ -35,7 +35,7 @@ class ActionModule(ActionBase):
             if (src and remote_src) or not src:
                 # everything is remote, so we just execute the module
                 # without changing any of the module arguments
-                raise _AnsibleActionDone(result=self._execute_module(task_vars=task_vars))
+                raise _AnsibleActionDone(result=self._execute_module(task_vars=task_vars, wrap_async=self._task.async_val))
 
             try:
                 src = self._find_needle('files', src)

--- a/lib/ansible/plugins/action/uri.py
+++ b/lib/ansible/plugins/action/uri.py
@@ -20,6 +20,8 @@ class ActionModule(ActionBase):
     TRANSFERS_FILES = True
 
     def run(self, tmp=None, task_vars=None):
+        self._supports_async = True
+
         if task_vars is None:
             task_vars = dict()
 


### PR DESCRIPTION
##### SUMMARY
Add missing self._supports_async to uri action plugin. Fixes #47660

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/uri.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```