### PR TITLE
IBM_Storage: Added a module to define domains on Spectrum Accelerate …

### DIFF
--- a/lib/ansible/modules/storage/ibm/ibm_sa_domain.py
+++ b/lib/ansible/modules/storage/ibm/ibm_sa_domain.py
@@ -33,6 +33,8 @@ options:
         description:
             - The desired state of the domain
         required: true
+        default: "present"
+        choices: [ "present", "absent" ]
     ldap_id:
         description:
             - ldap id to add to the domain.

--- a/lib/ansible/modules/storage/ibm/ibm_sa_domain.py
+++ b/lib/ansible/modules/storage/ibm/ibm_sa_domain.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2018 IBM CORPORATION
+# Copyright: (c) 2018, IBM CORPORATION
 # Author(s): Tzur Eliyahu <tzure@il.ibm.com>
 #
 # GNU General Public License v3.0+ (see COPYING or
@@ -17,21 +17,20 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: ibm_sa_domain
-short_description: Adds domains to or removes them from IBM Spectrum Accelerate storage systems.
+short_description: Manages domains in IBM Spectrum Accelerate storage systems.
 version_added: "2.8"
 
 description:
-    - "This module adds domains to or removes them
-        from IBM Spectrum Accelerate storage systems"
+    - "This module can be used to adds domains to or removes them from IBM Spectrum Accelerate storage systems"
 
 options:
     domain:
         description:
-            - domain name
+            - Name of the domain to be managed.
         required: true
     state:
         description:
-            - The desired state of the domain
+            - The desired state of the domain.
         required: true
         default: "present"
         choices: [ "present", "absent" ]
@@ -41,7 +40,7 @@ options:
         required: false
     size:
         description:
-            - domain size
+            - Size of the domain.
         required: false
     hard_capacity:
         description:
@@ -57,19 +56,19 @@ options:
         required: false
     max_dms:
         description:
-            - number of max dms.
+            - Number of max dms.
         required: false
     max_mirrors:
         description:
-            - number of max_mirrors.
+            - Number of max_mirrors.
         required: false
     max_pools:
         description:
-            - number of max_pools.
+            - Number of max_pools.
         required: false
     max_volumes:
         description:
-            - number of max_volumes.
+            - Number of max_volumes.
         required: false
     perf_class:
         description:
@@ -80,7 +79,7 @@ extends_documentation_fragment:
     - ibm_storage
 
 author:
-    - Tzur Eliyahu (tzure@il.ibm.com)
+    - Tzur Eliyahu (@tzure)
 '''
 
 EXAMPLES = '''
@@ -102,6 +101,11 @@ EXAMPLES = '''
     endpoints: hostdev-system
 '''
 RETURN = '''
+msg:
+    description: module return status.
+    returned: as needed
+    type: string
+    sample: "domain 'domain_name' created successfully."
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -138,14 +142,19 @@ def main():
     state = module.params['state']
 
     state_changed = False
+    msg = 'Domain \'{0}\''.format(module.params['domain'])
     if state == 'present' and not domain:
         state_changed = execute_pyxcli_command(
             module, 'domain_create', xcli_client)
+        msg += " created successfully."
     elif state == 'absent' and domain:
         state_changed = execute_pyxcli_command(
             module, 'domain_delete', xcli_client)
+        msg += " deleted successfully."
+    else:
+        msg += " state unchanged."
 
-    module.exit_json(changed=state_changed)
+    module.exit_json(changed=state_changed, msg=msg)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/storage/ibm/ibm_sa_domain.py
+++ b/lib/ansible/modules/storage/ibm/ibm_sa_domain.py
@@ -1,0 +1,150 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2018 IBM CORPORATION
+# Author(s): Tzur Eliyahu <tzure@il.ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: ibm_sa_domain
+short_description: Adds domains to or removes them from IBM Spectrum Accelerate storage systems.
+version_added: "2.8"
+
+description:
+    - "This module adds domains to or removes them
+        from IBM Spectrum Accelerate storage systems"
+
+options:
+    domain:
+        description:
+            - domain name
+        required: true
+    state:
+        description:
+            - The desired state of the domain
+        required: true
+    ldap_id:
+        description:
+            - ldap id to add to the domain.
+        required: false
+    size:
+        description:
+            - domain size
+        required: false
+    hard_capacity:
+        description:
+            - Hard capacity of the domain.
+        required: false
+    soft_capacity:
+        description:
+            - Soft capacity of the domain.
+        required: false
+    max_cgs:
+        description:
+            - Number of max cgs.
+        required: false
+    max_dms:
+        description:
+            - number of max dms.
+        required: false
+    max_mirrors:
+        description:
+            - number of max_mirrors.
+        required: false
+    max_pools:
+        description:
+            - number of max_pools.
+        required: false
+    max_volumes:
+        description:
+            - number of max_volumes.
+        required: false
+    perf_class:
+        description:
+            - Add the domain to a performance class.
+        required: false
+
+extends_documentation_fragment:
+    - ibm_storage
+
+author:
+    - Tzur Eliyahu (tzure@il.ibm.com)
+'''
+
+EXAMPLES = '''
+- name: Define new domain.
+  ibm_sa_domain:
+    domain: domain_name
+    size: domain_size
+    state: present
+    username: admin
+    password: secret
+    endpoints: hostdev-system
+
+- name: Delete domain.
+  ibm_sa_domain:
+    domain: domain_name
+    state: absent
+    username: admin
+    password: secret
+    endpoints: hostdev-system
+'''
+RETURN = '''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ibm_sa_utils import execute_pyxcli_command, \
+    connect_ssl, spectrum_accelerate_spec, is_pyxcli_installed
+
+
+def main():
+    argument_spec = spectrum_accelerate_spec()
+    argument_spec.update(
+        dict(
+            state=dict(default='present', choices=['present', 'absent']),
+            domain=dict(required=True),
+            size=dict(),
+            max_dms=dict(),
+            max_cgs=dict(),
+            ldap_id=dict(),
+            max_mirrors=dict(),
+            max_pools=dict(),
+            max_volumes=dict(),
+            perf_class=dict(),
+            hard_capacity=dict(),
+            soft_capacity=dict()
+        )
+    )
+
+    module = AnsibleModule(argument_spec)
+
+    is_pyxcli_installed(module)
+
+    xcli_client = connect_ssl(module)
+    domain = xcli_client.cmd.domain_list(
+        domain=module.params['domain']).as_single_element
+    state = module.params['state']
+
+    state_changed = False
+    if state == 'present' and not domain:
+        state_changed = execute_pyxcli_command(
+            module, 'domain_create', xcli_client)
+    elif state == 'absent' and domain:
+        state_changed = execute_pyxcli_command(
+            module, 'domain_delete', xcli_client)
+
+    module.exit_json(changed=state_changed)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
…storage array

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added a module to support adding and removing domains on the IBM Spectrum accelerate storage array.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ibm_sa_domain

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (add_ibm_storage_domain_module ab1128ccfd) last updated 2018/10/31 16:37:44 (GMT +300)
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
