### PR TITLE
Fix argument_spec for modules that are using the old version (#47693)

### DIFF
--- a/changelogs/fragments/47693-fix-argument-spec-for-netapp-modules.yaml
+++ b/changelogs/fragments/47693-fix-argument-spec-for-netapp-modules.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix argument spec for NetApp modules that are using the old version

--- a/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
@@ -15,7 +15,7 @@ author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
   - Create/Delete cluster peer relations on ONTAP
 extends_documentation_fragment:
-  - netapp.ontap
+  - netapp.na_ontap
 module: na_ontap_cluster_peer
 options:
   state:
@@ -57,7 +57,6 @@ version_added: "2.7"
 '''
 
 EXAMPLES = """
-
     - name: Create cluster peer
       na_ontap_cluster_peer:
         state: present
@@ -68,7 +67,6 @@ EXAMPLES = """
         username: "{{ netapp_username }}"
         password: "{{ netapp_password }}"
         dest_hostname: "{{ dest_netapp_hostname }}"
-
     - name: Delete cluster peer
       na_ontap_cluster_peer:
         state: absent
@@ -99,7 +97,7 @@ class NetAppONTAPClusterPeer(object):
 
     def __init__(self):
 
-        self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
+        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
             source_intercluster_lif=dict(required=False, type='str'),
@@ -125,14 +123,14 @@ class NetAppONTAPClusterPeer(object):
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
-            self.server = netapp_utils.setup_ontap_zapi(module=self.module)
+            self.server = netapp_utils.setup_na_ontap_zapi(module=self.module)
             # set destination server connection
             self.module.params['hostname'] = self.parameters['dest_hostname']
             if self.parameters.get('dest_username'):
                 self.module.params['username'] = self.parameters['dest_username']
             if self.parameters.get('dest_password'):
                 self.module.params['password'] = self.parameters['dest_password']
-            self.dest_server = netapp_utils.setup_ontap_zapi(module=self.module)
+            self.dest_server = netapp_utils.setup_na_ontap_zapi(module=self.module)
 
     def cluster_peer_get_iter(self, cluster):
         """

--- a/lib/ansible/modules/storage/netapp/na_ontap_net_vlan.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_net_vlan.py
@@ -14,7 +14,7 @@ DOCUMENTATION = '''
 module: na_ontap_net_vlan
 short_description: NetApp ONTAP network VLAN
 extends_documentation_fragment:
-    - netapp.ontap
+    - netapp.na_ontap
 version_added: '2.6'
 author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
@@ -71,7 +71,7 @@ class NetAppOntapVlan(object):
         """
         Initializes the NetAppOntapVlan function
         """
-        self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
+        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, choices=['present', 'absent'], default='present'),
             parent_interface=dict(required=True, type='str'),
@@ -95,7 +95,7 @@ class NetAppOntapVlan(object):
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
-            self.server = netapp_utils.setup_ontap_zapi(module=self.module)
+            self.server = netapp_utils.setup_na_ontap_zapi(module=self.module)
         return
 
     def create_vlan(self):
@@ -154,7 +154,7 @@ class NetAppOntapVlan(object):
         changed = False
         result = None
         results = netapp_utils.get_cserver(self.server)
-        cserver = netapp_utils.setup_ontap_zapi(module=self.module, vserver=results)
+        cserver = netapp_utils.setup_na_ontap_zapi(module=self.module, vserver=results)
         netapp_utils.ems_log_event("na_ontap_net_vlan", cserver)
         existing_vlan = self.does_vlan_exist()
         if existing_vlan:

--- a/lib/ansible/modules/storage/netapp/na_ontap_snapmirror.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_snapmirror.py
@@ -15,7 +15,7 @@ author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
   - Create/Delete/Initialize/Modify SnapMirror volume/vserver relationships
 extends_documentation_fragment:
-  - netapp.ontap
+  - netapp.na_ontap
 module: na_ontap_snapmirror
 options:
   state:
@@ -124,7 +124,7 @@ class NetAppONTAPSnapmirror(object):
 
     def __init__(self):
 
-        self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
+        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
             source_vserver=dict(required=False, type='str'),
@@ -159,7 +159,7 @@ class NetAppONTAPSnapmirror(object):
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
-            self.server = netapp_utils.setup_ontap_zapi(module=self.module)
+            self.server = netapp_utils.setup_na_ontap_zapi(module=self.module)
 
     def snapmirror_get_iter(self):
         """

--- a/lib/ansible/modules/storage/netapp/na_ontap_software_update.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_software_update.py
@@ -15,7 +15,7 @@ author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
   - Update ONTAP software
 extends_documentation_fragment:
-  - netapp.ontap
+  - netapp.na_ontap
 module: na_ontap_software_update
 options:
   state:
@@ -77,7 +77,7 @@ class NetAppONTAPSoftwareUpdate(object):
 
     def __init__(self):
 
-        self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
+        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
             node=dict(required=False, type='list'),
@@ -97,7 +97,7 @@ class NetAppONTAPSoftwareUpdate(object):
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
-            self.server = netapp_utils.setup_ontap_zapi(module=self.module)
+            self.server = netapp_utils.setup_na_ontap_zapi(module=self.module)
 
     def cluster_image_get_iter(self):
         """

--- a/lib/ansible/modules/storage/netapp/na_ontap_vserver_peer.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_vserver_peer.py
@@ -15,7 +15,7 @@ author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
   - Create/Delete vserver peer
 extends_documentation_fragment:
-  - netapp.ontap
+  - netapp.na_ontap
 module: na_ontap_vserver_peer
 options:
   state:
@@ -54,7 +54,6 @@ version_added: "2.7"
 '''
 
 EXAMPLES = """
-
     - name: Source vserver peer create
       na_ontap_vserver_peer:
         state: present
@@ -66,7 +65,6 @@ EXAMPLES = """
         username: "{{ netapp_username }}"
         password: "{{ netapp_password }}"
         dest_hostname: "{{ netapp_dest_hostname }}"
-
     - name: vserver peer delete
       na_ontap_vserver_peer:
         state: absent
@@ -96,7 +94,7 @@ class NetAppONTAPVserverPeer(object):
 
     def __init__(self):
 
-        self.argument_spec = netapp_utils.ontap_sf_host_argument_spec()
+        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
         self.argument_spec.update(dict(
             state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
             vserver=dict(required=True, type='str'),
@@ -122,14 +120,14 @@ class NetAppONTAPVserverPeer(object):
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
-            self.server = netapp_utils.setup_ontap_zapi(module=self.module)
+            self.server = netapp_utils.setup_na_ontap_zapi(module=self.module)
             if self.parameters.get('dest_hostname'):
                 self.module.params['hostname'] = self.parameters['dest_hostname']
                 if self.parameters.get('dest_username'):
                     self.module.params['username'] = self.parameters['dest_username']
                 if self.parameters.get('dest_password'):
                     self.module.params['password'] = self.parameters['dest_password']
-                self.dest_server = netapp_utils.setup_ontap_zapi(module=self.module)
+                self.dest_server = netapp_utils.setup_na_ontap_zapi(module=self.module)
 
     def vserver_peer_get_iter(self):
         """


### PR DESCRIPTION
* Use correct argument spec

(cherry picked from commit 0cf88809efcbef565f92756ddc7c49dd949c7307)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.1.post0 (backport/2.7/47621 aa8003d004) last updated 2018/11/05 13:09:11 (GMT -700)
  config file = None
  configured module search path = [u'/Users/chrisarchibald/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chrisarchibald/Code/github/ansible/lib/ansible
  executable location = /Users/chrisarchibald/Code/github/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 11 2016, 05:20:59) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
