### PR TITLE
Backport/2.7/47621

### DIFF
--- a/changelogs/fragments/47621-bugfix-for-na-ontap-snapmirror.yaml
+++ b/changelogs/fragments/47621-bugfix-for-na-ontap-snapmirror.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixes issues with source and destination location for na_ontap_snapmirror

--- a/lib/ansible/modules/storage/netapp/na_ontap_snapmirror.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_snapmirror.py
@@ -13,7 +13,8 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 author: NetApp Ansible Team (ng-ansibleteam@netapp.com)
 description:
-  - Create/Delete/Initialize/Modify SnapMirror volume/vserver relationships
+  - Create/Delete/Initialize SnapMirror volume/vserver relationships
+  - Modify schedule for a SnapMirror relationship
 extends_documentation_fragment:
   - netapp.ontap
 module: na_ontap_snapmirror
@@ -83,6 +84,7 @@ EXAMPLES = """
       na_ontap_snapmirror:
         state: absent
         destination_path: <path>
+        source_hostname: "{{ source_hostname }}"
         hostname: "{{ netapp_hostname }}"
         username: "{{ netapp_username }}"
         password: "{{ netapp_password }}"
@@ -222,19 +224,22 @@ class NetAppONTAPSnapmirror(object):
         Delete a SnapMirror relationship
         #1. Quiesce the SnapMirror relationship at destination
         #2. Break the SnapMirror relationship at the source
-        #3. Release the SnapMirror at destination
+        #3. Release the SnapMirror at source
         #4. Delete SnapMirror at destination
         """
         if not self.parameters.get('source_hostname'):
             self.module.fail_json(msg='Missing parameters for delete: Please specify the '
-                                      'source cluster to release the SnapMirror relation')
+                                      'source cluster hostname to release the SnapMirror relation')
         if self.parameters.get('source_username'):
-            self.module.params['username'] = self.parameters['dest_username']
+            self.module.params['username'] = self.parameters['source_username']
         if self.parameters.get('source_password'):
-            self.module.params['password'] = self.parameters['dest_password']
+            self.module.params['password'] = self.parameters['source_password']
+        self.module.params['hostname'] = self.parameters['source_hostname']
         self.source_server = netapp_utils.setup_ontap_zapi(module=self.module)
         self.snapmirror_quiesce()
-        self.snapmirror_break()
+        if self.parameters.get('relationship_type') and \
+                self.parameters.get('relationship_type') not in ['load_sharing', 'vault']:
+            self.snapmirror_break()
         if self.get_destination():
             self.snapmirror_release()
         self.snapmirror_delete()
@@ -325,7 +330,9 @@ class NetAppONTAPSnapmirror(object):
             initialize_zapi = 'snapmirror-initialize'
             if self.parameters.get('relationship_type') and self.parameters['relationship_type'] == 'load_sharing':
                 initialize_zapi = 'snapmirror-initialize-ls-set'
-            options = {'destination-location': self.parameters['destination_path']}
+                options = {'source-location': self.parameters['source_path']}
+            else:
+                options = {'destination-location': self.parameters['destination_path']}
             snapmirror_init = netapp_utils.zapi.NaElement.create_node_with_children(
                 initialize_zapi, **options)
             try:
@@ -411,6 +418,7 @@ class NetAppONTAPSnapmirror(object):
         current = self.snapmirror_get()
         cd_action = self.na_helper.get_cd_action(current, self.parameters)
         modify = self.na_helper.get_modified_attributes(current, self.parameters)
+
         if cd_action == 'create':
             self.snapmirror_create()
         elif cd_action == 'delete':


### PR DESCRIPTION
##### SUMMARY
Fixes issues with source and destination location for na_ontap_snapmirror

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.1.post0 (backport/2.7/47621 aa8003d004) last updated 2018/11/05 13:09:11 (GMT -700)
  config file = None
  configured module search path = [u'/Users/chrisarchibald/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chrisarchibald/Code/github/ansible/lib/ansible
  executable location = /Users/chrisarchibald/Code/github/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 11 2016, 05:20:59) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
