### PR TITLE
Fix ansible-test invocation of pytest.

### DIFF
--- a/test/runner/injector/injector.py
+++ b/test/runner/injector/injector.py
@@ -151,14 +151,22 @@ def injector():
     :rtype: list[str], dict[str, str]
     """
     command = os.path.basename(__file__)
-    executable = find_executable(command)
+
+    run_as_python_module = (
+        'pytest',
+    )
+
+    if command in run_as_python_module:
+        executable_args = ['-m', command]
+    else:
+        executable_args = [find_executable(command)]
 
     if config.coverage_file:
         args, env = coverage_command()
     else:
         args, env = [config.python_interpreter], os.environ.copy()
 
-    args += [executable]
+    args += executable_args
 
     if command in ('ansible', 'ansible-playbook', 'ansible-pull'):
         if config.remote_interpreter is None:


### PR DESCRIPTION
##### SUMMARY

Invocation is now done with `-m pytest` instead of requiring a `pytest` script for an entry point.

Previously ansible-test required the `pytest` entry-point to exist as a python script, which was then invoked using the desired Python interpreter (not necessarily matching the shebang of the script).

This did not work for OS package installations where the entry-point was named after the Python interpreter version, such as `pytest-X.Y`.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (at-pytest-fix bcc0a08641) last updated 2018/10/31 20:07:25 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
