### PR TITLE
Do not reboot after updating BIOS configuration

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -745,7 +745,7 @@ class RedfishUtils(object):
         data = response['data']
         set_bios_attr_uri = data["@Redfish.Settings"]["SettingsObject"]["@odata.id"]
 
-        payload = {"TargetSettingsURI": set_bios_attr_uri, "RebootJobType": "PowerCycle"}
+        payload = {"TargetSettingsURI": set_bios_attr_uri}
         response = self.post_request(self.root_uri + self.manager_uri + "/" + jobs, payload, HEADERS)
         if response['ret'] is False:
             return response
@@ -753,7 +753,8 @@ class RedfishUtils(object):
         response_output = response['resp'].__dict__
         job_id = response_output["headers"]["Location"]
         job_id = re.search("JID_.+", job_id).group()
-        return {'ret': True, 'msg': 'Config job created', 'job_id': job_id}
+        # Currently not passing job_id back to user but patch is coming
+        return {'ret': True, 'msg': "Config job %s created" % job_id}
 
     def get_fan_inventory(self):
         result = {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Don't reboot server after scheduling a BIOS configuration job, this allows doing a reboot at a later time, either using the redfish_command module or by any other means.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (dont-reboot-after-updating-bios-config 9103a9ebb7) last updated 2018/11/07 13:52:41 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /share1/git/ansible/lib/ansible
  executable location = /share1/git/ansible/bin/ansible
  python version = 2.7.5 (default, May 31 2018, 09:41:32) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


