### PR TITLE
Fix argument_spec for modules that are using the old version

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+i#!/usr/bin/python
 
 # (c) 2018, NetApp, Inc
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -13,34 +13,37 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
-  - Create/Delete vserver peer
+  - Create/Delete cluster peer relations on ONTAP
 extends_documentation_fragment:
-  - netapp.na_ontap
-module: na_ontap_vserver_peer
+  - netapp.ontap
+module: na_ontap_cluster_peer
 options:
   state:
     choices: ['present', 'absent']
     description:
-      - Whether the specified vserver peer should exist or not.
+      - Whether the specified cluster peer should exist or not.
     default: present
-  vserver:
+  source_intercluster_lif:
     description:
-      - Specifies name of the source Vserver in the relationship.
-  applications:
-    choices: ['snapmirror', 'file_copy', 'lun_copy']
+      - Intercluster address of the source cluster.
+      - Used as peer-address in destination cluster.
+  dest_intercluster_lif:
     description:
-      - List of applications which can make use of the peering relationship.
-  peer_vserver:
+      - Intercluster address of the destination cluster.
+      - Used as peer-address in source cluster.
+  passphrase:
     description:
-      - Specifies name of the peer Vserver in the relationship.
-  peer_cluster:
+      - The arbitrary passphrase that matches the one given to the peer cluster.
+  source_cluster_name:
     description:
-      - Specifies name of the peer Cluster.
-      - If peer Cluster is not given, it considers local Cluster.
+      - The name of the source cluster name in the peer relation to be deleted.
+  dest_cluster_name:
+    description:
+      - The name of the destination cluster name in the peer relation to be deleted.
   dest_hostname:
     description:
-     - Destination hostname or IP address.
-     - Required for creating the vserver peer relationship
+      - Destination cluster IP or hostname which needs to be peered.
+    required: True
   dest_username:
     description:
      - Destination username.
@@ -49,30 +52,30 @@ options:
     description:
      - Destination password.
      - Optional if this is same as source password.
-short_description: NetApp ONTAP Vserver peering
+short_description: NetApp ONTAP Manage Cluster peering
 version_added: "2.7"
 '''
 
 EXAMPLES = """
-    - name: Source vserver peer create
-      na_ontap_vserver_peer:
+    - name: Create cluster peer
+      na_ontap_cluster_peer:
         state: present
-        peer_vserver: ansible2
-        peer_cluster: ansibleCluster
-        vserver: ansible
-        applications: snapmirror
+        source_intercluster_lif: 1.2.3.4
+        dest_intercluster_lif: 5.6.7.8
+        passphrase: XXXX
         hostname: "{{ netapp_hostname }}"
         username: "{{ netapp_username }}"
         password: "{{ netapp_password }}"
-        dest_hostname: "{{ netapp_dest_hostname }}"
-    - name: vserver peer delete
-      na_ontap_vserver_peer:
+        dest_hostname: "{{ dest_netapp_hostname }}"
+    - name: Delete cluster peer
+      na_ontap_cluster_peer:
         state: absent
-        peer_vserver: ansible2
-        vserver: ansible
+        source_cluster_name: test-source-cluster
+        dest_cluster_name: test-dest-cluster
         hostname: "{{ netapp_hostname }}"
         username: "{{ netapp_username }}"
         password: "{{ netapp_password }}"
+        dest_hostname: "{{ dest_netapp_hostname }}"
 """
 
 RETURN = """
@@ -87,30 +90,30 @@ from ansible.module_utils.netapp_module import NetAppModule
 HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()
 
 
-class NetAppONTAPVserverPeer(object):
+class NetAppONTAPClusterPeer(object):
     """
-    Class with vserver peer methods
+    Class with cluster peer methods
     """
 
     def __init__(self):
 
-        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
+        self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
-            vserver=dict(required=True, type='str'),
-            peer_vserver=dict(required=True, type='str'),
-            peer_cluster=dict(required=False, type='str'),
-            applications=dict(required=False, type='list', choices=['snapmirror', 'file_copy', 'lun_copy']),
-            dest_hostname=dict(required=False, type='str'),
+            source_intercluster_lif=dict(required=False, type='str'),
+            dest_intercluster_lif=dict(required=False, type='str'),
+            passphrase=dict(required=False, type='str', no_log=True),
+            dest_hostname=dict(required=True, type='str'),
             dest_username=dict(required=False, type='str'),
-            dest_password=dict(required=False, type='str', no_log=True)
+            dest_password=dict(required=False, type='str', no_log=True),
+            source_cluster_name=dict(required=False, type='str'),
+            dest_cluster_name=dict(required=False, type='str')
         ))
 
         self.module = AnsibleModule(
             argument_spec=self.argument_spec,
-            required_if=[
-                ('state', 'present', ['dest_hostname'])
-            ],
+            required_together=[['source_intercluster_lif', 'dest_intercluster_lif', 'passphrase']],
+            required_if=[('state', 'absent', ['source_cluster_name', 'dest_cluster_name'])],
             supports_check_mode=True
         )
 
@@ -121,141 +124,144 @@ class NetAppONTAPVserverPeer(object):
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
             self.server = netapp_utils.setup_ontap_zapi(module=self.module)
-            if self.parameters.get('dest_hostname'):
-                self.module.params['hostname'] = self.parameters['dest_hostname']
-                if self.parameters.get('dest_username'):
-                    self.module.params['username'] = self.parameters['dest_username']
-                if self.parameters.get('dest_password'):
-                    self.module.params['password'] = self.parameters['dest_password']
-                self.dest_server = netapp_utils.setup_na_ontap_zapi(module=self.module)
+            # set destination server connection
+            self.module.params['hostname'] = self.parameters['dest_hostname']
+            if self.parameters.get('dest_username'):
+                self.module.params['username'] = self.parameters['dest_username']
+            if self.parameters.get('dest_password'):
+                self.module.params['password'] = self.parameters['dest_password']
+            self.dest_server = netapp_utils.setup_ontap_zapi(module=self.module)
 
-    def vserver_peer_get_iter(self):
+    def cluster_peer_get_iter(self, cluster):
         """
-        Compose NaElement object to query current vserver using peer-vserver and vserver parameters
-        :return: NaElement object for vserver-get-iter with query
+        Compose NaElement object to query current source cluster using peer-cluster-name and peer-addresses parameters
+        :param cluster: type of cluster (source or destination)
+        :return: NaElement object for cluster-get-iter with query
         """
-        vserver_peer_get = netapp_utils.zapi.NaElement('vserver-peer-get-iter')
+        cluster_peer_get = netapp_utils.zapi.NaElement('cluster-peer-get-iter')
         query = netapp_utils.zapi.NaElement('query')
-        vserver_peer_info = netapp_utils.zapi.NaElement('vserver-peer-info')
-        vserver_peer_info.add_new_child('peer-vserver', self.parameters['peer_vserver'])
-        vserver_peer_info.add_new_child('vserver', self.parameters['vserver'])
-        query.add_child_elem(vserver_peer_info)
-        vserver_peer_get.add_child_elem(query)
-        return vserver_peer_get
+        cluster_peer_info = netapp_utils.zapi.NaElement('cluster-peer-info')
+        if cluster == 'source':
+            peer_lif, peer_cluster = 'dest_intercluster_lif', 'dest_cluster_name'
+        else:
+            peer_lif, peer_cluster = 'source_intercluster_lif', 'source_cluster_name'
+        peer_addresses = netapp_utils.zapi.NaElement('peer-addresses')
+        if self.parameters.get(peer_lif):
+            peer_addresses.add_new_child('remote-inet-address', self.parameters[peer_lif])
+            cluster_peer_info.add_child_elem(peer_addresses)
+        if self.parameters.get(peer_cluster):
+            cluster_peer_info.add_new_child('cluster-name', self.parameters[peer_cluster])
+        query.add_child_elem(cluster_peer_info)
+        cluster_peer_get.add_child_elem(query)
+        return cluster_peer_get
 
-    def vserver_peer_get(self):
+    def cluster_peer_get(self, cluster):
         """
-        Get current vserver peer info
-        :return: Dictionary of current vserver peer details if query successful, else return None
+        Get current cluster peer info
+        :param cluster: type of cluster (source or destination)
+        :return: Dictionary of current cluster peer details if query successful, else return None
         """
-        vserver_peer_get_iter = self.vserver_peer_get_iter()
-        vserver_info = dict()
+        cluster_peer_get_iter = self.cluster_peer_get_iter(cluster)
+        cluster_info = dict()
+        if cluster == 'source':
+            server = self.server
+        else:
+            server = self.dest_server
         try:
-            result = self.server.invoke_successfully(vserver_peer_get_iter, enable_tunneling=True)
+            result = server.invoke_successfully(cluster_peer_get_iter, enable_tunneling=True)
         except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error fetching vserver peer %s: %s'
-                                      % (self.parameters['vserver'], to_native(error)),
+            self.module.fail_json(msg='Error fetching cluster peer %s: %s'
+                                      % (self.parameters['dest_cluster_name'], to_native(error)),
                                   exception=traceback.format_exc())
-        # return vserver peer details
+        # return cluster peer details
         if result.get_child_by_name('num-records') and \
-                int(result.get_child_content('num-records')) > 0:
-            vserver_peer_info = result.get_child_by_name('attributes-list').get_child_by_name('vserver-peer-info')
-            vserver_info['peer_vserver'] = vserver_peer_info.get_child_content('peer-vserver')
-            vserver_info['vserver'] = vserver_peer_info.get_child_content('vserver')
-            vserver_info['peer_state'] = vserver_peer_info.get_child_content('peer-state')
-            return vserver_info
+                int(result.get_child_content('num-records')) >= 1:
+            cluster_peer_info = result.get_child_by_name('attributes-list').get_child_by_name('cluster-peer-info')
+            cluster_info['cluster_name'] = cluster_peer_info.get_child_content('cluster-name')
+            peers = cluster_peer_info.get_child_by_name('peer-addresses')
+            cluster_info['peer-addresses'] = [peer.get_content() for peer in peers.get_children()]
+            return cluster_info
         return None
 
-    def vserver_peer_delete(self):
+    def cluster_peer_delete(self, cluster):
         """
-        Delete a vserver peer
+        Delete a cluster peer on source or destination
+        For source cluster, peer cluster-name = destination cluster name and vice-versa
+        :param cluster: type of cluster (source or destination)
+        :return:
         """
-        vserver_peer_delete = netapp_utils.zapi.NaElement.create_node_with_children(
-            'vserver-peer-delete', **{'peer-vserver': self.parameters['peer_vserver'],
-                                      'vserver': self.parameters['vserver']})
+        if cluster == 'source':
+            server, peer_cluster_name = self.server, self.parameters['dest_cluster_name']
+        else:
+            server, peer_cluster_name = self.dest_server, self.parameters['source_cluster_name']
+        cluster_peer_delete = netapp_utils.zapi.NaElement.create_node_with_children(
+            'cluster-peer-delete', **{'cluster-name': peer_cluster_name})
         try:
-            self.server.invoke_successfully(vserver_peer_delete,
-                                            enable_tunneling=True)
+            server.invoke_successfully(cluster_peer_delete, enable_tunneling=True)
         except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error deleting vserver peer %s: %s'
-                                      % (self.parameters['vserver'], to_native(error)),
+            self.module.fail_json(msg='Error deleting cluster peer %s: %s'
+                                      % (peer_cluster_name, to_native(error)),
                                   exception=traceback.format_exc())
 
-    def get_peer_cluster_name(self):
+    def cluster_peer_create(self, cluster):
         """
-        Get local cluster name
-        :return: cluster name
+        Create a cluster peer on source or destination
+        For source cluster, peer address = destination inter-cluster LIF and vice-versa
+        :param cluster: type of cluster (source or destination)
+        :return: None
         """
-        cluster_info = netapp_utils.zapi.NaElement('cluster-identity-get')
+        cluster_peer_create = netapp_utils.zapi.NaElement.create_node_with_children(
+            'cluster-peer-create', **{'passphrase': self.parameters['passphrase']})
+        peer_addresses = netapp_utils.zapi.NaElement('peer-addresses')
+        if cluster == 'source':
+            server, peer_address = self.server, self.parameters['dest_intercluster_lif']
+        else:
+            server, peer_address = self.dest_server, self.parameters['source_intercluster_lif']
+        peer_addresses.add_new_child('remote-inet-address', peer_address)
+        cluster_peer_create.add_child_elem(peer_addresses)
         try:
-            result = self.server.invoke_successfully(cluster_info, enable_tunneling=True)
-            return result.get_child_by_name('attributes').get_child_by_name(
-                'cluster-identity-info').get_child_content('cluster-name')
+            server.invoke_successfully(cluster_peer_create, enable_tunneling=True)
         except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error fetching peer cluster name for peer vserver %s: %s'
-                                      % (self.parameters['peer_vserver'], to_native(error)),
-                                  exception=traceback.format_exc())
-
-    def vserver_peer_create(self):
-        """
-        Create a vserver peer
-        """
-        if self.parameters.get('applications') is None:
-            self.module.fail_json(msg='applications parameter is missing')
-        if self.parameters.get('peer_cluster') is None:
-            self.parameters['peer_cluster'] = self.get_peer_cluster_name()
-        vserver_peer_create = netapp_utils.zapi.NaElement.create_node_with_children(
-            'vserver-peer-create', **{'peer-vserver': self.parameters['peer_vserver'],
-                                      'vserver': self.parameters['vserver'],
-                                      'peer-cluster': self.parameters['peer_cluster']})
-        applications = netapp_utils.zapi.NaElement('applications')
-        for application in self.parameters['applications']:
-            applications.add_new_child('vserver-peer-application', application)
-        vserver_peer_create.add_child_elem(applications)
-        try:
-            self.server.invoke_successfully(vserver_peer_create,
-                                            enable_tunneling=True)
-        except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error creating vserver peer %s: %s'
-                                      % (self.parameters['vserver'], to_native(error)),
-                                  exception=traceback.format_exc())
-
-    def vserver_peer_accept(self):
-        """
-        Accept a vserver peer at destination
-        """
-        # peer-vserver -> remote (source vserver is provided)
-        # vserver -> local (destination vserver is provided)
-        vserver_peer_accept = netapp_utils.zapi.NaElement.create_node_with_children(
-            'vserver-peer-accept', **{'peer-vserver': self.parameters['vserver'],
-                                      'vserver': self.parameters['peer_vserver']})
-        try:
-            self.dest_server.invoke_successfully(vserver_peer_accept, enable_tunneling=True)
-        except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error accepting vserver peer %s: %s'
-                                      % (self.parameters['peer_vserver'], to_native(error)),
+            self.module.fail_json(msg='Error creating cluster peer %s: %s'
+                                  % (peer_address, to_native(error)),
                                   exception=traceback.format_exc())
 
     def apply(self):
         """
-        Apply action to create/delete or accept vserver peer
+        Apply action to cluster peer
+        :return: None
         """
-        current = self.vserver_peer_get()
-        cd_action = self.na_helper.get_cd_action(current, self.parameters)
-        if cd_action == 'create':
-            self.vserver_peer_create()
-            self.vserver_peer_accept()
-        elif cd_action == 'delete':
-            self.vserver_peer_delete()
+        source = self.cluster_peer_get('source')
+        destination = self.cluster_peer_get('destination')
+        source_action = self.na_helper.get_cd_action(source, self.parameters)
+        destination_action = self.na_helper.get_cd_action(destination, self.parameters)
+        self.na_helper.changed = False
+        # create only if expected cluster peer relation is not present on both source and destination clusters
+        if source_action == 'create' and destination_action == 'create':
+            self.cluster_peer_create('source')
+            self.cluster_peer_create('destination')
+            self.na_helper.changed = True
+        # delete peer relation in cluster where relation is present
+        else:
+            if source_action == 'delete':
+                self.cluster_peer_delete('source')
+                self.na_helper.changed = True
+            if destination_action == 'delete':
+                self.cluster_peer_delete('destination')
+                self.na_helper.changed = True
 
         self.module.exit_json(changed=self.na_helper.changed)
 
 
 def main():
-    """Execute action"""
-    community_obj = NetAppONTAPVserverPeer()
+    """
+    Execute action
+    :return: None
+    """
+    community_obj = NetAppONTAPClusterPeer()
     community_obj.apply()
 
 
 if __name__ == '__main__':
     main()
+

--- a/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
@@ -264,4 +264,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
@@ -1,4 +1,4 @@
-i#!/usr/bin/python
+#!/usr/bin/python
 
 # (c) 2018, NetApp, Inc
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -15,7 +15,7 @@ author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
   - Create/Delete cluster peer relations on ONTAP
 extends_documentation_fragment:
-  - netapp.ontap
+  - netapp.na_ontap
 module: na_ontap_cluster_peer
 options:
   state:
@@ -97,7 +97,7 @@ class NetAppONTAPClusterPeer(object):
 
     def __init__(self):
 
-        self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
+        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
             source_intercluster_lif=dict(required=False, type='str'),
@@ -123,14 +123,14 @@ class NetAppONTAPClusterPeer(object):
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
-            self.server = netapp_utils.setup_ontap_zapi(module=self.module)
+            self.server = netapp_utils.setup_na_ontap_zapi(module=self.module)
             # set destination server connection
             self.module.params['hostname'] = self.parameters['dest_hostname']
             if self.parameters.get('dest_username'):
                 self.module.params['username'] = self.parameters['dest_username']
             if self.parameters.get('dest_password'):
                 self.module.params['password'] = self.parameters['dest_password']
-            self.dest_server = netapp_utils.setup_ontap_zapi(module=self.module)
+            self.dest_server = netapp_utils.setup_na_ontap_zapi(module=self.module)
 
     def cluster_peer_get_iter(self, cluster):
         """

--- a/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
-                    'supported_by': 'certified'}
+                    'supported_by': 'community'}
 
 
 DOCUMENTATION = '''
