### PR TITLE
docker_container: improve race condition behavior for detach:no, auto_remove:yes behavior

### DIFF
--- a/changelogs/fragments/47712-docker_container-detach-auto-remove.yml
+++ b/changelogs/fragments/47712-docker_container-detach-auto-remove.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - fixing race condition when ``detach`` and ``auto_remove`` are both ``true``."

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -32,7 +32,7 @@ HAS_DOCKER_ERROR = None
 try:
     from requests.exceptions import SSLError
     from docker import __version__ as docker_version
-    from docker.errors import APIError, TLSParameterError
+    from docker.errors import APIError, NotFound, TLSParameterError
     from docker.tls import TLSConfig
     from docker import auth
 
@@ -110,6 +110,9 @@ if not HAS_DOCKER_PY:
             pass
 
     class APIError(Exception):  # noqa: F811
+        pass
+
+    class NotFound(Exception):  # noqa: F811
         pass
 
 
@@ -442,6 +445,8 @@ class AnsibleDockerClient(Client):
                 self.log("Inspecting container Id %s" % result['Id'])
                 result = self.inspect_container(container=result['Id'])
                 self.log("Completed container inspection")
+            except NotFound as exc:
+                return None
             except Exception as exc:
                 self.fail("Error inspecting container: %s" % exc)
 


### PR DESCRIPTION
##### SUMMARY
As noticed while developing #47709 and #47711, there is a race condition happening when `detach == False` and `auto_remove == True` which happens if the container is removed between listing of all containers and inspecting the container in docker_common's `get_container()`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/docker_commons.py
docker_container

##### ANSIBLE VERSION
```
2.8.0
```
