### PR TITLE
[2.7] docker_image, docker_image_facts, docker_volume: add basic integration tests

### DIFF
--- a/test/integration/targets/docker_image/aliases
+++ b/test/integration/targets/docker_image/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group2
+skip/osx
+skip/freebsd
+destructive

--- a/test/integration/targets/docker_image/meta/main.yml
+++ b/test/integration/targets/docker_image/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_docker

--- a/test/integration/targets/docker_image/tasks/main.yml
+++ b/test/integration/targets/docker_image/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+- name: Create random name prefix and test registry name
+  set_fact:
+    name_prefix: "{{ 'ansible-test-%0x' % ((2**32) | random) }}"
+    registry_name: "{{ 'ansible-test-registry-%0x' % ((2**32) | random) }}"
+- name: Create image and container list
+  set_fact:
+    inames: []
+    cnames:
+    - "{{ registry_name }}"
+
+- debug:
+    msg: "Using name prefix {{ name_prefix }} and test registry name {{ registry_name }}"
+
+- block:
+  - name: Start test registry
+    docker_container:
+      name: "{{ registry_name }}"
+      image: registry:2.6.1
+      ports: 5000
+
+  - name: Get registry URL
+    set_fact:
+      registry_address: "localhost:{{ docker_container.NetworkSettings.Ports['5000/tcp'].0.HostPort }}"
+
+  - debug: msg="Registry available under {{ registry_address }}"
+
+  - include_tasks: run-test.yml
+    with_fileglob:
+    - "tests/*.yml"
+
+  always:
+  - name: "Make sure all images are removed"
+    docker_image:
+      name: "{{ item }}"
+      state: absent
+    with_items: "{{ inames }}"
+  - name: "Get registry logs"
+    command: "docker logs {{ registry_name }}"
+    register: registry_logs
+  - name: "Printing registry logs"
+    debug: var=registry_logs.stdout_lines
+  - name: "Make sure all containers are removed"
+    docker_container:
+      name: "{{ item }}"
+      state: absent
+      stop_timeout: 1
+    with_items: "{{ cnames }}"
+
+  # Skip for CentOS 6
+  when: ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6

--- a/test/integration/targets/docker_image/tasks/run-test.yml
+++ b/test/integration/targets/docker_image/tasks/run-test.yml
@@ -1,0 +1,3 @@
+---
+- name: "Loading tasks from {{ item }}"
+  include_tasks: "{{ item }}"

--- a/test/integration/targets/docker_image/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_image/tasks/tests/basic.yml
@@ -1,0 +1,107 @@
+---
+####################################################################
+## basic ###########################################################
+####################################################################
+
+- name: Make sure image is not there
+  docker_image:
+    name: "hello-world:latest"
+    state: absent
+  register: absent_1
+
+- name: Make sure image is not there (idempotency)
+  docker_image:
+    name: "hello-world:latest"
+    state: absent
+  register: absent_2
+
+- assert:
+    that:
+    - absent_2 is not changed
+
+- name: Make sure image is there
+  docker_image:
+    name: "hello-world:latest"
+    state: present
+    pull: no
+  register: present_1
+
+- name: Make sure image is there (idempotent)
+  docker_image:
+    name: "hello-world:latest"
+    state: present
+    pull: yes
+  register: present_2
+
+- assert:
+    that:
+    - present_1 is changed
+    - present_2 is not changed
+
+####################################################################
+## interact with test registry #####################################
+####################################################################
+
+- name: Make sure image is not there
+  docker_image:
+    name: "{{ registry_address }}/test/hello-world:latest"
+    state: absent
+
+- name: Push image to test registry
+  docker_image:
+    name: "hello-world:latest"
+    repository: "{{ registry_address }}/test/hello-world"
+    push: yes
+  register: push_1
+
+- name: Push image to test registry (idempotent)
+  docker_image:
+    name: "hello-world:latest"
+    repository: "{{ registry_address }}/test/hello-world"
+    push: yes
+  register: push_2
+
+- assert:
+    that:
+    - push_1 is changed
+    - push_2 is not changed
+
+- name: Get facts of local image
+  docker_image_facts:
+    name: "{{ registry_address }}/test/hello-world:latest"
+  register: facts_1
+
+- name: Make sure image is not there
+  docker_image:
+    name: "{{ registry_address }}/test/hello-world:latest"
+    state: absent
+
+- name: Get facts of local image (absent)
+  docker_image_facts:
+    name: "{{ registry_address }}/test/hello-world:latest"
+  register: facts_2
+
+- name: Pull image from test registry
+  docker_image:
+    name: "{{ registry_address }}/test/hello-world:latest"
+    state: present
+  register: pull_1
+
+- name: Pull image from test registry (idempotency)
+  docker_image:
+    name: "{{ registry_address }}/test/hello-world:latest"
+    state: present
+  register: pull_2
+
+- name: Get facts of local image (present)
+  docker_image_facts:
+    name: "{{ registry_address }}/test/hello-world:latest"
+  register: facts_3
+
+- assert:
+    that:
+    - pull_1 is changed
+    - pull_2 is not changed
+    - facts_1.images | length == 1
+    - facts_2.images | length == 0
+    - facts_3.images | length == 1

--- a/test/integration/targets/docker_image_facts/aliases
+++ b/test/integration/targets/docker_image_facts/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group2
+skip/osx
+skip/freebsd
+destructive

