### PR TITLE
docker_* modules: simplify idempotency comparisons

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -591,6 +591,10 @@ def compare_generic(a, b, method, type):
         # if the other is empty for set/list/dict
         if type == 'value':
             return False
+        # For allow_more_present, allow a to be None
+        if method == 'allow_more_present' and a is None:
+            return True
+        # Otherwise, the iterable object which is not None must have length 0
         return len(b if a is None else a) == 0
     # Do proper comparison (both objects not None)
     if type == 'value':

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -603,9 +603,14 @@ def compare_generic(a, b, method, type):
         if method == 'strict':
             return a == b
         else:
-            set_a = set(a)
-            set_b = set(b)
-            return set_b >= set_a
+            i = 0
+            for v in a:
+                while i < len(b) and b[i] != v:
+                    i += 1
+                if i == len(b):
+                    return False
+                i += 1
+            return True
     elif type == 'dict':
         if method == 'strict':
             return a == b

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -541,3 +541,99 @@ class AnsibleDockerClient(Client):
         new_tag = self.find_image(name, tag)
 
         return new_tag, old_tag == new_tag
+
+
+def compare_dict_allow_more_present(av, bv):
+    '''
+    Compare two dictionaries for whether every entry of the first is in the second.
+    '''
+    for key, value in av.items():
+        if key not in bv:
+            return False
+        if bv[key] != value:
+            return False
+    return True
+
+
+def compare_generic(a, b, method, type):
+    '''
+    Compare values a and b as described by method and type.
+
+    Returns ``True`` if the values compare equal, and ``False`` if not.
+
+    ``a`` is usually the module's parameter, while ``b`` is a property
+    of the current object. ``a`` must not be ``None`` (except for
+    ``type == 'value'``).
+
+    Valid values for ``method`` are:
+    - ``ignore`` (always compare as equal);
+    - ``strict`` (only compare if really equal)
+    - ``allow_more_present`` (allow b to have elements which a does not have).
+
+    Valid values for ``type`` are:
+    - ``value``: for simple values (strings, numbers, ...);
+    - ``list``: for ``list``s or ``tuple``s where order matters;
+    - ``set``: for ``list``s, ``tuple``s or ``set``s where order does not
+      matter;
+    - ``set(dict)``: for ``list``s, ``tuple``s or ``sets`` where order does
+      not matter and which contain ``dict``s; ``allow_more_present`` is used
+      for the ``dict``s, and these are assumed to be dictionaries of values;
+    - ``dict``: for dictionaries of values.
+    '''
+    if method == 'ignore':
+        return True
+    # If a or b is None:
+    if a is None or b is None:
+        # If both are None: equality
+        if a == b:
+            return True
+        # Otherwise, not equal for values, and equal
+        # if the other is empty for set/list/dict
+        if type == 'value':
+            return False
+        return len(b if a is None else a) == 0
+    # Do proper comparison (both objects not None)
+    if type == 'value':
+        return a == b
+    elif type == 'list':
+        if method == 'strict':
+            return a == b
+        else:
+            set_a = set(a)
+            set_b = set(b)
+            return set_b >= set_a
+    elif type == 'dict':
+        if method == 'strict':
+            return a == b
+        else:
+            return compare_dict_allow_more_present(a, b)
+    elif type == 'set':
+        set_a = set(a)
+        set_b = set(b)
+        if method == 'strict':
+            return set_a == set_b
+        else:
+            return set_b >= set_a
+    elif type == 'set(dict)':
+        for av in a:
+            found = False
+            for bv in b:
+                if compare_dict_allow_more_present(av, bv):
+                    found = True
+                    break
+            if not found:
+                return False
+        if method == 'strict':
+            # If we would know that both a and b do not contain duplicates,
+            # we could simply compare len(a) to len(b) to finish this test.
+            # We can assume that b has no duplicates (as it is returned by
+            # docker), but we don't know for a.
+            for bv in b:
+                found = False
+                for av in a:
+                    if compare_dict_allow_more_present(av, bv):
+                        found = True
+                        break
+                if not found:
+                    return False
+        return True