@@ -15,7 +15,7 @@ author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
   - Create/Delete cluster peer relations on ONTAP
 extends_documentation_fragment:
-  - netapp.ontap
+  - netapp.na_ontap
 module: na_ontap_cluster_peer
 options:
   state:
@@ -23,14 +23,14 @@ options:
     description:
       - Whether the specified cluster peer should exist or not.
     default: present
-  source_intercluster_lif:
+  source_intercluster_lifs:
     description:
-      - Intercluster address of the source cluster.
-      - Used as peer-address in destination cluster.
-  dest_intercluster_lif:
+      - Intercluster addresses of the source cluster.
+      - Used as peer-addresses in destination cluster.
+  dest_intercluster_lifs:
     description:
-      - Intercluster address of the destination cluster.
-      - Used as peer-address in source cluster.
+      - Intercluster addresses of the destination cluster.
+      - Used as peer-addresses in source cluster.
   passphrase:
     description:
       - The arbitrary passphrase that matches the one given to the peer cluster.
@@ -61,8 +61,8 @@ EXAMPLES = """
     - name: Create cluster peer
       na_ontap_cluster_peer:
         state: present
-        source_intercluster_lif: 1.2.3.4
-        dest_intercluster_lif: 5.6.7.8
+        source_intercluster_lifs: 1.2.3.4,1.2.3.5
+        dest_intercluster_lifs: 1.2.3.6,1.2.3.7
         passphrase: XXXX
         hostname: "{{ netapp_hostname }}"
         username: "{{ netapp_username }}"
@@ -99,11 +99,11 @@ class NetAppONTAPClusterPeer(object):
 
     def __init__(self):
 
-        self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
+        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
-            source_intercluster_lif=dict(required=False, type='str'),
-            dest_intercluster_lif=dict(required=False, type='str'),
+            source_intercluster_lifs=dict(required=False, type='list'),
+            dest_intercluster_lifs=dict(required=False, type='list'),
             passphrase=dict(required=False, type='str', no_log=True),
             dest_hostname=dict(required=True, type='str'),
             dest_username=dict(required=False, type='str'),
@@ -114,7 +114,7 @@ class NetAppONTAPClusterPeer(object):
 
         self.module = AnsibleModule(
             argument_spec=self.argument_spec,
-            required_together=[['source_intercluster_lif', 'dest_intercluster_lif', 'passphrase']],
+            required_together=[['source_intercluster_lifs', 'dest_intercluster_lifs', 'passphrase']],
             required_if=[('state', 'absent', ['source_cluster_name', 'dest_cluster_name'])],
             supports_check_mode=True
         )
@@ -132,7 +132,7 @@ class NetAppONTAPClusterPeer(object):
                 self.module.params['username'] = self.parameters['dest_username']
             if self.parameters.get('dest_password'):
                 self.module.params['password'] = self.parameters['dest_password']
-            self.dest_server = netapp_utils.setup_ontap_zapi(module=self.module)
+            self.dest_server = netapp_utils.setup_na_ontap_zapi(module=self.module)
 
     def cluster_peer_get_iter(self, cluster):
         """
