### PR TITLE
conditional: fix direct boolean "shortcut"

### DIFF
--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -92,10 +92,6 @@ class Conditional:
             ds = getattr(self, '_ds')
 
         try:
-            # this allows for direct boolean assignments to conditionals "when: False"
-            if isinstance(self.when, bool):
-                return self.when
-
             for conditional in self.when:
                 if not self._check_conditional(conditional, templar, all_vars):
                     return False
@@ -116,6 +112,10 @@ class Conditional:
         original = conditional
         if conditional is None or conditional == '':
             return True
+
+        # this allows for direct boolean assignments to conditionals "when: False"
+        if isinstance(conditional, bool):
+            return conditional
 
         if templar.is_template(conditional):
             display.warning('when statements should not include jinja2 '

--- a/test/units/playbook/test_conditional.py
+++ b/test/units/playbook/test_conditional.py
@@ -1,6 +1,7 @@
 
 from units.compat import unittest
 from units.mock.loader import DictDataLoader
+from units.compat.mock import MagicMock
 
 from ansible.plugins.strategy import SharedPluginLoaderObj
 from ansible.template import Templar
@@ -32,6 +33,20 @@ class TestConditional(unittest.TestCase):
         when = [u"True"]
         ret = self._eval_con(when, {})
         self.assertTrue(ret)
+
+    def test_true_boolean(self):
+        self.cond.when = [True]
+        m = MagicMock()
+        ret = self.cond.evaluate_conditional(m, {})
+        self.assertTrue(ret)
+        self.assertFalse(m.is_template.called)
+
+    def test_false_boolean(self):
+        self.cond.when = [False]
+        m = MagicMock()
+        ret = self.cond.evaluate_conditional(m, {})
+        self.assertFalse(ret)
+        self.assertFalse(m.is_template.called)
 
     def test_undefined(self):
         when = [u"{{ some_undefined_thing }}"]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`when` appears to be always a list, even for `when: False`:
```
 0.0s evaluate_conditional: self.when=[False]
 0.0s evaluate_conditional: type(self.when)=<type 'list'>
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
conditional

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
devel
```

##### ADDITIONAL INFORMATION