### PR TITLE
[stable-2.7] Prevent duplicate entries in rhsm_repository module

### DIFF
--- a/changelogs/rhsm_repository-loop-fix-improvements.yaml
+++ b/changelogs/rhsm_repository-loop-fix-improvements.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - rhsm_repository - compile regular expressions to improve performance when looping over available repositories
+  - rhsm_repository - prevent duplicate repository entries from being entered in the final command

--- a/lib/ansible/modules/packaging/os/rhsm_repository.py
+++ b/lib/ansible/modules/packaging/os/rhsm_repository.py
@@ -115,10 +115,10 @@ def get_repository_list(module, list_parameter):
         '+----------------------------------------------------------+',
         '    Available Repositories in /etc/yum.repos.d/redhat.repo'
     ]
-    repo_id_re_str = r'Repo ID:   (.*)'
-    repo_name_re_str = r'Repo Name: (.*)'
-    repo_url_re_str = r'Repo URL:  (.*)'
-    repo_enabled_re_str = r'Enabled:   (.*)'
+    repo_id_re = re.compile(r'Repo ID:\s+(.*)')
+    repo_name_re = re.compile(r'Repo Name:\s+(.*)')
+    repo_url_re = re.compile(r'Repo URL:\s+(.*)')
+    repo_enabled_re = re.compile(r'Enabled:\s+(.*)')
 
     repo_id = ''
     repo_name = ''
@@ -126,37 +126,38 @@ def get_repository_list(module, list_parameter):
     repo_enabled = ''
 
     repo_result = []
-
-    for line in out.split('\n'):
-        if line in skip_lines:
+    for line in out.splitlines():
+        if line == '' or line in skip_lines:
             continue
 
-        repo_id_re = re.match(repo_id_re_str, line)
-        if repo_id_re:
-            repo_id = repo_id_re.group(1)
+        repo_id_match = repo_id_re.match(line)
+        if repo_id_match:
+            repo_id = repo_id_match.group(1)
             continue
 
-        repo_name_re = re.match(repo_name_re_str, line)
-        if repo_name_re:
-            repo_name = repo_name_re.group(1)
+        repo_name_match = repo_name_re.match(line)
+        if repo_name_match:
+            repo_name = repo_name_match.group(1)
             continue
 
-        repo_url_re = re.match(repo_url_re_str, line)
-        if repo_url_re:
-            repo_url = repo_url_re.group(1)
+        repo_url_match = repo_url_re.match(line)
+        if repo_url_match:
+            repo_url = repo_url_match.group(1)
             continue
 
-        repo_enabled_re = re.match(repo_enabled_re_str, line)
-        if repo_enabled_re:
-            repo_enabled = repo_enabled_re.group(1)
+        repo_enabled_match = repo_enabled_re.match(line)
+        if repo_enabled_match:
+            repo_enabled = repo_enabled_match.group(1)
 
-        repo = {
-            "id": repo_id,
-            "name": repo_name,
-            "url": repo_url,
-            "enabled": True if repo_enabled == '1' else False
-        }
+            repo = {
+                "id": repo_id,
+                "name": repo_name,
+                "url": repo_url,
+                "enabled": True if repo_enabled == '1' else False
+            }
+
         repo_result.append(repo)
+
     return repo_result
 
 
@@ -206,7 +207,7 @@ def repository_modify(module, state, name):
 
     if not module.check_mode:
         rc, out, err = run_subscription_manager(module, rhsm_arguments)
-        results = out.split('\n')
+        results = out.splitlines()
     module.exit_json(results=results, changed=changed, repositories=updated_repo_list, diff=diff)
 
 


### PR DESCRIPTION
* Complie regular expressions for better performance
* Skip on empty lines

This fixes a bug where the previous repo would be inserted in the result twice since an empty line did not match any of the conditions that would exit the loop iteration.
