### PR TITLE
Update openshift version pin to latest working release

### DIFF
--- a/test/integration/targets/k8s/runme.sh
+++ b/test/integration/targets/k8s/runme.sh
@@ -21,5 +21,5 @@ ansible-playbook -v playbooks/merge_type_fail.yml "$@"
 # Run full test suite
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/openshift-recent"
 source "${MYTMPDIR}/openshift-recent/bin/activate"
-$PYTHON -m pip install 'openshift==0.7.2'
+$PYTHON -m pip install 'openshift>=0.8.1'
 ansible-playbook -v playbooks/full_test.yml "$@"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Addresses #48137 

openshift 0.8.1 fixed the issue with case sensitivity that broke Ansible tests for 0.8.0. A regression test has been added to the openshift repo and the new version has been released.

This PR updates the version pin so that it grabs this new version of openshift or anything newer. An issue has also been filed against the openshift python client repo to incorporate the tests that Ansible runs into the CI process to catch these breakages earlier.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s