### PR TITLE
Backport/2.7/48148: net_put module leaves empty files behind 

### DIFF
--- a/changelogs/fragments/48148_net_put_cleanup.yaml
+++ b/changelogs/fragments/48148_net_put_cleanup.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "net_put - fix when net_put module leaves temp files in some network OS cases e.g. routerOS"

--- a/lib/ansible/plugins/action/net_put.py
+++ b/lib/ansible/plugins/action/net_put.py
@@ -23,6 +23,7 @@ import time
 import uuid
 import hashlib
 import sys
+import re
 
 from ansible.module_utils._text import to_text, to_bytes
 from ansible.module_utils.connection import Connection
@@ -148,7 +149,11 @@ class ActionModule(ActionBase):
                 proto=proto, timeout=timeout
             )
         except Exception as exc:
-            if (to_text(exc)).find("No such file or directory") > 0:
+            pattern = to_text(exc)
+            not_found_exc = "No such file or directory"
+            if re.search(not_found_exc, pattern, re.I):
+                if os.path.exists(source_file):
+                    os.remove(source_file)
                 return True
             else:
                 try:
@@ -162,6 +167,7 @@ class ActionModule(ActionBase):
             with open(source_file, 'r') as f:
                 old_content = f.read()
         except (IOError, OSError) as ioexc:
+            os.remove(source_file)
             raise IOError(ioexc)
 
         sha1 = hashlib.sha1()


### PR DESCRIPTION
##### SUMMARY
Cherry-pick #48148 to 2.7

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
net_put

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```
