### PR TITLE
ovirt_vm: Add option to apply the configuration change on "Next Run"

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -581,6 +581,12 @@ options:
             - "If I(true), the VM will migrate even if it is defined as non-migratable."
         version_added: "2.8"
         type: bool
+    next_run:
+        description:
+            - "If I(true), the update will not be applied to the VM immediately and will be only applied when virtual machine is restarted."
+            - NOTE - If there are multiple next run configuration changes on the VM, the first change may get reverted if this option is not passed.
+        version_added: "2.8"
+        type: bool
 
 notes:
     - If VM is in I(UNASSIGNED) or I(UNKNOWN) state before any operation, the module will fail.
@@ -2049,6 +2055,7 @@ def main():
         export_domain=dict(default=None),
         export_ova=dict(type='dict'),
         force_migrate=dict(type='bool'),
+        next_run=dict(type='bool'),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -2084,6 +2091,7 @@ def main():
             ret = vms_module.create(
                 entity=vm,
                 result_state=otypes.VmStatus.DOWN if vm is None else None,
+                update_params={'next_run': module.params['next_run']} if module.params['next_run'] is not None else None,
                 clone=module.params['clone'],
                 clone_permissions=module.params['clone_permissions'],
             )


### PR DESCRIPTION
The PR adds new option "next_run" so that user can decide if the
configuration has to be applied on the VM immediately or it has
to be configured on next restart.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_vm
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible --version
ansible 2.7.1
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
