### PR TITLE
docs - adapted abadger's changelog announcement email into dev process

### DIFF
--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -1,61 +1,174 @@
 .. _community_development_process:
 
-*******************************
-The Ansible Development Process
-*******************************
+*****************************
+The Ansible Development Cycle
+*****************************
+
+The Ansible development cycle happens on two levels. At a macro level, the team plans releases and tracks progress with roadmaps and projects. At a micro level, each PR has its own lifecycle.
 
 .. contents::
    :local:
 
-This section discusses how the Ansible development and triage process works.
+Macro development: roadmaps, releases, and projects
+===================================================
 
-Road Maps
-=========
+If you want to follow the conversation about what features will be added to Ansible for upcoming releases and what bugs are being fixed, you can watch these resources:
 
-The Ansible Core team provides a road map for each upcoming release. These road maps can be found :ref:`here <roadmaps>`.
+* the :ref:`roadmaps`
+* the :ref:`Ansible Release Schedule <release_and_maintenance>`
+* various GitHub `projects <https://github.com/ansible/ansible/projects>`_ - for example:
 
-.. Roadmaps are User-oriented.  We should also list the Roadmap Projects and the Blocker Bug
-   Projects here
-
-.. How the actual release schedule, slipping, etc relates to (release_and_maintenance.rst) probably
-   also belongs here somewhere
+   * the `2.8 release project <https://github.com/ansible/ansible/projects/30>`_
+   * the `network bugs project <https://github.com/ansible/ansible/projects/20>`_
+   * the `core documentation project <https://github.com/ansible/ansible/projects/27>`_
 
 .. _community_pull_requests:
 
-Pull Requests
-=============
+Micro development: the lifecycle of a PR
+========================================
 
-Ansible accepts code via **pull requests** ("PRs" for short). GitHub provides a great overview of `how the pull request process works <https://help.github.com/articles/about-pull-requests/>`_ in general.
+Ansible accepts code via **pull requests** ("PRs" for short). GitHub provides a great overview of `how the pull request process works <https://help.github.com/articles/about-pull-requests/>`_ in general. Here's an overview of the PR lifecycle:
 
-Because Ansible receives many pull requests, we use an automated process to help us through the process of reviewing and merging pull requests. That process is managed by `Ansibullbot`_.
+* Contributor opens a PR
+* Ansibot reviews the PR
+* Ansibot assigns labels
+* Ansibot pings maintainers
+* Shippable runs the test suite
+* Developers, maintainers, community review the PR
+* Contributor addresses any feedback from reviewers
+* Developers, maintainers, community re-review
+* PR merged or closed
 
