### PR TITLE
swap out RM for 2.8, it me now

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_8.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_8.rst
@@ -15,7 +15,7 @@ Expected
 Release Manager
 ---------------
 
-Ryan Brown (IRC: ryansb; GitHub: @ryansb)
+Adam Miller (IRC: maxamillion; GitHub: @maxamillion)
 
 Planned work
 ============


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Set myself as the Release Manager for Ansible 2.8 release.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (roadmap/2.8 9ebd1ce4bb) last updated 2018/11/02 16:08:56 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/admiller/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 3.6.6 (default, Jul 19 2018, 14:25:17) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```
