### PR TITLE
win_uri: stop output from mixing with module result - 2.7 (#48140)

### DIFF
--- a/changelogs/fragments/win_uri-junk-data.yaml
+++ b/changelogs/fragments/win_uri-junk-data.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_uri - stop junk output from being returned to Ansible - https://github.com/ansible/ansible/issues/47998

--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -231,7 +231,7 @@ if ($return_content -or $dest) {
         $resp_st.Close()
 
         if ($return_content) {
-            $memory_st.Seek(0, [System.IO.SeekOrigin]::Begin)
+            $memory_st.Seek(0, [System.IO.SeekOrigin]::Begin) > $null
             $content_bytes = $memory_st.ToArray()
             $result.content = [System.Text.Encoding]::UTF8.GetString($content_bytes)
             if ($result.ContainsKey("content_type") -and $result.content_type -Match ($JSON_CANDIDATES -join '|')) {
@@ -244,7 +244,7 @@ if ($return_content -or $dest) {
         }
 
         if ($dest) {
-            $memory_st.Seek(0, [System.IO.SeekOrigin]::Begin)
+            $memory_st.Seek(0, [System.IO.SeekOrigin]::Begin) > $null
             $changed = $true
 
             if (Test-AnsiblePath -Path $dest) {
@@ -260,7 +260,7 @@ if ($return_content -or $dest) {
 
             $result.changed = $changed
             if ($changed -and (-not $check_mode)) {
-                $memory_st.Seek(0, [System.IO.SeekOrigin]::Begin)
+                $memory_st.Seek(0, [System.IO.SeekOrigin]::Begin) > $null
                 $file_stream = [System.IO.File]::Create($dest)
                 try {
                     $memory_st.CopyTo($file_stream)


### PR DESCRIPTION
(cherry picked from commit 8a9d7b3695c017a956f2bb219e8b6676896f5f89)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/48140

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_uri

##### ANSIBLE VERSION
```paste below
2.7
```