### PR TITLE
issue-47881 making udp calls an option

### DIFF
--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -81,6 +81,7 @@ options:
             - Sets the transport protocol
         default: 'tcp'
         choices: ['tcp', 'udp']
+        version_added: 2.8
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -231,7 +231,7 @@ class RecordManager(object):
     def __do_update(self, update):
         response = None
         try:
-            if module.params["protocol"] == 'tcp':
+            if self.module.params["protocol"] == 'tcp':
                 response = dns.query.tcp(update, self.module.params['server'], timeout=10, port=self.module.params['port'])
             else:
                 response = dns.query.udp(update, self.module.params['server'], timeout=10, port=self.module.params['port'])

--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -76,7 +76,11 @@ options:
     value:
         description:
             - Sets the record value.
-
+    protocol:
+        description:
+            - Sets the transport protocol
+        default: 'tcp'
+        choices: ['tcp', 'udp']
 '''
 
 EXAMPLES = '''
@@ -227,7 +231,10 @@ class RecordManager(object):
     def __do_update(self, update):
         response = None
         try:
-            response = dns.query.tcp(update, self.module.params['server'], timeout=10, port=self.module.params['port'])
+            if module.params["protocol"] == 'tcp':
+                response = dns.query.tcp(update, self.module.params['server'], timeout=10, port=self.module.params['port'])
+            else:
+                response = dns.query.udp(update, self.module.params['server'], timeout=10, port=self.module.params['port'])
         except (dns.tsig.PeerBadKey, dns.tsig.PeerBadSignature) as e:
             self.module.fail_json(msg='TSIG update error (%s): %s' % (e.__class__.__name__, to_native(e)))
         except (socket_error, dns.exception.Timeout) as e:
@@ -365,6 +372,7 @@ class RecordManager(object):
 def main():
     tsig_algs = ['HMAC-MD5.SIG-ALG.REG.INT', 'hmac-md5', 'hmac-sha1', 'hmac-sha224',
                  'hmac-sha256', 'hmac-sha384', 'hmac-sha512']
+    protocols = ['tcp', 'udp']
 
     module = AnsibleModule(
         argument_spec=dict(
@@ -378,7 +386,8 @@ def main():
             record=dict(required=True, type='str'),
             type=dict(required=False, default='A', type='str'),
             ttl=dict(required=False, default=3600, type='int'),
-            value=dict(required=False, default=None, type='list')
+            value=dict(required=False, default=None, type='list'),
+            protocol=dict(required=False, default='tcp', choices=protocols, type='str')
         ),
         supports_check_mode=True
     )

--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -231,7 +231,7 @@ class RecordManager(object):
     def __do_update(self, update):
         response = None
         try:
-            if self.module.params["protocol"] == 'tcp':
+            if self.module.params['protocol'] == 'tcp':
                 response = dns.query.tcp(update, self.module.params['server'], timeout=10, port=self.module.params['port'])
             else:
                 response = dns.query.udp(update, self.module.params['server'], timeout=10, port=self.module.params['port'])

--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -362,7 +362,7 @@ class RecordManager(object):
         query = dns.message.make_query(self.fqdn, self.module.params['type'])
 
         try:
-            if self.module.params['protocol'] == 'tcp': 
+            if self.module.params['protocol'] == 'tcp':
                 lookup = dns.query.tcp(query, self.module.params['server'], timeout=10, port=self.module.params['port'])
             else:
                 lookup = dns.query.udp(query, self.module.params['server'], timeout=10, port=self.module.params['port'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
UDP is a valid nsupdate protocol, in fact the linux commands start with udp and change to tcp if the request is too long.  TCP is the default nsupdate communication, so, I added a udp option as `protocol` with default tcp and the ability to make a udp call with a change. 

Fixes #47881
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nsupdate
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ckyriaki/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
