### PR TITLE
Get rabbitmq and erlang GPG keys from S3 in tests.

### DIFF
--- a/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
+++ b/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
@@ -17,13 +17,13 @@
   apt: name=apt-transport-https state=latest force=yes
 
 - name: Add Erlang Solutions public GPG key
-  apt_key: url=https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc state=present
+  apt_key: url=https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/setup_rabbitmq/erlang_solutions.asc state=present
 
 - name: Add Erlang Solutions repository
   apt_repository: repo="deb https://packages.erlang-solutions.com/ubuntu {{ ansible_distribution_release }} contrib" filename='erlang-solutions' state=present update_cache=yes
 
 - name: Add RabbitMQ public GPG key
-  apt_key: url=https://www.rabbitmq.com/rabbitmq-release-signing-key.asc state=present
+  apt_key: url=https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/setup_rabbitmq/rabbitmq-release-signing-key.asc state=present
 
 - name: Add RabbitMQ repository
   apt_repository: repo='deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main' filename='rabbitmq' state=present update_cache=yes


### PR DESCRIPTION
##### SUMMARY

Get rabbitmq and erlang GPG keys from S3 in tests.

This will reduce test failures due to unavailability of keys from their previous download locations.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

setup_rabbitmq

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (rabbitmq-test-update 4c956b96ee) last updated 2018/11/07 09:43:14 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.14 (default, Mar 22 2018, 11:39:16) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
