### PR TITLE
add note regarding {host,group}_vars directory lookup semantics

### DIFF
--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -140,7 +140,7 @@ As described above, it is easy to assign variables to hosts that will be used la
 The YAML version:
 
 .. code-block:: yaml
-    
+
     atlanta:
       host1:
         http_port: 80
@@ -308,9 +308,7 @@ Tip: The ``group_vars/`` and ``host_vars/`` directories can exist in
 the playbook directory OR the inventory directory. If both paths exist, variables in the playbook
 directory will override variables set in the inventory directory.
 
-Tip: When running the ``ansible`` command (rather than
-``ansible-playbook``) there is by default no "playbook directory". The
-command will only look for ``group_vars/`` and ``host_vars/`` in the
+Tip: The ``ansible-playbook`` command looks for playbooks in the current working directory by default. Other Ansible commands (for example, ``ansible``, ``ansible-console``, etc.) will only look for ``group_vars/`` and ``host_vars/`` in the
 inventory directory unless you provide the ``--playbook-dir`` option
 on the command line.
 
@@ -508,4 +506,3 @@ Here is an example of how to instantly deploy to created containers::
        Questions? Help? Ideas?  Stop by the list on Google Groups
    `irc.freenode.net <http://irc.freenode.net>`_
        #ansible IRC chat channel
-

--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -308,6 +308,12 @@ Tip: The ``group_vars/`` and ``host_vars/`` directories can exist in
 the playbook directory OR the inventory directory. If both paths exist, variables in the playbook
 directory will override variables set in the inventory directory.
 
+Tip: When running the ``ansible`` command (rather than
+``ansible-playbook``) there is by default no "playbook directory". The
+command will only look for ``group_vars/`` and ``host_vars/`` in the
+inventory directory unless you provide the ``--playbook-dir`` option
+on the command line.
+
 Tip: Keeping your inventory file and variables in a git repo (or other version control)
 is an excellent way to track changes to your inventory and host variables.
 


### PR DESCRIPTION
While the 'ansible-playbook' command will look for {host,group}_vars in
both the playbook and inventory directories, the 'ansible' command
will only look in the inventory directory. This follows from a close
reading of the documentation but isn't explicit and leads to the
perhaps unexpected result that you can run both commands with the same
configuration in the same directory and get different results.

This commit adds a note to the documentation making the difference in
behavior explicit.

Closes #48065

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
See #48065
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.1
  config file = /home/lars/projects/bumoc/rhosp-director-config/playbooks-post-deploy/ansible.cfg
  configured module search path = [u'/home/lars/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/lars/projects/bumoc/rhosp-director-config/.venv/lib/python2.7/site-packages/ansible
  executable location = /home/lars/projects/bumoc/rhosp-director-config/.venv/bin/ansible
  python version = 2.7.15 (default, Oct 15 2018, 15:24:06) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```
