### PR TITLE
Typo and style fixes in docs and messages for svc module

### DIFF
--- a/lib/ansible/modules/system/svc.py
+++ b/lib/ansible/modules/system/svc.py
@@ -37,21 +37,21 @@ options:
     downed:
         description:
             - Should a 'down' file exist or not, if it exists it disables auto startup.
-              defaults to no. Downed does not imply stopped.
+              Defaults to no. Downed does not imply stopped.
         type: bool
         default: 'no'
     enabled:
         description:
-            - Wheater the service is enabled or not, if disabled it also implies stopped.
-              Make note that a service can be enabled and downed (no auto restart).
+            - Whether the service is enabled or not, if disabled it also implies stopped.
+              Take note that a service can be enabled and downed (no auto restart).
         type: bool
     service_dir:
         description:
-            - directory svscan watches for services
+            - Directory svscan watches for services
         default: /service
     service_src:
         description:
-            - directory where services are defined, the source of symlinks to service_dir.
+            - Directory where services are defined, the source of symlinks to service_dir.
 '''
 
 EXAMPLES = '''
@@ -273,7 +273,7 @@ def main():
                 else:
                     svc.disable()
             except (OSError, IOError) as e:
-                module.fail_json(msg="Could change service link: %s" % to_native(e))
+                module.fail_json(msg="Could not change service link: %s" % to_native(e))
 
     if state is not None and state != svc.state:
         changed = True
@@ -290,7 +290,7 @@ def main():
                 else:
                     os.unlink(d_file)
             except (OSError, IOError) as e:
-                module.fail_json(msg="Could change downed file: %s " % (to_native(e)))
+                module.fail_json(msg="Could not change downed file: %s " % (to_native(e)))
 
     module.exit_json(changed=changed, svc=svc.report())
 


### PR DESCRIPTION
##### SUMMARY
Minor typo and style fixes in documentation.

Fixed two error messages which incorrectly used "Could" instead of "Could *not*".

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
svc

##### ANSIBLE VERSION
(Including this as requested, but my changes are based on the latest version of the file in the devel branch.)
```
ansible 2.7.0
  config file = /home/njohnston/.ansible.cfg
  configured module search path = [u'/home/njohnston/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```

##### ADDITIONAL INFORMATION
None, this is a trivial change.