### PR TITLE
Add support for 25G and 100G interfaces

### DIFF
--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -168,6 +168,10 @@ def normalize_interface(name):
         if_type = 'port-channel'
     elif name.lower().startswith('nv'):
         if_type = 'nve'
+    elif name.lower().startswith('twe'):
+        if_type = 'TwentyFiveGigE'
+    elif name.lower().startswith('hu'):
+        if_type = 'HundredGigE'
     else:
         if_type = None
 

--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -118,7 +118,7 @@ from ansible.module_utils.network.ios.ios import ios_argument_spec
 
 def get_interface_type(interface):
     intf_type = 'unknown'
-    if interface.upper()[:2] in ('ET', 'GI', 'FA', 'TE', 'FO'):
+    if interface.upper()[:2] in ('ET', 'GI', 'FA', 'TE', 'FO', 'HU', 'TWE'):
         intf_type = 'ethernet'
     elif interface.upper().startswith('VL'):
         intf_type = 'svi'


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #47670 
- Adds support for 25G and 100G interfaces

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ios.py
ios_l2_interface.py

##### ANSIBLE VERSION
```
devel
```