### PR TITLE
Document lineinfile regexp gotcha

### DIFF
--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -48,6 +48,8 @@ options:
       - If the regular expression is not matched, the line will be
         added to the file in keeping with`insertbefore` or `insertafter`
         settings.
+      - When modifying a line the regexp should typically match both the initial state of
+        the line as well as its state after replacement by C(line) to ensure idempotence.
       - Uses Python regular expressions. See U(http://docs.python.org/2/library/re.html).
     version_added: '1.7'
   state:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
You typically want the lineinfile module to operate in an indempotent way, similar to using "sed -i", so your regexp needs to match the line to edit both before and after the edit, otherwise on a second run the regexp will no longer match the original text line and you will end up with a second copy of the replacement line at the top/bottom of the file.

Spent a bunch of time trying to figure out why lineinfile would add more copies of my replacement line at the bottom of the file on subsequent runs, from some searching it seems this is not an
uncommon issue to run into and worth documenting.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lineinfile module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel 8e561d1eb4) last updated 2018/10/31 23:08:34 (GMT -700)
  config file = None
  configured module search path = [u'/Users/panisset/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/panisset/Desktop/toto/ansible/lib/ansible
  executable location = /Users/panisset/Desktop/toto/ansible/bin/ansible
  python version = 2.7.15 (default, Oct  2 2018, 11:47:18) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Only updates documentation strings
```
