### PR TITLE
Vultr server gather facts fails when firewall is enabled on a VM

### DIFF
--- a/lib/ansible/modules/cloud/vultr/vultr_server_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_server_facts.py
@@ -114,7 +114,7 @@ class AnsibleVultrServerFacts(Vultr):
 
         self.returns = {
             "APPID": dict(key='application', convert_to='int', transform=self._get_application_name),
-            "FIREWALLGROUPID": dict(key='firewallgroup', convert_to='int', transform=self._get_firewallgroup_name),
+            "FIREWALLGROUPID": dict(key='firewallgroup', transform=self._get_firewallgroup_name),
             "SUBID": dict(key='id', convert_to='int'),
             "VPSPLANID": dict(key='plan', convert_to='int', transform=self._get_plan_name),
             "allowed_bandwidth_gb": dict(convert_to='int'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`vultr_server_facts` fails when a VM has a firewall enabled. Works normally without firewall.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vultr_server_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.0
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
`vultr_server_facts` with firewall on VM before change:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
The full traceback is:
Traceback (most recent call last):
  File "<stdin>", line 113, in <module>
  File "<stdin>", line 105, in _ansiballz_main
  File "<stdin>", line 48, in invoke_module
  File "/tmp/ansible_vultr_server_facts_payload_EYlPlh/__main__.py", line 188, in <module>
  File "/tmp/ansible_vultr_server_facts_payload_EYlPlh/__main__.py", line 180, in main
  File "/tmp/ansible_vultr_server_facts_payload_EYlPlh/ansible_vultr_server_facts_payload.zip/ansible/module_utils/vultr.py", line 268, in get_result
  File "/tmp/ansible_vultr_server_facts_payload_EYlPlh/ansible_vultr_server_facts_payload.zip/ansible/module_utils/vultr.py", line 250, in normalize_result
ValueError: invalid literal for int() with base 10: '8950f8b6'

fatal: [localhost -> localhost]: FAILED! => {
    "changed": false, 
    "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 113, in <module>\n  File \"<stdin>\", line 105, in _ansiballz_main\n  File \"<stdin>\", line 48, in invoke_module\n  File \"/tmp/ansible_vultr_server_facts_payload_EYlPlh/__main__.py\", line 188, in <module>\n  File \"/tmp/ansible_vultr_server_facts_payload_EYlPlh/__main__.py\", line 180, in main\n  File \"/tmp/ansible_vultr_server_facts_payload_EYlPlh/ansible_vultr_server_facts_payload.zip/ansible/module_utils/vultr.py\", line 268, in get_result\n  File \"/tmp/ansible_vultr_server_facts_payload_EYlPlh/ansible_vultr_server_facts_payload.zip/ansible/module_utils/vultr.py\", line 250, in normalize_result\nValueError: invalid literal for int() with base 10: '8950f8b6'\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", 
    "rc": 1
}
```
after change: works great.