### PR TITLE
[stable-2.7] RabbitMQ documentation update #46504

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_exchange.py
+++ b/lib/ansible/modules/messaging/rabbitmq_exchange.py
@@ -31,7 +31,6 @@ options:
     state:
         description:
             - Whether the exchange should be present or absent
-            - Only present implemented atm
         choices: [ "present", "absent" ]
         required: false
         default: present

--- a/lib/ansible/modules/messaging/rabbitmq_queue.py
+++ b/lib/ansible/modules/messaging/rabbitmq_queue.py
@@ -31,7 +31,6 @@ options:
     state:
         description:
             - Whether the queue should be present or absent
-            - Only present implemented atm
         choices: [ "present", "absent" ]
         default: present
     login_user:


### PR DESCRIPTION
##### SUMMARY

… implemented, but it is (#46504)

* Remove message suggesting that state: absent is not implemented for queues

* Remove message suggesting that state: absent is not implemented for exchanges

(cherry picked from commit a24700d12094051de43d464a22c047a4c42624df)


##### ISSUE TYPE
- Docs Pull Request
