### PR TITLE
ec2_group add rule description fix

### DIFF
--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -1114,6 +1114,28 @@
           - 'result.changed'
       when: result.ip_permissions_egress[0].ip_ranges[0].description is undefined
 
+    # =========================================================================================
+    - name: add rules without descriptions ready for adding descriptions to existing rules
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        <<: *aws_connection_info
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        # purge the other rules so assertions work for the subsequent tests for rule descriptions
+        purge_rules_egress: true
+        purge_rules: true
+        state: present
+        rules:
+        - proto: "tcp"
+          ports:
+          - 8281
+          cidr_ipv6: 1001:d00::/24
+        rules_egress:
+        - proto: "tcp"
+          ports:
+          - 8282
+          cidr_ip: 2.2.2.2/32
+
     # ============================================================
     - name: test adding a rule and egress rule descriptions (expected changed=true)
       ec2_group:
@@ -1188,6 +1210,7 @@
       assert:
         that:
           - 'result.changed'
+          - 'result.ip_permissions | length > 0'
       when: result.ip_permissions_egress[0].ip_ranges[0].description is defined
 
     - name: if an older version of botocore is installed everything should stay the same (expected changed=false)


### PR DESCRIPTION
##### SUMMARY

ec2_group should not remove security group rules that
have their rule descriptions updated.

Update descriptions first, then do the comparison of whether
or not groups should be removed.

Fixes #47904
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
ec2_group

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (devel 96a20e0780) last updated 2018/11/03 10:51:34 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.15 (default, Oct  2 2018, 11:47:18) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.2)]
```

##### ADDITIONAL INFORMATION
Should be backported to 2.6 and 2.7