### PR TITLE
[backport 2.7] Fix idempotency issues in set_bios_attributes

### DIFF
--- a/changelogs/fragments/47462-fix-redfish_config-idempotency.yaml
+++ b/changelogs/fragments/47462-fix-redfish_config-idempotency.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Fix idempotency issues when setting BIOS attributes via redfish_config module (https://github.com/ansible/ansible/pull/47462)"

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -663,6 +663,15 @@ class RedfishUtils(object):
             return response
         result['ret'] = True
         data = response['data']
+
+        # First, check if BIOS attribute exists
+        if attr['bios_attr_name'] not in data[u'Attributes']:
+            return {'ret': False, 'msg': "BIOS attribute not found"}
+
+        # Find out if value is already set to what we want. If yes, return
+        if data[u'Attributes'][attr['bios_attr_name']] == attr['bios_attr_value']:
+            return {'ret': True, 'changed': False, 'msg': "BIOS attribute already set"}
+
         set_bios_attr_uri = data["@Redfish.Settings"]["SettingsObject"]["@odata.id"]
 
         # Example: bios_attr = {\"name\":\"value\"}
@@ -671,7 +680,7 @@ class RedfishUtils(object):
         response = self.patch_request(self.root_uri + set_bios_attr_uri, payload, HEADERS)
         if response['ret'] is False:
             return response
-        return {'ret': True}
+        return {'ret': True, 'changed': True, 'msg': "Modified BIOS attribute"}
 
     def create_bios_config_job(self):
         result = {}

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -249,7 +249,6 @@ def main():
     # Return data back or fail with proper message
     if result['ret'] is True:
         del result['ret']
-        result['changed'] = True
         module.exit_json(changed=True, msg='Action was successful')
     else:
         module.fail_json(msg=to_native(result['msg']))

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -227,8 +227,7 @@ def main():
 
     # Return data back or fail with proper message
     if result['ret'] is True:
-        del result['ret']
-        module.exit_json(changed=True, msg='Action was successful')
+        module.exit_json(changed=result['changed'], msg=to_native(result['msg']))
     else:
         module.fail_json(msg=to_native(result['msg']))
 


### PR DESCRIPTION
- Added check to see if attribute even exists, if not, it exits.
- Then checks if attribute is already set to value we want to update
  it to. If yes, then it exits and changed=False
- Otherwise updates the attribute and changed=True

(cherry picked from commit 1c37471274573af03f9d1b60ff1913a75629e997)

##### SUMMARY
Backport #47462 from devel to 2.7. This PR fixes #46338 which addresses the broken idempotency behavior of the `redfish_config` module introduced in 2.7.


##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
redfish_config.py
redfish_utils.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```ansible 2.7.1.post0 (backport/2.7/47462 3a75110fbe) last updated 2018/10/30 08:09:10 (GMT -400)
  config file = /home/jyundt/git/ansible/ansible.cfg
  configured module search path = [u'/home/jyundt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jyundt/git/ansible/lib/ansible
  executable location = /home/jyundt/git/ansible/bin/ansible
  python version = 2.7.13 (default, May 23 2018, 14:21:55) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```

##### ADDITIONAL INFORMATION
See #46338 for additional details.


cc @jose-delarosa @nlopez