### PR TITLE
[docker_network] Add handling for Python booleans in driver_options

### DIFF
--- a/changelogs/fragments/docker_network-driver_options.yaml
+++ b/changelogs/fragments/docker_network-driver_options.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "docker_network - ``driver_options`` containing Python booleans would cause Docker to throw exceptions."

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -268,6 +268,21 @@ def get_ip_version(cidr):
     raise ValueError('"{0}" is not a valid CIDR'.format(cidr))
 
 
+def get_driver_options(driver_options):
+    result = dict()
+    if driver_options is not None:
+        for k, v in driver_options.items():
+            # Go doesn't like 'True' or 'False'
+            if v is True:
+                v = 'true'
+            elif v is False:
+                v = 'false'
+            else:
+                v = str(v)
+            result[str(k)] = v
+    return result
+
+
 class DockerNetworkManager(object):
 
     def __init__(self, client):
@@ -287,6 +302,9 @@ class DockerNetworkManager(object):
 
         if self.parameters.ipam_options:
             self.parameters.ipam_config = [self.parameters.ipam_options]
+
+        if self.parameters.driver_options:
+            self.parameters.driver_options = get_driver_options(self.parameters.driver_options)
 
         state = self.parameters.state
         if state == 'present':

--- a/test/integration/targets/docker_network/tasks/tests/options.yml
+++ b/test/integration/targets/docker_network/tasks/tests/options.yml
@@ -2,10 +2,9 @@
 - name: Registering network name
   set_fact:
     nname_1: "{{ name_prefix ~ '-network-1' }}"
-    nname_2: "{{ name_prefix ~ '-network-2' }}"
 - name: Registering network name
   set_fact:
-    dnetworks: "{{ dnetworks }} + [nname_1, nname_2]"
+    dnetworks: "{{ dnetworks }} + [nname_1]"
 
 ####################################################################
 ## internal ########################################################
@@ -40,3 +39,56 @@
     - internal_1 is changed
     - internal_2 is not changed
     - internal_3 is changed
+
+####################################################################
+## driver_options ##################################################
+####################################################################
+
+- name: driver_options
+  docker_network:
+    name: "{{ nname_1 }}"
+    driver_options:
+      com.docker.network.bridge.enable_icc: 'false'
+  register: driver_options_1
+
+- name: driver_options (idempotency)
+  docker_network:
+    name: "{{ nname_1 }}"
+    driver_options:
+      com.docker.network.bridge.enable_icc: 'false'
+  register: driver_options_2
+
+- name: driver_options (idempotency with string translation)
+  docker_network:
+    name: "{{ nname_1 }}"
+    driver_options:
+      com.docker.network.bridge.enable_icc: False
+  register: driver_options_3
+
+- name: driver_options (change)
+  docker_network:
+    name: "{{ nname_1 }}"
+    driver_options:
+      com.docker.network.bridge.enable_icc: 'true'
+  register: driver_options_4
+
+- name: driver_options (idempotency with string translation)
+  docker_network:
+    name: "{{ nname_1 }}"
+    driver_options:
+      com.docker.network.bridge.enable_icc: True
+  register: driver_options_5
+
+- name: cleanup
+  docker_network:
+    name: "{{ nname_1 }}"
+    state: absent
+    force: yes
+
+- assert:
+    that:
+    - driver_options_1 is changed
+    - driver_options_2 is not changed
+    - driver_options_3 is not changed
+    - driver_options_4 is changed
+    - driver_options_5 is not changed


### PR DESCRIPTION
##### SUMMARY
Properly handles Python booleans in the configuration for `driver_options`, which would cause exceptions from Docker previously. Turns out that it's not set up to properly marshal booleans into strings.

Fixes #26708

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_network

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (docker_network_driver_options a4bf1307c6) last updated 2018/11/05 11:11:57 (GMT -500)
  config file = None
  configured module search path = [u'/home/darkelf/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/darkelf/ansible/lib/ansible
  executable location = /home/darkelf/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
New integration tests passing in `ubuntu1604` docker image.