### PR TITLE
tower tests: tower_{job,workflow}_template jobs: use same retries value

### DIFF
--- a/test/integration/targets/tower_job_template/tasks/main.yml
+++ b/test/integration/targets/tower_job_template/tasks/main.yml
@@ -35,7 +35,7 @@
     return_content: true
   register: result
   until: result.json.status == "successful"
-  retries: 15
+  retries: 60
   delay: 1
 
 - name: Create a Job Template


### PR DESCRIPTION
##### SUMMARY
Use same `retries` value for both  `tower_workflow_template` and  `tower_job_template` jobs.

This update won't fix the issue reported by @acalm, see this [build](https://app.shippable.com/github/ansible/ansible/runs/91158/91/console):
- first run, `tower_job_template : Wait for the project to be status=successful` task failed (15 attempts) -> `status` is `failed`
- second run, `tower_job_template : Wait for the project to be status=successful` task successful (4 attempts) -> `status` is `pending` 3 times then `successful`

but i don't see any reason to not use the same `retries` value for both tasks.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
 test/integration/targets/tower_job_template/tasks/main.yml

##### ANSIBLE VERSION
```paste below
2.8
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
