### PR TITLE
Add default nolog param for PreSharedKey argument in ec2_vpc_vpn.py module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_vpn.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_vpn.py
@@ -699,7 +699,7 @@ def main():
         vpn_gateway_id=dict(type='str'),
         tags=dict(default={}, type='dict'),
         connection_type=dict(default='ipsec.1', type='str'),
-        tunnel_options=dict(type='list', default=[]),
+        tunnel_options=dict(no_log=True, type='list', default=[]),
         static_only=dict(default=False, type='bool'),
         customer_gateway_id=dict(type='str'),
         vpn_connection_id=dict(type='str'),

--- a/lib/ansible/modules/cloud/amazon/ec2_win_password.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_win_password.py
@@ -27,8 +27,12 @@ options:
     required: true
   key_file:
     description:
-      - Path to the file containing the key pair used on the instance.
-    required: true
+      - Path to the file containing the key pair used on the instance, conflicts with key_data.
+    required: false
+  key_data:
+    description:
+      - Variable that references the private key (usually stored in vault), conflicts with key_file.
+    required: false
   key_passphrase:
     version_added: "2.0"
     description:
@@ -66,6 +70,14 @@ EXAMPLES = '''
     instance_id: i-XXXXXX
     region: us-east-1
     key_file: "~/aws-creds/my_test_key.pem"
+
+# Example of getting a password using a variable
+- name: get the Administrator password
+  ec2_win_password:
+    profile: my-boto-profile
+    instance_id: i-XXXXXX
+    region: us-east-1
+    key_data: "{{ ec2_private_key }}"
 
 # Example of getting a password with a password protected key
 - name: get the Administrator password
@@ -108,8 +120,9 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
         instance_id=dict(required=True),
-        key_file=dict(required=True, type='path'),
+        key_file=dict(required=False, default=None, type='path'),
         key_passphrase=dict(no_log=True, default=None, required=False),
+        key_data=dict(no_log=True, default=None, required=False),
         wait=dict(type='bool', default=False, required=False),
         wait_timeout=dict(default=120, required=False, type='int'),
     )
@@ -124,6 +137,7 @@ def main():
 
     instance_id = module.params.get('instance_id')
     key_file = module.params.get('key_file')
+    key_data = module.params.get('key_data')
     if module.params.get('key_passphrase') is None:
         b_key_passphrase = None
     else:
@@ -151,16 +165,22 @@ def main():
     if wait and datetime.datetime.now() >= end:
         module.fail_json(msg="wait for password timeout after %d seconds" % wait_timeout)
 
-    try:
-        f = open(key_file, 'rb')
-    except IOError as e:
-        module.fail_json(msg="I/O error (%d) opening key file: %s" % (e.errno, e.strerror))
-    else:
+    if key_file is not None and key_data is None:
         try:
-            with f:
-                key = load_pem_private_key(f.read(), b_key_passphrase, default_backend())
+            f = open(key_file, 'rb')
+        except IOError as e:
+            module.fail_json(msg="I/O error (%d) opening key file: %s" % (e.errno, e.strerror))
+        else:
+            try:
+                with f:
+                    key = load_pem_private_key(f.read(), b_key_passphrase, default_backend())
+            except (ValueError, TypeError) as e:
+                module.fail_json(msg="unable to parse key file")
+    elif key_data is not None and key_file is None:
+        try:
+            key = load_pem_private_key(key_data, b_key_passphrase, default_backend())
         except (ValueError, TypeError) as e:
-            module.fail_json(msg="unable to parse key file")
+            module.fail_json(msg="unable to parse key data")
 
     try:
         decrypted = key.decrypt(decoded, PKCS1v15())

--- a/lib/ansible/modules/cloud/amazon/ec2_win_password.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_win_password.py
@@ -30,6 +30,7 @@ options:
       - Path to the file containing the key pair used on the instance, conflicts with key_data.
     required: false
   key_data:
+    version_added: "2.8"
     description:
       - Variable that references the private key (usually stored in vault), conflicts with key_file.
     required: false

--- a/lib/ansible/modules/cloud/amazon/ec2_win_password.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_win_password.py
@@ -168,15 +168,14 @@ def main():
 
     if key_file is not None and key_data is None:
         try:
-            f = open(key_file, 'rb')
+            with open(key_file, 'rb') as f:
+                key = load_pem_private_key(f.read(), b_key_passphrase, default_backend())
         except IOError as e:
+            # Handle bad files
             module.fail_json(msg="I/O error (%d) opening key file: %s" % (e.errno, e.strerror))
-        else:
-            try:
-                with f:
-                    key = load_pem_private_key(f.read(), b_key_passphrase, default_backend())
-            except (ValueError, TypeError) as e:
-                module.fail_json(msg="unable to parse key file")
+        except (ValueError, TypeError) as e:
+            # Handle issues loading key
+            module.fail_json(msg="unable to parse key file")
     elif key_data is not None and key_file is None:
         try:
             key = load_pem_private_key(key_data, b_key_passphrase, default_backend())


### PR DESCRIPTION
##### SUMMARY
Currently when hardcoding the PreSharedKey for VPC VPNs it is outputted in cleartext. You can set nolog for the whole task but then you miss relevant output. Although we would be now hiding the tunnel CIDRs if specified, it is better than displaying passwords in output.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2_vpc_vpn.py

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/var/lib/jenkins/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /var/lib/jenkins/workspace/ansible_test/ec2_vpc_vpn_venv/lib/python2.7/site-packages/ansible
  executable location = /var/lib/jenkins/workspace/ansible_test/ec2_vpc_vpn_venv/bin/ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

```

##### ADDITIONAL INFORMATION
