### PR TITLE
Particular long and shorthand YAML example supposedly equivalent - with this fix, it is.

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -173,9 +173,11 @@ Finally, you may wish to assign tags to the tasks inside the roles you specify. 
 
     - hosts: webservers
       roles:
-        - role: bar
-          tags: ["foo"]
-        # using YAML shorthand, this is equivalent to the above
+        - role: foo
+          tags:
+            - bar
+            - baz
+        # using YAML shorthand, this is equivalent to the above:
         - { role: foo, tags: ["bar", "baz"] }
 
 Or, again, using the newer syntax::


### PR DESCRIPTION
##### SUMMARY

There is one particular example of YAML and JSON supposedly equivalent, but the two are not equivalent.

This fixes the problem by changing the YAML to be equivalent to the JSON, and to also correspond with material a few lines further down in the same file.

##### ISSUE TYPE

- Docs Pull Request
