### PR TITLE
Fixes to bigip_static_route

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_static_route.py
+++ b/lib/ansible/modules/network/f5/bigip_static_route.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017 F5 Networks Inc.
+# Copyright: (c) 2017, F5 Networks Inc.
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -13,6 +13,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'certified'}
 
 DOCUMENTATION = r'''
+---
 module: bigip_static_route
 short_description: Manipulate static routes on a BIG-IP
 description:
@@ -91,10 +92,11 @@ EXAMPLES = r'''
     netmask: 255.255.255.255
     gateway_address: 10.2.2.3
     name: test-route
-    password: secret
-    server: lb.mydomain.come
-    user: admin
-    validate_certs: no
+    provider:
+      password: secret
+      server: lb.mydomain.come
+      user: admin
+      validate_certs: no
   delegate_to: localhost
 '''
 
@@ -166,6 +168,7 @@ try:
     from library.module_utils.network.f5.ipaddress import ipv6_netmask_to_cidr
     from library.module_utils.compat.ipaddress import ip_address
     from library.module_utils.compat.ipaddress import ip_network
+    from library.module_utils.compat.ipaddress import ip_interface
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
@@ -180,6 +183,7 @@ except ImportError:
     from ansible.module_utils.network.f5.ipaddress import ipv6_netmask_to_cidr
     from ansible.module_utils.compat.ipaddress import ip_address
     from ansible.module_utils.compat.ipaddress import ip_network
+    from ansible.module_utils.compat.ipaddress import ip_interface
 
 
 class Parameters(AnsibleF5Parameters):
@@ -249,8 +253,12 @@ class ModuleParameters(Parameters):
         if self._values['gateway_address'] is None:
             return None
         try:
-            ip = ip_network(u'%s' % str(self._values['gateway_address']))
-            return str(ip.network_address)
+            if '%' in self._values['gateway_address']:
+                addr = self._values['gateway_address'].split('%')[0]
+            else:
+                addr = self._values['gateway_address']
+            ip_interface(u'%s' % str(addr))
+            return str(self._values['gateway_address'])
         except ValueError:
             raise F5ModuleError(
                 "The provided gateway_address is not an IP address"
@@ -274,7 +282,7 @@ class ModuleParameters(Parameters):
         try:
             ip = ip_network(u'%s' % str(self.destination_ip))
             if self.route_domain:
-                return '{0}%{2}/{1}'.format(str(ip.network_address), ip.prefixlen, self.route_domain)
+                return '{0}%{1}/{2}'.format(str(ip.network_address), self.route_domain, ip.prefixlen)
             else:
                 return '{0}/{1}'.format(str(ip.network_address), ip.prefixlen)
         except ValueError:

--- a/test/units/modules/network/f5/test_bigip_static_route.py
+++ b/test/units/modules/network/f5/test_bigip_static_route.py
@@ -14,9 +14,6 @@ from nose.plugins.skip import SkipTest
 if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
-from units.compat import unittest
-from units.compat.mock import Mock
-from units.compat.mock import patch
 from ansible.module_utils.basic import AnsibleModule
 
 try:
@@ -24,17 +21,25 @@ try:
     from library.modules.bigip_static_route import ModuleParameters
     from library.modules.bigip_static_route import ModuleManager
     from library.modules.bigip_static_route import ArgumentSpec
-    from library.module_utils.network.f5.common import F5ModuleError
-    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    from test.unit.modules.utils import set_module_args
+
+    # In Ansible 2.8, Ansible changed import paths.
+    from test.units.compat import unittest
+    from test.units.compat.mock import Mock
+    from test.units.compat.mock import patch
+
+    from test.units.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_static_route import ApiParameters
         from ansible.modules.network.f5.bigip_static_route import ModuleParameters
         from ansible.modules.network.f5.bigip_static_route import ModuleManager
         from ansible.modules.network.f5.bigip_static_route import ArgumentSpec
-        from ansible.module_utils.network.f5.common import F5ModuleError
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+
+        # Ansible 2.8 imports
+        from units.compat import unittest
+        from units.compat.mock import Mock
+        from units.compat.mock import patch
+
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Corrects documentation. Fixes unit tests, Fixes ip address checks
for gateway_address

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bigip_static_route

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.7 (default, Oct 24 2018, 22:47:56) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
