### PR TITLE
Update ``make`` module honor the return code of the ``make`` command

### DIFF
--- a/lib/ansible/modules/system/make.py
+++ b/lib/ansible/modules/system/make.py
@@ -139,8 +139,9 @@ def main():
             #  do anything
             changed = False
         else:
-            # The target isn't upd to date, so we need to run it
-            rc, out, err = run_command(base_command, module)
+            # The target isn't up to date, so we need to run it
+            rc, out, err = run_command(base_command, module,
+                                       check_rc=True)
             changed = True
 
     # We don't report the return code, as if this module failed


### PR DESCRIPTION
##### SUMMARY
tl;dr: ``make`` module now fails (as expected) if the ``make`` command returned a non-zero exit code.

Observed behavior: tasks using the ``make`` module did not fail despite the ``make`` command returned a non-zero exit code. This leads to a  – excuse me – terrible user experience when authoring Playbooks etc.

Behavior modified to: return code of ``make`` command is honored, so that tasks fail if the ``make`` command returned a non-zero exit code.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
``make`` module

##### ANSIBLE VERSION

```
  config file = /home/johndoe/.ansible.cfg
  configured module search path = [u'/home/johndoe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15+ (default, Aug 31 2018, 11:56:52) [GCC 8.2.0]
```

##### ADDITIONAL INFORMATION
Well, I am not sure I completely get what the comment right above my change is trying to tell me.
However, if the ``make`` module does not honor the return code of the ``make`` command, users are better off without this module, since it makes it difficult to identify sources of unexpected behavior.
E.g.: you wonder why your remote setup does not work; you spend a lot of time on debugging, just to find out that your Makefile did not run (which Ansible did not tell you) because of a missing dependency or something likewise trivial.

Hope this patch is adequate.