### PR TITLE
Match config prompts that aren't maint-mode

### DIFF
--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -19,8 +19,9 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
 import copy
+import re
+import sys
 
 from ansible import constants as C
 from ansible.module_utils._text import to_text
@@ -117,8 +118,10 @@ class ActionModule(_ActionModule):
                 socket_path = self._connection.socket_path
 
             conn = Connection(socket_path)
+            # Match prompts ending in )# except those with (maint-mode)#
+            config_prompt = re.compile(r'^.*\((?!maint-mode).*\)#$')
             out = conn.get_prompt()
-            while to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
+            while config_prompt.match(to_text(out, errors='surrogate_then_replace').strip()):
                 display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
                 conn.send_command('exit')
                 out = conn.get_prompt()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Replaces config mode check in nxos action plugin with regex that ignores instances of `(maint-mode)#` when checking terminal state

Fixes #46944

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```