--- a/lib/ansible/modules/cloud/docker/docker_config.py
+++ b/lib/ansible/modules/cloud/docker/docker_config.py
@@ -152,7 +152,7 @@ except ImportError:
     # missing docker-py handled in ansible.module_utils.docker
     pass
 
-from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseClass
+from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseClass, compare_generic
 from ansible.module_utils._text import to_native, to_bytes
 
 
@@ -224,22 +224,8 @@ class ConfigManager(DockerBaseClass):
             if attrs.get('Labels', {}).get('ansible_key'):
                 if attrs['Labels']['ansible_key'] != self.data_key:
                     data_changed = True
-            labels_changed = False
-            if self.labels and attrs.get('Labels'):
-                # check if user requested a label change
-                for label in attrs['Labels']:
-                    if self.labels.get(label) and self.labels[label] != attrs['Labels'][label]:
-                        labels_changed = True
-            # check if user added a label
-            labels_added = False
-            if self.labels:
-                if attrs.get('Labels'):
-                    for label in self.labels:
-                        if label not in attrs['Labels']:
-                            labels_added = True
-                else:
-                    labels_added = True
-            if data_changed or labels_added or labels_changed or self.force:
+            labels_changed = not compare_generic(self.labels, attrs.get('Labels'), 'allow_more_present', 'dict')
+            if data_changed or labels_changed or self.force:
                 # if something changed or force, delete and re-create the config
                 self.absent()
                 config_id = self.create_config()

