### PR TITLE
ios_facts: Strip header from running-config

### DIFF
--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -282,6 +282,9 @@ class Config(FactsBase):
         super(Config, self).populate()
         data = self.responses[0]
         if data:
+            data = re.sub(
+                r'^Building configuration...\s+Current configuration : \d+ bytes\n',
+                '', data, flags=re.MULTILINE)
             self.facts['config'] = data
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
IOS prepends a show running-config with lines that are not part of the configuration, keeping the output 
from being an entirely valid configuration:
R1#show run
Building configuration...

Current configuration : 2045 bytes
...

In order to be able to use the config from ios_facts as-is, strip this header.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (ios-running 7f3280300a) last updated 2018/11/03 19:51:14 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/paul/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/paul/ansible-dev/ansible/lib/ansible
  executable location = /home/paul/ansible-dev/ansible/bin/ansible
  python version = 3.7.1 (default, Oct 22 2018, 10:41:28) [GCC 8.2.1 20180831]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before
```
ok: [csr-test1] => {
    "ansible_facts": {
        "ansible_net_config": "Building configuration...\n\nCurrent configuration : 2045 bytes\n!\n! Last configuration change
```
after
```
ok: [csr-test1] => {
    "ansible_facts": {
        "ansible_net_config": "!\n! Last configuration change
```
