### PR TITLE
ec2_instance: ebs_optimized is not sub-option of 'network'

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -53,6 +53,7 @@ files:
   $modules/cloud/amazon/ec2_asg.py: $team_ansible s-hertel ryansb
   $modules/cloud/amazon/ec2_group.py: $team_ansible
   $modules/cloud/amazon/ec2_group_facts.py: willthames
+  $modules/cloud/amazon/ec2_instance.py: Shaps
   $modules/cloud/amazon/ec2_instance_facts.py: willthames
   $modules/cloud/amazon/ec2_key.py: $team_ansible
   $modules/cloud/amazon/ec2_lc.py: $team_ansible

--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -1602,7 +1602,7 @@ def main():
     if module.params.get('network'):
         if 'ebs_optimized' in module.params['network']:
             module.deprecate("network.ebs_optimized is deprecated."
-                           "Use the top level ebs_optimized parameter instead")
+                             "Use the top level ebs_optimized parameter instead", 2.9)
         if module.params.get('network').get('interfaces'):
             if module.params.get('security_group'):
                 module.fail_json(msg="Parameter network.interfaces can't be used with security_group")
@@ -1652,7 +1652,7 @@ def main():
         module.params['filters'] = filters
 
     if module.params.get('cpu_options') and not module.botocore_at_least('1.10.16'):
-          module.fail_json(msg="cpu_options is only supported with botocore >= 1.10.16")
+        module.fail_json(msg="cpu_options is only supported with botocore >= 1.10.16")
 
     existing_matches = find_instances(ec2, filters=module.params.get('filters'))
     changed = False

--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -1113,6 +1113,9 @@ def build_top_level_options(params):
         spec['Placement'] = {'Tenancy': params.get('tenancy')}
     if params.get('ebs_optimized') is not None:
         spec['EbsOptimized'] = params.get('ebs_optimized')
+    elif (params.get('network') or {}).get('ebs_optimized') is not None:
+        # Backward compatibility for workaround described in https://github.com/ansible/ansible/issues/48159
+        spec['EbsOptimized'] = params['network'].get('ebs_optimized')
     if params.get('instance_initiated_shutdown_behavior'):
         spec['InstanceInitiatedShutdownBehavior'] = params.get('instance_initiated_shutdown_behavior')
     if params.get('termination_protection') is not None:
@@ -1597,6 +1600,9 @@ def main():
     )
 
     if module.params.get('network'):
+        if 'ebs_optimized' in module.params['network']:
+            module.deprecate("network.ebs_optimized is deprecated."
+                           "Use the top level ebs_optimized parameter instead")
         if module.params.get('network').get('interfaces'):
             if module.params.get('security_group'):
                 module.fail_json(msg="Parameter network.interfaces can't be used with security_group")
@@ -1646,7 +1652,7 @@ def main():
         module.params['filters'] = filters
 
     if module.params.get('cpu_options') and not module.botocore_at_least('1.10.16'):
-            module.fail_json(msg="cpu_options is only supported with botocore >= 1.10.16")
+          module.fail_json(msg="cpu_options is only supported with botocore >= 1.10.16")
 
     existing_matches = find_instances(ec2, filters=module.params.get('filters'))
     changed = False

--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -1111,8 +1111,8 @@ def build_top_level_options(params):
         spec['CreditSpecification'] = {'CpuCredits': params.get('cpu_credit_specification')}
     if params.get('tenancy') is not None:
         spec['Placement'] = {'Tenancy': params.get('tenancy')}
-    if (params.get('network') or {}).get('ebs_optimized') is not None:
-        spec['EbsOptimized'] = params['network'].get('ebs_optimized')
+    if params.get('ebs_optimized') is not None:
+        spec['EbsOptimized'] = params.get('ebs_optimized')
     if params.get('instance_initiated_shutdown_behavior'):
         spec['InstanceInitiatedShutdownBehavior'] = params.get('instance_initiated_shutdown_behavior')
     if params.get('termination_protection') is not None:

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/defaults/main.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/defaults/main.yml
@@ -18,3 +18,19 @@ ec2_ami_image:
   us-east-2: ami-9cbf9bf9
   us-west-1: ami-7c280d1c
   us-west-2: ami-0c2aba6c
