### PR TITLE
Add service discovery

### DIFF
--- a/lib/ansible/modules/cloud/amazon/service_discovery.py
+++ b/lib/ansible/modules/cloud/amazon/service_discovery.py
@@ -1,0 +1,337 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: service_discovery
+short_description: thin wrap for boto3 servicediscovery client
+description:
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/servicediscovery.html
+    service discovery comes in two parts, a namespace and a service discovery "registry"
+    Namespace is somewhat owned by route53
+    Registries are owned by the namespace
+    ECS containers may announce themselves to the registry
+    There may be other things that use registries
+    This module tries to allow creating service discovery registries
+notes:
+    
+version_added: "2.8"
+author:
+    - "tad merchant @ezmac"
+
+requirements: [ json, botocore, boto3 ]
+options:
+    state:
+        description:
+          - The desired state of the service
+        required: true
+        choices: ["present", "absent"]
+    name:
+        description:
+          - The name of the service
+        required: true
+    creator_request_id:
+        description:
+          - A unique string that identifies the request and that allows failed CreateService requests to be retried without the risk of executing the operation twice. CreatorRequestId can be any unique string, for example, a date/time stamp.
+This field is autopopulated if not provided.
+        required: false
+    description:
+        description: Description for the service.
+    dns_config: 
+        required: True
+        description:
+           Required even when deleting to get the namespace_id; At minimum, dns_config may have only the namespace_id when deleting
+           for any creation, a full dns_config is required
+           A complex type that contains information about the records that you want Route 53 to create when you register an instance.
+           Something like: {
+              namespace_id: string
+              routing_policy: [MULTIVALUE, WEIGHTED]
+              dns_records:[
+                {
+                  Type: [A, AAAA, SRV, CNAME],
+                  TTL: int,
+                  }]
+              }
+    health_check_config:
+        required: false
+        description: Public dns only
+        {
+          Type: "string" ([HTTP, HTTPS, TCP]),
+          ResourcePath: "string",
+          FailureThreshold: int
+        }
+
+    health_check_custom_config:
+        required: False
+        description: Private DNS only
+        {
+          failure_threshold: int
+        }
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+'''
+
+RETURN = '''
+Probably something like:
+{
+    'Service': {
+        'Id': 'string',
+        'Arn': 'string',
+        'Name': 'string',
+        'Description': 'string',
+        'InstanceCount': 123,
+        'DnsConfig': {
+            'NamespaceId': 'string',
+            'RoutingPolicy': 'MULTIVALUE'|'WEIGHTED',
+            'DnsRecords': [
+                {
+                    'Type': 'SRV'|'A'|'AAAA'|'CNAME',
+                    'TTL': 123
+                },
+            ]
+        },
+        'HealthCheckConfig': {
+            'Type': 'HTTP'|'HTTPS'|'TCP',
+            'ResourcePath': 'string',
+            'FailureThreshold': 123
+        },
+        'HealthCheckCustomConfig': {
+            'FailureThreshold': 123
+        },
+        'CreateDate': datetime(2015, 1, 1),
+        'CreatorRequestId': 'string'
+    }
+}
+
+'''
+import time
+
+DEPLOYMENT_CONFIGURATION_TYPE_MAP = {
+    'maximum_percent': 'int',
+    'minimum_healthy_percent': 'int'
+}
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import ec2_argument_spec
+from ansible.module_utils.ec2 import snake_dict_to_camel_dict, camel_dict_to_snake_dict, map_complex_type, get_ec2_security_group_ids_from_names
+from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from pprint import pprint
+
+try:
+    import botocore
+    import boto3
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+
+class ServiceDiscovery:
+    """Handles route 53 Services"""
+
+
+    def __init__(self, module):
+        self.module = module
+        self.sd = module.client('servicediscovery')
+
+    def get_namespace(self, namespace_id):
+        self.sd.get_namespace(Id= id)
+
+    def describe_service(self, cluster_name, service_name):
+        response = self.sd.get_services(
+        )
+        msg = ''
+        if len(response['failures']) > 0:
+            c = self.find_in_array(response['failures'], service_name, 'arn')
+            msg += ", failure reason is " + c['reason']
+            if c and c['reason'] == 'MISSING':
+                return None
+            # fall thru and look through found ones
+        if len(response['services']) > 0:
+            c = self.find_in_array(response['services'], service_name)
+            if c:
+                return c
+        raise Exception("Unknown problem describing service %s." % service_name)
+
+    def get_operation(self, operation_id):
+        return self.sd.get_operation(operation_id)
+
+    def create_private_dns_namespace(self, name, creator_request_id, description, vpc):
+        # creator_req_id totes not needed, will be auto poulated if not given
+
+        return self.sd.get_operation(operation_id)
+
+    def delete_namespace(self, id):
+        response = self.sd.delete_namespace(id)
+        return response
+
+
+
+    def delete_service(self, service_id):
+        response = self.sd.delete_service(Id=service_id)
+        # Boto returns empty dict.
+        return response
+
+
+    def create_service(self, name, creator_request_id, description, dns_config, health_check_config, health_check_custom_config):
+
+        dns_records = dns_config['dns_records']
+        dns_config= snake_dict_to_camel_dict(dns_config, capitalize_first=True)
+        dns_config['DnsRecords']=dns_records
+        health_check_config= snake_dict_to_camel_dict(health_check_config, capitalize_first=True)
+        health_check_custom_config= snake_dict_to_camel_dict(health_check_custom_config, capitalize_first=True)
+
+        params = dict(
+            Name = name,
+            DnsConfig = dns_config)
+
+        if description:
+            params['description']=description
+        if creator_request_id:
+            params['CreatorRequestId'] = creator_request_id
+        if health_check_config:
+            params['HealthCheckConfig']=health_check_config
+        if health_check_custom_config:
+            params['HealthCheckCustomConfig']=health_check_custom_config
+        response = self.sd.create_service(**params)
+
+        return self.jsonize(response['Service'])
+    def get_services_by_name(self, service_name, namespace_id):
+        services = self.list_services(namespace_id)
+        if (not services):
+          return None;
+        matching_services= []
+        for s in services['Services']:
+            if s['Name']==service_name:
+                matching_services.append(s)
+        return matching_services
+
+    def list_services(self, namespace_id):
+        # namespaces suck because there's not a guarantee that they're distinct
+        # I will try to make that guarantee for amazon.
+        # namespaces listed will include ID, arn, name, and type
+
+        filters = ansible_dict_to_boto3_filter_list({'NAMESPACE_ID': namespace_id})
+        services = self.sd.list_services(Filters=filters)
+        
+        return services
+
+
+    def jsonize(self, service):
+        # some fields are datetime which is not JSON serializable
+        # make them strings
+        if 'createdAt' in service:
+            service['createdAt'] = str(service['createdAt'])
+        if 'deployments' in service:
+            for d in service['deployments']:
+                if 'createdAt' in d:
+                    d['createdAt'] = str(d['createdAt'])
+                if 'updatedAt' in d:
+                    d['updatedAt'] = str(d['updatedAt'])
+        if 'events' in service:
+            for e in service['events']:
+                if 'createdAt' in e:
+                    e['createdAt'] = str(e['createdAt'])
+        return service
+
+
+    # Boto provides these functions:
+
+    # can_paginate()
+    # create_service()
+    # delete_service()
+    # deregister_instance()
+    # get_instance()
+    # get_instances_health_status()
+    # get_operation()
+    # get_paginator()
+    # get_service()
+    # get_waiter()
+    # list_services()
+    # register_instance()
+    # update_instance_custom_health_status()
+    # update_service()
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+        state=dict(required=True, choices=['present', 'absent']),
+        name=dict(required=True, type='str'),
+        id=dict(required=False, type='str'),
+        creator_request_id=dict(required=False, type='str'),
+        description=dict(required=False, type='str'),
+        dns_config=dict(required=False, type='dict'),
+        health_check_config=dict(required=False, type='dict'),
+        health_check_custom_config=dict(required=False, type='dict'),
+    ))
+
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              supports_check_mode=False,
+                              mutually_exclusive=[['health_check_config','health_check_custom_config']]
+
+                              )
+    # TODO: there's some thought about whn to require an ID.
+
+    sd_mgr = ServiceDiscovery(module)
+
+    if module.params['state'] == 'present':
+        try:
+            service = sd_mgr.get_services_by_name(module.params['name'], module.params['dns_config']['namespace_id'])
+            if (len(service) == 1):
+                module.exit_json( changed=False, **camel_dict_to_snake_dict(service[0]))
+            if (not service):
+                service = sd_mgr.create_service(
+                    module.params['name'],
+                    module.params['creator_request_id'],
+                    module.params['description'],
+                    module.params['dns_config'],
+                    module.params['health_check_config'],
+                    module.params['health_check_custom_config'])
+                
+                module.exit_json( changed=True, **camel_dict_to_snake_dict(service))
+            #TODO
+        except Exception as e:
+            module.fail_json(msg="Exception describing service '" + module.params['name'] +  "': " + str(e))
+    if module.params['state'] == 'absent':
+        try:
+            service = sd_mgr.get_services_by_name(module.params['name'], module.params['dns_config']['namespace_id'])
+            if (len(service) == 1):
+                deletion = sd_mgr.delete_service(service[0]['Id'])
+                module.exit_json( changed=True)
+            else:
+                module.fail_json(changed=False, msg="Failed to find service")
+
+
+        except Exception as e:
+            module.fail_json(msg="Exception describing service '" + module.params['name'] +  "': " + str(e))
+
+        
+
+
+
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/service_discovery.py
+++ b/lib/ansible/modules/cloud/amazon/service_discovery.py
@@ -300,9 +300,6 @@ class ServiceDiscovery:
         return matching_services
 
     def list_services(self, namespace_id):
-        # namespaces suck because there's not a guarantee that they're distinct
-        # I will try to make that guarantee for amazon.
-        # namespaces listed will include ID, arn, name, and type
 
         filters = ansible_dict_to_boto3_filter_list({'NAMESPACE_ID': namespace_id})
         services = self.sd.list_services(Filters=filters)

--- a/lib/ansible/modules/cloud/amazon/service_discovery.py
+++ b/lib/ansible/modules/cloud/amazon/service_discovery.py
@@ -22,17 +22,17 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: service_discovery
-short_description: thin wrap for boto3 servicediscovery client
+short_description: thin wrap for boto servicediscovery client
 description:
-    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/servicediscovery.html
-    service discovery comes in two parts, a namespace and a service discovery "registry"
-    Namespace is somewhat owned by route53
-    Registries are owned by the namespace
-    ECS containers may announce themselves to the registry
-    There may be other things that use registries
-    This module tries to allow creating service discovery registries
+    - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/servicediscovery.html
+    - service discovery comes in two parts, a namespace and a service discovery "registry"
+    - Namespace is somewhat owned by route53
+    - Registries are owned by the namespace
+    - ECS containers may announce themselves to the registry
+    - There may be other things that use registries
+    - This module tries to allow creating service discovery registries
 notes:
-    
+    - Because lack of domain name in aws, lack of personal need, and general laziness; I have not tested any public parts. - @ezmac
 version_added: "2.8"
 author:
     - "tad merchant @ezmac"
@@ -51,40 +51,44 @@ options:
     creator_request_id:
         description:
           - A unique string that identifies the request and that allows failed CreateService requests to be retried without the risk of executing the operation twice. CreatorRequestId can be any unique string, for example, a date/time stamp.
-This field is autopopulated if not provided.
+            This field is autopopulated if not provided.
         required: false
     description:
         description: Description for the service.
-    dns_config: 
+    dns_config:
         required: True
-        description:
-           Required even when deleting to get the namespace_id; At minimum, dns_config may have only the namespace_id when deleting
-           for any creation, a full dns_config is required
-           A complex type that contains information about the records that you want Route 53 to create when you register an instance.
-           Something like: {
-              namespace_id: string
-              routing_policy: [MULTIVALUE, WEIGHTED]
-              dns_records:[
-                {
-                  Type: [A, AAAA, SRV, CNAME],
-                  TTL: int,
-                  }]
-              }
+        description: A complex type that contains information about the records that you want Route 53 to create when you register an instance.
+        suboptions:
+            namespace_id:
+                description: ID of the service discovery namespace you will associate this service with
+            routing_policy:
+                description: The routing policy that you want to apply to all records that Route 53 creates when you register an instance and specify this service.
+                suboptions:
+                    dns_records:
+                        description: complex type describing what type of dns record will be created when a service registers
+                        suboptions:
+                            type:
+                                description: SRV|A|AAAA|CNAME
+                            ttl:
+                                description: How long the record will live
     health_check_config:
         required: false
-        description: Public dns only
-        {
-          Type: "string" ([HTTP, HTTPS, TCP]),
-          ResourcePath: "string",
-          FailureThreshold: int
-        }
+        description:  Required when service discovery namespace is public
+        suboptions:
+            failure_threshold:
+                description: The number of consecutive health checks that an endpoint must pass or fail for Route 53 to change the current status of the endpoint from unhealthy to healthy or vice versa.
+            type:
+                description: Health check type ( 'HTTP'|'HTTPS'|'TCP' )
+            resource_path:
+                description: The path that you want Route 53 to request when performing health checks.
 
     health_check_custom_config:
         required: False
-        description: Private DNS only
-        {
-          failure_threshold: int
-        }
+        description: Required when service discovery namespace is private
+        suboptions:
+            failure_threshold:
+                description: The number of consecutive health checks that an endpoint must pass or fail for Route 53 to change the current status of the endpoint from unhealthy to healthy or vice versa.
+
 extends_documentation_fragment:
     - aws
     - ec2
@@ -92,53 +96,126 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
+
+Private:
+  - service_discovery:
+      name: "sd-example" # becomes sd-example.your-private-sd-namespace.
+      state: "present"
+      dns_config:
+        namespace_id: "looonnnggg-id-with-like-numbers-and-letters-and-dashes"
+        routing_policy: "WEIGHTED"
+        dns_records:
+          - Type: "SRV"
+            TTL: 60
+      health_check_custom_config:
+        failure_threshold: 1
+Public:
+  - service_discovery:
+      name: "sd-example" # becomes sd-example.your-public-sd-namespace.tld
+      state: "present"
+      dns_config:
+        namespace_id: "looonnnggg-id-with-like-numbers-and-letters-and-dashes"
+        routing_policy: "WEIGHTED"
+        dns_records:
+          - Type: "SRV"
+            TTL: 60
+      health_check_config:
+          Type: "HTTP"
+          ResourcePath: "/health-check"
+          FailureThreshold: 2
 '''
 
 RETURN = '''
-Probably something like:
-{
-    'Service': {
-        'Id': 'string',
-        'Arn': 'string',
-        'Name': 'string',
-        'Description': 'string',
-        'InstanceCount': 123,
-        'DnsConfig': {
-            'NamespaceId': 'string',
-            'RoutingPolicy': 'MULTIVALUE'|'WEIGHTED',
-            'DnsRecords': [
-                {
-                    'Type': 'SRV'|'A'|'AAAA'|'CNAME',
-                    'TTL': 123
-                },
-            ]
-        },
-        'HealthCheckConfig': {
-            'Type': 'HTTP'|'HTTPS'|'TCP',
-            'ResourcePath': 'string',
-            'FailureThreshold': 123
-        },
-        'HealthCheckCustomConfig': {
-            'FailureThreshold': 123
-        },
-        'CreateDate': datetime(2015, 1, 1),
-        'CreatorRequestId': 'string'
-    }
-}
-
+service:
+    description: Details of created service.
+    returned: when creating a service
+    type: complex
+    contains:
+        id:
+            description: Identifier of service discovery service
+            returned: always
+            type: string
+        arn:
+            description: arn of service discovery service
+            returned: always
+            type: string
+        name:
+            description: name of service discovery service
+            returned: always
+            type: string
+        description:
+            description: description of service discovery service
+            returned: always
+            type: string
+        instance_count:
+            description: The number of instances that are currently associated with the service. Instances that were previously associated with the service but that have been deleted are not included in the count.
+            returned: always
+            type: int
+        dns_config:
+            description: A complex type that contains information about the records that you want Route 53 to create when you register an instance.
+            returned: always
+            type: complex
+            contains:
+                namespace_id:
+                    description: The ID of the namespace to use for DNS configuration.
+                    type: string
+                    returned: always
+                routing_policy:
+                    description: The routing policy that you want to apply to all records that Route 53 creates when you register an instance and specify this service. (MULTIVALUE|WEIGHTED)
+                    type: string
+                    returned: always
+                dns_records: 
+                    description: An array that contains one DnsRecord object for each record that you want Route 53 to create when you register an instance.
+                    type: complex
+                    contains: 
+                        type:
+                            description: The type of the resource, which indicates the type of value that Route 53 returns in response to DNS queries.
+                            type: string
+                            returned: always
+                        ttl:
+                            description: The type of the resource, which indicates the type of value that Route 53 returns in response to DNS queries.
+                            type: int
+                            returned: always
+        health_check_custom_config:
+            type: complex
+            returned: when service discovery namespace is dns_private type
+            contains:
+                failure_threshold:
+                    description: The number of consecutive health checks that an endpoint must pass or fail for Route 53 to change the current status of the endpoint from unhealthy to healthy or vice versa.
+                    type: int
+                    returned: always
+        health_check_config:
+            type: complex
+            returned: when service discovery namespace is dns_public type
+            contains:
+                failure_threshold:
+                    description: The number of consecutive health checks that an endpoint must pass or fail for Route 53 to change the current status of the endpoint from unhealthy to healthy or vice versa.
+                    type: int
+                    returned: always
+                resource_path:
+                    description: The path that you want Route 53 to request when performing health checks.
+                    type: string
+                    returned: always
+                type:
+                    type: string
+                    returned: always
+                    description: The type of health check that you want to create, which indicates how Route 53 determines whether an endpoint is healthy.
+        create_date:
+            type: datetime
+            returned: always
+            description: datetime of creation
+        creator_request_id:
+            type: string
+            returned: always
+            description: A unique string that identifies the request and that allows failed requests to be retried without the risk of executing an operation twice.
 '''
 import time
 
