### PR TITLE
[Backport 2.7] VMware: correct logic to pass ESXi SSL thumbprint

### DIFF
--- a/changelogs/fragments/47563-vmware_host-refactor_SSL_thumbprint.yaml
+++ b/changelogs/fragments/47563-vmware_host-refactor_SSL_thumbprint.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_host - fixes the retry mechanism of AddHost task.

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -27,7 +27,8 @@ from ansible.module_utils.basic import env_fallback
 
 
 class TaskError(Exception):
-    pass
+    def __init__(self, *args, **kwargs):
+        super(TaskError, self).__init__(*args, **kwargs)
 
 
 def wait_for_task(task, max_backoff=64, timeout=3600):
@@ -51,12 +52,15 @@ def wait_for_task(task, max_backoff=64, timeout=3600):
             return True, task.info.result
         if task.info.state == vim.TaskInfo.State.error:
             error_msg = task.info.error
+            host_thumbprint = None
             try:
                 error_msg = error_msg.msg
+                if hasattr(task.info.error, 'thumbprint'):
+                    host_thumbprint = task.info.error.thumbprint
             except AttributeError:
                 pass
             finally:
-                raise_from(TaskError(error_msg), task.info.error)
+                raise_from(TaskError(error_msg, host_thumbprint), task.info.error)
         if task.info.state in [vim.TaskInfo.State.running, vim.TaskInfo.State.queued]:
             sleep_time = min(2 ** failure_counter + randint(1, 1000) / 1000, max_backoff)
             time.sleep(sleep_time)

--- a/lib/ansible/modules/cloud/vmware/vmware_host.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host.py
@@ -259,10 +259,14 @@ class VMwareHost(PyVmomi):
                 return success, result
             except TaskError as task_error_exception:
                 task_error = task_error_exception.args[0]
-                if self.esxi_ssl_thumbprint == '' and isinstance(task_error, vim.fault.SSLVerifyFault):
+                if len(task_error_exception.args) == 2:
+                    host_thumbprint = task_error_exception.args[1]
+                else:
+                    host_thumbprint = None
+                if self.esxi_ssl_thumbprint == '' and host_thumbprint:
                     # User has not specified SSL Thumbprint for ESXi host,
                     # try to grab it using SSLVerifyFault exception
-                    host_connect_spec.sslThumbprint = task_error.thumbprint
+                    host_connect_spec.sslThumbprint = host_thumbprint
                 else:
                     self.module.fail_json(msg="Failed to add host %s to vCenter: %s" % (self.esxi_hostname,
                                                                                         to_native(task_error)))


### PR DESCRIPTION
##### SUMMARY
Due to refactoring of task_error and wait_for_task method,
SSL thumbprint was lost in error message. This fixes the
retry mechanism of AddHost task.

Fixes: #47563

(cherry picked from commit e7c83d6aa9bbbb7ffe12a367a361f8658829accb)
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
changelogs/fragments/47563-vmware_host-refactor_SSL_thumbprint.yaml
lib/ansible/module_utils/vmware.py
lib/ansible/modules/cloud/vmware/vmware_host.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
Stable-2.7
```