### PR TITLE
Added services in hostvars

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -198,7 +198,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             "device_roles": self.extract_device_role,
             "platforms": self.extract_platform,
             "device_types": self.extract_device_type,
-			"services": self.extract_services,
+            "services": self.extract_services,
             "manufacturers": self.extract_manufacturer
         }
 
@@ -448,3 +448,4 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self.group_by = self.get_option("group_by")
         self.query_filters = self.get_option("query_filters")
         self.main()
+

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -260,7 +260,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         try:
             url = urljoin(self.api_endpoint, "/api/ipam/services/?device=" + str(host["name"]))
             device_lookup = self._fetch_information(url)
-            return [device_lookup["results"]]
+            return device_lookup["results"]
         except Exception:
             return
 
@@ -370,13 +370,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def refresh_url(self):
         query_parameters = [("limit", 0)]
-        query_parameters.extend(filter(lambda x: x,
-                                       map(self.validate_query_parameters, self.query_filters)))
-        self.device_url = self.api_endpoint + "/api/dcim/devices/" + "?" + urlencode(query_parameters)
-        self.virtual_machines_url = "".join([self.api_endpoint,
-                                             "/api/virtualization/virtual-machines/",
-                                             "?",
-                                             urlencode(query_parameters)])
+        if self.query_filters:
+            query_parameters.extend(filter(lambda x: x,
+                                           map(self.validate_query_parameters, self.query_filters)))
+        self.device_url = urljoin(self.api_endpoint,
+                                  "/api/dcim/devices/?" + urlencode(query_parameters))
+        self.virtual_machines_url = urljoin(self.api_endpoint,
+                                            "/api/virtualization/virtual-machines/?" + urlencode(query_parameters))
 
     def fetch_hosts(self):
         return chain(

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -252,7 +252,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             return [self.manufacturers_lookup[host["device_type"]["manufacturer"]["id"]]]
         except Exception:
             return
-			
+
     def extract_services(self, host):
         try:
             url = urljoin(self.api_endpoint, "/api/ipam/services/?device=" + str(host["name"]))
@@ -260,7 +260,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             return device_lookup["results"]
         except Exception:
             return
-			
+
     def extract_primary_ip(self, host):
         try:
             address = host["primary_ip"]["address"]
@@ -448,4 +448,3 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self.group_by = self.get_option("group_by")
         self.query_filters = self.get_option("query_filters")
         self.main()
-

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -198,8 +198,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             "device_roles": self.extract_device_role,
             "platforms": self.extract_platform,
             "device_types": self.extract_device_type,
-            "config_context": self.extract_config_context,
-            "services": self.extract_services,
+			"services": self.extract_services,
             "manufacturers": self.extract_manufacturer
         }
 
@@ -248,14 +247,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         except Exception:
             return
 
-    def extract_config_context(self, host):
+    def extract_manufacturer(self, host):
         try:
-            url = urljoin(self.api_endpoint, "/api/dcim/devices/" + str(host["id"]))
-            device_lookup = self._fetch_information(url)
-            return [device_lookup["config_context"]]
+            return [self.manufacturers_lookup[host["device_type"]["manufacturer"]["id"]]]
         except Exception:
             return
-
+			
     def extract_services(self, host):
         try:
             url = urljoin(self.api_endpoint, "/api/ipam/services/?device=" + str(host["name"]))
@@ -263,13 +260,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             return device_lookup["results"]
         except Exception:
             return
-
-    def extract_manufacturer(self, host):
-        try:
-            return [self.manufacturers_lookup[host["device_type"]["manufacturer"]["id"]]]
-        except Exception:
-            return
-
+			
     def extract_primary_ip(self, host):
         try:
             address = host["primary_ip"]["address"]


