### PR TITLE
Correct yum and dnf autoremove behavior

### DIFF
--- a/changelogs/fragments/yumdnf-autoremove.yaml
+++ b/changelogs/fragments/yumdnf-autoremove.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "fix yum and dnf autoremove input sanitization to properly warn user if invalid options passed and update documentation to match"

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -41,8 +41,9 @@ options:
   state:
     description:
       - Whether to install (C(present), C(latest)), or remove (C(absent)) a package.
+      - Default is C(None), however in effect the default action is C(present) unless the C(autoremove) option is
+        enabled for this module, then C(absent) is inferred.
     choices: ['absent', 'present', 'installed', 'removed', 'latest']
-    default: "present"
 
   enablerepo:
     description:
@@ -1015,11 +1016,6 @@ class DnfModule(YumDnf):
             if LooseVersion(dnf.__version__) < LooseVersion('2.0.1'):
                 self.module.fail_json(
                     msg="Autoremove requires dnf>=2.0.1. Current dnf version is %s" % dnf.__version__,
-                    results=[],
-                )
-            if self.state not in ["absent", None]:
-                self.module.fail_json(
-                    msg="Autoremove should be used alone or with state=absent",
                     results=[],
                 )
 

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -56,8 +56,9 @@ options:
       - C(present) and C(installed) will simply ensure that a desired package is installed.
       - C(latest) will update the specified package if it's not of the latest available version.
       - C(absent) and C(removed) will remove the specified package.
+      - Default is C(None), however in effect the default action is C(present) unless the C(autoremove) option is¬
+        enabled for this module, then C(absent) is inferred.
     choices: [ absent, installed, latest, present, removed ]
-    default: present
   enablerepo:
     description:
       - I(Repoid) of repositories to enable for the install/update operation.


### PR DESCRIPTION
##### SUMMARY
Correct yum and dnf autoremove behavior

Fixes #47184

Backport of PR 47902

Signed-off-by: Adam Miller <admiller@redhat.com>
(cherry picked from commit 1c777976c5134f310a97609da12776fc08551271)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum
dnf

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.1.post0 (backport/2.7/47902 8801d5a87e) last updated 2018/11/05 16:45:17 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, Oct 15 2018, 15:24:06) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```

