### PR TITLE
2.7: yum: fix 'package == version' syntax (#47744)

### DIFF
--- a/changelogs/fragments/47689-yum-fix-version-syntax.yaml
+++ b/changelogs/fragments/47689-yum-fix-version-syntax.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - yum - fix "package == version" syntax (https://github.com/ansible/ansible/pull/47744)

--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -94,7 +94,7 @@ class YumDnf(with_metaclass(ABCMeta, object)):
 
         # Fail if someone passed a space separated string
         # https://github.com/ansible/ansible/issues/46301
-        if any((' ' in name and '@' not in name for name in self.names)):
+        if any((' ' in name and '@' not in name and '==' not in name for name in self.names)):
             module.fail_json(
                 msg='It appears that a space separated string of packages was passed in '
                     'as an argument. To operate on several packages, pass a comma separated '

--- a/test/integration/targets/yum/tasks/repo.yml
+++ b/test/integration/targets/yum/tasks/repo.yml
@@ -556,3 +556,35 @@
         name: foo
         state: absent
   when: not (ansible_distribution == "Fedora" and ansible_distribution_major_version|int < 26)
+
+# https://github.com/ansible/ansible/issues/47689
+- block:
+    - name: Install foo == 1.0
+      yum:
+        name: "foo == 1.0"
+        state: present
+      register: yum_result
+
+    - name: Check foo with rpm
+      shell: rpm -q foo
+      register: rpm_result
+
+    - name: Verify installation
+      assert:
+        that:
+            - "yum_result.changed"
+            - "rpm_result.stdout.startswith('foo-1.0-1')"
+
+    - name: Verify yum module outputs
+      assert:
+        that:
+            - "'msg' in yum_result"
+            - "'rc' in yum_result"
+            - "'results' in yum_result"
+  always:
+    - name: Clean up
+      yum:
+        name: foo
+        state: absent
+
+  when: ansible_pkg_mgr == 'yum'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/47744
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
(cherry picked from commit 4b8f2c99d2f2e31f1c363fdf767a07136beced69)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION