### PR TITLE
Foreman url is required, and hence doesn't have a default

### DIFF
--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -21,10 +21,10 @@ DOCUMENTATION = '''
       - requests (python library)
     options:
       url:
-        description: URL to the Foreman server
+        description: URL to the Foreman server.  If unset, will connect to the local host over HTTPS.
         env:
           - name: FOREMAN_URL
-        required: True
+        default: null
         ini:
           - section: callback_foreman
             key: url
@@ -105,6 +105,9 @@ class CallbackModule(CallbackBase):
                 self._disable_plugin('The `requests` python module is too old.')
         else:
             self._disable_plugin('The `requests` python module is not installed.')
+
+        if self.FOREMAN_URL is None:
+            self.FOREMAN_URL = 'https://' + os.uname()[1]
 
         if self.FOREMAN_URL.startswith('https://'):
             if not os.path.exists(self.FOREMAN_SSL_CERT[0]):

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -25,7 +25,6 @@ DOCUMENTATION = '''
         env:
           - name: FOREMAN_URL
         required: True
-        default: http://localhost:3000
         ini:
           - section: callback_foreman
             key: url


### PR DESCRIPTION
##### SUMMARY
The documentation for the callback plugin `foreman` says that there is a default value for the `url` option, but this isn't true.  Fix this.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`foreman` callback plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/third-party/foreman-ansible-modules/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```