@@ -144,12 +144,13 @@ class NetAppONTAPClusterPeer(object):
         query = netapp_utils.zapi.NaElement('query')
         cluster_peer_info = netapp_utils.zapi.NaElement('cluster-peer-info')
         if cluster == 'source':
-            peer_lif, peer_cluster = 'dest_intercluster_lif', 'dest_cluster_name'
+            peer_lifs, peer_cluster = 'dest_intercluster_lifs', 'dest_cluster_name'
         else:
-            peer_lif, peer_cluster = 'source_intercluster_lif', 'source_cluster_name'
-        peer_addresses = netapp_utils.zapi.NaElement('peer-addresses')
-        if self.parameters.get(peer_lif):
-            peer_addresses.add_new_child('remote-inet-address', self.parameters[peer_lif])
+            peer_lifs, peer_cluster = 'source_intercluster_lifs', 'source_cluster_name'
+        if self.parameters.get(peer_lifs):
+            peer_addresses = netapp_utils.zapi.NaElement('peer-addresses')
+            for peer in self.parameters.get(peer_lifs):
+                peer_addresses.add_new_child('remote-inet-address', peer)
             cluster_peer_info.add_child_elem(peer_addresses)
         if self.parameters.get(peer_cluster):
             cluster_peer_info.add_new_child('cluster-name', self.parameters[peer_cluster])
@@ -208,7 +209,7 @@ class NetAppONTAPClusterPeer(object):
     def cluster_peer_create(self, cluster):
         """
         Create a cluster peer on source or destination
-        For source cluster, peer address = destination inter-cluster LIF and vice-versa
+        For source cluster, peer addresses = destination inter-cluster LIFs and vice-versa
         :param cluster: type of cluster (source or destination)
         :return: None
         """
@@ -216,10 +217,11 @@ class NetAppONTAPClusterPeer(object):
             'cluster-peer-create', **{'passphrase': self.parameters['passphrase']})
         peer_addresses = netapp_utils.zapi.NaElement('peer-addresses')
         if cluster == 'source':
-            server, peer_address = self.server, self.parameters['dest_intercluster_lif']
+            server, peer_address = self.server, self.parameters['dest_intercluster_lifs']
         else:
-            server, peer_address = self.dest_server, self.parameters['source_intercluster_lif']
-        peer_addresses.add_new_child('remote-inet-address', peer_address)
+            server, peer_address = self.dest_server, self.parameters['source_intercluster_lifs']
+        for each in peer_address:
+            peer_addresses.add_new_child('remote-inet-address', each)
         cluster_peer_create.add_child_elem(peer_addresses)
         try:
             server.invoke_successfully(cluster_peer_create, enable_tunneling=True)

--- a/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
@@ -7,43 +7,40 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
-                    'supported_by': 'community'}
+                    'supported_by': 'certified'}
 
 
 DOCUMENTATION = '''
 author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
-  - Create/Delete cluster peer relations on ONTAP
+  - Create/Delete vserver peer
 extends_documentation_fragment:
   - netapp.na_ontap
-module: na_ontap_cluster_peer
+module: na_ontap_vserver_peer
 options:
   state:
     choices: ['present', 'absent']
     description:
-      - Whether the specified cluster peer should exist or not.
+      - Whether the specified vserver peer should exist or not.
     default: present
-  source_intercluster_lifs:
+  vserver:
     description:
-      - Intercluster addresses of the source cluster.
-      - Used as peer-addresses in destination cluster.
-  dest_intercluster_lifs:
+      - Specifies name of the source Vserver in the relationship.
+  applications:
+    choices: ['snapmirror', 'file_copy', 'lun_copy']
     description:
-      - Intercluster addresses of the destination cluster.
-      - Used as peer-addresses in source cluster.
-  passphrase:
+      - List of applications which can make use of the peering relationship.
+  peer_vserver:
     description:
-      - The arbitrary passphrase that matches the one given to the peer cluster.
-  source_cluster_name:
+      - Specifies name of the peer Vserver in the relationship.
+  peer_cluster:
     description:
-      - The name of the source cluster name in the peer relation to be deleted.
-  dest_cluster_name:
-    description:
-      - The name of the destination cluster name in the peer relation to be deleted.
+      - Specifies name of the peer Cluster.
+      - If peer Cluster is not given, it considers local Cluster.
   dest_hostname:
     description:
-      - Destination cluster IP or hostname which needs to be peered.
-    required: True
+     - Destination hostname or IP address.
+     - Required for creating the vserver peer relationship
   dest_username:
     description:
      - Destination username.
@@ -52,32 +49,30 @@ options:
     description:
      - Destination password.
      - Optional if this is same as source password.
-short_description: NetApp ONTAP Manage Cluster peering
+short_description: NetApp ONTAP Vserver peering
 version_added: "2.7"
 '''
 
 EXAMPLES = """
-
-    - name: Create cluster peer
-      na_ontap_cluster_peer:
+    - name: Source vserver peer create
+      na_ontap_vserver_peer:
         state: present
-        source_intercluster_lifs: 1.2.3.4,1.2.3.5
-        dest_intercluster_lifs: 1.2.3.6,1.2.3.7
-        passphrase: XXXX
+        peer_vserver: ansible2
+        peer_cluster: ansibleCluster
+        vserver: ansible
+        applications: snapmirror
         hostname: "{{ netapp_hostname }}"
         username: "{{ netapp_username }}"
         password: "{{ netapp_password }}"
-        dest_hostname: "{{ dest_netapp_hostname }}"
-
-    - name: Delete cluster peer
-      na_ontap_cluster_peer:
+        dest_hostname: "{{ netapp_dest_hostname }}"
+    - name: vserver peer delete
+      na_ontap_vserver_peer:
         state: absent
-        source_cluster_name: test-source-cluster
-        dest_cluster_name: test-dest-cluster
+        peer_vserver: ansible2
+        vserver: ansible
         hostname: "{{ netapp_hostname }}"
         username: "{{ netapp_username }}"
         password: "{{ netapp_password }}"
-        dest_hostname: "{{ dest_netapp_hostname }}"
 """
 
 RETURN = """
@@ -92,9 +87,9 @@ from ansible.module_utils.netapp_module import NetAppModule
 HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()
 
 
-class NetAppONTAPClusterPeer(object):
+class NetAppONTAPVserverPeer(object):
     """
-    Class with cluster peer methods
+    Class with vserver peer methods
     """
 
     def __init__(self):
@@ -102,20 +97,20 @@ class NetAppONTAPClusterPeer(object):
         self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
-            source_intercluster_lifs=dict(required=False, type='list'),
-            dest_intercluster_lifs=dict(required=False, type='list'),
-            passphrase=dict(required=False, type='str', no_log=True),
-            dest_hostname=dict(required=True, type='str'),
+            vserver=dict(required=True, type='str'),
+            peer_vserver=dict(required=True, type='str'),
+            peer_cluster=dict(required=False, type='str'),
+            applications=dict(required=False, type='list', choices=['snapmirror', 'file_copy', 'lun_copy']),
+            dest_hostname=dict(required=False, type='str'),
             dest_username=dict(required=False, type='str'),
-            dest_password=dict(required=False, type='str', no_log=True),
-            source_cluster_name=dict(required=False, type='str'),
-            dest_cluster_name=dict(required=False, type='str')
+            dest_password=dict(required=False, type='str', no_log=True)
         ))
 
         self.module = AnsibleModule(
             argument_spec=self.argument_spec,
-            required_together=[['source_intercluster_lifs', 'dest_intercluster_lifs', 'passphrase']],
-            required_if=[('state', 'absent', ['source_cluster_name', 'dest_cluster_name'])],
+            required_if=[
+                ('state', 'present', ['dest_hostname'])
+            ],
             supports_check_mode=True
         )
 
@@ -126,143 +121,139 @@ class NetAppONTAPClusterPeer(object):
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
             self.server = netapp_utils.setup_ontap_zapi(module=self.module)
-            # set destination server connection
-            self.module.params['hostname'] = self.parameters['dest_hostname']
-            if self.parameters.get('dest_username'):
-                self.module.params['username'] = self.parameters['dest_username']
-            if self.parameters.get('dest_password'):
-                self.module.params['password'] = self.parameters['dest_password']
-            self.dest_server = netapp_utils.setup_na_ontap_zapi(module=self.module)
+            if self.parameters.get('dest_hostname'):
+                self.module.params['hostname'] = self.parameters['dest_hostname']
+                if self.parameters.get('dest_username'):
+                    self.module.params['username'] = self.parameters['dest_username']
+                if self.parameters.get('dest_password'):
+                    self.module.params['password'] = self.parameters['dest_password']
+                self.dest_server = netapp_utils.setup_na_ontap_zapi(module=self.module)
 
-    def cluster_peer_get_iter(self, cluster):
+    def vserver_peer_get_iter(self):
         """