+# We need to use ENA enabled AMIs to get EBS optimized instances.
+ec2_ebs_optimized_ami_image:
+  ap-northeast-1: ami-00f9d04b3b3092052
+  ap-northeast-2: ami-0c764df09c35858b8
+  ap-south-1: ami-00796998f258969fd
+  ap-southeast-1: ami-085fd1bd447be68e8
+  ap-southeast-2: ami-0b8dea0e70b969adc
+  ca-central-1: ami-05cac140c6a1fb960
+  eu-central-1: ami-02ea8f348fa28c108
+  eu-west-1: ami-0a5e707736615003c
+  eu-west-2: ami-017b0e29fac27906b
+  sa-east-1: ami-0160a8b6087883cb6
+  us-east-1: ami-013be31976ca2c322
+  us-east-2: ami-0350c5670171b5391
+  us-west-1: ami-01beb64058d271bc4
+  us-west-2: ami-061e7ebbc234015fe

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/ebs_optimized.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/ebs_optimized.yml
@@ -10,14 +10,12 @@
 - name: Make EBS optimized instance in the testing subnet of the test VPC
   ec2_instance:
     name: "{{ resource_prefix }}-test-ebs-optimized-instance-in-vpc"
-    image_id: "ami-7c491f05"
+    image_id: "{{ ec2_ebs_optimized_ami_image[aws_region] }}"
     tags:
       TestId: "{{ resource_prefix }}"
     security_groups: "{{ sg.group_id }}"
     vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-    network:
-      assign_public_ip: false
-      ebs_optimized: true
+    ebs_optimized: true
     instance_type: t3.nano
     <<: *aws_connection_info
   register: ebs_opt_in_vpc
@@ -34,7 +32,3 @@
   assert:
     that:
       - "{{ ebs_opt_instance_fact.instances.0.ebs_optimized }}"
-
-
-
-

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/ebs_optimized.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/ebs_optimized.yml
@@ -1,0 +1,40 @@
+- name: set connection information for all tasks
+  set_fact:
+    aws_connection_info: &aws_connection_info
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token }}"
+      region: "{{ aws_region }}"
+  no_log: true
+
+- name: Make EBS optimized instance in the testing subnet of the test VPC
+  ec2_instance:
+    name: "{{ resource_prefix }}-test-ebs-optimized-instance-in-vpc"
+    image_id: "ami-7c491f05"
+    tags:
+      TestId: "{{ resource_prefix }}"
+    security_groups: "{{ sg.group_id }}"
+    vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+    network:
+      assign_public_ip: false
+      ebs_optimized: true
+    instance_type: t3.nano
+    <<: *aws_connection_info
+  register: ebs_opt_in_vpc
+
+- name: Get ec2 instance facts
+  ec2_instance_facts:
+    filters:
+      "tag:Name": "{{ resource_prefix }}-test-ebs-optimized-instance-in-vpc"
+      "instance-state-name": "running"
+    <<: *aws_connection_info
+  register: ebs_opt_instance_fact
+
+- name: Assert instance is ebs_optimized
+  assert:
+    that:
+      - "{{ ebs_opt_instance_fact.instances.0.ebs_optimized }}"
+
+
+
+

--- a/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/main.yml
+++ b/test/integration/targets/ec2_instance/playbooks/roles/ec2_instance/tasks/main.yml
@@ -97,6 +97,7 @@
     - include_tasks: default_vpc_tests.yml
     - include_tasks: iam_instance_role.yml
     - include_tasks: checkmode_tests.yml
+    - include_tasks: ebs_optimized.yml
 
 
     # ============================================================

--- a/test/integration/targets/ec2_instance/playbooks/version_fail.yml
+++ b/test/integration/targets/ec2_instance/playbooks/version_fail.yml
@@ -13,7 +13,7 @@
               security_token: "{{ security_token }}"
               region: "{{ aws_region }}"
           no_log: True
-          
+
         - name: Include vars file in roles/ec2_instance/defaults/main.yml
           include_vars:
             file: 'roles/ec2_instance/defaults/main.yml'
@@ -31,8 +31,8 @@
           register: ec2_instance_cpu_options_creation
           ignore_errors: yes
 
-        - name: check that graceful error message is returned when creation with cpu_options and old botocore 
+        - name: check that graceful error message is returned when creation with cpu_options and old botocore
           assert:
             that:
               - ec2_instance_cpu_options_creation.failed
-              - 'ec2_instance_cpu_options_creation.msg == "cpu_options is only supported with botocore >= 1.10.16"' 
+              - 'ec2_instance_cpu_options_creation.msg == "cpu_options is only supported with botocore >= 1.10.16"'


### PR DESCRIPTION
##### SUMMARY
Updated ec2_instance to look for `ebs_optimized` as top level option instead of sub-option of `network`.
Fixes #48159

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_instance.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (ec2_instance_ebs_optimized_fix 4f4595fc4b) last updated 2018/11/08 11:05:55 (GMT +100)
  config file = /home/shaps/.ansible.cfg
  configured module search path = [u'/home/shaps/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/shaps/Documents/code/ansible/lib/ansible
  executable location = /home/shaps/Documents/code/ansible/bin/ansible
  python version = 2.7.15 (default, Oct 15 2018, 15:26:09) [GCC 8.2.1 20180801 (Red Hat 8.2.1-2)]

```

##### ADDITIONAL INFORMATION
N/A