### PR TITLE
aci_aptiplp: Support missing policy_group

### DIFF
--- a/changelogs/fragments/aci_access_port_to_interface_policy_leaf_profile-missing_policy_group.yaml
+++ b/changelogs/fragments/aci_access_port_to_interface_policy_leaf_profile-missing_policy_group.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- aci_access_port_to_interface_policy_leaf_profile-missing_policy_group - Support missing policy_group
+- aci_access_port_to_interface_policy_leaf_profile - Support missing policy_group

--- a/changelogs/fragments/aci_access_port_to_interface_policy_leaf_profile-missing_policy_group.yaml
+++ b/changelogs/fragments/aci_access_port_to_interface_policy_leaf_profile-missing_policy_group.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- aci_access_port_to_interface_policy_leaf_profile-missing_policy_group - Support missing policy_group

--- a/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
+++ b/test/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
@@ -8,6 +8,18 @@
     msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
   when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
 
+- name: Ensuring bindings do not already exist
+  aci_access_port_to_interface_policy_leaf_profile:
+    host: "{{ aci_hostname }}"
+    username: "{{ aci_username }}"
+    password: "{{ aci_password }}"
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    leaf_interface_profile: leafintprftest
+    access_port_selector: anstest_accessportselector
+    state: absent
+
 - name: Ensuring Interface Policy Leaf profile exists for kick off
   aci_interface_policy_leaf_profile: &aci_interface_policy_leaf_profile_present
     host: "{{ aci_hostname }}"
@@ -53,7 +65,7 @@
     - accessport_to_intf_check_mode_present is changed
     - accessport_to_intf_present is changed
     - accessport_to_intf_present.previous == []
-    - 'accessport_to_intf_present.sent == {"infraHPortS": {"attributes": {"name": "anstest_accessportselector"}, "children": [{"infraRsAccBaseGrp": {"attributes": {"tDn": "uni/infra/funcprof/accportgrp-None"}}}]}}'
+    - 'accessport_to_intf_present.sent == {"infraHPortS": {"attributes": {"name": "anstest_accessportselector"}}}'
     - accessport_to_intf_idempotent is not changed
     - accessport_to_intf_idempotent.sent == {}
     - accessport_to_intf_update is changed


### PR DESCRIPTION
##### SUMMARY
This PR ensures the module works correctly when policy_group was not defined.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aci_access_port_to_interface_policy_leaf_profile

##### ANSIBLE VERSION
v2.8