### PR TITLE
Fix note about type evaluation in INI format

### DIFF
--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -94,8 +94,8 @@ In the above example, trying to ansible against the host alias "jumper" (which m
 Note that this is using a feature of the inventory file to define some special variables.
 Generally speaking, this is not the best way to define variables that describe your system policy, but we'll share suggestions on doing this later.
 
-.. note:: Values passed in the INI format using the ``key=value`` syntax are not interpreted as Python literal structure
-          (strings, numbers, tuples, lists, dicts, booleans, None), but as a string. For example ``var=FALSE`` would create a string equal to 'FALSE'.
+.. note:: Values passed in the INI format using the ``key=value`` syntax are interpreted as Python literal structure
+          (strings, numbers, tuples, lists, dicts, booleans, None), alternatively as a string. For example ``var=FALSE`` would create a string equal to 'FALSE'.
           Do not rely on types set during definition, always make sure you specify type with a filter when needed when consuming the variable.
 
 If you are adding a lot of hosts following similar patterns, you can do this rather than listing each hostname:


### PR DESCRIPTION
According plugins/inventory/ini.py plugin documentation values **are** "interpreted as Python literal".

Probably actual version was meant to describe YAML format (because `*not*` was introduced together with yaml based inventories #28596) but author forgot to change name of format note describes.

##### SUMMARY

Fix documentation about type evaluation for INI format.

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
docs and inventory ini plugin

##### ANSIBLE VERSION
2.7 

##### ADDITIONAL INFORMATION

[Link to original documentation for plugin](https://github.com/ansible/ansible/blob/d2c7665be9965a82f14dab91248a78ed7def9c2d/lib/ansible/plugins/inventory/ini.py#L17)