### PR TITLE
[stable-2.7] Add missing self._supports_async to uri action plugin (#47677)

### DIFF
--- a/changelogs/fragments/uri-supports-async.yaml
+++ b/changelogs/fragments/uri-supports-async.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- uri - Ensure the ``uri`` module supports async (https://github.com/ansible/ansible/issues/47660)


### PR DESCRIPTION
* Add missing self._supports_async to uri action plugin. Fixes #47660

* Additional changes needed to support async

* Missed a call to execute_module
(cherry picked from commit 3633e21)


Co-authored-by: Matt Martz <matt@sivel.net>