### PR TITLE
docker_container: fix container removal when auto_remove is used

### DIFF
--- a/changelogs/fragments/48061-docker_container-auto_removal.yml
+++ b/changelogs/fragments/48061-docker_container-auto_removal.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - do not fail when removing a container which has ``auto_remove: yes``."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -803,6 +803,7 @@ try:
         from docker.types import Ulimit, LogConfig
     else:
         from docker.utils.types import Ulimit, LogConfig
+    from docker.errors import NotFound
 except Exception as dummy:
     # missing docker-py handled in ansible.module_utils.docker
     pass
@@ -2419,7 +2420,7 @@ class ContainerManager(DockerBaseClass):
                 if status != 0:
                     self.fail(output, status=status)
                 if self.parameters.cleanup:
-                    self.container_remove(container_id, force=True, ignore_failure=self.parameters.auto_remove)
+                    self.container_remove(container_id, force=True)
                 insp = self._get_container(container_id)
                 if insp.raw:
                     insp.raw['Output'] = output
@@ -2428,7 +2429,7 @@ class ContainerManager(DockerBaseClass):
                 return insp
         return self._get_container(container_id)
 
-    def container_remove(self, container_id, link=False, force=False, ignore_failure=False):
+    def container_remove(self, container_id, link=False, force=False):
         volume_state = (not self.parameters.keep_volumes)
         self.log("remove container container:%s v:%s link:%s force%s" % (container_id, volume_state, link, force))
         self.results['actions'].append(dict(removed=container_id, volume_state=volume_state, link=link, force=force))
@@ -2437,9 +2438,10 @@ class ContainerManager(DockerBaseClass):
         if not self.check_mode:
             try:
                 response = self.client.remove_container(container_id, v=volume_state, link=link, force=force)
+            except NotFound as exc:
+                pass
             except Exception as exc:
-                if not ignore_failure:
-                    self.fail("Error removing container %s: %s" % (container_id, str(exc)))
+                self.fail("Error removing container %s: %s" % (container_id, str(exc)))
         return response
 
     def container_update(self, container_id, update_parameters):


### PR DESCRIPTION
##### SUMMARY
When a container with `auto_remove: yes` is removed by `docker_container`, it will often fail because it first stops the container (which triggers auto removal), and then tries to remove it. This PR adds a `NotFound` check to the removal: in case `NotFound` is raised, `remove_container` acts like it succeeded.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.8.0
```