+Ansibullbot
+-----------
+
+Because Ansible receives many pull requests, and because we love automating things, we've automated several steps of the process of reviewing and merging pull requests with a tool called Ansibullbot, or Ansibot for short.
+
+Overview
+^^^^^^^^
+
+`Ansibullbot <https://github.com/ansible/ansibullbot/blob/master/ISSUE_HELP.md>`_ serves many functions:
+
+- Responds quickly to PR submitters to thank them for submitting their PR
+- Identifies the community maintainer responsible for reviewing PRs for any files affected
+- Tracks the current status of PRs
+- Pings responsible parties to remind them of any PR actions for which they may be responsible
+- Provides maintainers with the ability to move PRs through the workflow
+- Identifies PRs abandoned by their submitters so that we can close them
+- Identifies modules abandoned by their maintainers so that we can find new maintainers
+
+Community Maintainers
+^^^^^^^^^^^^^^^^^^^^^
+
+Each module has at least one assigned maintainer, listed in a `maintainer's file <https://github.com/ansible/ansible/blob/devel/.github/BOTMETA.yml>`_:
+
+Some modules have no community maintainers assigned. In this case, the maintainer is listed as ``$team_ansible``. Ultimately, it's our goal to have at least one community maintainer for every module.
+
+The maintainer's job is to review PRs and decide whether that PR should be merged (``shipit``) or revised (``needs_revision``).
+
+The ultimate goal of any pull request is to reach **shipit** status, where the Core team then decides whether the PR is ready to be merged. Not every PR that reaches the **shipit** label is actually ready to be merged, but the better our reviewers are, and the better our guidelines are, the more likely it will be that a PR that reaches **shipit** will be mergeable.
+
+
+Workflow
+^^^^^^^^
+
+Ansibullbot runs continuously. You can generally expect to see changes to your issue or pull request within thirty minutes. Ansibullbot examines every open pull request in the repositories, and enforces state roughly according to the following workflow:
+
+-  If a pull request has no workflow labels, it's considered **new**. Files in the pull request are identified, and the maintainers of those files are pinged by the bot, along with instructions on how to review the pull request. (Note: sometimes we strip labels from a pull request to "reboot" this process.)
+-  If the module maintainer is not ``$team_ansible``, the pull request then goes into the **community_review** state.
+-  If the module maintainer is ``$team_ansible``, the pull request then goes into the **core_review** state (and probably sits for a while).
+-  If the pull request is in **community_review** and has received comments from the maintainer:
+
+   -  If the maintainer says ``shipit``, the pull request is labeled **shipit**, whereupon the Core team assesses it for final merge.
+   -  If the maintainer says ``needs_info``, the pull request is labeled **needs_info** and the submitter is asked for more info.
+   -  If the maintainer says **needs_revision**, the pull request is labeled **needs_revision** and the submitter is asked to fix some things.
+
+-  If the submitter says ``ready_for_review``, the pull request is put back into **community_review** or **core_review** and the maintainer is notified that the pull request is ready to be reviewed again.
+-  If the pull request is labeled **needs_revision** or **needs_info** and the submitter has not responded lately:
+
+   -  The submitter is first politely pinged after two weeks, pinged again after two more weeks and labeled **pending action**, and the issue or pull request will be closed two weeks after that.
+   -  If the submitter responds at all, the clock is reset.
+-  If the pull request is labeled **community_review** and the reviewer has not responded lately:
+
+   -  The reviewer is first politely pinged after two weeks, pinged again after two more weeks and labeled **pending_action**, and then may be reassigned to ``$team_ansible`` or labeled **core_review**, or often the submitter of the pull request is asked to step up as a maintainer.
+-  If Shippable tests fail, or if the code is not able to be merged, the pull request is automatically put into **needs_revision** along with a message to the submitter explaining why.
+
+
+There are corner cases and frequent refinements, but this is the workflow in general.
+
+PR Labels
+^^^^^^^^^
+
+There are two types of PR Labels generally: *workflow labels* and *information labels*.
+
+Workflow Labels
+"""""""""""""""
+
+-  **community_review**: Pull requests for modules that are currently awaiting review by their maintainers in the Ansible community.
+-  **core_review**: Pull requests for modules that are currently awaiting review by their maintainers on the Ansible Core team.
+-  **needs_info**: Waiting on info from the submitter.
+-  **needs_rebase**: Waiting on the submitter to rebase.
+-  **needs_revision**: Waiting on the submitter to make changes.
+-  **shipit**: Waiting for final review by the core team for potential merge.
+
+Informational Labels
+""""""""""""""""""""
+
+-  **backport**: this is applied automatically if the PR is requested against any branch that is not devel. The bot immediately assigns the labels backport and ``core_review``.
+-  **bugfix_pull_request**: applied by the bot based on the templatized description of the PR.
+-  **cloud**: applied by the bot based on the paths of the modified files.
+-  **docs_pull_request**: applied by the bot based on the templatized description of the PR.
+-  **easyfix**: applied manually, inconsistently used but sometimes useful.
+-  **feature_pull_request**: applied by the bot based on the templatized description of the PR.
+-  **networking**: applied by the bot based on the paths of the modified files.
+-  **owner_pr**: largely deprecated. Formerly workflow, now informational. Originally, PRs submitted by the maintainer would automatically go to **shipit** based on this label. If the submitter is also a maintainer, we notify the other maintainers and still require one of the maintainers (including the submitter) to give a **shipit**.
+-  **pending_action**: applied by the bot to PRs that are not moving. Reviewed every couple of weeks by the community team, who tries to figure out the appropriate action (closure, asking for new maintainers, etc).
+
+
+Special Labels
+""""""""""""""
+
+-  **new_plugin**: this is for new modules or plugins that are not yet in Ansible.
+
+**Note:** `new_plugin` kicks off a completely separate process, and frankly it doesn't work very well at present. We're working our best to improve this process.
+
+Making your PR merge-worthy
+===========================
+
+We don't merge every PR. Here are some tips for making your PR useful, attractive, and merge-worthy.
 
 .. _development_changelogs:
 
 Changelogs
 ----------
 
-Please add a changelog fragment with any PR that is
-:ref:`changelog-worthy <creating_new_changelog_fragments>`. New modules and
-plugins do not require changelogs as our tooling will automatically add any new
-module or plugin.
+Changelogs help users and developers keep up with changes to Ansible.
+Ansible builds a changelog for each release from fragments. You must add a changelog fragment to any PR that changes functionality or fixes a bug.
+You don't have to add a changelog fragment for PRs that add new
+modules and plugins, because our tooling does that for you automatically.
 
-Ansbile requires a changelog for any PRs to be merged that should appear in the
-changelog have a changelog fragment.
-This includes all :ref:`changelog-worthy changes
-<creating_new_changelog_fragments>`. Minor bugfixes that are going to be
-backported we would want changelog entries in the backport PR (if they didn't
-already appear in the devel PR) as our changlog policy is for minor releases to
-list a short summary of all changes.
+We build short summary changelogs for minor releases as well as for major releases. If you backport a bugfix, include a changelog fragment with the backport PR.
 
-.. _creating_new_changelog_fragments:
+.. _creating_a_changelog_fragment:
 
-Creating New Fragments
-~~~~~~~~~~~~~~~~~~~~~~
+Creating a changelog fragment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Create a new file with a unique and descriptive name in ``changelogs/fragments/`` that ends in ``.yaml`` such as ``user-40696-backup-shadow-file.yaml``
+A basic changelog fragment is a ``.yaml`` file placed in the
+``changelogs/fragments/`` directory.  Each file contains a yaml dict with
+keys like ``"bugfixes"`` or ``"major_changes"`` followed by a list of
+changelog entries of bugfixes or features.  Each changelog entry is
+rst embedded inside of the yaml file which means that certain
+constructs would need to be escaped so they can be interpreted by rst
+and not by yaml (or escaped for both yaml and rst if that's your
+desire).  Each PR should use a new fragment file rather than adding to
+an existing one.
 
-A single changelog fragment may contain multiple sections but most will only contain one section. Here are the valid sections and a description of each:
+To create a changelog entry, create a new file with a unique name in the ``changelogs/fragments/`` directory. The file name should include the PR number and a description of the change. It must end with the file extension ``.yaml``. For example: ``40696-user-backup-shadow-file.yaml``
+
+A single changelog fragment may contain multiple sections but most will only contain one section.
+The toplevel keys (bugfixes, major_changes, etc) are defined in the
+`config file <https://github.com/ansible/ansible/blob/devel/changelogs/config.yaml>` for our release note tool. Here are the valid sections and a description of each:
 
 **major_changes**
     Major changes to Ansible itself. Generally does not include module or plugin changes.
@@ -75,7 +188,9 @@ A single changelog fragment may contain multiple sections but most will only con
 **known_issues**
   Known issues that are currently not fixed or will not be fixed.
 
-Most changelog entries will be ``bugfixes`` or ``minor_changes``. When writing a changelog entry that pertains to a particular module, start the entry with ``- [module name] -`` and include a link to the related issue if one exists. Here are some examples:
+Most changelog entries will be ``bugfixes`` or ``minor_changes``. When writing a changelog entry that pertains to a particular module, start the entry with ``- [module name] -`` and include a link to the related issue if one exists.
+
+Here are some examples:
 
 .. code-block:: yaml
 
@@ -87,47 +202,24 @@ Most changelog entries will be ``bugfixes`` or ``minor_changes``. When writing a
   minor_changes:
     - lineinfile - add warning when using an empty regexp (https://github.com/ansible/ansible/issues/29443)
 
-Commit the changelog fragment and include it with the pull request.
+.. code-block:: yaml
 
-
-How to
-~~~~~~
-A basic changelog fragment is a ``.yaml`` file placed in the
-``changelogs/fragments/`` directory.  Each file contains a yaml dict with
-keys like ``"bugfixes"`` or ``"major_changes"`` followed by a list of
-changelog entries of bugfixes or features.  Each changelog entry is
-rst embedded inside of the yaml file which means that certain
-constructs would need to be escaped so they can be interpreted by rst
-and not by yaml (or escaped for both yaml and rst if that's your
-desire).  Each PR should use a new fragment file rather than adding to
-an existing one.
-
-Here's an example of a changelog fragment for a bugfix:
-
-bugfixes:
- * copy module - The copy module was attempting to change the mode of files for
+  bugfixes:
+    - copy module - The copy module was attempting to change the mode of files for
    remote_src=True even if mode was not set as a parameter.  This failed on
    filesystems which do not have permission bits
    (https://github.com/ansible/ansible/pull/40099)
 
- * You can find more example changelog fragments in the changelog
-   directory for a previous release:
-   https://github.com/ansible/ansible/tree/stable-2.6/changelogs/fragments
+You can find more example changelog fragments in the `changelog directory <https://github.com/ansible/ansible/tree/stable-2.6/changelogs/fragments>`_ for the 2.6 release. You can also find documentation of the format, including hints on embedding rst in the yaml, in the `reno documentation <https://docs.openstack.org/reno/latest/user/usage.html#editing-a-release-note>`_.
 
- * You can also find documentation of the format including hints on
-   embedding rst in the yaml in the reno documentation:
-   https://docs.openstack.org/reno/latest/user/usage.html#editing-a-release-note
+Once you've written the changelog fragment for your PR, commit the file and include it with the pull request.
 
- * The toplevel keys (bugfixes, major_changes, etc) are defined in the
-   config file for our release note tool.  You can find the keys
-   recognized for the current release here:
-   https://github.com/ansible/ansible/blob/devel/changelogs/config.yaml#L6
 
-Backport Pull Request Process
------------------------------
+Backporting merged PRs
+======================
 
-After the pull request submitted to Ansible for the ``devel`` branch is
-accepted and merged, the following instructions will help you create a
+All Ansible PRs must be merged to the ``devel`` branch first.
+After a pull request has been accepted and merged to the ``devel`` branch, the following instructions will help you create a
 pull request to backport the change to a previous stable branch.
 
 We do **not** backport features.
@@ -187,99 +279,3 @@ We do **not** backport features.
     from devel to stable branches in Ansible. Take a look at the `cherry-picker
     documentation <https://pypi.org/p/cherry-picker#cherry-picking>`_ for
     details on installing, configuring, and using it.
-
-
-Ansibullbot
-===========
-
-Overview
---------
-
-`Ansibullbot`_ serves many functions:
-
-- Responds quickly to PR submitters to thank them for submitting their PR
-- Identifies the community maintainer responsible for reviewing PRs for any files affected
-- Tracks the current status of PRs
-- Pings responsible parties to remind them of any PR actions for which they may be responsible
-- Provides maintainers with the ability to move PRs through the workflow
-- Identifies PRs abandoned by their submitters so that we can close them
-- Identifies modules abandoned by their maintainers so that we can find new maintainers
-
-Community Maintainers
----------------------
-
-Each module has at least one assigned maintainer, listed in a `maintainer's file`_:
-
-.. _Ansibullbot: https://github.com/ansible/ansibullbot/blob/master/ISSUE_HELP.md
-.. _maintainer's file: https://github.com/ansible/ansible/blob/devel/.github/BOTMETA.yml
-
-Some modules have no community maintainers assigned. In this case, the maintainer is listed as ``$team_ansible``. Ultimately, it's our goal to have at least one community maintainer for every module.
-
-The maintainer's job is to review PRs and decide whether that PR should be merged (``shipit``) or revised (``needs_revision``).
-
-The ultimate goal of any pull request is to reach **shipit** status, where the Core team then decides whether the PR is ready to be merged. Not every PR that reaches the **shipit** label is actually ready to be merged, but the better our reviewers are, and the better our guidelines are, the more likely it will be that a PR that reaches **shipit** will be mergeable.
-
-
-
-Workflow
---------
-
-Ansibullbot runs continuously. You can generally expect to see changes to your issue or pull request within thirty minutes. Ansibullbot examines every open pull request in the repositories, and enforces state roughly according to the following workflow:
-
--  If a pull request has no workflow labels, it's considered **new**. Files in the pull request are identified, and the maintainers of those files are pinged by the bot, along with instructions on how to review the pull request. (Note: sometimes we strip labels from a pull request to "reboot" this process.)
--  If the module maintainer is not ``$team_ansible``, the pull request then goes into the **community_review** state.
--  If the module maintainer is ``$team_ansible``, the pull request then goes into the **core_review** state (and probably sits for a while).
--  If the pull request is in **community_review** and has received comments from the maintainer:
-
-   -  If the maintainer says ``shipit``, the pull request is labeled **shipit**, whereupon the Core team assesses it for final merge.
-   -  If the maintainer says ``needs_info``, the pull request is labeled **needs_info** and the submitter is asked for more info.
-   -  If the maintainer says **needs_revision**, the pull request is labeled **needs_revision** and the submitter is asked to fix some things.
-
--  If the submitter says ``ready_for_review``, the pull request is put back into **community_review** or **core_review** and the maintainer is notified that the pull request is ready to be reviewed again.
--  If the pull request is labeled **needs_revision** or **needs_info** and the submitter has not responded lately:
-
-   -  The submitter is first politely pinged after two weeks, pinged again after two more weeks and labeled **pending action**, and the issue or pull request will be closed two weeks after that.
-   -  If the submitter responds at all, the clock is reset.
--  If the pull request is labeled **community_review** and the reviewer has not responded lately:
-
-   -  The reviewer is first politely pinged after two weeks, pinged again after two more weeks and labeled **pending_action**, and then may be reassigned to ``$team_ansible`` or labeled **core_review**, or often the submitter of the pull request is asked to step up as a maintainer.
--  If Shippable tests fail, or if the code is not able to be merged, the pull request is automatically put into **needs_revision** along with a message to the submitter explaining why.
-
-
-There are corner cases and frequent refinements, but this is the workflow in general.
-
-PR Labels
----------
-
-There are two types of PR Labels generally: *workflow labels* and *information labels*.
-
-Workflow Labels
-~~~~~~~~~~~~~~~
-
--  **community_review**: Pull requests for modules that are currently awaiting review by their maintainers in the Ansible community.
--  **core_review**: Pull requests for modules that are currently awaiting review by their maintainers on the Ansible Core team.
--  **needs_info**: Waiting on info from the submitter.
--  **needs_rebase**: Waiting on the submitter to rebase.
--  **needs_revision**: Waiting on the submitter to make changes.
--  **shipit**: Waiting for final review by the core team for potential merge.
-
-Informational Labels
-~~~~~~~~~~~~~~~~~~~~
-
--  **backport**: this is applied automatically if the PR is requested against any branch that is not devel. The bot immediately assigns the labels backport and ``core_review``.
--  **bugfix_pull_request**: applied by the bot based on the templatized description of the PR.
--  **cloud**: applied by the bot based on the paths of the modified files.
--  **docs_pull_request**: applied by the bot based on the templatized description of the PR.
--  **easyfix**: applied manually, inconsistently used but sometimes useful.
--  **feature_pull_request**: applied by the bot based on the templatized description of the PR.
--  **networking**: applied by the bot based on the paths of the modified files.
--  **owner_pr**: largely deprecated. Formerly workflow, now informational. Originally, PRs submitted by the maintainer would automatically go to **shipit** based on this label. If the submitter is also a maintainer, we notify the other maintainers and still require one of the maintainers (including the submitter) to give a **shipit**.
--  **pending_action**: applied by the bot to PRs that are not moving. Reviewed every couple of weeks by the community team, who tries to figure out the appropriate action (closure, asking for new maintainers, etc).
-
-
-Special Labels
-~~~~~~~~~~~~~~
-
--  **new_plugin**: this is for new modules or plugins that are not yet in Ansible.
-
-   **Note:** `new_plugin` kicks off a completely separate process, and frankly it doesn't work very well at present. We're working our best to improve this process.

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -27,7 +27,7 @@ Pull Requests
 
 Ansible accepts code via **pull requests** ("PRs" for short). GitHub provides a great overview of `how the pull request process works <https://help.github.com/articles/about-pull-requests/>`_ in general.
 
-Because Ansible receives many pull requests, we use an automated process to help us through the process of reviewing and merging pull requests. That process is managed by **Ansibullbot**.
+Because Ansible receives many pull requests, we use an automated process to help us through the process of reviewing and merging pull requests. That process is managed by `Ansibullbot`_.
 
 
 .. _development_changelogs:
@@ -36,19 +36,19 @@ Changelogs
 ----------
 
 Please add a changelog fragment with any PR that is
-changelog-worthy (features, major bugfixes, backwards
-incompatiblities, etc) except for new modules and plugins (Our tooling
-will automatically add any new module or plugin)
+:ref:`changelog-worthy <creating_new_changelog_fragments>`. New modules and
+plugins do not require changelogs as our tooling will automatically add any new
+module or plugin.
 
-Ansbile developers in the community will require a changelog for any PRs to be
-merged that should appear in the changelog have a changelog fragment.
-This includes new features, major bugfixes, backward incompatibilities,
-deprecations, and other things that users should know on update.
+Ansbile requires a changelog for any PRs to be merged that should appear in the
+changelog have a changelog fragment.
+This includes all :ref:`changelog-worthy changes
+<creating_new_changelog_fragments>`. Minor bugfixes that are going to be
+backported we would want changelog entries in the backport PR (if they didn't
+already appear in the devel PR) as our changlog policy is for minor releases to
+list a short summary of all changes.
 
-Minor bugfixes that are going to be backported we would want changelog
-entries in the backport PR (if they didn't already appear in the devel
-PR) as our changlog policy is for minor releases to list a short
-summary of all changes.
+.. _creating_new_changelog_fragments:
 
 Creating New Fragments
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -29,6 +29,57 @@ Ansible accepts code via **pull requests** ("PRs" for short). GitHub provides a 
 
 Because Ansible receives many pull requests, we use an automated process to help us through the process of reviewing and merging pull requests. That process is managed by **Ansibullbot**.
 
+Changelogs
+----------
+
+Please add a changelog fragment with any PR that is
+changelog-worthy (features, major bugfixes, backwards
+incompatiblities, etc) except for new modules and plugins (Our tooling
+will automatically add any new module or plugin)
+
+Ansbile developers in the community will require a changelog for any PRs to be
+merged that should appear in the changelog have a changelog fragment.
+This includes new features, major bugfixes, backward incompatibilities,
+deprecations, and other things that users should know on update.
+
+Minor bugfixes that are going to be backported we would want changelog
+entries in the backport PR (if they didn't already appear in the devel
+PR) as our changlog policy is for minor releases to list a short
+summary of all changes.
+
+How to
+~~~~~~
+A basic changelog fragment is a ``.yaml`` file placed in the
+``changelogs/fragments/`` directory.  Each file contains a yaml dict with
+keys like ``"bugfixes"`` or ``"major_changes"`` followed by a list of
+changelog entries of bugfixes or features.  Each changelog entry is
+rst embedded inside of the yaml file which means that certain
+constructs would need to be escaped so they can be interpreted by rst
+and not by yaml (or escaped for both yaml and rst if that's your
+desire).  Each PR should use a new fragment file rather than adding to
+an existing one.
+
+Here's an example of a changelog fragment for a bugfix:
+
+bugfixes:
+ * copy module - The copy module was attempting to change the mode of files for
+   remote_src=True even if mode was not set as a parameter.  This failed on
+   filesystems which do not have permission bits
+   (https://github.com/ansible/ansible/pull/40099)
+
+ * You can find more example changelog fragments in the changelog
+   directory for a previous release:
+   https://github.com/ansible/ansible/tree/stable-2.6/changelogs/fragments
+
+ * You can also find documentation of the format including hints on
+   embedding rst in the yaml in the reno documentation:
+   https://docs.openstack.org/reno/latest/user/usage.html#editing-a-release-note
+
+ * The toplevel keys (bugfixes, major_changes, etc) are defined in the
+   config file for our release note tool.  You can find the keys
+   recognized for the current release here:
+   https://github.com/ansible/ansible/blob/devel/changelogs/config.yaml#L6
+
 Backport Pull Request Process
 -----------------------------
 

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -97,7 +97,7 @@ Workflow labels
 -  **shipit**: Waiting for final review by the core team for potential merge.
 
 Information labels
-""""""""""""""""""""
+""""""""""""""""""
 
 -  **backport**: this is applied automatically if the PR is requested against any branch that is not devel. The bot immediately assigns the labels backport and ``core_review``.
 -  **bugfix_pull_request**: applied by the bot based on the templatized description of the PR.

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -29,6 +29,9 @@ Ansible accepts code via **pull requests** ("PRs" for short). GitHub provides a 
 
 Because Ansible receives many pull requests, we use an automated process to help us through the process of reviewing and merging pull requests. That process is managed by **Ansibullbot**.
 
+
+.. _development_changelogs:
+
 Changelogs
 ----------
 
@@ -46,6 +49,46 @@ Minor bugfixes that are going to be backported we would want changelog
 entries in the backport PR (if they didn't already appear in the devel
 PR) as our changlog policy is for minor releases to list a short
 summary of all changes.
+
+Creating New Fragments
+~~~~~~~~~~~~~~~~~~~~~~
+
+Create a new file with a unique and descriptive name in ``changelogs/fragments/`` that ends in ``.yaml`` such as ``user-40696-backup-shadow-file.yaml``
+
+A single changelog fragment may contain multiple sections but most will only contain one section. Here are the valid sections and a description of each:
+
+**major_changes**
+    Major changes to Ansible itself. Generally does not include module or plugin changes.
+
+**minor_changes**
+  Minor changes to Ansible, modules, or plugins. This includes new features, new parameters added to modules, or behavior changes to existing parameters.
+
+**deprecated_features**
+  Features that have been deprecated and are scheduled for removal in a future release.
+
+**removed_features**
+  Features that were previously deprecated and are now removed.
+
+**bugfixes**
+  Fixes that resolve issues. If there is a specific issue related to this bugfix, add a link in the changelog entry.
+
+**known_issues**
+  Known issues that are currently not fixed or will not be fixed.
+
+Most changelog entries will be ``bugfixes`` or ``minor_changes``. When writing a changelog entry that pertains to a particular module, start the entry with ``- [module name] -`` and include a link to the related issue if one exists. Here are some examples:
+
+.. code-block:: yaml
+
+  bugfixes:
+    - win_updates - fixed issue where running win_updates on async fails without any error
+
+.. code-block:: yaml
+
+  minor_changes:
+    - lineinfile - add warning when using an empty regexp (https://github.com/ansible/ansible/issues/29443)
+
+Commit the changelog fragment and include it with the pull request.
+
 
 How to
 ~~~~~~

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -137,19 +137,19 @@ Making your PR merge-worthy
 
 We don't merge every PR. Here are some tips for making your PR useful, attractive, and merge-worthy.
 
-.. _development_changelogs:
+.. _community_changelogs:
 
 Changelogs
 ----------
 
 Changelogs help users and developers keep up with changes to Ansible.
-Ansible builds a changelog for each release from fragments. You must add a changelog fragment to any PR that changes functionality or fixes a bug.
+Ansible builds a changelog for each release from fragments. You **must** add a changelog fragment to any PR that changes functionality or fixes a bug.
 You don't have to add a changelog fragment for PRs that add new
 modules and plugins, because our tooling does that for you automatically.
 
 We build short summary changelogs for minor releases as well as for major releases. If you backport a bugfix, include a changelog fragment with the backport PR.
 
-.. _creating_a_changelog_fragment:
+.. _changelogs_how_to:
 
 Creating a changelog fragment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -161,8 +161,8 @@ changelog entries of bugfixes or features.  Each changelog entry is
 rst embedded inside of the yaml file which means that certain
 constructs would need to be escaped so they can be interpreted by rst
 and not by yaml (or escaped for both yaml and rst if that's your
-desire).  Each PR should use a new fragment file rather than adding to
-an existing one.
+desire).  Each PR **must** use a new fragment file rather than adding to
+an existing one, so we can trace the change back to the PR that introduced it.
 
 To create a changelog entry, create a new file with a unique name in the ``changelogs/fragments/`` directory. The file name should include the PR number and a description of the change. It must end with the file extension ``.yaml``. For example: ``40696-user-backup-shadow-file.yaml``
 
@@ -207,8 +207,7 @@ Here are some examples:
   bugfixes:
     - copy module - The copy module was attempting to change the mode of files for
    remote_src=True even if mode was not set as a parameter.  This failed on
-   filesystems which do not have permission bits
-   (https://github.com/ansible/ansible/pull/40099)
+   filesystems which do not have permission bits.
 
 You can find more example changelog fragments in the `changelog directory <https://github.com/ansible/ansible/tree/stable-2.6/changelogs/fragments>`_ for the 2.6 release. You can also find documentation of the format, including hints on embedding rst in the yaml, in the `reno documentation <https://docs.openstack.org/reno/latest/user/usage.html#editing-a-release-note>`_.
 

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -27,7 +27,8 @@ If you want to follow the conversation about what features will be added to Ansi
 Micro development: the lifecycle of a PR
 ========================================
 
-Ansible accepts code via **pull requests** ("PRs" for short). GitHub provides a great overview of `how the pull request process works <https://help.github.com/articles/about-pull-requests/>`_ in general. Here's an overview of the PR lifecycle:
+Ansible accepts code via **pull requests** ("PRs" for short). GitHub provides a great overview of `how the pull request process works <https://help.github.com/articles/about-pull-requests/>`_ in general. The ultimate goal of any pull request is to get merged and become part of Ansible Core.
+Here's an overview of the PR lifecycle:
 
 * Contributor opens a PR
 * Ansibot reviews the PR
@@ -39,13 +40,10 @@ Ansible accepts code via **pull requests** ("PRs" for short). GitHub provides a 
 * Developers, maintainers, community re-review
 * PR merged or closed
 
-Ansibullbot
------------
+Automated PR review: ansibullbot
+--------------------------------
 
 Because Ansible receives many pull requests, and because we love automating things, we've automated several steps of the process of reviewing and merging pull requests with a tool called Ansibullbot, or Ansibot for short.
-
-Overview
-^^^^^^^^
 
 `Ansibullbot <https://github.com/ansible/ansibullbot/blob/master/ISSUE_HELP.md>`_ serves many functions:
 
@@ -57,20 +55,8 @@ Overview
 - Identifies PRs abandoned by their submitters so that we can close them
 - Identifies modules abandoned by their maintainers so that we can find new maintainers
 
-Community Maintainers
-^^^^^^^^^^^^^^^^^^^^^
-
-Each module has at least one assigned maintainer, listed in a `maintainer's file <https://github.com/ansible/ansible/blob/devel/.github/BOTMETA.yml>`_:
-
-Some modules have no community maintainers assigned. In this case, the maintainer is listed as ``$team_ansible``. Ultimately, it's our goal to have at least one community maintainer for every module.
-
-The maintainer's job is to review PRs and decide whether that PR should be merged (``shipit``) or revised (``needs_revision``).
-
-The ultimate goal of any pull request is to reach **shipit** status, where the Core team then decides whether the PR is ready to be merged. Not every PR that reaches the **shipit** label is actually ready to be merged, but the better our reviewers are, and the better our guidelines are, the more likely it will be that a PR that reaches **shipit** will be mergeable.
-
-
-Workflow
-^^^^^^^^
+Ansibot workflow
+^^^^^^^^^^^^^^^^
 
 Ansibullbot runs continuously. You can generally expect to see changes to your issue or pull request within thirty minutes. Ansibullbot examines every open pull request in the repositories, and enforces state roughly according to the following workflow:
 
@@ -93,15 +79,14 @@ Ansibullbot runs continuously. You can generally expect to see changes to your i
    -  The reviewer is first politely pinged after two weeks, pinged again after two more weeks and labeled **pending_action**, and then may be reassigned to ``$team_ansible`` or labeled **core_review**, or often the submitter of the pull request is asked to step up as a maintainer.
 -  If Shippable tests fail, or if the code is not able to be merged, the pull request is automatically put into **needs_revision** along with a message to the submitter explaining why.
 
-
 There are corner cases and frequent refinements, but this is the workflow in general.
 
-PR Labels
+PR labels
 ^^^^^^^^^
 
-There are two types of PR Labels generally: *workflow labels* and *information labels*.
+There are two types of PR Labels generally: **workflow** labels and **information** labels.
 
-Workflow Labels
+Workflow labels
 """""""""""""""
 
 -  **community_review**: Pull requests for modules that are currently awaiting review by their maintainers in the Ansible community.
