### PR TITLE
Make it easier to resolve units.compat to run Unit Tests locally

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -265,7 +265,7 @@ files:
   $modules/packaging/language/npm.py:
     ignored: chrishoffman
     maintainers: shane-walker xcambar
-  $modules/packaging/language/pip.py: lujeni robinro
+  $modules/packaging/language/pip.py: lujeni webknjaz
   $modules/packaging/os/apk.py:
     ignored: kbrebanov
     maintainers: tdtrask

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1114,7 +1114,7 @@ macros:
   team_linode: intheclouddan lwm displague rmcintosh
   team_manageiq: gtanzillo abellotti zgalor yaacov cben
   team_meraki: dagwieers kbreit
-  team_netapp: hulquest lmprice ndswartz amit0701 schmots1 carchi8py
+  team_netapp: hulquest lmprice ndswartz amit0701 schmots1 carchi8py lonico
   team_netbox: sieben anthony25 fragmentedpacket nikkytub pilou-
   team_netscaler: chiradeep giorgos-nikolopoulos
   team_netvisor: Qalthos amitsi

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1114,7 +1114,7 @@ macros:
   team_linode: intheclouddan lwm displague rmcintosh
   team_manageiq: gtanzillo abellotti zgalor yaacov cben
   team_meraki: dagwieers kbreit
-  team_netapp: hulquest lmprice ndswartz amit0701 schmots1 carchi8py lonico 
+  team_netapp: hulquest lmprice ndswartz amit0701 schmots1 carchi8py lonico
   team_netbox: sieben anthony25 fragmentedpacket nikkytub pilou-
   team_netscaler: chiradeep giorgos-nikolopoulos
   team_netvisor: Qalthos amitsi

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1114,7 +1114,7 @@ macros:
   team_linode: intheclouddan lwm displague rmcintosh
   team_manageiq: gtanzillo abellotti zgalor yaacov cben
   team_meraki: dagwieers kbreit
-  team_netapp: hulquest lmprice ndswartz amit0701 schmots1 carchi8py lonico
+  team_netapp: hulquest lmprice ndswartz amit0701 schmots1 carchi8py lonico 
   team_netbox: sieben anthony25 fragmentedpacket nikkytub pilou-
   team_netscaler: chiradeep giorgos-nikolopoulos
   team_netvisor: Qalthos amitsi

--- a/docs/docsite/rst/roadmap/ROADMAP_2_8.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_8.rst
@@ -15,7 +15,7 @@ Expected
 Release Manager
 ---------------
 
-Ryan Brown (IRC: ryansb; GitHub: @ryansb)
+Adam Miller (IRC: maxamillion; GitHub: @maxamillion)
 
 Planned work
 ============

--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -46,7 +46,7 @@ fi
 FULL_PATH=$($PYTHON_BIN -c "import os; print(os.path.realpath('$HACKING_DIR'))")
 export ANSIBLE_HOME="$(dirname "$FULL_PATH")"
 
-PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib"
+PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib:$ANSIBLE_HOME/test"
 PREFIX_PATH="$ANSIBLE_HOME/bin"
 PREFIX_MANPATH="$ANSIBLE_HOME/docs/man"
 

--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -4,7 +4,7 @@
 set HACKING_DIR (dirname (status -f))
 set FULL_PATH (python -c "import os; print(os.path.realpath('$HACKING_DIR'))")
 set ANSIBLE_HOME (dirname $FULL_PATH)
-set PREFIX_PYTHONPATH $ANSIBLE_HOME/lib
+set PREFIX_PYTHONPATH $ANSIBLE_HOME/lib:$ANSIBLE_HOME/test
 set PREFIX_PATH $ANSIBLE_HOME/bin
 set PREFIX_MANPATH $ANSIBLE_HOME/docs/man
 

--- a/lib/ansible/modules/network/f5/bigip_service_policy.py
+++ b/lib/ansible/modules/network/f5/bigip_service_policy.py
@@ -50,6 +50,7 @@ options:
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
+  - Wojciech Wypior (@wojtek0806)
 '''
 
 EXAMPLES = r'''
@@ -89,47 +90,51 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
 
 try:
-    from library.module_utils.network.f5.bigip import HAS_F5SDK
-    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
-    from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    try:
-        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
+    from library.module_utils.network.f5.common import fq_name
+    from library.module_utils.network.f5.common import exit_json
+    from library.module_utils.network.f5.common import fail_json
+    from library.module_utils.network.f5.common import transform_name
+    from library.module_utils.network.f5.icontrol import module_provisioned
 except ImportError:
-    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
-    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
-    from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    try:
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
+    from ansible.module_utils.network.f5.common import fq_name
+    from ansible.module_utils.network.f5.common import exit_json
+    from ansible.module_utils.network.f5.common import fail_json
+    from ansible.module_utils.network.f5.common import transform_name
+    from ansible.module_utils.network.f5.icontrol import module_provisioned
 
 
 class Parameters(AnsibleF5Parameters):
     api_map = {
         'portMisusePolicy': 'port_misuse_policy',
-        'timerPolicy': 'timer_policy'
+        'timerPolicy': 'timer_policy',
     }
 
     api_attributes = [
-        'description', 'timerPolicy', 'portMisusePolicy'
+        'description',
+        'timerPolicy',
+        'portMisusePolicy',
     ]
 
     returnables = [
-        'description', 'timer_policy', 'port_misuse_policy'
+        'description',
+        'timer_policy',
+        'port_misuse_policy',
     ]
 
     updatables = [
-        'description', 'timer_policy', 'port_misuse_policy'
+        'description',
+        'timer_policy',
+        'port_misuse_policy',
     ]
 
 
@@ -231,14 +236,6 @@ class ModuleManager(object):
             return True
         return False
 
-    def module_provisioned(self, module):
-        resource = self.client.api.tm.sys.dbs.db.load(
-            name='provisioned.cpu.{0}'.format(module)
-        )
-        if int(resource.value) == 0:
-            return False
-        return True
-
     def should_update(self):
         result = self._update_changed_options()
         if result:
@@ -250,13 +247,10 @@ class ModuleManager(object):
         result = dict()
         state = self.want.state
 
