### PR TITLE
[stable-2.7] Pin openshift version for k8s test.

### DIFF
--- a/test/integration/targets/k8s/runme.sh
+++ b/test/integration/targets/k8s/runme.sh
@@ -21,5 +21,5 @@ ansible-playbook -v playbooks/merge_type_fail.yml "$@"
 # Run full test suite
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/openshift-recent"
 source "${MYTMPDIR}/openshift-recent/bin/activate"
-$PYTHON -m pip install 'openshift>=0.7.0'
+$PYTHON -m pip install 'openshift==0.7.2'
 ansible-playbook -v playbooks/full_test.yml "$@"


### PR DESCRIPTION
##### SUMMARY

[stable-2.7] Pin openshift version for k8s test.

This will avoid spontaneous test failure for new releases of openshift on PyPI.

(cherry picked from commit 150cdd793190172a8b0df9056cad64479de321d2)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

k8s integration test

##### ANSIBLE VERSION

```
2.7
```
