### PR TITLE
Add new configuration for nxos_vxlan_vtep_vni

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
+++ b/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
@@ -67,6 +67,12 @@ options:
     description:
       - Suppress arp under layer 2 VNI.
     type: bool
+  suppress_arp_disable:
+    description:
+      - Overrides the global ARP suppression config.
+        This is available on NX-OS 9K series running 9.2.x or higher.
+    type: bool
+    version_added: "2.8"
   state:
     description:
       - Determines whether the config should be present or not
@@ -98,6 +104,7 @@ from ansible.module_utils.network.common.config import CustomNetworkConfig
 BOOL_PARAMS = [
     'assoc_vrf',
     'suppress_arp',
+    'suppress_arp_disable',
 ]
 PARAM_TO_DEFAULT_KEYMAP = {
     'multicast_group': '',
@@ -111,7 +118,8 @@ PARAM_TO_COMMAND_KEYMAP = {
     'ingress_replication': 'ingress-replication protocol',
     'multicast_group': 'mcast-group',
     'peer_list': 'peer-ip',
-    'suppress_arp': 'suppress-arp'
+    'suppress_arp': 'suppress-arp',
+    'suppress_arp_disable': 'suppress-arp disable',
 }
 
 
@@ -287,13 +295,18 @@ def main():
         multicast_group=dict(required=False, type='str'),
         peer_list=dict(required=False, type='list'),
         suppress_arp=dict(required=False, type='bool'),
+        suppress_arp_disable=dict(required=False, type='bool'),
         ingress_replication=dict(required=False, type='str', choices=['bgp', 'static', 'default']),
         state=dict(choices=['present', 'absent'], default='present', required=False),
     )
 
     argument_spec.update(nxos_argument_spec)
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=[('suppress_arp', 'suppress_arp_disable')],
+        supports_check_mode=True,
+    )
 
     warnings = list()
     check_args(module, warnings)
@@ -302,6 +315,7 @@ def main():
     if module.params['assoc_vrf']:
         mutually_exclusive_params = ['multicast_group',
                                      'suppress_arp',
+                                     'suppress_arp_disable',
                                      'ingress_replication']
         for param in mutually_exclusive_params:
             if module.params[param]:

--- a/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
+++ b/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
@@ -302,9 +302,14 @@ def main():
 
     argument_spec.update(nxos_argument_spec)
 
+    mutually_exclusive = [('suppress_arp', 'suppress_arp_disable'),
+                          ('assoc_vrf', 'multicast_group'),
+                          ('assoc_vrf', 'suppress_arp'),
+                          ('assoc_vrf', 'suppress_arp_disable'),
+                          ('assoc_vrf', 'ingress_replication')]
     module = AnsibleModule(
         argument_spec=argument_spec,
-        mutually_exclusive=[('suppress_arp', 'suppress_arp_disable')],
+        mutually_exclusive=mutually_exclusive,
         supports_check_mode=True,
     )
 
@@ -312,15 +317,6 @@ def main():
     check_args(module, warnings)
     result = {'changed': False, 'commands': [], 'warnings': warnings}
 
-    if module.params['assoc_vrf']:
-        mutually_exclusive_params = ['multicast_group',
-                                     'suppress_arp',
-                                     'suppress_arp_disable',
-                                     'ingress_replication']
-        for param in mutually_exclusive_params:
-            if module.params[param]:
-                module.fail_json(msg='assoc_vrf cannot be used with '
-                                     '{0} param'.format(param))
     if module.params['peer_list']:
         if module.params['peer_list'][0] != 'default' and module.params['ingress_replication'] != 'static':
             module.fail_json(msg='ingress_replication=static is required '


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
On N9K running 9.2.x or higher a new CLI command is added which is necessary for vxlan configuration. This PR is for adding that configuration.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_vxlan_vtep_vni
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (devel 38844194ae) last updated 2018/10/29 16:01:49 (GMT -400)
  config file = /root/agents-ci/ansible/test/integration/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

```

##### ADDITIONAL INFORMATION
```
On N9K running 9.2.x a new CLI is added for vxlan configuration.
* suppress_arp_disable

* The integration tests including this suppress_arp_disable cannot be added due to hardware limitations on various platforms. See issue which was closed a year ago for this:
https://github.com/ansible/ansible/issues/27924

* However, tests are run against some particular platforms where this is supported and they pass.

```
