### PR TITLE
add expand_csv_tags to aws_ec2 inventory plugin

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -331,16 +331,26 @@ class Constructable(object):
                     if key:
                         prefix = keyed.get('prefix', '')
                         sep = keyed.get('separator', '_')
+                        expand_csv = keyed.get('expand_csv_tags', False)
 
                         if isinstance(key, string_types):
-                            groups.append('%s%s%s' % (prefix, sep, key))
+                            if expand_csv:
+                                for group in key.split(","):
+                                    groups.append('%s%s%s' % (prefix, sep, group))
+                            else:
+                                groups.append('%s%s%s' % (prefix, sep, key))
                         elif isinstance(key, list):
                             for name in key:
                                 groups.append('%s%s%s' % (prefix, sep, name))
                         elif isinstance(key, Mapping):
                             for (gname, gval) in key.items():
-                                name = '%s%s%s' % (gname, sep, gval)
-                                groups.append('%s%s%s' % (prefix, sep, name))
+                                if expand_csv:
+                                    for group in gval.split(","):
+                                        name = '%s%s%s' % (gname, sep, group)
+                                        groups.append('%s%s%s' % (prefix, sep, name))
+                                else:
+                                    name = '%s%s%s' % (gname, sep, gval)
+                                    groups.append('%s%s%s' % (prefix, sep, name))
                         else:
                             raise AnsibleParserError("Invalid group name format, expected a string or a list of them or dictionary, got: %s" % type(key))
                     else:

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -108,6 +108,10 @@ keyed_groups:
   # add hosts to tag_Name_Value groups for each Name/Value tag pair
   - prefix: tag
     key: tags
+  # create separate group tag_Name_Value for expanded CSV in tag value
+  - key: tags
+    prefix: 'tag'
+    expand_csv_tags: True
   # add hosts to e.g. instance_type_z3_tiny
   - prefix: instance_type
     key: instance_type


### PR DESCRIPTION
##### SUMMARY
Add 'expand_csv_tags' option to keyed_groups in aws_ec2 inventory plugin
It do the same thing as expand_csv_tags in ec2.py - let you create tags as CSV, ex:
tag:
Consul: master,client
will create groups
tags_Consul_master
tags_Consul_client
instead of tags_Consul_master_client

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
aws_ec2

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (add_csv_expand 1b6e106d6d) last updated 2018/10/31 08:01:44 (GMT +200)
  config file = None
  configured module search path = ['/home/mfabrykowski/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mfabrykowski/ansible/ansible/lib/ansible
  executable location = /home/mfabrykowski/ansible/ansible/bin/ansible
  python version = 3.5.6 (default, Aug 27 2018, 15:48:28) [GCC 8.2.1 20180801 (Red Hat 8.2.1-2)]
```

##### ADDITIONAL INFORMATION
BEFORE:
test.aws_ec2.yml
```
plugin: aws_ec2
boto_profile: boto_profile
  - us-west-1
filters:
  tag:Space: MySpace
strict_permissions: True
strict: True
keyed_groups:
  - key: tags.Consul
    separator: '_'
    prefix: Consul
```
will give output:
```
(abc) mfabrykowski @ marcinowy @ /tmp
└─ $ ansible-inventory -i /tmp/test2.aws_ec2.yml --graph
@all:
  |--@Consul_client:
  |  |--host1
  |  |--host2
  |--@Consul_master_client:
  |  |--host3
  |  |--host4
  |  |--host5
  |--@aws_ec2:
  |  |--host1
  |  |--host2
  |  |--host3
  |  |--host4
  |  |--host5
  |--@ungrouped:
```

AFTER:
test.aws_ec2.yml
```
plugin: aws_ec2
boto_profile: boto_profile
  - us-west-1
filters:
  tag:Space: MySpace
strict_permissions: True
strict: True
keyed_groups:
  - key: tags.Consul
    separator: '_'
    prefix: Consul
    expand_csv_tags: True
```
will give output:
```
(abc) mfabrykowski @ marcinowy @ /tmp
└─ $ ansible-inventory -i /tmp/test2.aws_ec2.yml --graph
@all:
  |--@Consul_client:
  |  |--host1
  |  |--host2
  |  |--host3
  |  |--host4
  |  |--host5
  |--@Consul_master:
  |  |--host3
  |  |--host4
  |  |--host5
  |--@aws_ec2:
  |  |--host1
  |  |--host2
  |  |--host3
  |  |--host4
  |  |--host5
  |--@ungrouped:
```
