### PR TITLE
Ecs service force new deployment

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -86,7 +86,8 @@ options:
         description:
           - Force deployment of service even if there are no changes
         required: false
-        version_added: 2.6
+        version_added: 2.7
+        type: bool
     deployment_configuration:
         description:
           - Optional parameters that control the deployment_configuration; format is '{"maximum_percent":<integer>, "minimum_healthy_percent":<integer>}

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -425,12 +425,13 @@ class EcsServiceManager:
             service=service_name,
             taskDefinition=task_definition,
             desiredCount=desired_count,
-            deploymentConfiguration=deployment_configuration,
-            forceNewDeployment=force_new_deployment)
+            deploymentConfiguration=deployment_configuration)
         if network_configuration:
             params['networkConfiguration'] = network_configuration
         if self.health_check_setable(params):
             params['healthCheckGracePeriodSeconds'] = health_check_grace_period_seconds
+        if force_new_deployment:
+            params['forceNewDeployment'] = force_new_deployment
         response = self.ecs.update_service(**params)
         return self.jsonize(response['service'])
 
@@ -521,6 +522,9 @@ def main():
     if module.params['launch_type']:
         if not module.botocore_at_least('1.8.4'):
             module.fail_json(msg='botocore needs to be version 1.8.4 or higher to use launch_type')
+    if module.params['force_new_deployment']:
+        if not module.botocore_at_least('1.8.4'):
+            module.fail_json(msg='botocore needs to be version 1.8.4 or higher to use force_new_deployment')
 
     if module.params['state'] == 'present':
 

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -527,7 +527,9 @@ def main():
         update = False
 
         if existing and 'status' in existing and existing['status'] == "ACTIVE":
-            if service_mgr.is_matching_service(module.params, existing):
+            if module.params['force_new_deployment']:
+                update = True
+            elif service_mgr.is_matching_service(module.params, existing):
                 matching = True
                 results['service'] = existing
             else:

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -86,7 +86,7 @@ options:
         description:
           - Force deployment of service even if there are no changes
         required: false
-        version_added: 2.7
+        version_added: 2.8
         type: bool
     deployment_configuration:
         description:

--- a/test/integration/targets/ecs_cluster/playbooks/network_force_new_deployment.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/network_force_new_deployment.yml
@@ -1,0 +1,110 @@
+- hosts: localhost
+  connection: local
+  vars:
+     resource_prefix: 'ansible-testing-fnd'
+
+  tasks:
+    - block:
+        - name: set up aws connection info
+          set_fact:
+            aws_connection_info: &aws_connection_info
+              aws_access_key: "{{ aws_access_key }}"
+              aws_secret_key: "{{ aws_secret_key }}"
+              security_token: "{{ security_token }}"
+              region: "{{ aws_region }}"
+          no_log: True
+
+        - name: create ecs cluster
+          ecs_cluster:
+            name: "{{ resource_prefix }}"
+            state: present
+            <<: *aws_connection_info
+
+        - name: create ecs_taskdefinition
+          ecs_taskdefinition:
+            containers:
+              - name: my_container
+                image: ubuntu
+                memory: 128
+            family: "{{ resource_prefix }}"
+            state: present
+            <<: *aws_connection_info
+          register: ecs_taskdefinition_creation
+
+        - name: create ecs_service
+          ecs_service:
+            name: "{{ resource_prefix }}"
+            cluster: "{{ resource_prefix }}"
+            task_definition: "{{ resource_prefix }}"
+            desired_count: 1
+            state: present
+            <<: *aws_connection_info
+          register: ecs_service_creation
+
+        - name: ecs_service works fine even when older botocore is used
+          assert:
+            that:
+              - ecs_service_creation.changed
+
+
+
+        - name: create ecs_service using force_new_deployment
+          ecs_service:
+            name: "{{ resource_prefix }}"
+            cluster: "{{ resource_prefix }}"
+            task_definition: "{{ resource_prefix }}"
+            desired_count: 1
+            force_new_deployment: true
+            state: present
+            <<: *aws_connection_info
+          register: ecs_service_creation_force_new_deploy
+          ignore_errors: yes
+
+        - name: check that module returns success
+          assert:
+            that:
+              - ecs_service_creation_force_new_deploy.changed
+
+      always:
+        - name: scale down ecs service
+          ecs_service:
+            name: "{{ resource_prefix }}"
+            cluster: "{{ resource_prefix }}"
+            task_definition: "{{ resource_prefix }}"
+            desired_count: 0
+            state: present
+            <<: *aws_connection_info
+          ignore_errors: yes
+
+        - name: pause to wait for scale down
+          pause:
+            seconds: 30
+
+        - name: remove ecs service
+          ecs_service:
+            name: "{{ resource_prefix }}"
+            cluster: "{{ resource_prefix }}"
+            task_definition: "{{ resource_prefix }}"
+            desired_count: 1
+            state: absent
+            <<: *aws_connection_info
+          ignore_errors: yes
+
+        - name: remove ecs task definition
+          ecs_taskdefinition:
+            containers:
+              - name: my_container
+                image: ubuntu
+                memory: 128
+            family: "{{ resource_prefix }}"
+            revision: "{{ ecs_taskdefinition_creation.taskdefinition.revision }}"
+            state: absent
+            <<: *aws_connection_info
+          ignore_errors: yes
+
+        - name: remove ecs cluster
+          ecs_cluster:
+            name: "{{ resource_prefix }}"
+            state: absent
+            <<: *aws_connection_info
+          ignore_errors: yes

