### PR TITLE
[2.7] vultr: fix for API returned unexpected empty list

### DIFF
--- a/changelogs/fragments/48036-vultr-fix-empty-list-handling.yaml
+++ b/changelogs/fragments/48036-vultr-fix-empty-list-handling.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vultr - fixed the handling of an inconsistency in the response from
+    Vultr API when it returns an unexpected empty list instead a empty dict.

--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -201,7 +201,7 @@ class Vultr:
             return {}
 
         try:
-            return self.module.from_json(to_text(res))
+            return self.module.from_json(to_native(res)) or {}
         except ValueError as e:
             self.module.fail_json(msg="Could not process response into json: %s" % e)
 

--- a/test/legacy/roles/vultr_server_facts/tasks/main.yml
+++ b/test/legacy/roles/vultr_server_facts/tasks/main.yml
@@ -1,8 +1,23 @@
 # Copyright (c) 2018, Yanis Guenane <yanis+ansible@guenane.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
+- name: setup ensure VM is absent
+  vultr_server:
+    name: "{{ vultr_server_name }}"
+    state: absent
+  register: result
+
+# Servers can only be destroyed 5 min after creation
+- name: wait for 5 min until VM is absent
+  local_action: wait_for
+  when: result is changed
+
 - name: test gather vultr server facts - empty resources
   vultr_server_facts:
+- name: verify test gather vultr server facts - empty resources
+  assert:
+    that:
+    - ansible_facts.vultr_server_facts | count == 0
 
 - name: Create the server
   vultr_server:


### PR DESCRIPTION
(cherry picked from commit 788247583b9bdfaf24984a207e8495bb402c790c)

##### SUMMARY
backport of #48036

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vultr

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