@@ -111,7 +96,7 @@ Workflow Labels
 -  **needs_revision**: Waiting on the submitter to make changes.
 -  **shipit**: Waiting for final review by the core team for potential merge.
 
-Informational Labels
+Information labels
 """"""""""""""""""""
 
 -  **backport**: this is applied automatically if the PR is requested against any branch that is not devel. The bot immediately assigns the labels backport and ``core_review``.
@@ -131,6 +116,18 @@ Special Labels
 -  **new_plugin**: this is for new modules or plugins that are not yet in Ansible.
 
 **Note:** `new_plugin` kicks off a completely separate process, and frankly it doesn't work very well at present. We're working our best to improve this process.
+
+Human PR review
+---------------
+
+After Ansibot reviews the PR and applies labels, the PR is ready for human review. The most likely reviewers for any PR are the maintainers for the module that PR modifies.
+
+Each module has at least one assigned :ref:`maintainer <maintainers>`, listed in the `BOTMETA.yml <https://github.com/ansible/ansible/blob/devel/.github/BOTMETA.yml>`_ file.
+
+The maintainer's job is to review PRs that affect that module and decide whether they should be merged (``shipit``) or revised (``needs_revision``). We'd like to have at least one community maintainer for every module. If a module has no community maintainers assigned, the maintainer is listed as ``$team_ansible``.
+
+Once a human applies the ``shipit`` label, the :ref:`committers <community_committer_guidelines>` decide whether the PR is ready to be merged. Not every PR that gets the ``shipit`` label is actually ready to be merged, but the better our reviewers are, and the better our guidelines are, the more likely it will be that a PR that reaches **shipit** will be mergeable.
+
 
 Making your PR merge-worthy
 ===========================
