### PR TITLE
rds_instance: Fix TargetDBInstanceIdentifier assignment in wrong place

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -760,6 +760,9 @@ def get_final_snapshot(client, module, snapshot_identifier):
 
 
 def get_parameters(client, module, parameters, method_name):
+    if method_name == 'restore_db_instance_to_point_in_time':
+        parameters['TargetDBInstanceIdentifier'] = module.params['db_instance_identifier']
+
     required_options = get_boto3_client_method_parameters(client, method_name, required=True)
     if any([parameters.get(k) is None for k in required_options]):
         module.fail_json(msg='To {0} requires the parameters: {1}'.format(
@@ -778,8 +781,6 @@ def get_parameters(client, module, parameters, method_name):
         parameters['Tags'] = ansible_dict_to_boto3_tag_list(parameters['Tags'])
     if method_name == 'modify_db_instance':
         parameters = get_options_with_changing_values(client, module, parameters)
-    if method_name == 'restore_db_instance_to_point_in_time':
-        parameters['TargetDBInstanceIdentifier'] = module.params['db_instance_identifier']
 
     return parameters
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #46689
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
rds_instance

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
  config file = /home/luktom/.ansible.cfg
  configured module search path = [u'/home/luktom/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
