### PR TITLE
Fix lvg module idempotency (stable-2.7)

### DIFF
--- a/changelogs/fragments/lvg_fix_47301.yaml
+++ b/changelogs/fragments/lvg_fix_47301.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- lvg - fixed an idempotency regression in the lvg module (https://github.com/ansible/ansible/issues/47301)

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -150,7 +150,7 @@ def main():
 
     dev_list = []
     if module.params['pvs']:
-        dev_list = module.params['pvs']
+        dev_list = list(module.params['pvs'])
     elif state == 'present':
         module.fail_json(msg="No physical volumes given.")
 
@@ -167,7 +167,7 @@ def main():
         # get pv list
         pvs_cmd = module.get_bin_path('pvs', True)
         if dev_list:
-            pvs_filter = ' || '. join(['pv_name = {0}'.format(x) for x in dev_list])
+            pvs_filter = ' || '. join(['pv_name = {0}'.format(x) for x in dev_list + module.params['pvs']])
             pvs_filter = "--select '%s'" % pvs_filter
         else:
             pvs_filter = ''

--- a/test/integration/targets/lvg/aliases
+++ b/test/integration/targets/lvg/aliases
@@ -1,0 +1,5 @@
+destructive
+needs/privileged
+shippable/posix/group1
+skip/freebsd
+skip/osx

--- a/test/integration/targets/lvg/tasks/main.yml
+++ b/test/integration/targets/lvg/tasks/main.yml
@@ -1,0 +1,48 @@
+- name: Install required packages (Linux)
+  package:
+    name: lvm2
+    state: present
+  when: ansible_system == 'Linux'
+
+- name: Test lvg module
+  block:
+    - name: Create file to use as a disk device
+      command: "dd if=/dev/zero of={{ ansible_user_dir }}/ansible_testing/img1 bs=1M count=10"
+
+    - name: Create loop device for file
+      command: "losetup --show -f {{ ansible_user_dir }}/ansible_testing/img1"
+      register: loop_device1
+
+    - name: Create volume group on disk device
+      lvg:
+        vg: testvg
+        pvs: "{{ loop_device1.stdout }}"
+
+    - name: Create the volume group again to verify idempotence
+      lvg:
+        vg: testvg
+        pvs: "{{ loop_device1.stdout }}"
+      register: repeat_vg_create
+
+    - name: Do all assertions to verify expected results
+      assert:
+        that:
+          - repeat_vg_create is not changed
+
+  always:
+    - name: Remove test volume group
+      lvg:
+        vg: testvg
+        state: absent
+
+    - name: Detach loop device
+      command: "losetup -d {{ loop_device1.stdout }}"
+      when:
+        - loop_device1 is defined
+        - loop_device1.stdout is defined
+        - loop_device1.stdout is match("/dev/.*")
+
+    - name: Remove the file
+      file:
+        path: "{{ ansible_user_dir }}/ansible_testing/img1"
+        state: absent


### PR DESCRIPTION
##### SUMMARY

In [1] changes were made to ensure that the physical
devices were appropriately filtered, but the dev_list
which is used to prepare the filter is modified from
the original arguments to resolve any symlinks. This
results in the existing devices given in the module
args to be left out of the filter, resulting
in the module trying to add the same device again
every time the task is executed.

In this PR we change dev_list to be a copy of the
module arguments so that we're able to add the given
pv list from the module arguments into the filter
as well, ensuring that there is idempotence when
running the task again.

[1] https://github.com/ansible/ansible/pull/38446

Fixes # 47301
Backport # 47620

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lvg

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mvutcovici/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, May 31 2018, 09:41:32) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
