### PR TITLE
Win Chocolatey API Key

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -34,7 +34,6 @@ $proxy_username = Get-AnsibleParam -obj $params -name "proxy_username" -type "st
 $proxy_password = Get-AnsibleParam -obj $params -name "proxy_password" -type "str" -failifempty ($null -ne $proxy_username)
 $skip_scripts = Get-AnsibleParam -obj $params -name "skip_scripts" -type "bool" -default $false
 $source = Get-AnsibleParam -obj $params -name "source" -type "str"
-$install_source = Get-AnsibleParam -obj $params -name "install_source" -type "str"
 $source_username = Get-AnsibleParam -obj $params -name "source_username" -type "str"
 $source_password = Get-AnsibleParam -obj $params -name "source_password" -type "str" -failifempty ($null -ne $source_username)
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "absent","downgrade","latest","present","reinstalled"
@@ -170,8 +169,7 @@ Function Install-Chocolatey {
         [String]$proxy_password,
         [String]$source,
         [String]$source_username,
-        [String]$source_password,
-        [String]$install_source
+        [String]$source_password
     )
 
     $choco_app = Get-Command -Name choco.exe -CommandType Application -ErrorAction SilentlyContinue
@@ -203,10 +201,7 @@ Function Install-Chocolatey {
             }
         }
 
