### PR TITLE
IBM storage: fix domain issue by adding more keywords to pyxcli available fields

### DIFF
--- a/changelogs/fragments/ibm-storag_add_domain_keywords_to_module.yml
+++ b/changelogs/fragments/ibm-storag_add_domain_keywords_to_module.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Added missing domain module fields to the ibm_sa_utils module."

--- a/lib/ansible/module_utils/ibm_sa_utils.py
+++ b/lib/ansible/module_utils/ibm_sa_utils.py
@@ -19,7 +19,10 @@ AVAILABLE_PYXCLI_FIELDS = ['pool', 'size', 'snapshot_size',
                            'domain', 'perf_class', 'vol',
                            'iscsi_chap_name', 'iscsi_chap_secret',
                            'cluster', 'host', 'lun', 'override',
-                           'fcaddress', 'iscsi_name']
+                           'fcaddress', 'iscsi_name', 'max_dms',
+                           'max_cgs', 'ldap_id', 'max_mirrors',
+                           'max_pools', 'max_volumes', 'hard_capacity',
+                           'soft_capacity']
 
 
 def xcli_wrapper(func):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The storage domain module requires more fields than what was previously defined in our utility module. 
I've added the missing fields to the ibm_sa_utils module for our domain module, so it can define max pools, max volumes, max cgs and so on.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ibm_sa_utils.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (fix_ibm_domain_issue_on_utils 8106d8aa0c) last updated 2018/11/08 15:41:40 (GMT +300)
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
