### PR TITLE
Fix #47864 : Add the ability to download a specific version of an S3 object

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -583,9 +583,10 @@ def download_s3file(module, s3, bucket, obj, dest, retries, version=None):
     except botocore.exceptions.BotoCoreError as e:
         module.fail_json_aws(e, msg="Could not find the key %s." % obj)
 
+    optional_kwargs = {'ExtraArgs': {'VersionId': version}} if version else {}
     for x in range(0, retries + 1):
         try:
-            s3.download_file(bucket, obj, dest)
+            s3.download_file(bucket, obj, dest, **optional_kwargs)
             module.exit_json(msg="GET operation complete", changed=True)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             # actually fail on last pass through the loop.


### PR DESCRIPTION
##### SUMMARY

Fix #47864 : Add the ability to download a specific version of an S3 object

As descibed in #47864 aws_s3 ignore the version specified while downloading the object.

Example of ansible config to test the code :

```
- name: Get a specific version of an object.
  aws_s3:
    bucket: mybucket
    object: /my/desired/key.txt
    version: 48c9ee5131af7a716edc22df9772aa6f
    dest: /usr/local/myfile.txt
    mode: get
```

`aws_s3.py` use boto `s3.download_file(bucket, obj, dest)` command to download the s3 object.
However it does not take into account the version of the object.

Looking on boto doc https://github.com/boto/boto3/issues/1120, it is possible to specify object VersionId as ExtraArgs of s3.download_file.

```
s3.download_file(bucket, obj, dest, ExtraArgs={'VersionId': version})
```


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

aws_s3

