### PR TITLE
vultr: fix for API returned unexpected empty list

### DIFF
--- a/changelogs/fragments/48036-vultr-fix-empty-list-handling.yaml
+++ b/changelogs/fragments/48036-vultr-fix-empty-list-handling.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vultr - fixed the handling of an inconsistency in the response from
+    Vultr API when it returns an unexpected empty list instead a empty dict.

--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -201,7 +201,7 @@ class Vultr:
             return {}
 
         try:
-            return self.module.from_json(to_text(res))
+            return self.module.from_json(to_native(res)) or {}
         except ValueError as e:
             self.module.fail_json(msg="Could not process response into json: %s" % e)
 

--- a/test/legacy/roles/vultr_server_facts/tasks/main.yml
+++ b/test/legacy/roles/vultr_server_facts/tasks/main.yml
@@ -1,8 +1,23 @@
 # Copyright (c) 2018, Yanis Guenane <yanis+ansible@guenane.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
+- name: setup ensure VM is absent
+  vultr_server:
+    name: "{{ vultr_server_name }}"
+    state: absent
+  register: result
+
+# Servers can only be destroyed 5 min after creation
+- name: wait for 5 min until VM is absent
+  local_action: wait_for
+  when: result is changed
+
 - name: test gather vultr server facts - empty resources
   vultr_server_facts:
+- name: verify test gather vultr server facts - empty resources
+  assert:
+    that:
+    - ansible_facts.vultr_server_facts | count == 0
 
 - name: Create the server
   vultr_server:


### PR DESCRIPTION
##### SUMMARY
Fix for an inconsistency in the API returns. Fixes #47994 

~~~
 $ curl -H 'API-Key: ...' https://api.vultr.com/v1/server/list
~~~

This is what we get from the API if we have instances:
~~~json

{"19913110":{"SUBID":"19913110","os":"CentOS 7 x64","ram":"1024 MB","disk":"Virtual 25 GB","main_ip":"209.250.240.159","vcpu_count":"1","location":"Amsterdam","DCID":"7","default_password":"","date_created":"2018-11-03 05:55:04","pending_charges":"0.00","status":"pending","cost_per_month":"5.00","current_bandwidth_gb":0,"allowed_bandwidth_gb":"1000","netmask_v4":"255.255.254.0","gateway_v4":"209.250.240.1","power_status":"running","server_state":"none","VPSPLANID":"201","v6_main_ip":"","v6_network_size":"","v6_network":"","v6_networks":[],"label":"ansibletest","internal_ip":"","kvm_url":"","auto_backups":"no","tag":"","OSID":"167","APPID":"0","FIREWALLGROUPID":"0"}}%
~~~
This is what we get if there aren't any instances:
~~~json
[]% 
~~~

o_O

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vultr

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
