### PR TITLE
Fixes for na_ontap_cluster_peer

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -114,6 +114,10 @@ Noteworthy module changes
   a return value called ``diff`` was returned of type ``list``. To enable proper diff output, this was changed to
   type ``dict``; the original ``list`` is returned as ``diff.differences``.
 
+* The ``na_ontap_cluster_peer`` module has replace ``source_intercluster_lif`` and ``dest_intercluster_lif`` string options with
+  ``source_intercluster_lifs`` and ``dest_intercluster_lifs`` list options
+
+
 Plugins
 =======
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -114,7 +114,7 @@ Noteworthy module changes
   a return value called ``diff`` was returned of type ``list``. To enable proper diff output, this was changed to
   type ``dict``; the original ``list`` is returned as ``diff.differences``.
 
-* The ``na_ontap_cluster_peer`` module has replace ``source_intercluster_lif`` and ``dest_intercluster_lif`` string options with
+* The ``na_ontap_cluster_peer`` module has replaced ``source_intercluster_lif`` and ``dest_intercluster_lif`` string options with
   ``source_intercluster_lifs`` and ``dest_intercluster_lifs`` list options
 
 

--- a/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_cluster_peer.py
@@ -27,10 +27,12 @@ options:
     description:
       - Intercluster addresses of the source cluster.
       - Used as peer-addresses in destination cluster.
+    version_added: "2.8"
   dest_intercluster_lifs:
     description:
       - Intercluster addresses of the destination cluster.
       - Used as peer-addresses in source cluster.
+    version_added: "2.8"
   passphrase:
     description:
       - The arbitrary passphrase that matches the one given to the peer cluster.
@@ -125,7 +127,7 @@ class NetAppONTAPClusterPeer(object):
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:
-            self.server = netapp_utils.setup_ontap_zapi(module=self.module)
+            self.server = netapp_utils.setup_na_ontap_zapi(module=self.module)
             # set destination server connection
             self.module.params['hostname'] = self.parameters['dest_hostname']
             if self.parameters.get('dest_username'):
@@ -133,6 +135,8 @@ class NetAppONTAPClusterPeer(object):
             if self.parameters.get('dest_password'):
                 self.module.params['password'] = self.parameters['dest_password']
             self.dest_server = netapp_utils.setup_na_ontap_zapi(module=self.module)
+            # reset to source host connection for asup logs
+            self.module.params['hostname'] = self.parameters['hostname']
 
     def cluster_peer_get_iter(self, cluster):
         """


### PR DESCRIPTION
##### SUMMARY
Allow for more than 1 source and destination address

* source_intercluster_lif (string) is now source_intercluster_lifs (list)
* dest_intercluster_lif (string) is now dest_intercluster_lifs(list)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
* na_ontap_cluster_peer

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (netapp-1043 ecc1885692) last updated 2018/11/07 14:58:48 (GMT -700)
  config file = None
  configured module search path = [u'/Users/chrisarchibald/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chrisarchibald/Code/github/ansible/lib/ansible
  executable location = /Users/chrisarchibald/Code/github/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 11 2016, 05:20:59) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