@@ -156,7 +153,7 @@ Creating a changelog fragment
 
 A basic changelog fragment is a ``.yaml`` file placed in the
 ``changelogs/fragments/`` directory.  Each file contains a yaml dict with
-keys like ``"bugfixes"`` or ``"major_changes"`` followed by a list of
+keys like ``bugfixes`` or ``major_changes`` followed by a list of
 changelog entries of bugfixes or features.  Each changelog entry is
 rst embedded inside of the yaml file which means that certain
 constructs would need to be escaped so they can be interpreted by rst

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -3,7 +3,7 @@
 Release and maintenance
 =======================
 
-.. contents:: Topics
+.. contents::
    :local:
 
 .. _release_cycle:
@@ -96,7 +96,7 @@ releases of Ansible, there can sometimes be exceptions for critical issues.
 
 .. _GitHub: https://github.com/ansible/ansible
 
-.. _changelogs_how_to:
+.. _release_changelogs:
 
 Changelogs
 ~~~~~~~~~~
@@ -105,8 +105,7 @@ Older versions logged changes in ``stable-<version>`` branches at ``stable-<vers
 
 We now generate changelogs based on fragments. Here is the generated changelog for 2.6_ as an example. When creating new features or fixing bugs, create a changelog fragment describing the change. A changelog entry is not needed for new modules or plugins. Details for those items will be generated from the module documentation.
 
