### PR TITLE
[2.7] net_put: Fix trivial documentation typo

### DIFF
--- a/lib/ansible/modules/network/files/net_put.py
+++ b/lib/ansible/modules/network/files/net_put.py
@@ -44,7 +44,7 @@ options:
     required: no
   mode:
     description:
-      - Set the file transfer mode. If mode is set to I(template) then I(src)
+      - Set the file transfer mode. If mode is set to I(text) then I(src)
         file will go through Jinja2 template engine to replace any vars if
         present in the src file. If mode is set to I(binary) then file will be
         copied as it is to destination device.


### PR DESCRIPTION
Backport of #48035

In commit 30688fe the template value of the mode parameter was renamed to text. Change another mention of this parameter.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
net_put

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/paul/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.1 (default, Oct 22 2018, 10:41:28) [GCC 8.2.1 20180831]
```