-        Compose NaElement object to query current source cluster using peer-cluster-name and peer-addresses parameters
-        :param cluster: type of cluster (source or destination)
-        :return: NaElement object for cluster-get-iter with query
+        Compose NaElement object to query current vserver using peer-vserver and vserver parameters
+        :return: NaElement object for vserver-get-iter with query
         """
-        cluster_peer_get = netapp_utils.zapi.NaElement('cluster-peer-get-iter')
+        vserver_peer_get = netapp_utils.zapi.NaElement('vserver-peer-get-iter')
         query = netapp_utils.zapi.NaElement('query')
-        cluster_peer_info = netapp_utils.zapi.NaElement('cluster-peer-info')
-        if cluster == 'source':
-            peer_lifs, peer_cluster = 'dest_intercluster_lifs', 'dest_cluster_name'
-        else:
-            peer_lifs, peer_cluster = 'source_intercluster_lifs', 'source_cluster_name'
-        if self.parameters.get(peer_lifs):
-            peer_addresses = netapp_utils.zapi.NaElement('peer-addresses')
-            for peer in self.parameters.get(peer_lifs):
-                peer_addresses.add_new_child('remote-inet-address', peer)
-            cluster_peer_info.add_child_elem(peer_addresses)
-        if self.parameters.get(peer_cluster):
-            cluster_peer_info.add_new_child('cluster-name', self.parameters[peer_cluster])
-        query.add_child_elem(cluster_peer_info)
-        cluster_peer_get.add_child_elem(query)
-        return cluster_peer_get
+        vserver_peer_info = netapp_utils.zapi.NaElement('vserver-peer-info')
+        vserver_peer_info.add_new_child('peer-vserver', self.parameters['peer_vserver'])
+        vserver_peer_info.add_new_child('vserver', self.parameters['vserver'])
+        query.add_child_elem(vserver_peer_info)
+        vserver_peer_get.add_child_elem(query)
+        return vserver_peer_get
 
-    def cluster_peer_get(self, cluster):
+    def vserver_peer_get(self):
         """
-        Get current cluster peer info
-        :param cluster: type of cluster (source or destination)
-        :return: Dictionary of current cluster peer details if query successful, else return None
+        Get current vserver peer info
+        :return: Dictionary of current vserver peer details if query successful, else return None
         """
-        cluster_peer_get_iter = self.cluster_peer_get_iter(cluster)
-        cluster_info = dict()
-        if cluster == 'source':
-            server = self.server
-        else:
-            server = self.dest_server
+        vserver_peer_get_iter = self.vserver_peer_get_iter()
+        vserver_info = dict()
         try:
-            result = server.invoke_successfully(cluster_peer_get_iter, enable_tunneling=True)
+            result = self.server.invoke_successfully(vserver_peer_get_iter, enable_tunneling=True)
         except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error fetching cluster peer %s: %s'
-                                      % (self.parameters['dest_cluster_name'], to_native(error)),
+            self.module.fail_json(msg='Error fetching vserver peer %s: %s'
+                                      % (self.parameters['vserver'], to_native(error)),
                                   exception=traceback.format_exc())
-        # return cluster peer details
+        # return vserver peer details
         if result.get_child_by_name('num-records') and \
-                int(result.get_child_content('num-records')) >= 1:
-            cluster_peer_info = result.get_child_by_name('attributes-list').get_child_by_name('cluster-peer-info')
-            cluster_info['cluster_name'] = cluster_peer_info.get_child_content('cluster-name')
-            peers = cluster_peer_info.get_child_by_name('peer-addresses')
-            cluster_info['peer-addresses'] = [peer.get_content() for peer in peers.get_children()]
-            return cluster_info
+                int(result.get_child_content('num-records')) > 0:
+            vserver_peer_info = result.get_child_by_name('attributes-list').get_child_by_name('vserver-peer-info')
+            vserver_info['peer_vserver'] = vserver_peer_info.get_child_content('peer-vserver')
+            vserver_info['vserver'] = vserver_peer_info.get_child_content('vserver')
+            vserver_info['peer_state'] = vserver_peer_info.get_child_content('peer-state')
+            return vserver_info
         return None
 
-    def cluster_peer_delete(self, cluster):
+    def vserver_peer_delete(self):
         """
-        Delete a cluster peer on source or destination
-        For source cluster, peer cluster-name = destination cluster name and vice-versa
-        :param cluster: type of cluster (source or destination)
-        :return:
+        Delete a vserver peer
         """
-        if cluster == 'source':
-            server, peer_cluster_name = self.server, self.parameters['dest_cluster_name']
-        else:
-            server, peer_cluster_name = self.dest_server, self.parameters['source_cluster_name']
-        cluster_peer_delete = netapp_utils.zapi.NaElement.create_node_with_children(
-            'cluster-peer-delete', **{'cluster-name': peer_cluster_name})
+        vserver_peer_delete = netapp_utils.zapi.NaElement.create_node_with_children(
+            'vserver-peer-delete', **{'peer-vserver': self.parameters['peer_vserver'],
+                                      'vserver': self.parameters['vserver']})
         try:
-            server.invoke_successfully(cluster_peer_delete, enable_tunneling=True)
+            self.server.invoke_successfully(vserver_peer_delete,
+                                            enable_tunneling=True)
         except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error deleting cluster peer %s: %s'
-                                      % (peer_cluster_name, to_native(error)),
+            self.module.fail_json(msg='Error deleting vserver peer %s: %s'
+                                      % (self.parameters['vserver'], to_native(error)),
                                   exception=traceback.format_exc())
 
-    def cluster_peer_create(self, cluster):
+    def get_peer_cluster_name(self):
         """
-        Create a cluster peer on source or destination
-        For source cluster, peer addresses = destination inter-cluster LIFs and vice-versa
-        :param cluster: type of cluster (source or destination)
-        :return: None
+        Get local cluster name
+        :return: cluster name
         """
-        cluster_peer_create = netapp_utils.zapi.NaElement.create_node_with_children(
-            'cluster-peer-create', **{'passphrase': self.parameters['passphrase']})
-        peer_addresses = netapp_utils.zapi.NaElement('peer-addresses')
-        if cluster == 'source':
-            server, peer_address = self.server, self.parameters['dest_intercluster_lifs']
-        else:
-            server, peer_address = self.dest_server, self.parameters['source_intercluster_lifs']
-        for each in peer_address:
-            peer_addresses.add_new_child('remote-inet-address', each)
-        cluster_peer_create.add_child_elem(peer_addresses)
+        cluster_info = netapp_utils.zapi.NaElement('cluster-identity-get')
         try:
-            server.invoke_successfully(cluster_peer_create, enable_tunneling=True)
+            result = self.server.invoke_successfully(cluster_info, enable_tunneling=True)
+            return result.get_child_by_name('attributes').get_child_by_name(
+                'cluster-identity-info').get_child_content('cluster-name')
         except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error creating cluster peer %s: %s'
-                                  % (peer_address, to_native(error)),
+            self.module.fail_json(msg='Error fetching peer cluster name for peer vserver %s: %s'
+                                      % (self.parameters['peer_vserver'], to_native(error)),
+                                  exception=traceback.format_exc())
+
+    def vserver_peer_create(self):
+        """
+        Create a vserver peer
+        """
+        if self.parameters.get('applications') is None:
+            self.module.fail_json(msg='applications parameter is missing')
+        if self.parameters.get('peer_cluster') is None:
+            self.parameters['peer_cluster'] = self.get_peer_cluster_name()
+        vserver_peer_create = netapp_utils.zapi.NaElement.create_node_with_children(
+            'vserver-peer-create', **{'peer-vserver': self.parameters['peer_vserver'],
+                                      'vserver': self.parameters['vserver'],
+                                      'peer-cluster': self.parameters['peer_cluster']})
+        applications = netapp_utils.zapi.NaElement('applications')
+        for application in self.parameters['applications']:
+            applications.add_new_child('vserver-peer-application', application)
+        vserver_peer_create.add_child_elem(applications)
+        try:
+            self.server.invoke_successfully(vserver_peer_create,
+                                            enable_tunneling=True)
+        except netapp_utils.zapi.NaApiError as error:
+            self.module.fail_json(msg='Error creating vserver peer %s: %s'
+                                      % (self.parameters['vserver'], to_native(error)),
+                                  exception=traceback.format_exc())
+
+    def vserver_peer_accept(self):
+        """
+        Accept a vserver peer at destination
+        """
+        # peer-vserver -> remote (source vserver is provided)
+        # vserver -> local (destination vserver is provided)
+        vserver_peer_accept = netapp_utils.zapi.NaElement.create_node_with_children(
+            'vserver-peer-accept', **{'peer-vserver': self.parameters['vserver'],
+                                      'vserver': self.parameters['peer_vserver']})
+        try:
+            self.dest_server.invoke_successfully(vserver_peer_accept, enable_tunneling=True)
+        except netapp_utils.zapi.NaApiError as error:
+            self.module.fail_json(msg='Error accepting vserver peer %s: %s'
+                                      % (self.parameters['peer_vserver'], to_native(error)),
                                   exception=traceback.format_exc())
 
     def apply(self):
         """
