### PR TITLE
OpenStack: add an alias for name

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_subnets_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnets_facts.py
@@ -24,10 +24,12 @@ requirements:
     - "python >= 2.7"
     - "openstacksdk"
 options:
-   subnet:
+   name:
      description:
-        - Name or ID of the subnet
+        - Name or ID of the subnet.
+        - Alias 'subnet' added in version 2.8.
      required: false
+     aliases: ['subnet']
    filters:
      description:
         - A dictionary of meta data to use for further filtering.  Elements of
@@ -131,13 +133,13 @@ openstack_subnets:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_cloud_from_module
 
 
 def main():
 
     argument_spec = openstack_full_argument_spec(
-        name=dict(required=False, default=None),
+        name=dict(required=False, default=None, aliases=['subnet']),
         filters=dict(required=False, type='dict', default=None)
     )
     module = AnsibleModule(argument_spec)

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -283,8 +283,6 @@ lib/ansible/modules/cloud/openstack/os_server.py E324
 lib/ansible/modules/cloud/openstack/os_server_action.py E324
 lib/ansible/modules/cloud/openstack/os_stack.py E324
 lib/ansible/modules/cloud/openstack/os_subnet.py E326
-lib/ansible/modules/cloud/openstack/os_subnets_facts.py E322
-lib/ansible/modules/cloud/openstack/os_subnets_facts.py E323
 lib/ansible/modules/cloud/openstack/os_volume.py E322
 lib/ansible/modules/cloud/openstack/os_zone.py E326
 lib/ansible/modules/cloud/ovirt/ovirt_affinity_label.py E317


### PR DESCRIPTION
##### SUMMARY
This fix adds an additional alias for name parameter viz. subnet

Fixes: #37352

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/openstack/os_subnets_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8-devel
```