### PR TITLE
Correct yum and dnf autoremove behavior

### DIFF
--- a/changelogs/fragments/yumdnf-autoremove.yaml
+++ b/changelogs/fragments/yumdnf-autoremove.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "fix yum and dnf autoremove input sanitization to properly warn user if invalid options passed and update documentation to match"

--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -40,7 +40,7 @@ yumdnf_argument_spec = dict(
         security=dict(type='bool', default=False),
         skip_broken=dict(type='bool', default=False),
         # removed==absent, installed==present, these are accepted as aliases
-        state=dict(type='str', default='present', choices=['absent', 'installed', 'latest', 'present', 'removed']),
+        state=dict(type='str', default=None, choices=['absent', 'installed', 'latest', 'present', 'removed']),
         update_cache=dict(type='bool', default=False, aliases=['expire-cache']),
         update_only=dict(required=False, default="no", type='bool'),
         validate_certs=dict(type='bool', default=True),
@@ -102,6 +102,19 @@ class YumDnf(with_metaclass(ABCMeta, object)):
                 msg='It appears that a space separated string of packages was passed in '
                     'as an argument. To operate on several packages, pass a comma separated '
                     'string of packages or a list of packages.'
+            )
+
+        # Sanity checking for autoremove
+        if self.state is None:
+            if self.autoremove:
+                self.state = "absent"
+            else:
+                self.state = "present"
+
+        if self.autoremove and (self.state != "absent"):
+            self.module.fail_json(
+                msg="Autoremove should be used alone or with state=absent",
+                results=[],
             )
 
         # This should really be redefined by both the yum and dnf module but a

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -44,7 +44,6 @@ options:
       - Default is C(None), however in effect the default action is C(present) unless the C(autoremove) option is
         enabled for this module, then C(absent) is inferred.
     choices: ['absent', 'present', 'installed', 'removed', 'latest']
-    default: None
 
   enablerepo:
     description:

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -41,8 +41,10 @@ options:
   state:
     description:
       - Whether to install (C(present), C(latest)), or remove (C(absent)) a package.
+      - Default is C(None), however in effect the default action is C(present) unless the C(autoremove) option is
+        enabled for this module, then C(absent) is inferred.
     choices: ['absent', 'present', 'installed', 'removed', 'latest']
-    default: "present"
+    default: None
 
   enablerepo:
     description:
@@ -1039,11 +1041,6 @@ class DnfModule(YumDnf):
             if LooseVersion(dnf.__version__) < LooseVersion('2.0.1'):
                 self.module.fail_json(
                     msg="Autoremove requires dnf>=2.0.1. Current dnf version is %s" % dnf.__version__,
-                    results=[],
-                )
-            if self.state not in ["absent", None]:
-                self.module.fail_json(
-                    msg="Autoremove should be used alone or with state=absent",
                     results=[],
                 )
 

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -55,8 +55,10 @@ options:
       - C(present) and C(installed) will simply ensure that a desired package is installed.
       - C(latest) will update the specified package if it's not of the latest available version.
       - C(absent) and C(removed) will remove the specified package.
+      - Default is C(None), however in effect the default action is C(present) unless the C(autoremove) option is¬
+        enabled for this module, then C(absent) is inferred.
     choices: [ absent, installed, latest, present, removed ]
-    default: present
+    default: None
   enablerepo:
     description:
       - I(Repoid) of repositories to enable for the install/update operation.

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -58,7 +58,6 @@ options:
       - Default is C(None), however in effect the default action is C(present) unless the C(autoremove) option is¬
         enabled for this module, then C(absent) is inferred.
     choices: [ absent, installed, latest, present, removed ]
-    default: None
   enablerepo:
     description:
       - I(Repoid) of repositories to enable for the install/update operation.


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Sanity check args passed to autoremove

Fixes #47184

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum
dnf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (issue/47184-dnf-yum-autoremove-not-as-documented 99866f167d) last updated 2018/10/31 17:08:53 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, Oct 15 2018, 15:24:06) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```
