### PR TITLE
Document template plugin's convert_data option

### DIFF
--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -17,6 +17,9 @@ DOCUMENTATION = """
     options:
       _terms:
         description: list of files to template
+      convert_data:
+        type: bool
+        description: whether to convert YAML into data. If False, strings that are YAML will be left untouched.
 """
 
 EXAMPLES = """


### PR DESCRIPTION
##### SUMMARY
`convert_data` is a useful option that I can never remember the name of

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
template lookup

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel 064530b72e) last updated 2018/11/02 11:41:15 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/opensource/ansible/lib/ansible
  executable location = /Users/will/src/opensource/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
