### PR TITLE
docker_container: improve paused tests

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2239,6 +2239,7 @@ class ContainerManager(DockerBaseClass):
                         self.fail("Error %s container %s: %s" % (
                             "pausing" if self.parameters.paused else "unpausing", container.Id, str(exc)
                         ))
+                    container = self._get_container(container.Id)
                 self.results['changed'] = True
                 self.results['actions'].append(dict(set_paused=self.parameters.paused))
 

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -2508,24 +2508,21 @@
 - name: paused
   docker_container:
     image: alpine:3.8
-    command: "/bin/sh -c 'sleep 1s ; yes'"
+    command: "/bin/sh -c 'sleep 10m'"
     name: "{{ cname }}"
     state: started
     paused: yes
     stop_timeout: 1
   register: paused_1
 
-- pause:
-    seconds: 2
-
-- name: paused (logs)
-  command: docker logs --tail=20 "{{ cname }}"
+- name: inspect paused
+  command: "docker inspect -f {% raw %}'{{.State.Status}} {{.State.Paused}}'{% endraw %} {{ cname }}"
   register: paused_2
 
 - name: paused (idempotent)
   docker_container:
     image: alpine:3.8
-    command: "/bin/sh -c 'sleep 1s ; yes'"
+    command: "/bin/sh -c 'sleep 10m'"
     name: "{{ cname }}"
     state: started
     paused: yes
@@ -2542,17 +2539,8 @@
     stop_timeout: 1
   register: paused_4
 
-- pause:
-    seconds: 2
-
-- name: paused (stop)
-  docker_container:
-    name: "{{ cname }}"
-    state: stopped
-    stop_timeout: 1
-
-- name: paused (logs)
-  command: docker logs --tail=20 "{{ cname }}"
+- name: inspect paused
+  command: "docker inspect -f {% raw %}'{{.State.Status}} {{.State.Paused}}'{% endraw %} {{ cname }}"
   register: paused_5
 
 - name: cleanup
@@ -2564,10 +2552,10 @@
 - assert:
     that:
     - paused_1 is changed
-    - paused_2.stdout_lines | length == 0
+    - 'paused_2.stdout == "paused true"'
     - paused_3 is not changed
     - paused_4 is changed
-    - paused_5.stdout_lines | length > 0
+    - 'paused_5.stdout == "running false"'
 
 ####################################################################
 ## pid_mode ########################################################


### PR DESCRIPTION
##### SUMMARY
This improves the `paused` tests to avoid spurious test fails ([example](https://app.shippable.com/github/ansible/ansible/runs/91328/49/tests)). It also makes sure that the container facts returned by the module contain the updated paused information (this was missing in #47900).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.8.0
```
