### PR TITLE
teach ansible how to use systemd-nspawn

### DIFF
--- a/lib/ansible/plugins/connection/nspawn.py
+++ b/lib/ansible/plugins/connection/nspawn.py
@@ -1,0 +1,64 @@
+from __future__ import (absolute_import, division, print_function)
+
+from ansible import constants as C
+from ansible.plugins.connection.chroot import Connection as ChrootConnection
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+    author: Lars Kellogg-Stedman <lars@redhat.com>
+    connection: nspawn
+    short_description: Interact with local systemd-nspawn container
+    description:
+        - Run commands or put/fetch files to an existing systemd-nspawn
+          container on the Ansible controller. Unlike the chroot driver,
+          this will ensure that /proc, /sys, and /dev are all properly
+          configured.
+        - Set "ansible_nspawn_extra_args" to pass additional arguments to
+          systemd-nspawn (e.g., --bind, --private-network, --private-user,
+          etc).
+    version_added: "2.8"
+    options:
+      remote_addr:
+        description:
+            - The path of the chroot you want to access
+        default: inventory_hostname
+        vars:
+            - name: ansible_host
+      executable:
+        description:
+            - User specified executable shell (defaults to /bin/sh)
+        ini:
+          - section: defaults
+            key: executable
+        env:
+          - name: ANSIBLE_EXECUTABLE
+        vars:
+          - name: ansible_executable
+      nspawn_extra_args:
+        description:
+          - Extra command line arguments to pass to systemd-nspawn
+        env:
+          - name: ANSIBLE_NSPAWN_EXTRA_ARGS
+        vars:
+          - name: ansible_nspawn_extra_args
+"""
+
+
+class Connection(ChrootConnection):
+    transport = 'nspawn'
+    transport_cmd = 'systemd-nspawn'
+
+    def _local_command(self, cmd):
+        executable = (C.DEFAULT_EXECUTABLE.split()[0]
+                      if C.DEFAULT_EXECUTABLE
+                      else '/bin/sh')
+
+        extra_args = []
+
+        if self.get_option('nspawn_extra_args'):
+            extra_args = self.get_option('nspawn_extra_args').split()
+
+        return ([self._transport_cmd] +
+                extra_args +
+                ['-D', self.chroot, executable, '-c', cmd])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is a thin clone of the `chroot` connection driver that uses
`systemd-nspawn` to spawn processes in a chroot environment. Unlike
vanilla chroot, `systemd-nspawn` takes care of setting up/tearing down
directories like `/proc` and `/sys` and offers a variety of options for
controlling namespacing in the chrooted environment.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
systemd-nspawn connection plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (feature/nspawn c2b2dfdd51) last updated 2018/10/29 16:20:46 (GMT -400)
  config file = /home/lars/projects/piconfig/ansible.cfg
  configured module search path = [u'/home/lars/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/lars/src/ansible/lib/ansible
  executable location = /home/lars/projects/piconfig/.venv/bin/ansible
  python version = 2.7.15 (default, Oct 15 2018, 15:24:06) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Using the `ansible_nspawn_extra_args` command it is possible to pass additional command line arguments to `systemd-nspawn`.  For example, with the following inventory...

```
---
all:
  hosts:
    /mnt:
      ansible_connection: nspawn
      ansible_nspawn_extra_args: "--private-network"
```

...Ansible would connect to the chroot on `/mnt` using the command:

    systemd-nspawn -D /mnt --private-network /bin/sh -c '...'

If we were to use the following playbook...

```
---
- hosts: all
  tasks:
    - debug:
        var: ansible_interfaces
```

We would see:

```
PLAY [all] ************************************************************************************

TASK [Gathering Facts] ************************************************************************
ok: [/mnt]

TASK [debug] **********************************************************************************
ok: [/mnt] => {
    "ansible_interfaces": [
        "lo"
    ]
}

PLAY RECAP ************************************************************************************
/mnt                       : ok=2    changed=0    unreachable=0    failed=0    skipped=0
```