-        if($install_source){
-            $script_url = $install_source
-        }
-        elseif ($source) {
+        if($source) {
             # check if the URL already contains the path to install.ps1
             if ($source.EndsWith("install.ps1")) {
                 $script_url = $source
@@ -485,7 +480,7 @@ Function Uninstall-ChocolateyPackage {
 
 # get the full path to choco.exe, otherwise install/upgrade to at least 0.10.5
 $choco_path = Install-Chocolatey -proxy_url $proxy_url -proxy_username $proxy_username `
-    -proxy_password $proxy_password -source $source -install_source $install_source `
+    -proxy_password $proxy_password -source $source `
     -source_username $source_username -source_password $source_password `
 
 # get the version of all specified packages

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -34,6 +34,7 @@ $proxy_username = Get-AnsibleParam -obj $params -name "proxy_username" -type "st
 $proxy_password = Get-AnsibleParam -obj $params -name "proxy_password" -type "str" -failifempty ($null -ne $proxy_username)
 $skip_scripts = Get-AnsibleParam -obj $params -name "skip_scripts" -type "bool" -default $false
 $source = Get-AnsibleParam -obj $params -name "source" -type "str"
+$install_source = Get-AnsibleParam -obj $params -name "install_source" -type "str"
 $source_username = Get-AnsibleParam -obj $params -name "source_username" -type "str"
 $source_password = Get-AnsibleParam -obj $params -name "source_password" -type "str" -failifempty ($null -ne $source_username)
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "absent","downgrade","latest","present","reinstalled"
@@ -169,7 +170,8 @@ Function Install-Chocolatey {
         [String]$proxy_password,
         [String]$source,
         [String]$source_username,
-        [String]$source_password
+        [String]$source_password,
+        [String]$install_source
     )
 
     $choco_app = Get-Command -Name choco.exe -CommandType Application -ErrorAction SilentlyContinue
@@ -201,7 +203,10 @@ Function Install-Chocolatey {
             }
         }
 
-        if ($source) {
+        if($install_source){
+            $script_url = $install_source
+        }
+        elseif ($source) {
             # check if the URL already contains the path to install.ps1
             if ($source.EndsWith("install.ps1")) {
                 $script_url = $source
@@ -480,8 +485,8 @@ Function Uninstall-ChocolateyPackage {
 
 # get the full path to choco.exe, otherwise install/upgrade to at least 0.10.5
 $choco_path = Install-Chocolatey -proxy_url $proxy_url -proxy_username $proxy_username `
-    -proxy_password $proxy_password -source $source -source_username $source_username `
-    -source_password $source_password
+    -proxy_password $proxy_password -source $source -install_source $install_source `
+    -source_username $source_username -source_password $source_password `
 
 # get the version of all specified packages
 $package_info = @{}

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -138,11 +138,6 @@ options:
     - This value is also used when Chocolatey is not installed as the location
       of the install.ps1 script and only supports URLs for this case.
     type: str
-  install_source:
-    description:
-    - Specify the source of the install script.
-    - This uses the exact URL given and does not attempt to append 'install.ps1'.
-    type: str    
   source_username:
     description:
     - A username to use with I(source) when accessing a feed that requires

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -138,6 +138,11 @@ options:
     - This value is also used when Chocolatey is not installed as the location
       of the install.ps1 script and only supports URLs for this case.
     type: str
+  install_source:
+    description:
+    - Specify the source of the install script.
+    - This uses the exact URL given and does not attempt to append 'install.ps1'.
+    type: str    
   source_username:
     description:
     - A username to use with I(source) when accessing a feed that requires

--- a/lib/ansible/modules/windows/win_chocolatey_source.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey_source.ps1
@@ -179,25 +179,7 @@ Function New-ChocolateySource {
     if ($res.rc -ne 0) {
         Fail-Json -obj $result -message "Failed to add Chocolatey source '$name': $($res.stderr)"
     }
-<#
-    if($null -ne $source_api){
-        $arguments = [System.Collections.ArrayList]@($choco_app.Path,"setapikey","--source", $source, "--api-key", $source_api)
-        if($check_mode){
-            $arguments.Add("--what-if") > $null
-        }
-        if ($admin_only -eq $true) {
-            $arguments.Add("--admin-only") > $null
-        } 
-        else {
-            $admin_only = $false
-        }
-        $command = Argv-ToString -arguments $arguments
-        $res = Run-Command -command $command
-        if ($res.rc -ne 0) {
-            Fail-Json -obj $result -message "Failed to set API key for Chocolatey source '$name': $($res.stderr)"
-        }
-    }
-#>
+
     $source_info = @{
         name = $name
         source = $source
@@ -287,16 +269,6 @@ if ($state -eq "absent" -and $null -ne $actual_source) {
             $result.changed = $true
         }
     }
-<#
-    if ($change) {
-        $actual_source = New-ChocolateySource -choco_app $choco_app -name $name -source $source `
-            -source_username $source_username -source_password $source_password -source_api $source_api  `
-            -certificate $certificate -certificate_password $certificate_password `
-            -priority $priority -bypass_proxy $bypass_proxy -allow_self_service $allow_self_service `
-            -admin_only $admin_only
-        $result.changed = $true
-    }
-#>
     # enable/disable the source if necessary
     if ($state -ne "disabled" -and $actual_source.disabled) {
         $arguments = [System.Collections.ArrayList]@($choco_app.Path, "source", "enable", "--name", $name)

--- a/lib/ansible/modules/windows/win_chocolatey_source.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey_source.ps1
@@ -256,7 +256,7 @@ if ($state -eq "absent" -and $null -ne $actual_source) {
         if ($null -ne $source_password -and $update_password -eq "always") {
             $change = $true
         }
-        if($null -ne $source_api){ #need to double check if key can be pulled
+        if($null -ne $source_api){ 
             $change = $true
         }
         if ($null -ne $certificate -and $certificate -ne $actual_source.certificate) {

--- a/lib/ansible/modules/windows/win_chocolatey_source.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey_source.ps1
@@ -25,6 +25,7 @@ $priority = Get-AnsibleParam -obj $params -name "priority" -type "int"
 $source = Get-AnsibleParam -obj $params -name "source" -type "str" -failifempty ($state -ne "absent")
 $source_username = Get-AnsibleParam -obj $params -name "source_username" -type "str"
 $source_password = Get-AnsibleParam -obj $params -name "source_password" -type "str" -failifempty ($null -ne $source_username)
+$source_api = Get-AnsibleParam -obj $params -name "source_api" -type "str"
 $update_password = Get-AnsibleParam -obj $params -name "update_password" -type "str" -default "always" -validateset "always", "on_create"
 
 $result = @{
@@ -115,6 +116,7 @@ Function New-ChocolateySource {
         $source,
         $source_username,
         $source_password,
+        $source_api,
         $certificate,
         $certificate_password,
         $priority,
@@ -172,6 +174,24 @@ Function New-ChocolateySource {
     $res = Run-Command -command $command
     if ($res.rc -ne 0) {
         Fail-Json -obj $result -message "Failed to add Chocolatey source '$name': $($res.stderr)"
+    }
+
+    if($null -ne $source_api){
+        $arguments = [System.Collections.ArrayList]@($choco_app.Path,"setapikey","--source", $source, "--api-key", $source_api)
+        if($check_mode){
+            $arguments.Add("--what-if") > $null
+        }
+        if ($admin_only -eq $true) {
+            $arguments.Add("--admin-only") > $null
+        } 
+        else {
+            $admin_only = $false
+        }
+        $command = Argv-ToString -arguments $arguments
+        $res = Run-Command -command $command
+        if ($res.rc -ne 0) {
+            Fail-Json -obj $result -message "Failed to set API key for Chocolatey source '$name': $($res.stderr)"
+        }
     }
 
     $source_info = @{
@@ -236,6 +256,9 @@ if ($state -eq "absent" -and $null -ne $actual_source) {
         if ($null -ne $source_password -and $update_password -eq "always") {
             $change = $true
         }
+        if($null -ne $source_api){ #need to double check if key can be pulled
+            $change = $true
+        }
         if ($null -ne $certificate -and $certificate -ne $actual_source.certificate) {
             $change = $true
         }
@@ -263,7 +286,7 @@ if ($state -eq "absent" -and $null -ne $actual_source) {
 
     if ($change) {
         $actual_source = New-ChocolateySource -choco_app $choco_app -name $name -source $source `
-            -source_username $source_username -source_password $source_password `
+            -source_username $source_username -source_password $source_password -source_api $source_api  `
             -certificate $certificate -certificate_password $certificate_password `
             -priority $priority -bypass_proxy $bypass_proxy -allow_self_service $allow_self_service `
             -admin_only $admin_only

--- a/lib/ansible/modules/windows/win_chocolatey_source.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey_source.ps1
@@ -136,6 +136,10 @@ Function New-ChocolateySource {
         $arguments.Add("--password") > $null
         $arguments.Add($source_password) > $null
     }
+    if($null -ne $source_api){
+        $arguments.Add("--api-key") > $null
+        $arguments.Add($source_api) > $null
+    }
     if ($null -ne $certificate) {
         $arguments.Add("--cert") > $null
         $arguments.Add($certificate) > $null
@@ -175,7 +179,7 @@ Function New-ChocolateySource {
     if ($res.rc -ne 0) {
         Fail-Json -obj $result -message "Failed to add Chocolatey source '$name': $($res.stderr)"
     }
-
+<#
     if($null -ne $source_api){
         $arguments = [System.Collections.ArrayList]@($choco_app.Path,"setapikey","--source", $source, "--api-key", $source_api)
         if($check_mode){
@@ -193,7 +197,7 @@ Function New-ChocolateySource {
             Fail-Json -obj $result -message "Failed to set API key for Chocolatey source '$name': $($res.stderr)"
         }
     }
-
+#>
     $source_info = @{
         name = $name
         source = $source
@@ -283,7 +287,7 @@ if ($state -eq "absent" -and $null -ne $actual_source) {
             $result.changed = $true
         }
     }
-
+<#
     if ($change) {
         $actual_source = New-ChocolateySource -choco_app $choco_app -name $name -source $source `
             -source_username $source_username -source_password $source_password -source_api $source_api  `
@@ -292,7 +296,7 @@ if ($state -eq "absent" -and $null -ne $actual_source) {
             -admin_only $admin_only
         $result.changed = $true
     }
-
+#>
     # enable/disable the source if necessary
     if ($state -ne "disabled" -and $actual_source.disabled) {
         $arguments = [System.Collections.ArrayList]@($choco_app.Path, "source", "enable", "--name", $name)

--- a/lib/ansible/modules/windows/win_chocolatey_source.py
+++ b/lib/ansible/modules/windows/win_chocolatey_source.py
@@ -67,6 +67,10 @@ options:
     description:
     - The password for I(source_username).
     - Required if I(source_username) is set.
+  source_api:
+    description:
+    - The api key of the source.
+    - This will run as a secondary command if included.
   state:
     description:
     - When C(absent), will remove the source.


### PR DESCRIPTION
##### SUMMARY
This allows for custom source to utilize an API key rather than using a username and password.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_chocolatey_source

##### ANSIBLE VERSION
```
$ /usr/bin/ansible-playbook --version

ansible-playbook 2.6.3

  config file = /etc/ansible/ansible.cfg

  configured module search path = [u'/etc/ansible/ansible-common/modules']

  ansible python module location = /var/lib/awx/venv/ansible/lib/python2.7/site-packages/ansible

  executable location = /usr/bin/ansible-playbook

  python version = 2.7.5 (default, Feb 20 2018, 09:19:12) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
When trying to pull a package from a different source Chocolatey is capable of using API keys, not just using a username and password. Using a username and password is not the greatest solution. Passwords change, user accounts are removed. An API key is, in my opinion, a better solution. I was surprised that this was not apart of the module already. So I've added it.  

```
name: ".NET Core Windows Hosting"
  win_chocolatey:
     name: dotnetcore-windowshosting
     state: present
     source: https://internal.repo.com/uri/to/repo/
     source_api: "super-secret-key"
```