-        Apply action to cluster peer
-        :return: None
+        Apply action to create/delete or accept vserver peer
         """
-        source = self.cluster_peer_get('source')
-        destination = self.cluster_peer_get('destination')
-        source_action = self.na_helper.get_cd_action(source, self.parameters)
-        destination_action = self.na_helper.get_cd_action(destination, self.parameters)
-        self.na_helper.changed = False
-        # create only if expected cluster peer relation is not present on both source and destination clusters
-        if source_action == 'create' and destination_action == 'create':
-            self.cluster_peer_create('source')
-            self.cluster_peer_create('destination')
-            self.na_helper.changed = True
-        # delete peer relation in cluster where relation is present
-        else:
-            if source_action == 'delete':
-                self.cluster_peer_delete('source')
-                self.na_helper.changed = True
-            if destination_action == 'delete':
-                self.cluster_peer_delete('destination')
-                self.na_helper.changed = True
+        current = self.vserver_peer_get()
+        cd_action = self.na_helper.get_cd_action(current, self.parameters)
+        if cd_action == 'create':
+            self.vserver_peer_create()
+            self.vserver_peer_accept()
+        elif cd_action == 'delete':
+            self.vserver_peer_delete()
 
         self.module.exit_json(changed=self.na_helper.changed)
 
 
 def main():
-    """
-    Execute action
-    :return: None
-    """
-    community_obj = NetAppONTAPClusterPeer()
+    """Execute action"""
+    community_obj = NetAppONTAPVserverPeer()
     community_obj.apply()
 
 

--- a/lib/ansible/modules/storage/netapp/na_ontap_net_vlan.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_net_vlan.py
@@ -8,13 +8,13 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
-                    'supported_by': 'certified'}
+                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 module: na_ontap_net_vlan
 short_description: NetApp ONTAP network VLAN
 extends_documentation_fragment:
-    - netapp.ontap
+    - netapp.na_ontap
 version_added: '2.6'
 author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
@@ -71,7 +71,7 @@ class NetAppOntapVlan(object):
         """
         Initializes the NetAppOntapVlan function
         """
-        self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
+        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, choices=['present', 'absent'], default='present'),
             parent_interface=dict(required=True, type='str'),
@@ -95,7 +95,7 @@ class NetAppOntapVlan(object):
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
-            self.server = netapp_utils.setup_ontap_zapi(module=self.module)
+            self.server = netapp_utils.setup_na_ontap_zapi(module=self.module)
         return
 
     def create_vlan(self):
@@ -154,7 +154,7 @@ class NetAppOntapVlan(object):
         changed = False
         result = None
         results = netapp_utils.get_cserver(self.server)
-        cserver = netapp_utils.setup_ontap_zapi(module=self.module, vserver=results)
+        cserver = netapp_utils.setup_na_ontap_zapi(module=self.module, vserver=results)
         netapp_utils.ems_log_event("na_ontap_net_vlan", cserver)
         existing_vlan = self.does_vlan_exist()
         if existing_vlan:

--- a/lib/ansible/modules/storage/netapp/na_ontap_net_vlan.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_net_vlan.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
-                    'supported_by': 'community'}
+                    'supported_by': 'certified'}
 
 DOCUMENTATION = '''
 module: na_ontap_net_vlan

--- a/lib/ansible/modules/storage/netapp/na_ontap_snapmirror.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_snapmirror.py
@@ -15,7 +15,7 @@ author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
   - Create/Delete/Initialize/Modify SnapMirror volume/vserver relationships
 extends_documentation_fragment:
-  - netapp.ontap
+  - netapp.na_ontap
 module: na_ontap_snapmirror
 options:
   state:
@@ -124,7 +124,7 @@ class NetAppONTAPSnapmirror(object):
 
     def __init__(self):
 
-        self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
+        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
             source_vserver=dict(required=False, type='str'),
@@ -159,7 +159,7 @@ class NetAppONTAPSnapmirror(object):
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
-            self.server = netapp_utils.setup_ontap_zapi(module=self.module)
+            self.server = netapp_utils.setup_na_ontap_zapi(module=self.module)
 
     def snapmirror_get_iter(self):
         """

--- a/lib/ansible/modules/storage/netapp/na_ontap_software_update.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_software_update.py
@@ -15,7 +15,7 @@ author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
   - Update ONTAP software
 extends_documentation_fragment:
-  - netapp.ontap
+  - netapp.na_ontap
 module: na_ontap_software_update
 options:
   state:
@@ -77,7 +77,7 @@ class NetAppONTAPSoftwareUpdate(object):
 
     def __init__(self):
 
-        self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
+        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
             node=dict(required=False, type='list'),
@@ -97,7 +97,7 @@ class NetAppONTAPSoftwareUpdate(object):
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
-            self.server = netapp_utils.setup_ontap_zapi(module=self.module)
+            self.server = netapp_utils.setup_na_ontap_zapi(module=self.module)
 
     def cluster_image_get_iter(self):
         """

--- a/lib/ansible/modules/storage/netapp/na_ontap_vserver_peer.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_vserver_peer.py
@@ -259,4 +259,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/storage/netapp/na_ontap_vserver_peer.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_vserver_peer.py
@@ -15,7 +15,7 @@ author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
   - Create/Delete vserver peer
 extends_documentation_fragment:
-  - netapp.ontap
+  - netapp.na_ontap
 module: na_ontap_vserver_peer
 options:
   state:
@@ -94,7 +94,7 @@ class NetAppONTAPVserverPeer(object):
 
     def __init__(self):
 
-        self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
+        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
             vserver=dict(required=True, type='str'),
@@ -120,14 +120,14 @@ class NetAppONTAPVserverPeer(object):
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
-            self.server = netapp_utils.setup_ontap_zapi(module=self.module)
+            self.server = netapp_utils.setup_na_ontap_zapi(module=self.module)
             if self.parameters.get('dest_hostname'):
                 self.module.params['hostname'] = self.parameters['dest_hostname']
                 if self.parameters.get('dest_username'):
                     self.module.params['username'] = self.parameters['dest_username']
                 if self.parameters.get('dest_password'):
                     self.module.params['password'] = self.parameters['dest_password']
-                self.dest_server = netapp_utils.setup_ontap_zapi(module=self.module)
+                self.dest_server = netapp_utils.setup_na_ontap_zapi(module=self.module)
 
     def vserver_peer_get_iter(self):
         """

--- a/lib/ansible/modules/storage/netapp/na_ontap_vserver_peer.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_vserver_peer.py
@@ -13,37 +13,34 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
-  - Create/Delete cluster peer relations on ONTAP
+  - Create/Delete vserver peer
 extends_documentation_fragment:
   - netapp.ontap
-module: na_ontap_cluster_peer
+module: na_ontap_vserver_peer
 options:
   state:
     choices: ['present', 'absent']
     description:
-      - Whether the specified cluster peer should exist or not.
+      - Whether the specified vserver peer should exist or not.
     default: present
-  source_intercluster_lif:
+  vserver:
     description:
-      - Intercluster address of the source cluster.
-      - Used as peer-address in destination cluster.
-  dest_intercluster_lif:
+      - Specifies name of the source Vserver in the relationship.
+  applications:
+    choices: ['snapmirror', 'file_copy', 'lun_copy']
     description:
-      - Intercluster address of the destination cluster.
-      - Used as peer-address in source cluster.
-  passphrase:
+      - List of applications which can make use of the peering relationship.
+  peer_vserver:
     description:
-      - The arbitrary passphrase that matches the one given to the peer cluster.
-  source_cluster_name:
+      - Specifies name of the peer Vserver in the relationship.
+  peer_cluster:
     description:
-      - The name of the source cluster name in the peer relation to be deleted.
-  dest_cluster_name:
-    description:
-      - The name of the destination cluster name in the peer relation to be deleted.
+      - Specifies name of the peer Cluster.
+      - If peer Cluster is not given, it considers local Cluster.
   dest_hostname:
     description:
-      - Destination cluster IP or hostname which needs to be peered.
-    required: True
+     - Destination hostname or IP address.
+     - Required for creating the vserver peer relationship
   dest_username:
     description:
      - Destination username.
@@ -52,30 +49,30 @@ options:
     description:
      - Destination password.
      - Optional if this is same as source password.
