### PR TITLE
Add util files for NetApp Unit tests and python 3 support. (netapp-1012)

### DIFF
--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -138,6 +138,9 @@ def setup_na_ontap_zapi(module, vserver=None):
         server = zapi.NaServer(hostname)
         server.set_username(username)
         server.set_password(password)
+        if vserver:
+            server.set_vserver(vserver)
+        # Todo : Replace hard-coded values with configurable parameters.
         server.set_api_version(major=1, minor=110)
         # default is HTTP
         if https:

--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -132,20 +132,13 @@ def setup_na_ontap_zapi(module, vserver=None):
     https = module.params['https']
     validate_certs = module.params['validate_certs']
     port = module.params['http_port']
-    version = module.params['ontapi']
 
     if HAS_NETAPP_LIB:
         # set up zapi
         server = zapi.NaServer(hostname)
         server.set_username(username)
         server.set_password(password)
-        if vserver:
-            server.set_vserver(vserver)
-        if version:
-            minor = version
-        else:
-            minor = 110
-        server.set_api_version(major=1, minor=minor)
+        server.set_api_version(major=1, minor=110)
         # default is HTTP
         if https:
             if port is None:

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -18,6 +18,8 @@ setuptools > 0.6 # pytest-xdist installed via requirements does not work with ve
 unittest2 ; python_version < '2.7'
 netaddr
 ipaddress
+netapp-lib
+solidfire-sdk-python
 
 # requirements for F5 specific modules
 f5-sdk ; python_version >= '2.7'

--- a/test/units/modules/test_netapp_utils.py
+++ b/test/units/modules/test_netapp_utils.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2018 NetApp
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+''' unit tests for module_utils netapp.py '''
+from __future__ import absolute_import, division, print_function
+
+try:
+    from netapp_lib.api.zapi import zapi
+    HAS_NETAPP_ZAPI = True
+except ImportError:
+    HAS_NETAPP_ZAPI = False
+
+try:
+    from ansible.module_utils.ansible_release import __version__ as ansible_version
+except ImportError:
+    ansible_version = 'unknown'
+
+from units.compat import unittest
+import ansible.module_utils.netapp as my_module
+HAS_NETAPP_ZAPI_MSG = "pip install netapp_lib is required"
+
+
+class MockONTAPConnection(object):
+    ''' mock a server connection to ONTAP host '''
+
+    def __init__(self, kind=None, parm1=None):
+        ''' save arguments '''
+        self.type = kind
+        self.parm1 = parm1
+        self.xml_in = None
+        self.xml_out = None
+
+    def invoke_successfully(self, xml, enable_tunneling):  # pylint: disable=unused-argument
+        ''' mock invoke_successfully returning xml data '''
+        self.xml_in = xml
+        if self.type == 'vserver':
+            xml = self.build_vserver_info(self.parm1)
+        self.xml_out = xml
+        return xml
+
+    @staticmethod
+    def build_vserver_info(vserver):
+        ''' build xml data for vserser-info '''
+        xml = zapi.NaElement('xml')
+        attributes = zapi.NaElement('attributes-list')
+        attributes.add_node_with_children('vserver-info',
+                                          **{'vserver-name': vserver})
+        xml.add_child_elem(attributes)
+        return xml
+
+
+class TestEMSLogVersion(unittest.TestCase):
+    ''' validate version is read successfully from ansible release.py '''
+
+    def setUp(self):
+        self.assertTrue(HAS_NETAPP_ZAPI, HAS_NETAPP_ZAPI_MSG)
+        self.source = 'unittest'
+        self.server = MockONTAPConnection()
+
+    def test_ems_log_event_version(self):
+        ''' validate Ansible version is correctly read '''
+        my_module.ems_log_event(self.source, self.server)
+        xml = self.server.xml_in
+        version = xml.get_child_content('app-version')
+        self.assertEquals(version, ansible_version)
+        print("Ansible version: %s" % ansible_version)
+
+
+class TestGetCServer(unittest.TestCase):
+    ''' validate cserver name is extracted correctly '''
+
+    def setUp(self):
+        self.assertTrue(HAS_NETAPP_ZAPI, HAS_NETAPP_ZAPI_MSG)
+        self.svm_name = 'svm1'
+        self.server = MockONTAPConnection('vserver', self.svm_name)
+
+    def test_get_cserver(self):
+        ''' validate cluster vserser name is correctly retrieved '''
+        cserver = my_module.get_cserver(self.server)
+        self.assertEquals(cserver, self.svm_name)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/units/modules/test_netapp_utils.py
+++ b/test/units/modules/test_netapp_utils.py
@@ -3,8 +3,13 @@
 
 ''' unit tests for module_utils netapp.py '''
 from __future__ import absolute_import, division, print_function
+import sys
+import inspect
+import os
 
 try:
+    import netapp_lib.api.zapi
+    sys.path.insert(0, os.path.dirname(inspect.getfile(netapp_lib.api.zapi)))
     from netapp_lib.api.zapi import zapi
     HAS_NETAPP_ZAPI = True
 except ImportError:


### PR DESCRIPTION
##### SUMMARY
Add util files for NetApp Unit tests and python 3 support. These are the common files

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (netapp-1012 c30a504ef5) last updated 2018/11/05 11:01:39 (GMT -700)
  config file = None
  configured module search path = [u'/Users/chrisarchibald/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chrisarchibald/Code/github/ansible/lib/ansible
  executable location = /Users/chrisarchibald/Code/github/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 11 2016, 05:20:59) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
