### PR TITLE
VMware: customize cdrom of VM deployed from template

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1005,9 +1005,9 @@ class PyVmomiHelper(PyVmomi):
             if self.params["cdrom"]["type"] == "iso" and ("iso_path" not in self.params["cdrom"] or not self.params["cdrom"]["iso_path"]):
                 self.module.fail_json(msg="cdrom.iso_path is mandatory in case cdrom.type is iso")
 
-            if vm_obj and vm_obj.config.template:
-                # Changing CD-ROM settings on a template is not supported
-                return
+            # if vm_obj and vm_obj.config.template:
+            # Changing CD-ROM settings on a template is not supported
+                # return
 
             cdrom_spec = None
             cdrom_device = self.get_vm_cdrom_device(vm=vm_obj)

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -32,3 +32,5 @@
 - include: disk_mode_d1_c1_f0.yml
 - include: linked_clone_d1_c1_f0.yml
 - include: boot_firmware_d1_c1_f0.yml
+# Comment this testcase out since VCSIM does not support template operations
+# - include: template_cdrom_d1_c1_f0.yml

--- a/test/integration/targets/vmware_guest/tasks/template_cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/template_cdrom_d1_c1_f0.yml
@@ -1,0 +1,113 @@
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/killall' }}"
+- name: start vcsim with no folders
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=0' }}"
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of Clusters from vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=CCR' }}"
+  register: clusterlist
+
+- debug: var=vcsim_instance
+- debug: var=clusterlist
+
+- name: Create a new VM
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    name: Test-vm
+    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    cluster: "{{ clusterlist['json'][0] }}"
+    resource_pool: Resources
+    guest_id: centos64Guest
+    hardware:
+      memory_mb: 512
+      num_cpus: 1
+      scsi: paravirtual
+    disk:
+    - size_mb: 128
+      type: thin
+      datastore: LocalDS_0
+    cdrom:
+      type: client
+    networks:
+    - device_type: e1000
+      name: VM Network
+      type: dhcp
+  register: test_vm
+
+- debug: var=test_vm
+
+- name: assert the VM was created
+  assert:
+    that:
+      - "test_vm.failed == false"
+      - "test_vm.changed == true"
+
+- name: Convert the VM to template
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    name: Test-vm
+    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    cluster: "{{ clusterlist['json'][0] }}"
+    state: present
+    is_template: True
+  register: test_vm
+
+- debug: var=test_vm
+
+- name: assert the VM was converted
+  assert:
+    that:
+      - "test_vm.failed == false"
+      - "test_vm.changed == true"
+
+- name: Deploy a new VM from template
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    name: Test-vm2
+    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    cluster: "{{ clusterlist['json'][0] }}"
+    resource_pool: Resources
+    template: Test-vm
+    hardware:
+      memory_mb: 1024
+      num_cpus: 2
+    cdrom:
+      type: iso
+      iso_path: "[LocalDS_0] base.iso"
+  register: test_vm
+
+- debug: var=test_vm
+
+- name: assert the VM was created
+  assert:
+    that:
+      - "test_vm.failed == false"
+      - "test_vm.changed == true"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #42047 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (fix_pr42047 8a36bd28a3) last updated 2018/11/02 15:06:33 (GMT +800)
  config file = /root/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/ansible/lib/ansible
  executable location = /root/ansible/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
If the new VM deployed from a template ('template' parameter is set), CD-ROM configuration can not be modified of the new deployed VM, after the fix, the new deployed VM's CD-ROM can be customized.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
The iso path specified below must exist, or the iso file will not be mounted after VM power on.
template: Test-vm
hardware:
      memory_mb: 1024
      num_cpus: 2
cdrom:
      type: iso
      iso_path: "[datastore0] test.iso"
```
