### PR TITLE
Remove f5-sdk from bigip_virtual_address module

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_virtual_address.py
+++ b/lib/ansible/modules/network/f5/bigip_virtual_address.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017 F5 Networks Inc.
+# Copyright: (c) 2017, F5 Networks Inc.
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -189,6 +189,7 @@ options:
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
+  - Wojciech Wypior (@wojtek0806)
 '''
 
 EXAMPLES = r'''
@@ -268,31 +269,29 @@ from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE
 from distutils.version import LooseVersion
 
 try:
-    from library.module_utils.network.f5.bigip import HAS_F5SDK
-    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import transform_name
+    from library.module_utils.network.f5.common import exit_json
+    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.ipaddress import is_valid_ip
-    try:
-        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
+    from library.module_utils.network.f5.icontrol import tmos_version
 except ImportError:
-    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
-    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import transform_name
+    from ansible.module_utils.network.f5.common import exit_json
+    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
-    try:
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
+    from ansible.module_utils.network.f5.icontrol import tmos_version
 
 
 class Parameters(AnsibleF5Parameters):
@@ -444,7 +443,7 @@ class Parameters(AnsibleF5Parameters):
     def route_advertisement(self):
         if self._values['route_advertisement'] is None:
             return None
-        version = self.client.api.tmos_version
+        version = tmos_version(self.client)
         if LooseVersion(version) <= LooseVersion('13.0.0'):
             if self._values['route_advertisement'] == 'disabled':
                 return 'disabled'
@@ -452,13 +451,6 @@ class Parameters(AnsibleF5Parameters):
                 return 'enabled'
         else:
             return self._values['route_advertisement']
-
-    def to_return(self):
-        result = {}
-        for returnable in self.returnables:
-            result[returnable] = getattr(self, returnable)
-        result = self._filter_params(result)
-        return result
 
 
 class ApiParameters(Parameters):
@@ -502,24 +494,6 @@ class ModuleParameters(Parameters):
             )
 
     @property
-    def route_domain(self):
-        if self._values['route_domain'] is None:
-            return None
-        try:
-            return int(self._values['route_domain'])
-        except ValueError:
-            try:
-                rd = self.client.api.tm.net.route_domains.route_domain.load(
-                    name=self._values['route_domain'],
-                    partition=self.partition
-                )
-                return int(rd.id)
-            except iControlUnexpectedHTTPError:
-                raise F5ModuleError(
-                    "The specified 'route_domain' was not found."
-                )
-
-    @property
     def full_address(self):
         if self.route_domain is not None:
             return '{0}%{1}'.format(self.address, self.route_domain)
@@ -535,9 +509,43 @@ class ModuleParameters(Parameters):
             result = self._values['name']
         return result
 
+    @property
+    def route_domain(self):
+        if self._values['route_domain'] is None:
+            return None
+        try:
+            return int(self._values['route_domain'])
+        except ValueError:
+            uri = "https://{0}:{1}/mgmt/tm/net/route-domain/{2}".format(
+                self.client.provider['server'],
+                self.client.provider['server_port'],
+                transform_name(self._values['partition'], self._values['route_domain'])
+            )
+            resp = self.client.api.get(uri)
+            try:
+                response = resp.json()
+            except ValueError:
+                raise F5ModuleError(
+                    "The specified 'route_domain' was not found."
+                )
+            if resp.status == 404 or 'code' in response and response['code'] == 404:
+                raise F5ModuleError(
+                    "The specified 'route_domain' was not found."
+                )
+
+            return int(response['id'])
+
 
 class Changes(Parameters):
-    pass
+    def to_return(self):
+        result = {}
+        try:
+            for returnable in self.returnables:
+                result[returnable] = getattr(self, returnable)
+            result = self._filter_params(result)
+        except Exception:
+            pass
+        return result
 
 
 class UsableChanges(Changes):
@@ -547,7 +555,7 @@ class UsableChanges(Changes):
             return None
         if self._values['route_domain'] is None:
             return self._values['address']
-        result = "{0}%{1}".format(self._values['address'], self._values['route_domain'])
+        result = "{0}%{1}".format(self._values['address'], self.route_domain)
         return result
 
     @property
