### PR TITLE
Backports fix build errors due to missing certified_supported label (#46835)

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -573,7 +573,7 @@ def process_support_levels(plugin_info, templates, output_dir, plugin_type):
                                                       " Ansible Network Team<network_maintained>` in"
                                                       " a relationship similar to how the Ansible Core Team"
                                                       " maintains the Core modules."},
-                    'Ansible Partners': {'slug': 'partner_supported',
+                    'Ansible Partners': {'slug': 'certified_supported',
                                          'modules': [],
                                          'output': 'partner_maintained.rst',
                                          'blurb': """

--- a/docs/docsite/rst/user_guide/modules_support.rst
+++ b/docs/docsite/rst/user_guide/modules_support.rst
@@ -1,36 +1,42 @@
 .. _modules_support:
 
+****************************
 Module Maintenance & Support
-----------------------------
+****************************
 
-.. toctree:: :maxdepth: 1
+..contents::
+  :depth: 2
+  :local:
+
+Maintenance
+===========
 
 To help identify maintainers and understand how the included modules are officially supported, each module now has associated metadata that provides additional clarity for maintenance and support.
 
 Core
-````
+----
 
 :ref:`Core Maintained<core_supported>` modules are maintained by the Ansible Engineering Team.
 These modules are integral to the basic foundations of the Ansible distribution.
 
 Network
-```````
+-------
 
 :ref:`Network Maintained<network_supported>` modules are are maintained by the Ansible Network Team. Please note there are additional networking modules that are categorized as Certified or Community not maintained by Ansible.
 
 
 Certified
-`````````
+---------
 
-Certified modules are part of a future planned program currently in development.
+:ref:`Certified<certified_supported>` modules are maintained by Ansible Partners.
 
 Community
-`````````
+---------
 
 :ref:`Community Maintained<community_supported>` modules are submitted and maintained by the Ansible community.  These modules are not maintained by Ansible, and are included as a convenience.
 
 Issue Reporting
-```````````````
+===============
 
 If you believe you have found a bug in a module and are already running the latest stable or development version of Ansible, first look at the `issue tracker in the Ansible repo <https://github.com/ansible/ansible/issues>`_ to see if an issue has already been filed. If not, please file one.
 
@@ -43,23 +49,23 @@ The modules are hosted on GitHub in a subdirectory of the `Ansible <https://gith
 NOTE: If you have a Red Hat Ansible Engine product subscription, please follow the standard issue reporting process via the Red Hat Customer Portal.
 
 Support
-```````
+=======
 
 For more information on how included Ansible modules are supported by Red Hat,
 please refer to the following `knowledgebase article <https://access.redhat.com/articles/3166901>`_ as well as other resources on the `Red Hat Customer Portal. <https://access.redhat.com/>`_
 
 .. seealso::
 
-   :doc:`../modules/modules_by_category`
+   :ref:`Modules by category<modules_by_category>`
        A complete list of all available modules.
-   :doc:`intro_adhoc`
+   :ref:`intro_adhoc`
        Examples of using modules in /usr/bin/ansible
-   :doc:`playbooks`
+   :ref:`working_with_playbooks`
        Examples of using modules with /usr/bin/ansible-playbook
-   :doc:`../dev_guide/developing_modules`
+   :ref:`developing_modules`
        How to write your own modules
-   :doc:`../dev_guide/developing_api`
-       Examples of using modules with the Python API
+   `List of Ansible Certified Modules <https://access.redhat.com/articles/3642632>`_
+       High level list of Ansible certified modules from Partners
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
    `irc.freenode.net <http://irc.freenode.net>`_


### PR DESCRIPTION
* fix build errors due to missing certified_supported label

* fixed references and toc

(cherry picked from commit db3d920cfd9891817d480bb55a50ee7a9521715f)
fixes 
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
backports https://github.com/ansible/ansible/pull/46835
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible/ansible/issues/46838

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request



##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs.ansible.com
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