-DEPLOYMENT_CONFIGURATION_TYPE_MAP = {
-    'maximum_percent': 'int',
-    'minimum_healthy_percent': 'int'
-}
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import ec2_argument_spec
 from ansible.module_utils.ec2 import snake_dict_to_camel_dict, camel_dict_to_snake_dict, map_complex_type, get_ec2_security_group_ids_from_names
 from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from pprint import pprint
 
 try:
     import botocore
@@ -148,7 +225,7 @@ except ImportError:
 
 
 class ServiceDiscovery:
-    """Handles route 53 Services"""
+    """Handles Service discovery registries"""
 
 
     def __init__(self, module):
@@ -158,21 +235,12 @@ class ServiceDiscovery:
     def get_namespace(self, namespace_id):
         self.sd.get_namespace(Id= id)
 
-    def describe_service(self, cluster_name, service_name):
-        response = self.sd.get_services(
-        )
-        msg = ''
-        if len(response['failures']) > 0:
-            c = self.find_in_array(response['failures'], service_name, 'arn')
-            msg += ", failure reason is " + c['reason']
-            if c and c['reason'] == 'MISSING':
-                return None
-            # fall thru and look through found ones
-        if len(response['services']) > 0:
-            c = self.find_in_array(response['services'], service_name)
-            if c:
-                return c
-        raise Exception("Unknown problem describing service %s." % service_name)
+    def get_service(self, service_id):
+        response = self.sd.get_service(Id=service_id)
+        if response['Service']:
+           return self.jsonize(response['Service'])
+        else:
+           return None
 
     def get_operation(self, operation_id):
         return self.sd.get_operation(operation_id)
