### PR TITLE
remove redundant md5 hashing

### DIFF
--- a/changelogs/fragments/remove_redundant_md5.yml
+++ b/changelogs/fragments/remove_redundant_md5.yml
@@ -1,0 +1,3 @@
+bugfixes:
+    - remove rendundant path uniquifying in inventory plugins.  This removes
+      use of md5 hashing and fixes inventory plugins when run in FIPS mode.

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -251,7 +251,7 @@ class Cacheable(object):
     _cache = {}
 
     def get_cache_key(self, path):
-        return "{0}_{1}_{2}".format(self.NAME, self._get_cache_prefix(path), self._get_config_identifier(path))
+        return "{0}_{1}".format(self.NAME, self._get_cache_prefix(path))
 
     def _get_cache_prefix(self, path):
         ''' create predictable unique prefix for plugin/inventory '''
@@ -265,11 +265,6 @@ class Cacheable(object):
         d2 = n.hexdigest()
 
         return 's_'.join([d1[:5], d2[:5]])
-
-    def _get_config_identifier(self, path):
-        ''' create predictable config-specific prefix for plugin/inventory '''
-
-        return hashlib.md5(path.encode()).hexdigest()
 
     def clear_cache(self):
         self._cache = {}


### PR DESCRIPTION
(cherry picked from commit d590f10d32b5a3c9417a5be021ba5ddfc6f1f453)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
inventory
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```
