### PR TITLE
fix boolean logic for overwrite parameter

### DIFF
--- a/changelogs/fragments/47916-grafana_dashboard-fix-logic-behind-overwrite-param.yaml
+++ b/changelogs/fragments/47916-grafana_dashboard-fix-logic-behind-overwrite-param.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "reverted change in af55b8e which caused the overwrite parameter to be ignored"

--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -256,7 +256,7 @@ def grafana_create_dashboard(module, data):
             result['changed'] = False
         else:
             # update
-            if 'overwrite' in data and data['overwrite'] == 'yes':
+            if 'overwrite' in data and data['overwrite']:
                 payload['overwrite'] = True
             if 'message' in data and data['message']:
                 payload['message'] = data['message']


### PR DESCRIPTION
##### SUMMARY
changes in af55b8e992 broke the overwrite parameter from working. It is converted to a python Boolean by the AnsibleModule argument spec logic. However this change attempts to compare it with the string "yes". This will never resolve to true so the module always behaves as if the overwrite parameter is set to False

Changes from af55b8e992
```
-            if 'overwrite' in data and data['overwrite']:
+            if 'overwrite' in data and data['overwrite'] == 'yes':
```

This PR reverts the above line to `if 'overwrite' in data and data['overwrite']:`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
grafana_dashboard

##### ANSIBLE VERSION
```paste below
ansible 2.8.0.dev0 (grafana_fix_overwrite_bool f26eab6d2a) last updated 2018/11/01 11:06:25 (GMT +100)
  config file = /home/a/.ansible.cfg
  configured module search path = [u'/home/a/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/a/Projects/ansible/ansible/lib/ansible
  executable location = /home/a/Projects/ansible/ansible/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]

```

##### ADDITIONAL INFORMATION

Using the current devel version of grafana_dashboard to update an existing dashboard leads to the following failure.

```paste below
The full traceback is:
WARNING: The below traceback may *not* be related to the actual failure.
  File "/tmp/ansible_grafana_dashboard_payload_gXWLvb/__main__.py", line 408, in main
    result = grafana_create_dashboard(module, module.params)
  File "/tmp/ansible_grafana_dashboard_payload_gXWLvb/__main__.py", line 278, in grafana_create_dashboard
    raise GrafanaAPIException('Unable to update the dashboard %s : %s' % (uid, body['message']))

fatal: [localhost -> localhost]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "client_cert": null, 
            "client_key": null, 
            "grafana_api_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "grafana_url": "http://example.com", 
            "message": "updating dashboard via ansible", 
            "org_id": 1, 
            "overwrite": true, 
            "path": "/tmp/screen.json", 
            "slug": "screen", 
            "state": "present", 
            "uid": null, 
            "url": "http://example.com", 
            "url_password": "admin", 
            "url_username": "admin", 
            "use_proxy": true, 
            "validate_certs": true
        }
    }, 
    "msg": "error : Unable to update the dashboard screen : A dashboard with the same name already exists"
}
```

with the fix I am proposing

```
changed: [localhost -> localhost] => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "client_cert": null, 
            "client_key": null, 
            "grafana_api_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "grafana_url": "http://example.com", 
            "message": "updating dashbaord via ansible", 
            "org_id": 1, 
            "overwrite": true, 
            "path": "/tmp/screen.json", 
            "slug": "screen", 
            "state": "present", 
            "uid": null, 
            "url": "http://example.com", 
            "url_password": "admin", 
            "url_username": "admin", 
            "use_proxy": true, 
            "validate_certs": true
        }
    }, 
    "msg": "Dashboard screen updated", 
    "uid": "screen"
}
```