### PR TITLE
Adjust location for cloudstorageaccount modules

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -152,7 +152,7 @@ try:
     from azure.mgmt.containerservice import ContainerServiceClient
     from azure.mgmt.marketplaceordering import MarketplaceOrderingAgreements
     from azure.mgmt.trafficmanager import TrafficManagerManagementClient
-    from azure.storage.cloudstorageaccount import CloudStorageAccount
+    from azure.storage.common.cloudstorageaccount import CloudStorageAccount
     from azure.storage.blob import PageBlobService, BlockBlobService
     from adal.authentication_context import AuthenticationContext
     from azure.mgmt.sql import SqlManagementClient

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
@@ -145,7 +145,7 @@ state:
 
 try:
     from msrestazure.azure_exceptions import CloudError
-    from azure.storage.cloudstorageaccount import CloudStorageAccount
+    from azure.storage.common.cloudstorageaccount import CloudStorageAccount
     from azure.common import AzureMissingResourceHttpError
 except ImportError:
     # This is handled in azure_rm_common


### PR DESCRIPTION

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
module/cloud/azure

##### ANSIBLE VERSION
```
> /Users/wawrzek/Work/Others/ansible #>ansible --version  
  ansible 2.7.1
  config file = /Users/wawrzek/.ansible.cfg
  configured module search path = ['/Users/wawrzek/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.7.1/libexec/lib/python3.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.7.0 (default, Oct  2 2018, 09:19:48) [Clang 9.0.0 (clang-900.0.39.2)]
```

##### SUMMARY

Trying to follow [Ansible in Azure documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/ansible-install-configure#create-azure-credentials) I got following error:

```    "msg": "Do you have azure>=2.0.0 installed? Try `pip install ansible[azure]`- No module named 'azure.storage.cloudstorageaccount'"```

Above message suggested to use pip. I was using brew. So I decided to looked at sources and found that simple adjusting cloudstorageaccount module import fixed it. Brew using vanilla azure-storage-common version 1.3.0, so it should work everywhere. Current path is for the file:

``` azure-storage-common-1.3.0/azure/storage/common/cloudstorageaccount.py ```



