### PR TITLE
Make the flatpak module work with Python 3.

### DIFF
--- a/lib/ansible/modules/packaging/os/flatpak.py
+++ b/lib/ansible/modules/packaging/os/flatpak.py
@@ -127,6 +127,7 @@ stdout:
 import subprocess
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
 
 
 def install_flat(module, binary, remote, name, method):
@@ -203,7 +204,7 @@ def _flatpak_command(module, noop, command):
     result['stderr'] = stderr_data
     if result['rc'] != 0:
         module.fail_json(msg="Failed to execute flatpak command", **result)
-    return stdout_data
+    return to_native(stdout_data)
 
 
 def main():

--- a/lib/ansible/modules/packaging/os/flatpak_remote.py
+++ b/lib/ansible/modules/packaging/os/flatpak_remote.py
@@ -120,6 +120,7 @@ stdout:
 
 import subprocess
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes, to_native
 
 
 def add_remote(module, binary, name, flatpakrepo_url, method):
@@ -168,7 +169,7 @@ def _flatpak_command(module, noop, command):
     result['stderr'] = stderr_data
     if result['rc'] != 0:
         module.fail_json(msg="Failed to execute flatpak command", **result)
-    return stdout_data
+    return to_native(stdout_data)
 
 
 def main():
@@ -205,7 +206,7 @@ def main():
     if not binary:
         module.fail_json(msg="Executable '%s' was not found on the system." % executable, **result)
 
-    remote_already_exists = remote_exists(module, binary, bytes(name, 'utf-8'), method)
+    remote_already_exists = remote_exists(module, binary, to_bytes(name), method)
 
     if state == 'present' and not remote_already_exists:
         add_remote(module, binary, name, flatpakrepo_url, method)


### PR DESCRIPTION

##### SUMMARY
Uses functions that work in both Python 2 and Python3, i.e. to_bytes and to_text, instead of their Python 2 functions.

Fixes #46994
Fixes #46995

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
flatpak

##### ANSIBLE VERSION
```paste below
ansible 2.7.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/matthias/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.1 (default, Oct 22 2018, 10:41:28) [GCC 8.2.1 20180831]
```
