### PR TITLE
Add default no_log param for PreSharedKey argument in ec2_vpc_vpn.py module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_vpn.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_vpn.py
@@ -699,7 +699,7 @@ def main():
         vpn_gateway_id=dict(type='str'),
         tags=dict(default={}, type='dict'),
         connection_type=dict(default='ipsec.1', type='str'),
-        tunnel_options=dict(type='list', default=[]),
+        tunnel_options=dict(no_log=True, type='list', default=[]),
         static_only=dict(default=False, type='bool'),
         customer_gateway_id=dict(type='str'),
         vpn_connection_id=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
Currently when hardcoding the PreSharedKey for VPC VPNs it is outputted in cleartext. You can set nolog for the whole task but then you miss relevant output. Although we would be now hiding the tunnel CIDRs if specified, it is better than displaying passwords in output.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2_vpc_vpn.py

##### ANSIBLE VERSION
```
ansible 2.6.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/var/lib/jenkins/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /var/lib/jenkins/workspace/ansible_test/ec2_vpc_vpn_venv/lib/python2.7/site-packages/ansible
  executable location = /var/lib/jenkins/workspace/ansible_test/ec2_vpc_vpn_venv/bin/ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

```

##### ADDITIONAL INFORMATION