### PR TITLE
VMware: Handle exception for no snapshot while cloning

### DIFF
--- a/changelogs/fragments/47920-vmware_guest-handle_no_root_snapshot.yaml
+++ b/changelogs/fragments/47920-vmware_guest-handle_no_root_snapshot.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Handle exception when there is no snapshot available in virtual machine or template while cloning using vmware_guest.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -2073,6 +2073,8 @@ class PyVmomiHelper(PyVmomi):
                     clonespec.customization = self.customspec
 
                 if snapshot_src is not None:
+                    if vm_obj.snapshot is None:
+                        self.module.fail_json(msg="No snapshots present for virtual machine or template [%(template)s]" % self.params)
                     snapshot = self.get_snapshots_by_name_recursively(snapshots=vm_obj.snapshot.rootSnapshotList,
                                                                       snapname=snapshot_src)
                     if len(snapshot) != 1:


### PR DESCRIPTION
##### SUMMARY
Handle exception when there is no snapshot available in virtual machine or template while cloning using vmware_guest.

Fixes: #47920

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/47920-vmware_guest-handle_no_root_snapshot.yaml
lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8-devel
```