-        try:
-            if state == "present":
-                changed = self.present()
-            elif state == "absent":
-                changed = self.absent()
-        except iControlUnexpectedHTTPError as e:
-            raise F5ModuleError(str(e))
+        if state == "present":
+            changed = self.present()
+        elif state == "absent":
+            changed = self.absent()
 
         reportable = ReportableChanges(params=self.changes.to_return())
         changes = reportable.to_return()
@@ -279,19 +273,17 @@ class ModuleManager(object):
         else:
             return self.create()
 
-    def exists(self):
-        result = self.client.api.tm.net.service_policys.service_policy.exists(
-            name=self.want.name,
-            partition=self.want.partition
-        )
-        return result
+    def absent(self):
+        if self.exists():
+            return self.remove()
+        return False
 
     def update(self):
         self.have = self.read_current_from_device()
         if not self.should_update():
             return False
         if self.want.port_misuse_policy:
-            if not self.module_provisioned('afm'):
+            if not module_provisioned(self.client, 'afm'):
                 raise F5ModuleError(
                     "To configure a 'port_misuse_policy', you must have AFM provisioned."
                 )
@@ -311,7 +303,7 @@ class ModuleManager(object):
     def create(self):
         self._set_changed_options()
         if self.want.port_misuse_policy:
-            if not self.module_provisioned('afm'):
+            if not module_provisioned(self.client, 'afm'):
                 raise F5ModuleError(
                     "To configure a 'port_misuse_policy', you must have AFM provisioned."
                 )
@@ -320,42 +312,89 @@ class ModuleManager(object):
         self.create_on_device()
         return True
 
+    def exists(self):
+        uri = "https://{0}:{1}/mgmt/tm/net/service-policy/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError:
+            return False
+        if resp.status == 404 or 'code' in response and response['code'] == 404:
+            return False
+        return True
+
     def create_on_device(self):
         params = self.changes.api_params()
-        self.client.api.tm.net.service_policys.service_policy.create(
-            name=self.want.name,
-            partition=self.want.partition,
-            **params
+        params['name'] = self.want.name
+        params['partition'] = self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/net/service-policy/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
         )
+        resp = self.client.api.post(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
     def update_on_device(self):
         params = self.changes.api_params()
-        resource = self.client.api.tm.net.service_policys.service_policy.load(
-            name=self.want.name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/net/service-policy/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
         )
-        resource.modify(**params)
+        resp = self.client.api.patch(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
 
-    def absent(self):
-        if self.exists():
-            return self.remove()
-        return False
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
     def remove_from_device(self):
-        resource = self.client.api.tm.net.service_policys.service_policy.load(
-            name=self.want.name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/net/service-policy/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
         )
-        if resource:
-            resource.delete()
+        response = self.client.api.delete(uri)
+        if response.status == 200:
+            return True
+        raise F5ModuleError(response.content)
 
     def read_current_from_device(self):
-        resource = self.client.api.tm.net.service_policys.service_policy.load(
-            name=self.want.name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/net/service-policy/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
         )
-        result = resource.attrs
-        return ApiParameters(params=result)
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return ApiParameters(params=response)
 
 
 class ArgumentSpec(object):
@@ -387,18 +426,17 @@ def main():
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode
     )
-    if not HAS_F5SDK:
-        module.fail_json(msg="The python f5-sdk module is required")
+
+    client = F5RestClient(**module.params)
 
     try:
-        client = F5Client(**module.params)
         mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        module.exit_json(**results)
+        exit_json(module, results, client)
     except F5ModuleError as ex:
         cleanup_tokens(client)
-        module.fail_json(msg=str(ex))
+        fail_json(module, ex, client)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_smtp.py
+++ b/lib/ansible/modules/network/f5/bigip_smtp.py
@@ -74,7 +74,6 @@ options:
     description:
       - When C(present), ensures that the SMTP configuration exists.
       - When C(absent), ensures that the SMTP configuration does not exist.
-    required: False
     default: present
     choices:
       - present
@@ -150,31 +149,27 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
 
 try:
-    from library.module_utils.network.f5.bigip import HAS_F5SDK
-    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
-    from library.module_utils.network.f5.common import is_valid_hostname
     from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.common import exit_json
+    from library.module_utils.network.f5.common import fail_json
+    from library.module_utils.network.f5.common import transform_name
+    from library.module_utils.network.f5.common import is_valid_hostname
     from library.module_utils.network.f5.ipaddress import is_valid_ip
-    try:
-        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
 except ImportError:
-    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
-    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
-    from ansible.module_utils.network.f5.common import is_valid_hostname
     from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.common import exit_json
+    from ansible.module_utils.network.f5.common import fail_json
+    from ansible.module_utils.network.f5.common import transform_name
+    from ansible.module_utils.network.f5.common import is_valid_hostname
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
-    try:
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -187,25 +182,41 @@ class Parameters(AnsibleF5Parameters):
         'encryptedConnection': 'encryption',
         'authenticationEnabled': 'authentication_enabled',
         'authenticationDisabled': 'authentication_disabled',
-        'fromAddress': 'from_address'
+        'fromAddress': 'from_address',
     }
 
     api_attributes = [
-        'username', 'passwordEncrypted', 'localHostName', 'smtpServerHostName',
-        'smtpServerPort', 'encryptedConnection', 'authenticationEnabled',
-        'authenticationDisabled', 'fromAddress'
+        'username',
+        'passwordEncrypted',
+        'localHostName',
+        'smtpServerHostName',
+        'smtpServerPort',
+        'encryptedConnection',
+        'authenticationEnabled',
+        'authenticationDisabled',
+        'fromAddress',
     ]
 
     returnables = [
-        'smtp_server_username', 'smtp_server_password', 'local_host_name',
-        'smtp_server', 'smtp_server_port', 'encryption', 'authentication',
-        'from_address'
+        'smtp_server_username',
+        'smtp_server_password',
+        'local_host_name',
+        'smtp_server',
+        'smtp_server_port',
+        'encryption',
+        'authentication',
+        'from_address',
     ]
 
     updatables = [
-        'smtp_server_username', 'smtp_server_password', 'local_host_name',
-        'smtp_server', 'smtp_server_port', 'encryption', 'authentication',
-        'from_address'
+        'smtp_server_username',
+        'smtp_server_password',
+        'local_host_name',
+        'smtp_server',
+        'smtp_server_port',
+        'encryption',
+        'authentication',
+        'from_address',
     ]
 
 
