### PR TITLE
[2.7] docker_container: improve race condition behavior for detach:no, auto_remove:yes behavior 

### DIFF
--- a/changelogs/fragments/47712-docker_container-detach-auto-remove.yml
+++ b/changelogs/fragments/47712-docker_container-detach-auto-remove.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - fixing race condition when ``detach`` and ``auto_remove`` are both ``true``."

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -35,7 +35,7 @@ HAS_DOCKER_ERROR = None
 try:
     from requests.exceptions import SSLError
     from docker import __version__ as docker_version
-    from docker.errors import APIError, TLSParameterError, NotFound
+    from docker.errors import APIError, NotFound, TLSParameterError
     from docker.tls import TLSConfig
     from docker.constants import DEFAULT_DOCKER_API_VERSION
     from docker import auth
@@ -117,6 +117,9 @@ if not HAS_DOCKER_PY:
             pass
 
     class APIError(Exception):
+        pass
+
+    class NotFound(Exception):  # noqa: F811
         pass
 
 
@@ -442,6 +445,8 @@ class AnsibleDockerClient(Client):
                 self.log("Inspecting container Id %s" % result['Id'])
                 result = self.inspect_container(container=result['Id'])
                 self.log("Completed container inspection")
+            except NotFound as exc:
+                return None
             except Exception as exc:
                 self.fail("Error inspecting container: %s" % exc)
 


### PR DESCRIPTION
##### SUMMARY
Backport of #47712 to stable-2.7: fixes race condition when container is destroyed during `get_container()` execution.

Fixes some spurious test failures. @abadger if you encounter such failures with the docker_container tests, this PR should help.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/docker_commons.py
docker_container

##### ANSIBLE VERSION
```
2.7.1
```
