### PR TITLE
ovirt_vm: fix cloud_init_persist doc

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -360,7 +360,7 @@ options:
     cloud_init_persist:
         description:
             - "If I(true) the C(cloud_init) or C(sysprep) parameters will be saved for the virtual machine
-               and won't be virtual machine won't be started as run-once."
+               and virtual machine won't be started as run-once."
         type: bool
         version_added: "2.5"
         aliases: [ 'sysprep_persist' ]
@@ -2123,8 +2123,8 @@ def main():
                     ),
                     wait_condition=lambda vm: vm.status == otypes.VmStatus.UP,
                     # Start action kwargs:
-                    use_cloud_init=True if not module.params.get('cloud_init_persist') and module.params.get('cloud_init') is not None else None,
-                    use_sysprep=True if not module.params.get('cloud_init_persist') and module.params.get('sysprep') is not None else None,
+                    use_cloud_init=True if module.params.get('cloud_init_persist') and module.params.get('cloud_init') is not None else None,
+                    use_sysprep=True if module.params.get('cloud_init_persist') and module.params.get('sysprep') is not None else None,
                     vm=otypes.Vm(
                         placement_policy=otypes.VmPlacementPolicy(
                             hosts=[otypes.Host(name=module.params['host'])]

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -359,11 +359,12 @@ options:
         version_added: "2.3"
     cloud_init_persist:
         description:
-            - "If I(true) the C(cloud_init) or C(sysprep) parameters will be saved for the virtual machine
-               and virtual machine won't be started as run-once."
+            - "If I(yes) the C(cloud_init) or C(sysprep) parameters will be saved for the virtual machine
+               and the virtual machine won't be started as run-once."
         type: bool
         version_added: "2.5"
         aliases: [ 'sysprep_persist' ]
+        default: 'no'
     kernel_params_persist:
         description:
             - "If I(true) C(kernel_params), C(initrd_path) and C(kernel_path) will persist in virtual machine configuration,
@@ -2123,8 +2124,8 @@ def main():
                     ),
                     wait_condition=lambda vm: vm.status == otypes.VmStatus.UP,
                     # Start action kwargs:
-                    use_cloud_init=True if module.params.get('cloud_init_persist') and module.params.get('cloud_init') is not None else None,
-                    use_sysprep=True if module.params.get('cloud_init_persist') and module.params.get('sysprep') is not None else None,
+                    use_cloud_init=True if not module.params.get('cloud_init_persist') and module.params.get('cloud_init') is not None else None,
+                    use_sysprep=True if not module.params.get('cloud_init_persist') and module.params.get('sysprep') is not None else None,
                     vm=otypes.Vm(
                         placement_policy=otypes.VmPlacementPolicy(
                             hosts=[otypes.Host(name=module.params['host'])]


### PR DESCRIPTION
##### SUMMARY
Fixes #45900 
Follow-up for #47348

With #47348 merged, use_cloud_init is still sent as False if cloud_init_persist is set to True.
Unless I'm missing other logic behind cloud_init_persist, use_cloud_init should be sent as True if both cloud_init_persist is True and cloud_init has a value.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request


##### COMPONENT NAME
ovirt_vms

##### ANSIBLE VERSION
2.8.0.dev0
