### PR TITLE
Support for device read write limit parameters

### DIFF
--- a/changelogs/fragments/47814-docker_container-device-io-limit-parameters.yaml
+++ b/changelogs/fragments/47814-docker_container-device-io-limit-parameters.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_container - Add support for device I/O rate limit parameters. This includes `device_read_bps`, `device_write_bps`, `device_read_iops` and `device_write_iops`"

--- a/changelogs/fragments/47814-docker_container-device-io-limit-parameters.yaml
+++ b/changelogs/fragments/47814-docker_container-device-io-limit-parameters.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-- "docker_container - Add support for device I/O rate limit parameters. This includes `device_read_bps`, `device_write_bps`, `device_read_iops` and `device_write_iops`"
+- "docker_container - Add support for device I/O rate limit parameters. This includes ``device_read_bps``, ``device_write_bps``, ``device_read_iops`` and ``device_write_iops``"

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -593,6 +593,74 @@
     - devices_4 is changed
 
 ####################################################################
+## device_read_bps #################################################
+####################################################################
+
+- name: device_read_bps
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    device_read_bps:
+      - path: /dev/random
+        rate: 20M
+      - path: /dev/urandom
+        rate: 10K
+  register: device_read_bps_1
+
+- name: device_read_bps (idempotency)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    device_read_bps:
+      - path: /dev/urandom
+        rate: 10K
+      - path: /dev/random
+        rate: 20M
+  register: device_read_bps_2
+
+- name: device_read_bps (lesser entries)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    device_read_bps:
+      - path: /dev/random
+        rate: 20M
+  register: device_read_bps_3
+
+- name: device_read_bps (changed)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    device_read_bps:
+      - path: /dev/random
+        rate: 10M
+      - path: /dev/urandom
+        rate: 5K
+    stop_timeout: 1
+  register: device_read_bps_4
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    stop_timeout: 1
+
+- assert:
+    that:
+    - device_read_bps_1 is changed
+    - device_read_bps_2 is not changed
+    - device_read_bps_3 is not changed
+    - device_read_bps_4 is changed
+
+####################################################################
 ## dns_opts ########################################################
 ####################################################################
 

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -661,6 +661,133 @@
     - device_read_bps_4 is changed
 
 ####################################################################
+## device_read_iops ################################################
+####################################################################
+
+- name: device_read_iops
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    device_read_iops:
+      - path: /dev/random
+        rate: 10
+      - path: /dev/urandom
+        rate: 20
+  register: device_read_iops_1
+
+- name: device_read_iops (idempotency)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    device_read_iops:
+      - path: /dev/urandom
+        rate: 20
+      - path: /dev/random
+        rate: 10
+  register: device_read_iops_2
+
+- name: device_read_iops (less)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    device_read_iops:
+      - path: /dev/random
+        rate: 10
+  register: device_read_iops_3
+
+- name: device_read_iops (changed)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    device_read_iops:
+      - path: /dev/random
+        rate: 30
+      - path: /dev/urandom
+        rate: 50
+    stop_timeout: 1
+  register: device_read_iops_4
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    stop_timeout: 1
+
+- assert:
+    that:
+    - device_read_iops_1 is changed
+    - device_read_iops_2 is not changed
+    - device_read_iops_3 is not changed
+    - device_read_iops_4 is changed
+
+####################################################################
+## device_write_bps and device_write_iops ##########################
+####################################################################
+
+- name: device_write_bps and device_write_iops
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    device_write_bps:
+      - path: /dev/random
+        rate: 10M
+    device_write_iops:
+      - path: /dev/urandom
+        rate: 30
+  register: device_write_limit_1
+
+- name: device_write_bps and device_write_iops (idempotency)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    device_write_bps:
+      - path: /dev/random
+        rate: 10M
+    device_write_iops:
+      - path: /dev/urandom
+        rate: 30
+  register: device_write_limit_2
+
+- name: device_write_bps device_write_iops (changed)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    device_write_bps:
+      - path: /dev/random
+        rate: 20K
+    device_write_iops:
+      - path: /dev/urandom
+        rate: 100
+    stop_timeout: 1
+  register: device_write_limit_3
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    stop_timeout: 1
+
+- assert:
+    that:
+    - device_write_limit_1 is changed
+    - device_write_limit_2 is not changed
+    - device_write_limit_3 is changed
+
+####################################################################
 ## dns_opts ########################################################
 ####################################################################
 


### PR DESCRIPTION
##### SUMMARY
Now it is possible to specify read write rate limit for block devices in `docker_conatainer` module.

Add following options in docker_container module
  - device_read_bps
  - device_write_bps
  - device_read_iops
  - device_write_iops
Fixes #36831

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (device-read-write-rate-fix-36831 9f019939ad) last updated 2018/10/30 19:19:56 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/ansible/lib/ansible
  executable location = /home/user/ansible/bin/ansible
  python version = 3.6.6 (default, Jul 19 2018, 14:25:17) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Specify device read/write limit:

```
docker_container:
    name: test
    image: ubuntu:18.04
    state: started
    device_read_bps:
      - path: /dev/sda
        rate: 20mb
    device_write_iops:
      - path: /dev/sdb
        rate: 300
```
