### PR TITLE
2.6: Backport _cond_not_supported_warn() (#41126)

### DIFF
--- a/changelogs/fragments/46275-fix-_cond_not_supported_warn.yaml
+++ b/changelogs/fragments/46275-fix-_cond_not_supported_warn.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Fix for "AttributeError: 'StrategyModule' object has no attribute '_cond_not_supported_warn'" (https://github.com/ansible/ansible/issues/46275)

--- a/changelogs/fragments/46275-fix-_cond_not_supported_warn.yaml
+++ b/changelogs/fragments/46275-fix-_cond_not_supported_warn.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-    - Fix for "AttributeError: 'StrategyModule' object has no attribute '_cond_not_supported_warn'" (https://github.com/ansible/ansible/issues/46275)
+    - Fix for StrategyModule object has no attribute _cond_not_supported_warn (https://github.com/ansible/ansible/issues/46275)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -943,6 +943,9 @@ class StrategyBase:
 
         return ret
 
+    def _cond_not_supported_warn(self, task_name):
+        display.warning("%s task does not support when conditional" % task_name)
+
     def _execute_meta(self, task, play_context, iterator, target_host):
 
         # meta tasks store their args in the _raw_params field of args,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/46275

(Partially cherry picked from commit 5f7ffd39dc8e8043aaed59c365b0e9c759ee829b)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
strategy

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.6
```

##### ADDITIONAL INFORMATION