### PR TITLE
add support for specifying volume metadata

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume.py
@@ -58,6 +58,10 @@ options:
      description:
        - Scheduler hints passed to volume API in form of dict
      version_added: "2.4"
+   metadata:
+     description:
+       - Metadata for the volume
+     version_added: "2.8"
 requirements:
      - "python >= 2.7"
      - "openstacksdk"
@@ -111,6 +115,9 @@ def _present_volume(module, cloud):
     if module.params['scheduler_hints']:
         volume_args['scheduler_hints'] = module.params['scheduler_hints']
 
+    if module.params['metadata']:
+        volume_args['metadata'] = module.params['metadata']
+
     volume = cloud.create_volume(
         wait=module.params['wait'], timeout=module.params['timeout'],
         **volume_args)
@@ -140,7 +147,8 @@ def main():
         snapshot_id=dict(default=None),
         volume=dict(default=None),
         state=dict(default='present', choices=['absent', 'present']),
-        scheduler_hints=dict(default=None, type='dict')
+        scheduler_hints=dict(default=None, type='dict'),
+        metadata=dict(default=None, type='dict')
     )
     module_kwargs = openstack_module_kwargs(
         mutually_exclusive=[


### PR DESCRIPTION
add possibility to specify metadata (properties) to be set on the volume

##### SUMMARY
In some cases it is required to specify metadata for the volume. With this PR this is added

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module/cloud/openstack/os_volume

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.7.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/gtema/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.1 (default, Oct 23 2018, 18:19:07) [GCC 8.2.1 20180801 (Red Hat 8.2.1-2)]


```

##### ADDITIONAL INFORMATION
a new module parameter (dict) metadata is being added