### PR TITLE
xfconf: "get": don't set changed flag, don't require value

### DIFF
--- a/lib/ansible/modules/system/xfconf.py
+++ b/lib/ansible/modules/system/xfconf.py
@@ -153,12 +153,7 @@ def main():
     channel = module.params['channel']
     property = module.params['property']
     value_type = module.params['value_type']
-    if module.params['value'].lower() == "true":
-        value = "true"
-    elif module.params['value'] == "false":
-        value = "false"
-    else:
-        value = module.params['value']
+    value = module.params['value']
 
     state = state_values[module.params['state']]
 
@@ -173,6 +168,10 @@ def main():
         elif value_type is None or value_type == "":
             module.fail_json(msg='State %s requires "value_type" to be set'
                              % str(state))
+        if value.lower() == "true":
+            value = "true"
+        elif value.lower() == "false":
+            value = "false"
 
     # Create a Xfconf preference
     xfconf = XfconfPreference(module,
@@ -182,6 +181,10 @@ def main():
                               value)
     # Now we get the current value, if not found don't fail
     dummy, current_value = xfconf.call("get", fail_onerr=False)
+    
+    # For state "get", fill in "value" with what we already know
+    if state == "get":
+        value = current_value
 
     # Check if the current value equals the value we want to set.  If not, make
     # a change

--- a/lib/ansible/modules/system/xfconf.py
+++ b/lib/ansible/modules/system/xfconf.py
@@ -181,7 +181,7 @@ def main():
                               value)
     # Now we get the current value, if not found don't fail
     dummy, current_value = xfconf.call("get", fail_onerr=False)
-    
+
     # For state "get", fill in "value" with what we already know
     if state == "get":
         value = current_value


### PR DESCRIPTION
##### SUMMARY
This change removes the need to pass a value when state equals "get" (it can still be passed -- it'll just be ignored, same as before), and makes sure that "get" always leaves the changed flag at false.

Below is a short ansible playbook for an XFCE4 machine that demonstrates both these behaviors and runs cleanly with the updated xfconf.py.

(Also, thank you very much to jbenden for creating this module!)

```
---
- hosts: 127.0.0.1
  connection: local

  tasks:
    - name: Fetch the theme
      xfconf:
        channel: xfwm4
        property: "/general/theme"
        state: get
        value: ''
      register: theme

    - debug:
        msg: "The theme is {{ theme.ansible_facts.xfconf.new_value }}"
        
    - name: Fetch the theme in a way that will blow up
      xfconf:
        channel: xfwm4
        property: "/general/theme"
        state: get
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
xfconf

##### ANSIBLE VERSION
```paste below
devel
```