### PR TITLE
Prevent duplicate entries in rhsm_repository module

### DIFF
--- a/changelogs/rhsm_repository-loop-fix-improvements.yaml
+++ b/changelogs/rhsm_repository-loop-fix-improvements.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - rhsm_repository - compile regular expressions to improve performance when looping over available repositories
+  - rhsm_repository - prevent duplicate repository entries from being entered in the final command

--- a/lib/ansible/modules/packaging/os/rhsm_repository.py
+++ b/lib/ansible/modules/packaging/os/rhsm_repository.py
@@ -115,10 +115,10 @@ def get_repository_list(module, list_parameter):
         '+----------------------------------------------------------+',
         '    Available Repositories in /etc/yum.repos.d/redhat.repo'
     ]
-    repo_id_re_str = r'Repo ID:   (.*)'
-    repo_name_re_str = r'Repo Name: (.*)'
-    repo_url_re_str = r'Repo URL:  (.*)'
-    repo_enabled_re_str = r'Enabled:   (.*)'
+    repo_id_re = re.compile(r'Repo ID:\s+(.*)')
+    repo_name_re = re.compile(r'Repo Name:\s+(.*)')
+    repo_url_re = re.compile(r'Repo URL:\s+(.*)')
+    repo_enabled_re = re.compile(r'Enabled:\s+(.*)')
 
     repo_id = ''
     repo_name = ''
@@ -131,32 +131,34 @@ def get_repository_list(module, list_parameter):
         if line in skip_lines:
             continue
 
-        repo_id_re = re.match(repo_id_re_str, line)
-        if repo_id_re:
-            repo_id = repo_id_re.group(1)
+        repo_id_match = repo_id_re.match(line)
+        if repo_id_match:
+            repo_id = repo_id_match.group(1)
             continue
 
-        repo_name_re = re.match(repo_name_re_str, line)
-        if repo_name_re:
-            repo_name = repo_name_re.group(1)
+        repo_name_match = repo_name_re.match(line)
+        if repo_name_match:
+            repo_name = repo_name_match.group(1)
             continue
 
-        repo_url_re = re.match(repo_url_re_str, line)
-        if repo_url_re:
-            repo_url = repo_url_re.group(1)
+        repo_url_match = repo_url_re.match(line)
+        if repo_url_match:
+            repo_url = repo_url_match.group(1)
             continue
 
-        repo_enabled_re = re.match(repo_enabled_re_str, line)
-        if repo_enabled_re:
-            repo_enabled = repo_enabled_re.group(1)
+        repo_enabled_match = repo_enabled_re.match(line)
+        if repo_enabled_match:
+            repo_enabled = repo_enabled_match.group(1)
 
-        repo = {
-            "id": repo_id,
-            "name": repo_name,
-            "url": repo_url,
-            "enabled": True if repo_enabled == '1' else False
-        }
+            repo = {
+                "id": repo_id,
+                "name": repo_name,
+                "url": repo_url,
+                "enabled": True if repo_enabled == '1' else False
+            }
+
         repo_result.append(repo)
+
     return repo_result
 
 

--- a/lib/ansible/modules/packaging/os/rhsm_repository.py
+++ b/lib/ansible/modules/packaging/os/rhsm_repository.py
@@ -126,9 +126,8 @@ def get_repository_list(module, list_parameter):
     repo_enabled = ''
 
     repo_result = []
-
-    for line in out.split('\n'):
-        if line in skip_lines:
+    for line in out.splitlines():
+        if line == '' or line in skip_lines:
             continue
 
         repo_id_match = repo_id_re.match(line)
@@ -208,7 +207,7 @@ def repository_modify(module, state, name):
 
     if not module.check_mode:
         rc, out, err = run_subscription_manager(module, rhsm_arguments)
-        results = out.split('\n')
+        results = out.splitlines()
     module.exit_json(results=results, changed=changed, repositories=updated_repo_list, diff=diff)
 
 


### PR DESCRIPTION
##### SUMMARY

When looping over available repositories, compile the regular expressions to improve performance.

A bug existed that would add each matched repository twice. When looping over the list of available repositories, a blank line would not match any of conditionals with a `continue` statement. This resulted in the current value of `repo` being appended a second time to the results, which then doubled the amount of arguments for the final command.

```
['repos',
 '--enable',
 'rhel-7-server-openstack-12-tools-rpms',
 '--enable',
 'rhel-7-server-openstack-12-tools-rpms',
 '--enable',
 'rhel-7-server-extras-rpms',
 '--enable',
 'rhel-7-server-extras-rpms',
 '--enable',
 'rhel-7-server-rh-common-rpms',
 '--enable',
 'rhel-7-server-rh-common-rpms']
```

This PR fixes that by explicitly continuing the loop if the line is empty.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`rhsm_repository.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
2.7
2.6
2.5
```