### PR TITLE
ldap_attr bugfix

### DIFF
--- a/lib/ansible/modules/net_tools/ldap/ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attr.py
@@ -173,7 +173,7 @@ class LdapAttr(LdapGeneric):
 
         # Normalize values
         if isinstance(self.module.params['values'], list):
-            self.values = map(to_bytes, self.module.params['values'])
+            self.values = list(map(to_bytes, self.module.params['values']))
         else:
             self.values = [to_bytes(self.module.params['values'])]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Similar to  #46818, this fixes an error when using multiple values with `ldap_attr`.
The error is `TypeError: object of type 'map' has no len()`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ldap_attr

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```