@@ -198,7 +266,10 @@ class ServiceDiscovery:
 
         dns_records = dns_config['dns_records']
         dns_config= snake_dict_to_camel_dict(dns_config, capitalize_first=True)
-        dns_config['DnsRecords']=dns_records
+        dns_config['DnsRecords']=[]
+        # use correct casing for aws api
+        for c in dns_records:
+            dns_config['DnsRecords'].append({'Type': c['type'], 'TTL': c['ttl']})
         health_check_config= snake_dict_to_camel_dict(health_check_config, capitalize_first=True)
         health_check_custom_config= snake_dict_to_camel_dict(health_check_custom_config, capitalize_first=True)
 
@@ -212,6 +283,7 @@ class ServiceDiscovery:
             params['CreatorRequestId'] = creator_request_id
         if health_check_config:
             params['HealthCheckConfig']=health_check_config
+
         if health_check_custom_config:
             params['HealthCheckCustomConfig']=health_check_custom_config
         response = self.sd.create_service(**params)
@@ -279,7 +351,7 @@ def main():
     argument_spec.update(dict(
         state=dict(required=True, choices=['present', 'absent']),
         name=dict(required=True, type='str'),
-        id=dict(required=False, type='str'),
+        #id=dict(required=False, type='str'),
         creator_request_id=dict(required=False, type='str'),
         description=dict(required=False, type='str'),
         dns_config=dict(required=False, type='dict'),
@@ -289,18 +361,21 @@ def main():
 
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               supports_check_mode=False,
-                              mutually_exclusive=[['health_check_config','health_check_custom_config']]
-
+                              mutually_exclusive=[['health_check_config','health_check_custom_config']],
+                              required_if=[('state', 'present', ['name', 'dns_config'])]
                               )
-    # TODO: there's some thought about whn to require an ID.
+# TODO: There's no real use for ID right now, but you should be able to delete a registry by id
 
     sd_mgr = ServiceDiscovery(module)
 
     if module.params['state'] == 'present':
         try:
+            changed=False
             service = sd_mgr.get_services_by_name(module.params['name'], module.params['dns_config']['namespace_id'])
+            # service returned by get_services_by_name includes Id, Name, Arn only
             if (len(service) == 1):
-                module.exit_json( changed=False, **camel_dict_to_snake_dict(service[0]))
+                # if a service was found, use get_service to get the full info
+                service=sd_mgr.get_service(service[0]['Id'])
             if (not service):
                 service = sd_mgr.create_service(
                     module.params['name'],
@@ -309,29 +384,22 @@ def main():
                     module.params['dns_config'],
                     module.params['health_check_config'],
                     module.params['health_check_custom_config'])
-                
-                module.exit_json( changed=True, **camel_dict_to_snake_dict(service))
+                changed=True
+                # service returned by sd_mgr is already unwrapped dict;
+            module.exit_json( changed=changed, Service = camel_dict_to_snake_dict(service))
             #TODO
         except Exception as e:
-            module.fail_json(msg="Exception describing service '" + module.params['name'] +  "': " + str(e))
+            module.fail_json(msg="Exception for servicediscovery '" + module.params['name'] +  "': " + str(e))
     if module.params['state'] == 'absent':
         try:
             service = sd_mgr.get_services_by_name(module.params['name'], module.params['dns_config']['namespace_id'])
             if (len(service) == 1):
                 deletion = sd_mgr.delete_service(service[0]['Id'])
-                module.exit_json( changed=True)
+                module.exit_json(changed=True)
             else:
                 module.fail_json(changed=False, msg="Failed to find service")
-
-
         except Exception as e:
-            module.fail_json(msg="Exception describing service '" + module.params['name'] +  "': " + str(e))
-
-        
-
-
-
-
+            module.fail_json(msg="Exception for servicediscovery '" + module.params['name'] +  "': " + str(e))
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/service_discovery.py
+++ b/lib/ansible/modules/cloud/amazon/service_discovery.py
@@ -383,7 +383,7 @@ def main():
                     module.params['health_check_custom_config'])
                 changed=True
                 # service returned by sd_mgr is already unwrapped dict;
