### PR TITLE
Fix regression in synchronize when using ssh passwords

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -321,7 +321,8 @@ EXAMPLES = '''
 import os
 import errno
 
-from ansible.module_utils.basic import AnsibleModule, to_bytes
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.six.moves import shlex_quote
 
 
@@ -440,7 +441,7 @@ def main():
                 msg="to use rsync connection with passwords, you must install the sshpass program"
             )
         _sshpass_pipe = os.pipe()
-        cmd = ['sshpass', '-d' + _sshpass_pipe[0]] + cmd
+        cmd = ['sshpass', '-d' + to_native(_sshpass_pipe[0], errors='surrogate_or_strict')] + cmd
     if compress:
         cmd.append('--compress')
     if rsync_timeout:


### PR DESCRIPTION
The change to add sshpass support for rsync broke synchronize when
a password was provided at all.  Have to convert an int into a string to
make it work.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

synchronize

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
devel
```

##### ADDITIONAL INFORMATION
Regression from https://github.com/ansible/ansible/pull/30743