### PR TITLE
apt: warn users on auto-install dep

### DIFF
--- a/changelogs/fragments/47704-apt-warn-auto-intall.yml
+++ b/changelogs/fragments/47704-apt-warn-auto-intall.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- apt - Show a warning hint in case apt auto-installs its dependecies.

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -933,6 +933,7 @@ def main():
             module.fail_json(msg="%s must be installed to use check mode. "
                                  "If run normally this module can auto-install it." % PYTHON_APT)
         try:
+            module.warn("Updating cache and auto-installing missing dependency: %s" % PYTHON_APT)
             module.run_command(['apt-get', 'update'], check_rc=True)
             module.run_command(['apt-get', 'install', '--no-install-recommends', PYTHON_APT, '-y', '-q'], check_rc=True)
             global apt, apt_pkg


### PR DESCRIPTION
##### SUMMARY
Show users a warning hint if the dependency gets auto-installed, fixes #47444

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
![selection_192](https://user-images.githubusercontent.com/23809/47614970-b15fb300-daa8-11e8-9156-f48f91c8179d.png)

/cc @mkrizek 