### PR TITLE
pip: produce better error msg on import error

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.7.rst
@@ -221,6 +221,10 @@ Noteworthy module changes
 
     #> ansible -m include_role -a 'name=myrole' all
 
+* The ``pip`` module has added a dependency on ``setuptools`` to support version requirements, this requirement is for
+  the Python interpreter that executes the module and not the Python interpreter that the module is managing.
+
+
 Plugins
 =======
 

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -241,16 +241,19 @@ import sys
 import tempfile
 import operator
 import shlex
+import traceback
 from distutils.version import LooseVersion
 
+SETUPTOOLS_IMP_ERR = None
 try:
     from pkg_resources import Requirement
 
     HAS_SETUPTOOLS = True
 except ImportError:
     HAS_SETUPTOOLS = False
+    SETUPTOOLS_IMP_ERR = traceback.format_exc()
 
-from ansible.module_utils.basic import AnsibleModule, is_executable
+from ansible.module_utils.basic import AnsibleModule, is_executable, missing_required_lib
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import PY3
 
@@ -573,7 +576,8 @@ def main():
     )
 
     if not HAS_SETUPTOOLS:
-        module.fail_json(msg="No setuptools found in remote host, please install it first.")
+        module.fail_json(msg=missing_required_lib("setuptools"),
+                         exception=SETUPTOOLS_IMP_ERR)
 
     state = module.params['state']
     name = module.params['name']


### PR DESCRIPTION
##### SUMMARY
To help with identifying where setuptools is required this uses a common function that returns the hostname and Python iterpreter that is used. Now on a failure Ansible will return `Failed to import the required Python library (setuptools) on <hostname> Python <python>. Please read module documentation and install in the appropriate location.`

Somewhat fixes https://github.com/ansible/ansible/issues/47361

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
```paste below
devel
```