### PR TITLE
fix curses.setupterm() error in pause module

### DIFF
--- a/changelogs/fragments/pause-catch-error-when-no-std-exists.yml
+++ b/changelogs/fragments/pause-catch-error-when-no-std-exists.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pause - handle exception when there is no stdout (https://github.com/ansible/ansible/pull/47851)

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -44,7 +44,7 @@ try:
     try:
         curses.setupterm()
         HAS_CURSES = True
-    except curses.error:
+    except (curses.error, TypeError):
         HAS_CURSES = False
 except ImportError:
     HAS_CURSES = False


### PR DESCRIPTION
##### SUMMARY
When run playbook in celery task, curses.setupterm()  will be failed, In celery worker may be no sys.stdin fileno, so catch this error

```
  File "<frozen importlib._bootstrap>", line 675, in _load
  File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 205, in _call_with_frames_removed
  File "/Users/guang/.virtualenvs/ansible/lib/python3.6/site-packages/ansible/plugins/action/pause.py", line 45, in <module>
    curses.setupterm()
TypeError: argument must be an int, or have a fileno() method.
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/pause

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.5.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
