### PR TITLE
Fix ec2.py dynamic inventory script when pulling down RDS cluster information

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -248,7 +248,7 @@ class Ec2Inventory(object):
 
         if isinstance(obj, (datetime, date)):
             return obj.isoformat()
-        raise TypeError ("Type %s not serializable" % type(obj))
+        raise TypeError("Type %s not serializable" % type(obj))
 
     def __init__(self):
         ''' Main execution path '''

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -160,6 +160,7 @@ import argparse
 import re
 from time import time
 from copy import deepcopy
+from datetime import date, datetime
 import boto
 from boto import ec2
 from boto import rds
@@ -241,6 +242,13 @@ class Ec2Inventory(object):
 
     def _empty_inventory(self):
         return {"_meta": {"hostvars": {}}}
+
+    def _json_serial(self, obj):
+        """JSON serializer for objects not serializable by default json code"""
+
+        if isinstance(obj, (datetime, date)):
+            return obj.isoformat()
+        raise TypeError ("Type %s not serializable" % type(obj))
 
     def __init__(self):
         ''' Main execution path '''
@@ -726,13 +734,6 @@ class Ec2Inventory(object):
         account_id = boto.connect_iam().get_user().arn.split(':')[4]
         c_dict = {}
         for c in clusters:
-            # remove these datetime objects as there is no serialisation to json
-            # currently in place and we don't need the data yet
-            if 'EarliestRestorableTime' in c:
-                del c['EarliestRestorableTime']
-            if 'LatestRestorableTime' in c:
-                del c['LatestRestorableTime']
-
             if not self.ec2_instance_filters:
                 matches_filter = True
             else:
@@ -1699,9 +1700,9 @@ class Ec2Inventory(object):
         string '''
 
         if pretty:
-            return json.dumps(data, sort_keys=True, indent=2)
+            return json.dumps(data, sort_keys=True, indent=2, default=self._json_serial)
         else:
-            return json.dumps(data)
+            return json.dumps(data, default=self._json_serial)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

As far as I can tell, the ec2.py dynamic inventory script is currently broken if it tries to pull down RDS cluster information. That's because the API returns a `CreateClusterTime` datetime. This datetime cannot be serialized to JSON, causing the code to throw an error.

This pull request addresses the same issue that #26481 addressed, but fixes it via the [requested change](https://github.com/ansible/ansible/pull/26481#discussion_r149943765) that never ended up getting pulled into the PR. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/mors/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mors/.pyenv/versions/3.7.0/lib/python3.7/site-packages/ansible
  executable location = /home/mors/.pyenv/versions/3.7.0/bin/ansible
  python version = 3.7.0 (default, Oct 19 2018, 23:48:25) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
