### PR TITLE
[WIP] Extend ConfigureRemotingForAnsible.ps1 about a possibility to usage an existing certificate

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -13,19 +13,29 @@
 #
 # Use option -CertValidityDays to specify how long this certificate is valid
 # starting from today. So you would specify -CertValidityDays 3650 to get
-# a 10-year valid certificate.
+# (almost) a 10-year valid certificate.
 #
 # Use option -ForceNewSSLCert if the system has been SysPreped and a new
 # SSL Certificate must be forced on the WinRM Listener when re-running this
 # script. This is necessary when a new SID and CN name is created.
+#
+# Use option -UseExistingCert to use an existing computer certificate.
+# A certificate SubjectName and AlternativeSubjectNames are matched
+# and validity period checked too. The option has a precedence before
+# CreateSelfSignedCert - if the correct certificate will be found a new
+# self-signed certificate will not be created.
+#
+# Use option -RequiredIssuerCN in conjuction with the option -UseExistingCert
+# to use only certificate from a specific CA, e.g. from a CA integrated
+# with an Active Directory domain.
 #
 # Use option -EnableCredSSP to enable CredSSP as an authentication option.
 #
 # Use option -DisableBasicAuth to disable basic authentication.
 #
 # Use option -SkipNetworkProfileCheck to skip the network profile check.
-# Without specifying this the script will only run if the device's interfaces
-# are in DOMAIN or PRIVATE zones.  Provide this switch if you want to enable
+# Without specifying this the script will only run If the device's interfaces
+# are in DOMAIN or PRIVATE zones.  Provide this switch If you want to enable
 # WinRM on a device with an interface in PUBLIC zone.
 #
 # Use option -SubjectName to specify the CN name of the certificate. This
@@ -40,17 +50,19 @@
 # Updated by Jordan Borean <jborean93@gmail.com>
 # Updated by Erwan Quélin <erwan.quelin@gmail.com>
 # Updated by David Norman <david@dkn.email>
+# Updated by Wojciech Sciesinski <wojciech[at]sciesinski[dot]net>
 #
-# Version 1.0 - 2014-07-06
-# Version 1.1 - 2014-11-11
-# Version 1.2 - 2015-05-15
-# Version 1.3 - 2016-04-04
-# Version 1.4 - 2017-01-05
-# Version 1.5 - 2017-02-09
-# Version 1.6 - 2017-04-18
-# Version 1.7 - 2017-11-23
-# Version 1.8 - 2018-02-23
-# Version 1.9 - 2018-09-21
+# Version 1.0  - 2014-07-06
+# Version 1.1  - 2014-11-11
+# Version 1.2  - 2015-05-15
+# Version 1.3  - 2016-04-04
+# Version 1.4  - 2017-01-05
+# Version 1.5  - 2017-02-09
+# Version 1.6  - 2017-04-18
+# Version 1.7  - 2017-11-23
+# Version 1.8  - 2018-02-23
+# Version 1.9  - 2018-09-21
+# Version 1.10 - 2018-11-03
 
 # Support -Verbose option
 [CmdletBinding()]
@@ -58,9 +70,11 @@
 Param (
     [string]$SubjectName = $env:COMPUTERNAME,
     [int]$CertValidityDays = 1095,
-    [switch]$SkipNetworkProfileCheck,
     $CreateSelfSignedCert = $true,
     [switch]$ForceNewSSLCert,
+    [switch]$UseExistingCert,
+    [string]$RequiredIssuerCN,
+    [bool]$SkipNetworkProfileCheck,
     [switch]$GlobalHttpFirewallAccess,
     [switch]$DisableBasicAuth = $false,
     [switch]$EnableCredSSP
@@ -82,7 +96,7 @@ Function Write-VerboseLog
 Function Write-HostLog
 {
     $Message = $args[0]
-    Write-Output $Message
+    $Message | Out-Host
     Write-Log $Message
 }
 
@@ -93,7 +107,7 @@ Function New-LegacySelfSignedCert
         [int]$ValidDays = 1095
     )
 
-    $hostnonFQDN = $env:computerName 
+    $hostnonFQDN = $env:computerName
     $hostFQDN = [System.Net.Dns]::GetHostByName(($env:computerName)).Hostname
     $SignatureAlgorithm = "SHA256"
 