@@ -622,7 +630,7 @@ class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
         self.client = kwargs.get('client', None)
-        self.have = None
+        self.have = ApiParameters()
         self.want = ModuleParameters(client=self.client, params=self.module.params)
         self.changes = UsableChanges()
 
@@ -652,22 +660,29 @@ class ModuleManager(object):
             return True
         return False
 
+    def _announce_deprecations(self, result):
+        warnings = result.pop('__warnings', [])
+        for warning in warnings:
+            self.client.module.deprecate(
+                msg=warning['msg'],
+                version=warning['version']
+            )
+
     def exec_module(self):
         changed = False
         result = dict()
         state = self.want.state
 
-        try:
-            if state in ['present', 'enabled', 'disabled']:
-                changed = self.present()
-            elif state == "absent":
-                changed = self.absent()
-        except iControlUnexpectedHTTPError as e:
-            raise F5ModuleError(str(e))
+        if state in ['present', 'enabled', 'disabled']:
+            changed = self.present()
+        elif state == "absent":
+            changed = self.absent()
 
-        changes = self.changes.to_return()
+        reportable = ReportableChanges(params=self.changes.to_return())
+        changes = reportable.to_return()
         result.update(**changes)
         result.update(dict(changed=changed))
+        self._announce_deprecations(result)
         return result
 
     def should_update(self):
@@ -688,27 +703,34 @@ class ModuleManager(object):
             changed = self.remove()
         return changed
 
-    def read_current_from_device(self):
-        name = self.want.name
-        name = name.replace('%', '%25')
-        resource = self.client.api.tm.ltm.virtual_address_s.virtual_address.load(
-            name=name,
-            partition=self.want.partition
-        )
-        result = resource.attrs
-        return ApiParameters(params=result)
+    def remove(self):
+        if self.module.check_mode:
+            return True
+        self.remove_from_device()
+        if self.exists():
+            raise F5ModuleError("Failed to delete the virtual address")
+        return True
 
-    def exists(self):
-        # This addresses cases where the name includes a % sign. The URL in the REST
-        # API escapes a % sign as %25. If you don't do this, you will get errors in
-        # the exists() method.
-        name = self.want.name
-        name = name.replace('%', '%25')
-        result = self.client.api.tm.ltm.virtual_address_s.virtual_address.exists(
-            name=name,
-            partition=self.want.partition
-        )
-        return result
+    def create(self):
+        self._set_changed_options()
+        if self.want.traffic_group is None:
+            self.want.update({'traffic_group': '/Common/traffic-group-1'})
+        if self.want.arp is None:
+            self.want.update({'arp': True})
+        if self.want.spanning is None:
+            self.want.update({'spanning': False})
+
+        if self.want.arp and self.want.spanning:
+            raise F5ModuleError(
+                "'arp' and 'spanning' cannot both be enabled on virtual address."
+            )
+        if self.module.check_mode:
+            return True
+        self.create_on_device()
+        if self.exists():
+            return True
+        else:
+            raise F5ModuleError("Failed to create the virtual address")
 
     def update(self):
         self.have = self.read_current_from_device()
@@ -736,63 +758,102 @@ class ModuleManager(object):
         self.update_on_device()
         return True
 
+    def exists(self):
+        # This addresses cases where the name includes a % sign. The URL in the REST
+        # API escapes a % sign as %25. If you don't do this, you will get errors in
+        # the exists() method.
+        name = self.want.name
+        name = name.replace('%', '%25')
+        uri = "https://{0}:{1}/mgmt/tm/ltm/virtual-address/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, name)
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError:
+            return False
+        if resp.status == 404 or 'code' in response and response['code'] == 404:
+            return False
+        return True
+
+    def read_current_from_device(self):
+        name = self.want.name
+        name = name.replace('%', '%25')
+        uri = "https://{0}:{1}/mgmt/tm/ltm/virtual-address/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, name)
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return ApiParameters(params=response)
+
     def update_on_device(self):
         params = self.changes.api_params()
         name = self.want.name
         name = name.replace('%', '%25')
-        resource = self.client.api.tm.ltm.virtual_address_s.virtual_address.load(
-            name=name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/ltm/virtual-address/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, name)
         )
