### PR TITLE
Fix return statement where we short circuit _get_delegated_vars

### DIFF
--- a/changelogs/fragments/loop-cache-include-apply.yml
+++ b/changelogs/fragments/loop-cache-include-apply.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- delegate_to - Fix issue where delegate_to was upplied via ``apply`` on an include, where a loop was present on the include

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -489,7 +489,7 @@ class VariableManager:
     def _get_delegated_vars(self, play, task, existing_variables):
         if not hasattr(task, 'loop'):
             # This "task" is not a Task, so we need to skip it
-            return {}
+            return {}, None
 
         # we unfortunately need to template the delegate_to field here,
         # as we're fetching vars before post_validate has been called on


### PR DESCRIPTION
##### SUMMARY
Fix return statement where we short circuit _get_delegated_vars

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/vars/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```