### PR TITLE
[2.7] ACME: add support for POST-as-GET

### DIFF
--- a/changelogs/fragments/44988-acme-post-as-get.yaml
+++ b/changelogs/fragments/44988-acme-post-as-get.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ACME modules support `POST-as-GET <https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380>`__ and will be able to access Let's Encrypt ACME v2 endpoint after November 1st, 2019."

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -451,7 +451,7 @@ class ACMEDirectory(object):
         self.directory_root = module.params['acme_directory']
         self.version = module.params['acme_version']
 
-        self.directory, dummy = account.get_request(self.directory_root)
+        self.directory, dummy = account.get_request(self.directory_root, get_only=True)
 
         # Check whether self.version matches what we expect
         if self.version == 1:
@@ -534,7 +534,10 @@ class ACMEAccount(object):
 
     def sign_request(self, protected, payload, key_data):
         try:
-            payload64 = nopad_b64(self.module.jsonify(payload).encode('utf8'))
+            if payload is None:
+                payload64 = ''
+            else:
+                payload64 = nopad_b64(self.module.jsonify(payload).encode('utf8'))
             protected64 = nopad_b64(self.module.jsonify(protected).encode('utf8'))
         except Exception as e:
             raise ModuleFailException("Failed to encode payload / headers as JSON: {0}".format(e))
@@ -549,6 +552,9 @@ class ACMEAccount(object):
         Sends a JWS signed HTTP POST request to the ACME server and returns
         the response as dictionary
         https://tools.ietf.org/html/draft-ietf-acme-acme-14#section-6.2
+
+        If payload is None, a POST-as-GET is performed.
+        (https://tools.ietf.org/html/draft-ietf-acme-acme-15#section-6.3)
         '''
         key_data = key_data or self.key_data
         jws_header = jws_header or self.jws_header
@@ -594,14 +600,31 @@ class ACMEAccount(object):
 
             return result, info
 
-    def get_request(self, uri, parse_json_result=True, headers=None):
-        resp, info = fetch_url(self.module, uri, method='GET', headers=headers)
+    def get_request(self, uri, parse_json_result=True, headers=None, get_only=False):
+        '''
+        Perform a GET-like request. Will try POST-as-GET for ACMEv2, with fallback
+        to GET if server replies with a status code of 405.
+        '''
+        if not get_only and self.version != 1:
+            # Try POST-as-GET
+            content, info = self.send_signed_request(uri, None, parse_json_result=False)
+            if info['status'] == 405:
+                # Instead, do unauthenticated GET
+                get_only = True
+        else:
+            # Do unauthenticated GET
+            get_only = True
 
-        try:
-            content = resp.read()
-        except AttributeError:
-            content = info.get('body')
+        if get_only:
+            # Perform unauthenticated GET
+            resp, info = fetch_url(self.module, uri, method='GET', headers=headers)
 
+            try:
+                content = resp.read()
+            except AttributeError:
+                content = info.get('body')
+
+        # Process result
         if parse_json_result:
             result = {}
             if content:
@@ -682,10 +705,19 @@ class ACMEAccount(object):
         '''
         if self.uri is None:
             raise ModuleFailException("Account URI unknown")
-        data = {}
         if self.version == 1:
+            data = {}
             data['resource'] = 'reg'
-        result, info = self.send_signed_request(self.uri, data)
+            result, info = self.send_signed_request(self.uri, data)
+        else:
+            # try POST-as-GET first (draft-15 or newer)
+            data = None
+            result, info = self.send_signed_request(self.uri, data)
+            # check whether that failed with a malformed request error
+            if info['status'] >= 400 and result.get('type') == 'urn:ietf:params:acme:error:malformed':
+                # retry as a regular POST (with no changed data) for pre-draft-15 ACME servers
+                data = {}
+                result, info = self.send_signed_request(self.uri, data)
         if info['status'] in (400, 403) and result.get('type') == 'urn:ietf:params:acme:error:unauthorized':
             # Returned when account is deactivated
             return None

--- a/test/runner/lib/cloud/acme.py
+++ b/test/runner/lib/cloud/acme.py
@@ -43,7 +43,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:1.3.0'
+            self.image = 'quay.io/ansible/acme-test-container:1.4.1'
         self.container_name = ''
 
     def _wait_for_service(self, protocol, acme_host, port, local_part, name):


### PR DESCRIPTION
##### SUMMARY
Backport of #45051 (prequisite for other) and #44988 to stable-2.7: adjusts to changes to the [ACME protocol](https://tools.ietf.org/html/draft-ietf-acme-acme-16) which now mandates authenticated POST-as-GET instead of unauthenticated GET calls. Will be enforced by Let's Encrypt in November 2019 (as of [current plans](https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380)), which means that the current implementation will stop working by then. With this backport, it should still work afterwards.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/acme.py
acme_certificate

##### ANSIBLE VERSION
```
2.7.1
```
