### PR TITLE
docker_network: Adding basic integration test for overlay network

### DIFF
--- a/test/integration/targets/docker_network/tasks/tests/overlay.yml
+++ b/test/integration/targets/docker_network/tasks/tests/overlay.yml
@@ -1,0 +1,56 @@
+---
+- name: Registering network name
+  set_fact:
+    nname_1: "{{ name_prefix ~ '-network-1' }}"
+- name: Registering network name
+  set_fact:
+    dnetworks: "{{ dnetworks }} + [nname_1]"
+
+####################################################################
+## overlay #########################################################
+####################################################################
+
+# Overlay networks require swarm initialization before they'll work
+- name: swarm
+  docker_swarm:
+    state: present
+    advertise_addr: 192.168.1.1
+
+- name: overlay
+  docker_network:
+    name: "{{ nname_1 }}"
+    driver: overlay
+    driver_options:
+      com.docker.network.driver.overlay.vxlanid_list: "257"
+  register: overlay_1
+
+- name: overlay (idempotency)
+  docker_network:
+    name: "{{ nname_1 }}"
+    driver: overlay
+    driver_options:
+      com.docker.network.driver.overlay.vxlanid_list: "257"
+  register: overlay_2
+
+- name: overlay (change)
+  docker_network:
+    name: "{{ nname_1 }}"
+    driver: bridge
+  register: overlay_3
+
+- name: cleanup network
+  docker_network:
+    name: "{{ nname_1 }}"
+    state: absent
+    force: yes
+
+- name: cleanup swarm
+  docker_swarm:
+    state: absent
+    force: yes
+
+- assert:
+    that:
+    - overlay_1 is changed
+    - overlay_2 is not changed
+    - overlay_3 is changed


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/ansible/issues/19271 claims that overlay networks aren't working. This may have been true in 2.2, but in 2.8, that doesn't seem to be the case. In order to prove this, I've added an integration test for overlay networks. Note that overlay networks require a `docker_swarm` to be set up first, so that's in there as well.

I'm also not including a changelog fragment, since this doesn't modify any user-facing functionality.

Fixes #19271

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_network

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (docker_network_overlay 7804936387) last updated 2018/10/29 14:34:30 (GMT -500)
  config file = None
  configured module search path = [u'/home/darkelf/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/darkelf/ansible/lib/ansible
  executable location = /home/darkelf/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
Ran the integration test locally with `ubuntu1604` docker and it's passing.