### PR TITLE
Remove me as pip module maintainer

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -265,7 +265,7 @@ files:
   $modules/packaging/language/npm.py:
     ignored: chrishoffman
     maintainers: shane-walker xcambar
-  $modules/packaging/language/pip.py: lujeni
+  $modules/packaging/language/pip.py: lujeni webknjaz
   $modules/packaging/os/apk.py:
     ignored: kbrebanov
     maintainers: tdtrask

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -265,7 +265,7 @@ files:
   $modules/packaging/language/npm.py:
     ignored: chrishoffman
     maintainers: shane-walker xcambar
-  $modules/packaging/language/pip.py: lujeni robinro
+  $modules/packaging/language/pip.py: lujeni
   $modules/packaging/os/apk.py:
     ignored: kbrebanov
     maintainers: tdtrask


### PR DESCRIPTION
##### SUMMARY
This removes me as pip module maintainer. I currently and in the foreseeable future don't have the time to help maintain this fairly popular module and in the last months changes were merged anyway without waiting for my review.
@Lujeni and @mattupstate are also listed as maintainers, but to my knowledge were not at all active in that role in the last year.

This essentially leaves the pip module without an active maintainer. If someone wants to pick up that role I'd be happy to assist for the start. Feel free to add me to reviews or contact me directly.

@HD650 recently made a sizeable change to the module, not sure about future plans though.  @webknjaz was very active in reviewing these changes and might have opinions about the future of the module as well as the rest of the core team. Thanks for your work!

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
all