### PR TITLE
Add N3K-F type to nxos platforms

### DIFF
--- a/test/integration/targets/prepare_nxos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nxos_tests/tasks/main.yml
@@ -66,8 +66,12 @@
 - set_fact: chassis_type="{{ nxos_inventory_output.stdout_lines[0]['TABLE_inv']['ROW_inv'][0]['productid'].split('-')[1] }}"
 
 # Check if platform is fretta
-- set_fact: fretta={% for row in nxos_inventory_output.stdout_lines[0]['TABLE_inv']['ROW_inv'] if 'FM-R' in row['productid'] %}"true"{% endfor %}
-  when: platform is match("N9K")
+- set_fact: fretta={% for row in nxos_inventory_output.stdout_lines[0]['TABLE_inv']['ROW_inv'] if '-R' in row['productid'] %}"true"{% endfor %}
+  when: platform is match("N9K|N3K")
+
+# Set platform to N3K-F for fretta
+- set_fact: platform="N3K-F"
+  when: ( platform is match("N3K")) and ( fretta is search("true"))
 
 # Set platform to N9K-F for fretta
 - set_fact: platform="N9K-F"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add a new platform type N3K-F which is similar to N9K-F but a variation of N3K.
 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (devel 38844194ae) last updated 2018/10/29 16:01:49 (GMT -400)
  config file = /root/agents-ci/ansible/test/integration/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```

##### ADDITIONAL INFORMATION
* This PR is for adding a new platform type N3K-F (similar to N9K-F). 
* Only ```prepare_nxos_tests/tasks/main.yml``` is changed to set a new fact. No code changes on any modules.
* We used to determine N9K-F using ```FM-R``` string in the module types, however ```-R``` is enough for getting that information as it is common to both N9K-F and N3K-F.
