### PR TITLE
Add default region for aws_ec2 plugin

### DIFF
--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -324,14 +324,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             session = boto3.session.Session(profile_name=self.boto_profile)
         except (botocore.exceptions.ProfileNotFound) as e:
             raise AnsibleError("Profile not found: %s" % to_native(e))
-        
+
         if regions == []:
             region_name = session.region_name
             if region_name is not None:
                 regions.append(region_name)
             else:
                 regions = session.get_available_regions('ec2')
-        
+
         for region in regions:
             try:
                 connection = session.client('ec2', region, **credentials)

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -48,8 +48,10 @@ DOCUMENTATION = '''
               - name: AWS_SESSION_TOKEN
               - name: EC2_SECURITY_TOKEN
         regions:
-          description: A list of regions in which to describe EC2 instances. By default this is all regions except us-gov-west-1
-              and cn-north-1.
+          description: A list of regions in which to describe EC2 instances. By default this is region from environment
+              environment variable or region from boto configuration or all regions except us-gov-west-1 and cn-north-1.
+          env:
+              - name: AWS_DEFAULT_REGION
         hostnames:
           description: A list in order of precedence for hostname variables. You can use the options specified in
               U(http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html#options). To use tags as hostnames


### PR DESCRIPTION
##### SUMMARY
Add default regions for the aws_ec2 plugin.

Fixes #45288

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_ec2

##### ANSIBLE VERSION
```
ansible 2.7.1
  config file = /root/.ansible.cfg
  configured module search path = [u'/root/ansible/core/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, Aug 16 2018, 14:17:09) [GCC 6.4.0]
```

##### ADDITIONAL INFORMATION
If `regions` tag is absent in the `*.aws_ec2.yml` configuration file, the **default** region will be:
1. `AWS_DEFAULT_REGION` environment variable if exists
2. region from `boto config` if exists
3. all regions available for EC2
