### PR TITLE
ovirt_host_network: Fix type conversion

### DIFF
--- a/changelogs/fragments/ovirt_host_network_fix_type_conversion.yaml
+++ b/changelogs/fragments/ovirt_host_network_fix_type_conversion.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ovirt_host_network - Fix type conversion (https://github.com/ansible/ansible/pull/47617).

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -220,12 +220,12 @@ def get_bond_options(mode, usr_opts):
         )
     )
 
-    opts_dict = DEFAULT_MODE_OPTS.get(mode, {})
+    opts_dict = DEFAULT_MODE_OPTS.get(str(mode), {})
     if usr_opts is not None:
         opts_dict.update(**usr_opts)
 
     options.extend(
-        [otypes.Option(name=opt, value=value)
+        [otypes.Option(name=opt, value=str(value))
          for opt, value in six.iteritems(opts_dict)]
     )
     return options


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When user specify `bond` `mode` option as integer, module always report state as CHANGED.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_host_network

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7.1
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
When you run multiple times:
```yaml
- name: Create bond
    ovirt_host_network:
      auth: "{{ ovirt_auth }}"
      name: myhost
      bond:
        name: bond0
        mode: 1
        options:
          miimon: '200'
        interfaces:
          - eth0
          - eth1
      networks:
       - name: ovirtmgmt
         boot_protocol: dhcp
      save: true
      check: true
```

You always get CHANGED. Report OK, as there are no changes.
Backport of : https://github.com/ansible/ansible/pull/47617