### PR TITLE
Pin openshift version for k8s test.

### DIFF
--- a/test/integration/targets/k8s/runme.sh
+++ b/test/integration/targets/k8s/runme.sh
@@ -21,5 +21,5 @@ ansible-playbook -v playbooks/merge_type_fail.yml "$@"
 # Run full test suite
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/openshift-recent"
 source "${MYTMPDIR}/openshift-recent/bin/activate"
-$PYTHON -m pip install 'openshift>=0.7.0'
+$PYTHON -m pip install 'openshift==0.7.2'
 ansible-playbook -v playbooks/full_test.yml "$@"


### PR DESCRIPTION
##### SUMMARY

Pin openshift version for k8s test.

This will avoid spontaneous test failure for new releases of openshift on PyPI.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

k8s integration test

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (pin-openshift-test 1e60f61b9b) last updated 2018/11/05 15:30:29 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
