### PR TITLE
Skip non-management Packet IP addresses

### DIFF
--- a/contrib/inventory/packet_net.py
+++ b/contrib/inventory/packet_net.py
@@ -298,10 +298,15 @@ class PacketInventory(object):
         if device.state not in self.packet_device_states:
             return
 
-        # Select the best destination address
+        # Select the best destination address. Only include management
+        # addresses as non-management (elastic) addresses need manual
+        # host configuration to be routable.
+        # See https://help.packet.net/article/54-elastic-ips.
         dest = None
         for ip_address in device.ip_addresses:
-            if ip_address['public'] is True and ip_address['address_family'] == 4:
+            if ip_address['public'] is True and \
+               ip_address['address_family'] == 4 and \
+               ip_address['management'] is True:
                 dest = ip_address['address']
 
         if not dest:


### PR DESCRIPTION
Non-management (elastic) IP addresses require manual configuration on
the host as described in https://help.packet.net/article/54-elastic-ips.
Skip those so that only the automatically configured management
addresses are used. Otherwise, a non-routable address may be returned in
the inventory.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #48166.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

contrib/inventory/packet_net.py

##### ANSIBLE VERSION
```
ansible 2.5.2
  config file = /home/dan/.ansible.cfg
  configured module search path = [u'/home/dan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May  9 2018, 11:32:33) [GCC 7.3.1 20180130 (Red Hat 7.3.1-2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Makes the packet.net dynamic inventory only include management addresses, which are automatically supported in packet and most likely to be routable.