### PR TITLE
[backport 2.7] Check if `enabled_snat` is set in modules arguments (#46754)

### DIFF
--- a/changelogs/fragments/os_router_enable_snat_fix.yaml
+++ b/changelogs/fragments/os_router_enable_snat_fix.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - Fixed an issue where ``os_router`` would attempt to recreate router,
+    because lack of ``enabled_snat`` parameter was treated as difference,
+    if default Neutron policy for snat is set. (https://github.com/ansible/ansible/issues/29903)

--- a/lib/ansible/modules/cloud/openstack/os_router.py
+++ b/lib/ansible/modules/cloud/openstack/os_router.py
@@ -227,8 +227,10 @@ def _needs_update(cloud, module, router, network, internal_subnet_ids, internal_
     if router['admin_state_up'] != module.params['admin_state_up']:
         return True
     if router['external_gateway_info']:
-        if router['external_gateway_info'].get('enable_snat', True) != module.params['enable_snat']:
-            return True
+        # check if enable_snat is set in module params
+        if module.params['enable_snat'] is not None:
+            if router['external_gateway_info'].get('enable_snat', True) != module.params['enable_snat']:
+                return True
     if network:
         if not router['external_gateway_info']:
             return True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
If `enabled_snat` is not set at all in module arguments but Neutron
policy sets it by default in Openstack, then `os_router` will attempt to
recreate otherwise perfectly good router.

Follow up for https://github.com/ansible/ansible/issues/44432#issuecomment-428531031

(cherry picked from commit c2b7174d31ba4643606707ce64a0c6d3762a984e)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
os_router

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
