### PR TITLE
New v2_runner_on_start callback added

### DIFF
--- a/changelogs/fragments/host-start-callback.yaml
+++ b/changelogs/fragments/host-start-callback.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- callbacks - New ``v2_runner_on_start`` callback added to indicate the start of execution for a host in a specific task (https://github.com/ansible/ansible/pull/47684)

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -414,7 +414,7 @@ class CallbackBase(AnsiblePlugin):
         pass
 
     def v2_runner_on_start(self, host, task):
-        """Event used when host begins execution
+        """Event used when host begins execution of a task
 
         .. versionadded:: 2.8
         """

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -412,3 +412,10 @@ class CallbackBase(AnsiblePlugin):
 
     def v2_runner_retry(self, result):
         pass
+
+    def v2_runner_on_start(self, host, task):
+        """Event used when host begins execution
+
+        .. versionadded:: 2.8
+        """
+        pass

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -317,6 +317,7 @@ class StrategyBase:
 
                     worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader, self._variable_manager, shared_loader_obj)
                     self._workers[self._cur_worker] = worker_prc
+                    self._tqm.send_callback('v2_runner_on_start', host, task)
                     worker_prc.start()
                     display.debug("worker is %d (out of %d available)" % (self._cur_worker + 1, len(self._workers)))
                     queued = True


### PR DESCRIPTION
##### SUMMARY
New v2_runner_on_start callback added to indicate the start of execution for a host in a specific task

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```
lib/ansible/plugins/callback/__init__.py
lib/ansible/plugins/strategy/__init__.py
```

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

##### ADDITIONAL INFORMATION

This callback will allow for collecting host timings.