### PR TITLE
[2.6] docker_* modules: simplify idempotency comparisons, fix paused in docker_container

### DIFF
--- a/changelogs/fragments/47900-docker_container-paused.yml
+++ b/changelogs/fragments/47900-docker_container-paused.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - fix ``paused`` option (which never worked)."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -618,7 +618,11 @@ import shlex
 from distutils.version import LooseVersion
 
 from ansible.module_utils.basic import human_to_bytes
-from ansible.module_utils.docker_common import HAS_DOCKER_PY_2, HAS_DOCKER_PY_3, AnsibleDockerClient, DockerBaseClass, sanitize_result
+from ansible.module_utils.docker_common import (
+    HAS_DOCKER_PY_2, HAS_DOCKER_PY_3, AnsibleDockerClient,
+    DockerBaseClass, sanitize_result,
+    compare_generic,
+)
 from ansible.module_utils.six import string_types
 
 try:
@@ -1249,79 +1253,11 @@ class Container(DockerBaseClass):
                 return True
         return False
 
-    def _compare_dict_allow_more_present(self, av, bv):
-        '''
-        Compare two dictionaries for whether every entry of the first is in the second.
-        '''
-        for key, value in av.items():
-            if key not in bv:
-                return False
-            if bv[key] != value:
-                return False
-        return True
-
     def _compare(self, a, b, compare):
         '''
         Compare values a and b as described in compare.
         '''
