### PR TITLE
fix grafana_dashboard KeyError when create new dashboard #47119

### DIFF
--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -208,7 +208,8 @@ def grafana_dashboard_exists(module, grafana_url, uid, headers):
     if info['status'] == 200:
         dashboard_exists = True
         try:
-            dashboard = json.loads(r.read())
+            response = json.loads(r.read())
+            dashboard = response['dashboard']
         except Exception as e:
             raise GrafanaAPIException(e)
     elif info['status'] == 404:
@@ -225,6 +226,8 @@ def grafana_create_dashboard(module, data):
     try:
         with open(data['path'], 'r') as json_file:
             payload = json.load(json_file)
+            if 'dashboard' not in payload:
+                payload = {'dashboard': payload}
     except Exception as e:
         raise GrafanaAPIException("Can't load json file %s" % to_native(e))
 
@@ -256,7 +259,7 @@ def grafana_create_dashboard(module, data):
 
     result = {}
     if dashboard_exists is True:
-        if dashboard == payload:
+        if dashboard == payload['dashboard']:
             # unchanged
             result['uid'] = uid
             result['msg'] = "Dashboard %s unchanged." % uid


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix ```KeyError: 'dashboard'``` when trying to create or update a dashboard with 'overwrite' option
Fixes #47119
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
grafan_dashboard

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.7.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]

```