-short_description: NetApp ONTAP Manage Cluster peering
+short_description: NetApp ONTAP Vserver peering
 version_added: "2.7"
 '''
 
 EXAMPLES = """
-    - name: Create cluster peer
-      na_ontap_cluster_peer:
+    - name: Source vserver peer create
+      na_ontap_vserver_peer:
         state: present
-        source_intercluster_lif: 1.2.3.4
-        dest_intercluster_lif: 5.6.7.8
-        passphrase: XXXX
+        peer_vserver: ansible2
+        peer_cluster: ansibleCluster
+        vserver: ansible
+        applications: snapmirror
         hostname: "{{ netapp_hostname }}"
         username: "{{ netapp_username }}"
         password: "{{ netapp_password }}"
-        dest_hostname: "{{ dest_netapp_hostname }}"
-    - name: Delete cluster peer
-      na_ontap_cluster_peer:
+        dest_hostname: "{{ netapp_dest_hostname }}"
+    - name: vserver peer delete
+      na_ontap_vserver_peer:
         state: absent
-        source_cluster_name: test-source-cluster
-        dest_cluster_name: test-dest-cluster
+        peer_vserver: ansible2
+        vserver: ansible
         hostname: "{{ netapp_hostname }}"
         username: "{{ netapp_username }}"
         password: "{{ netapp_password }}"
-        dest_hostname: "{{ dest_netapp_hostname }}"
 """
 
 RETURN = """
@@ -90,9 +87,9 @@ from ansible.module_utils.netapp_module import NetAppModule
 HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()
 
 
-class NetAppONTAPClusterPeer(object):
+class NetAppONTAPVserverPeer(object):
     """
-    Class with cluster peer methods
+    Class with vserver peer methods
     """
 
     def __init__(self):
@@ -100,20 +97,20 @@ class NetAppONTAPClusterPeer(object):
         self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
-            source_intercluster_lif=dict(required=False, type='str'),
-            dest_intercluster_lif=dict(required=False, type='str'),
-            passphrase=dict(required=False, type='str', no_log=True),
-            dest_hostname=dict(required=True, type='str'),
+            vserver=dict(required=True, type='str'),
+            peer_vserver=dict(required=True, type='str'),
+            peer_cluster=dict(required=False, type='str'),
+            applications=dict(required=False, type='list', choices=['snapmirror', 'file_copy', 'lun_copy']),
+            dest_hostname=dict(required=False, type='str'),
             dest_username=dict(required=False, type='str'),
-            dest_password=dict(required=False, type='str', no_log=True),
-            source_cluster_name=dict(required=False, type='str'),
-            dest_cluster_name=dict(required=False, type='str')
+            dest_password=dict(required=False, type='str', no_log=True)
         ))
 
         self.module = AnsibleModule(
             argument_spec=self.argument_spec,
-            required_together=[['source_intercluster_lif', 'dest_intercluster_lif', 'passphrase']],
-            required_if=[('state', 'absent', ['source_cluster_name', 'dest_cluster_name'])],
+            required_if=[
+                ('state', 'present', ['dest_hostname'])
+            ],
             supports_check_mode=True
         )
 
@@ -124,141 +121,139 @@ class NetAppONTAPClusterPeer(object):
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
             self.server = netapp_utils.setup_ontap_zapi(module=self.module)
-            # set destination server connection
-            self.module.params['hostname'] = self.parameters['dest_hostname']
-            if self.parameters.get('dest_username'):
-                self.module.params['username'] = self.parameters['dest_username']
-            if self.parameters.get('dest_password'):
-                self.module.params['password'] = self.parameters['dest_password']
-            self.dest_server = netapp_utils.setup_ontap_zapi(module=self.module)
+            if self.parameters.get('dest_hostname'):
+                self.module.params['hostname'] = self.parameters['dest_hostname']
+                if self.parameters.get('dest_username'):
+                    self.module.params['username'] = self.parameters['dest_username']
+                if self.parameters.get('dest_password'):
+                    self.module.params['password'] = self.parameters['dest_password']
+                self.dest_server = netapp_utils.setup_ontap_zapi(module=self.module)
 
-    def cluster_peer_get_iter(self, cluster):
+    def vserver_peer_get_iter(self):
         """
-        Compose NaElement object to query current source cluster using peer-cluster-name and peer-addresses parameters
-        :param cluster: type of cluster (source or destination)
-        :return: NaElement object for cluster-get-iter with query
+        Compose NaElement object to query current vserver using peer-vserver and vserver parameters
+        :return: NaElement object for vserver-get-iter with query
         """
-        cluster_peer_get = netapp_utils.zapi.NaElement('cluster-peer-get-iter')
+        vserver_peer_get = netapp_utils.zapi.NaElement('vserver-peer-get-iter')
         query = netapp_utils.zapi.NaElement('query')
-        cluster_peer_info = netapp_utils.zapi.NaElement('cluster-peer-info')
-        if cluster == 'source':
-            peer_lif, peer_cluster = 'dest_intercluster_lif', 'dest_cluster_name'
-        else:
-            peer_lif, peer_cluster = 'source_intercluster_lif', 'source_cluster_name'
-        peer_addresses = netapp_utils.zapi.NaElement('peer-addresses')
-        if self.parameters.get(peer_lif):
-            peer_addresses.add_new_child('remote-inet-address', self.parameters[peer_lif])
-            cluster_peer_info.add_child_elem(peer_addresses)
-        if self.parameters.get(peer_cluster):
-            cluster_peer_info.add_new_child('cluster-name', self.parameters[peer_cluster])
-        query.add_child_elem(cluster_peer_info)
-        cluster_peer_get.add_child_elem(query)
-        return cluster_peer_get
+        vserver_peer_info = netapp_utils.zapi.NaElement('vserver-peer-info')
+        vserver_peer_info.add_new_child('peer-vserver', self.parameters['peer_vserver'])
+        vserver_peer_info.add_new_child('vserver', self.parameters['vserver'])
+        query.add_child_elem(vserver_peer_info)
+        vserver_peer_get.add_child_elem(query)
+        return vserver_peer_get
 
-    def cluster_peer_get(self, cluster):
+    def vserver_peer_get(self):
         """
-        Get current cluster peer info
-        :param cluster: type of cluster (source or destination)
-        :return: Dictionary of current cluster peer details if query successful, else return None
+        Get current vserver peer info
+        :return: Dictionary of current vserver peer details if query successful, else return None
         """
-        cluster_peer_get_iter = self.cluster_peer_get_iter(cluster)
-        cluster_info = dict()
-        if cluster == 'source':
-            server = self.server
-        else:
-            server = self.dest_server
+        vserver_peer_get_iter = self.vserver_peer_get_iter()
+        vserver_info = dict()
         try:
-            result = server.invoke_successfully(cluster_peer_get_iter, enable_tunneling=True)
+            result = self.server.invoke_successfully(vserver_peer_get_iter, enable_tunneling=True)
         except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error fetching cluster peer %s: %s'
-                                      % (self.parameters['dest_cluster_name'], to_native(error)),
+            self.module.fail_json(msg='Error fetching vserver peer %s: %s'
+                                      % (self.parameters['vserver'], to_native(error)),
                                   exception=traceback.format_exc())
-        # return cluster peer details
+        # return vserver peer details
         if result.get_child_by_name('num-records') and \
-                int(result.get_child_content('num-records')) >= 1:
-            cluster_peer_info = result.get_child_by_name('attributes-list').get_child_by_name('cluster-peer-info')
-            cluster_info['cluster_name'] = cluster_peer_info.get_child_content('cluster-name')
-            peers = cluster_peer_info.get_child_by_name('peer-addresses')
-            cluster_info['peer-addresses'] = [peer.get_content() for peer in peers.get_children()]
-            return cluster_info
+                int(result.get_child_content('num-records')) > 0:
+            vserver_peer_info = result.get_child_by_name('attributes-list').get_child_by_name('vserver-peer-info')
+            vserver_info['peer_vserver'] = vserver_peer_info.get_child_content('peer-vserver')
+            vserver_info['vserver'] = vserver_peer_info.get_child_content('vserver')
+            vserver_info['peer_state'] = vserver_peer_info.get_child_content('peer-state')
+            return vserver_info
         return None
 
-    def cluster_peer_delete(self, cluster):
+    def vserver_peer_delete(self):
         """
-        Delete a cluster peer on source or destination
-        For source cluster, peer cluster-name = destination cluster name and vice-versa
-        :param cluster: type of cluster (source or destination)
-        :return:
+        Delete a vserver peer
         """
-        if cluster == 'source':
-            server, peer_cluster_name = self.server, self.parameters['dest_cluster_name']
-        else:
-            server, peer_cluster_name = self.dest_server, self.parameters['source_cluster_name']
-        cluster_peer_delete = netapp_utils.zapi.NaElement.create_node_with_children(
-            'cluster-peer-delete', **{'cluster-name': peer_cluster_name})
+        vserver_peer_delete = netapp_utils.zapi.NaElement.create_node_with_children(
+            'vserver-peer-delete', **{'peer-vserver': self.parameters['peer_vserver'],
+                                      'vserver': self.parameters['vserver']})
         try:
-            server.invoke_successfully(cluster_peer_delete, enable_tunneling=True)
+            self.server.invoke_successfully(vserver_peer_delete,
+                                            enable_tunneling=True)
         except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error deleting cluster peer %s: %s'
-                                      % (peer_cluster_name, to_native(error)),
+            self.module.fail_json(msg='Error deleting vserver peer %s: %s'
+                                      % (self.parameters['vserver'], to_native(error)),
                                   exception=traceback.format_exc())
 
-    def cluster_peer_create(self, cluster):
+    def get_peer_cluster_name(self):
         """
-        Create a cluster peer on source or destination
-        For source cluster, peer address = destination inter-cluster LIF and vice-versa
-        :param cluster: type of cluster (source or destination)
-        :return: None
+        Get local cluster name
+        :return: cluster name
         """
-        cluster_peer_create = netapp_utils.zapi.NaElement.create_node_with_children(
-            'cluster-peer-create', **{'passphrase': self.parameters['passphrase']})
-        peer_addresses = netapp_utils.zapi.NaElement('peer-addresses')
-        if cluster == 'source':
-            server, peer_address = self.server, self.parameters['dest_intercluster_lif']
-        else:
-            server, peer_address = self.dest_server, self.parameters['source_intercluster_lif']
-        peer_addresses.add_new_child('remote-inet-address', peer_address)
-        cluster_peer_create.add_child_elem(peer_addresses)
+        cluster_info = netapp_utils.zapi.NaElement('cluster-identity-get')
         try:
-            server.invoke_successfully(cluster_peer_create, enable_tunneling=True)
+            result = self.server.invoke_successfully(cluster_info, enable_tunneling=True)
+            return result.get_child_by_name('attributes').get_child_by_name(
+                'cluster-identity-info').get_child_content('cluster-name')
         except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error creating cluster peer %s: %s'
-                                  % (peer_address, to_native(error)),
+            self.module.fail_json(msg='Error fetching peer cluster name for peer vserver %s: %s'
+                                      % (self.parameters['peer_vserver'], to_native(error)),
+                                  exception=traceback.format_exc())
+
+    def vserver_peer_create(self):
+        """
+        Create a vserver peer
+        """
+        if self.parameters.get('applications') is None:
+            self.module.fail_json(msg='applications parameter is missing')
+        if self.parameters.get('peer_cluster') is None:
+            self.parameters['peer_cluster'] = self.get_peer_cluster_name()
+        vserver_peer_create = netapp_utils.zapi.NaElement.create_node_with_children(
+            'vserver-peer-create', **{'peer-vserver': self.parameters['peer_vserver'],
+                                      'vserver': self.parameters['vserver'],
+                                      'peer-cluster': self.parameters['peer_cluster']})
+        applications = netapp_utils.zapi.NaElement('applications')
+        for application in self.parameters['applications']:
+            applications.add_new_child('vserver-peer-application', application)
+        vserver_peer_create.add_child_elem(applications)
+        try:
+            self.server.invoke_successfully(vserver_peer_create,
+                                            enable_tunneling=True)
+        except netapp_utils.zapi.NaApiError as error:
+            self.module.fail_json(msg='Error creating vserver peer %s: %s'
+                                      % (self.parameters['vserver'], to_native(error)),
+                                  exception=traceback.format_exc())
+
+    def vserver_peer_accept(self):
+        """
+        Accept a vserver peer at destination
+        """
+        # peer-vserver -> remote (source vserver is provided)
+        # vserver -> local (destination vserver is provided)
+        vserver_peer_accept = netapp_utils.zapi.NaElement.create_node_with_children(
+            'vserver-peer-accept', **{'peer-vserver': self.parameters['vserver'],
+                                      'vserver': self.parameters['peer_vserver']})
+        try:
+            self.dest_server.invoke_successfully(vserver_peer_accept, enable_tunneling=True)
+        except netapp_utils.zapi.NaApiError as error:
+            self.module.fail_json(msg='Error accepting vserver peer %s: %s'
+                                      % (self.parameters['peer_vserver'], to_native(error)),
                                   exception=traceback.format_exc())
 
     def apply(self):
         """
-        Apply action to cluster peer
-        :return: None
+        Apply action to create/delete or accept vserver peer
         """
-        source = self.cluster_peer_get('source')
-        destination = self.cluster_peer_get('destination')
-        source_action = self.na_helper.get_cd_action(source, self.parameters)
-        destination_action = self.na_helper.get_cd_action(destination, self.parameters)
-        self.na_helper.changed = False
-        # create only if expected cluster peer relation is not present on both source and destination clusters
-        if source_action == 'create' and destination_action == 'create':
-            self.cluster_peer_create('source')
-            self.cluster_peer_create('destination')
-            self.na_helper.changed = True
-        # delete peer relation in cluster where relation is present
-        else:
-            if source_action == 'delete':
-                self.cluster_peer_delete('source')
-                self.na_helper.changed = True
-            if destination_action == 'delete':
-                self.cluster_peer_delete('destination')
-                self.na_helper.changed = True
+        current = self.vserver_peer_get()
+        cd_action = self.na_helper.get_cd_action(current, self.parameters)
+        if cd_action == 'create':
+            self.vserver_peer_create()
+            self.vserver_peer_accept()
+        elif cd_action == 'delete':
+            self.vserver_peer_delete()
 
         self.module.exit_json(changed=self.na_helper.changed)
 
 
 def main():
-    """
-    Execute action
-    :return: None
-    """
-    community_obj = NetAppONTAPClusterPeer()
+    """Execute action"""
+    community_obj = NetAppONTAPVserverPeer()
     community_obj.apply()
 
 

--- a/lib/ansible/modules/storage/netapp/na_ontap_vserver_peer.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_vserver_peer.py
@@ -13,34 +13,37 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
-  - Create/Delete vserver peer
+  - Create/Delete cluster peer relations on ONTAP
 extends_documentation_fragment:
-  - netapp.na_ontap
-module: na_ontap_vserver_peer
+  - netapp.ontap
+module: na_ontap_cluster_peer
 options:
   state:
     choices: ['present', 'absent']
     description:
-      - Whether the specified vserver peer should exist or not.
+      - Whether the specified cluster peer should exist or not.
     default: present
-  vserver:
+  source_intercluster_lif:
     description:
-      - Specifies name of the source Vserver in the relationship.
-  applications:
-    choices: ['snapmirror', 'file_copy', 'lun_copy']
+      - Intercluster address of the source cluster.
+      - Used as peer-address in destination cluster.
+  dest_intercluster_lif:
     description:
-      - List of applications which can make use of the peering relationship.
-  peer_vserver:
+      - Intercluster address of the destination cluster.
+      - Used as peer-address in source cluster.
+  passphrase:
     description:
-      - Specifies name of the peer Vserver in the relationship.
-  peer_cluster:
+      - The arbitrary passphrase that matches the one given to the peer cluster.
+  source_cluster_name:
     description:
-      - Specifies name of the peer Cluster.
-      - If peer Cluster is not given, it considers local Cluster.
+      - The name of the source cluster name in the peer relation to be deleted.
+  dest_cluster_name:
+    description:
+      - The name of the destination cluster name in the peer relation to be deleted.
   dest_hostname:
     description:
-     - Destination hostname or IP address.
-     - Required for creating the vserver peer relationship
+      - Destination cluster IP or hostname which needs to be peered.
+    required: True
   dest_username:
     description:
      - Destination username.
@@ -49,32 +52,30 @@ options:
     description:
      - Destination password.
      - Optional if this is same as source password.
-short_description: NetApp ONTAP Vserver peering
+short_description: NetApp ONTAP Manage Cluster peering
 version_added: "2.7"
 '''
 
 EXAMPLES = """
-
-    - name: Source vserver peer create
-      na_ontap_vserver_peer:
+    - name: Create cluster peer
+      na_ontap_cluster_peer:
         state: present
-        peer_vserver: ansible2
-        peer_cluster: ansibleCluster
-        vserver: ansible
-        applications: snapmirror
+        source_intercluster_lif: 1.2.3.4
+        dest_intercluster_lif: 5.6.7.8
+        passphrase: XXXX
         hostname: "{{ netapp_hostname }}"
         username: "{{ netapp_username }}"
         password: "{{ netapp_password }}"
-        dest_hostname: "{{ netapp_dest_hostname }}"
-
-    - name: vserver peer delete
-      na_ontap_vserver_peer:
+        dest_hostname: "{{ dest_netapp_hostname }}"
+    - name: Delete cluster peer
+      na_ontap_cluster_peer:
         state: absent
-        peer_vserver: ansible2
-        vserver: ansible
+        source_cluster_name: test-source-cluster
+        dest_cluster_name: test-dest-cluster
         hostname: "{{ netapp_hostname }}"
         username: "{{ netapp_username }}"
         password: "{{ netapp_password }}"
+        dest_hostname: "{{ dest_netapp_hostname }}"
 """
 
 RETURN = """
@@ -89,30 +90,30 @@ from ansible.module_utils.netapp_module import NetAppModule
 HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()
 
 
-class NetAppONTAPVserverPeer(object):
+class NetAppONTAPClusterPeer(object):
     """
