### PR TITLE
[backport 2.7] Fixes HTTP redirect issue (#45513)

### DIFF
--- a/changelogs/fragments/45704-fix-redfish_facts-http-redirect.yaml
+++ b/changelogs/fragments/45704-fix-redfish_facts-http-redirect.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Fix issue with HTTP redirects with redfish_facts module (https://github.com/ansible/ansible/pull/45704)"

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -27,7 +27,8 @@ class RedfishUtils(object):
                             url_username=self.creds['user'],
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
-                            timeout=10, use_proxy=False)
+                            follow_redirects='all',
+                            use_proxy=False)
             data = json.loads(resp.read())
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
@@ -45,6 +46,7 @@ class RedfishUtils(object):
                             url_username=self.creds['user'],
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
+                            follow_redirects='all',
                             use_proxy=False)
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
@@ -62,6 +64,7 @@ class RedfishUtils(object):
                             url_username=self.creds['user'],
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
+                            follow_redirects='all',
                             use_proxy=False)
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}
@@ -79,6 +82,7 @@ class RedfishUtils(object):
                             url_username=self.creds['user'],
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
+                            follow_redirects='all',
                             use_proxy=False)
         except HTTPError as e:
             return {'ret': False, 'msg': "HTTP Error: %s" % e.code}


### PR DESCRIPTION
(cherry picked from commit e701b5a4127f114c0f20ac5160c2577e73f0b39a)

##### SUMMARY
Backport request of #45704 to 2.7. This PR fixes #45513: redirects do not properly work with the redfish_facts module introduced in 2.7

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
redfish_facts
redfish_utils.py

##### ANSIBLE VERSION

```
ansible 2.7.1.post0 (backport/2.7/45704 f8e79bb872) last updated 2018/10/30 11:21:57 (GMT -400)
  config file = None
  configured module search path = [u'/Users/jacobyundt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jacobyundt/git/ansible/lib/ansible
  executable location = /Users/jacobyundt/git/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
See #45513 for additional details.

cc @nlopez
