### PR TITLE
Add default option to plugin get_option

### DIFF
--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -53,11 +53,11 @@ class AnsiblePlugin(with_metaclass(ABCMeta, object)):
     def __init__(self):
         self._options = {}
 
-    def get_option(self, option, hostvars=None):
+    def get_option(self, option, hostvars=None, default=None):
         if option not in self._options:
             option_value = C.config.get_config_value(option, plugin_type=get_plugin_class(self), plugin_name=self._load_name, variables=hostvars)
             self.set_option(option, option_value)
-        return self._options.get(option)
+        return self._options.get(option, default)
 
     def set_option(self, option, value):
         self._options[option] = value


### PR DESCRIPTION
##### SUMMARY

Add a default option/value to *get_option()* implementation of Ansible plugins (configurations)

This allow us to define a default option when tying to get a value using the native (dictionary) getter.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

lib/ansible/plugins