### PR TITLE
dnf yum: fix tests running on Fedora 29

### DIFF
--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -430,6 +430,14 @@
 
 # ENVIRONMENT UPGRADE
 # see commit de299ef77c03a64a8f515033a79ac6b7db1bc710
+
+# Newer Fedora Docker images come with coreutils-single which is incompatible
+# with coreutils (required by @Web Server). We force the install of coreutils
+# before running the environment group install.
+# https://github.com/fedora-cloud/docker-brew-fedora/issues/58
+- name: ensure coreutils is installed over coreutils-single
+  command: dnf install --allowerasing -y coreutils
+
 - name: install Web Server environment
   dnf:
     name: "@Web Server"

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -437,12 +437,20 @@
 # https://github.com/fedora-cloud/docker-brew-fedora/issues/58
 - name: ensure coreutils is installed over coreutils-single
   command: dnf install --allowerasing -y coreutils
+  changed_when: '"Nothing to do" not in coreutils_install.stdout'
+  register: coreutils_install
 
-- name: install Web Server environment
-  dnf:
-    name: "@Web Server"
-    state: latest
-  register: dnf_result
+- block:
+  - name: install Web Server environment
+    dnf:
+      name: "@Web Server"
+      state: latest
+    register: dnf_result
+
+  always:
+  - name: reinstall coreutils-single if coreutils was installed
+    command: dnf install --allowerasing -y coreutils-single
+    when: coreutils_install is changed
 
 - name: verify installation of the environment
   assert:

--- a/test/integration/targets/dnf/tasks/dnfreleasever.yml
+++ b/test/integration/targets/dnf/tasks/dnfreleasever.yml
@@ -19,7 +19,7 @@
   dnf:
     name: filesystem
     installroot: '/{{dnfroot.stdout}}'
-    releasever: 22
+    releasever: '{{ansible_distribution_version|int - 1}}'
   register: dnf_result
 
 - name: check filesystem version
@@ -40,7 +40,7 @@
 - name: verify the version
   assert:
     that:
-      - "rpm_result.stdout.find('fc22') != -1"
+      - "rpm_result.stdout.find('fc' ~ (ansible_distribution_version|int - 1)) != -1"
 
 - name: cleanup installroot
   file:

--- a/test/integration/targets/yum/files/yum.conf
+++ b/test/integration/targets/yum/files/yum.conf
@@ -1,0 +1,5 @@
+[main]
+gpgcheck=1
+installonly_limit=3
+clean_requirements_on_remove=True
+tsflags=nodocs

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -127,20 +127,22 @@
     force: False
   register: yum_conf_copy
 
-- name: install sos with state latest in check mode with config file param
-  yum: name=sos state=latest conf_file=/etc/yum.conf
-  check_mode: true
-  register: yum_result
-- name: verify install sos with state latest in check mode with config file param
-  assert:
-    that:
+- block:
+  - name: install sos with state latest in check mode with config file param
+    yum: name=sos state=latest conf_file=/etc/yum.conf
+    check_mode: true
+    register: yum_result
+  - name: verify install sos with state latest in check mode with config file param
+    assert:
+      that:
         - "yum_result is changed"
 
-- name: remove tmp yum.conf file if we created it
-  file:
-    path: /etc/yum.conf
-    state: absent
-  when: yum_conf_copy is changed
+  always:
+  - name: remove tmp yum.conf file if we created it
+    file:
+      path: /etc/yum.conf
+      state: absent
+    when: yum_conf_copy is changed
 
 - name: install sos with state latest in check mode
   yum: name=sos state=latest

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -120,6 +120,13 @@
     that:
         - "yum_result is successful"
 
+- name: copy yum.conf file in case it is missing
+  copy:
+    src: yum.conf
+    dest: /etc/yum.conf
+    force: False
+  register: yum_conf_copy
+
 - name: install sos with state latest in check mode with config file param
   yum: name=sos state=latest conf_file=/etc/yum.conf
   check_mode: true
@@ -128,6 +135,12 @@
   assert:
     that:
         - "yum_result is changed"
+
+- name: remove tmp yum.conf file if we created it
+  file:
+    path: /etc/yum.conf
+    state: absent
+  when: yum_conf_copy is changed
 
 - name: install sos with state latest in check mode
   yum: name=sos state=latest


### PR DESCRIPTION
##### SUMMARY
The Fedora 29 docker image has the following issues;

* It comes with `coreutils-single` installed which conflicts with all the environment group dnf packages
* Doesn't work with the hardcoded releasever set in the test
* Does not have a `/etc/yum.conf` file due to changes in the dnf versions

This PR fixes those tests to start working on this newer version

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
dnf
yum

##### ANSIBLE VERSION
```paste below
devel
```