### PR DESCRIPTION
##### SUMMARY
services addition in hostvars in netbox dynamic inventory
Fixed #47918

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netbox-services in hostvars in netbox dynamic inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/oliver/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
Before change
```
ansible-inventory 2.7.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/monitoring/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-inventory
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
Using /etc/ansible/ansible.cfg as config file
/home/monitoring/ansible/netbox_inventory.yml did not meet host_list requirements, check plugin documentation if this is unexpected
/home/monitoring/ansible/netbox_inventory.yml did not meet virtualbox requirements, check plugin documentation if this is unexpected
Fetching: https://netboxdev.hyperslice.net/api/dcim/sites/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/regions/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/tenancy/tenants/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/racks/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/device-roles/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/device-types/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/manufacturers/?limit=0
Fetching: https://netboxdev.hyperslice.net//api/dcim/devices/?limit=0&name=someserver
Fetching: https://netboxdev.hyperslice.net//api/virtualization/virtual-machines/?limit=0&name=someserver
Parsed /home/monitoring/ansible/netbox_inventory.yml inventory source with netbox plugin
{
    "config_context": [
        {}
    ],
    "device_roles": [
        "Dummy server"
    ],
    "device_types": [
        "Dummy"
    ],
    "manufacturers": [
        "Dummy"
    ],
    "sites": [
        "Dummy site"
    ]
}
```
After Change
```
ansible-inventory -vvv -i ./netbox_inventory.yml --host someserver
ansible-inventory 2.7.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/monitoring/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-inventory
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
Using /etc/ansible/ansible.cfg as config file
/home/monitoring/ansible/netbox_inventory.yml did not meet host_list requirements, check plugin documentation if this is unexpected
/home/monitoring/ansible/netbox_inventory.yml did not meet virtualbox requirements, check plugin documentation if this is unexpected
Fetching: https://netboxdev.hyperslice.net/api/dcim/sites/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/regions/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/tenancy/tenants/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/racks/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/device-roles/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/device-types/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/manufacturers/?limit=0
Fetching: https://netboxdev.hyperslice.net//api/dcim/devices/?limit=0&name=someserver
Fetching: https://netboxdev.hyperslice.net//api/virtualization/virtual-machines/?limit=0&name=someserver
Parsed /home/monitoring/ansible/netbox_inventory.yml inventory source with netbox plugin
{
    "config_context": [
        {}
    ],
    "device_roles": [
        "Dummy server"
    ],
    "device_types": [
        "Dummy"
    ],
    "manufacturers": [
        "Dummy"
    ],
    "services": [
        [
            {
                "created": "2018-11-01",
                "custom_fields": {
                    "key_text": null
                },
                "description": "",
                "device": {
                    "display_name": "someserver",
                    "id": 13084,
                    "name": "someserver",
                    "url": "https://netboxdev.hyperslice.net/api/dcim/devices/13084/"
                },
                "id": 28,
                "ipaddresses": [
                    {
                        "address": "10.2.1.1/24",
                        "family": 4,
                        "id": 145531,
                        "url": "https://netboxdev.hyperslice.net/api/ipam/ip-addresses/145531/"
                    }
                ],
                "last_updated": "2018-11-01T12:13:39.326592Z",
                "name": "SSH",
                "port": 22,
                "protocol": {
                    "label": "TCP",
                    "value": 6
                },
                "virtual_machine": null
            },
            {
                "created": "2018-11-01",
                "custom_fields": {
                    "key_text": null
                },
                "description": "",
                "device": {
                    "display_name": "someserver",
                    "id": 13084,
                    "name": "someserver",
                    "url": "https://netboxdev/api/dcim/devices/13084/"
                },
                "id": 29,
                "ipaddresses": [],
                "last_updated": "2018-11-01T11:59:18.855776Z",
                "name": "awebsite.org",
                "port": 443,
                "protocol": {
                    "label": "TCP",
                    "value": 6
                },
                "virtual_machine": null
            },
            {
                "created": "2018-11-01",
                "custom_fields": {
                    "key_text": null
                },
                "description": "",
                "device": {
                    "display_name": "someserver",
                    "id": 13084,
                    "name": "someserver",
                    "url": "https://netboxdev/api/dcim/devices/13084/"
                },
                "id": 30,
                "ipaddresses": [],
                "last_updated": "2018-11-01T11:59:32.669569Z",
                "name": "anothersite.net",
                "port": 443,
                "protocol": {
                    "label": "TCP",
                    "value": 6
                },
                "virtual_machine": null
            },
            {
                "created": "2018-11-01",
                "custom_fields": {
                    "key_text": null
                },
                "description": "",
                "device": {
                    "display_name": "someserver",
                    "id": 13084,
                    "name": "someserver",
                    "url": "https://netboxdev/api/dcim/devices/13084/"
                },
                "id": 31,
                "ipaddresses": [],
                "last_updated": "2018-11-01T11:59:54.599007Z",
                "name": "arbitaryservice",
                "port": 5544,
                "protocol": {
                    "label": "UDP",
                    "value": 17
                },
                "virtual_machine": null
            }
        ]
    ],
    "sites": [
        "Dummy site"
    ]
}
```