-            module.exit_json( changed=changed, Service = camel_dict_to_snake_dict(service))
+            module.exit_json( changed=changed, service = camel_dict_to_snake_dict(service))
             #TODO
         except Exception as e:
             module.fail_json(msg="Exception for servicediscovery '" + module.params['name'] +  "': " + str(e))

--- a/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
+++ b/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
@@ -1,0 +1,341 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: service_discovery
+short_description: thin wrap for boto serviceDiscovery library
+description:
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/servicediscovery.html
+notes:
+    
+version_added: ""
+author:
+    - "tad merchant @ezmac"
+
+requirements: [ json, botocore, boto3 ]
+options:
+    state:
+        description:
+          - The desired state of the service
+        required: true
+        choices: ["present", "absent", "deleting"]
+    name:
+        description:
+          - The name of the service
+        required: true
+    creator_request_id:
+        description:
+          - A unique string that identifies the request and that allows failed CreateService requests to be retried without the risk of executing the operation twice. CreatorRequestId can be any unique string, for example, a date/time stamp.
+This field is autopopulated if not provided.
+        required: false
+        version_added: 2.4
+    description:
+        description: Description for the service..
+    dns_config: 
+        required: true
+        description: RTFM
+           A complex type that contains information about the records that you want Route 53 to create when you register an instance.
+           fastly, you'll probably want:
+              namespace_id: string
+              routing_policy: [MULTIVALUE, WEIGHTED]
+              dns_records:[
+                {
+                  type: [a, aaaa, srv, cname],
+                  ttl: int,
+                  
+                  }]
+      health_check_config: {}, # public zone only so I did not document
+
+
+
+
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+'''
+
+RETURN = '''
+Probably something like:
+{
+    'Service': {
+        'Id': 'string',
+        'Arn': 'string',
+        'Name': 'string',
+        'Description': 'string',
+        'InstanceCount': 123,
+        'DnsConfig': {
+            'NamespaceId': 'string',
+            'RoutingPolicy': 'MULTIVALUE'|'WEIGHTED',
+            'DnsRecords': [
+                {
+                    'Type': 'SRV'|'A'|'AAAA'|'CNAME',
+                    'TTL': 123
+                },
+            ]
+        },
+        'HealthCheckConfig': {
+            'Type': 'HTTP'|'HTTPS'|'TCP',
+            'ResourcePath': 'string',
+            'FailureThreshold': 123
+        },
+        'HealthCheckCustomConfig': {
+            'FailureThreshold': 123
+        },
+        'CreateDate': datetime(2015, 1, 1),
+        'CreatorRequestId': 'string'
+    }
+}
+
+'''
+import time
+
+DEPLOYMENT_CONFIGURATION_TYPE_MAP = {
+    'maximum_percent': 'int',
+    'minimum_healthy_percent': 'int'
+}
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible.module_utils.ec2 import ec2_argument_spec
+from ansible.module_utils.ec2 import snake_dict_to_camel_dict, map_complex_type, get_ec2_security_group_ids_from_names
+import botocore.waiter as core_waiter
+import functools
+
+
+try:
+    import botocore
+    import boto3
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+#class ServiceDiscoveryWaiter(
+
+sd_waiter_config = {
+    "version": 2,
+    "waiters": {
+        "NamespaceCreated": {
+            "delay": 5,
+            "maxAttempts": 10,
+            "operation": "GetOperation",
+            "acceptors": [
+                {
+                    "state": "success",
+                    "matcher": "path",
+                    "argument": "Operation.Status",
+                    "expected": "SUCCESS"
+                }
+            ]
+        }
+    }
+} 
+class ServiceDiscovery:
+    """Handles route 53 Services"""
+
+
+    def __init__(self, module):
+        self.module = module
+        self.sd = module.client('servicediscovery')
+
+    def get_namespace(self, namespace_id):
+        self.sd.get_namespace(Id= id)
+
+    def describe_service(self, cluster_name, service_name):
+        response = self.sd.get_services(
+        )
+        msg = ''
+        if len(response['failures']) > 0:
+            c = self.find_in_array(response['failures'], service_name, 'arn')
+            msg += ", failure reason is " + c['reason']
+            if c and c['reason'] == 'MISSING':
+                return None
+            # fall thru and look through found ones
+        if len(response['services']) > 0:
+            c = self.find_in_array(response['services'], service_name)
+            if c:
+                return c
+        raise Exception("Unknown problem describing service %s." % service_name)
+
+    def get_operation(self, operation_id):
+        operation = self.sd.get_operation(OperationId = operation_id)
+        return operation
+
+    def get_namespaces_by_name(self, namespace_name, type):
+        namespaces = self.list_namespaces(type)
+        if (not namespaces):
+          return None;
+        matching_namespaces= []
+        for ns in namespaces['Namespaces']:
+            if ns['Name']==namespace_name:
+                matching_namespaces.append(ns)
+        return matching_namespaces
+
+    def get_namespace(self, namespace_id):
+        self.sd.get_namespace(Id=namespace_id)['Namespace']
+
+    def create_namespace(self, name, type, description, creator_request_id, vpc_id, wait):
+        if type=="DNS_PRIVATE":
+            return self.create_private_dns_namespace(name,
+                                              description,
+                                              creator_request_id,
+                                              vpc_id,
+                                              wait
+                                              )
+        if type=="DNS_PUBLIC":
+            return self.create_public_dns_namespace(name,
+                                             description,
+                                             creator_request_id,
+                                             wait
+                                             )
+        
+    def list_namespaces(self, type):
+        # namespaces suck because there's not a guarantee that they're distinct
+        # I will try to make that guarantee for amazon.
+        # namespaces listed will include ID, arn, name, and type
+
+        filters = ansible_dict_to_boto3_filter_list({'TYPE': type})
+        return self.sd.list_namespaces(Filters=filters)
+
+    def create_public_dns_namespace(self, name, description, creator_request_id, wait):
+        # creator_req_id totes not needed, will be auto poulated if not given
+        params = dict(
+            Name=name,
+        )
+        if creator_request_id:
+            params['CreatorRequestId'] = creator_request_id
+        if description:
+            params['description'] = description
+        response = self.sd.create_public_dns_namespace(**params)
+
+        operation = response['OperationId']
+        if wait:
+            waiter=core_waiter.Waiter(
+            'namespace_created',
+                core_waiter.WaiterModel(waiter_config=sd_waiter_config).get_waiter("NamespaceCreated"),
+                    self.sd.get_operation
+            )
+            waiter.wait(OperationId=operation)
+        
+    def create_private_dns_namespace(self, name, description, creator_request_id, vpc_id, wait):
+        # creator_req_id totes not needed, will be auto poulated if not given
+        params = dict(
+            Name=name,
+            Vpc=vpc_id
+        )
+        if creator_request_id:
+            params['CreatorRequestId'] = creator_request_id
+        if description:
+            params['description'] = description
+        response = self.sd.create_private_dns_namespace(**params)
+
+        operation = response['OperationId']
+        if wait:
+            waiter=core_waiter.Waiter(
+            'namespace_created',
+                core_waiter.WaiterModel(waiter_config=sd_waiter_config).get_waiter("NamespaceCreated"),
+                    self.sd.get_operation
+            )
+            return waiter.wait(OperationId=operation)
+        
+
+    def delete_namespace(self, id):
+        response = self.sd.delete_namespace(id)
+        return response
+
+
+    def jsonize(self, service):
+        # some fields are datetime which is not JSON serializable
+        # make them strings
+        if 'createdAt' in service:
+            service['createdAt'] = str(service['createdAt'])
+        if 'deployments' in service:
+            for d in service['deployments']:
+                if 'createdAt' in d:
+                    d['createdAt'] = str(d['createdAt'])
+                if 'updatedAt' in d:
+                    d['updatedAt'] = str(d['updatedAt'])
+        if 'events' in service:
+            for e in service['events']:
+                if 'createdAt' in e:
+                    e['createdAt'] = str(e['createdAt'])
+        return service
+
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+        state=dict(required=True, choices=['present', 'absent']),
+        type=dict(required=False, type='str',choices=['DNS_PRIVATE', 'DNS_PUBLIC']),
+        id=dict(required=False, type=str),
+        name=dict(required=True, type='str'),
+        creator_request_id=dict(required=False, type='str'),
+        description=dict(required=False, type='str'),
+        wait=dict(required=False, type='bool', default=True),
+        vpc_id=dict(required=False, type='str')
+    ))
+    # namespaces sssuuuuucccckkkk.
+
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              supports_check_mode=False,
+                              required_if=[('state', 'present', ['type']),
+                                          ('type', 'private', ['vpc_id'])]
+                              )
+
+    sd_mgr = ServiceDiscovery(module)
+
+
+    results = dict(changed=False)
+    if module.params['state'] == 'present':
+
+        try:
+            existing = sd_mgr.get_namespaces_by_name(module.params['name'], module.params['type'])
+
+
+            if (len(existing) == 1):
+                module.exit_json( changed=False, **camel_dict_to_snake_dict(existing[0]))
+            if (not existing):
+                namespace = sd_mgr.create_namespace(module.params['name'],
+                                        module.params['type'],
+                                        module.params['description'],
+                                        module.params['creator_request_id'],
+                                        module.params['vpc_id'],
+                                        module.params['wait'])
+                module.exit_json( changed=True, **camel_dict_to_snake_dict(namespace))
+
+        except Exception as e:
+
+            module.fail_json(msg="Exception describing service '" + module.params['name'] + "' in cluster '" + "': " + str(e))
+
+        
+
+
+
+        module.exit_json(**existing)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
+++ b/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
@@ -205,9 +205,6 @@ class ServiceDiscoveryNamespace:
                                              )
         
     def list_namespaces(self, type):
-        # namespaces suck because there's not a guarantee that they're distinct
-        # I will try to make that guarantee for amazon.
-        # namespaces listed will include ID, arn, name, and type
 
         if type:
             filters = ansible_dict_to_boto3_filter_list({'TYPE': type})

--- a/test/integration/targets/ecs_cluster/playbooks/full_test.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/full_test.yml
@@ -3,3 +3,4 @@
 
   roles:
     - ecs_cluster
+    - service_discovery

--- a/test/integration/targets/ecs_cluster/playbooks/roles/service_discovery/defaults/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/service_discovery/defaults/main.yml
@@ -1,0 +1,1 @@
+namespace_name: "test-namespace"

--- a/test/integration/targets/ecs_cluster/playbooks/roles/service_discovery/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/service_discovery/tasks/main.yml
@@ -1,0 +1,88 @@
+---
+# tasks file for ecs_cluster
+
+- block:
+    # ============================================================
+    - name: set up aws connection info
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          aws_access_key: "{{ aws_access_key }}"
+          aws_secret_key: "{{ aws_secret_key }}"
+          security_token: "{{ security_token }}"
+          region: "{{ aws_region }}"
+      no_log: yes
+
+    - name: create a vpc to work in
+      ec2_vpc_net:
+        cidr_block: 10.0.0.0/16
+        state: present
+        name: '{{ resource_prefix }}_ecs_cluster'
+        resource_tags:
+          name: '{{ resource_prefix }}_ecs_cluster'
+        <<: *aws_connection_info
+      register: setup_vpc
+    - name: Debug setup_vpc
+      debug: var=setup_vpc
+
+    - name: create private service discovery namespace
+      service_discovery_namespace:
+        name: "private-{{ namespace_name}}"
+        state: present
+        type: DNS_PRIVATE
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+        <<: *aws_connection_info
+      register: service_discovery_private_namespace
+
+    - name: check that service_discovery_namespace changed
+      assert:
+        that:
+          - service_discovery_private_namespace.changed
+    - name: create service discovery registry
+      service_discovery:
+        name: "private-{{ namespace_name}}"
+        state: present
+        dns_config:
+          namespace_id: "{{ service_discovery_private_namespace.namespace.id }}"
+          routing_policy: "WEIGHTED"
+          dns_records:
+            - type: "SRV"
+              ttl: 60
+        <<: *aws_connection_info
+      register: service_discovery_registry
+
+    - name: check that sd registry changed
+      assert:
+        that:
+          - service_discovery_registry.changed
+
+
+  always:
+    # tear down: registry, namespace, vpc
+    - name: announce teardown start
+      debug:
+        msg: "***** testing complete. commence teardown *****"
+
+    # ignore errors so that test repeats are more reliable
+    - name: remove private service_discovery registry
+      service_discovery:
+        name: "private-{{ namespace_name }}"
+        state: absent
+        dns_config:
+          namespace_id: "{{ service_discovery_private_namespace.namespace.id}}"
+        <<: *aws_connection_info
+      ignore_errors: yes
+
+    - name: remove private service_discovery_namespace
+      service_discovery_namespace:
+        name: "private-{{ namespace_name }}"
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes
+
+    - name: remove setup vpc
+      ec2_vpc_net:
+        cidr_block: 10.0.0.0/16
+        state: absent
+        name: '{{ resource_prefix }}_ecs_cluster'
+        <<: *aws_connection_info
+      ignore_errors: no

--- a/test/integration/targets/ecs_cluster/playbooks/service_discovery_test.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/service_discovery_test.yml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  connection: local
+
+  roles:
+    - service_discovery

--- a/test/integration/targets/ecs_cluster/runme.sh
+++ b/test/integration/targets/ecs_cluster/runme.sh
@@ -13,11 +13,11 @@ trap 'rm -rf "${MYTMPDIR}"' EXIT
 PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
 
 
-# TODO need a full playbook to start using the full role.  maybe some other tests.
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
 source "${MYTMPDIR}/botocore-recent/bin/activate"
 $PYTHON -m pip install 'botocore>=1.8.4' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/service_discovery_test.yml "$@"
+
 
 # Test graceful failure for older versions of botocore
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.7.40"

--- a/test/integration/targets/ecs_cluster/runme.sh
+++ b/test/integration/targets/ecs_cluster/runme.sh
@@ -12,6 +12,24 @@ trap 'rm -rf "${MYTMPDIR}"' EXIT
 # but for the python3 tests we need virtualenv to use python3
 PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
 
+
+# TODO need a full playbook to start using the full role.  maybe some other tests.
+virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
+source "${MYTMPDIR}/botocore-recent/bin/activate"
+$PYTHON -m pip install 'botocore>=1.8.4' boto3
+ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/service_discovery_test.yml "$@"
+
+# Test graceful failure for older versions of botocore
+virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.7.40"
+source "${MYTMPDIR}/botocore-1.7.40/bin/activate"
+$PYTHON -m pip install 'botocore<=1.7.40' boto3
+ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/network_fail.yml "$@"
+
+
+
+
+
+
 # Test graceful failure for older versions of botocore
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.7.40"
 source "${MYTMPDIR}/botocore-1.7.40/bin/activate"


### PR DESCRIPTION
##### SUMMARY

Adds two new modules in the cloud/amazon namespace, service_discovery and service_discovery_namespace with the aim of allowing these to be created more easily.  This is in preparation to add service discovery support to ecs_service.

It might be possible to do both of these in one module, but two made more sense to me when I was working on it.

Not sure if this is written to how the community wants modules to work, but I'm open to feedback.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
service_discovery
service_discovery_namespace

##### ANSIBLE VERSION
```paste below
ansible 2.8.0.dev0 (add_service_discovery 6e62b5a7b7) last updated 2018/11/07 15:50:32 (GMT -400)
  config file = None
  configured module search path = ['/home/tad/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/tad/code/ansible/lib/ansible
  executable location = /home/tad/code/ansible/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]

```

##### ADDITIONAL INFORMATION

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/servicediscovery.html