### PR TITLE
Azure dynamic inventory plugin to use Subscription ID with CLI auth

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -994,7 +994,7 @@ class AzureRMAuth(object):
                 except Exception as e:
                     self.fail("cloud_environment {0} could not be resolved: {1}".format(raw_cloud_env, e.message), exception=traceback.format_exc())
 
-        # Use Subscription ID if specified by the client instead of the one in CLI
+        # Use Subscription ID if specified by the client instead of the one in CLI
         if subscription_id is not None:
              self.subscription_id = subscription_id
         else:

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -996,12 +996,12 @@ class AzureRMAuth(object):
 
         # Use Subscription ID if specified by the client instead of the one in CLI
         if subscription_id is not None:
-             self.subscription_id = subscription_id
+            self.subscription_id = subscription_id
         else:
-             if self.credentials.get('subscription_id', None) is None and self.credentials.get('credentials') is None:
-                 self.fail("Credentials did not include a subscription_id value.")
-             self.log("setting subscription_id [%s]" % self.credentials['subscription_id'])
-             self.subscription_id = self.credentials['subscription_id']
+            if self.credentials.get('subscription_id', None) is None and self.credentials.get('credentials') is None:
+                self.fail("Credentials did not include a subscription_id value.")
+            self.log("setting subscription_id [%s]" % self.credentials['subscription_id'])
+            self.subscription_id = self.credentials['subscription_id']
 
         # get authentication authority
         # for adfs, user could pass in authority or not.

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -994,10 +994,14 @@ class AzureRMAuth(object):
                 except Exception as e:
                     self.fail("cloud_environment {0} could not be resolved: {1}".format(raw_cloud_env, e.message), exception=traceback.format_exc())
 
-        if self.credentials.get('subscription_id', None) is None and self.credentials.get('credentials') is None:
-            self.fail("Credentials did not include a subscription_id value.")
-        self.log("setting subscription_id")
-        self.subscription_id = self.credentials['subscription_id']
+        # Use Subscription ID if specified by the client instead of the one in CLI
+        if subscription_id is not None:
+             self.subscription_id = subscription_id
+        else:
+             if self.credentials.get('subscription_id', None) is None and self.credentials.get('credentials') is None:
+                 self.fail("Credentials did not include a subscription_id value.")
+             self.log("setting subscription_id [%s]" % self.credentials['subscription_id'])
+             self.subscription_id = self.credentials['subscription_id']
 
         # get authentication authority
         # for adfs, user could pass in authority or not.

--- a/lib/ansible/plugins/inventory/azure_rm.py
+++ b/lib/ansible/plugins/inventory/azure_rm.py
@@ -253,7 +253,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         self.azure_auth = AzureRMAuth(**auth_options)
 
-        self._clientconfig = AzureRMRestConfiguration(self.azure_auth.azure_credentials, self.azure_auth.subscription_id,
+        # Allow user to step / force a subscription ID while using CLI
+        subscription_id = self.get_option('subscription_id')
+        if subscription_id is None:
+            subscription_id = self.azure_auth.subscription_id
+
+        self._clientconfig = AzureRMRestConfiguration(self.azure_auth.azure_credentials, subscription_id,
                                                       self.azure_auth._cloud_environment.endpoints.resource_manager)
         self._client = ServiceClient(self._clientconfig.credentials, self._clientconfig)
 

--- a/lib/ansible/plugins/inventory/azure_rm.py
+++ b/lib/ansible/plugins/inventory/azure_rm.py
@@ -253,12 +253,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         self.azure_auth = AzureRMAuth(**auth_options)
 
-        # Allow user to step / force a subscription ID while using CLI
-        subscription_id = self.get_option('subscription_id')
-        if subscription_id is None:
-            subscription_id = self.azure_auth.subscription_id
-
-        self._clientconfig = AzureRMRestConfiguration(self.azure_auth.azure_credentials, subscription_id,
+        self._clientconfig = AzureRMRestConfiguration(self.azure_auth.azure_credentials, self.azure_auth.subscription_id,
                                                       self.azure_auth._cloud_environment.endpoints.resource_manager)
         self._client = ServiceClient(self._clientconfig.credentials, self._clientconfig)
 


### PR DESCRIPTION
##### SUMMARY

Use the Subscription ID if set in the dynamic inventory configurations.
This allows users managing multiple subscriptions to specify the right one
without relying on the current CLI configuration.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

lib/ansible/plugins/inventory/azure_rm