### PR TITLE
[2.6] docker_container: fix ipc_mode and pid_mode idempotency

### DIFF
--- a/changelogs/fragments/47997-docker_container-ipc-pid-mode.yml
+++ b/changelogs/fragments/47997-docker_container-ipc-pid-mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - fix ``ipc_mode`` and ``pid_mode`` idempotency if the ``host:<container-name>`` form is used (as opposed to ``host:<container-id>``)."


### PR DESCRIPTION
##### SUMMARY
Backport of #47997 to stable-2.6: fix `ipc_mode` and `pid_mode` idempotency.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.6.7
```