-    Class with vserver peer methods
+    Class with cluster peer methods
     """
 
     def __init__(self):
 
-        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
+        self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
-            vserver=dict(required=True, type='str'),
-            peer_vserver=dict(required=True, type='str'),
-            peer_cluster=dict(required=False, type='str'),
-            applications=dict(required=False, type='list', choices=['snapmirror', 'file_copy', 'lun_copy']),
-            dest_hostname=dict(required=False, type='str'),
+            source_intercluster_lif=dict(required=False, type='str'),
+            dest_intercluster_lif=dict(required=False, type='str'),
+            passphrase=dict(required=False, type='str', no_log=True),
+            dest_hostname=dict(required=True, type='str'),
             dest_username=dict(required=False, type='str'),
-            dest_password=dict(required=False, type='str', no_log=True)
+            dest_password=dict(required=False, type='str', no_log=True),
+            source_cluster_name=dict(required=False, type='str'),
+            dest_cluster_name=dict(required=False, type='str')
         ))
 
         self.module = AnsibleModule(
             argument_spec=self.argument_spec,
-            required_if=[
-                ('state', 'present', ['dest_hostname'])
-            ],
+            required_together=[['source_intercluster_lif', 'dest_intercluster_lif', 'passphrase']],
+            required_if=[('state', 'absent', ['source_cluster_name', 'dest_cluster_name'])],
             supports_check_mode=True
         )
 
@@ -123,141 +124,144 @@ class NetAppONTAPVserverPeer(object):
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
             self.server = netapp_utils.setup_ontap_zapi(module=self.module)
-            if self.parameters.get('dest_hostname'):
-                self.module.params['hostname'] = self.parameters['dest_hostname']
-                if self.parameters.get('dest_username'):
-                    self.module.params['username'] = self.parameters['dest_username']
-                if self.parameters.get('dest_password'):
-                    self.module.params['password'] = self.parameters['dest_password']
-                self.dest_server = netapp_utils.setup_na_ontap_zapi(module=self.module)
+            # set destination server connection
+            self.module.params['hostname'] = self.parameters['dest_hostname']
+            if self.parameters.get('dest_username'):
+                self.module.params['username'] = self.parameters['dest_username']
+            if self.parameters.get('dest_password'):
+                self.module.params['password'] = self.parameters['dest_password']
+            self.dest_server = netapp_utils.setup_ontap_zapi(module=self.module)
 
-    def vserver_peer_get_iter(self):
+    def cluster_peer_get_iter(self, cluster):
         """
-        Compose NaElement object to query current vserver using peer-vserver and vserver parameters
-        :return: NaElement object for vserver-get-iter with query
+        Compose NaElement object to query current source cluster using peer-cluster-name and peer-addresses parameters
+        :param cluster: type of cluster (source or destination)
+        :return: NaElement object for cluster-get-iter with query
         """
-        vserver_peer_get = netapp_utils.zapi.NaElement('vserver-peer-get-iter')
+        cluster_peer_get = netapp_utils.zapi.NaElement('cluster-peer-get-iter')
         query = netapp_utils.zapi.NaElement('query')
-        vserver_peer_info = netapp_utils.zapi.NaElement('vserver-peer-info')
-        vserver_peer_info.add_new_child('peer-vserver', self.parameters['peer_vserver'])
-        vserver_peer_info.add_new_child('vserver', self.parameters['vserver'])
-        query.add_child_elem(vserver_peer_info)
-        vserver_peer_get.add_child_elem(query)
-        return vserver_peer_get
+        cluster_peer_info = netapp_utils.zapi.NaElement('cluster-peer-info')
+        if cluster == 'source':
+            peer_lif, peer_cluster = 'dest_intercluster_lif', 'dest_cluster_name'
+        else:
+            peer_lif, peer_cluster = 'source_intercluster_lif', 'source_cluster_name'
+        peer_addresses = netapp_utils.zapi.NaElement('peer-addresses')
+        if self.parameters.get(peer_lif):
+            peer_addresses.add_new_child('remote-inet-address', self.parameters[peer_lif])
+            cluster_peer_info.add_child_elem(peer_addresses)
+        if self.parameters.get(peer_cluster):
+            cluster_peer_info.add_new_child('cluster-name', self.parameters[peer_cluster])
+        query.add_child_elem(cluster_peer_info)
+        cluster_peer_get.add_child_elem(query)
+        return cluster_peer_get
 
-    def vserver_peer_get(self):
+    def cluster_peer_get(self, cluster):
         """
