### PR TITLE
docker_container: improve tests to avoid spurious test fails

### DIFF
--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -518,9 +518,15 @@
 
 - assert:
     that:
-    - "'Hello from Docker!' in detach_no_cleanup.ansible_facts.docker_container.Output"
+    # NOTE that 'Output' sometimes fails to contain the correct output
+    #      of hello-world. We don't know why this happens, but it happens
+    #      often enough to be annoying. That's why we disable this for now,
+    #      and simply test that 'Output' is contained in the result.
+    - "'Output' in detach_no_cleanup.ansible_facts.docker_container"
+    # - "'Hello from Docker!' in detach_no_cleanup.ansible_facts.docker_container.Output"
     - detach_no_cleanup_cleanup is changed
-    - "'Hello from Docker!' in detach_cleanup.ansible_facts.docker_container.Output"
+    - "'Output' in detach_cleanup.ansible_facts.docker_container"
+    # - "'Hello from Docker!' in detach_cleanup.ansible_facts.docker_container.Output"
     - detach_cleanup_cleanup is not changed
     - "'Cannot retrieve result as auto_remove is enabled' == detach_auto_remove.ansible_facts.docker_container.Output"
     - detach_auto_remove_cleanup is not changed


### PR DESCRIPTION
##### SUMMARY
Sometimes, the docker_container tests are unstable because the `detach: no` test behaves strangely (`Output` does not contain the output expected from `hello-world`). While we have no idea why this happens and cannot reproduce it properly, it happens often enough to justify changing the test so that it simply checks for `Output` to be present, instead of `Output` containing a specific text.

Fixes #47896.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.8.0
```