@@ -362,13 +373,10 @@ class ModuleManager(object):
         result = dict()
         state = self.want.state
 
-        try:
-            if state == "present":
-                changed = self.present()
-            elif state == "absent":
-                changed = self.absent()
-        except iControlUnexpectedHTTPError as e:
-            raise F5ModuleError(str(e))
+        if state == "present":
+            changed = self.present()
+        elif state == "absent":
+            changed = self.absent()
 
         reportable = ReportableChanges(params=self.changes.to_return())
         changes = reportable.to_return()
@@ -391,12 +399,10 @@ class ModuleManager(object):
         else:
             return self.create()
 
-    def exists(self):
-        result = self.client.api.tm.sys.smtp_servers.smtp_server.exists(
-            name=self.want.name,
-            partition=self.want.partition
-        )
-        return result
+    def absent(self):
+        if self.exists():
+            return self.remove()
+        return False
 
     def update(self):
         self.have = self.read_current_from_device()
@@ -422,42 +428,88 @@ class ModuleManager(object):
         self.create_on_device()
         return True
 
+    def exists(self):
+        uri = "https://{0}:{1}/mgmt/tm/sys/smtp-server/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError:
+            return False
+        if resp.status == 404 or 'code' in response and response['code'] == 404:
+            return False
+        return True
+
     def create_on_device(self):
         params = self.want.api_params()
-        self.client.api.tm.sys.smtp_servers.smtp_server.create(
-            name=self.want.name,
-            partition=self.want.partition,
-            **params
+        params['name'] = self.want.name
+        params['partition'] = self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/smtp-server/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
         )
+        resp = self.client.api.post(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
     def update_on_device(self):
         params = self.want.api_params()
-        resource = self.client.api.tm.sys.smtp_servers.smtp_server.load(
-            name=self.want.name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/smtp-server/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
         )
-        resource.modify(**params)
+        resp = self.client.api.patch(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
 
-    def absent(self):
-        if self.exists():
-            return self.remove()
-        return False
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
     def remove_from_device(self):
-        resource = self.client.api.tm.sys.smtp_servers.smtp_server.load(
-            name=self.want.name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/smtp-server/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
         )
-        if resource:
-            resource.delete()
+        resp = self.client.api.delete(uri)
+        if resp.status == 200:
+            return True
 
     def read_current_from_device(self):
-        resource = self.client.api.tm.sys.smtp_servers.smtp_server.load(
-            name=self.want.name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/smtp-server/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
         )
-        result = resource.attrs
-        return ApiParameters(params=result)
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return ApiParameters(params=response)
 
 
 class ArgumentSpec(object):
@@ -498,18 +550,17 @@ def main():
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode
     )
-    if not HAS_F5SDK:
-        module.fail_json(msg="The python f5-sdk module is required")
+
+    client = F5RestClient(**module.params)
 
     try:
-        client = F5Client(**module.params)
         mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        module.exit_json(**results)
+        exit_json(module, results, client)
     except F5ModuleError as ex:
         cleanup_tokens(client)
-        module.fail_json(msg=str(ex))
+        fail_json(module, ex, client)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_snat_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_snat_pool.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2016 F5 Networks Inc.
+# Copyright: (c) 2016, F5 Networks Inc.
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -44,6 +44,7 @@ options:
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
+  - Wojciech Wypior (@wojtek0806)
 '''
 
 EXAMPLES = r'''
@@ -94,29 +95,27 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
 
 try:
-    from library.module_utils.network.f5.bigip import HAS_F5SDK
-    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.common import transform_name
+    from library.module_utils.network.f5.common import exit_json
+    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.network.f5.ipaddress import is_valid_ip
-    try:
-        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
 except ImportError:
-    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
-    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.common import transform_name
+    from ansible.module_utils.network.f5.common import exit_json
+    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
-    try:
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -134,34 +133,12 @@ class Parameters(AnsibleF5Parameters):
         'members'
     ]
 
-    def to_return(self):
-        result = {}
-        for returnable in self.returnables:
-            result[returnable] = getattr(self, returnable)
-        result = self._filter_params(result)
-        return result
 
-    def api_params(self):
-        result = {}
-        for api_attribute in self.api_attributes:
-            if self.api_map is not None and api_attribute in self.api_map:
-                result[api_attribute] = getattr(self, self.api_map[api_attribute])
-            else:
-                result[api_attribute] = getattr(self, api_attribute)
-        result = self._filter_params(result)
-        return result
+class ApiParameters(Parameters):
+    pass
 
-    @property
-    def members(self):
-        if self._values['members'] is None:
-            return None
-        result = set()
-        for member in self._values['members']:
-            member = self._clear_member_prefix(member)
-            address = self._format_member_address(member)
-            result.update([address])
-        return list(result)
 
+class ModuleParameters(Parameters):
     def _clear_member_prefix(self, member):
         result = os.path.basename(member)
         return result
@@ -175,8 +152,35 @@ class Parameters(AnsibleF5Parameters):
                 'The provided member address is not a valid IP address'
             )
 
+    @property
+    def members(self):
+        if self._values['members'] is None:
+            return None
+        result = set()
+        for member in self._values['members']:
+            member = self._clear_member_prefix(member)
+            address = self._format_member_address(member)
+            result.update([address])
+        return list(result)
+
 
 class Changes(Parameters):
+    def to_return(self):
+        result = {}
+        for returnable in self.returnables:
+            try:
+                result[returnable] = getattr(self, returnable)
+            except Exception:
+                pass
+            result = self._filter_params(result)
+        return result
+
+
+class UsableChanges(Changes):
+    pass
+
+
+class ReportableChanges(Changes):
     pass
 
 
@@ -192,15 +196,6 @@ class Difference(object):
         except AttributeError:
             return self.__default(param)
 