-        Get current vserver peer info
-        :return: Dictionary of current vserver peer details if query successful, else return None
+        Get current cluster peer info
+        :param cluster: type of cluster (source or destination)
+        :return: Dictionary of current cluster peer details if query successful, else return None
         """
-        vserver_peer_get_iter = self.vserver_peer_get_iter()
-        vserver_info = dict()
+        cluster_peer_get_iter = self.cluster_peer_get_iter(cluster)
+        cluster_info = dict()
+        if cluster == 'source':
+            server = self.server
+        else:
+            server = self.dest_server
         try:
-            result = self.server.invoke_successfully(vserver_peer_get_iter, enable_tunneling=True)
+            result = server.invoke_successfully(cluster_peer_get_iter, enable_tunneling=True)
         except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error fetching vserver peer %s: %s'
-                                      % (self.parameters['vserver'], to_native(error)),
+            self.module.fail_json(msg='Error fetching cluster peer %s: %s'
+                                      % (self.parameters['dest_cluster_name'], to_native(error)),
                                   exception=traceback.format_exc())
-        # return vserver peer details
+        # return cluster peer details
         if result.get_child_by_name('num-records') and \
-                int(result.get_child_content('num-records')) > 0:
-            vserver_peer_info = result.get_child_by_name('attributes-list').get_child_by_name('vserver-peer-info')
-            vserver_info['peer_vserver'] = vserver_peer_info.get_child_content('peer-vserver')
-            vserver_info['vserver'] = vserver_peer_info.get_child_content('vserver')
-            vserver_info['peer_state'] = vserver_peer_info.get_child_content('peer-state')
-            return vserver_info
+                int(result.get_child_content('num-records')) >= 1:
+            cluster_peer_info = result.get_child_by_name('attributes-list').get_child_by_name('cluster-peer-info')
+            cluster_info['cluster_name'] = cluster_peer_info.get_child_content('cluster-name')
+            peers = cluster_peer_info.get_child_by_name('peer-addresses')
+            cluster_info['peer-addresses'] = [peer.get_content() for peer in peers.get_children()]
+            return cluster_info
         return None
 
-    def vserver_peer_delete(self):
+    def cluster_peer_delete(self, cluster):
         """
-        Delete a vserver peer
+        Delete a cluster peer on source or destination
+        For source cluster, peer cluster-name = destination cluster name and vice-versa
+        :param cluster: type of cluster (source or destination)
+        :return:
         """
-        vserver_peer_delete = netapp_utils.zapi.NaElement.create_node_with_children(
-            'vserver-peer-delete', **{'peer-vserver': self.parameters['peer_vserver'],
-                                      'vserver': self.parameters['vserver']})
+        if cluster == 'source':
+            server, peer_cluster_name = self.server, self.parameters['dest_cluster_name']
+        else:
+            server, peer_cluster_name = self.dest_server, self.parameters['source_cluster_name']
+        cluster_peer_delete = netapp_utils.zapi.NaElement.create_node_with_children(
+            'cluster-peer-delete', **{'cluster-name': peer_cluster_name})
         try:
-            self.server.invoke_successfully(vserver_peer_delete,
-                                            enable_tunneling=True)
+            server.invoke_successfully(cluster_peer_delete, enable_tunneling=True)
         except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error deleting vserver peer %s: %s'
-                                      % (self.parameters['vserver'], to_native(error)),
+            self.module.fail_json(msg='Error deleting cluster peer %s: %s'
+                                      % (peer_cluster_name, to_native(error)),
                                   exception=traceback.format_exc())
 
-    def get_peer_cluster_name(self):
+    def cluster_peer_create(self, cluster):
         """
-        Get local cluster name
-        :return: cluster name
+        Create a cluster peer on source or destination
+        For source cluster, peer address = destination inter-cluster LIF and vice-versa
+        :param cluster: type of cluster (source or destination)
+        :return: None
         """
-        cluster_info = netapp_utils.zapi.NaElement('cluster-identity-get')
+        cluster_peer_create = netapp_utils.zapi.NaElement.create_node_with_children(
+            'cluster-peer-create', **{'passphrase': self.parameters['passphrase']})
+        peer_addresses = netapp_utils.zapi.NaElement('peer-addresses')
+        if cluster == 'source':
+            server, peer_address = self.server, self.parameters['dest_intercluster_lif']
+        else:
+            server, peer_address = self.dest_server, self.parameters['source_intercluster_lif']
+        peer_addresses.add_new_child('remote-inet-address', peer_address)
+        cluster_peer_create.add_child_elem(peer_addresses)
         try:
-            result = self.server.invoke_successfully(cluster_info, enable_tunneling=True)
-            return result.get_child_by_name('attributes').get_child_by_name(
-                'cluster-identity-info').get_child_content('cluster-name')
+            server.invoke_successfully(cluster_peer_create, enable_tunneling=True)
         except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error fetching peer cluster name for peer vserver %s: %s'
-                                      % (self.parameters['peer_vserver'], to_native(error)),
-                                  exception=traceback.format_exc())
-
-    def vserver_peer_create(self):
-        """
-        Create a vserver peer
-        """
-        if self.parameters.get('applications') is None:
-            self.module.fail_json(msg='applications parameter is missing')
-        if self.parameters.get('peer_cluster') is None:
-            self.parameters['peer_cluster'] = self.get_peer_cluster_name()
-        vserver_peer_create = netapp_utils.zapi.NaElement.create_node_with_children(
-            'vserver-peer-create', **{'peer-vserver': self.parameters['peer_vserver'],
-                                      'vserver': self.parameters['vserver'],
-                                      'peer-cluster': self.parameters['peer_cluster']})
-        applications = netapp_utils.zapi.NaElement('applications')
-        for application in self.parameters['applications']:
-            applications.add_new_child('vserver-peer-application', application)
-        vserver_peer_create.add_child_elem(applications)
-        try:
-            self.server.invoke_successfully(vserver_peer_create,
-                                            enable_tunneling=True)
-        except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error creating vserver peer %s: %s'
-                                      % (self.parameters['vserver'], to_native(error)),
-                                  exception=traceback.format_exc())
-
-    def vserver_peer_accept(self):
-        """
-        Accept a vserver peer at destination
-        """
-        # peer-vserver -> remote (source vserver is provided)
-        # vserver -> local (destination vserver is provided)
-        vserver_peer_accept = netapp_utils.zapi.NaElement.create_node_with_children(
-            'vserver-peer-accept', **{'peer-vserver': self.parameters['vserver'],
-                                      'vserver': self.parameters['peer_vserver']})
-        try:
-            self.dest_server.invoke_successfully(vserver_peer_accept, enable_tunneling=True)
-        except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error accepting vserver peer %s: %s'
-                                      % (self.parameters['peer_vserver'], to_native(error)),
+            self.module.fail_json(msg='Error creating cluster peer %s: %s'
+                                  % (peer_address, to_native(error)),
                                   exception=traceback.format_exc())
 
     def apply(self):
         """
-        Apply action to create/delete or accept vserver peer
+        Apply action to cluster peer
+        :return: None
         """
-        current = self.vserver_peer_get()
-        cd_action = self.na_helper.get_cd_action(current, self.parameters)
-        if cd_action == 'create':
-            self.vserver_peer_create()
-            self.vserver_peer_accept()
-        elif cd_action == 'delete':
-            self.vserver_peer_delete()
+        source = self.cluster_peer_get('source')
+        destination = self.cluster_peer_get('destination')
+        source_action = self.na_helper.get_cd_action(source, self.parameters)
+        destination_action = self.na_helper.get_cd_action(destination, self.parameters)
+        self.na_helper.changed = False
+        # create only if expected cluster peer relation is not present on both source and destination clusters
+        if source_action == 'create' and destination_action == 'create':
+            self.cluster_peer_create('source')
+            self.cluster_peer_create('destination')
+            self.na_helper.changed = True
+        # delete peer relation in cluster where relation is present
+        else:
+            if source_action == 'delete':
+                self.cluster_peer_delete('source')
+                self.na_helper.changed = True
+            if destination_action == 'delete':
+                self.cluster_peer_delete('destination')
+                self.na_helper.changed = True
 
         self.module.exit_json(changed=self.na_helper.changed)
 
 
 def main():
-    """Execute action"""
-    community_obj = NetAppONTAPVserverPeer()
+    """
+    Execute action
+    :return: None
+    """
+    community_obj = NetAppONTAPClusterPeer()
     community_obj.apply()
 
 
 if __name__ == '__main__':
     main()
+

--- a/lib/ansible/modules/storage/netapp/na_ontap_vserver_peer.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_vserver_peer.py
@@ -15,7 +15,7 @@ author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
   - Create/Delete vserver peer
 extends_documentation_fragment:
-  - netapp.ontap
+  - netapp.na_ontap
 module: na_ontap_vserver_peer
 options:
   state:
@@ -96,7 +96,7 @@ class NetAppONTAPVserverPeer(object):
 
     def __init__(self):
 
-        self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
+        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
             vserver=dict(required=True, type='str'),
@@ -129,7 +129,7 @@ class NetAppONTAPVserverPeer(object):
                     self.module.params['username'] = self.parameters['dest_username']
                 if self.parameters.get('dest_password'):
                     self.module.params['password'] = self.parameters['dest_password']
-                self.dest_server = netapp_utils.setup_ontap_zapi(module=self.module)
+                self.dest_server = netapp_utils.setup_na_ontap_zapi(module=self.module)
 
     def vserver_peer_get_iter(self):
         """


### PR DESCRIPTION
##### SUMMARY
Fix argument_spec for modules that are using the old version

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
* na_ontap_cluster_peer.py
* na_ontap_net_vlan.py
* na_ontap_snapmirror.py
* na_ontap_software_update.py
* na_ontap_vserver_peer.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0.a1.post0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/jenkins/workspace/ansible-playbooks_master-G4Z7YDNWRBYEXYJXQYF7JFYEUHU5W7D3MEYPILJ5JRUED6LGLCRQ/ansible/lib/ansible
  executable location = /tmp/jenkins/workspace/ansible-playbooks_master-G4Z7YDNWRBYEXYJXQYF7JFYEUHU5W7D3MEYPILJ5JRUED6LGLCRQ/ansible/bin/ansible
  python version = 2.7.5 (default, Feb 20 2018, 09:19:12) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
