### PR TITLE
virt: Fix return type of list_vms

### DIFF
--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -89,7 +89,7 @@ RETURN = '''
 # for list_vms command
 list_vms:
     description: The list of vms defined on the remote system
-    type: dictionary
+    type: list
     returned: success
     sample: [
         "build.example.org",


### PR DESCRIPTION
##### SUMMARY
The return type is a list not a dictionary.  The sample output is correct.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/misc/virt.py

##### ANSIBLE VERSION
```
ansible 2.7.1
```

##### ADDITIONAL INFORMATION
[Original documentation link](https://docs.ansible.com/ansible/latest/modules/virt_module.html)
