### PR TITLE
Allow AnsibleVaultEncryptedUnicode to pass through exec_jsonrpc

### DIFF
--- a/changelogs/fragments/48306-ansible-connection-json
+++ b/changelogs/fragments/48306-ansible-connection-json
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- Use custom JSON encoder in conneciton.py so that ansible objects (AnsibleVaultEncryptedUnicode, for example)
+  can be sent to the persistent connection process


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #47200 

~~Before I start copying over the rest of AnsibleJSONEncoder, does anyone have a better idea of how to get that functionality into module_utils?~~

I just duplicated AnsibleJSONEncoder into connection. Could probably move it somewhere else.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/connection.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```