### PR TITLE
fix yum proxy regex (closes #47797)

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -710,7 +710,7 @@ class YumModule(YumDnf):
                     for item in scheme:
                         os.environ[item + "_proxy"] = re.sub(
                             r"(http://)",
-                            r"\1" + namepass, proxy_url
+                            r"\g<1>" + namepass, proxy_url
                         )
             yield
         except yum.Errors.YumBaseError:

--- a/test/integration/targets/yum/tasks/proxy.yml
+++ b/test/integration/targets/yum/tasks/proxy.yml
@@ -6,7 +6,7 @@
 
     - lineinfile:
         path: /etc/tinyproxy/tinyproxy.conf
-        line: "BasicAuth testuser testpassword"
+        line: "BasicAuth 1testuser 1testpassword"
         state: present
 
     # systemd doesn't play nice with this in a container for some reason
@@ -15,7 +15,7 @@
 
     - lineinfile:
         path: /etc/yum.conf
-        line: "proxy=http://testuser:testpassword@127.0.0.1:8888"
+        line: "proxy=http://1testuser:1testpassword@127.0.0.1:8888"
         state: present
 
     - yum:
@@ -35,7 +35,7 @@
 
     - lineinfile:
         path: /etc/yum.conf
-        line: "proxy=http://testuser:testpassword@127.0.0.1:8888"
+        line: "proxy=http://1testuser:1testpassword@127.0.0.1:8888"
         state: absent
 
     - lineinfile:
@@ -45,12 +45,12 @@
 
     - lineinfile:
         path: /etc/yum.conf
-        line: "proxy_username=testuser"
+        line: "proxy_username=1testuser"
         state: present
 
     - lineinfile:
         path: /etc/yum.conf
-        line: "proxy_password=testpassword"
+        line: "proxy_password=1testpassword"
         state: present
 
     - yum:
@@ -75,7 +75,7 @@
 
     - lineinfile:
         path: /etc/yum.conf
-        line: "proxy=http://testuser:testpassword@127.0.0.1:8888"
+        line: "proxy=http://1testuser:1testpassword@127.0.0.1:8888"
         state: absent
 
     - lineinfile:
@@ -85,12 +85,12 @@
 
     - lineinfile:
         path: /etc/yum.conf
-        line: "proxy_username=testuser"
+        line: "proxy_username=1testuser"
         state: absent
 
     - lineinfile:
         path: /etc/yum.conf
-        line: "proxy_password=testpassword"
+        line: "proxy_password=1testpassword"
         state: absent
   when:
     - (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version|int == 7)


### PR DESCRIPTION
##### SUMMARY
Change the backref in a regex used in `set_env_proxy()` of the yum module so that usernames which begin with a number aren't erroneously interpolated as part of the backref.

Fixes #47797

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
yum

##### ANSIBLE VERSION
```bash
$  ansible --version
ansible 2.7.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/paulharvey/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, Oct 15 2018, 15:24:06) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```

##### ADDITIONAL INFORMATION
Before this change, the following would fail with "sre_constants.error: invalid group reference":

```bash
$ sed -i 's/testuser/1testuser/g' test/integration/targets/yum/tasks/proxy.yml
$ sudo test/runner/ansible-test integration --docker centos7 -v yum
```

After the change:
```bash
$ sed -i 's/testuser/1testuser/g' test/integration/targets/yum/tasks/proxy.yml
$ sudo test/runner/ansible-test integration --docker centos7 -v yum
   <snip>
PLAY RECAP *********************************************************************
testhost                   : ok=282  changed=123  unreachable=0    failed=0    skipped=15
```