-For more information on changelogs, please reference the developer documentation
-:ref:`developer documentation <changelogs_how_to>`.
+We've got :ref:`examples and instructions on creating changelog fragments <changelogs_how_to>` in the Community Guide.
 
 
 Release candidates

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -99,51 +99,14 @@ releases of Ansible, there can sometimes be exceptions for critical issues.
 .. _changelogs_how_to:
 
 Changelogs
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~
 
 Older versions logged changes in ``stable-<version>`` branches at ``stable-<version>/CHANGELOG.md``. For example, here is the changelog for 2.4_ on GitHub.
 
 We now generate changelogs based on fragments. Here is the generated changelog for 2.6_ as an example. When creating new features or fixing bugs, create a changelog fragment describing the change. A changelog entry is not needed for new modules or plugins. Details for those items will be generated from the module documentation.
 
-Creating New Fragments
-----------------------
-
-Create a new file with a unique and descriptive name in ``changelogs/fragments/`` that ends in ``.yaml`` such as ``user-40696-backup-shadow-file.yaml``
-
-A single changelog fragment may contain multiple sections but most will only contain one section. Here are the valid sections and a description of each:
-
-**major_changes**
-    Major changes to Ansible itself. Generally does not include module or plugin changes.
-
-**minor_changes**
-  Minor changes to Ansible, modules, or plugins. This includes new features, new parameters added to modules, or behavior changes to existing parameters.
-
-**deprecated_features**
-  Features that have been deprecated and are scheduled for removal in a future release.
-
-**removed_features**
-  Features that were previously deprecated and are now removed.
-
-**bugfixes**
-  Fixes that resolve issues. If there is a specific issue related to this bugfix, add a link in the changelog entry.
-
-**known_issues**
-  Known issues that are currently not fixed or will not be fixed.
-
-Most changelog entries will be ``bugfixes`` or ``minor_changes``. When writing a changelog entry that pertains to a particular module, start the entry with ``- [module name] -`` and include a link to the related issue if one exists. Here are some examples:
-
-.. code-block:: yaml
-
-  bugfixes:
-    - win_updates - fixed issue where running win_updates on async fails without any error
-
-.. code-block:: yaml
-
-  minor_changes:
-    - lineinfile - add warning when using an empty regexp (https://github.com/ansible/ansible/issues/29443)
-
-Commit the changelog fragment and include it with the pull request.
-
+For more information on changelogs, please reference the developer documentation
+:ref:`developer documentation <changelogs_how_to>`.
 
 
 Release candidates


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add docs for developer guides about changelog fragments
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (docs/changelogs 7792f827d2) last updated 2018/11/06 11:01:05 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.15 (default, Oct 15 2018, 15:24:06) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```

