### PR TITLE
Changed single file zip write parameter for arcname to use os.path.ba…

### DIFF
--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -423,7 +423,8 @@ def main():
                 try:
                     if format == 'zip':
                         arcfile = zipfile.ZipFile(dest, 'w', zipfile.ZIP_DEFLATED, True)
-                        arcfile.write(path, path[len(arcroot):])
+                        arcname = os.path.basename(path)
+                        arcfile.write(path, arcname)
                         arcfile.close()
                         state = 'archive'  # because all zip files are archives
 


### PR DESCRIPTION
…sename rather than string splicing path

Fixes #46277

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Previously, single file compression used string splicing to get arcname paramter for zip.write. Changes it to use os.path.basename.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #46277
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
archive
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (archive_module_arcroot_len_path_bug baa7a0db45) last updated 2018/11/06 18:50:37 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mlghugma/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mlghugma/ansible/lib/ansible
  executable location = /home/mlghugma/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Tested with both archiving with file in a directory and without. Without directory no longer truncs first character of filename. 
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
