### PR TITLE
[Backport 2.7] VMware: Fix documentation for cloning template

### DIFF
--- a/changelogs/fragments/46700-vmware_doc-standalone_esxi.yaml
+++ b/changelogs/fragments/46700-vmware_doc-standalone_esxi.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Fix documentation for cloning template.

--- a/docs/docsite/rst/vmware/scenario_clone_template.rst
+++ b/docs/docsite/rst/vmware/scenario_clone_template.rst
@@ -24,8 +24,6 @@ Scenario Requirements
 
 * Hardware
 
-    * At least one standalone ESXi server or
-
     * vCenter Server with at least one ESXi server
 
 * Access / Credentials


### PR DESCRIPTION
##### SUMMARY
Fixes: #46700

(cherry picked from commit ab0d90f88284e95b65da5f67613e2da4ebf532ad)
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/46700-vmware_doc-standalone_esxi.yaml
docs/docsite/rst/vmware/scenario_clone_template.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
Stable-2.7
```
