### PR TITLE
Fix vars_prompt "private" description and improve example

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_prompts.rst
+++ b/docs/docsite/rst/user_guide/playbooks_prompts.rst
@@ -12,21 +12,21 @@ in a push-script.
 
 Here is a most basic example::
 
-      ---
-      - hosts: all
-        vars_prompt:
+    ---
+    - hosts: all
+      vars_prompt:
 
-          - name: username
-            prompt: "What is your username?"
-            private: no
+        - name: username
+          prompt: "What is your username?"
+          private: no
 
-          - name: password
-            prompt: "What is your password?"
+        - name: password
+          prompt: "What is your password?"
 
-        tasks: 
+      tasks: 
 
-          - debug: 
-              msg: 'Logging in as {{ username }}'
+        - debug: 
+            msg: 'Logging in as {{ username }}'
 
 The user input is hidden by default but it can be made visible by setting ``private: no``.
 

--- a/docs/docsite/rst/user_guide/playbooks_prompts.rst
+++ b/docs/docsite/rst/user_guide/playbooks_prompts.rst
@@ -12,27 +12,29 @@ in a push-script.
 
 Here is a most basic example::
 
-    ---
-    - hosts: all
-      remote_user: root
+      ---
+      - hosts: all
+        vars_prompt:
 
-      vars:
-        from: "camelot"
+          - name: username
+            prompt: "What is your username?"
+            private: no
 
-      vars_prompt:
-        - name: "name"
-          prompt: "what is your name?"
-        - name: "quest"
-          prompt: "what is your quest?"
-        - name: "favcolor"
-          prompt: "what is your favorite color?"
+          - name: password
+            prompt: "What is your password?"
 
+        tasks: 
+
+          - debug: 
+              msg: 'Logging in as {{ username }}'
+
+The user input is hidden by default but it can be made visible by setting ``private: no``.
 
 .. note::
     Prompts for individual ``vars_prompt`` variables will be skipped for any variable that is already defined through the command line ``--extra-vars`` option, or when running from a non-interactive session (such as cron or Ansible Tower). See :ref:`passing_variables_on_the_command_line` in the /Variables/ chapter.
 
 If you have a variable that changes infrequently, it might make sense to
-provide a default value that can be overridden.  This can be accomplished using
+provide a default value that can be overridden. This can be accomplished using
 the default argument::
 
    vars_prompt:
@@ -40,19 +42,6 @@ the default argument::
      - name: "release_version"
        prompt: "Product release version"
        default: "1.0"
-
-An alternative form of vars_prompt allows for hiding input from the user, and may later support
-some other options, but otherwise works equivalently::
-
-   vars_prompt:
-
-     - name: "some_password"
-       prompt: "Enter password"
-       private: yes
-
-     - name: "release_version"
-       prompt: "Product release version"
-       private: no
 
 If `Passlib <https://passlib.readthedocs.io/en/stable/>`_ is installed, vars_prompt can also encrypt the
 entered value so you can use it, for instance, with the user module to define a password::


### PR DESCRIPTION
##### SUMMARY

Remove example about "private: no" and make the first example show both the default case and the "private: no" case.

Fixes #44906

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vars_prompt

##### ANSIBLE VERSION
N/A

##### ADDITIONAL INFORMATION
N/A
