### PR TITLE
Docker inventory service/stack groups for docker swarm

### DIFF
--- a/changelogs/fragments/inventory-docker-service-stack-groups.yaml
+++ b/changelogs/fragments/inventory-docker-service-stack-groups.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - inventory/docker - Group containers by docker-swarm "service" and "stack"

--- a/contrib/inventory/docker.py
+++ b/contrib/inventory/docker.py
@@ -621,6 +621,14 @@ class DockerInventory(object):
                 if image_name:
                     self.groups["image_%s" % (image_name)].append(name)
 
+                stack_name = inspect.get('Config', dict()).get('Labels', dict()).get('com.docker.stack.namespace')
+                if stack_name:
+                    self.groups["stack_%s" % stack_name].append(name)
+
+                service_name = inspect.get('Config', dict()).get('Labels', dict()).get('com.docker.swarm.service.name')
+                if service_name:
+                    self.groups["service_%s" % service_name].append(name)
+
                 self.groups[id].append(name)
                 self.groups[name].append(name)
                 if short_id not in self.groups:

--- a/contrib/inventory/docker.py
+++ b/contrib/inventory/docker.py
@@ -196,6 +196,8 @@ When run in --list mode (the default), container instances are grouped by:
  - container name
  - container short id
  - image_name  (image_<image name>)
+ - stack_name  (stack_<stack name>)
+ - service_name  (service_<service name>)
  - docker_host
  - running
  - stopped


### PR DESCRIPTION
##### SUMMARY

This adds host grouping based on "service" and "stack" to the docker.py inventory script.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

docker.py inventory

##### ANSIBLE VERSION

```
ansible 2.7.0
  config file = None
  configured module search path = [u'/home/eric/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

This makes no change to existing functionality but extends the grouping of containers based on image to group on stack and service as well. This is done by conditionally keying the a host's groups off of the labels `com.docker.stack.namespace` and `com.docker.swarm.service.name`.

The derived groups are in the format `service_<service_name>` and `stack_<stack_name>`

You can find the docker-compose file I used to create these groups [here](https://github.com/sosheskaz/docker-composes/blob/c0e81091aeed6d7cf170d4b12c920354b2198c70/ansible-mock.yml).

Excerpt from "pretty" docker.py output:
```sh
$ contrib/inventory/docker.py | jq .service_ansible_mock_host
[
  "ansible_mock_host.2.qo2m6mrmtfy8f8zl64yogsyef",
  "ansible_mock_host.1.hxnrh84blwmscu2pmgl4p5ann",
  "ansible_mock_host.3.sn74oapkk5ay3la148js5z93n",
  "ansible_mock_host.4.zi8jyrocpts7hw8x0sba9k47b",
  "ansible_mock_host.5.i5t8il409jgua2olw1wfw5ucg",
  "ansible_mock_host.3.ly13cxwzvibmuf6volsr8t1z8",
  "ansible_mock_host.2.bkiiay0a48a3koxkgbvvte9me"
]

$ contrib/inventory/docker.py | jq .stack_ansible_mock
[
  "ansible_mock_host.2.qo2m6mrmtfy8f8zl64yogsyef",
  "ansible_mock_host.1.hxnrh84blwmscu2pmgl4p5ann",
  "ansible_mock_host.3.sn74oapkk5ay3la148js5z93n",
  "ansible_mock_host.4.zi8jyrocpts7hw8x0sba9k47b",
  "ansible_mock_host.5.i5t8il409jgua2olw1wfw5ucg",
  "ansible_mock_host.3.ly13cxwzvibmuf6volsr8t1z8",
  "ansible_mock_host.2.bkiiay0a48a3koxkgbvvte9me"
]

# warnings omitted from output for legibility
$ ansible -i contrib/inventory/docker.py 'stack_ansible_mock:&running' \
-m ping -e ansible_connection=docker -e ansible_python_interpreter=/usr/local/bin/python
ansible_mock_host.1.hxnrh84blwmscu2pmgl4p5ann | SUCCESS => {
    "changed": false,
    "ping": "pong"
}
ansible_mock_host.5.i5t8il409jgua2olw1wfw5ucg | SUCCESS => {
    "changed": false,
    "ping": "pong"
}
ansible_mock_host.3.sn74oapkk5ay3la148js5z93n | SUCCESS => {
    "changed": false,
    "ping": "pong"
}
ansible_mock_host.4.zi8jyrocpts7hw8x0sba9k47b | SUCCESS => {
    "changed": false,
    "ping": "pong"
}
ansible_mock_host.2.qo2m6mrmtfy8f8zl64yogsyef | SUCCESS => {
    "changed": false,
    "ping": "pong"
}
```