### PR TITLE
become_method: make dzdo more like sudo

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -76,7 +76,7 @@ BECOME_ERROR_STRINGS = {
     'pbrun': '',
     'pfexec': '',
     'doas': 'Permission denied',
-    'dzdo': '',
+    'dzdo': 'Sorry, try again.',
     'ksu': 'Password incorrect',
     'pmrun': 'You are not permitted to run this command',
     'enable': '',

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -542,11 +542,15 @@ class PlayContext(Base):
                 becomecmd = '%s %s %s -c %s' % (exe, flags, executable, success_cmd)
 
             elif self.become_method == 'dzdo':
+                # If we have a password, we run dzdo with a randomly-generated
+                # prompt set using -p. Otherwise we run it with -n, if
+                # requested, which makes it fail if it would have prompted for a
+                # password.
 
                 exe = self.become_exe or 'dzdo'
                 if self.become_pass:
                     prompt = '[dzdo via ansible, key=%s] password: ' % randbits
-                    becomecmd = '%s %s -p %s -u %s %s' % (exe, flags, shlex_quote(prompt), self.become_user, command)
+                    becomecmd = '%s %s -p %s -u %s %s' % (exe, flags.replace('-n', ''), shlex_quote(prompt), self.become_user, command)
                 else:
                     becomecmd = '%s %s -u %s %s' % (exe, flags, self.become_user, command)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
dzdo is basically a drop-in replacement for sudo and supports the same
command line options.

There is no become_flags set for dzdo like there is for sudo, so users
will have to set that separately to have exactly the same functionality.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
become_method dzdo

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (dzdo-like-sudo 479c6ff42e) last updated 2018/11/01 17:03:16 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/ansible-ansible/lib/ansible
  executable location = /home/user/ansible-ansible/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
