### PR TITLE
docker_container: simplify minimal required version per option handling

### DIFF
--- a/changelogs/fragments/47711-docker_container-minimal-version-checks.yml
+++ b/changelogs/fragments/47711-docker_container-minimal-version-checks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - refactored minimal docker-py/API version handling, and fixing such handling of some options."

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -188,6 +188,8 @@ class AnsibleDockerClient(Client):
 
         NEEDS_DOCKER_PY2 = (LooseVersion(min_docker_version) >= LooseVersion('2.0.0'))
 
+        self.docker_py_version = LooseVersion(docker_version)
+
         if HAS_DOCKER_MODELS and HAS_DOCKER_SSLADAPTER:
             self.fail("Cannot have both the docker-py and docker python modules installed together as they use the same namespace and "
                       "cause a corrupt installation. Please uninstall both packages, and re-install only the docker-py or docker python "
@@ -201,7 +203,7 @@ class AnsibleDockerClient(Client):
                 msg = "Failed to import docker or docker-py - %s. Try `pip install docker` or `pip install docker-py` (Python 2.6)"
             self.fail(msg % HAS_DOCKER_ERROR)
 
-        if LooseVersion(docker_version) < LooseVersion(min_docker_version):
+        if self.docker_py_version < LooseVersion(min_docker_version):
             if NEEDS_DOCKER_PY2:
                 if docker_version < LooseVersion('2.0'):
                     msg = "Error: docker-py version is %s, while this module requires docker %s. Try `pip uninstall docker-py` and then `pip install docker`"
@@ -226,9 +228,10 @@ class AnsibleDockerClient(Client):
             self.fail("Error connecting: %s" % exc)
 
         if min_docker_api_version is not None:
-            docker_api_version = self.version()['ApiVersion']
-            if LooseVersion(docker_api_version) < LooseVersion(min_docker_api_version):
-                self.fail('docker API version is %s. Minimum version required is %s.' % (docker_api_version, min_docker_api_version))
+            self.docker_api_version_str = self.version()['ApiVersion']
+            self.docker_api_version = LooseVersion(self.docker_api_version_str)
+            if self.docker_api_version < LooseVersion(min_docker_api_version):
+                self.fail('docker API version is %s. Minimum version required is %s.' % (self.docker_api_version_str, min_docker_api_version))
 
     def log(self, msg, pretty_print=False):
         pass

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -798,7 +798,7 @@ from ansible.module_utils.six import string_types
 try:
     from docker import utils
     from ansible.module_utils.docker_common import docker_version
-    if LooseVersion(docker_version) >= LooseVersion('2.0'):
+    if LooseVersion(docker_version) >= LooseVersion('1.10.0'):
         from docker.types import Ulimit, LogConfig
     else:
         from docker.utils.types import Ulimit, LogConfig

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -76,11 +76,9 @@ options:
   cpu_period:
     description:
       - Limit CPU CFS (Completely Fair Scheduler) period
-    default: 0
   cpu_quota:
     description:
       - Limit CPU CFS (Completely Fair Scheduler) quota
-    default: 0
   cpuset_cpus:
     description:
       - CPUs in which to allow execution C(1,3) or C(1-3).
@@ -243,7 +241,6 @@ options:
         Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
         C(T) (tebibyte), or C(P) (pebibyte). Minimum is C(4M)."
       - Omitting the unit defaults to bytes.
-    default: 0
   labels:
      description:
        - Dictionary of key value pairs.
@@ -278,14 +275,12 @@ options:
         Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
         C(T) (tebibyte), or C(P) (pebibyte)."
       - Omitting the unit defaults to bytes.
-    default: 0
   memory_swap:
     description:
       - "Total memory limit (memory + swap, format: C(<number>[<unit>])).
         Number is a positive integer. Unit can be C(B) (byte), C(K) (kibibyte, 1024B),
         C(M) (mebibyte), C(G) (gibibyte), C(T) (tebibyte), or C(P) (pebibyte)."
       - Omitting the unit defaults to bytes.
-    default: 0
   memory_swappiness:
     description:
         - Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.
@@ -318,11 +313,9 @@ options:
     description:
       - Whether or not to disable OOM Killer for the container.
     type: bool
-    default: 'no'
   oom_score_adj:
     description:
       - An integer value containing the score given to the container in order to tune OOM killer preferences.
-    default: 0
     version_added: "2.2"
   output_logs:
     description:
@@ -405,7 +398,6 @@ options:
   restart_retries:
     description:
        - Use with restart policy to control maximum number of restart attempts.
-    default: 0
   runtime:
     description:
       - Runtime to use for the container.
@@ -2143,7 +2135,7 @@ class ContainerManager(DockerBaseClass):
             client.module.warn('log_options is ignored when log_driver is not specified')
         if client.module.params.get('healthcheck') and not client.module.params.get('healthcheck').get('test'):
             client.module.warn('healthcheck is ignored when test is not specified')
-        if client.module.params.get('restart_retries') and not client.module.params.get('restart_policy'):
+        if client.module.params.get('restart_retries') is not None and not client.module.params.get('restart_policy'):
             client.module.warn('restart_retries is ignored when restart_policy is not specified')
 
         self.client = client

--- a/test/integration/targets/docker_config/tasks/main.yml
+++ b/test/integration/targets/docker_config/tasks/main.yml
@@ -1,7 +1,3 @@
-- name: Check Docker API version
-  command: "{{ ansible_python.executable }} -c 'import docker; print(docker.from_env().version()[\"ApiVersion\"])'"
-  register: docker_api_version
-  ignore_errors: yes
-
+---
 - include_tasks: test_docker_config.yml
-  when: docker_api_version.rc == 0 and docker_api_version.stdout is version('1.30', '>=')
+  when: docker_api_version is version('1.30', '>=')

--- a/test/integration/targets/docker_config/tasks/test_docker_config.yml
+++ b/test/integration/targets/docker_config/tasks/test_docker_config.yml
@@ -1,3 +1,4 @@
+---
 - name: Make sure we're not already using Docker swarm
   docker_swarm:
     state: absent

--- a/test/integration/targets/docker_container/tasks/main.yml
+++ b/test/integration/targets/docker_container/tasks/main.yml
@@ -1,4 +1,23 @@
 ---
+# Detect docker API and docker-py versions
+- name: Check Docker API version
+  command: "{{ ansible_python.executable }} -c 'import docker; print(docker.from_env().version()[\"ApiVersion\"])'"
+  register: docker_api_version_stdout
+  ignore_errors: yes
+
+- name: Check docker-py API version
+  command: "{{ ansible_python.executable }} -c 'import docker; print(docker.__version__)'"
+  register: docker_py_version_stdout
+  ignore_errors: yes
+
+- set_fact:
+    docker_api_version: "{{ docker_api_version_stdout.stdout or '0.0' }}"
+    docker_py_version: "{{ docker_py_version_stdout.stdout or '0.0' }}"
+
+- debug:
+    msg: "Docker API version: {{ docker_api_version }}; docker-py library version: {{ docker_py_version }}"
+
+# Create random name prefix (for containers, networks, ...)
 - name: Create random container name prefix
   set_fact:
     cname_prefix: "{{ 'ansible-test-%0x' % ((2**32) | random) }}"
@@ -8,6 +27,7 @@
 - debug:
     msg: "Using container name prefix {{ cname_prefix }}"
 
+# Run the tests
 - block:
   - include_tasks: run-test.yml
     with_fileglob:
@@ -26,6 +46,6 @@
       state: absent
       force: yes
     with_items: "{{ dnetworks }}"
+    when: docker_py_version is version('1.9.0', '>=')
 
-  # Skip for CentOS 6
-  when: ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6
+  when: docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')

--- a/test/integration/targets/docker_container/tasks/main.yml
+++ b/test/integration/targets/docker_container/tasks/main.yml
@@ -1,22 +1,4 @@
 ---
-# Detect docker API and docker-py versions
-- name: Check Docker API version
-  command: "{{ ansible_python.executable }} -c 'import docker; print(docker.from_env().version()[\"ApiVersion\"])'"
-  register: docker_api_version_stdout
-  ignore_errors: yes
-
-- name: Check docker-py API version
-  command: "{{ ansible_python.executable }} -c 'import docker; print(docker.__version__)'"
-  register: docker_py_version_stdout
-  ignore_errors: yes
-
-- set_fact:
-    docker_api_version: "{{ docker_api_version_stdout.stdout or '0.0' }}"
-    docker_py_version: "{{ docker_py_version_stdout.stdout or '0.0' }}"
-
-- debug:
-    msg: "Docker API version: {{ docker_api_version }}; docker-py library version: {{ docker_py_version }}"
-
 # Create random name prefix (for containers, networks, ...)
 - name: Create random container name prefix
   set_fact:

--- a/test/integration/targets/docker_container/tasks/main.yml
+++ b/test/integration/targets/docker_container/tasks/main.yml
@@ -28,6 +28,6 @@
       state: absent
       force: yes
     with_items: "{{ dnetworks }}"
-    when: docker_py_version is version('1.9.0', '>=')
+    when: docker_py_version is version('1.10.0', '>=')
 
   when: docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -21,7 +21,7 @@
   - "{{ nname_2 }}"
   loop_control:
     loop_var: network_name
-  when: docker_py_version is version('1.9.0', '>=')
+  when: docker_py_version is version('1.10.0', '>=')
 
 ####################################################################
 ## auto_remove #####################################################
@@ -2483,7 +2483,7 @@
       - networks_4 is changed
       - networks_5 is changed
 
-  when: docker_py_version is version('1.9.0', '>=')
+  when: docker_py_version is version('1.10.0', '>=')
 
 ####################################################################
 ## oom_killer ######################################################
@@ -3979,4 +3979,4 @@
   - "{{ nname_2 }}"
   loop_control:
     loop_var: network_name
-  when: docker_py_version is version('1.9.0', '>=')
+  when: docker_py_version is version('1.10.0', '>=')

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -21,6 +21,7 @@
   - "{{ nname_2 }}"
   loop_control:
     loop_var: network_name
+  when: docker_py_version is version('1.9.0', '>=')
 
 ####################################################################
 ## auto_remove #####################################################
@@ -34,6 +35,7 @@
     state: started
     auto_remove: yes
   register: auto_remove_1
+  ignore_errors: yes
 
 - name: Give container 1 second to be sure it terminated
   pause:
@@ -44,11 +46,18 @@
     name: "{{ cname }}"
     state: absent
   register: auto_remove_2
+  ignore_errors: yes
 
 - assert:
     that:
     - auto_remove_1 is changed
     - auto_remove_2 is not changed
+  when: docker_py_version is version('2.1.0', '>=')
+- assert:
+    that:
+    - auto_remove_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.1.0') in auto_remove_1.msg"
+  when: docker_py_version is version('2.1.0', '<')
 
 ####################################################################
 ## blkio_weight ####################################################
@@ -509,6 +518,7 @@
     auto_remove: yes
     cleanup: yes
   register: detach_auto_remove
+  ignore_errors: yes
 
 - name: cleanup (unnecessary)
   docker_container:
@@ -522,8 +532,11 @@
     - detach_no_cleanup_cleanup is changed
     - "'Hello from Docker!' in detach_cleanup.ansible_facts.docker_container.Output"
     - detach_cleanup_cleanup is not changed
+- assert:
+    that:
     - "'Cannot retrieve result as auto_remove is enabled' == detach_auto_remove.ansible_facts.docker_container.Output"
     - detach_auto_remove_cleanup is not changed
+  when: docker_py_version is version('2.1.0', '>=')
 
 ####################################################################
 ## devices #########################################################
@@ -602,6 +615,7 @@
       - path: /dev/urandom
         rate: 10K
   register: device_read_bps_1
+  ignore_errors: yes
 
 - name: device_read_bps (idempotency)
   docker_container:
@@ -615,6 +629,7 @@
       - path: /dev/random
         rate: 20M
   register: device_read_bps_2
+  ignore_errors: yes
 
 - name: device_read_bps (lesser entries)
   docker_container:
@@ -626,6 +641,7 @@
       - path: /dev/random
         rate: 20M
   register: device_read_bps_3
+  ignore_errors: yes
 
 - name: device_read_bps (changed)
   docker_container:
@@ -640,6 +656,7 @@
         rate: 5K
     stop_timeout: 1
   register: device_read_bps_4
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -653,6 +670,12 @@
     - device_read_bps_2 is not changed
     - device_read_bps_3 is not changed
     - device_read_bps_4 is changed
+  when: docker_py_version is version('1.9.0', '>=')
+- assert:
+    that:
+    - device_read_bps_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.9.0') in device_read_bps_1.msg"
+  when: docker_py_version is version('1.9.0', '<')
 
 ####################################################################
 ## device_read_iops ################################################
@@ -670,6 +693,7 @@
       - path: /dev/urandom
         rate: 20
   register: device_read_iops_1
+  ignore_errors: yes
 
 - name: device_read_iops (idempotency)
   docker_container:
@@ -683,6 +707,7 @@
       - path: /dev/random
         rate: 10
   register: device_read_iops_2
+  ignore_errors: yes
 
 - name: device_read_iops (less)
   docker_container:
@@ -694,6 +719,7 @@
       - path: /dev/random
         rate: 10
   register: device_read_iops_3
+  ignore_errors: yes
 
 - name: device_read_iops (changed)
   docker_container:
@@ -708,6 +734,7 @@
         rate: 50
     stop_timeout: 1
   register: device_read_iops_4
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -721,6 +748,12 @@
     - device_read_iops_2 is not changed
     - device_read_iops_3 is not changed
     - device_read_iops_4 is changed
+  when: docker_py_version is version('1.9.0', '>=')
+- assert:
+    that:
+    - device_read_iops_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.9.0') in device_read_iops_1.msg"
+  when: docker_py_version is version('1.9.0', '<')
 
 ####################################################################
 ## device_write_bps and device_write_iops ##########################
@@ -739,6 +772,7 @@
       - path: /dev/urandom
         rate: 30
   register: device_write_limit_1
+  ignore_errors: yes
 
 - name: device_write_bps and device_write_iops (idempotency)
   docker_container:
@@ -753,6 +787,7 @@
       - path: /dev/urandom
         rate: 30
   register: device_write_limit_2
+  ignore_errors: yes
 
 - name: device_write_bps device_write_iops (changed)
   docker_container:
@@ -768,6 +803,7 @@
         rate: 100
     stop_timeout: 1
   register: device_write_limit_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -780,6 +816,12 @@
     - device_write_limit_1 is changed
     - device_write_limit_2 is not changed
     - device_write_limit_3 is changed
+  when: docker_py_version is version('1.9.0', '>=')
+- assert:
+    that:
+    - device_write_limit_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.9.0') in device_write_limit_1.msg"
+  when: docker_py_version is version('1.9.0', '<')
 
 ####################################################################
 ## dns_opts ########################################################
@@ -795,6 +837,7 @@
     - "timeout:10"
     - rotate
   register: dns_opts_1
+  ignore_errors: yes
 
 - name: dns_opts (idempotency)
   docker_container:
@@ -806,6 +849,7 @@
     - rotate
     - "timeout:10"
   register: dns_opts_2
+  ignore_errors: yes
 
 - name: dns_opts (less resolv.conf options)
   docker_container:
@@ -816,6 +860,7 @@
     dns_opts:
     - "timeout:10"
   register: dns_opts_3
+  ignore_errors: yes
 
 - name: dns_opts (more resolv.conf options)
   docker_container:
@@ -828,6 +873,7 @@
     - no-check-names
     stop_timeout: 1
   register: dns_opts_4
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -841,6 +887,12 @@
     - dns_opts_2 is not changed
     - dns_opts_3 is not changed
     - dns_opts_4 is changed
+  when: docker_py_version is version('1.10.0', '>=')
+- assert:
+    that:
+    - dns_opts_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.10.0') in dns_opts_1.msg"
+  when: docker_py_version is version('1.10.0', '<')
 
 ####################################################################
 ## dns_search_domains ##############################################
@@ -1391,6 +1443,7 @@
       retries: 2
     stop_timeout: 1
   register: healthcheck_1
+  ignore_errors: yes
 
 - name: healthcheck (idempotency)
   docker_container:
@@ -1408,6 +1461,7 @@
       retries: 2
     stop_timeout: 1
   register: healthcheck_2
+  ignore_errors: yes
 
 - name: healthcheck (changed)
   docker_container:
@@ -1425,6 +1479,7 @@
       retries: 3
     stop_timeout: 1
   register: healthcheck_3
+  ignore_errors: yes
 
 - name: healthcheck (no change)
   docker_container:
@@ -1434,6 +1489,7 @@
     state: started
     stop_timeout: 1
   register: healthcheck_4
+  ignore_errors: yes
 
 - name: healthcheck (disabled)
   docker_container:
@@ -1446,6 +1502,7 @@
       - NONE
     stop_timeout: 1
   register: healthcheck_5
+  ignore_errors: yes
 
 - name: healthcheck (disabled, idempotency)
   docker_container:
@@ -1458,6 +1515,7 @@
       - NONE
     stop_timeout: 1
   register: healthcheck_6
+  ignore_errors: yes
 
 - name: healthcheck (string in healthcheck test, changed)
   docker_container:
@@ -1469,6 +1527,7 @@
       test: "sleep 1"
     stop_timeout: 1
   register: healthcheck_7
+  ignore_errors: yes
 
 - name: healthcheck (string in healthcheck test, idempotency)
   docker_container:
@@ -1480,6 +1539,7 @@
       test: "sleep 1"
     stop_timeout: 1
   register: healthcheck_8
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -1497,6 +1557,12 @@
     - healthcheck_6 is not changed
     - healthcheck_7 is changed
     - healthcheck_8 is not changed
+  when: docker_py_version is version('2.0.0', '>=')
+- assert:
+    that:
+    - healthcheck_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.0.0') in healthcheck_1.msg"
+  when: docker_py_version is version('2.0.0', '<')
 
 ####################################################################
 ## hostname ########################################################
@@ -1554,6 +1620,7 @@
     init: yes
     state: started
   register: init_1
+  ignore_errors: yes
 
 - name: init (idempotency)
   docker_container:
@@ -1563,6 +1630,7 @@
     init: yes
     state: started
   register: init_2
+  ignore_errors: yes
 
 - name: init (change)
   docker_container:
@@ -1573,6 +1641,7 @@
     state: started
     stop_timeout: 1
   register: init_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -1585,6 +1654,12 @@
     - init_1 is changed
     - init_2 is not changed
     - init_3 is changed
+  when: docker_py_version is version('2.2.0', '>=')
+- assert:
+    that:
+    - init_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.2.0') in init_1.msg"
+  when: docker_py_version is version('2.2.0', '<')
 
 ####################################################################
 ## interactive #####################################################
@@ -2335,77 +2410,80 @@
 ## networks, purge_networks ########################################
 ####################################################################
 
-- name: networks, purge_networks
-  docker_container:
-    image: alpine:3.8
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    state: started
-    purge_networks: yes
-    networks:
-    - name: bridge
-    - name: "{{ nname_1 }}"
-  register: networks_1
+- block:
+  - name: networks, purge_networks
+    docker_container:
+      image: alpine:3.8
+      command: '/bin/sh -c "sleep 10m"'
+      name: "{{ cname }}"
+      state: started
+      purge_networks: yes
+      networks:
+      - name: bridge
+      - name: "{{ nname_1 }}"
+    register: networks_1
 
-- name: networks, purge_networks (idempotency)
-  docker_container:
-    image: alpine:3.8
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    state: started
-    purge_networks: yes
-    networks:
-    - name: "{{ nname_1 }}"
-    - name: bridge
-  register: networks_2
+  - name: networks, purge_networks (idempotency)
+    docker_container:
+      image: alpine:3.8
+      command: '/bin/sh -c "sleep 10m"'
+      name: "{{ cname }}"
+      state: started
+      purge_networks: yes
+      networks:
+      - name: "{{ nname_1 }}"
+      - name: bridge
+    register: networks_2
 
-- name: networks (less networks)
-  docker_container:
-    image: alpine:3.8
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    state: started
-    networks:
-    - name: bridge
-  register: networks_3
+  - name: networks (less networks)
+    docker_container:
+      image: alpine:3.8
+      command: '/bin/sh -c "sleep 10m"'
+      name: "{{ cname }}"
+      state: started
+      networks:
+      - name: bridge
+    register: networks_3
 
-- name: networks, purge_networks (less networks)
-  docker_container:
-    image: alpine:3.8
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    state: started
-    purge_networks: yes
-    networks:
-    - name: bridge
-  register: networks_4
+  - name: networks, purge_networks (less networks)
+    docker_container:
+      image: alpine:3.8
+      command: '/bin/sh -c "sleep 10m"'
+      name: "{{ cname }}"
+      state: started
+      purge_networks: yes
+      networks:
+      - name: bridge
+    register: networks_4
 
-- name: networks, purge_networks (more networks)
-  docker_container:
-    image: alpine:3.8
-    command: '/bin/sh -c "sleep 10m"'
-    name: "{{ cname }}"
-    state: started
-    purge_networks: yes
-    networks:
-    - name: bridge
-    - name: "{{ nname_2 }}"
-    stop_timeout: 1
-  register: networks_5
+  - name: networks, purge_networks (more networks)
+    docker_container:
+      image: alpine:3.8
+      command: '/bin/sh -c "sleep 10m"'
+      name: "{{ cname }}"
+      state: started
+      purge_networks: yes
+      networks:
+      - name: bridge
+      - name: "{{ nname_2 }}"
+      stop_timeout: 1
+    register: networks_5
 
-- name: cleanup
-  docker_container:
-    name: "{{ cname }}"
-    state: absent
-    stop_timeout: 1
+  - name: cleanup
+    docker_container:
+      name: "{{ cname }}"
+      state: absent
+      stop_timeout: 1
 
-- assert:
-    that:
-    - networks_1 is changed
-    - networks_2 is not changed
-    - networks_3 is not changed
-    - networks_4 is changed
-    - networks_5 is changed
+  - assert:
+      that:
+      - networks_1 is changed
+      - networks_2 is not changed
+      - networks_3 is not changed
+      - networks_4 is changed
+      - networks_5 is changed
+
+  when: docker_py_version is version('1.9.0', '>=')
 
 ####################################################################
 ## oom_killer ######################################################
@@ -2419,6 +2497,7 @@
     oom_killer: yes
     state: started
   register: oom_killer_1
+  ignore_errors: yes
 
 - name: oom_killer (idempotency)
   docker_container:
@@ -2428,6 +2507,7 @@
     oom_killer: yes
     state: started
   register: oom_killer_2
+  ignore_errors: yes
 
 - name: oom_killer (change)
   docker_container:
@@ -2438,6 +2518,7 @@
     state: started
     stop_timeout: 1
   register: oom_killer_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -2450,6 +2531,12 @@
     - oom_killer_1 is changed
     - oom_killer_2 is not changed
     - oom_killer_3 is changed
+  when: docker_py_version is version('2.0.0', '>=')
+- assert:
+    that:
+    - oom_killer_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.0.0') in oom_killer_1.msg"
+  when: docker_py_version is version('2.0.0', '<')
 
 ####################################################################
 ## oom_score_adj ###################################################
@@ -2463,6 +2550,7 @@
     oom_score_adj: 5
     state: started
   register: oom_score_adj_1
+  ignore_errors: yes
 
 - name: oom_score_adj (idempotency)
   docker_container:
@@ -2472,6 +2560,7 @@
     oom_score_adj: 5
     state: started
   register: oom_score_adj_2
+  ignore_errors: yes
 
 - name: oom_score_adj (change)
   docker_container:
@@ -2482,6 +2571,7 @@
     state: started
     stop_timeout: 1
   register: oom_score_adj_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -2494,6 +2584,12 @@
     - oom_score_adj_1 is changed
     - oom_score_adj_2 is not changed
     - oom_score_adj_3 is changed
+  when: docker_py_version is version('2.0.0', '>=')
+- assert:
+    that:
+    - oom_score_adj_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.0.0') in oom_score_adj_1.msg"
+  when: docker_py_version is version('2.0.0', '<')
 
 ####################################################################
 ## output_logs #####################################################
@@ -2589,6 +2685,8 @@
     state: started
     pid_mode: "container:{{ pid_mode_helper.ansible_facts.docker_container.Id }}"
   register: pid_mode_1
+  ignore_errors: yes
+  # docker-py < 2.0 does not support "arbitrary" pid_mode values
 
 - name: pid_mode (idempotency)
   docker_container:
@@ -2598,6 +2696,8 @@
     state: started
     pid_mode: "container:{{ pid_mode_helper.ansible_facts.docker_container.Id }}"
   register: pid_mode_2
+  ignore_errors: yes
+  # docker-py < 2.0 does not support "arbitrary" pid_mode values
 
 - name: pid_mode (change)
   docker_container:
@@ -2625,6 +2725,13 @@
     - pid_mode_1 is changed
     - pid_mode_2 is not changed
     - pid_mode_3 is changed
+  when: docker_py_version is version('2.0.0', '>=')
+- assert:
+    that:
+    - pid_mode_1 is failed
+    - pid_mode_2 is failed
+    - pid_mode_3 is changed
+  when: docker_py_version is version('2.0.0', '<')
 
 ####################################################################
 ## privileged ######################################################
@@ -2985,6 +3092,7 @@
     runtime: runc
     state: started
   register: runtime_1
+  ignore_errors: yes
 
 - name: runtime (idempotency)
   docker_container:
@@ -2994,6 +3102,7 @@
     runtime: runc
     state: started
   register: runtime_2
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -3005,6 +3114,12 @@
     that:
     - runtime_1 is changed
     - runtime_2 is not changed
+  when: docker_py_version is version('2.4.0', '>=')
+- assert:
+    that:
+    - runtime_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.4.0') in runtime_1.msg"
+  when: docker_py_version is version('2.4.0', '<')
 
 ####################################################################
 ## security_opts ###################################################
@@ -3239,6 +3354,7 @@
       net.ipv4.icmp_echo_ignore_all: 1
       net.ipv4.ip_forward: 1
   register: sysctls_1
+  ignore_errors: yes
 
 - name: sysctls (idempotency)
   docker_container:
@@ -3250,6 +3366,7 @@
       net.ipv4.ip_forward: 1
       net.ipv4.icmp_echo_ignore_all: 1
   register: sysctls_2
+  ignore_errors: yes
 
 - name: sysctls (less sysctls)
   docker_container:
@@ -3260,6 +3377,7 @@
     sysctls:
       net.ipv4.icmp_echo_ignore_all: 1
   register: sysctls_3
+  ignore_errors: yes
 
 - name: sysctls (more sysctls)
   docker_container:
@@ -3272,6 +3390,7 @@
       net.ipv6.conf.default.accept_redirects: 0
     stop_timeout: 1
   register: sysctls_4
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -3285,6 +3404,12 @@
     - sysctls_2 is not changed
     - sysctls_3 is not changed
     - sysctls_4 is changed
+  when: docker_py_version is version('1.10.0', '>=')
+- assert:
+    that:
+    - sysctls_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.10.0') in sysctls_1.msg"
+  when: docker_py_version is version('1.10.0', '<')
 
 ####################################################################
 ## tmpfs ###########################################################
@@ -3514,6 +3639,7 @@
     userns_mode: host
     state: started
   register: userns_mode_1
+  ignore_errors: yes
 
 - name: userns_mode (idempotency)
   docker_container:
@@ -3523,6 +3649,7 @@
     userns_mode: host
     state: started
   register: userns_mode_2
+  ignore_errors: yes
 
 - name: userns_mode (change)
   docker_container:
@@ -3533,6 +3660,7 @@
     state: started
     stop_timeout: 1
   register: userns_mode_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -3545,6 +3673,12 @@
     - userns_mode_1 is changed
     - userns_mode_2 is not changed
     - userns_mode_3 is changed
+  when: docker_py_version is version('1.10.0', '>=')
+- assert:
+    that:
+    - userns_mode_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.10.0') in userns_mode_1.msg"
+  when: docker_py_version is version('1.10.0', '<')
 
 ####################################################################
 ## uts #############################################################
@@ -3558,6 +3692,7 @@
     uts: host
     state: started
   register: uts_1
+  ignore_errors: yes
 
 - name: uts (idempotency)
   docker_container:
@@ -3567,6 +3702,7 @@
     uts: host
     state: started
   register: uts_2
+  ignore_errors: yes
 
 - name: uts (change)
   docker_container:
@@ -3577,6 +3713,7 @@
     state: started
     stop_timeout: 1
   register: uts_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -3589,6 +3726,12 @@
     - uts_1 is changed
     - uts_2 is not changed
     - uts_3 is changed
+  when: docker_py_version is version('3.5.0', '>=')
+- assert:
+    that:
+    - uts_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 3.5.0') in uts_1.msg"
+  when: docker_py_version is version('3.5.0', '<')
 
 ####################################################################
 ## keep_volumes ####################################################
@@ -3836,3 +3979,4 @@
   - "{{ nname_2 }}"
   loop_control:
     loop_var: network_name
+  when: docker_py_version is version('1.9.0', '>=')

--- a/test/integration/targets/setup_docker/tasks/main.yml
+++ b/test/integration/targets/setup_docker/tasks/main.yml
@@ -17,3 +17,21 @@
         state: present
         name: 'docker{{ extra_packages }}'
         extra_args: "-c {{ role_path }}/../../../runner/requirements/constraints.txt"
+
+    # Detect docker API and docker-py versions
+    - name: Check Docker API version
+      command: "{{ ansible_python.executable }} -c 'import docker; print(docker.from_env().version()[\"ApiVersion\"])'"
+      register: docker_api_version_stdout
+      ignore_errors: yes
+
+    - name: Check docker-py API version
+      command: "{{ ansible_python.executable }} -c 'import docker; print(docker.__version__)'"
+      register: docker_py_version_stdout
+      ignore_errors: yes
+
+    - set_fact:
+        docker_api_version: "{{ docker_api_version_stdout.stdout or '0.0' }}"
+        docker_py_version: "{{ docker_py_version_stdout.stdout or '0.0' }}"
+
+    - debug:
+        msg: "Docker API version: {{ docker_api_version }}; docker-py library version: {{ docker_py_version }}"


### PR DESCRIPTION
##### SUMMARY
docker_container supports some options which require a newer docker/docker-py version and/or a newer docker API version. Currently, checking whether this is done correctly is done manually with some feature flags and comparisons. This PR attempts to improve on this situation by allowing to specify minimal versions with a minimal amount of effort (that's implemented in the first commit), and by automating the whole "can this option be passed here or not" game (not yet done).

@akshay196 this is what I meant in my comment in #36831.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.8.0
```
