### PR TITLE
Removes f5-sdk from bigip_ssl_certificate

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_ssl_certificate.py
+++ b/lib/ansible/modules/network/f5/bigip_ssl_certificate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017 F5 Networks Inc.
+# Copyright: (c) 2017, F5 Networks Inc.
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -13,6 +13,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'certified'}
 
 DOCUMENTATION = r'''
+---
 module: bigip_ssl_certificate
 short_description: Import/Delete certificates from BIG-IP
 description:
@@ -61,6 +62,7 @@ requirements:
   - BIG-IP >= v12
 author:
   - Tim Rupp (@caphrim007)
+  - Wojciech Wypior (@wojtek0806)
 '''
 
 EXAMPLES = r'''
@@ -118,7 +120,6 @@ source_path:
   sample: /var/config/rest/downloads/cert1.crt
 '''
 
-
 import hashlib
 import os
 import re
@@ -127,31 +128,27 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
 
 try:
-    from library.module_utils.network.f5.bigip import HAS_F5SDK
-    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
-    from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-
-    try:
-        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
+    from library.module_utils.network.f5.common import exit_json
+    from library.module_utils.network.f5.common import fail_json
+    from library.module_utils.network.f5.common import fq_name
+    from library.module_utils.network.f5.common import transform_name
+    from library.module_utils.network.f5.icontrol import upload_file
 except ImportError:
-    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
-    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
-    from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-
-    try:
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
+    from ansible.module_utils.network.f5.common import exit_json
+    from ansible.module_utils.network.f5.common import fail_json
+    from ansible.module_utils.network.f5.common import fq_name
+    from ansible.module_utils.network.f5.common import transform_name
+    from ansible.module_utils.network.f5.icontrol import upload_file
 
 try:
     from StringIO import StringIO
@@ -160,28 +157,30 @@ except ImportError:
 
 
 class Parameters(AnsibleF5Parameters):
+    download_path = '/var/config/rest/downloads'
+
     api_map = {
         'sourcePath': 'source_path',
-        'issuerCert': 'issuer_cert'
+        'issuerCert': 'issuer_cert',
     }
 