--- a/test/integration/targets/ecs_cluster/playbooks/network_force_new_deployment.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/network_force_new_deployment.yml
@@ -46,8 +46,6 @@
             that:
               - ecs_service_creation.changed
 
-
-
         - name: create ecs_service using force_new_deployment
           ecs_service:
             name: "{{ resource_prefix }}"

--- a/test/integration/targets/ecs_cluster/playbooks/network_force_new_deployment_fail.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/network_force_new_deployment_fail.yml
@@ -1,0 +1,111 @@
+- hosts: localhost
+  connection: local
+  vars:
+     resource_prefix: 'ansible-testing-fndf'
+
+  tasks:
+    - block:
+        - name: set up aws connection info
+          set_fact:
+            aws_connection_info: &aws_connection_info
+              aws_access_key: "{{ aws_access_key }}"
+              aws_secret_key: "{{ aws_secret_key }}"
+              security_token: "{{ security_token }}"
+              region: "{{ aws_region }}"
+          no_log: True
+
+        - name: create ecs cluster
+          ecs_cluster:
+            name: "{{ resource_prefix }}"
+            state: present
+            <<: *aws_connection_info
+
+        - name: create ecs_taskdefinition
+          ecs_taskdefinition:
+            containers:
+              - name: my_container
+                image: ubuntu
+                memory: 128
+            family: "{{ resource_prefix }}"
+            state: present
+            <<: *aws_connection_info
+          register: ecs_taskdefinition_creation
+
+        - name: create ecs_service
+          ecs_service:
+            name: "{{ resource_prefix }}"
+            cluster: "{{ resource_prefix }}"
+            task_definition: "{{ resource_prefix }}"
+            desired_count: 1
+            state: present
+            <<: *aws_connection_info
+          register: ecs_service_creation
+
+        - name: ecs_service works fine even when older botocore is used
+          assert:
+            that:
+              - ecs_service_creation.changed
+
+
+
+        - name: create ecs_service using force_new_deployment
+          ecs_service:
+            name: "{{ resource_prefix }}"
+            cluster: "{{ resource_prefix }}"
+            task_definition: "{{ resource_prefix }}"
+            desired_count: 1
+            force_new_deployment: true
+            state: present
+            <<: *aws_connection_info
+          register: ecs_service_creation_force_new_deploy
+          ignore_errors: yes
+
+        - name: check that graceful failure message is returned from ecs_service
+          assert:
+            that:
+              - ecs_service_creation_force_new_deploy.failed
+              - 'ecs_service_creation_force_new_deploy.msg == "botocore needs to be version 1.8.4 or higher to use force_new_deployment"'
+
+      always:
+        - name: scale down ecs service
+          ecs_service:
+            name: "{{ resource_prefix }}"
+            cluster: "{{ resource_prefix }}"
+            task_definition: "{{ resource_prefix }}"
+            desired_count: 0
+            state: present
+            <<: *aws_connection_info
+          ignore_errors: yes
+
+        - name: pause to wait for scale down
+          pause:
+            seconds: 30
+
+        - name: remove ecs service
+          ecs_service:
+            name: "{{ resource_prefix }}"
+            cluster: "{{ resource_prefix }}"
+            task_definition: "{{ resource_prefix }}"
+            desired_count: 1
+            state: absent
+            <<: *aws_connection_info
+          ignore_errors: yes
+
+        - name: remove ecs task definition
+          ecs_taskdefinition:
+            containers:
+              - name: my_container
+                image: ubuntu
+                memory: 128
+            family: "{{ resource_prefix }}"
+            revision: "{{ ecs_taskdefinition_creation.taskdefinition.revision }}"
+            state: absent
+            <<: *aws_connection_info
+          ignore_errors: yes
+
+        - name: remove ecs cluster
+          ecs_cluster:
+            name: "{{ resource_prefix }}"
+            state: absent
+            <<: *aws_connection_info
+          ignore_errors: yes

