### PR TITLE
Fix junos_command.py network module to support spaces in rpc args

### DIFF
--- a/lib/ansible/modules/network/junos/junos_command.py
+++ b/lib/ansible/modules/network/junos/junos_command.py
@@ -4,6 +4,7 @@
 # (c) 2017, Ansible by Red Hat, inc
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+import shlex
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
@@ -266,7 +267,7 @@ def parse_rpcs(module):
     items = list()
 
     for rpc in (module.params['rpcs'] or list()):
-        parts = split(rpc)
+        parts = shlex.split(rpc)
 
         name = parts.pop(0)
         args = dict()

--- a/lib/ansible/modules/network/junos/junos_command.py
+++ b/lib/ansible/modules/network/junos/junos_command.py
@@ -4,7 +4,6 @@
 # (c) 2017, Ansible by Red Hat, inc
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import shlex
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 


### PR DESCRIPTION
##### SUMMARY
junos_command.py module doesn't support spaces in rpcs arguments.
This patch fixes it

##### ISSUE TYPE
- BugFix  Request

##### COMPONENT NAME
 - junos_command network module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.7.1
  config file = /Users/sid/.ansible.cfg
  configured module search path = [u'/Users/sid/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Sep 18 2018, 20:30:39) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.10.43.1)]
```

##### ADDITIONAL INFORMATION
You should quote argument with spaces.
Example:
```yaml
---
    - name: add license to device
      junos_command:
        rpcs: 
          - "request-license-add key-data='a a a'"
```
