### PR TITLE
VMware: further improvements to the scenario_clone_template

### DIFF
--- a/docs/docsite/rst/vmware/scenario_clone_template.rst
+++ b/docs/docsite/rst/vmware/scenario_clone_template.rst
@@ -34,14 +34,32 @@ Scenario Requirements
 
     * Administrator user with following privileges
 
-        - ``VirtualMachine.Provisioning.Clone`` on the virtual machine you are cloning
-        - ``VirtualMachine.Inventory.CreateFromExisting`` on the datacenter or virtual machine folder
-        - ``VirtualMachine.Config.AddNewDisk`` on the datacenter or virtual machine folder
-        - ``Resource.Assign`` virtual machine to resource pool on the destination host, cluster, or resource pool
         - ``Datastore.AllocateSpace`` on the destination datastore or datastore folder
-        - ``Network.AssignNetwork`` on the network to which the virtual machine will be assigned
+        - ``Network.Assign`` on the network to which the virtual machine will be assigned
+        - ``Resource.AssignVMToPool`` on the destination host, cluster, or resource pool
+        - ``VirtualMachine.Config.AddNewDisk`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Config.AddRemoveDevice`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Interact.PowerOn`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Inventory.CreateFromExisting`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Provisioning.Clone`` on the virtual machine you are cloning
         - ``VirtualMachine.Provisioning.Customize`` on the virtual machine or virtual machine folder if you are customizing the guest operating system
+        - ``VirtualMachine.Provisioning.DeployTemplate`` on the template you are using
         - ``VirtualMachine.Provisioning.ReadCustSpecs`` on the root vCenter Server if you are customizing the guest operating system
+        
+        Depending on your requirements, you could also need one or more of the following privileges: 
+
+        - ``VirtualMachine.Config.CPUCount`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Config.Memory`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Config.DiskExtend`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Config.Annotation`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Config.AdvancedConfig`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Config.EditDevice`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Config.Resource`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Config.Settings`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Config.UpgradeVirtualHardware`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Interact.SetCDMedia`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Interact.SetFloppyMedia`` on the datacenter or virtual machine folder
+        - ``VirtualMachine.Interact.DeviceConnection`` on the datacenter or virtual machine folder
 
 Assumptions
 ===========


### PR DESCRIPTION
Following #47889, this patch will:

- add a mandatory privilege for "cloning from a template" scenario (VirtualMachine.Provisioning.DeployTemplate)
- fix a privilege naming error (Resource.Assign --> Resource.AssignVMToPool)
- add some important privileges to the list (VirtualMachine.Interact.PowerOn and VirtualMachine.Config.AddRemoveDevice)
- add some optional privileges (VirtualMachine.Config.DiskExtend/Annotation/CPUCount/Memory/etc)
- sort the privileges list

+label: docsite_pr
+label: vmware

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
docs/docsite/rst/vmware/scenario_clone_template.rst

##### ANSIBLE VERSION
```paste below
2.8devel
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
