### PR TITLE
Fix parsing ansible port value when passed as a variable

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -225,7 +225,7 @@ class PlayContext(Base):
             self.remote_user = play.remote_user
 
         if play.port:
-            self.port = int(play.port)
+            self.port = play.port
 
         if play.become is not None:
             self.become = play.become


### PR DESCRIPTION
##### SUMMARY
This comiut fixes the issue when we pass ssh_port as a variable, python raises exception that the value cannot be converted to int.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible play context

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/sabyrzhan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
Here we are passing `ssh_port` as a variable. Because of it exception is thrown.

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

inventory.ini
[all:vars]
ssh_port=61000


example-playbook.yml
---
- hosts: add_userkey
  remote_user: "{{ remote_user_login }}"
  vars:
    ansible_ssh_user: "{{ remote_user_login }}"
    ansible_ssh_pass: "{{ remote_user_pass }}"
    ansible_sudo_pass: "{{ remote_user_pass }}"
  port: "{{ ssh_port }}"

Error:
ERROR! Unexpected Exception, this is probably a bug: invalid literal for int() with base 10: '{{ ssh_port }}'


```
