### PR TITLE
Improve debug logging of filetree with path being walked and items found

### DIFF
--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -183,6 +183,7 @@ class LookupModule(LookupBase):
             term_file = os.path.basename(term)
             dwimmed_path = self._loader.path_dwim_relative(basedir, 'files', os.path.dirname(term))
             path = os.path.join(dwimmed_path, term_file)
+            display.debug("Walking '{0}'".format(path))
             for root, dirs, files in os.walk(path, topdown=True):
                 for entry in dirs + files:
                     relpath = os.path.relpath(os.path.join(root, entry), path)
@@ -191,6 +192,7 @@ class LookupModule(LookupBase):
                     if relpath not in [entry['path'] for entry in ret]:
                         props = file_props(path, relpath)
                         if props is not None:
+                            display.debug("  found '{0}'".format(os.path.join(path, relpath)))
                             ret.append(props)
 
         return ret


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When the filetree path is invalid, there is no debug logging feedback to help you figure it out.  While the feedback in the corresponding issue says it was not possible, it was.  I added `-vvvvv` logging for the beginning of the walk and each item found.

Fixes #24300

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
filetree

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (better-filetree-logging 7c434e4559) last updated 2018/10/31 17:04:47 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /ansible/lib/ansible
  executable location = /ansible/bin/ansible
  python version = 2.7.15 (default, Sep 12 2018, 02:38:23) [GCC 6.4.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Here's a `with_filetree` task that had a bad input, before the change - why did it fail to find anything?
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [Fail if anything in the template source directory is a link] ***************************************************************************************************************************
task path: /my/playbooks/tasks/filetree-example.yaml:27
```

Here's the `-vvvvv` level debug output after the change:
```
TASK [Fail if anything in the template source directory is a link] ***************************************************************************************************************************
task path: /my/playbooks/tasks/filetree-example.yaml:27
Walking '/my/templates/filetree_example }}'
```

Looks like I mistyped my path.  Easier to identify when you have debug logging.   Once I fixed it:
```
TASK [Fail if anything in the template source directory is a link] ***************************************************************************************************************************
task path: /my/playbooks/tasks/filetree-example.yaml:27
Walking '/my/templates/filetree_example'
  Found '/my/templates/filetree_example/dir1/file1'
  Found '/my/templates/filetree_example/file2'
```