--- a/test/units/module_utils/test_docker_common.py
+++ b/test/units/module_utils/test_docker_common.py
@@ -1,0 +1,462 @@
+import pytest
+
+from ansible.module_utils.docker_common import (
+    compare_dict_allow_more_present,
+    compare_generic,
+)
+
+DICT_ALLOW_MORE_PRESENT = (
+    {
+        'av': {},
+        'bv': {'a': 1},
+        'result': True
+    },
+    {
+        'av': {'a': 1},
+        'bv': {'a': 1, 'b': 2},
+        'result': True
+    },
+    {
+        'av': {'a': 1},
+        'bv': {'b': 2},
+        'result': False
+    },
+    {
+        'av': {'a': 1},
+        'bv': {'a': None, 'b': 1},
+        'result': False
+    },
+    {
+        'av': {'a': None},
+        'bv': {'b': 1},
+        'result': False
+    },
+)
+
+COMPARE_GENERIC = [
+    ########################################################################################
+    # value
+    {
+        'a': 1,
+        'b': 2,
+        'method': 'strict',
+        'type': 'value',
+        'result': False
+    },
+    {
+        'a': 'hello',
+        'b': 'hello',
+        'method': 'strict',
+        'type': 'value',
+        'result': True
+    },
+    {
+        'a': None,
+        'b': 'hello',
+        'method': 'strict',
+        'type': 'value',
+        'result': False
+    },
+    {
+        'a': None,
+        'b': None,
+        'method': 'strict',
+        'type': 'value',
+        'result': True
+    },
+    {
+        'a': 1,
+        'b': 2,
+        'method': 'ignore',
+        'type': 'value',
+        'result': True
+    },
+    {
+        'a': None,
+        'b': 2,
+        'method': 'ignore',
+        'type': 'value',
+        'result': True
+    },
+    ########################################################################################
+    # list
+    {
+        'a': [
+            'x',
+        ],
+        'b': [
+            'y',
+        ],
+        'method': 'strict',
+        'type': 'list',
+        'result': False
+    },
+    {
+        'a': [
+            'x',
+        ],
+        'b': [
+            'x',
+            'x',
+        ],
+        'method': 'strict',
+        'type': 'list',
+        'result': False
+    },
+    {
+        'a': [
+            'x',
+            'y',
+        ],
+        'b': [
+            'x',
+            'y',
+        ],
+        'method': 'strict',
+        'type': 'list',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'y',
+        ],
+        'b': [
+            'y',
+            'x',
+        ],
+        'method': 'strict',
+        'type': 'list',
+        'result': False
+    },
+    {
+        'a': [
+            'x',
+            'y',
+        ],
+        'b': [
+            'x',
+        ],
+        'method': 'allow_more_present',
+        'type': 'list',
+        'result': False
+    },
+    {
+        'a': [
+            'x',
+        ],
+        'b': [
+            'x',
+            'y',
+        ],
+        'method': 'allow_more_present',
+        'type': 'list',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'x',
+            'y',
+        ],
+        'b': [
+            'x',
+            'y',
+        ],
+        'method': 'allow_more_present',
+        'type': 'list',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'z',
+        ],
+        'b': [
+            'x',
+            'y',
+            'x',
+            'z',
+        ],
+        'method': 'allow_more_present',
+        'type': 'list',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'y',
+        ],
+        'b': [
+            'y',
+            'x',
+        ],
+        'method': 'ignore',
+        'type': 'list',
+        'result': True
+    },
+    ########################################################################################
+    # set
+    {
+        'a': [
+            'x',
+        ],
+        'b': [
+            'y',
+        ],
+        'method': 'strict',
+        'type': 'set',
+        'result': False
+    },
+    {
+        'a': [
+            'x',
+        ],
+        'b': [
+            'x',
+            'x',
+        ],
+        'method': 'strict',
+        'type': 'set',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'y',
+        ],
+        'b': [
+            'x',
+            'y',
+        ],
+        'method': 'strict',
+        'type': 'set',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'y',
+        ],
+        'b': [
+            'y',
+            'x',
+        ],
+        'method': 'strict',
+        'type': 'set',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'y',
+        ],
+        'b': [
+            'x',
+        ],
+        'method': 'allow_more_present',
+        'type': 'set',
+        'result': False
+    },
+    {
+        'a': [
+            'x',
+        ],
+        'b': [
+            'x',
+            'y',
+        ],
+        'method': 'allow_more_present',
+        'type': 'set',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'x',
+            'y',
+        ],
+        'b': [
+            'x',
+            'y',
+        ],
+        'method': 'allow_more_present',
+        'type': 'set',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'z',
+        ],
+        'b': [
+            'x',
+            'y',
+            'x',
+            'z',
+        ],
+        'method': 'allow_more_present',
+        'type': 'set',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'a',
+        ],
+        'b': [
+            'y',
+            'z',
+        ],
+        'method': 'ignore',
+        'type': 'set',
+        'result': True
+    },
+    ########################################################################################
+    # set(dict)
+    {
+        'a': [
+            {'x': 1},
+        ],
+        'b': [
+            {'y': 1},
+        ],
+        'method': 'strict',
+        'type': 'set(dict)',
+        'result': False
+    },
+    {
+        'a': [
+            {'x': 1},
+        ],
+        'b': [
+            {'x': 1},
+        ],
+        'method': 'strict',
+        'type': 'set(dict)',
+        'result': True
+    },
+    {
+        'a': [
+            {'x': 1},
+        ],
+        'b': [
+            {'x': 1, 'y': 2},
+        ],
+        'method': 'strict',
+        'type': 'set(dict)',
+        'result': True
+    },
+    {
+        'a': [
+            {'x': 1},
+            {'x': 2, 'y': 3},
+        ],
+        'b': [
+            {'x': 1},
+            {'x': 2, 'y': 3},
+        ],
+        'method': 'strict',
+        'type': 'set(dict)',
+        'result': True
+    },
+    {
+        'a': [
+            {'x': 1},
+        ],
+        'b': [
+            {'x': 1, 'z': 2},
+            {'x': 2, 'y': 3},
+        ],
+        'method': 'allow_more_present',
+        'type': 'set(dict)',
+        'result': True
+    },
+    {
+        'a': [
+            {'x': 1, 'y': 2},
+        ],
+        'b': [
+            {'x': 1},
+            {'x': 2, 'y': 3},
+        ],
+        'method': 'allow_more_present',
+        'type': 'set(dict)',
+        'result': False
+    },
+    {
+        'a': [
+            {'x': 1, 'y': 3},
+        ],
+        'b': [
+            {'x': 1},
+            {'x': 1, 'y': 3, 'z': 4},
+        ],
+        'method': 'allow_more_present',
+        'type': 'set(dict)',
+        'result': True
+    },
+    {
+        'a': [
+            {'x': 1},
+            {'x': 2, 'y': 3},
+        ],
+        'b': [
+            {'x': 1},
+        ],
+        'method': 'ignore',
+        'type': 'set(dict)',
+        'result': True
+    },
+    ########################################################################################
+    # dict
+    {
+        'a': {'x': 1},
+        'b': {'y': 1},
+        'method': 'strict',
+        'type': 'dict',
+        'result': False
+    },
+    {
+        'a': {'x': 1},
+        'b': {'x': 1, 'y': 2},
+        'method': 'strict',
+        'type': 'dict',
+        'result': False
+    },
+    {
+        'a': {'x': 1},
+        'b': {'x': 1},
+        'method': 'strict',
+        'type': 'dict',
+        'result': True
+    },
+    {
+        'a': {'x': 1, 'z': 2},
+        'b': {'x': 1, 'y': 2},
+        'method': 'strict',
+        'type': 'dict',
+        'result': False
+    },
+    {
+        'a': {'x': 1, 'z': 2},
+        'b': {'x': 1, 'y': 2},
+        'method': 'ignore',
+        'type': 'dict',
+        'result': True
+    },
+] + [{
+    'a': entry['av'],
+    'b': entry['bv'],
+    'method': 'allow_more_present',
+    'type': 'dict',
+    'result': entry['result']
+} for entry in DICT_ALLOW_MORE_PRESENT]
+
+@pytest.mark.parametrize("entry", DICT_ALLOW_MORE_PRESENT)
+def test_dict_allow_more_present(entry):
+    assert compare_dict_allow_more_present(entry['av'], entry['bv']) == entry['result']
+
+@pytest.mark.parametrize("entry", COMPARE_GENERIC)
+def test_compare_generic(entry):
+    assert compare_generic(entry['a'], entry['b'], entry['method'], entry['type']) == entry['result']

