### PR TITLE
changed the default log level to INFO

### DIFF
--- a/changelogs/fragments/log_level.yaml
+++ b/changelogs/fragments/log_level.yaml
@@ -1,4 +1,4 @@
 minor_changes:
 - Changed the default log level for `DEFAULT_LOG_PATH <https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-log-path>`_
-  to ``INFO`` unless ``DEFAULT_DEBUG <https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-debug>`_
+  to ``INFO`` unless `DEFAULT_DEBUG <https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-debug>`_
   is set

--- a/changelogs/fragments/log_level.yaml
+++ b/changelogs/fragments/log_level.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+- Changed the default log level for `DEFAULT_LOG_PATH <https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-log-path>`_
+  to ``INFO`` unless ``DEFAULT_DEBUG <https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-debug>`_
+  is set

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -117,6 +117,10 @@ Plugins
   has changed to ``%USERPROFILE%\.ansible_async``. To control this path now, either set the ``ansible_async_dir``
   variable or the ``async_dir`` value in the ``powershell`` section of the config ini.
 
+* The default log level when `DEFAULT_LOG_PATH <https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-log-path>`_
+  is set is now ``INFO``. The ``DEBUG`` log level is only used when `DEFAULT_DEBUG <https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-debug>`_
+  is set.
+
 Porting custom scripts
 ======================
 

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -60,7 +60,8 @@ logger = None
 if getattr(C, 'DEFAULT_LOG_PATH'):
     path = C.DEFAULT_LOG_PATH
     if path and (os.path.exists(path) and os.access(path, os.W_OK)) or os.access(os.path.dirname(path), os.W_OK):
-        logging.basicConfig(filename=path, level=logging.DEBUG, format='%(asctime)s %(name)s %(message)s')
+        level = logging.DEBUG if C.DEFAULT_DEBUG else logging.INFO
+        logging.basicConfig(filename=path, level=level, format='%(asctime)s %(name)s %(message)s')
         mypid = str(os.getpid())
         user = getpass.getuser()
         logger = logging.getLogger("p=%s u=%s | " % (mypid, user))


### PR DESCRIPTION
##### SUMMARY
This PR changes the default log level from `DEBUG` to `INFO`. Current when `DEFAULT_LOG_PATH` is set, the output is based on the `DEBUG` level and for some libraries this is a lot of data, e.g. winrm and psrp have an entry for each HTTP request sent (which is a lot).

I am proposing we change the default level to `INFO` and only set `DEBUG` if `DEFAULT_DEBUG` is set.

Relates to https://github.com/ansible/ansible/pull/47645

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
display

##### ANSIBLE VERSION
```paste below
devel
```