### PR TITLE
aci_epg: parameter bd is not required

### DIFF
--- a/lib/ansible/modules/network/aci/aci_epg.py
+++ b/lib/ansible/modules/network/aci/aci_epg.py
@@ -42,7 +42,6 @@ options:
   bd:
     description:
     - Name of the bridge domain being associated with the EPG.
-    required: yes
     aliases: [ bd_name, bridge_domain ]
   priority:
     description:
@@ -350,9 +349,13 @@ def main():
                 fwdCtrl=fwd_control,
                 prefGrMemb=preferred_group,
             ),
-            child_configs=[
-                dict(fvRsBd=dict(attributes=dict(tnFvBDName=bd))),
-            ],
+            child_configs=[dict(
+                fvRsBd=dict(
+                    attributes=dict(
+                        tnFvBDName=bd,
+                    ),
+                ),
+            )],
         )
 
         aci.get_diff(aci_class='fvAEPg')


### PR DESCRIPTION
##### SUMMARY
Parameter `bd` is not required.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
aci_epg

##### ANSIBLE VERSION
v2.8