### PR TITLE
Add port_security_enabled argument to os_port module

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -86,6 +86,11 @@ options:
      choices: [normal, direct, direct-physical, macvtap, baremetal, virtio-forwarder]
      default: normal
      version_added: "2.8"
+   port_security_enabled:
+     description:
+       - Whether to enable or disable the port security on the network.
+     type: bool
+     version_added: "2.8"
 '''
 
 EXAMPLES = '''
@@ -202,6 +207,10 @@ vnic_type:
     description: Type of the created port
     returned: success
     type: str
+port_security_enabled:
+    description: Port security state on the network.
+    returned: success
+    type: bool
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -217,7 +226,8 @@ def _needs_update(module, port, cloud):
                       'mac_address',
                       'device_owner',
                       'device_id',
-                      'binding:vnic_type']
+                      'binding:vnic_type',
+                      'port_security_enabled']
     compare_dict = ['allowed_address_pairs',
                     'extra_dhcp_opts']
     compare_list = ['security_groups']
@@ -283,7 +293,8 @@ def _compose_port_args(module, cloud):
                            'extra_dhcp_opts',
                            'device_owner',
                            'device_id',
-                           'binding:vnic_type']
+                           'binding:vnic_type',
+                           'port_security_enabled']
     for optional_param in optional_parameters:
         if module.params[optional_param] is not None:
             port_kwargs[optional_param] = module.params[optional_param]
@@ -319,6 +330,7 @@ def main():
         vnic_type=dict(default='normal',
                        choices=['normal', 'direct', 'direct-physical',
                                 'macvtap', 'baremetal', 'virtio-forwarder']),
+        port_security_enabled=dict(default=None, type='bool')
     )
 
     module_kwargs = openstack_module_kwargs(


### PR DESCRIPTION
##### SUMMARY
Port security could be set during creation of the port on the network.
Add port_security_enabled boolean during port creation.

Fixes: #24694

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
os_port

##### ANSIBLE VERSION
ansible 2.7.0
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/home/stack/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /tmp/ansible_venv/lib/python2.7/site-packages/ansible
executable location = /tmp/ansible_venv/bin/ansible
python version = 2.7.5 (default, May 31 2018, 09:41:32) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

##### ADDITIONAL INFORMATION
Depends-On: https://review.openstack.org/#/c/613759
