### PR TITLE
Make service_facts return value documentation visible

### DIFF
--- a/lib/ansible/modules/system/service_facts.py
+++ b/lib/ansible/modules/system/service_facts.py
@@ -47,22 +47,30 @@ EXAMPLES = '''
 
 RETURN = '''
 ansible_facts:
-  description: facts to add to ansible_facts about the services on the system
+  description: Facts to add to ansible_facts about the services on the system
   returned: always
   type: complex
   contains:
-    "services": {
-      "network": {
-        "source": "sysv",
-        "state": "running",
-        "name": "network"
-      },
-      arp-ethers.service: {
-        "source": "systemd",
-        "state": "stopped",
-        "name": "arp-ethers.service"
-      }
-    }
+    services:
+      description: States of the services with service name as key.
+      returned: always
+      type: complex
+      contains:
+        source:
+          description: Init system of the service. One of C(systemd), C(sysv), C(upstart).
+          returned: always
+          type: string
+          sample: sysv
+        state:
+          description: State of the service. Either C(running) or C(stopped).
+          returned: always
+          type: string
+          sample: running
+        name:
+          description: Name of the service.
+          returned: always
+          type: string
+          sample: arp-ethers.service
 '''
 
 


### PR DESCRIPTION
##### SUMMARY

service_facts module return value documentation is not visible in devel. See https://docs.ansible.com/ansible/devel/modules/service_facts_module.html

Fix syntax and show the structure in a table instead of a json example.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
service_facts

##### ANSIBLE VERSION
N/A

##### ADDITIONAL INFORMATION
N/A
