### PR TITLE
module_utils/mysql: Fixing unexpected keyword argument 'cursorclass' error after migratio…

### DIFF
--- a/changelogs/fragments/47809-module_utils_mysql-unexpected-keyword-argument-cursorclass.yml
+++ b/changelogs/fragments/47809-module_utils_mysql-unexpected-keyword-argument-cursorclass.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql - fixing unexpected keyword argument 'cursorclass' issue after migration from MySQLdb to PyMySQL.

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -28,13 +28,14 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
-import sys
 
 try:
     import pymysql as mysql_driver
+    _mysql_cursor_param = 'cursor'
 except ImportError:
     try:
         import MySQLdb as mysql_driver
+        _mysql_cursor_param = 'cursorclass'
     except ImportError:
         mysql_driver = None
 
@@ -76,9 +77,6 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
 
     db_connection = mysql_driver.connect(**config)
     if cursor_class is not None:
-        if mysql_driver is sys.modules['pymysql']:
-            return db_connection.cursor(cursor=mysql_driver.cursors.DictCursor)
-        else:
-            return db_connection.cursor(cursorclass=mysql_driver.cursors.DictCursor)
+        return db_connection.cursor(**{_mysql_cursor_param: mysql_driver.cursors.DictCursor})
     else:
         return db_connection.cursor()

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -28,6 +28,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import sys
 
 try:
     import pymysql as mysql_driver
@@ -75,6 +76,9 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
 
     db_connection = mysql_driver.connect(**config)
     if cursor_class is not None:
-        return db_connection.cursor(cursorclass=mysql_driver.cursors.DictCursor)
+        if mysql_driver is sys.modules['pymysql']:
+            return db_connection.cursor(cursor=mysql_driver.cursors.DictCursor)
+        else:
+            return db_connection.cursor(cursorclass=mysql_driver.cursors.DictCursor)
     else:
         return db_connection.cursor()


### PR DESCRIPTION
…n from MySQLdb to PyMySQL

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With Ansible 2.7.1 and the migration from MySQLdb to PyMySQL all my MySQL related tasks failed since the call `db_connection.cursor(cursorclass=mysql_driver.cursors.DictCursor)` is trying to trigger https://github.com/PyMySQL/PyMySQL/blob/v0.9.2/pymysql/connections.py#L483 which has no argument cursorclass. 

```
<localhost> EXEC /bin/sh -c 'echo ~root && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1540904667.96-27683954372616 `" && echo ansible-tmp-1540904667.96-27683954372616="` echo /root/.ansible/tmp/ansible-tmp-1540904667.96-27683954372616 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/database/proxysql/proxysql_backend_servers.py
<localhost> PUT /root/.ansible/tmp/ansible-local-4588xiOIZd/tmpPPDmmb TO /root/.ansible/tmp/ansible-tmp-1540904667.96-27683954372616/AnsiballZ_proxysql_backend_servers.py
<localhost> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1540904667.96-27683954372616/ /root/.ansible/tmp/ansible-tmp-1540904667.96-27683954372616/AnsiballZ_proxysql_backend_servers.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1540904667.96-27683954372616/AnsiballZ_proxysql_backend_servers.py && sleep 0'
<localhost> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1540904667.96-27683954372616/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1540904667.96-27683954372616/AnsiballZ_proxysql_backend_servers.py", line 113, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1540904667.96-27683954372616/AnsiballZ_proxysql_backend_servers.py", line 105, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1540904667.96-27683954372616/AnsiballZ_proxysql_backend_servers.py", line 48, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/tmp/ansible_proxysql_backend_servers_payload_3rvJlX/__main__.py", line 504, in <module>
  File "/tmp/ansible_proxysql_backend_servers_payload_3rvJlX/__main__.py", line 450, in main
  File "/tmp/ansible_proxysql_backend_servers_payload_3rvJlX/ansible_proxysql_backend_servers_payload.zip/ansible/module_utils/mysql.py", line 81, in mysql_connect
TypeError: cursor() got an unexpected keyword argument 'cursorclass'
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/mysql.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible --version
ansible 2.7.1
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Sep 26 2018, 18:42:22) [GCC 6.3.0 20170516]
```