-    updatables = ['content', 'issuer_cert']
-
-    returnables = [
-        'filename', 'checksum', 'source_path', 'issuer_cert'
+    updatables = [
+        'content',
+        'issuer_cert',
+        'source_path',
     ]
 
-    api_attributes = ['issuerCert']
+    returnables = [
+        'filename',
+        'checksum',
+        'source_path',
+        'issuer_cert',
+    ]
 
-    def _get_hash(self, content):
-        k = hashlib.sha1()
-        s = StringIO(content)
-        while True:
-            data = s.read(1024)
-            if not data:
-                break
-            k.update(data.encode('utf-8'))
-        return k.hexdigest()
+    api_attributes = [
+        'issuerCert',
+        'sourcePath',
+    ]
 
 
 class ApiParameters(Parameters):
@@ -202,6 +201,16 @@ class ApiParameters(Parameters):
 
 
 class ModuleParameters(Parameters):
+    def _get_hash(self, content):
+        k = hashlib.sha1()
+        s = StringIO(content)
+        while True:
+            data = s.read(1024)
+            if not data:
+                break
+            k.update(data.encode('utf-8'))
+        return k.hexdigest()
+
     @property
     def issuer_cert(self):
         if self._values['issuer_cert'] is None:
@@ -228,7 +237,7 @@ class ModuleParameters(Parameters):
     @property
     def source_path(self):
         result = 'file://' + os.path.join(
-            ModuleManager.download_path,
+            self.download_path,
             self.filename
         )
         return result
@@ -277,6 +286,16 @@ class Difference(object):
             return attr1
 
     @property
+    def source_path(self):
+        if self.want.source_path is None:
+            return None
+        if self.want.source_path == self.have.source_path:
+            if self.content:
+                return self.want.source_path
+        if self.want.source_path != self.have.source_path:
+                return self.want.source_path
+
+    @property
     def content(self):
         if self.want.checksum != self.have.checksum:
             result = dict(
@@ -287,8 +306,6 @@ class Difference(object):
 
 
 class ModuleManager(object):
-    download_path = '/var/config/rest/downloads'
-
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
         self.client = kwargs.get('client', None)
@@ -301,13 +318,10 @@ class ModuleManager(object):
         result = dict()
         state = self.want.state
 
-        try:
-            if state == "present":
-                changed = self.present()
-            elif state == "absent":
-                changed = self.absent()
-        except iControlUnexpectedHTTPError as e:
-            raise F5ModuleError(str(e))
+        if state == "present":
+            changed = self.present()
+        elif state == "absent":
+            changed = self.absent()
 
         reportable = ReportableChanges(params=self.changes.to_return())
         changes = reportable.to_return()
@@ -390,35 +404,77 @@ class ModuleManager(object):
         return False
 
     def exists(self):
-        result = self.client.api.tm.sys.file.ssl_certs.ssl_cert.exists(
-            name=self.want.filename,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/file/ssl-cert/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.filename)
         )
-        return result
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError:
+            return False
+        if resp.status == 404 or 'code' in response and response['code'] == 404:
+            return False
+        return True
+
+    def upload_file_to_device(self, content, name):
+        url = 'https://{0}:{1}/mgmt/shared/file-transfer/uploads'.format(
+            self.client.provider['server'],
+            self.client.provider['server_port']
+        )
+        try:
+            upload_file(self.client, url, content, name)
+        except F5ModuleError:
+            raise F5ModuleError(
+                "Failed to upload the file."
+            )
 
     def update_on_device(self):
-        params = self.changes.api_params()
         content = StringIO(self.want.content)
-        self.client.api.shared.file_transfer.uploads.upload_stringio(
-            content, self.want.filename
+        self.upload_file_to_device(content, self.want.filename)
+        params = self.changes.api_params()
+        uri = "https://{0}:{1}/mgmt/tm/sys/file/ssl-cert/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.filename)
         )
-        resource = self.client.api.tm.sys.file.ssl_certs.ssl_cert.load(
-            name=self.want.filename,
-            partition=self.want.partition
-        )
-        resource.update(**params)
+        resp = self.client.api.put(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
     def create_on_device(self):
         content = StringIO(self.want.content)
-        self.client.api.shared.file_transfer.uploads.upload_stringio(
-            content, self.want.filename
+        self.upload_file_to_device(content, self.want.filename)
+        uri = "https://{0}:{1}/mgmt/tm/sys/file/ssl-cert/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
         )
-
-        resource = self.client.api.tm.sys.file.ssl_certs.ssl_cert.create(
+        params = dict(
             sourcePath=self.want.source_path,
             name=self.want.filename,
             partition=self.want.partition
         )
+
+        resp = self.client.api.post(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
         # This needs to be done because of the way that BIG-IP creates certificates.
         #
@@ -427,25 +483,55 @@ class ModuleManager(object):
         # a create so that *more* are available.
         params = self.want.api_params()
         if params:
-            resource.update(**params)
+            uri = "https://{0}:{1}/mgmt/tm/sys/file/ssl-cert/{2}".format(
+                self.client.provider['server'],
+                self.client.provider['server_port'],
+                transform_name(self.want.partition, self.want.filename)
+            )
+            resp = self.client.api.put(uri, json=params)
+            try:
+                response = resp.json()
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
+
+            if 'code' in response and response['code'] == 400:
+                if 'message' in response:
+                    raise F5ModuleError(response['message'])
+                else:
+                    raise F5ModuleError(resp.content)
 
     def read_current_from_device(self):
-        resource = self.client.api.tm.sys.file.ssl_certs.ssl_cert.load(
-            name=self.want.filename,
-            partition=self.want.partition,
-            requests_params=dict(
-                params='expandSubcollections=true'
-            )
+        uri = "https://{0}:{1}/mgmt/tm/sys/file/ssl-cert/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.filename)
         )
-        result = resource.attrs
-        return ApiParameters(params=result)
+
+        query = '?expandSubcollections=true'
+        resp = self.client.api.get(uri + query)
+
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return ApiParameters(params=response)
 
     def remove_from_device(self):
-        resource = self.client.api.tm.sys.file.ssl_certs.ssl_cert.load(
-            name=self.want.filename,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/file/ssl-cert/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.filename)
         )
-        resource.delete()
+        response = self.client.api.delete(uri)
+        if response.status == 200:
+            return True
+        raise F5ModuleError(response.content)
 
 
 class ArgumentSpec(object):
@@ -478,18 +564,16 @@ def main():
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode
     )
-    if not HAS_F5SDK:
-        module.fail_json(msg="The python f5-sdk module is required")
+    client = F5RestClient(**module.params)
 
     try:
-        client = F5Client(**module.params)
         mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        module.exit_json(**results)
+        exit_json(module, results, client)
     except F5ModuleError as ex:
         cleanup_tokens(client)
-        module.fail_json(msg=str(ex))
+        fail_json(module, ex, client)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Removes f5-sdk from bigip_ssl_certificate

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bigip_ssl_certificate

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.7 (default, Oct 24 2018, 22:47:56) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
