### PR TITLE
VMware: restore timeout in set_vm_power_state operation

### DIFF
--- a/changelogs/fragments/47722-vmware_guest_powerstate-restore_timeout.yaml
+++ b/changelogs/fragments/47722-vmware_guest_powerstate-restore_timeout.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Restore timeout in set_vm_power_state operation in vmware_guest_powerstate module.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
@@ -207,7 +207,7 @@ def main():
                                      "given are invalid: %s" % (module.params.get('state'),
                                                                 to_native(e.msg)))
         else:
-            result = set_vm_power_state(pyv.content, vm, module.params['state'], module.params['force'])
+            result = set_vm_power_state(pyv.content, vm, module.params['state'], module.params['force'], module.params['state_change_timeout'])
     else:
         module.fail_json(msg="Unable to set power state for non-existing virtual machine : '%s'" % (module.params.get('uuid') or module.params.get('name')))
 


### PR DESCRIPTION
##### SUMMARY
'state_change_timeout' parameter was removed, this introduced
regression.

Fixes: #47722

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/47722-vmware_guest_powerstate-restore_timeout.yaml
lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8-devel
```