### PR TITLE
connection/ssh: Don't warn when closing already closed connection

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1122,7 +1122,9 @@ class Connection(ConnectionBase):
             p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
             status_code = p.wait()
-            if status_code != 0:
+            if status_code == 255 and ('No such file or directory' in stderr):
+                display.debug("ControlPath is already closed:%s" % stderr)
+            elif status_code != 0:
                 display.warning("Failed to reset connection:%s" % stderr)
 
         self.close()


### PR DESCRIPTION
##### SUMMARY
If someone is requesting to reset the connection and the ControlPath doesn't exist,
no need to warn about it, because that's the state the user requested.

If any other error occurs, then display the warning.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ssh connection plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/cognifloyd/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
The warning message when a ControlPath doesn't exist has prompted me to wrap a `meta: reset_connection` task in an include where that include only occurs if the ControlPath file exists.
If I'm trying to get rid of the Control Socket, I don't need a big scary warning message.