### PR TITLE
mail: fixed STARTTLS module working with python 3.7.0 (#47412)

### DIFF
--- a/changelogs/fragments/tls_mail.yml
+++ b/changelogs/fragments/tls_mail.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - fix mail notification module when using starttls and py3.7

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -248,8 +248,8 @@ def main():
     try:
         if secure != 'never':
             try:
-                smtp = smtplib.SMTP_SSL(host=host, timeout=timeout)
-                code, smtpmessage = smtp.connect(host, port=port)
+                smtp = smtplib.SMTP_SSL(host=host, port=port, timeout=timeout)
+                code, smtpmessage = smtp.connect(host, port)
                 secure_state = True
             except ssl.SSLError as e:
                 if secure == 'always':
@@ -257,8 +257,8 @@ def main():
                                                (host, port, to_native(e)), exception=traceback.format_exc())
 
         if not secure_state:
-            smtp = smtplib.SMTP(timeout=timeout)
-            code, smtpmessage = smtp.connect(host, port=port)
+            smtp = smtplib.SMTP(host=host, port=port, timeout=timeout)
+            code, smtpmessage = smtp.connect(host, port)
 
     except smtplib.SMTPException as e:
         module.fail_json(rc=1, msg='Unable to Connect %s:%s: %s' % (host, port, to_native(e)), exception=traceback.format_exc())


### PR DESCRIPTION
(cherry picked from commit 8c9070ec05dcfda5e5b0e107b677ec976a9b6f8a)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/notification/mail
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```
