### PR TITLE
pam_limits: properly support nice and priority limits

### DIFF
--- a/lib/ansible/modules/system/pam_limits.py
+++ b/lib/ansible/modules/system/pam_limits.py
@@ -140,15 +140,17 @@ from ansible.module_utils._text import to_native
 
 
 def _assert_is_valid_value(module, item, value, prefix=''):
-    if item in [ 'nice', 'priority' ]:
+    if item in ['nice', 'priority']:
         try:
             valid = -20 <= int(value) <= 19
         except ValueError:
             valid = False
         if not valid:
-            module.fail_json(msg="%sValue of %r for item %r is invalid. Value must be a number in the range -20 to 19 inclusive. Refer to the limits.conf(5) manual pages for more details." % (prefix, value, item))
+            module.fail_json(msg="%sValue of %r for item %r is invalid. Value must be a number in the range -20 to 19 inclusive. "
+                                 "Refer to the limits.conf(5) manual pages for more details." % (prefix, value, item))
     elif not (value in ['unlimited', 'infinity', '-1'] or value.isdigit()):
-        module.fail_json(msg="%sValue of %r for item %r is invalid. Value must be 'unlimited', 'infinity', '-1' or a positive number. Refer to the limits.conf(5) manual pages for more details." % (prefix, value))
+        module.fail_json(msg="%sValue of %r for item %r is invalid. Value must be 'unlimited', 'infinity', '-1' or a positive number. "
+                             "Refer to the limits.conf(5) manual pages for more details." % (prefix, value))
 
 
 def main():
@@ -260,7 +262,7 @@ def main():
                 nf.write(line)
                 continue
 
-            if line_type not in [ 'nice', 'priority' ]:
+            if line_type not in ['nice', 'priority']:
                 actual_value_unlimited = actual_value in ['unlimited', 'infinity', '-1']
                 value_unlimited = value in ['unlimited', 'infinity', '-1']
             else:

--- a/lib/ansible/modules/system/pam_limits.py
+++ b/lib/ansible/modules/system/pam_limits.py
@@ -150,7 +150,7 @@ def _assert_is_valid_value(module, item, value, prefix=''):
                                  "Refer to the limits.conf(5) manual pages for more details." % (prefix, value, item))
     elif not (value in ['unlimited', 'infinity', '-1'] or value.isdigit()):
         module.fail_json(msg="%sValue of %r for item %r is invalid. Value must be 'unlimited', 'infinity', '-1' or a positive number. "
-                             "Refer to the limits.conf(5) manual pages for more details." % (prefix, value))
+                             "Refer to the limits.conf(5) manual pages for more details." % (prefix, value, item))
 
 
 def main():

--- a/lib/ansible/modules/system/pam_limits.py
+++ b/lib/ansible/modules/system/pam_limits.py
@@ -149,8 +149,9 @@ def _assert_is_valid_value(module, item, value, prefix=''):
             module.fail_json(msg="%sValue of %r for item %r is invalid. Value must be a number in the range -20 to 19 inclusive. "
                                  "Refer to the limits.conf(5) manual pages for more details." % (prefix, value, item))
     elif not (value in ['unlimited', 'infinity', '-1'] or value.isdigit()):
-        module.fail_json(msg="%sValue of %r for item %r is invalid. Value must be 'unlimited', 'infinity', '-1' or a positive number. "
-                             "Refer to the limits.conf(5) manual pages for more details." % (prefix, value, item))
+        module.fail_json(msg="%sValue of %r for item %r is invalid. Value must either be 'unlimited', 'infinity' or -1, all of "
+                             "which indicate no limit, or a limit of 0 or larger. Refer to the limits.conf(5) manual pages for "
+                             "more details." % (prefix, value, item))
 
 
 def main():


### PR DESCRIPTION


##### SUMMARY
Unlike all other limits, *nice* and *priority* must have a value between -19 and 20 and -1, unlimited and infinity are unsupported. See [limits.conf(5)](https://linux.die.net/man/5/limits.conf) for details.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Module pam_limits

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.3
  config file = /home/peter/.ansible.cfg
  configured module search path = [u'/home/peter/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Sep 26 2018, 18:42:22) [GCC 6.3.0 20170516]
```