@@ -170,19 +184,23 @@ Function Enable-GlobalHttpFirewallAccess
 
     # try to find/enable the default rule first
     $add_rule = $false
-    $matching_rules = $fw.Rules | ? { $_.Name -eq "Windows Remote Management (HTTP-In)" }
+    $matching_rules = $fw.Rules | Where-Object { $_.Name -eq "Windows Remote Management (HTTP-In)" }
     $rule = $null
-    If ($matching_rules) {
-        If ($matching_rules -isnot [Array]) {
+    If ($matching_rules)
+    {
+        If ($matching_rules -isnot [Array])
+        {
             Write-Verbose "Editing existing single HTTP firewall rule"
             $rule = $matching_rules
         }
-        Else {
+        Else
+        {
             # try to find one with the All or Public profile first
             Write-Verbose "Found multiple existing HTTP firewall rules..."
-            $rule = $matching_rules | % { $_.Profiles -band 4 }[0]
+            $rule = $matching_rules | ForEach-Object { $_.Profiles -band 4 }[0]
 
-            If (-not $rule -or $rule -is [Array]) {
+            If (-not $rule -or $rule -is [Array])
+            {
                 Write-Verbose "Editing an arbitrary single HTTP firewall rule (multiple existed)"
                 # oh well, just pick the first one
                 $rule = $matching_rules[0]
@@ -190,7 +208,8 @@ Function Enable-GlobalHttpFirewallAccess
         }
     }
 
-    If (-not $rule) {
+    If (-not $rule)
+    {
         Write-Verbose "Creating a new HTTP firewall rule"
         $rule = New-Object -ComObject HNetCfg.FWRule
         $rule.Name = "Windows Remote Management (HTTP-In)"
@@ -209,12 +228,158 @@ Function Enable-GlobalHttpFirewallAccess
     $rule.Action = 1
     $rule.Grouping = "Windows Remote Management"
 
-    If ($add_rule) {
+    If ($add_rule)
+    {
         $fw.Rules.Add($rule)
     }
 
     Write-Verbose "HTTP firewall rule $($rule.Name) updated"
 }
+
+Function Get-ExistingCert {
+
+    Param (
+        [string]$SubjectName,
+        [string]$RequiredIssuerCN
+    )
+
+    [Bool]$ExistsCorrectCert = $false
+
+    Try
+    {
+        $SubjectNameFQDN = [System.Net.Dns]::GetHostByName(($SubjectName)).Hostname
+    }
+    Catch {
+        $SubjectNameFQDN = $null
+    }
+
+    $ExistingCerts = $(Get-ChildItem -Path Cert:\LocalMachine\My\ | Where-Object -FilterScript  { $_.HasPrivateKey } | Sort-Object -Property NotAfter -Descending)
+    $ExistingCertsCount = $( $ExistingCerts | Measure-Object).Count
+
+    Write-Verbose "At the host found $ExistingCertsCount existing certificates."
+
+    ForEach ( $ExistingCert in $ExistingCerts )
+    {
+        Write-Verbose "Checking the certificate: $($ExistingCert.Thumbprint)"
+
+        # The certificate with the longest validity period will be prefered
+        If ( $ExistsCorrectCert )
+        {
+            Break
+        }
+
+        # Check time-validity of a certificate
+        If ( $ExistingCert.NotBefore -lt $Now -or $ExistingCert -gt $Now )
+        {
+            # Check if a certificate has 'X509v3 Enhanced Key Usage: Server Authentication'
+            $EnhancedKeyUsages = $ExistingCert | Select-Object -ExpandProperty Extensions |  Where-Object { $_.ToString() -eq 'System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension' }
+            $EnhancedKeyUsagesCount =  ($EnhancedKeyUsages | Measure-Object).Count
+
+            If ( $EnhancedKeyUsagesCount -gt 0 )
+            {
+                $EnhancedKeyUsagesDetails = $($EnhancedKeyUsages | Select-object -ExpandProperty EnhancedKeyUsages)
+                $ServerAuthenticationUsageFound = $($($EnhancedKeyUsagesDetails | Where-Object { ($_.Value).ToString() -eq '1.3.6.1.5.5.7.3.1' } | Measure-Object).Count -gt 0)
+
+                If ( $ServerAuthenticationUsageFound )
+                {
+                    # Required SubjectName will be checked also in the AlternativeNames
+                    [String[]]$ExistingCertDNSNames = $($ExistingCert | select-Object -Property DnsNameList).dnsnamelist.unicode
+
+                    If ( $ExistingCertDNSNames -contains $SubjectName -or
+                        ($ExistingCertDNSNames -contains $SubjectNameFQDN -and
+                        $null -ne $SubjectNameFQDN) -or
+                        $ExistingCert.Subject -eq "CN=$SubjectName" -or
+                        ( $ExistingCert.Subject -eq "CN=$SubjectNameFQDN" -and
+                        $null -ne $SubjectNameFQDN) )
+                    {
+                        If ( -not( [String]::IsNullOrEmpty($RequiredIssuerCN)) )
+                        {
+                            If ( $($ExistingCert.Issuer).contains(',') )
+                            {
+                                $IssuerCN = $ExistingCert.issuer.Substring(0,$ExistingCert.issuer.IndexOf(','))
+                            }
+                            Else
+                            {
+                                $IssuerCN = $ExistingCert.issuer
+                            }
+
+                            # Replacement of double CN= because user can provide that in the parameter or not
+                            $RequiredIssuerCN = $("CN=$RequiredIssuerCN" -ireplace [regex]::Escape("CN=CN="), 'CN=')
+                            If ( $RequiredIssuerCN -eq $IssuerCN )
+                            {
+                                $UseThumbprint = $ExistingCert.Thumbprint
+                                $ExistsCorrectCert = $true
+                            }
+                            else {
+                                Write-Verbose "The certificate $($ExistingCert.Thumbprint) will not be used - issuer doesn't match."
+                            }
+                        }
+                        Else
+                        {
+                            $UseThumbprint = $ExistingCert.Thumbprint
+                            $ExistsCorrectCert = $true
+                        }
+                    }
+                    else {
+                        Write-Verbose "The certificate $($ExistingCert.Thumbprint) will not be used - name doesn't match."
+                    }
+                }
+            }
+            Else {
+                Write-Verbose "The certificate $($ExistingCert.Thumbprint) will not be used - x509v3 extention validity."
+            }
+        }
+        Else
+        {
+            Write-Verbose "The certificate $($ExistingCert.Thumbprint) will not be used - time validity."
+        }
+    }
+
+    If ( $ExistsCorrectCert )
+    {
+        $Result = New-Object -TypeName psobject -Property @{'Thumbprint' = $UseThumbprint}
+    }
+    Else
+    {
+        $Result = New-Object -TypeName psobject -Property @{'Thumbprint' = $null}
+    }
+
+    $Result
+}
+
+Function Get-CertificateToUse {
+
+    Param (
+        [string]$SubjectName,
+        [int]$CertValidityDays = 1095,
+        [switch]$UseExistingCert,
+        [string]$RequiredIssuerCN
+    )
+
+    [bool]$GenerateSelfSignedCert = $true
+
+    If ( $UseExistingCert )
+    {
+        $ExistingCert = Get-ExistingCert -SubjectName $SubjectName -RequiredIssuerCN $RequiredIssuerCN
+
+        If ( $null -ne $ExistingCert.Thumbprint )
+        {
+            $thumbprint = $ExistingCert.Thumbprint
+            Write-Verbose "Existing certificate will be used; thumbprint: $thumbprint"
+            [bool]$GenerateSelfSignedCert = $false
+        }
+    }
+
+    If ( $GenerateSelfSignedCert )
+    {
+        # We cannot use New-SelfSignedCertificate on 2012R2 and earlier
+        $thumbprint = New-LegacySelfSignedCert -SubjectName $SubjectName -ValidDays $CertValidityDays
+        Write-Verbose "Self-signed SSL certificate generated; thumbprint: $thumbprint"
+    }
+
+    $thumbprint
+}
+
 
 # Setup error handling.
 Trap
@@ -232,7 +397,7 @@ $myWindowsPrincipal=new-object System.Security.Principal.WindowsPrincipal($myWin
 $adminRole=[System.Security.Principal.WindowsBuiltInRole]::Administrator
 
 # Check to see if we are currently running "as Administrator"
-if (-Not $myWindowsPrincipal.IsInRole($adminRole))
+If (-Not $myWindowsPrincipal.IsInRole($adminRole))
 {
     Write-Output "ERROR: You need elevated Administrator privileges in order to run this script."
     Write-Output "       Start Windows PowerShell by using the Run as Administrator option."
@@ -259,7 +424,7 @@ If ($PSVersionTable.PSVersion.Major -lt 3)
 
 # Find and start the WinRM service.
 Write-Verbose "Verifying WinRM service."
-If (!(Get-Service "WinRM"))
+If (-not (Get-Service "WinRM"))
 {
     Write-Log "Unable to find the WinRM service."
     Throw "Unable to find the WinRM service."
@@ -272,18 +437,19 @@ ElseIf ((Get-Service "WinRM").Status -ne "Running")
     Write-Verbose "Starting WinRM service."
     Start-Service -Name "WinRM" -ErrorAction Stop
     Write-Log "Started WinRM service."
-
 }
 
 # WinRM should be running; check that we have a PS session config.
-If (!(Get-PSSessionConfiguration -Verbose:$false) -or (!(Get-ChildItem WSMan:\localhost\Listener)))
+If (-not (Get-PSSessionConfiguration -Verbose:$false) -or (-not (Get-ChildItem WSMan:\localhost\Listener)))
 {
-  If ($SkipNetworkProfileCheck) {
+  If ($SkipNetworkProfileCheck)
+  {
     Write-Verbose "Enabling PS Remoting without checking Network profile."
     Enable-PSRemoting -SkipNetworkProfileCheck -Force -ErrorAction Stop
     Write-Log "Enabled PS Remoting without checking Network profile."
   }
-  Else {
+  Else
+  {
     Write-Verbose "Enabling PS Remoting."
     Enable-PSRemoting -Force -ErrorAction Stop
     Write-Log "Enabled PS Remoting."
@@ -300,9 +466,11 @@ $token_path = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
 $token_prop_name = "LocalAccountTokenFilterPolicy"
 $token_key = Get-Item -Path $token_path
 $token_value = $token_key.GetValue($token_prop_name, $null)
-if ($token_value -ne 1) {
+If ($token_value -ne 1)
+{
     Write-Verbose "Setting LocalAccountTOkenFilterPolicy to 1"
-    if ($null -ne $token_value) {
+    If ($null -ne $token_value)
+    {
         Remove-ItemProperty -Path $token_path -Name $token_prop_name
     }
     New-ItemProperty -Path $token_path -Name $token_prop_name -Value 1 -PropertyType DWORD > $null
@@ -310,11 +478,17 @@ if ($token_value -ne 1) {
 
 # Make sure there is a SSL listener.
 $listeners = Get-ChildItem WSMan:\localhost\Listener
-If (!($listeners | Where {$_.Keys -like "TRANSPORT=HTTPS"}))
+If (-not ($listeners | Where-Object {$_.Keys -like "TRANSPORT=HTTPS"}))
 {
-    # We cannot use New-SelfSignedCertificate on 2012R2 and earlier
-    $thumbprint = New-LegacySelfSignedCert -SubjectName $SubjectName -ValidDays $CertValidityDays
-    Write-HostLog "Self-signed SSL certificate generated; thumbprint: $thumbprint"
+
+    $certSelectParams = @{
+        'SubjectName' = $SubjectName
+        'CertValidityDays' = $CertValidityDays
+        'UseExistingCert' = $UseExistingCert
+        'RequiredIssuerCN' = $RequiredIssuerCN
+    }
+
+    $thumbprint = Get-CertificateToUse @certSelectParams -Verbose:$([bool](Write-Verbose ([String]::Empty) 4>&1))
 
     # Create the hashtables of settings to be used.
     $valueset = @{
@@ -327,21 +501,25 @@ If (!($listeners | Where {$_.Keys -like "TRANSPORT=HTTPS"}))
         Address = "*"
     }
 
-    Write-Verbose "Enabling SSL listener."
-    New-WSManInstance -ResourceURI 'winrm/config/Listener' -SelectorSet $selectorset -ValueSet $valueset
-    Write-Log "Enabled SSL listener."
+    Write-Verbose "Enabling SSL listener with the certificate identified by thumbprint: $thumbprint."
+    New-WSManInstance -ResourceURI 'winrm/config/Listener' -SelectorSet $selectorset -ValueSet $valueset | Out-Null
+    Write-Log "Enabled SSL listener with the certificate identified by thumbprint: $thumbprint."
 }
 Else
 {
     Write-Verbose "SSL listener is already active."
 
-    # Force a new SSL cert on Listener if the $ForceNewSSLCert
+    # Force a new SSL cert on Listener If the $ForceNewSSLCert
     If ($ForceNewSSLCert)
     {
+        $certSelectParams = @{
+            'SubjectName' = $SubjectName
+            'CertValidityDays' = $CertValidityDays
+            'UseExistingCert' = $UseExistingCert
+            'RequiredIssuerCN' = $RequiredIssuerCN
+        }
 
-        # We cannot use New-SelfSignedCertificate on 2012R2 and earlier
-        $thumbprint = New-LegacySelfSignedCert -SubjectName $SubjectName -ValidDays $CertValidityDays
-        Write-HostLog "Self-signed SSL certificate generated; thumbprint: $thumbprint"
+        $thumbprint = Get-CertificateToUse @certSelectParams -Verbose:$([bool](Write-Verbose ([String]::Empty) 4>&1))
 
         $valueset = @{
             CertificateThumbprint = $thumbprint
@@ -355,17 +533,19 @@ Else
         }
         Remove-WSManInstance -ResourceURI 'winrm/config/Listener' -SelectorSet $selectorset
 
+        Write-Verbose "Recreating SSL listener with the certificate identified by thumbprint: $thumbprint."
         # Add new Listener with new SSL cert
-        New-WSManInstance -ResourceURI 'winrm/config/Listener' -SelectorSet $selectorset -ValueSet $valueset
+        New-WSManInstance -ResourceURI 'winrm/config/Listener' -SelectorSet $selectorset -ValueSet $valueset | Out-Null
+        Write-Log "Recreated SSL listener with the certificate identified by thumbprint: $thumbprint."
     }
 }
 
 # Check for basic authentication.
 $basicAuthSetting = Get-ChildItem WSMan:\localhost\Service\Auth | Where-Object {$_.Name -eq "Basic"}
 
-If ($DisableBasicAuth) 
+If ($DisableBasicAuth)
 {
-    If (($basicAuthSetting.Value) -eq $true) 
+    If (($basicAuthSetting.Value) -eq $true)
     {
         Write-Verbose "Disabling basic auth support."
         Set-Item -Path "WSMan:\localhost\Service\Auth\Basic" -Value $false
@@ -375,8 +555,8 @@ If ($DisableBasicAuth)
     {
         Write-Verbose "Basic auth is already disabled."
     }
-} 
-Else 
+}
+Else
 {
     If (($basicAuthSetting.Value) -eq $false)
     {
@@ -394,7 +574,7 @@ Else
 If ($EnableCredSSP)
 {
     # Check for CredSSP authentication
-    $credsspAuthSetting = Get-ChildItem WSMan:\localhost\Service\Auth | Where {$_.Name -eq "CredSSP"}
+    $credsspAuthSetting = Get-ChildItem WSMan:\localhost\Service\Auth | Where-Object {$_.Name -eq "CredSSP"}
     If (($credsspAuthSetting.Value) -eq $false)
     {
         Write-Verbose "Enabling CredSSP auth support."
@@ -403,7 +583,8 @@ If ($EnableCredSSP)
     }
 }
 
-If ($GlobalHttpFirewallAccess) {
+If ($GlobalHttpFirewallAccess)
+{
     Enable-GlobalHttpFirewallAccess
 }
 
@@ -413,13 +594,13 @@ $fwtest2 = netsh advfirewall firewall show rule name="Allow WinRM HTTPS" profile
 If ($fwtest1.count -lt 5)
 {
     Write-Verbose "Adding firewall rule to allow WinRM HTTPS."
-    netsh advfirewall firewall add rule profile=any name="Allow WinRM HTTPS" dir=in localport=5986 protocol=TCP action=allow
+    netsh advfirewall firewall add rule profile=any name="Allow WinRM HTTPS" dir=in localport=5986 protocol=TCP action=allow  | Out-Null
     Write-Log "Added firewall rule to allow WinRM HTTPS."
 }
 ElseIf (($fwtest1.count -ge 5) -and ($fwtest2.count -lt 5))
 {
     Write-Verbose "Updating firewall rule to allow WinRM HTTPS for any profile."
-    netsh advfirewall firewall set rule name="Allow WinRM HTTPS" new profile=any
+    netsh advfirewall firewall set rule name="Allow WinRM HTTPS" new profile=any  | Out-Null
     Write-Log "Updated firewall rule to allow WinRM HTTPS for any profile."
 }
 Else
@@ -428,20 +609,21 @@ Else
 }
 
 # Test a remoting connection to localhost, which should work.
-$httpResult = Invoke-Command -ComputerName "localhost" -ScriptBlock {$env:COMPUTERNAME} -ErrorVariable httpError -ErrorAction SilentlyContinue
-$httpsOptions = New-PSSessionOption -SkipCACheck -SkipCNCheck -SkipRevocationCheck
+$httpResult = Invoke-Command -ComputerName "$env:computername" -ScriptBlock {$env:COMPUTERNAME} -ErrorVariable httpError -ErrorAction SilentlyContinue
 
-$httpsResult = New-PSSession -UseSSL -ComputerName "localhost" -SessionOption $httpsOptions -ErrorVariable httpsError -ErrorAction SilentlyContinue
+$httpsOptions = New-PSSessionOption -SkipCACheck -SkipCNCheck -SkipRevocationCheck
+$httpsResult = New-PSSession -UseSSL -ComputerName "$env:computername" -SessionOption $httpsOptions -ErrorVariable httpsError -ErrorAction SilentlyContinue
+Remove-PSSession -Id $httpsResult.Id -ErrorAction Ignore
 
 If ($httpResult -and $httpsResult)
 {
     Write-Verbose "HTTP: Enabled | HTTPS: Enabled"
 }
-ElseIf ($httpsResult -and !$httpResult)
+ElseIf ($httpsResult -and (-not $httpResult))
 {
     Write-Verbose "HTTP: Disabled | HTTPS: Enabled"
 }
-ElseIf ($httpResult -and !$httpsResult)
+ElseIf ($httpResult -and (-not $httpsResult))
 {
     Write-Verbose "HTTP: Enabled | HTTPS: Disabled"
 }

--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -34,8 +34,8 @@
 # Use option -DisableBasicAuth to disable basic authentication.
 #
 # Use option -SkipNetworkProfileCheck to skip the network profile check.
-# Without specifying this the script will only run If the device's interfaces
-# are in DOMAIN or PRIVATE zones.  Provide this switch If you want to enable
+# Without specifying this the script will only run if the device's interfaces
+# are in DOMAIN or PRIVATE zones.  Provide this switch if you want to enable
 # WinRM on a device with an interface in PUBLIC zone.
 #
 # Use option -SubjectName to specify the CN name of the certificate. This
@@ -380,7 +380,6 @@ Function Get-CertificateToUse {
     $thumbprint
 }
 
-
 # Setup error handling.
 Trap
 {
@@ -509,7 +508,7 @@ Else
 {
     Write-Verbose "SSL listener is already active."
 
-    # Force a new SSL cert on Listener If the $ForceNewSSLCert
+    # Force a new SSL cert on Listener if the $ForceNewSSLCert
     If ($ForceNewSSLCert)
     {
         $certSelectParams = @{

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -1,4 +1,3 @@
-examples/scripts/ConfigureRemotingForAnsible.ps1 PSAvoidUsingCmdletAliases
 examples/scripts/upgrade_to_ps3.ps1 PSAvoidUsingWriteHost
 examples/scripts/upgrade_to_ps3.ps1 PSUseApprovedVerbs
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.ArgvParser.psm1 PSUseApprovedVerbs


### PR DESCRIPTION
##### SUMMARY
The tool ConfigureRemotingForAnsible.ps1 now can use existing at the host certificate to configure WinRM HTTPS listener, not every time self-signed certificate is generated.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
example for configuring Windows-based managed hosts

##### ADDITIONAL INFORMATION
In some cases - like for domain-joined hosts a host certificate is issued and can be used to configure WinRM https listener.

A certificate will be used when all circumstances will be met
- the parameter 'UseExistingCert' will be used
- a certificate will be valid in time of the script executing
- a certificate will have an extension 'server authentication'
- a name in a certificate (SubjectName or Alternative Subject Name are checked) will be correct

Additionally, an issuer (Certificates Authority) of the certificate can be checked - by using the parameter 'RequiredIssuerCN'.

Additionally, I've cleaned the code - by changing aliases to the full cmdlets names and unification of usage brackets style.