-        method = compare['comparison']
-        if method == 'ignore':
-            return True
-        # If a or b is None:
-        if a is None or b is None:
-            # If both are None: equality
-            if a == b:
-                return True
-            # Otherwise, not equal for values, and equal
-            # if the other is empty for set/list/dict
-            if compare['type'] == 'value':
-                return False
-            return len(b if a is None else a) == 0
-        # Do proper comparison (both objects not None)
-        if compare['type'] == 'value':
-            return a == b
-        elif compare['type'] == 'list':
-            if method == 'strict':
-                return a == b
-            else:
-                set_a = set(a)
-                set_b = set(b)
-                return set_b >= set_a
-        elif compare['type'] == 'dict':
-            if method == 'strict':
-                return a == b
-            else:
-                return self._compare_dict_allow_more_present(a, b)
-        elif compare['type'] == 'set':
-            set_a = set(a)
-            set_b = set(b)
-            if method == 'strict':
-                return set_a == set_b
-            else:
-                return set_b >= set_a
-        elif compare['type'] == 'set(dict)':
-            for av in a:
-                found = False
-                for bv in b:
-                    if self._compare_dict_allow_more_present(av, bv):
-                        found = True
-                        break
-                if not found:
-                    return False
-            if method == 'strict':
-                # If we would know that both a and b do not contain duplicates,
-                # we could simply compare len(a) to len(b) to finish this test.
-                # We can assume that b has no duplicates (as it is returned by
-                # docker), but we don't know for a.
-                for bv in b:
-                    found = False
-                    for av in a:
-                        if self._compare_dict_allow_more_present(av, bv):
-                            found = True
-                            break
-                    if not found:
-                        return False
-            return True
+        return compare_generic(a, b, compare['comparison'], compare['type'])
 
     def has_different_configuration(self, image):
         '''

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1824,6 +1824,7 @@ class ContainerManager(DockerBaseClass):
                         self.fail("Error %s container %s: %s" % (
                             "pausing" if self.parameters.paused else "unpausing", container.Id, str(exc)
                         ))
+                    container = self._get_container(container.Id)
                 self.results['changed'] = True
                 self.results['actions'].append(dict(set_paused=self.parameters.paused))
 

--- a/test/units/module_utils/test_docker_common.py
+++ b/test/units/module_utils/test_docker_common.py
@@ -1,0 +1,464 @@
+import pytest
+
+from ansible.module_utils.docker_common import (
+    compare_dict_allow_more_present,
+    compare_generic,
+)
+
+DICT_ALLOW_MORE_PRESENT = (
+    {
+        'av': {},
+        'bv': {'a': 1},
+        'result': True
+    },
+    {
+        'av': {'a': 1},
+        'bv': {'a': 1, 'b': 2},
+        'result': True
+    },
+    {
+        'av': {'a': 1},
+        'bv': {'b': 2},
+        'result': False
+    },
+    {
+        'av': {'a': 1},
+        'bv': {'a': None, 'b': 1},
+        'result': False
+    },
+    {
+        'av': {'a': None},
+        'bv': {'b': 1},
+        'result': False
+    },
+)
+
+COMPARE_GENERIC = [
+    ########################################################################################
+    # value
+    {
+        'a': 1,
+        'b': 2,
+        'method': 'strict',
+        'type': 'value',
+        'result': False
+    },
+    {
+        'a': 'hello',
+        'b': 'hello',
+        'method': 'strict',
+        'type': 'value',
+        'result': True
+    },
+    {
+        'a': None,
+        'b': 'hello',
+        'method': 'strict',
+        'type': 'value',
+        'result': False
+    },
+    {
+        'a': None,
+        'b': None,
+        'method': 'strict',
+        'type': 'value',
+        'result': True
+    },
+    {
+        'a': 1,
+        'b': 2,
+        'method': 'ignore',
+        'type': 'value',
+        'result': True
+    },
+    {
+        'a': None,
+        'b': 2,
+        'method': 'ignore',
+        'type': 'value',
+        'result': True
+    },
+    ########################################################################################
+    # list
+    {
+        'a': [
+            'x',
+        ],
+        'b': [
+            'y',
+        ],
+        'method': 'strict',
+        'type': 'list',
+        'result': False
+    },
+    {
+        'a': [
+            'x',
+        ],
+        'b': [
+            'x',
+            'x',
+        ],
+        'method': 'strict',
+        'type': 'list',
+        'result': False
+    },
+    {
+        'a': [
+            'x',
+            'y',
+        ],
+        'b': [
+            'x',
+            'y',
+        ],
+        'method': 'strict',
+        'type': 'list',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'y',
+        ],
+        'b': [
+            'y',
+            'x',
+        ],
+        'method': 'strict',
+        'type': 'list',
+        'result': False
+    },
+    {
+        'a': [
+            'x',
+            'y',
+        ],
+        'b': [
+            'x',
+        ],
+        'method': 'allow_more_present',
+        'type': 'list',
+        'result': False
+    },
+    {
+        'a': [
+            'x',
+        ],
+        'b': [
+            'x',
+            'y',
+        ],
+        'method': 'allow_more_present',
+        'type': 'list',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'x',
+            'y',
+        ],
+        'b': [
+            'x',
+            'y',
+        ],
+        'method': 'allow_more_present',
+        'type': 'list',
+        'result': False
+    },
+    {
+        'a': [
+            'x',
+            'z',
+        ],
+        'b': [
+            'x',
+            'y',
+            'x',
+            'z',
+        ],
+        'method': 'allow_more_present',
+        'type': 'list',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'y',
+        ],
+        'b': [
+            'y',
+            'x',
+        ],
+        'method': 'ignore',
+        'type': 'list',
+        'result': True
+    },
+    ########################################################################################
+    # set
+    {
+        'a': [
+            'x',
+        ],
+        'b': [
+            'y',
+        ],
+        'method': 'strict',
+        'type': 'set',
+        'result': False
+    },
+    {
+        'a': [
+            'x',
+        ],
+        'b': [
+            'x',
+            'x',
+        ],
+        'method': 'strict',
+        'type': 'set',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'y',
+        ],
+        'b': [
+            'x',
+            'y',
+        ],
+        'method': 'strict',
+        'type': 'set',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'y',
+        ],
+        'b': [
+            'y',
+            'x',
+        ],
+        'method': 'strict',
+        'type': 'set',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'y',
+        ],
+        'b': [
+            'x',
+        ],
+        'method': 'allow_more_present',
+        'type': 'set',
+        'result': False
+    },
+    {
+        'a': [
+            'x',
+        ],
+        'b': [
+            'x',
+            'y',
+        ],
+        'method': 'allow_more_present',
+        'type': 'set',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'x',
+            'y',
+        ],
+        'b': [
+            'x',
+            'y',
+        ],
+        'method': 'allow_more_present',
+        'type': 'set',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'z',
+        ],
+        'b': [
+            'x',
+            'y',
+            'x',
+            'z',
+        ],
+        'method': 'allow_more_present',
+        'type': 'set',
+        'result': True
+    },
+    {
+        'a': [
+            'x',
+            'a',
+        ],
+        'b': [
+            'y',
+            'z',
+        ],
+        'method': 'ignore',
+        'type': 'set',
+        'result': True
+    },
+    ########################################################################################
+    # set(dict)
+    {
+        'a': [
+            {'x': 1},
+        ],
+        'b': [
+            {'y': 1},
+        ],
+        'method': 'strict',
+        'type': 'set(dict)',
+        'result': False
+    },
+    {
+        'a': [
+            {'x': 1},
+        ],
+        'b': [
+            {'x': 1},
+        ],
+        'method': 'strict',
+        'type': 'set(dict)',
+        'result': True
+    },
+    {
+        'a': [
+            {'x': 1},
+        ],
+        'b': [
+            {'x': 1, 'y': 2},
+        ],
+        'method': 'strict',
+        'type': 'set(dict)',
+        'result': True
+    },
+    {
+        'a': [
+            {'x': 1},
+            {'x': 2, 'y': 3},
+        ],
+        'b': [
+            {'x': 1},
+            {'x': 2, 'y': 3},
+        ],
+        'method': 'strict',
+        'type': 'set(dict)',
+        'result': True
+    },
+    {
+        'a': [
+            {'x': 1},
+        ],
+        'b': [
+            {'x': 1, 'z': 2},
+            {'x': 2, 'y': 3},
+        ],
+        'method': 'allow_more_present',
+        'type': 'set(dict)',
+        'result': True
+    },
+    {
+        'a': [
+            {'x': 1, 'y': 2},
+        ],
+        'b': [
+            {'x': 1},
+            {'x': 2, 'y': 3},
+        ],
+        'method': 'allow_more_present',
+        'type': 'set(dict)',
+        'result': False
+    },
+    {
+        'a': [
+            {'x': 1, 'y': 3},
+        ],
+        'b': [
+            {'x': 1},
+            {'x': 1, 'y': 3, 'z': 4},
+        ],
+        'method': 'allow_more_present',
+        'type': 'set(dict)',
+        'result': True
+    },
+    {
+        'a': [
+            {'x': 1},
+            {'x': 2, 'y': 3},
+        ],
+        'b': [
+            {'x': 1},
+        ],
+        'method': 'ignore',
+        'type': 'set(dict)',
+        'result': True
+    },
+    ########################################################################################
+    # dict
+    {
+        'a': {'x': 1},
+        'b': {'y': 1},
+        'method': 'strict',
+        'type': 'dict',
+        'result': False
+    },
+    {
+        'a': {'x': 1},
+        'b': {'x': 1, 'y': 2},
+        'method': 'strict',
+        'type': 'dict',
+        'result': False
+    },
+    {
+        'a': {'x': 1},
+        'b': {'x': 1},
+        'method': 'strict',
+        'type': 'dict',
+        'result': True
+    },
+    {
+        'a': {'x': 1, 'z': 2},
+        'b': {'x': 1, 'y': 2},
+        'method': 'strict',
+        'type': 'dict',
+        'result': False
+    },
+    {
+        'a': {'x': 1, 'z': 2},
+        'b': {'x': 1, 'y': 2},
+        'method': 'ignore',
+        'type': 'dict',
+        'result': True
+    },
+] + [{
+    'a': entry['av'],
+    'b': entry['bv'],
+    'method': 'allow_more_present',
+    'type': 'dict',
+    'result': entry['result']
+} for entry in DICT_ALLOW_MORE_PRESENT]
+
+
+@pytest.mark.parametrize("entry", DICT_ALLOW_MORE_PRESENT)
+def test_dict_allow_more_present(entry):
+    assert compare_dict_allow_more_present(entry['av'], entry['bv']) == entry['result']
+
+
+@pytest.mark.parametrize("entry", COMPARE_GENERIC)
+def test_compare_generic(entry):
+    assert compare_generic(entry['a'], entry['b'], entry['method'], entry['type']) == entry['result']


### PR DESCRIPTION
##### SUMMARY
Backports of #47709 and #47900 and #48056 to stable-2.6: refactoring of idempotency comparisons, add some more tests, and fix paused state.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/docker_commons.py
docker_config
docker_configuration
docker_secret

##### ANSIBLE VERSION
```
2.6.7
```
