### PR TITLE
Backport ansible-test fixes to stable-2.5.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -10,6 +10,7 @@ matrix:
   include:
     - env: T=sanity/1
     - env: T=sanity/2
+    - env: T=sanity/3
 
     - env: T=units/2.6
     - env: T=units/2.7

--- a/shippable.yml
+++ b/shippable.yml
@@ -11,6 +11,7 @@ matrix:
     - env: T=sanity/1
     - env: T=sanity/2
     - env: T=sanity/3
+    - env: T=sanity/4
 
     - env: T=units/2.6
     - env: T=units/2.7

--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -1,4 +1,4 @@
-default name=quay.io/ansible/default-test-container:1.3.0 python=3
+default name=quay.io/ansible/default-test-container:1.4.1 python=3
 centos6 name=quay.io/ansible/centos6-test-container:1.4.0 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.4.0 seccomp=unconfined
 fedora24 name=quay.io/ansible/fedora24-test-container:1.4.0 seccomp=unconfined

--- a/test/runner/injector/injector.py
+++ b/test/runner/injector/injector.py
@@ -159,14 +159,22 @@ def injector():
     :rtype: list[str], dict[str, str]
     """
     command = os.path.basename(__file__)
-    executable = find_executable(command)
+
+    run_as_python_module = (
+        'pytest',
+    )
+
+    if command in run_as_python_module:
+        executable_args = ['-m', command]
+    else:
+        executable_args = [find_executable(command)]
 
     if config.coverage_file:
         args, env = coverage_command()
     else:
         args, env = [config.python_interpreter], os.environ.copy()
 
-    args += [executable]
+    args += executable_args
 
     if command in ('ansible', 'ansible-playbook', 'ansible-pull'):
         if config.remote_interpreter is None:

--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -117,7 +117,7 @@ class AnsibleCoreCI(object):
                 region = 'us-east-1'
 
             self.path = "%s-%s" % (self.path, region)
-            self.endpoints = AWS_ENDPOINTS[region],
+            self.endpoints = (AWS_ENDPOINTS[region],)
             self.ssh_key = SshKey(args)
 
             if self.platform == 'windows':
@@ -192,7 +192,7 @@ class AnsibleCoreCI(object):
         if self.started:
             display.info('Skipping started %s/%s instance %s.' % (self.platform, self.version, self.instance_id),
                          verbosity=1)
-            return
+            return None
 
         if is_shippable():
             return self.start_shippable()

--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -117,7 +117,7 @@ def delegate_tox(args, exclude, require, integration_targets):
     :type integration_targets: tuple[IntegrationTarget]
     """
     if args.python:
-        versions = args.python_version,
+        versions = (args.python_version,)
 
         if args.python_version not in SUPPORTED_PYTHON_VERSIONS:
             raise ApplicationError('tox does not support Python version %s' % args.python_version)

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1235,7 +1235,7 @@ def command_units(args):
         raise AllTargetsSkipped()
 
     if args.delegate:
-        raise Delegate(require=changes)
+        raise Delegate(require=changes, exclude=args.exclude)
 
     version_commands = []
 

--- a/test/runner/lib/sanity/__init__.py
+++ b/test/runner/lib/sanity/__init__.py
@@ -65,7 +65,7 @@ def command_sanity(args):
         raise AllTargetsSkipped()
 
     if args.delegate:
-        raise Delegate(require=changes)
+        raise Delegate(require=changes, exclude=args.exclude)
 
     install_command_requirements(args)
 

--- a/test/runner/lib/sanity/pylint.py
+++ b/test/runner/lib/sanity/pylint.py
@@ -99,7 +99,7 @@ class PylintTest(SanitySingleVersion):
                     invalid_ignores.append((line, 'Invalid version: %s' % version))
                     continue
 
-                if version != args.python_version and version != args.python_version.split('.')[0]:
+                if version not in (args.python_version, args.python_version.split('.')[0]):
                     continue  # ignore version specific entries for other versions
 
             ignore[path][code] = line
@@ -121,12 +121,26 @@ class PylintTest(SanitySingleVersion):
             contexts[context_name] = sorted(filtered_paths)
             available_paths -= filtered_paths
 