-    @property
-    def members(self):
-        if self.want.members is None:
-            return None
-        if set(self.want.members) == set(self.have.members):
-            return None
-        result = list(set(self.want.members))
-        return result
-
     def __default(self, param):
         attr1 = getattr(self.want, param)
         try:
@@ -210,14 +205,31 @@ class Difference(object):
         except AttributeError:
             return attr1
 
+    @property
+    def members(self):
+        if self.want.members is None:
+            return None
+        if set(self.want.members) == set(self.have.members):
+            return None
+        result = list(set(self.want.members))
+        return result
+
 
 class ModuleManager(object):
     def __init__(self, *args, **kwargs):
         self.module = kwargs.get('module', None)
         self.client = kwargs.get('client', None)
-        self.have = None
-        self.want = Parameters(params=self.module.params)
-        self.changes = Changes()
+        self.want = ModuleParameters(params=self.module.params)
+        self.have = ApiParameters()
+        self.changes = UsableChanges()
+
+    def _announce_deprecations(self, result):
+        warnings = result.pop('__warnings', [])
+        for warning in warnings:
+            self.module.deprecate(
+                msg=warning['msg'],
+                version=warning['version']
+            )
 
     def _set_changed_options(self):
         changed = {}
@@ -225,7 +237,7 @@ class ModuleManager(object):
             if getattr(self.want, key) is not None:
                 changed[key] = getattr(self.want, key)
         if changed:
-            self.changes = Changes(params=changed)
+            self.changes = UsableChanges(params=changed)
 
     def _update_changed_options(self):
         diff = Difference(self.want, self.have)
@@ -236,9 +248,12 @@ class ModuleManager(object):
             if change is None:
                 continue
             else:
-                changed[k] = change
+                if isinstance(change, dict):
+                    changed.update(change)
+                else:
+                    changed[k] = change
         if changed:
-            self.changes = Changes(params=changed)
+            self.changes = UsableChanges(params=changed)
             return True
         return False
 
@@ -247,31 +262,17 @@ class ModuleManager(object):
         result = dict()
         state = self.want.state
 
-        try:
-            if state == "present":
-                changed = self.present()
-            elif state == "absent":
-                changed = self.absent()
-        except iControlUnexpectedHTTPError as e:
-            raise F5ModuleError(str(e))
+        if state == "present":
+            changed = self.present()
+        elif state == "absent":
+            changed = self.absent()
 
-        changes = self.changes.to_return()
+        reportable = ReportableChanges(params=self.changes.to_return())
+        changes = reportable.to_return()
         result.update(**changes)
         result.update(dict(changed=changed))
-        self._announce_deprecations()
+        self._announce_deprecations(result)
         return result
-
-    def _announce_deprecations(self):
-        warnings = []
-        if self.want:
-            warnings += self.want._values.get('__warnings', [])
-        if self.have:
-            warnings += self.have._values.get('__warnings', [])
-        for warning in warnings:
-            self.module.deprecate(
-                msg=warning['msg'],
-                version=warning['version']
-            )
 
     def present(self):
         if self.exists():
@@ -284,21 +285,6 @@ class ModuleManager(object):
         if self.exists():
             changed = self.remove()
         return changed
-
-    def read_current_from_device(self):
-        resource = self.client.api.tm.ltm.snatpools.snatpool.load(
-            name=self.want.name,
-            partition=self.want.partition
-        )
-        result = resource.attrs
-        return Parameters(params=result)
-
-    def exists(self):
-        result = self.client.api.tm.ltm.snatpools.snatpool.exists(
-            name=self.want.name,
-            partition=self.want.partition
-        )
-        return result
 
     def should_update(self):
         result = self._update_changed_options()
@@ -315,15 +301,6 @@ class ModuleManager(object):
         self.update_on_device()
         return True
 
-    def update_on_device(self):
-        params = self.changes.api_params()
-
-        resource = self.client.api.tm.ltm.snatpools.snatpool.load(
-            name=self.want.name,
-            partition=self.want.partition
-        )
-        resource.modify(**params)
-
     def create(self):
         self._set_changed_options()
         if self.module.check_mode:
@@ -333,14 +310,6 @@ class ModuleManager(object):
             raise F5ModuleError("Failed to create the SNAT pool")
         return True
 
-    def create_on_device(self):
-        params = self.want.api_params()
-        self.client.api.tm.ltm.snatpools.snatpool.create(
-            name=self.want.name,
-            partition=self.want.partition,
-            **params
-        )
-
     def remove(self):
         if self.module.check_mode:
             return True
@@ -349,12 +318,91 @@ class ModuleManager(object):
             raise F5ModuleError("Failed to delete the SNAT pool")
         return True
 
