### PR TITLE
move some of basic into common

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -156,7 +156,14 @@ from ansible.module_utils.common._collections_compat import (
     Set, MutableSet,
 )
 from ansible.module_utils.common.process import get_bin_path
-from ansible.module_utils.common.file import is_executable
+from ansible.module_utils.common.file import (
+    PERM_BITS,
+    EXEC_PERM_BITS,
+    DEFAULT_PERM,
+    is_executable,
+    format_attributes,
+    get_flags_from_attributes
+)
 from ansible.module_utils.pycompat24 import get_exception, literal_eval
 from ansible.module_utils.six import (
     PY2,
@@ -248,11 +255,6 @@ PASSWD_ARG_RE = re.compile(r'^[-]{0,2}pass[-]?(word|wd)?')
 MODE_OPERATOR_RE = re.compile(r'[+=-]')
 USERS_RE = re.compile(r'[^ugo]')
 PERMS_RE = re.compile(r'[^rwxXstugo]')
-
-
-PERM_BITS = 0o7777       # file mode permission bits
-EXEC_PERM_BITS = 0o0111  # execute permission bits
-DEFAULT_PERM = 0o0666    # default file permission bits
 
 # Used for determining if the system is running a new enough python version
 # and should only restrict on our documented minimum versions
@@ -743,22 +745,6 @@ def _lenient_lowercase(lst):
         except AttributeError:
             lowered.append(value)
     return lowered
-
-
-def format_attributes(attributes):
-    attribute_list = []
-    for attr in attributes:
-        if attr in FILE_ATTRIBUTES:
-            attribute_list.append(FILE_ATTRIBUTES[attr])
-    return attribute_list
-
-
-def get_flags_from_attributes(attributes):
-    flags = []
-    for key, attr in FILE_ATTRIBUTES.items():
-        if attr in attributes:
-            flags.append(key)
-    return ''.join(flags)
 
 
 def _json_encode_fallback(obj):

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -167,6 +167,7 @@ from ansible.module_utils.common.file import (
 from ansible.module_utils.common.sys_info import (
     get_platform,
     get_distribution,
+    get_distribution_version,
     load_platform_subclass,
     _get_all_subclasses as get_all_subclasses
 )

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -164,6 +164,12 @@ from ansible.module_utils.common.file import (
     format_attributes,
     get_flags_from_attributes
 )
+from ansible.module_utils.common.sys_info import (
+    get_platform,
+    get_distribution,
+    load_platform_subclass,
+    _get_all_subclasses as get_all_subclasses
+)
 from ansible.module_utils.pycompat24 import get_exception, literal_eval
 from ansible.module_utils.six import (
     PY2,
@@ -267,91 +273,6 @@ if not _PY_MIN:
         '"msg": "Ansible requires a minimum of Python2 version 2.6 or Python3 version 3.5. Current version: %s"}' % ''.join(sys.version.splitlines())
     )
     sys.exit(1)
-
-
-def get_platform():
-    ''' what's the platform?  example: Linux is a platform. '''
-    return platform.system()
-
-
-def get_distribution():
-    ''' return the distribution name '''
-    if platform.system() == 'Linux':
-        try:
-            supported_dists = platform._supported_dists + ('arch', 'alpine', 'devuan')
-            distribution = platform.linux_distribution(supported_dists=supported_dists)[0].capitalize()
-            if not distribution and os.path.isfile('/etc/system-release'):
-                distribution = platform.linux_distribution(supported_dists=['system'])[0].capitalize()
-                if 'Amazon' in distribution:
-                    distribution = 'Amazon'
-                else:
-                    distribution = 'OtherLinux'
-        except:
-            # FIXME: MethodMissing, I assume?
-            distribution = platform.dist()[0].capitalize()
-    else:
-        distribution = None
-    return distribution
-
-
-def get_distribution_version():
-    ''' return the distribution version '''
-    if platform.system() == 'Linux':
-        try:
-            distribution_version = platform.linux_distribution()[1]
-            if not distribution_version and os.path.isfile('/etc/system-release'):
-                distribution_version = platform.linux_distribution(supported_dists=['system'])[1]
-        except:
-            # FIXME: MethodMissing, I assume?
-            distribution_version = platform.dist()[1]
-    else:
-        distribution_version = None
-    return distribution_version
-
-
-def get_all_subclasses(cls):
-    '''
-    used by modules like Hardware or Network fact classes to retrieve all subclasses of a given class.
-    __subclasses__ return only direct sub classes. This one go down into the class tree.
-    '''
-    # Retrieve direct subclasses
-    subclasses = cls.__subclasses__()
-    to_visit = list(subclasses)
-    # Then visit all subclasses
-    while to_visit:
-        for sc in to_visit:
-            # The current class is now visited, so remove it from list
-            to_visit.remove(sc)
-            # Appending all subclasses to visit and keep a reference of available class
-            for ssc in sc.__subclasses__():
-                subclasses.append(ssc)
-                to_visit.append(ssc)
-    return subclasses
-
-
-def load_platform_subclass(cls, *args, **kwargs):
-    '''
-    used by modules like User to have different implementations based on detected platform.  See User
-    module for an example.
-    '''
-
-    this_platform = get_platform()
-    distribution = get_distribution()
-    subclass = None
-
-    # get the most specific superclass for this platform
-    if distribution is not None:
-        for sc in get_all_subclasses(cls):
-            if sc.distribution is not None and sc.distribution == distribution and sc.platform == this_platform:
-                subclass = sc
-    if subclass is None:
-        for sc in get_all_subclasses(cls):
-            if sc.platform == this_platform and sc.distribution is None:
-                subclass = sc
-    if subclass is None:
-        subclass = cls
-
-    return super(cls, subclass).__new__(subclass)
 
 
 def json_dict_unicode_to_bytes(d, encoding='utf-8', errors='surrogate_or_strict'):

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -157,9 +157,9 @@ from ansible.module_utils.common._collections_compat import (
 )
 from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils.common.file import (
-    PERM_BITS,
-    EXEC_PERM_BITS,
-    DEFAULT_PERM,
+    _PERM_BITS as PERM_BITS,
+    _EXEC_PERM_BITS as EXEC_PERM_BITS,
+    _DEFAULT_PERM as DEFAULT_PERM,
     is_executable,
     format_attributes,
     get_flags_from_attributes

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -169,7 +169,7 @@ from ansible.module_utils.common.sys_info import (
     get_distribution,
     get_distribution_version,
     load_platform_subclass,
-    _get_all_subclasses as get_all_subclasses,
+    get_all_subclasses,
 )
 from ansible.module_utils.pycompat24 import get_exception, literal_eval
 from ansible.module_utils.six import (

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -162,14 +162,14 @@ from ansible.module_utils.common.file import (
     _DEFAULT_PERM as DEFAULT_PERM,
     is_executable,
     format_attributes,
-    get_flags_from_attributes
+    get_flags_from_attributes,
 )
 from ansible.module_utils.common.sys_info import (
     get_platform,
     get_distribution,
     get_distribution_version,
     load_platform_subclass,
-    _get_all_subclasses as get_all_subclasses
+    _get_all_subclasses as get_all_subclasses,
 )
 from ansible.module_utils.pycompat24 import get_exception, literal_eval
 from ansible.module_utils.six import (

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -27,8 +27,39 @@ except ImportError:
     HAVE_SELINUX = False
 
 
-class LockTimeout(Exception):
-    pass
+FILE_ATTRIBUTES = {
+    'A': 'noatime',
+    'a': 'append',
+    'c': 'compressed',
+    'C': 'nocow',
+    'd': 'nodump',
+    'D': 'dirsync',
+    'e': 'extents',
+    'E': 'encrypted',
+    'h': 'blocksize',
+    'i': 'immutable',
+    'I': 'indexed',
+    'j': 'journalled',
+    'N': 'inline',
+    's': 'zero',
+    'S': 'synchronous',
+    't': 'notail',
+    'T': 'blockroot',
+    'u': 'undelete',
+    'X': 'compressedraw',
+    'Z': 'compresseddirty',
+}
+
+
+# Used for parsing symbolic file perms
+MODE_OPERATOR_RE = re.compile(r'[+=-]')
+USERS_RE = re.compile(r'[^ugo]')
+PERMS_RE = re.compile(r'[^rwxXstugo]')
+
+
+PERM_BITS = 0o7777          # file mode permission bits
+EXEC_PERM_BITS = 0o0111     # execute permission bits
+DEFAULT_PERM = 0o0666       # default file permission bits
 
 
 def is_executable(path):
@@ -43,6 +74,34 @@ def is_executable(path):
     # looking for, then bitwise-and with the file's mode to determine if any
     # execute bits are set.
     return ((stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH) & os.stat(path)[stat.ST_MODE])
+
+
+def format_attributes(attributes):
+    attribute_list = [FILE_ATTRIBUTES.get(attr) for attr in attributes if attr in FILE_ATTRIBUTES]
+    return attribute_list
+
+
+def get_flags_from_attributes(attributes):
+    flags = [key for key, attr in FILE_ATTRIBUTES.items() if attr in attributes]
+    return ''.join(flags)
+
+
+def get_file_arg_spec():
+    arg_spec = dict(
+        mode=dict(type='raw'),
+        owner=dict(),
+        group=dict(),
+        seuser=dict(),
+        serole=dict(),
+        selevel=dict(),
+        setype=dict(),
+        attributes=dict(aliases=['attr'])
+    )
+    return arg_spec
+
+
+class LockTimeout(Exception):
+    pass
 
 
 class FileLock:

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -95,7 +95,7 @@ def get_file_arg_spec():
         serole=dict(),
         selevel=dict(),
         setype=dict(),
-        attributes=dict(aliases=['attr'])
+        attributes=dict(aliases=['attr']),
     )
     return arg_spec
 

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -57,9 +57,9 @@ USERS_RE = re.compile(r'[^ugo]')
 PERMS_RE = re.compile(r'[^rwxXstugo]')
 
 
-PERM_BITS = 0o7777          # file mode permission bits
-EXEC_PERM_BITS = 0o0111     # execute permission bits
-DEFAULT_PERM = 0o0666       # default file permission bits
+_PERM_BITS = 0o7777          # file mode permission bits
+_EXEC_PERM_BITS = 0o0111     # execute permission bits
+_DEFAULT_PERM = 0o0666       # default file permission bits
 
 
 def is_executable(path):

--- a/lib/ansible/module_utils/common/sys_info.py
+++ b/lib/ansible/module_utils/common/sys_info.py
@@ -83,11 +83,11 @@ def load_platform_subclass(cls, *args, **kwargs):
 
     # get the most specific superclass for this platform
     if distribution is not None:
-        for sc in _get_all_subclasses(cls):
+        for sc in get_all_subclasses(cls):
             if sc.distribution is not None and sc.distribution == distribution and sc.platform == this_platform:
                 subclass = sc
     if subclass is None:
-        for sc in _get_all_subclasses(cls):
+        for sc in get_all_subclasses(cls):
             if sc.platform == this_platform and sc.distribution is None:
                 subclass = sc
     if subclass is None:

--- a/lib/ansible/module_utils/common/sys_info.py
+++ b/lib/ansible/module_utils/common/sys_info.py
@@ -53,7 +53,7 @@ def get_distribution_version():
 
 def get_all_subclasses(cls):
     '''
-    used by modules like Hardware or Network fact classes to recursively retrieve all 
+    used by modules like Hardware or Network fact classes to recursively retrieve all
     subclasses of a given class not only the direct sub classes.
     '''
     # Retrieve direct subclasses

--- a/lib/ansible/module_utils/common/sys_info.py
+++ b/lib/ansible/module_utils/common/sys_info.py
@@ -1,0 +1,95 @@
+import os
+import platform
+
+def get_platform():
+    '''
+    :rtype: NativeString
+    :returns: Name of the platform the module is running on
+    '''
+    return platform.system()
+
+
+def get_distribution():
+    '''
+    :rtype: NativeString or None
+    :returns: Name of the distribution the module is running on
+    '''
+    distribution = None
+    additional_linux = ('alpine', 'arch', 'devuan')
+    supported_dists = platform._supported_dists + additional_linux
+
+    if platform.system() == 'Linux':
+        try:
+            distribution = platform.linux_distribution(supported_dists=supported_dists)[0].capitalize()
+            if not distribution and os.path.isfile('/etc/system-release'):
+                distribution = platform.linux_distribution(supported_dists=['system'])[0].capitalize()
+                if 'Amazon' in distribution:
+                    distribution = 'Amazon'
+                else:
+                    distribution = 'OtherLinux'
+        except:
+            # FIXME: MethodMissing, I assume?
+            distribution = platform.dist()[0].capitalize()
+    return distribution
+
+
+def get_distribution_version():
+    '''
+    :rtype: NativeString or None
+    :returns: A string representation of the version of the distribution
+    '''
+    distribution_version = None
+    if platform.system() == 'Linux':
+        try:
+            distribution_version = platform.linux_distribution()[1]
+            if not distribution_version and os.path.isfile('/etc/system-release'):
+                distribution_version = platform.linux_distribution(supported_dists=['system'])[1]
+        except Exception:
+            # FIXME: MethodMissing, I assume?
+            distribution_version = platform.dist()[1]
+    return distribution_version
+
+
+def _get_all_subclasses(cls):
+    '''
+    used by modules like Hardware or Network fact classes to retrieve all subclasses of a given class.
+    __subclasses__ return only direct sub classes. This one go down into the class tree.
+    '''
+    # Retrieve direct subclasses
+    subclasses = cls.__subclasses__()
+    to_visit = list(subclasses)
+    # Then visit all subclasses
+    while to_visit:
+        for sc in to_visit:
+            # The current class is now visited, so remove it from list
+            to_visit.remove(sc)
+            # Appending all subclasses to visit and keep a reference of available class
+            for ssc in sc.__subclasses__():
+                subclasses.append(ssc)
+                to_visit.append(ssc)
+    return subclasses
+
+
+def load_platform_subclass(cls, *args, **kwargs):
+    '''
+    used by modules like User to have different implementations based on detected platform.  See User
+    module for an example.
+    '''
+
+    this_platform = get_platform()
+    distribution = get_distribution()
+    subclass = None
+
+    # get the most specific superclass for this platform
+    if distribution is not None:
+        for sc in get_all_subclasses(cls):
+            if sc.distribution is not None and sc.distribution == distribution and sc.platform == this_platform:
+                subclass = sc
+    if subclass is None:
+        for sc in get_all_subclasses(cls):
+            if sc.platform == this_platform and sc.distribution is None:
+                subclass = sc
+    if subclass is None:
+        subclass = cls
+
+    return super(cls, subclass).__new__(subclass)

--- a/lib/ansible/module_utils/common/sys_info.py
+++ b/lib/ansible/module_utils/common/sys_info.py
@@ -51,10 +51,10 @@ def get_distribution_version():
     return distribution_version
 
 
-def _get_all_subclasses(cls):
+def get_all_subclasses(cls):
     '''
-    used by modules like Hardware or Network fact classes to retrieve all subclasses of a given class.
-    __subclasses__ return only direct sub classes. This one go down into the class tree.
+    used by modules like Hardware or Network fact classes to recursively retrieve all 
+    subclasses of a given class not only the direct sub classes.
     '''
     # Retrieve direct subclasses
     subclasses = cls.__subclasses__()

--- a/lib/ansible/module_utils/common/sys_info.py
+++ b/lib/ansible/module_utils/common/sys_info.py
@@ -1,6 +1,7 @@
 import os
 import platform
 
+
 def get_platform():
     '''
     :rtype: NativeString
@@ -82,11 +83,11 @@ def load_platform_subclass(cls, *args, **kwargs):
 
     # get the most specific superclass for this platform
     if distribution is not None:
-        for sc in get_all_subclasses(cls):
+        for sc in _get_all_subclasses(cls):
             if sc.distribution is not None and sc.distribution == distribution and sc.platform == this_platform:
                 subclass = sc
     if subclass is None:
-        for sc in get_all_subclasses(cls):
+        for sc in _get_all_subclasses(cls):
             if sc.platform == this_platform and sc.distribution is None:
                 subclass = sc
     if subclass is None:

--- a/test/units/executor/module_common/test_recursive_finder.py
+++ b/test/units/executor/module_common/test_recursive_finder.py
@@ -46,6 +46,7 @@ MODULE_UTILS_BASIC_IMPORTS = frozenset((('_text',),
                                         ('common', '_collections_compat'),
                                         ('common', 'file'),
                                         ('common', 'process'),
+                                        ('common', 'sys_info'),
                                         ('parsing', '__init__'),
                                         ('parsing', 'convert_bool'),
                                         ('pycompat24',),
@@ -61,6 +62,7 @@ MODULE_UTILS_BASIC_FILES = frozenset(('ansible/module_utils/parsing/__init__.py'
                                       'ansible/module_utils/parsing/convert_bool.py',
                                       'ansible/module_utils/common/__init__.py',
                                       'ansible/module_utils/common/file.py',
+                                      'ansible/module_utils/common/sys_info.py',
                                       'ansible/module_utils/pycompat24.py',
                                       ))
 

--- a/test/units/module_utils/basic/test_platform_distribution.py
+++ b/test/units/module_utils/basic/test_platform_distribution.py
@@ -18,11 +18,11 @@ realimport = builtins.__import__
 class TestPlatform(ModuleTestCase):
     def test_module_utils_basic_get_platform(self):
         with patch('platform.system', return_value='foo'):
-            from ansible.module_utils.basic import get_platform
+            from ansible.module_utils.common.sys_info import get_platform
             self.assertEqual(get_platform(), 'foo')
 
     def test_module_utils_basic_get_distribution(self):
-        from ansible.module_utils.basic import get_distribution
+        from ansible.module_utils.common.sys_info import get_distribution
 
         with patch('platform.system', return_value='Foo'):
             self.assertEqual(get_distribution(), None)
@@ -55,7 +55,7 @@ class TestPlatform(ModuleTestCase):
                     self.assertEqual(get_distribution(), "Bar")
 
     def test_module_utils_basic_get_distribution_version(self):
-        from ansible.module_utils.basic import get_distribution_version
+        from ansible.module_utils.common.sys_info import get_distribution_version
 
         with patch('platform.system', return_value='Foo'):
             self.assertEqual(get_distribution_version(), None)
@@ -90,19 +90,19 @@ class TestPlatform(ModuleTestCase):
             platform = "Linux"
             distribution = "Bar"
 
-        from ansible.module_utils.basic import load_platform_subclass
+        from ansible.module_utils.common.sys_info import load_platform_subclass
 
         # match just the platform class, not a specific distribution
-        with patch('ansible.module_utils.basic.get_platform', return_value="Linux"):
-            with patch('ansible.module_utils.basic.get_distribution', return_value=None):
+        with patch('ansible.module_utils.common.sys_info.get_platform', return_value="Linux"):
+            with patch('ansible.module_utils.common.sys_info.get_distribution', return_value=None):
                 self.assertIs(type(load_platform_subclass(LinuxTest)), Foo)
 
         # match both the distribution and platform class
-        with patch('ansible.module_utils.basic.get_platform', return_value="Linux"):
-            with patch('ansible.module_utils.basic.get_distribution', return_value="Bar"):
+        with patch('ansible.module_utils.common.sys_info.get_platform', return_value="Linux"):
+            with patch('ansible.module_utils.common.sys_info.get_distribution', return_value="Bar"):
                 self.assertIs(type(load_platform_subclass(LinuxTest)), Bar)
 
         # if neither match, the fallback should be the top-level class
-        with patch('ansible.module_utils.basic.get_platform', return_value="Foo"):
-            with patch('ansible.module_utils.basic.get_distribution', return_value=None):
+        with patch('ansible.module_utils.common.sys_info.get_platform', return_value="Foo"):
+            with patch('ansible.module_utils.common.sys_info.get_distribution', return_value=None):
                 self.assertIs(type(load_platform_subclass(LinuxTest)), LinuxTest)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Moving some tiny/trivial bits out of basic into common/file.py and common/sys_info.py. Following the categorization by @abadger https://gist.github.com/abadger/3edc108f5a5b88c1a9a46c4869d778fd and some irc disussions. Keeping PRs small and going for the easy stuff first.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (basic-to-common 7af337d1ba) last updated 2018/11/05 10:26:13 (GMT +200)
  config file = None
  configured module search path = ['/home/acalm/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/acalm/venv/ansible/lib/python3.6/site-packages/ansible
  executable location = /home/acalm/venv/ansible/bin/ansible
  python version = 3.6.5 (default, Apr 20 2018, 08:08:06) [GCC 6.4.0]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
