### PR TITLE
Revert "enhance recv calls in network_cli (#47345)"

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -182,7 +182,6 @@ import os
 import signal
 import socket
 import traceback
-import time
 from io import BytesIO
 
 from ansible.errors import AnsibleConnectionFailure
@@ -360,15 +359,6 @@ class Connection(NetworkConnectionBase):
                 display.debug("ssh connection has been closed successfully")
         super(Connection, self).close()
 
-    def receive_ssh_data(self, count, timeout):
-        if timeout:
-            start = time.time()
-            while not self._ssh_shell.recv_ready():
-                if time.time() - start >= timeout:
-                    raise AnsibleConnectionFailure("timeout waiting ssh data")
-                time.sleep(0.001)
-        return self._ssh_shell.recv(count)
-
     def receive(self, command=None, prompts=None, answer=None, newline=True, prompt_retry_check=False, check_all=False):
         '''
         Handles receiving of output from command
@@ -386,14 +376,12 @@ class Connection(NetworkConnectionBase):
         buffer_read_timeout = self.get_option('persistent_buffer_read_timeout')
         self._validate_timeout_value(buffer_read_timeout, "persistent_buffer_read_timeout")
 
-        receive_data_timeout = self._ssh_shell.gettimeout()
-
         while True:
             if command_prompt_matched:
                 try:
                     signal.signal(signal.SIGALRM, self._handle_buffer_read_timeout)
                     signal.setitimer(signal.ITIMER_REAL, buffer_read_timeout)
-                    data = self.receive_ssh_data(256, receive_data_timeout)
+                    data = self._ssh_shell.recv(256)
                     signal.alarm(0)
                     # if data is still received on channel it indicates the prompt string
                     # is wrongly matched in between response chunks, continue to read
@@ -407,7 +395,7 @@ class Connection(NetworkConnectionBase):
                 except AnsibleCmdRespRecv:
                     return self._command_response
             else:
-                data = self.receive_ssh_data(256, receive_data_timeout)
+                data = self._ssh_shell.recv(256)
 
             # when a channel stream is closed, received data will be empty
             if not data:

--- a/test/units/plugins/connection/test_network_cli.py
+++ b/test/units/plugins/connection/test_network_cli.py
@@ -126,8 +126,6 @@ class TestConnectionClass(unittest.TestCase):
 
         mock__shell = MagicMock()
         conn._ssh_shell = mock__shell
-        conn._ssh_shell.recv_ready.return_value = True
-        conn._ssh_shell.gettimeout.return_value = 10
 
         response = b"""device#command
         command response


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This reverts commit c649d0ea3238139f1add055fc719f413f398b175.

The change results in a deadlock in network_cli while it is
waiting to check the return value of recv_ready() which
was added in this commit to improve performance
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
network_cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
