### PR TITLE
clarify port.mode paramter requiremets, fail if unmet

### DIFF
--- a/changelogs/fragments/47938-docker_swarm_service-requirements.yaml
+++ b/changelogs/fragments/47938-docker_swarm_service-requirements.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- "docker_swarm_service - The ``publish``.``mode`` parameter was beign ignored if docker-py version was <3.0.0. Added a parameter validation test.
+- "docker_swarm_service - The ``publish``.``mode`` parameter was being ignored if docker-py version was < 3.0.0. Added a parameter validation test."

--- a/changelogs/fragments/47938-docker_swarm_service-requirements.yaml
+++ b/changelogs/fragments/47938-docker_swarm_service-requirements.yaml
@@ -1,2 +1,2 @@
-minor_changes:
-- "docker_swarm_service - fail if ``publish``.``mode`` parameter is given with a too old docker-py version."
+bugfixes:
+- "docker_swarm_service - The ``publish``.``mode`` parameter was beign ignored if docker-py version was <3.0.0. Added a parameter validation test.

--- a/changelogs/fragments/47938-docker_swarm_service-requirements.yaml
+++ b/changelogs/fragments/47938-docker_swarm_service-requirements.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_swarm_service - fail if ``publish``.``mode`` parameter is given with a too old docker-py version."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -455,9 +455,9 @@ EXAMPLES = '''
 '''
 
 import time
-from ansible.module_utils.docker_common import (
-    DockerBaseClass, AnsibleDockerClient, docker_version,
-)
+from ansible.module_utils.docker_common import DockerBaseClass
+from ansible.module_utils.docker_common import AnsibleDockerClient
+from ansible.module_utils.docker_common import docker_version
 from ansible.module_utils.basic import human_to_bytes
 from ansible.module_utils._text import to_text
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -191,7 +191,7 @@ options:
     - List of dictionaries describing the service published ports.
     - Every item must be a dictionary exposing the keys published_port, target_port, protocol (defaults to 'tcp')
     - Only used with api_version >= 1.25
-    - If api_version >= 1.32 the dictionaries can contain the attribute 'mode' set to 'ingress' or 'host' (default 'ingress').
+    - If api_version >= 1.32 and docker python library >= 3.0.0 the dictionaries can contain the attribute 'mode' set to 'ingress' or 'host' (default 'ingress').
   replicas:
     required: false
     default: -1
@@ -457,6 +457,7 @@ EXAMPLES = '''
 import time
 from ansible.module_utils.docker_common import DockerBaseClass
 from ansible.module_utils.docker_common import AnsibleDockerClient
+from ansible.module_utils.docker_common import HAS_DOCKER_PY_3
 from ansible.module_utils.basic import human_to_bytes
 from ansible.module_utils._text import to_text
 
@@ -1041,10 +1042,12 @@ class DockerServiceManager():
                          % (pv['param'], pv['min_version'])))
 
         for publish_def in self.client.module.params.get('publish', []):
-            if ('mode' in publish_def.keys() and
-                    (LooseVersion(self.client.version()['ApiVersion']) <
-                     LooseVersion('1.25'))):
-                self.client.module.fail_json(msg='publish.mode parameter supported only with api_version>=1.25')
+            if 'mode' in publish_def.keys():
+                if (LooseVersion(self.client.version()['ApiVersion']) <
+                     LooseVersion('1.25')):
+                    self.client.module.fail_json(msg='publish.mode parameter supported only with api_version>=1.25')
+                if not HAS_DOCKER_PY_3:
+                    self.client.module.fail_json(msg='publish.mode parameter requires docker python library>=3.0.0')
 
     def run(self):
         self.test_parameter_versions()

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -457,7 +457,7 @@ EXAMPLES = '''
 import time
 from ansible.module_utils.docker_common import DockerBaseClass
 from ansible.module_utils.docker_common import AnsibleDockerClient
-from ansible.module_utils.docker_common import HAS_DOCKER_PY_3
+from ansible.module_utils.docker_common import docker_version
 from ansible.module_utils.basic import human_to_bytes
 from ansible.module_utils._text import to_text
 
@@ -1045,7 +1045,7 @@ class DockerServiceManager():
             if 'mode' in publish_def.keys():
                 if LooseVersion(self.client.version()['ApiVersion']) < LooseVersion('1.25'):
                     self.client.module.fail_json(msg='publish.mode parameter supported only with api_version>=1.25')
-                if not HAS_DOCKER_PY_3:
+                if LooseVersion(docker_version) < LooseVersion('3.0.0'):
                     self.client.module.fail_json(msg='publish.mode parameter requires docker python library>=3.0.0')
 
     def run(self):

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -191,7 +191,7 @@ options:
     - List of dictionaries describing the service published ports.
     - Every item must be a dictionary exposing the keys published_port, target_port, protocol (defaults to 'tcp')
     - Only used with api_version >= 1.25
-    - If api_version >= 1.32 and docker python library >= 3.0.0 the dictionaries can contain the attribute 'mode' set to 'ingress' or 'host' (default 'ingress').
+    - If api_version >= 1.32 and docker python library >= 3.0.0 attribute 'mode' can be set to 'ingress' or 'host' (default 'ingress').
   replicas:
     required: false
     default: -1

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -1043,8 +1043,7 @@ class DockerServiceManager():
 
         for publish_def in self.client.module.params.get('publish', []):
             if 'mode' in publish_def.keys():
-                if (LooseVersion(self.client.version()['ApiVersion']) <
-                     LooseVersion('1.25')):
+                if LooseVersion(self.client.version()['ApiVersion']) < LooseVersion('1.25'):
                     self.client.module.fail_json(msg='publish.mode parameter supported only with api_version>=1.25')
                 if not HAS_DOCKER_PY_3:
                     self.client.module.fail_json(msg='publish.mode parameter requires docker python library>=3.0.0')

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -455,9 +455,9 @@ EXAMPLES = '''
 '''
 
 import time
-from ansible.module_utils.docker_common import DockerBaseClass
-from ansible.module_utils.docker_common import AnsibleDockerClient
-from ansible.module_utils.docker_common import docker_version
+from ansible.module_utils.docker_common import (
+    DockerBaseClass, AnsibleDockerClient, docker_version,
+)
 from ansible.module_utils.basic import human_to_bytes
 from ansible.module_utils._text import to_text
 


### PR DESCRIPTION
Fixes #47737 

Docker python library supports enpointspec.publishmode only since version `3.0.0`, and ignores it in previous releases publishing the port via vip.

This PR clarifies the documentation and has the module fail if the publish.mode parameter is used with a docker python library version <3.0.0