-        add_context(remaining_paths, 'ansible-test', lambda p: p.startswith('test/runner/'))
-        add_context(remaining_paths, 'units', lambda p: p.startswith('test/units/'))
-        add_context(remaining_paths, 'test', lambda p: p.startswith('test/'))
-        add_context(remaining_paths, 'hacking', lambda p: p.startswith('hacking/'))
-        add_context(remaining_paths, 'modules', lambda p: p.startswith('lib/ansible/modules/'))
-        add_context(remaining_paths, 'module_utils', lambda p: p.startswith('lib/ansible/module_utils/'))
+        def filter_path(path_filter=None):
+            """
+            :type path_filter: str
+            :rtype: (str) -> bool
+            """
+            def context_filter(path_to_filter):
+                """
+                :type path_to_filter: str
+                :rtype: bool
+                """
+                return path_to_filter.startswith(path_filter)
+
+            return context_filter
+
+        add_context(remaining_paths, 'ansible-test', filter_path('test/runner/'))
+        add_context(remaining_paths, 'units', filter_path('test/units/'))
+        add_context(remaining_paths, 'test', filter_path('test/'))
+        add_context(remaining_paths, 'hacking', filter_path('hacking/'))
+        add_context(remaining_paths, 'modules', filter_path('lib/ansible/modules/'))
+        add_context(remaining_paths, 'module_utils', filter_path('lib/ansible/module_utils/'))
         add_context(remaining_paths, 'ansible', lambda p: True)
 
         messages = []

--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -446,7 +446,7 @@ class TestTarget(CompletionTarget):
 
         if module_path and path.startswith(module_path) and name != '__init__' and ext in MODULE_EXTENSIONS:
             self.module = name[len(module_prefix or ''):].lstrip('_')
-            self.modules = self.module,
+            self.modules = (self.module,)
         else:
             self.module = None
             self.modules = tuple()

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -6,6 +6,7 @@ astroid == 1.5.3 ; python_version >= '3.5' # newer versions of astroid require n
 pylint == 1.7.4 ; python_version >= '3.5' # versions before 1.7.1 hang or fail to install on python 3.x
 pylint == 1.6.5 ; python_version <= '2.7' # versions after 1.6.5 hang or fail during test on python 2.x
 sphinx < 1.6 ; python_version < '2.7' # sphinx 1.6 and later require python 2.7 or later
+sphinx < 1.8 ; python_version >= '2.7' # sphinx 1.8 and later are currently incompatible with rstcheck 3.3
 wheel < 0.30.0 ; python_version < '2.7' # wheel 0.30.0 and later require python 2.7 or later
 yamllint != 1.8.0 ; python_version < '2.7' # yamllint 1.8.0 requires python 2.7+ while earlier/later versions do not
 isort < 4.2.8 # 4.2.8 changes import sort order requirements which breaks previously passing pylint tests

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -23,3 +23,4 @@ voluptuous >= 0.11.0 # Schema recursion via Self
 virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
 pyfmg == 0.6.1 # newer versions do not pass current unit tests
+pycparser < 2.19 ; python_version < '2.7' # pycparser 2.19 and later require python 2.7 or later

--- a/test/utils/shippable/sanity.sh
+++ b/test/utils/shippable/sanity.sh
@@ -16,8 +16,9 @@ else
 fi
 
 case "${group}" in
-    1) options=(--skip-test pylint) ;;
+    1) options=(--skip-test pylint --skip-test ansible-doc --skip-test docs-build) ;;
     2) options=(--test pylint) ;;
+    3) options=(--test ansible-doc --test docs-build) ;;
 esac
 
 # shellcheck disable=SC2086

--- a/test/utils/shippable/sanity.sh
+++ b/test/utils/shippable/sanity.sh
@@ -17,8 +17,9 @@ fi
 
 case "${group}" in
     1) options=(--skip-test pylint --skip-test ansible-doc --skip-test docs-build) ;;
-    2) options=(--test pylint) ;;
-    3) options=(--test ansible-doc --test docs-build) ;;
+    2) options=(--test ansible-doc --test docs-build) ;;
+    3) options=(--test pylint --exclude test/units/ --exclude lib/ansible/module_utils/ --exclude lib/ansible/modules/network/) ;;
+    4) options=(--test pylint           test/units/           lib/ansible/module_utils/           lib/ansible/modules/network/) ;;
 esac
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
##### SUMMARY

Backport ansible-test fixes to stable-2.5.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.11 (at-backport-2.5 44d7f8eb76) last updated 2018/11/01 16:41:28 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
