### PR TITLE
pamd: fixes for multiple issues

### DIFF
--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -277,10 +277,12 @@ from tempfile import NamedTemporaryFile
 from datetime import datetime
 
 
-RULE_REGEX = re.compile(r"""(?P<rule_type>auth|account|session|password)\s+
+RULE_REGEX = re.compile(r"""(?P<rule_type>-?(?:auth|account|session|password))\s+
                         (?P<control>\[.*\]|\S*)\s+
                         (?P<path>\S*)\s?
                         (?P<args>.*)""", re.X)
+
+VALID_TYPES = ['account', '-account', 'auth', '-auth', 'password', '-password', 'session', '-session']
 
 
 class PamdLine(object):
@@ -334,7 +336,6 @@ class PamdInclude(PamdLine):
 
 class PamdRule(PamdLine):
 
-    valid_types = ['account', 'auth', 'password', 'session']
     valid_simple_controls = ['required', 'requisite', 'sufficient', 'optional', 'include', 'substack', 'definitive']
     valid_control_values = ['success', 'open_err', 'symbol_err', 'service_err', 'system_err', 'buf_err',
                             'perm_denied', 'auth_err', 'cred_insufficient', 'authinfo_unavail', 'user_unknown',
@@ -422,7 +423,7 @@ class PamdRule(PamdLine):
 
     def validate(self):
         # Validate the rule type
-        if self.rule_type not in PamdRule.valid_types:
+        if self.rule_type not in VALID_TYPES:
             return False, "Rule type, " + self.rule_type + ", is not valid in rule " + self.line
         # Validate the rule control
         if isinstance(self._control, str) and self.rule_control not in PamdRule.valid_simple_controls:
@@ -764,13 +765,11 @@ def main():
         argument_spec=dict(
             name=dict(required=True, type='str'),
             type=dict(required=True,
-                      choices=['account', 'auth',
-                               'password', 'session']),
+                      choices=VALID_TYPES),
             control=dict(required=True, type='str'),
             module_path=dict(required=True, type='str'),
             new_type=dict(required=False,
-                          choices=['account', 'auth',
-                                   'password', 'session']),
+                          choices=VALID_TYPES),
             new_control=dict(required=False, type='str'),
             new_module_path=dict(required=False, type='str'),
             module_arguments=dict(required=False, type='list'),

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -248,7 +248,7 @@ action:
     description:
     - "That action that was taken and is one of: update_rule,
       insert_before_rule, insert_after_rule, args_present, args_absent,
-      absent. This was available in Ansible version 2.4 and removed in 2.7"
+      absent. This was available in Ansible version 2.4 and removed in 2.8"
     returned: always
     type: string
     sample: "update_rule"

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -749,7 +749,7 @@ def parse_module_arguments(module_arguments):
     # Return empty list if we have no args to parse
     if not module_arguments:
         return []
-    elif not module_arguments[0]:
+    elif isinstance(module_arguments, list) and len(module_arguments) == 1 and not module_arguments[0]:
         return []
 
     if not isinstance(module_arguments, list):

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -539,7 +539,7 @@ class PamdService(object):
                       new_type=None, new_control=None, new_path=None, new_args=None):
         # Get a list of rules we want to change
         rules_to_find = self.get(rule_type, rule_control, rule_path)
-        changed = 0
+        changes = 0
         # There are two cases to consider.
         # 1. The new rule doesn't exist before the existing rule
         # 2. The new rule exists
@@ -565,7 +565,7 @@ class PamdService(object):
                 # Fourth, set the current rule's previous to the new_rule
                 current_rule.prev = new_rule
 
-                changed += 1
+                changes += 1
 
             # Handle the case where it is the first rule in the list.
             elif previous_rule is None:
@@ -579,15 +579,15 @@ class PamdService(object):
                 new_rule.prev = current_rule.prev
                 new_rule.next = current_rule
                 current_rule.prev = new_rule
-                changed += 1
+                changes += 1
 
-        return changed
+        return changes
 
     def insert_after(self, rule_type, rule_control, rule_path,
                      new_type=None, new_control=None, new_path=None, new_args=None):
         # Get a list of rules we want to change
         rules_to_find = self.get(rule_type, rule_control, rule_path)
-        changed = 0
+        changes = 0
         # There are two cases to consider.
         # 1. The new rule doesn't exist after the existing rule
         # 2. The new rule exists
@@ -613,7 +613,7 @@ class PamdService(object):
                 # Fifth, set the current rule's next to the new_rule
                 current_rule.next = new_rule
 
-                changed += 1
+                changes += 1
 
             # This is the case where the current_rule is the last in the list
             elif next_rule is None:
@@ -623,9 +623,9 @@ class PamdService(object):
                 self._tail = new_rule
 
                 current_rule.next = new_rule
-                changed += 1
+                changes += 1
 
-        return changed
+        return changes
 
     def add_module_arguments(self, rule_type, rule_control, rule_path, args_to_add):
         # Get a list of rules we want to change
@@ -712,7 +712,7 @@ class PamdService(object):
         # Get a list of rules we want to change
         rules_to_find = self.get(rule_type, rule_control, rule_path)
 
-        changed = 0
+        changes = 0
 
         for current_rule in rules_to_find:
             if isinstance(args_to_remove, str):
@@ -730,9 +730,9 @@ class PamdService(object):
             # to remove.
             current_rule.rule_args = [arg for arg in current_rule.rule_args if arg not in args_to_remove]
 
-            changed += 1
+            changes += 1
 
-        return changed
+        return changes
 
     def validate(self):
         current_line = self._head

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -756,7 +756,7 @@ class PamdService(object):
 
         lines.insert(1, "# Updated by Ansible - " + datetime.now().isoformat())
 
-        return '\n'.join(lines)
+        return '\n'.join(lines) + '\n'
 
 
 def main():

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -279,8 +279,10 @@ from datetime import datetime
 
 RULE_REGEX = re.compile(r"""(?P<rule_type>-?(?:auth|account|session|password))\s+
                         (?P<control>\[.*\]|\S*)\s+
-                        (?P<path>\S*)\s?
-                        (?P<args>.*)""", re.X)
+                        (?P<path>\S*)\s*
+                        (?P<args>.*)\s*""", re.X)
+
+RULE_ARG_REGEX = re.compile(r"""(\[.*\]|\S*)""")
 
 VALID_TYPES = ['account', '-account', 'auth', '-auth', 'password', '-password', 'session', '-session']
 

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -762,7 +762,7 @@ def parse_module_arguments(module_arguments):
         for item in filter(None, RULE_ARG_REGEX.findall(arg)):
             if not item.startswith("["):
                 re.sub("\\s*=\\s*", "=", item)