--- a/test/integration/targets/ecs_cluster/playbooks/network_force_new_deployment_fail.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/network_force_new_deployment_fail.yml
@@ -46,8 +46,6 @@
             that:
               - ecs_service_creation.changed
 
-
-
         - name: create ecs_service using force_new_deployment
           ecs_service:
             name: "{{ resource_prefix }}"

--- a/test/integration/targets/ecs_cluster/runme.sh
+++ b/test/integration/targets/ecs_cluster/runme.sh
@@ -25,6 +25,23 @@ source "${MYTMPDIR}/botocore-1.7.44/bin/activate"
 $PYTHON -m pip install 'botocore>=1.7.44,<1.8.4' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/network_assign_public_ip_fail.yml "$@"
 
+# Test graceful failure for force new deployment #42518
+# applies for botocore < 1.8.4
+virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.8.4"
+source "${MYTMPDIR}/botocore-1.8.4/bin/activate"
+$PYTHON -m pip install 'botocore>=1.7.44,<1.8.4' boto3
+ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/network_force_new_deployment_fail.yml "$@"
+
+# Test force new deployment #42518
+# applies for botocore < 1.8.4
+virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.8.5"
+source "${MYTMPDIR}/botocore-1.8.5/bin/activate"
+$PYTHON -m pip install 'botocore>1.8.4' boto3
+ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/network_force_new_deployment.yml "$@"
+
+
+
+
 # Run full test suite
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
 source "${MYTMPDIR}/botocore-recent/bin/activate"

--- a/test/integration/targets/ecs_cluster/runme.sh
+++ b/test/integration/targets/ecs_cluster/runme.sh
@@ -39,9 +39,6 @@ source "${MYTMPDIR}/botocore-1.8.5/bin/activate"
 $PYTHON -m pip install 'botocore>1.8.4' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/network_force_new_deployment.yml "$@"
 
-
-
-
 # Run full test suite
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
 source "${MYTMPDIR}/botocore-recent/bin/activate"


### PR DESCRIPTION
##### SUMMARY

Adds force_new_deployment parameter to ecs_service module.

I picked up the work from via mentioned in https://github.com/ansible/ansible/pull/42518, added botocore version checks, and excluded the param from update service if not set so it will work with older versions of botocore.


##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
ecs_service

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (ecs_service_force_new_deployment 5dcbcddb21) last updated 2018/11/02 10:06:03 (GMT -400)
  config file = None
  configured module search path = ['/home/tad/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/tad/code/ansible/lib/ansible
  executable location = /home/tad/code/ansible/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```