### PR TITLE
Update env-setup

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -46,7 +46,7 @@ fi
 FULL_PATH=$($PYTHON_BIN -c "import os; print(os.path.realpath('$HACKING_DIR'))")
 export ANSIBLE_HOME="$(dirname "$FULL_PATH")"
 
-PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib"
+PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib:$ANSIBLE_HOME/test"
 PREFIX_PATH="$ANSIBLE_HOME/bin"
 PREFIX_MANPATH="$ANSIBLE_HOME/docs/man"
 

--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -4,7 +4,7 @@
 set HACKING_DIR (dirname (status -f))
 set FULL_PATH (python -c "import os; print(os.path.realpath('$HACKING_DIR'))")
 set ANSIBLE_HOME (dirname $FULL_PATH)
-set PREFIX_PYTHONPATH $ANSIBLE_HOME/lib
+set PREFIX_PYTHONPATH $ANSIBLE_HOME/lib:$ANSIBLE_HOME/test
 set PREFIX_PATH $ANSIBLE_HOME/bin
 set PREFIX_MANPATH $ANSIBLE_HOME/docs/man
 


### PR DESCRIPTION
Make it easier to run UTs locally, and to resolve units.compat.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With Ansible 2.7, I could run Unit Tests locally using:
```
python -tt <path_to_ut_file>
```
With Ansible 2.8, this fails because units.compat cannot be resolved.
```
Traceback (most recent call last):
  File "ansible/test/units/modules/storage/netapp/test_na_ontap_flexcache.py", line 12, in <module>
    from units.compat import unittest
ModuleNotFoundError: No module named 'units'
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hacking

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8.0.dev0
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
source source ansible/hacking/env-setup
python -tt <path_to_ut_file>

(ansible28) launicolas (feature/DEVOPS-1024-private-set-up-my-own-vsim-using *) ansible-playbooks $ python -tt ansible/test/units/modules/storage/netapp/test_na_ontap_flexcache.py 
Create: AnsibleExitJson({'changed': True},)
.b'<xml><attributes-list><flexcache-info><vserver/><origin-vserver>ovserver</origin-vserver><origin-volume>ovolume</origin-volume><origin-cluster>ocluster</origin-cluster><volume>volume</volume></flexcache-info></attributes-list><num-records>1</num-records></xml>'
b'<xml><attributes-list><flexcache-info><vserver/><origin-vserver>ovserver</origin-vserver><origin-volume>ovolume</origin-volume><origin-cluster>ocluster</origin-cluster><volume>volume</volume></flexcache-info></attributes-list><num-records>1</num-records></xml>'
Create: AnsibleExitJson({'changed': False},)
.b'<xml><attributes-list><flexcache-info><vserver>flex</vserver><origin-vserver>ovserver</origin-vserver><origin-volume>ovolume</origin-volume><origin-cluster>ocluster</origin-cluster><volume>volume</volume></flexcache-info></attributes-list><num-records>1</num-records></xml>'
b'<xml><attributes-list><flexcache-info><vserver>flex</vserver><origin-vserver>ovserver</origin-vserver><origin-volume>ovolume</origin-volume><origin-cluster>ocluster</origin-cluster><volume>volume</volume></flexcache-info></attributes-list><num-records>1</num-records></xml>'
b'<xml><attributes-list><flexcache-info><vserver>flex</vserver><origin-vserver>ovserver</origin-vserver><origin-volume>ovolume</origin-volume><origin-cluster>ocluster</origin-cluster><volume>volume</volume></flexcache-info></attributes-list><num-records>1</num-records></xml>'
Delete: AnsibleExitJson({'changed': True},)
.Delete: AnsibleExitJson({'changed': False},)
.b'<xml><attributes-list><flexcache-info><vserver/><origin-vserver>ovserver</origin-vserver><origin-volume>ovolume</origin-volume><origin-cluster>ocluster</origin-cluster><volume>volume</volume></flexcache-info></attributes-list><num-records>1</num-records></xml>'
info: {'origin_cluster': 'ocluster', 'origin_volume': 'ovolume', 'origin_vserver': 'ovserver', 'size': None, 'volume': 'volume', 'vserver': None}
.b'<xml><attributes-list><flexcache-info><vserver>repeats</vserver><origin-vserver>ovserver</origin-vserver><origin-volume>ovolume</origin-volume><origin-cluster>ocluster</origin-cluster><volume>volume</volume></flexcache-info><flexcache-info><vserver>repeats</vserver><origin-vserver>ovserver</origin-vserver><origin-volume>ovolume</origin-volume><origin-cluster>ocluster</origin-cluster><volume>volume</volume></flexcache-info></attributes-list><num-records>2</num-records></xml>'
...Info: missing required arguments: hostname, username, password, volume, vserver
.
----------------------------------------------------------------------
Ran 9 tests in 0.015s

OK

```
```