### PR TITLE
make yum update_only option actually work

### DIFF
--- a/changelogs/yum-update-only.yaml
+++ b/changelogs/yum-update-only.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "yum now properly supports update_only option"
+

--- a/changelogs/yum-update-only.yaml
+++ b/changelogs/yum-update-only.yaml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
   - "yum now properly supports update_only option"
-

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1279,7 +1279,7 @@ class YumModule(YumDnf):
         if cmd:     # update all
             rc, out, err = self.module.run_command(cmd)
             res['changed'] = True
-        elif self.update_only:
+        elif self.update_only and pkgs['update']:
             cmd = self.yum_basecmd + ['update'] + pkgs['update']
             lang_env = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
             rc, out, err = self.module.run_command(cmd, environ_update=lang_env)

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1280,10 +1280,8 @@ class YumModule(YumDnf):
             rc, out, err = self.module.run_command(cmd)
             res['changed'] = True
         elif self.update_only:
-            import q; q.q("ELIF SELF.UPDATE_ONLY: {}".format(pkgs))
             if pkgs['update']:
                 cmd = self.yum_basecmd + ['update'] + pkgs['update']
-                import q; q.q(cmd)
                 lang_env = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
                 rc, out, err = self.module.run_command(cmd, environ_update=lang_env)
                 out_lower = out.strip().lower()
@@ -1293,7 +1291,6 @@ class YumModule(YumDnf):
             else:
                 rc, out, err = [0, '', '']
         elif pkgs['install'] or will_update and not self.update_only:
-            import q; q.q("ELIF pkgs['install]': {}".format(pkgs))
             cmd = self.yum_basecmd + ['install'] + pkgs['install'] + pkgs['update']
             lang_env = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
             rc, out, err = self.module.run_command(cmd, environ_update=lang_env)


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #40615
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (issue/40615-yum-update-only 108e44c425) last updated 2018/11/01 15:34:11 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/admiller/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 3.6.6 (default, Jul 19 2018, 14:25:17) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```