-        resource.modify(**params)
+        resp = self.client.api.patch(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
 
-    def create(self):
-        self._set_changed_options()
-
-        if self.want.traffic_group is None:
-            self.want.update({'traffic_group': '/Common/traffic-group-1'})
-        if self.want.arp is None:
-            self.want.update({'arp': True})
-        if self.want.spanning is None:
-            self.want.update({'spanning': False})
-
-        if self.want.arp and self.want.spanning:
-            raise F5ModuleError(
-                "'arp' and 'spanning' cannot both be enabled on virtual address."
-            )
-        if self.module.check_mode:
-            return True
-        self.create_on_device()
-        if self.exists():
-            return True
-        else:
-            raise F5ModuleError("Failed to create the virtual address")
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
     def create_on_device(self):
         params = self.changes.api_params()
-        self.client.api.tm.ltm.virtual_address_s.virtual_address.create(
-            name=self.want.name,
-            partition=self.want.partition,
-            address=self.changes.address,
-            **params
+        params['name'] = self.want.name
+        params['partition'] = self.want.partition
+        params['address'] = self.changes.address
+        uri = "https://{0}:{1}/mgmt/tm/ltm/virtual-address/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
         )
+        resp = self.client.api.post(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
 
-    def remove(self):
-        if self.module.check_mode:
-            return True
-        self.remove_from_device()
-        if self.exists():
-            raise F5ModuleError("Failed to delete the virtual address")
-        return True
+        if 'code' in response and response['code'] in [400, 403, 409]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+
+        return response['selfLink']
 
     def remove_from_device(self):
         name = self.want.name
         name = name.replace('%', '%25')
-        resource = self.client.api.tm.ltm.virtual_address_s.virtual_address.load(
-            name=name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/ltm/virtual-address/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, name)
         )
-        resource.delete()
+        resp = self.client.api.delete(uri)
+        if resp.status == 200:
+            return True
 
 
 class ArgumentSpec(object):
@@ -871,18 +932,17 @@ def main():
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode
     )
-    if not HAS_F5SDK:
-        module.fail_json(msg="The python f5-sdk module is required")
+
+    client = F5RestClient(**module.params)
 
     try:
-        client = F5Client(**module.params)
         mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        module.exit_json(**results)
+        exit_json(module, results, client)
     except F5ModuleError as ex:
         cleanup_tokens(client)
-        module.fail_json(msg=str(ex))
+        fail_json(module, ex, client)
 
 
 if __name__ == '__main__':

--- a/test/units/modules/network/f5/test_bigip_virtual_address.py
+++ b/test/units/modules/network/f5/test_bigip_virtual_address.py
@@ -14,9 +14,6 @@ from nose.plugins.skip import SkipTest
 if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
-from units.compat import unittest
-from units.compat.mock import Mock
-from units.compat.mock import patch
 from ansible.module_utils.basic import AnsibleModule
 
 try:
@@ -24,17 +21,25 @@ try:
     from library.modules.bigip_virtual_address import ModuleParameters
     from library.modules.bigip_virtual_address import ModuleManager
     from library.modules.bigip_virtual_address import ArgumentSpec
-    from library.module_utils.network.f5.common import F5ModuleError
-    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    from test.unit.modules.utils import set_module_args
+
+    # In Ansible 2.8, Ansible changed import paths.
+    from test.units.compat import unittest
+    from test.units.compat.mock import Mock
+    from test.units.compat.mock import patch
+
+    from test.units.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_virtual_address import ApiParameters
         from ansible.modules.network.f5.bigip_virtual_address import ModuleParameters
         from ansible.modules.network.f5.bigip_virtual_address import ModuleManager
         from ansible.modules.network.f5.bigip_virtual_address import ArgumentSpec
-        from ansible.module_utils.network.f5.common import F5ModuleError
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+
+        # Ansible 2.8 imports
+        from units.compat import unittest
+        from units.compat.mock import Mock
+        from units.compat.mock import patch
+
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Removes the f5-sdk and fixes unit tests for ansible 2.8

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bigip_virtual_address

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.6 (default, Oct 16 2018, 07:17:20) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
