### PR TITLE
Correcting syntax of PyYAML package

### DIFF
--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -65,7 +65,7 @@ To work with documentation on your local machine, you need the following package
 .. code-block:: none
 
    - libyaml
-   - pyyaml
+   - PyYAML
    - nose
    - six
    - tornado


### PR DESCRIPTION
##### SUMMARY
Changing `pyyaml` to `PyYAML` in Documentation Contributions page

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
2.8
```

