### PR TITLE
Added support for private key pass phrase (#47525)

### DIFF
--- a/lib/ansible/modules/system/java_keystore.py
+++ b/lib/ansible/modules/system/java_keystore.py
@@ -37,6 +37,7 @@ options:
         description:
           - Pass phrase for reading the private key, if required.
         required: false
+        version_added: "2.8"
     password:
         description:
           - Password that should be used to secure the key store.

--- a/lib/ansible/modules/system/java_keystore.py
+++ b/lib/ansible/modules/system/java_keystore.py
@@ -33,6 +33,10 @@ options:
         description:
           - Private key that should be used to create the key store.
         required: true
+    private_key_password:
+        description:
+          - Pass phrase for reading the private key, if required.
+        required: false
     password:
         description:
           - Password that should be used to secure the key store.
@@ -186,7 +190,7 @@ def cert_changed(module, openssl_bin, keytool_bin, keystore_path, keystore_pass,
         os.remove(certificate_path)
 
 
-def create_jks(module, name, openssl_bin, keytool_bin, keystore_path, password):
+def create_jks(module, name, openssl_bin, keytool_bin, keystore_path, password, in_password):
     if module.check_mode:
         module.exit_json(changed=True)
     else:
@@ -200,8 +204,8 @@ def create_jks(module, name, openssl_bin, keytool_bin, keystore_path, password):
             if os.path.exists(keystore_p12_path):
                 os.remove(keystore_p12_path)
 
-            export_p12_cmd = "%s pkcs12 -export -name '%s' -in '%s' -inkey '%s' -out '%s' -passout 'pass:%s'" % (
-                openssl_bin, name, certificate_path, private_key_path, keystore_p12_path, password)
+            export_p12_cmd = "%s pkcs12 -export -name '%s' -in '%s' -inkey '%s' -out '%s' -passout 'pass:%s' -passin 'pass:%s'" % (
+                openssl_bin, name, certificate_path, private_key_path, keystore_p12_path, password, in_password)
             (rc, export_p12_out, export_p12_err) = run_commands(module, export_p12_cmd)
             if rc != 0:
                 return module.fail_json(msg=export_p12_out,
@@ -242,6 +246,7 @@ def update_jks_perm(module, keystore_path):
 def process_jks(module):
     name = module.params['name']
     password = module.params['password']
+    in_password = module.params['private_key_password']
     keystore_path = module.params['dest']
     force = module.params['force']
     openssl_bin = module.get_bin_path('openssl', True)
@@ -249,16 +254,16 @@ def process_jks(module):
 
     if os.path.exists(keystore_path):
         if force:
-            create_jks(module, name, openssl_bin, keytool_bin, keystore_path, password)
+            create_jks(module, name, openssl_bin, keytool_bin, keystore_path, password, in_password)
         else:
             if cert_changed(module, openssl_bin, keytool_bin, keystore_path, password, name):
-                create_jks(module, name, openssl_bin, keytool_bin, keystore_path, password)
+                create_jks(module, name, openssl_bin, keytool_bin, keystore_path, password, in_password)
             else:
                 if not module.check_mode:
                     update_jks_perm(module, keystore_path)
                 return module.exit_json(changed=False)
     else:
-        create_jks(module, name, openssl_bin, keytool_bin, keystore_path, password)
+        create_jks(module, name, openssl_bin, keytool_bin, keystore_path, password, in_password)
 
 
 class ArgumentSpec(object):
@@ -271,7 +276,8 @@ class ArgumentSpec(object):
             private_key=dict(required=True, no_log=True),
             password=dict(required=True, no_log=True),
             dest=dict(required=True),
-            force=dict(required=False, default=False, type='bool')
+            force=dict(required=False, default=False, type='bool'),
+            private_key_password=dict(required=False, no_log=True)
         )
         self.argument_spec = argument_spec
 

--- a/test/units/modules/system/test_java_keystore.py
+++ b/test/units/modules/system/test_java_keystore.py
@@ -65,7 +65,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
 
         with patch('os.remove', return_value=True):
             self.run_commands.side_effect = lambda args, kwargs: (0, '', '')
-            create_jks(module, "test", "openssl", "keytool", "/path/to/keystore.jks", "changeit")
+            create_jks(module, "test", "openssl", "keytool", "/path/to/keystore.jks", "changeit", "")
             module.exit_json.assert_called_once_with(
                 changed=True,
                 cmd="keytool -importkeystore "
@@ -95,12 +95,13 @@ class TestCreateJavaKeystore(ModuleTestCase):
 
         with patch('os.remove', return_value=True):
             self.run_commands.side_effect = [(1, '', ''), (0, '', '')]
-            create_jks(module, "test", "openssl", "keytool", "/path/to/keystore.jks", "changeit")
+            create_jks(module, "test", "openssl", "keytool", "/path/to/keystore.jks", "changeit", "")
             module.fail_json.assert_called_once_with(
                 cmd="openssl pkcs12 -export -name 'test' "
                     "-in '/tmp/foo.crt' -inkey '/tmp/foo.key' "
                     "-out '/tmp/keystore.p12' "
-                    "-passout 'pass:changeit'",
+                    "-passout 'pass:changeit' "
+                    "-passin 'pass:'",
                 msg='',
                 rc=1
             )
@@ -123,7 +124,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
 
         with patch('os.remove', return_value=True):
             self.run_commands.side_effect = [(0, '', ''), (1, '', '')]
-            create_jks(module, "test", "openssl", "keytool", "/path/to/keystore.jks", "changeit")
+            create_jks(module, "test", "openssl", "keytool", "/path/to/keystore.jks", "changeit", "")
             module.fail_json.assert_called_once_with(
                 cmd="keytool -importkeystore "
                     "-destkeystore '/path/to/keystore.jks' "

--- a/test/units/modules/system/test_java_keystore.py
+++ b/test/units/modules/system/test_java_keystore.py
@@ -77,6 +77,36 @@ class TestCreateJavaKeystore(ModuleTestCase):
                 stdout_lines=''
             )
 
+    def test_create_jks_keypass_fail_export_pkcs12(self):
+        set_module_args(dict(
+            certificate='cert-foo',
+            private_key='private-foo',
+            private_key_passphrase='passphrase-foo',
+            dest='/path/to/keystore.jks',
+            name='foo',
+            password='changeit'
+        ))
+
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode
+        )
+
+        module.fail_json = Mock()
+
+        with patch('os.remove', return_value=True):
+            self.run_commands.side_effect = [(1, '', ''), (0, '', '')]
+            create_jks(module, "test", "openssl", "keytool", "/path/to/keystore.jks", "changeit", "passphrase-foo")
+            module.fail_json.assert_called_once_with(
+                cmd="openssl pkcs12 -export -name 'test' "
+                    "-in '/tmp/foo.crt' -inkey '/tmp/foo.key' "
+                    "-out '/tmp/keystore.p12' "
+                    "-passout 'pass:changeit' "
+                    "-passin 'pass:passphrase-foo'",
+                msg='',
+                rc=1
+            )
+
     def test_create_jks_fail_export_pkcs12(self):
         set_module_args(dict(
             certificate='cert-foo',
@@ -100,8 +130,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
                 cmd="openssl pkcs12 -export -name 'test' "
                     "-in '/tmp/foo.crt' -inkey '/tmp/foo.key' "
                     "-out '/tmp/keystore.p12' "
-                    "-passout 'pass:changeit' "
-                    "-passin 'pass:'",
+                    "-passout 'pass:changeit'",
                 msg='',
                 rc=1
             )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added support for entering a pass phrase for private_key (optionally). Fixes #47525.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
java_keystore

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0
  config file = /home/fgiorget/.ansible.cfg
  configured module search path = [u'/home/fgiorget/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/venv/lib/python2.7/site-packages/ansible
  executable location = /tmp/venv/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
A new optional parameter named private_key_password has been added to the java_keystore module. If source private_key does not require a password, then the new parameter can be omitted (or set as a blank string).

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Steps to reproduce are available in the original issue description.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
TASK [java_keystore] **********************************************************************************************************************************************************************************************
Enter pass phrase for /tmp/cert.key:
```

After:
```
TASK [java_keystore] **********************************************************************************************************************************************************************************************
changed: [localhost]
```