--- a/test/units/module_utils/test_docker_common.py
+++ b/test/units/module_utils/test_docker_common.py
@@ -165,7 +165,7 @@ COMPARE_GENERIC = [
         ],
         'method': 'allow_more_present',
         'type': 'list',
-        'result': True
+        'result': False
     },
     {
         'a': [

--- a/test/units/module_utils/test_docker_common.py
+++ b/test/units/module_utils/test_docker_common.py
@@ -453,9 +453,11 @@ COMPARE_GENERIC = [
     'result': entry['result']
 } for entry in DICT_ALLOW_MORE_PRESENT]
 
+
 @pytest.mark.parametrize("entry", DICT_ALLOW_MORE_PRESENT)
 def test_dict_allow_more_present(entry):
     assert compare_dict_allow_more_present(entry['av'], entry['bv']) == entry['result']
+
 
 @pytest.mark.parametrize("entry", COMPARE_GENERIC)
 def test_compare_generic(entry):


### PR DESCRIPTION
##### SUMMARY
docker_container used to contain a framework for doing comparisons; we refactored that to fix some idempotency bugs (#45905, #44789). I propose to move the underlying comparison functions to `docker_common.py` to be able to use them in other modules as well.

As a first example, I've updated the docker_config and docker_secret modules to use it for comparing labels. As you can see, this simplified their idempotency checks a lot :)

Other modules which can benefit are docker_network and docker_volume. (Changes to docker_network will create conflicts with #47492, so we'll have to coordinate with that PR.) For both modules, note that they return differences in a different format than docker_container (they list effectively different parameters with subelements; while docker_container provides a list of different parameters together with the actual values, so the user can figure out herself which part differs if it is a dict/list/...). @DBendit @agronholm any opinions on this?

##### ISSUE TYPE
- Bugfix Pull Request

(It is not really a bugfix PR, but the other categories fit even less...)

##### COMPONENT NAME
lib/ansible/module_utils/docker_commons.py
docker_config
docker_configuration
docker_secret

##### ANSIBLE VERSION
```
2.8.0
```
