### PR TITLE
Adds bigip profile for http2

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_profile_http2.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_http2.py
@@ -1,0 +1,680 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright: (c) 2018, F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'certified'}
+
+DOCUMENTATION = r'''
+---
+module: bigip_profile_http2
+short_description: Manage HTTP2 profiles on a BIG-IP
+description:
+  - Manage HTTP2 profiles on a BIG-IP.
+version_added: 2.8
+options:
+  name:
+    description:
+      - Specifies the name of the profile.
+    required: True
+  parent:
+    description:
+      - Specifies the profile from which this profile inherits settings.
+      - When creating a new profile, if this parameter is not specified, the default
+        is the system-supplied C(http2) profile.
+    default: /Common/http2
+  description:
+    description:
+      - Description of the profile.
+  streams:
+    description:
+      - Specifies the number of outstanding concurrent requests that are allowed on a single HTTP/2 connection.
+      - When creating a new profile, if this parameter is not specified, the default is provided by the parent profile.
+      - The valid value range is C(1 - 256).
+    type: int
+  idle_timeout:
+    description:
+      - Specifies the number of seconds that an HTTP/2 connection is idly left open before being shut down.
+      - When creating a new profile, if this parameter is not specified, the default is provided by the parent profile.
+    type: int
+  insert_header:
+    description:
+      - Specifies whether an HTTP header indicating the use of HTTP/2 should be inserted into the request
+        that goes to the server.
+      - When creating a new profile, if this parameter is not specified, the default is provided by the parent profile.
+    type: bool
+  insert_header_name:
+    description:
+      - Specifies the name of the HTTP header controlled by C(insert_header) parameter.
+      - When creating a new profile, if this parameter is not specified, the default is provided by the parent profile.
+  enforce_tls_requirements:
+    description:
+      - Specifies whether the system requires TLS for communications between specified senders and recipients.
+      - When creating a new profile, if this parameter is not specified, the default is provided by the parent profile.
+    type: bool
+  activation_modes:
+    description:
+      - Specifies what will cause an incoming connection to be handled as a HTTP/2 connection.
+      - The C(alpn) and C(always) are mutually exclusive.
+      - When creating a new profile, if this parameter is not specified, the default is provided by the parent profile.
+    choices:
+      - alpn
+      - always
+    type: list
+  frame_size:
+    description:
+      - Specifies the size of data frames, in bytes, that HTTP/2 sends to the client.
+      - When creating a new profile, if this parameter is not specified, the default is provided by the parent profile.
+      - The valid value range in bytes is C(1024 - 16384).
+    type: int
+  write_size:
+    description:
+      - Specifies the total size of combined data frames, in bytes, that HTTP/2 sends in a single write.
+      - When creating a new profile, if this parameter is not specified, the default is provided by the parent profile.
+      - The valid value range in bytes is C(2048 - 32768).
+    type: int
+  receive_window:
+    description:
+      - Specifies the way that the HTTP/2 profile performs flow control.
+      - When creating a new profile, if this parameter is not specified, the default is provided by the parent profile.
+      - The valid value range in kilobytes is C(16 - 128).
+    type: int
+  header_table_size:
+    description:
+      - Specifies the size of the header table, in bytes.
+      - When creating a new profile, if this parameter is not specified, the default is provided by the parent profile.
+      - The valid value range in bytes is C(0 - 65535).
+    type: int
+  partition:
+    description:
+      - Device partition to manage resources on.
+    default: Common
+  state:
+    description:
+      - When C(present), ensures that the profile exists.
+      - When C(absent), ensures the profile is removed.
+    default: present
+    choices:
+      - present
+      - absent
+extends_documentation_fragment: f5
+author:
+  - Wojciech Wypior(@wojtek0806)
+'''
+
+EXAMPLES = r'''
+- name: Create HTTP2 profile
+  bigip_profile_http2:
+    name: my_profile
+    password: secret
+    server: lb.mydomain.com
+    insert_header: yes
+    insert_header_name: FOO
+    state: present
+    user: admin
+  delegate_to: localhost
+
+- name: Remove HTTP profile
+  bigip_profile_http2:
+    name: my_profile
+    state: absent
+    server: lb.mydomain.com
+    user: admin
+    password: secret
+  delegate_to: localhost
+
+- name: Add HTTP profile set activation modes
+  bigip_profile_http:
+    name: my_profile
+    server: lb.mydomain.com
+    user: admin
+    activation_modes:
+      - always
+    password: secret
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+description:
+  description: Description of the profile.
+  returned: changed
+  type: string
+  sample: My profile
+insert_header_name:
+  description: Specifies the name of the HTTP2 header
+  returned: changed
+  type: string
+  sample: X-HTTP2
+streams:
+  description: The number of outstanding concurrent requests allowed on a single HTTP/2 connection
+  returned: changed
+  type: int
+  sample: 30
+enforce_tls_requirements:
+  description: pecifies whether the system requires TLS for communications.
+  returned: changed
+  type: bool
+  sample: yes
+frame_size:
+  description: The size of the data frames
+  returned: changed
+  type: int
+  sample: 30
+activation_modes:
+  description: Specifies HTTP/2 connection handling modes
+  returned: changed
+  type: list
+  sample: ['always']
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+
+try:
+    from library.module_utils.network.f5.bigip import F5RestClient
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fq_name
+    from library.module_utils.network.f5.common import transform_name
+    from library.module_utils.network.f5.common import flatten_boolean
+    from library.module_utils.network.f5.common import is_empty_list
+    from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.common import exit_json
+    from library.module_utils.network.f5.common import fail_json
+except ImportError:
+    from ansible.module_utils.network.f5.bigip import F5RestClient
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fq_name
+    from ansible.module_utils.network.f5.common import transform_name
+    from ansible.module_utils.network.f5.common import flatten_boolean
+    from ansible.module_utils.network.f5.common import is_empty_list
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.common import exit_json
+    from ansible.module_utils.network.f5.common import fail_json
+
+
+class Parameters(AnsibleF5Parameters):
+    api_map = {
+        'activationModes': 'activation_modes',
+        'concurrentStreamsPerConnection': 'streams',
+        'connectionIdleTimeout': 'idle_timeout',
+        'defaultsFrom': 'parent',
+        'enforceTlsRequirements': 'enforce_tls_requirements',
+        'frameSize': 'frame_size',
+        'headerTableSize': 'header_table_size',
+        'insertHeader': 'insert_header',
+        'insertHeaderName': 'insert_header_name',
+        'receiveWindow': 'receive_window',
+        'writeSize': 'write_size',
+    }
+
+    api_attributes = [
+        'activationModes',
+        'concurrentStreamsPerConnection',
+        'connectionIdleTimeout',
+        'description',
+        'defaultsFrom',
+        'enforceTlsRequirements',
+        'frameSize',
+        'headerTableSize',
+        'insertHeader',
+        'insertHeaderName',
+        'receiveWindow',
+        'writeSize',
+    ]
+
+    returnables = [
+        'activation_modes',
+        'streams',
+        'description',
+        'idle_timeout',
+        'parent',
+        'enforce_tls_requirements',
+        'frame_size',
+        'header_table_size',
+        'insert_header',
+        'insert_header_name',
+        'receive_window',
+        'write_size',
+    ]
+
+    updatables = [
+        'activation_modes',
+        'streams',
+        'description',
+        'idle_timeout',
+        'parent',
+        'enforce_tls_requirements',
+        'frame_size',
+        'header_table_size',
+        'insert_header',
+        'insert_header_name',
+        'receive_window',
+        'write_size',
+    ]
+
+
+class ApiParameters(Parameters):
+    pass
+
+
+class ModuleParameters(Parameters):
+    @property
+    def parent(self):
+        if self._values['parent'] is None:
+            return None
+        result = fq_name(self.partition, self._values['parent'])
+        return result
+
+    @property
+    def streams(self):
+        streams = self._values['streams']
+        if streams is None:
+            return None
+        if streams < 1 or streams > 256:
+            raise F5ModuleError(
+                "Streams value must be between 1 and 256"
+            )
+        return self._values['streams']
+
+    @property
+    def receive_window(self):
+        window = self._values['receive_window']
+        if window is None:
+            return None
+        if window < 16 or window > 128:
+            raise F5ModuleError(
+                "Receive Window value must be between 16 and 128"
+            )
+        return self._values['receive_window']
+
+    @property
+    def header_table_size(self):
+        header = self._values['header_table_size']
+        if header is None:
+            return None
+        if header < 0 or header > 65535:
+            raise F5ModuleError(
+                "Header Table Size value must be between 0 and 65535"
+            )
+        return self._values['header_table_size']
+
+    @property
+    def write_size(self):
+        write = self._values['write_size']
+        if write is None:
+            return None
+        if write < 2048 or write > 32768:
+            raise F5ModuleError(
+                "Write Size value must be between 2048 and 32768"
+            )
+        return self._values['write_size']
+
+    @property
+    def frame_size(self):
+        frame = self._values['frame_size']
+        if frame is None:
+            return None
+        if frame < 1024 or frame > 16384:
+            raise F5ModuleError(
+                "Write Size value must be between 1024 and 16384"
+            )
+        return self._values['frame_size']
+
+    @property
+    def enforce_tls_requirements(self):
+        result = flatten_boolean(self._values['enforce_tls_requirements'])
+        if result is None:
+            return None
+        if result == 'yes':
+            return 'enabled'
+        return 'disabled'
+
+    @property
+    def insert_header(self):
+        result = flatten_boolean(self._values['insert_header'])
+        if result is None:
+            return None
+        if result == 'yes':
+            return 'enabled'
+        return 'disabled'
+
+    @property
+    def activation_modes(self):
+        value = self._values['activation_modes']
+        if value is None:
+            return None
+        if is_empty_list(value):
+            raise F5ModuleError(
+                "Activation Modes cannot be empty, please provide a value"
+            )
+        return value
+
+
+class Changes(Parameters):
+    def to_return(self):
+        result = {}
+        try:
+            for returnable in self.returnables:
+                result[returnable] = getattr(self, returnable)
+            result = self._filter_params(result)
+        except Exception:
+            pass
+        return result
+
+
+class UsableChanges(Changes):
+    pass
+
+
+class ReportableChanges(Changes):
+    @property
+    def insert_header(self):
+        if self._values['insert_header'] is None:
+            return None
+        elif self._values['insert_header'] == 'enabled':
+            return 'yes'
+        return 'no'
+
+    @property
+    def enforce_tls_requirements(self):
+        if self._values['enforce_tls_requirements'] is None:
+            return None
+        elif self._values['enforce_tls_requirements'] == 'enabled':
+            return 'yes'
+        return 'no'
+
+
+class Difference(object):
+    def __init__(self, want, have=None):
+        self.want = want
+        self.have = have
+
+    def compare(self, param):
+        try:
+            result = getattr(self, param)
+            return result
+        except AttributeError:
+            return self.__default(param)
+
+    def __default(self, param):
+        attr1 = getattr(self.want, param)
+        try:
+            attr2 = getattr(self.have, param)
+            if attr1 != attr2:
+                return attr1
+        except AttributeError:
+            return attr1
+
+    @property
+    def parent(self):
+        if self.want.parent != self.have.parent:
+            raise F5ModuleError(
+                "The parent profile cannot be changed"
+            )
+
+    @property
+    def description(self):
+        if self.want.description is None:
+            return None
+        if self.want.description == '':
+            if self.have.description is None or self.have.description == "none":
+                return None
+        if self.want.description != self.have.description:
+            return self.want.description
+
+
+class ModuleManager(object):
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
+        self.want = ModuleParameters(params=self.module.params)
+        self.have = ApiParameters()
+        self.changes = UsableChanges()
+
+    def _set_changed_options(self):
+        changed = {}
+        for key in Parameters.returnables:
+            if getattr(self.want, key) is not None:
+                changed[key] = getattr(self.want, key)
+        if changed:
+            self.changes = UsableChanges(params=changed)
+
+    def _update_changed_options(self):
+        diff = Difference(self.want, self.have)
+        updatables = Parameters.updatables
+        changed = dict()
+        for k in updatables:
+            change = diff.compare(k)
+            if change is None:
+                continue
+            else:
+                if isinstance(change, dict):
+                    changed.update(change)
+                else:
+                    changed[k] = change
+        if changed:
+            self.changes = UsableChanges(params=changed)
+            return True
+        return False
+
+    def exec_module(self):
+        changed = False
+        result = dict()
+        state = self.want.state
+
+        if state == "present":
+            changed = self.present()
+        elif state == "absent":
+            changed = self.absent()
+        reportable = ReportableChanges(params=self.changes.to_return())
+        changes = reportable.to_return()
+        result.update(**changes)
+        result.update(dict(changed=changed))
+        self._announce_deprecations(result)
+        return result
+
+    def _announce_deprecations(self, result):
+        warnings = result.pop('__warnings', [])
+        for warning in warnings:
+            self.client.module.deprecate(
+                msg=warning['msg'],
+                version=warning['version']
+            )
+
+    def present(self):
+        if self.exists():
+            return self.update()
+        else:
+            return self.create()
+
+    def absent(self):
+        if self.exists():
+            return self.remove()
+        return False
+
+    def update(self):
+        self.have = self.read_current_from_device()
+        if not self.should_update():
+            return False
+        if self.module.check_mode:
+            return True
+        self.update_on_device()
+        return True
+
+    def should_update(self):
+        result = self._update_changed_options()
+        if result:
+            return True
+        return False
+
+    def remove(self):
+        if self.module.check_mode:
+            return True
+        self.remove_from_device()
+        if self.exists():
+            raise F5ModuleError("Failed to delete the resource.")
+        return True
+
+    def create(self):
+        self._set_changed_options()
+        if self.module.check_mode:
+            return True
+        self.create_on_device()
+        return True
+
+    def exists(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/profile/http2/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError:
+            return False
+        if resp.status == 404 or 'code' in response and response['code'] == 404:
+            return False
+        return True
+
+    def create_on_device(self):
+        params = self.changes.api_params()
+        params['name'] = self.want.name
+        params['partition'] = self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/ltm/profile/http2/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port']
+        )
+        resp = self.client.api.post(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return response['selfLink']
+
+    def update_on_device(self):
+        params = self.changes.api_params()
+        uri = "https://{0}:{1}/mgmt/tm/ltm/profile/http2/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.patch(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+
+    def remove_from_device(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/profile/http2/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        response = self.client.api.delete(uri)
+        if response.status == 200:
+            return True
+        raise F5ModuleError(response.content)
+
+    def read_current_from_device(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/profile/http2/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return ApiParameters(params=response)
+
+
+class ArgumentSpec(object):
+    def __init__(self):
+        self.supports_check_mode = True
+        argument_spec = dict(
+            name=dict(required=True),
+            parent=dict(default='/Common/http2'),
+            activation_modes=dict(
+                type='list',
+                choices=[
+                    'alpn', 'always'
+                ],
+                mutually_exclusive=['always', 'alpn'],
+            ),
+            description=dict(),
+            enforce_tls_requirements=dict(type='bool'),
+            streams=dict(type='int'),
+            idle_timeout=dict(type='int'),
+            frame_size=dict(type='int'),
+            header_table_size=dict(type='int'),
+            insert_header=dict(type='bool'),
+            insert_header_name=dict(),
+            receive_window=dict(type='int'),
+            write_size=dict(type='int'),
+            state=dict(
+                default='present',
+                choices=['present', 'absent']
+            ),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
+            )
+        )
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
+
+
+def main():
+    spec = ArgumentSpec()
+
+    module = AnsibleModule(
+        argument_spec=spec.argument_spec,
+        supports_check_mode=spec.supports_check_mode,
+    )
+
+    client = F5RestClient(**module.params)
+
+    try:
+        mm = ModuleManager(module=module, client=client)
+        results = mm.exec_module()
+        cleanup_tokens(client)
+        exit_json(module, results, client)
+    except F5ModuleError as ex:
+        cleanup_tokens(client)
+        fail_json(module, ex, client)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/f5/fixtures/load_ltm_http2_profile.json
+++ b/test/units/modules/network/f5/fixtures/load_ltm_http2_profile.json
@@ -1,0 +1,27 @@
+{
+  "kind": "tm:ltm:profile:http2:http2state",
+  "name": "test",
+  "partition": "Common",
+  "fullPath": "/Common/test",
+  "generation": 5852,
+  "selfLink": "https://localhost/mgmt/tm/ltm/profile/http2/~Common~test?ver=13.1.0.8",
+  "activationModes": [
+    "always"
+  ],
+  "appService": "none",
+  "concurrentStreamsPerConnection": 10,
+  "connectionIdleTimeout": 300,
+  "defaultsFrom": "/Common/http2",
+  "defaultsFromReference": {
+    "link": "https://localhost/mgmt/tm/ltm/profile/http2/~Common~http2?ver=13.1.0.8"
+  },
+  "description": "this is awful documentation",
+  "enforceTlsRequirements": "enabled",
+  "frameSize": 2048,
+  "headerTableSize": 4096,
+  "includeContentLength": "disabled",
+  "insertHeader": "disabled",
+  "insertHeaderName": "X-HTTP2",
+  "receiveWindow": 32,
+  "writeSize": 16384
+}

--- a/test/units/modules/network/f5/test_bigip_profile_http2.py
+++ b/test/units/modules/network/f5/test_bigip_profile_http2.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright: (c) 2018, F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import sys
+
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from library.modules.bigip_profile_http2 import ApiParameters
+    from library.modules.bigip_profile_http2 import ModuleParameters
+    from library.modules.bigip_profile_http2 import ModuleManager
+    from library.modules.bigip_profile_http2 import ArgumentSpec
+
+    # In Ansible 2.8, Ansible changed import paths.
+    from test.units.compat import unittest
+    from test.units.compat.mock import Mock
+    from test.units.compat.mock import patch
+
+    from test.units.modules.utils import set_module_args
+except ImportError:
+    try:
+        from ansible.modules.network.f5.bigip_profile_http2 import ApiParameters
+        from ansible.modules.network.f5.bigip_profile_http2 import ModuleParameters
+        from ansible.modules.network.f5.bigip_profile_http2 import ModuleManager
+        from ansible.modules.network.f5.bigip_profile_http2 import ArgumentSpec
+
+        # Ansible 2.8 imports
+        from units.compat import unittest
+        from units.compat.mock import Mock
+        from units.compat.mock import patch
+
+        from units.modules.utils import set_module_args
+    except ImportError:
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+
+fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+fixture_data = {}
+
+
+def load_fixture(name):
+    path = os.path.join(fixture_path, name)
+
+    if path in fixture_data:
+        return fixture_data[path]
+
+    with open(path) as f:
+        data = f.read()
+
+    try:
+        data = json.loads(data)
+    except Exception:
+        pass
+
+    fixture_data[path] = data
+    return data
+
+
+class TestParameters(unittest.TestCase):
+    def test_module_parameters(self):
+        args = dict(
+            name='foo',
+            parent='bar',
+            description='This is a Test',
+            streams=20,
+            enforce_tls_requirements=True,
+            frame_size=1024,
+            activation_modes=['always'],
+            insert_header=True,
+            insert_header_name='FOO'
+
+        )
+
+        p = ModuleParameters(params=args)
+        assert p.name == 'foo'
+        assert p.parent == '/Common/bar'
+        assert p.description == 'This is a Test'
+        assert p.streams == 20
+        assert p.enforce_tls_requirements == 'enabled'
+        assert p.frame_size == 1024
+        assert p.activation_modes == ['always']
+        assert p.insert_header == 'enabled'
+        assert p.insert_header_name == 'FOO'
+
+    def test_api_parameters(self):
+        args = load_fixture('load_ltm_http2_profile.json')
+        p = ApiParameters(params=args)
+        assert p.name == 'test'
+        assert p.streams == 10
+        assert p.enforce_tls_requirements == 'enabled'
+
+
+class TestManager(unittest.TestCase):
+
+    def setUp(self):
+        self.spec = ArgumentSpec()
+
+    def test_create(self, *args):
+        # Configure the arguments that would be sent to the Ansible module
+        set_module_args(dict(
+            name='foo',
+            enforce_tls_requirements='yes',
+            parent='bar',
+            password='password',
+            server='localhost',
+            user='admin'
+        ))
+
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode
+        )
+        mm = ModuleManager(module=module)
+
+        # Override methods to force specific logic in the module to happen
+        mm.exists = Mock(return_value=False)
+        mm.create_on_device = Mock(return_value=True)
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['enforce_tls_requirements'] == 'yes'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This allows one to manage HTTP2 profiles on a BIG-IP

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bigip_profile_http2

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.6 (default, Oct 16 2018, 07:17:20) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