-    def remove_from_device(self):
-        resource = self.client.api.tm.ltm.snatpools.snatpool.load(
-            name=self.want.name,
-            partition=self.want.partition
+    def exists(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/snatpool/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
         )
-        resource.delete()
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError:
+            return False
+        if resp.status == 404 or 'code' in response and response['code'] == 404:
+            return False
+        return True
+
+    def create_on_device(self):
+        params = self.changes.api_params()
+        params['name'] = self.want.name
+        params['partition'] = self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/ltm/snatpool/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port']
+        )
+        resp = self.client.api.post(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return response['selfLink']
+
+    def update_on_device(self):
+        params = self.changes.api_params()
+        uri = "https://{0}:{1}/mgmt/tm/ltm/snatpool/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.patch(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+
+    def remove_from_device(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/snatpool/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        response = self.client.api.delete(uri)
+        if response.status == 200:
+            return True
+        raise F5ModuleError(response.content)
+
+    def read_current_from_device(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/snatpool/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        query = '?expandSubcollections=true'
+        resp = self.client.api.get(uri + query)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return ApiParameters(params=response)
 
 
 class ArgumentSpec(object):
@@ -391,18 +439,17 @@ def main():
         supports_check_mode=spec.supports_check_mode,
         required_if=spec.required_if
     )
-    if not HAS_F5SDK:
-        module.fail_json(msg="The python f5-sdk module is required")
+
+    client = F5RestClient(**module.params)
 
     try:
-        client = F5Client(**module.params)
         mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        module.exit_json(**results)
+        exit_json(module, results, client)
     except F5ModuleError as ex:
         cleanup_tokens(client)
-        module.fail_json(msg=str(ex))
+        fail_json(module, ex, client)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_snmp.py
+++ b/lib/ansible/modules/network/f5/bigip_snmp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017 F5 Networks Inc.
+# Copyright: (c) 2017, F5 Networks Inc.
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -13,6 +13,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'certified'}
 
 DOCUMENTATION = r'''
+---
 module: bigip_snmp
 short_description: Manipulate general SNMP settings on a BIG-IP
 description:
@@ -63,6 +64,7 @@ options:
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
+  - Wojciech Wypior (@wojtek0806)
 '''
 
 EXAMPLES = r'''
@@ -122,33 +124,27 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types
 
 try:
-    from library.module_utils.network.f5.bigip import HAS_F5SDK
-    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
-    from library.module_utils.network.f5.common import is_valid_hostname
     from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.common import transform_name
+    from library.module_utils.network.f5.common import exit_json
+    from library.module_utils.network.f5.common import fail_json
     from library.module_utils.compat.ipaddress import ip_network
-
-    try:
-        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
+    from library.module_utils.network.f5.common import is_valid_hostname
 except ImportError:
-    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
-    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
-    from ansible.module_utils.network.f5.common import is_valid_hostname
     from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.common import transform_name
+    from ansible.module_utils.network.f5.common import exit_json
+    from ansible.module_utils.network.f5.common import fail_json
     from ansible.module_utils.compat.ipaddress import ip_network
-
-    try:
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
+    from ansible.module_utils.network.f5.common import is_valid_hostname
 
 
 class Parameters(AnsibleF5Parameters):
@@ -158,30 +154,34 @@ class Parameters(AnsibleF5Parameters):
         'bigipTraps': 'device_warning_traps',
         'sysLocation': 'location',
         'sysContact': 'contact',
-        'allowedAddresses': 'allowed_addresses'
+        'allowedAddresses': 'allowed_addresses',
     }
 
     updatables = [
-        'agent_status_traps', 'agent_authentication_traps',
-        'device_warning_traps', 'location', 'contact', 'allowed_addresses'
+        'agent_status_traps',
+        'agent_authentication_traps',
+        'device_warning_traps',
+        'location',
+        'contact',
+        'allowed_addresses',
     ]
 
     returnables = [
-        'agent_status_traps', 'agent_authentication_traps',
-        'device_warning_traps', 'location', 'contact', 'allowed_addresses'
+        'agent_status_traps',
+        'agent_authentication_traps',
+        'device_warning_traps',
+        'location', 'contact',
+        'allowed_addresses',
     ]
 
     api_attributes = [
-        'agentTrap', 'authTrap', 'bigipTraps', 'sysLocation', 'sysContact',
-        'allowedAddresses'
+        'agentTrap',
+        'authTrap',
+        'bigipTraps',
+        'sysLocation',
+        'sysContact',
+        'allowedAddresses',
     ]
-
-    def to_return(self):
-        result = {}
-        for returnable in self.returnables:
-            result[returnable] = getattr(self, returnable)
-        result = self._filter_params(result)
-        return result
 
 
 class ApiParameters(Parameters):
@@ -228,7 +228,15 @@ class ModuleParameters(Parameters):
 
 
 class Changes(Parameters):
-    pass
+    def to_return(self):
+        result = {}
+        try:
+            for returnable in self.returnables:
+                result[returnable] = getattr(self, returnable)
+            result = self._filter_params(result)
+        except Exception:
+            pass
+        return result
 
 
 class UsableChanges(Changes):
@@ -305,10 +313,7 @@ class ModuleManager(object):
     def exec_module(self):
         result = dict()
 
-        try:
-            changed = self.update()
-        except iControlUnexpectedHTTPError as e:
-            raise F5ModuleError(str(e))
+        changed = self.update()
 
         reportable = ReportableChanges(params=self.changes.to_return())
         changes = reportable.to_return()
@@ -340,15 +345,41 @@ class ModuleManager(object):
         self.update_on_device()
         return True
 
-    def update_on_device(self):
-        params = self.want.api_params()
-        result = self.client.api.tm.sys.snmp.load()
-        result.modify(**params)
-
     def read_current_from_device(self):
-        resource = self.client.api.tm.sys.snmp.load()
-        result = resource.attrs
-        return ApiParameters(params=result)
+        uri = "https://{0}:{1}/mgmt/tm/sys/snmp/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return ApiParameters(params=response)
+
+    def update_on_device(self):
+        params = self.changes.api_params()
+        uri = "https://{0}:{1}/mgmt/tm/sys/snmp/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+        )
+        resp = self.client.api.patch(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
 
 class ArgumentSpec(object):
@@ -381,18 +412,17 @@ def main():
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode
     )
-    if not HAS_F5SDK:
-        module.fail_json(msg="The python f5-sdk module is required")
+
+    client = F5RestClient(**module.params)
 
     try:
-        client = F5Client(**module.params)
         mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        module.exit_json(**results)
+        exit_json(module, results, client)
     except F5ModuleError as ex:
         cleanup_tokens(client)
-        module.fail_json(msg=str(ex))
+        fail_json(module, ex, client)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/f5/bigip_snmp_community.py
+++ b/lib/ansible/modules/network/f5/bigip_snmp_community.py
@@ -147,6 +147,7 @@ options:
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
+  - Wojciech Wypior (@wojtek0806)
 '''
 
 EXAMPLES = r'''
@@ -157,10 +158,10 @@ EXAMPLES = r'''
     source: all
     oid: .1
     access: ro
-    password: secret
-    server: lb.mydomain.com
-    state: present
-    user: admin
+    provider:
+      password: secret
+      server: lb.mydomain.com
+      user: admin
   delegate_to: localhost
 
 - name: Create an SMNP v3 read-write community
@@ -174,61 +175,98 @@ EXAMPLES = r'''
     snmp_privacy_password: secret
     oid: .1
     access: rw
-    password: secret
-    server: lb.mydomain.com
-    state: present
-    user: admin
+    provider:
+      password: secret
+      server: lb.mydomain.com
+      user: admin
   delegate_to: localhost
 
 - name: Remove the default 'public' SNMP community
   bigip_snmp_community:
     name: public
     source: default
-    password: secret
-    server: lb.mydomain.com
     state: absent
-    user: admin
+    provider:
+      password: secret
+      server: lb.mydomain.com
+      user: admin
   delegate_to: localhost
 '''
 
 RETURN = r'''
-param1:
-  description: The new param1 value of the resource.
-  returned: changed
-  type: bool
-  sample: true
-param2:
-  description: The new param2 value of the resource.
+community:
+  description: The new community value.
   returned: changed
   type: string
-  sample: Foo is bar
+  sample: community1
+oid:
+  description: The new OID value.
+  returned: changed
+  type: string
+  sample: .1
+ip_version:
+  description: The new IP version value.
+  returned: changed
+  type: string
+  sample: .1
+snmp_auth_protocol:
+  description: The new SNMP auth protocol.
+  returned: changed
+  type: string
+  sample: sha
+snmp_privacy_protocol:
+  description: The new SNMP privacy protocol.
+  returned: changed
+  type: string
+  sample: aes
+access:
+  description: The new access level for the MIB.
+  returned: changed
+  type: string
+  sample: ro
+source:
+  description: The new source address to access the MIB.
+  returned: changed
+  type: string
+  sample: 1.1.1.1
+snmp_username:
+  description: The new SNMP username.
+  returned: changed
+  type: string
+  sample: user1
+snmp_auth_password:
+  description: The new password of the given snmp_username.
+  returned: changed
+  type: string
+  sample: secret1
+snmp_privacy_password:
+  description: The new password of the given snmp_username.
+  returned: changed
+  type: string
+  sample: secret2
 '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
 
 try:
-    from library.module_utils.network.f5.bigip import HAS_F5SDK
-    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
-    try:
-        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
+    from library.module_utils.network.f5.common import transform_name
+    from library.module_utils.network.f5.common import exit_json
+    from library.module_utils.network.f5.common import fail_json
 except ImportError:
-    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
-    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    try:
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
+    from ansible.module_utils.network.f5.common import transform_name
+    from ansible.module_utils.network.f5.common import exit_json
+    from ansible.module_utils.network.f5.common import fail_json
 
 
 class Parameters(AnsibleF5Parameters):
@@ -241,23 +279,48 @@ class Parameters(AnsibleF5Parameters):
         'username': 'snmp_username',
         'securityLevel': 'security_level',
         'authPassword': 'snmp_auth_password',
-        'privacyPassword': 'snmp_privacy_password'
+        'privacyPassword': 'snmp_privacy_password',
     }
 
     api_attributes = [
-        'source', 'oidSubset', 'ipv6', 'communityName', 'access', 'authPassword',
-        'authProtocol', 'username', 'securityLevel', 'privacyProtocol', 'privacyPassword'
+        'source',
+        'oidSubset',
+        'ipv6',
+        'communityName',
+        'access',
+        'authPassword',
+        'authProtocol',
+        'username',
+        'securityLevel',
+        'privacyProtocol',
+        'privacyPassword',
     ]
 
     returnables = [
-        'community', 'oid', 'ip_version', 'snmp_auth_protocol', 'snmp_privacy_protocol',
-        'access', 'source', 'snmp_username', 'snmp_auth_password', 'snmp_privacy_password'
+        'community',
+        'oid',
+        'ip_version',
+        'snmp_auth_protocol',
+        'snmp_privacy_protocol',
+        'access',
+        'source',
+        'snmp_username',
+        'snmp_auth_password',
+        'snmp_privacy_password',
     ]
 
     updatables = [
-        'community', 'oid', 'ip_version', 'snmp_auth_protocol', 'snmp_privacy_protocol',
-        'access', 'source', 'snmp_auth_password', 'snmp_privacy_password', 'security_level',
-        'snmp_username'
+        'community',
+        'oid',
+        'ip_version',
+        'snmp_auth_protocol',
+        'snmp_privacy_protocol',
+        'access',
+        'source',
+        'snmp_auth_password',
+        'snmp_privacy_password',
+        'security_level',
+        'snmp_username',
     ]
 
     @property
@@ -499,13 +562,10 @@ class BaseManager(object):
         result = dict()
         state = self.want.state
 
-        try:
-            if state == "present":
-                changed = self.present()
-            elif state == "absent":
-                changed = self.absent()
-        except iControlUnexpectedHTTPError as e:
-            raise F5ModuleError(str(e))
+        if state == "present":
+            changed = self.present()
+        elif state == "absent":
+            changed = self.absent()
 
         reportable = ReportableChanges(params=self.changes.to_return())
         changes = reportable.to_return()
@@ -571,43 +631,87 @@ class V1Manager(BaseManager):
         return True
 
     def exists(self):
-        result = self.client.api.tm.sys.snmp.communities_s.community.exists(
-            name=self.want.name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/snmp/communities/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
         )
-        return result
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError:
+            return False
+        if resp.status == 404 or 'code' in response and response['code'] == 404:
+            return False
+        return True
 
     def create_on_device(self):
         params = self.changes.api_params()
-        self.client.api.tm.sys.snmp.communities_s.community.create(
-            name=self.want.name,
-            partition=self.want.partition,
-            **params
+        params['name'] = self.want.name
+        params['partition'] = self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/snmp/communities/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
         )
+        resp = self.client.api.post(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
     def update_on_device(self):
         params = self.changes.api_params()
-        resource = self.client.api.tm.sys.snmp.communities_s.community.load(
-            name=self.want.name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/snmp/communities/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
         )
-        resource.modify(**params)
+        resp = self.client.api.patch(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
     def remove_from_device(self):
-        resource = self.client.api.tm.sys.snmp.communities_s.community.load(
-            name=self.want.name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/snmp/communities/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
         )
-        if resource:
-            resource.delete()
+        resp = self.client.api.delete(uri)
+        if resp.status == 200:
+            return True
 
     def read_current_from_device(self):
-        resource = self.client.api.tm.sys.snmp.communities_s.community.load(
-            name=self.want.name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/snmp/communities/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
         )
-        result = resource.attrs
-        return ApiParameters(params=result)
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return ApiParameters(params=response)
 
 
 class V2Manager(BaseManager):
@@ -648,43 +752,87 @@ class V2Manager(BaseManager):
         return True
 
     def exists(self):
-        result = self.client.api.tm.sys.snmp.users_s.user.exists(
-            name=self.want.snmp_username,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/snmp/users/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.snmp_username)
         )
-        return result
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError:
+            return False
+        if resp.status == 404 or 'code' in response and response['code'] == 404:
+            return False
+        return True
 
     def create_on_device(self):
         params = self.changes.api_params()
-        self.client.api.tm.sys.snmp.users_s.user.create(
-            name=self.want.snmp_username,
-            partition=self.want.partition,
-            **params
+        params['name'] = self.want.snmp_username
+        params['partition'] = self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/snmp/users/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
         )
+        resp = self.client.api.post(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
     def update_on_device(self):
         params = self.changes.api_params()
-        resource = self.client.api.tm.sys.snmp.users_s.user.load(
-            name=self.want.snmp_username,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/snmp/users/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.snmp_username)
         )
-        resource.modify(**params)
+        resp = self.client.api.patch(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
     def remove_from_device(self):
-        resource = self.client.api.tm.sys.snmp.users_s.user.load(
-            name=self.want.snmp_username,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/snmp/users/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.snmp_username)
         )
-        if resource:
-            resource.delete()
+        resp = self.client.api.delete(uri)
+        if resp.status == 200:
+            return True
 
     def read_current_from_device(self):
-        resource = self.client.api.tm.sys.snmp.users_s.user.load(
-            name=self.want.snmp_username,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/sys/snmp/users/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.snmp_username)
         )
-        result = resource.attrs
-        return ApiParameters(params=result)
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return ApiParameters(params=response)
 
 
 class ArgumentSpec(object):
@@ -743,18 +891,17 @@ def main():
         supports_check_mode=spec.supports_check_mode,
         required_if=spec.required_if
     )
-    if not HAS_F5SDK:
-        module.fail_json(msg="The python f5-sdk module is required")
+
+    client = F5RestClient(**module.params)
 
     try:
-        client = F5Client(**module.params)
         mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        module.exit_json(**results)
+        exit_json(module, results, client)
     except F5ModuleError as ex:
         cleanup_tokens(client)
-        module.fail_json(msg=str(ex))
+        fail_json(module, ex, client)
 
 
 if __name__ == '__main__':

--- a/test/units/modules/network/f5/test_bigip_service_policy.py
+++ b/test/units/modules/network/f5/test_bigip_service_policy.py
@@ -8,39 +8,38 @@ __metaclass__ = type
 
 import os
 import json
-import pytest
 import sys
 
 from nose.plugins.skip import SkipTest
 if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
-from units.compat import unittest
-from units.compat.mock import Mock
-from units.compat.mock import patch
 from ansible.module_utils.basic import AnsibleModule
-
-try:
-    from test.unit import utils
-except ImportError:
-    pass
 
 try:
     from library.modules.bigip_service_policy import ApiParameters
     from library.modules.bigip_service_policy import ModuleParameters
     from library.modules.bigip_service_policy import ModuleManager
     from library.modules.bigip_service_policy import ArgumentSpec
-    from library.module_utils.network.f5.common import F5ModuleError
-    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    from test.unit.modules.utils import set_module_args
+
+    # In Ansible 2.8, Ansible changed import paths.
+    from test.units.compat import unittest
+    from test.units.compat.mock import Mock
+    from test.units.compat.mock import patch
+
+    from test.units.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_service_policy import ApiParameters
         from ansible.modules.network.f5.bigip_service_policy import ModuleParameters
         from ansible.modules.network.f5.bigip_service_policy import ModuleManager
         from ansible.modules.network.f5.bigip_service_policy import ArgumentSpec
-        from ansible.module_utils.network.f5.common import F5ModuleError
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+
+        # Ansible 2.8 imports
+        from units.compat import unittest
+        from units.compat.mock import Mock
+        from units.compat.mock import patch
+
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -97,6 +96,14 @@ class TestManager(unittest.TestCase):
 
     def setUp(self):
         self.spec = ArgumentSpec()
+        try:
+            self.p1 = patch('library.modules.bigip_service_policy.module_provisioned')
+            self.m1 = self.p1.start()
+            self.m1.return_value = True
+        except Exception:
+            self.p1 = patch('ansible.modules.network.f5.bigip_service_policy.module_provisioned')
+            self.m1 = self.p1.start()
+            self.m1.return_value = True
 
     def test_create_selfip(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_smtp.py
+++ b/test/units/modules/network/f5/test_bigip_smtp.py
@@ -8,16 +8,12 @@ __metaclass__ = type
 
 import os
 import json
-import pytest
 import sys
 
 from nose.plugins.skip import SkipTest
 if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
-from units.compat import unittest
-from units.compat.mock import Mock
-from units.compat.mock import patch
 from ansible.module_utils.basic import AnsibleModule
 
 try:
@@ -25,17 +21,25 @@ try:
     from library.modules.bigip_smtp import ModuleParameters
     from library.modules.bigip_smtp import ModuleManager
     from library.modules.bigip_smtp import ArgumentSpec
-    from library.module_utils.network.f5.common import F5ModuleError
-    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    from test.unit.modules.utils import set_module_args
+
+    # In Ansible 2.8, Ansible changed import paths.
+    from test.units.compat import unittest
+    from test.units.compat.mock import Mock
+    from test.units.compat.mock import patch
+
+    from test.units.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_smtp import ApiParameters
         from ansible.modules.network.f5.bigip_smtp import ModuleParameters
         from ansible.modules.network.f5.bigip_smtp import ModuleManager
         from ansible.modules.network.f5.bigip_smtp import ArgumentSpec
-        from ansible.module_utils.network.f5.common import F5ModuleError
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+
+        # Ansible 2.8 imports
+        from units.compat import unittest
+        from units.compat.mock import Mock
+        from units.compat.mock import patch
+
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")

--- a/test/units/modules/network/f5/test_bigip_snat_pool.py
+++ b/test/units/modules/network/f5/test_bigip_snat_pool.py
@@ -14,25 +14,32 @@ from nose.plugins.skip import SkipTest
 if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
-from units.compat import unittest
-from units.compat.mock import Mock
-from units.compat.mock import patch
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    from library.modules.bigip_snat_pool import Parameters
+    from library.modules.bigip_snat_pool import ModuleParameters
+    from library.modules.bigip_snat_pool import ApiParameters
     from library.modules.bigip_snat_pool import ModuleManager
     from library.modules.bigip_snat_pool import ArgumentSpec
-    from library.module_utils.network.f5.common import F5ModuleError
-    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    from test.unit.modules.utils import set_module_args
+
+    # In Ansible 2.8, Ansible changed import paths.
+    from test.units.compat import unittest
+    from test.units.compat.mock import Mock
+    from test.units.compat.mock import patch
+
+    from test.units.modules.utils import set_module_args
 except ImportError:
     try:
-        from ansible.modules.network.f5.bigip_snat_pool import Parameters
+        from ansible.modules.network.f5.bigip_snat_pool import ModuleParameters
+        from ansible.modules.network.f5.bigip_snat_pool import ApiParameters
         from ansible.modules.network.f5.bigip_snat_pool import ModuleManager
         from ansible.modules.network.f5.bigip_snat_pool import ArgumentSpec
-        from ansible.module_utils.network.f5.common import F5ModuleError
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+
+        # Ansible 2.8 imports
+        from units.compat import unittest
+        from units.compat.mock import Mock
+        from units.compat.mock import patch
+
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
@@ -67,7 +74,7 @@ class TestParameters(unittest.TestCase):
             members=['10.10.10.10', '20.20.20.20'],
             partition='Common'
         )
-        p = Parameters(params=args)
+        p = ModuleParameters(params=args)
         assert p.name == 'my-snat-pool'
         assert p.state == 'present'
         assert len(p.members) == 2
@@ -78,10 +85,10 @@ class TestParameters(unittest.TestCase):
         args = dict(
             members=['/Common/10.10.10.10', '/foo/20.20.20.20']
         )
-        p = Parameters(params=args)
+        p = ApiParameters(params=args)
         assert len(p.members) == 2
         assert '/Common/10.10.10.10' in p.members
-        assert '/Common/20.20.20.20' in p.members
+        assert '/foo/20.20.20.20' in p.members
 
 
 class TestManager(unittest.TestCase):
@@ -126,7 +133,7 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(params=load_fixture('load_ltm_snatpool.json'))
+        current = ApiParameters(params=load_fixture('load_ltm_snatpool.json'))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,
@@ -152,7 +159,7 @@ class TestManager(unittest.TestCase):
             user='admin'
         ))
 
-        current = Parameters(params=load_fixture('load_ltm_snatpool.json'))
+        current = ApiParameters(params=load_fixture('load_ltm_snatpool.json'))
 
         module = AnsibleModule(
             argument_spec=self.spec.argument_spec,

--- a/test/units/modules/network/f5/test_bigip_snmp.py
+++ b/test/units/modules/network/f5/test_bigip_snmp.py
@@ -14,9 +14,6 @@ from nose.plugins.skip import SkipTest
 if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
-from units.compat import unittest
-from units.compat.mock import Mock
-from units.compat.mock import patch
 from ansible.module_utils.basic import AnsibleModule
 
 try:
@@ -24,17 +21,25 @@ try:
     from library.modules.bigip_snmp import ModuleParameters
     from library.modules.bigip_snmp import ModuleManager
     from library.modules.bigip_snmp import ArgumentSpec
-    from library.module_utils.network.f5.common import F5ModuleError
-    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    from test.unit.modules.utils import set_module_args
+
+    # In Ansible 2.8, Ansible changed import paths.
+    from test.units.compat import unittest
+    from test.units.compat.mock import Mock
+    from test.units.compat.mock import patch
+
+    from test.units.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_snmp import ApiParameters
         from ansible.modules.network.f5.bigip_snmp import ModuleParameters
         from ansible.modules.network.f5.bigip_snmp import ModuleManager
         from ansible.modules.network.f5.bigip_snmp import ArgumentSpec
-        from ansible.module_utils.network.f5.common import F5ModuleError
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+
+        # Ansible 2.8 imports
+        from units.compat import unittest
+        from units.compat.mock import Mock
+        from units.compat.mock import patch
+
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")

--- a/test/units/modules/network/f5/test_bigip_snmp_community.py
+++ b/test/units/modules/network/f5/test_bigip_snmp_community.py
@@ -15,9 +15,6 @@ from nose.plugins.skip import SkipTest
 if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
-from units.compat import unittest
-from units.compat.mock import Mock
-from units.compat.mock import patch
 from ansible.module_utils.basic import AnsibleModule
 
 try:
@@ -27,9 +24,15 @@ try:
     from library.modules.bigip_snmp_community import V1Manager
     from library.modules.bigip_snmp_community import V2Manager
     from library.modules.bigip_snmp_community import ArgumentSpec
+
     from library.module_utils.network.f5.common import F5ModuleError
-    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    from test.unit.modules.utils import set_module_args
+
+    # In Ansible 2.8, Ansible changed import paths.
+    from test.units.compat import unittest
+    from test.units.compat.mock import Mock
+    from test.units.compat.mock import patch
+
+    from test.units.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_snmp_community import ApiParameters
@@ -38,8 +41,14 @@ except ImportError:
         from ansible.modules.network.f5.bigip_snmp_community import V1Manager
         from ansible.modules.network.f5.bigip_snmp_community import V2Manager
         from ansible.modules.network.f5.bigip_snmp_community import ArgumentSpec
+
         from ansible.module_utils.network.f5.common import F5ModuleError
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+
+        # Ansible 2.8 imports
+        from units.compat import unittest
+        from units.compat.mock import Mock
+        from units.compat.mock import patch
+
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With Ansible 2.7, I could run a UT using
```
python -tt <path to UT file>
```

This fails with 2.8 as units.compat cannot be resolved.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hacking

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8.0.dev0
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
After adding the path in PYTHONPATH, I can

```
source ansible/hacking/env-setup
python -tt <path to UT file>
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```