### PR TITLE
VMware: improve readability and fix privileges names on vmware scenario_clone…

### DIFF
--- a/docs/docsite/rst/vmware/scenario_clone_template.rst
+++ b/docs/docsite/rst/vmware/scenario_clone_template.rst
@@ -36,14 +36,14 @@ Scenario Requirements
 
     * Administrator user with following privileges
 
-        - Virtual machine.Provisioning.Clone virtual machine on the virtual machine you are cloning
-        - Virtual machine.Inventory.Create from existing on the datacenter or virtual machine folder
-        - Virtual machine.Configuration.Add new disk on the datacenter or virtual machine folder
-        - Resource.Assign virtual machine to resource pool on the destination host, cluster, or resource pool
-        - Datastore.Allocate space on the destination datastore or datastore folder
-        - Network.Assign network on the network to which the virtual machine will be assigned
-        - Virtual machine.Provisioning.Customize on the virtual machine or virtual machine folder if you are customizing the guest operating system
-        - Virtual machine.Provisioning.Read customization specifications on the root vCenter Server if you are customizing the guest operating system
+        - ``VirtualMachine.Provisioning.Clone`` on the virtual machine you are cloning
+        - ``VirtualMachine.Inventory.CreateFromExisting`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Config.AddNewDisk`` on the datacenter or virtual machine folder
+        - ``Resource.Assign`` virtual machine to resource pool on the destination host, cluster, or resource pool
+        - ``Datastore.AllocateSpace`` on the destination datastore or datastore folder
+        - ``Network.AssignNetwork`` on the network to which the virtual machine will be assigned
+        - ``VirtualMachine.Provisioning.Customize`` on the virtual machine or virtual machine folder if you are customizing the guest operating system
+        - ``VirtualMachine.Provisioning.ReadCustSpecs`` on the root vCenter Server if you are customizing the guest operating system
 
 Assumptions
 ===========


### PR DESCRIPTION
Hi, this small patch will:
- fix the name of the required privileges by removing the spaces and use the proper capitalization;
- improve the formatting of the section by making a clear distinction between the privilege name and the following comment;

Thanks

+label: docsite_pr
+label: vmware

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
 docs/docsite/rst/vmware/scenario_clone_template.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8devel
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
