### PR TITLE
Add ACI cookie handling and refresh

### DIFF
--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -186,7 +186,7 @@ class ACIModule(object):
     def login(self):
         ''' Log in to APIC '''
 
-        cookie_file = self.module._remote_tmp + '/aci.p'
+        cookie_file = os.path.expanduser(self.module._remote_tmp) + '/aci_' + self.params['host'].replace(':', '.') + '.p'
         if os.path.exists(cookie_file):
             cookie = pickle.load(open(cookie_file, 'rb'))
             time_skew = int(time.time()) - int(cookie['time'])
@@ -259,8 +259,10 @@ class ACIModule(object):
             "time": time.time(),
             "cookie": self.headers['Cookie']
         }
-
-        pickle.dump(cookie, open(cookie_file, 'wb'), protocol=pickle.HIGHEST_PROTOCOL)
+        try:
+            pickle.dump(cookie, open(cookie_file, 'wb'), protocol=pickle.HIGHEST_PROTOCOL)
+        except:
+            self.module.fail_json(msg='Cannot save ACI cookie %s' % cookie_file)
 
     def cert_auth(self, path=None, payload='', method=None):
         ''' Perform APIC signature-based authentication, not the expected SSL client certificate authentication. '''


### PR DESCRIPTION
##### SUMMARY
Small fix for cookie persistence, until connection plugin is implemented.
Tested with ACI 3.2 and Python 2.7 and 3.7.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
aci_l3out

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (aci_cookie 056192cb73) last updated 2018/11/02 10:06:07 (GMT +200)
  config file = None
  configured module search path = [u'/Users/rdavyden/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/rdavyden/Documents/ACI/ansible/lib/ansible
  executable location = /Users/rdavyden/Documents/ACI/ansible/bin/ansible
  python version = 2.7.10 (default, Aug 17 2018, 17:41:52) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.0.42)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