--- a/test/integration/targets/docker_image_facts/meta/main.yml
+++ b/test/integration/targets/docker_image_facts/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_docker

--- a/test/integration/targets/docker_image_facts/tasks/main.yml
+++ b/test/integration/targets/docker_image_facts/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+- block:
+  - name: Make sure image is not there
+    docker_image:
+      name: alpine:3.7
+      state: absent
+
+  - name: Inspect a non-available image
+    docker_image_facts:
+      name: alpine:3.7
+    register: result
+
+  - assert:
+      that:
+      - "result.images|length == 0"
+
+  - name: Make sure images are there
+    docker_image:
+      name: "{{ item }}"
+      pull: yes
+      state: present
+    loop:
+    - "hello-world:latest"
+    - "alpine:3.8"
+
+  - name: Inspect an available image
+    docker_image_facts:
+      name: hello-world:latest
+    register: result
+
+  - assert:
+      that:
+      - "result.images|length == 1"
+      - "'hello-world:latest' in result.images[0].RepoTags"
+
+  - name: Inspect multiple images
+    docker_image_facts:
+      name:
+      - "hello-world:latest"
+      - "alpine:3.8"
+    register: result
+
+  - debug: var=result
+
+  - assert:
+      that:
+      - "result.images|length == 2"
+      - "'hello-world:latest' in result.images[0].RepoTags"
+      - "'alpine:3.8' in result.images[1].RepoTags"
+
+  # Skip for CentOS 6
+  when: ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6

--- a/test/integration/targets/docker_volume/aliases
+++ b/test/integration/targets/docker_volume/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group2
+skip/osx
+skip/freebsd
+destructive

--- a/test/integration/targets/docker_volume/meta/main.yml
+++ b/test/integration/targets/docker_volume/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_docker

--- a/test/integration/targets/docker_volume/tasks/main.yml
+++ b/test/integration/targets/docker_volume/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Create random name prefix
+  set_fact:
+    name_prefix: "{{ 'ansible-test-%0x' % ((2**32) | random) }}"
+    vnames: []
+
+- debug:
+    msg: "Using name prefix {{ name_prefix }}"
+
+- block:
+  - include_tasks: run-test.yml
+    with_fileglob:
+    - "tests/*.yml"
+
+  always:
+  - name: "Make sure all volumes are removed"
+    docker_volume:
+      name: "{{ item }}"
+      state: absent
+      force: yes
+    with_items: "{{ vnames }}"
+
+  # Skip for CentOS 6
+  when: ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6

--- a/test/integration/targets/docker_volume/tasks/run-test.yml
+++ b/test/integration/targets/docker_volume/tasks/run-test.yml
@@ -1,0 +1,3 @@
+---
+- name: "Loading tasks from {{ item }}"
+  include_tasks: "{{ item }}"

--- a/test/integration/targets/docker_volume/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_volume/tasks/tests/basic.yml
@@ -1,0 +1,92 @@
+---
+- name: Registering volume name
+  set_fact:
+    vname: "{{ name_prefix ~ '-basic' }}"
+- name: Registering container name
+  set_fact:
+    vnames: "{{ vnames }} + [vname]"
+
+####################################################################
+## basic ###########################################################
+####################################################################
+
+- name: Create a volume
+  docker_volume:
+    name: "{{ vname }}"
+  register: create_1
+
+- name: Create a volume (idempotency)
+  docker_volume:
+    name: "{{ vname }}"
+  register: create_2
+
+- name: Create a volume (force)
+  docker_volume:
+    name: "{{ vname }}"
+    force: yes
+  register: create_3
+
+- name: Remove a volume
+  docker_volume:
+    name: "{{ vname }}"
+    state: absent
+  register: absent_1
+
+- name: Remove a volume (idempotency)
+  docker_volume:
+    name: "{{ vname }}"
+    state: absent
+  register: absent_2
+
+- assert:
+    that:
+    - create_1 is changed
+    - create_2 is not changed
+    - create_3 is changed
+    - absent_1 is changed
+    - absent_2 is not changed
+
+####################################################################
+## driver_options ##################################################
+####################################################################
+
+- name: Create a volume with options
+  docker_volume:
+    name: "{{ vname }}"
+    driver: local
+    driver_options:
+      type: tempfs
+      device: tmpfs
+      o: size=100m,uid=1000
+  register: driver_options_1
+
+- name: Create a volume with options (idempotency)
+  docker_volume:
+    name: "{{ vname }}"
+    driver: local
+    driver_options:
+      type: tempfs
+      device: tmpfs
+      o: size=100m,uid=1000
+  register: driver_options_2
+
+- name: Create a volume with options (changed)
+  docker_volume:
+    name: "{{ vname }}"
+    driver: local
+    driver_options:
+      type: tempfs
+      device: tmpfs
+      o: size=200m,uid=1000
+  register: driver_options_3
+
+- name: Cleanup
+  docker_volume:
+    name: "{{ vname }}"
+    state: absent
+
+- assert:
+    that:
+    - driver_options_1 is changed
+    - driver_options_2 is not changed
+    - driver_options_3 is changed


### PR DESCRIPTION
##### SUMMARY
Backport of #47383: adds basic integration tests to docker_image, docker_image_facts, and docker_volume.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_image
docker_image_facts
docker_volume

##### ANSIBLE VERSION
```
2.7.1
```