-            parsed_args.extend(item)
+            parsed_args.append(item)
 
     return parsed_args
 

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -497,11 +497,6 @@ class PamdService(object):
 
         return lines
 
-    def has_rule(self, rule_type, rule_control, rule_path):
-        if self.get(rule_type, rule_control, rule_path):
-            return True
-        return False
-
     def update_rule(self, rule_type, rule_control, rule_path,
                     new_type=None, new_control=None, new_path=None, new_args=None):
         # Get a list of rules we want to change

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -662,25 +662,24 @@ class PamdService(object):
             rule_args_k = set(rule_args_d.keys())
 
             # if there is nothing in common and neither set is empty
-            if ((no_eq_new_args.isdisjoint(no_eq_rule_args))
-            and (len(no_eq_new_args) is not 0)
-            and (len(no_eq_rule_args) is not 0)):
-                rule_changed = True
-                for new_arg in no_eq_new_args:
-                    no_eq_rule_args.add(new_arg)
+            if no_eq_new_args.isdisjoint(no_eq_rule_args):
+                if((len(no_eq_new_args) != 0) and (len(no_eq_rule_args) != 0)):
+                    rule_changed = True
+                    for new_arg in no_eq_new_args:
+                        no_eq_rule_args.add(new_arg)
             # else there's an intersection and possibly new args
             else:
                 real_new_no_eq_args = no_eq_new_args.difference(no_eq_rule_args)
                 for new_arg in real_new_no_eq_args:
                     no_eq_rule_args.add(new_arg)
 
-            # if there are only new args that are not the same as any current rule args and neither set is empty
-            if((new_args_k.isdisjoint(rule_args_k))
-            and (len(new_args_k) is not 0)
-            and (len(rule_args_k) is not 0)):
-                rule_changed = True
-                for key in new_args_k:
-                    rule_args_d[key] = new_args_d[key]
+            # if there are only new args that are not the same as
+            # any current rule args and neither set is empty
+            if new_args_k.isdisjoint(rule_args_k):
+                if((len(new_args_k) != 0) and (len(rule_args_k) != 0)):
+                    rule_changed = True
+                    for key in new_args_k:
+                        rule_args_d[key] = new_args_d[key]
             # else there's an intersection and possibly new args
             else:
                 # what args are in both new_args_d and rule_args_d

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -512,24 +512,24 @@ class PamdService(object):
         for current_rule in rules_to_find:
             rule_changed = False
             if new_type:
