### PR TITLE
k8s_facts: fix handling of unknown resource types

### DIFF
--- a/changelogs/fragments/k8s_facts_fix.yaml
+++ b/changelogs/fragments/k8s_facts_fix.yaml
@@ -1,3 +1,4 @@
 ---
 bugfixes:
 - k8s_facts now returns a resources key in all situations
+- "k8s_facts: fix handling of unknown resource types"

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -183,6 +183,8 @@ class K8sAnsibleMixin(object):
 
     def kubernetes_facts(self, kind, api_version, name=None, namespace=None, label_selectors=None, field_selectors=None):
         resource = self.find_resource(kind, api_version)
+        if not resource:
+            return dict(resources=[])
         try:
             result = resource.get(name=name,
                                   namespace=namespace,


### PR DESCRIPTION
##### SUMMARY
k8s_facts can be asked about resource kind/apiver combinations that it knows nothing about. This patch makes the code handle such a case gracefully.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modules/clustering/k8s/k8s_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```ansible 2.7.1
  config file = None
  configured module search path = [u'/home/mmazur/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mmazur/.local/lib/python2.7/site-packages/ansible
  executable location = /home/mmazur/.local/bin/ansible
  python version = 2.7.15 (default, Sep 21 2018, 23:28:06) [GCC 8.2.1 20180801 (Red Hat 8.2.1-2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
A full trace of what happens when running k8s_facts with a non–existant kind/apiver combo, in which case K8sAnsibleMixin.find_resource returns None while called from kubernetes_facts() function:

```The full traceback is:
Traceback (most recent call last):
  File "/home/mmazur/.ansible/tmp/ansible-tmp-1540988557.34-258232659169781/AnsiballZ_k8s_facts.py", line 113, in <module>
    _ansiballz_main()
  File "/home/mmazur/.ansible/tmp/ansible-tmp-1540988557.34-258232659169781/AnsiballZ_k8s_facts.py", line 105, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/mmazur/.ansible/tmp/ansible-tmp-1540988557.34-258232659169781/AnsiballZ_k8s_facts.py", line 48, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/tmp/ansible_k8s_facts_payload_JmbBNj/__main__.py", line 176, in <module>
  File "/tmp/ansible_k8s_facts_payload_JmbBNj/__main__.py", line 172, in main
  File "/tmp/ansible_k8s_facts_payload_JmbBNj/__main__.py", line 153, in execute_module
  File "/tmp/ansible_k8s_facts_payload_JmbBNj/ansible_k8s_facts_payload.zip/ansible/module_utils/k8s/common.py", line 202, in kubernetes_facts
AttributeError: 'NoneType' object has no attribute 'get'

fatal: [localhost]: FAILED! => {
    "changed": false, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/mmazur/.ansible/tmp/ansible-tmp-1540988557.34-258232659169781/AnsiballZ_k8s_facts.py\", line 113, in <module>\n    _ansiballz_main()\n  File \"/home/mmazur/.ansible/tmp/ansible-tmp-1540988557.34-258232659169781/AnsiballZ_k8s_facts.py\", line 105, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/mmazur/.ansible/tmp/ansible-tmp-1540988557.34-258232659169781/AnsiballZ_k8s_facts.py\", line 48, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/tmp/ansible_k8s_facts_payload_JmbBNj/__main__.py\", line 176, in <module>\n  File \"/tmp/ansible_k8s_facts_payload_JmbBNj/__main__.py\", line 172, in main\n  File \"/tmp/ansible_k8s_facts_payload_JmbBNj/__main__.py\", line 153, in execute_module\n  File \"/tmp/ansible_k8s_facts_payload_JmbBNj/ansible_k8s_facts_payload.zip/ansible/module_utils/k8s/common.py\", line 202, in kubernetes_facts\nAttributeError: 'NoneType' object has no attribute 'get'\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", 
    "rc": 1
}
        to retry, use: --limit @/home/mmazur/dev/ansible-kubevirt-modules/tests/playbooks/kubevirt_facts_vmipreset.retry
```
