### PR TITLE
bump version of 'vcenter-test-container' to '1.4.0' (govmomi v0.19.0)

### DIFF
--- a/test/runner/lib/cloud/vcenter.py
+++ b/test/runner/lib/cloud/vcenter.py
@@ -36,7 +36,7 @@ class VcenterProvider(CloudProvider):
         if os.environ.get('ANSIBLE_VCSIM_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_VCSIM_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/vcenter-test-container:1.3.0'
+            self.image = 'quay.io/ansible/vcenter-test-container:1.4.0'
         self.container_name = ''
 
     def filter(self, targets, exclude):


### PR DESCRIPTION
##### SUMMARY
updates `vcenter-test-container` to `1.4.0` which has the latest tagged version of `govmomi` (`vcsim`) `v0.19.0`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- test/runner/lib/cloud/vcenter.py
- v{center,mware}_* tests

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (vcenter-test-container_v1.4.0 32c915501f) last updated 2018/11/05 14:08:12 (GMT -400)
  config file = /Users/deric/ansible/ansible.cfg
  configured module search path = [u'/Users/deric/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/deric/ansible/lib/ansible
  executable location = /Users/deric/ansible/bin/ansible
  python version = 2.7.15 (default, Oct  5 2018, 21:56:13) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.2)]
```

##### ADDITIONAL INFORMATION
This should be a drop in replacement for `vcenter-test-container:1.3.0`.

`govmomi` commits related to `vcsim`:

```
$ git log --oneline v0.18.0..v0.19.0 -- simulator vcsim
64d875b Added PerformanceManager simulator
f326096 vcsim: add dvpg networks to HostSystem.Parent
10392ff Merge pull request #1192 from thib-ack/maxWaitSecondsSimulator
8e04e3c Run goimports on go source files
17352fc vcsim: add support for tags API
c29d4b1 vcsim: Logout should not unregister PropertyCollector singleton
8bda0ee Fix format in test
8be5207 Add test for WaitOption.MaxWaitSeconds == 0 behaviour in simulator
900e1a3 Fix the WaitOption.MaxWaitSeconds == 0 behaviour in simulator
11fb0d5 vcsim: add ResetVM and SuspendVM support
39e6592 vcsim: add support for PropertyCollector incremental updates
619fbe2 vcsim: do not include DVS in HostSystem.Network
```