-                if(current_rule.rule_type is not new_type):
+                if(current_rule.rule_type != new_type):
                     rule_changed = True
                     current_rule.rule_type = new_type
             if new_control:
-                if(current_rule.rule_control is not new_control):
+                if(current_rule.rule_control != new_control):
                     rule_changed = True
                     current_rule.rule_control = new_control
             if new_path:
-                if(current_rule.rule_path is not new_path):
+                if(current_rule.rule_path != new_path):
                     rule_changed = True
                     current_rule.rule_path = new_path
             if new_args:
-                    if isinstance(new_args, str):
-                        new_args = new_args.replace(" = ", "=")
-                        new_args = new_args.split(' ')
-                    if(current_rule.rule_args is not new_args):
-                        rule_changed = True
-                        current_rule.rule_args = new_args
+                if isinstance(new_args, str):
+                    new_args = new_args.replace(" = ", "=")
+                    new_args = new_args.split(' ')
+                if(current_rule.rule_args != new_args):
+                    rule_changed = True
+                    current_rule.rule_args = new_args
             if rule_changed:
                 changes += 1
 

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -507,20 +507,32 @@ class PamdService(object):
         # Get a list of rules we want to change
         rules_to_find = self.get(rule_type, rule_control, rule_path)
 
+        changes = 0
         for current_rule in rules_to_find:
+            rule_changed = False
             if new_type:
-                current_rule.rule_type = new_type
+                if(current_rule.rule_type is not new_type):
+                    rule_changed = True
+                    current_rule.rule_type = new_type
             if new_control:
-                current_rule.rule_control = new_control
+                if(current_rule.rule_control is not new_control):
+                    rule_changed = True
+                    current_rule.rule_control = new_control
             if new_path:
-                current_rule.rule_path = new_path
+                if(current_rule.rule_path is not new_path):
+                    rule_changed = True
+                    current_rule.rule_path = new_path
             if new_args:
-                if isinstance(new_args, str):
-                    new_args = new_args.replace(" = ", "=")
-                    new_args = new_args.split(' ')
-                current_rule.rule_args = new_args
+                    if isinstance(new_args, str):
+                        new_args = new_args.replace(" = ", "=")
+                        new_args = new_args.split(' ')
+                    if(current_rule.rule_args is not new_args):
+                        rule_changed = True
+                        current_rule.rule_args = new_args
+            if rule_changed:
+                changes += 1
 
-        return len(rules_to_find)
+        return changes
 
     def insert_before(self, rule_type, rule_control, rule_path,
                       new_type=None, new_control=None, new_path=None, new_args=None):

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -248,7 +248,7 @@ action:
     description:
     - "That action that was taken and is one of: update_rule,
       insert_before_rule, insert_after_rule, args_present, args_absent,
-      absent."
+      absent. This was available in Ansible version 2.4 and removed in 2.7"
     returned: always
     type: string
     sample: "update_rule"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Provides fixes for a multitude of issues in the pamd module. This PR  supersedes #47420 and includes changes from #47178 

For #47418:
- Update the regex to account for leading dashes that are allowed in the pamd config file spec.
- Also created a VALID_TYPES constant to use throughout the module with all allowed types and their dash permutations. 
`['account', '-account', 'auth', '-auth', 'password', '-password', 'session', '-session']`

For #47083
See changes from @mskymoore to fix update_rule() idempotence issue

For #47197
See changes from #47178 for add_module_arguments() idempotence and duplicate argument issue. Also cleaned up and simplified the logic and forced `args_present` action to fail if a complex argument (a complex argument is defined in the spec as argument within square brackets) is passed in that we can't handle with this function (users is notified to use `updated` action instead.


Fixes #47418 
Fixes #47083 
Fixes #47197

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pamd

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.5
  config file = /Users/me/.ansible.cfg
  configured module search path = ['/Users/me/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/me/.virtualenvs/ansible/lib/python3.6/site-packages/ansible
  executable location = /Users/me/.virtualenvs/ansible/bin/ansible
  python version = 3.6.6 (default, Jul 21 2018, 22:49:24) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

Also tested with `2.7.0` and `devel`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See #47418 
See #47083 
See #47197
See #47178 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```