### PR TITLE
Also fetch roles for virtual machines from netbox inventory

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -246,8 +246,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 return [self.device_roles_lookup[host["device_role"]["id"]]]
             elif "role" in host:
                 return [self.device_roles_lookup[host["role"]["id"]]]
-            else:
-                return
         except Exception:
             return
 

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -242,7 +242,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def extract_device_role(self, host):
         try:
-            return [self.device_roles_lookup[host["device_role"]["id"]]]
+            if "device_role" in host:
+                return [self.device_roles_lookup[host["device_role"]["id"]]]
+            elif "role" in host:
+                return [self.device_roles_lookup[host["role"]["id"]]]
+            else:
+                return
         except Exception:
             return
 


### PR DESCRIPTION
##### SUMMARY
The extract_device_role function now checks if the host["device_role"] or the host["role"] is defined.
This was needed seeing that for virtual machines the role wasn't called "device_role" but just plain "role".

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
netbox-roles in netbox dynamic inventory

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Feb 20 2018, 09:19:12) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
Before change
```
ansible-inventory --list -i netbox_inventory.yml
{
    "_meta": {
        "hostvars": {
            "maplcmdb01": {
                "ansible_host": "10.51.10.238",
                "device_roles": [
                    "Server"
                ],
                "disk": 40,
                "memory": 2048,
                "primary_ip4": "10.51.10.238",
                "sites": [
                    "TESTSITE"
                ],
                "vcpus": 1
            },
            "maplcmdb02": {
                "ansible_host": "10.51.10.240",
                "device_roles": [
                    "Server"
                ],
                "disk": 40,
                "memory": 4096,
                "primary_ip4": "10.51.10.240",
                "sites": [
                    "TESTSITE"
                ],
                "vcpus": 2
            },
            "maplvault01": {
                "device_roles": [
                    "Server"
                ],
                "disk": 50,
                "memory": 2048,
                "sites": [
                    "TESTSITE"
                ],
                "tags": [
                    "vault"
                ],
                "vcpus": 1
            },
            "testdevice": {
                "device_roles": [
                    "Server"
                ],
                "device_types": [
                    "DL380G4"
                ],
                "manufacturers": [
                    "HP"
                ],
                "sites": [
                    "TESTSITE"
                ]
            }
        }
    },
    "all": {
        "children": [
            "device_roles_Server",
            "device_types_DL380G4",
            "manufacturers_HP",
            "sites_TESTSITE",
            "tags_vault",
            "ungrouped"
        ]
    },
    "device_roles_Server": {
        "hosts": [
            "testdevice"
        ]
    },
    "device_types_DL380G4": {
        "hosts": [
            "testdevice"
        ]
    },
    "manufacturers_HP": {
        "hosts": [
            "testdevice"
        ]
    },
    "sites_TESTSITE": {
        "hosts": [
            "maplcmdb01",
            "maplcmdb02",
            "maplvault01",
            "testdevice"
        ]
    },
    "tags_vault": {
        "hosts": [
            "maplvault01"
        ]
    }
}
```
After change
```
ansible-inventory --list -i netbox_inventory.yml
{
    "_meta": {
        "hostvars": {
            "maplcmdb01": {
                "ansible_host": "10.51.10.238",
                "device_roles": [
                    "Server"
                ],
                "disk": 40,
                "memory": 2048,
                "primary_ip4": "10.51.10.238",
                "sites": [
                    "TESTSITE"
                ],
                "vcpus": 1
            },
            "maplcmdb02": {
                "ansible_host": "10.51.10.240",
                "device_roles": [
                    "Server"
                ],
                "disk": 40,
                "memory": 4096,
                "primary_ip4": "10.51.10.240",
                "sites": [
                    "TESTSITE"
                ],
                "vcpus": 2
            },
            "maplvault01": {
                "device_roles": [
                    "Server"
                ],
                "disk": 50,
                "memory": 2048,
                "sites": [
                    "TESTSITE"
                ],
                "tags": [
                    "vault"
                ],
                "vcpus": 1
            },
            "testdevice": {
                "device_roles": [
                    "Server"
                ],
                "device_types": [
                    "DL380G4"
                ],
                "manufacturers": [
                    "HP"
                ],
                "sites": [
                    "TESTSITE"
                ]
            }
        }
    },
    "all": {
        "children": [
            "device_roles_Server",
            "device_types_DL380G4",
            "manufacturers_HP",
            "sites_TESTSITE",
            "tags_vault",
            "ungrouped"
        ]
    },
    "device_roles_Server": {
        "hosts": [
            "maplcmdb01",
            "maplcmdb02",
            "maplvault01",
            "testdevice"
        ]
    },
    "device_types_DL380G4": {
        "hosts": [
            "testdevice"
        ]
    },
    "manufacturers_HP": {
        "hosts": [
            "testdevice"
        ]
    },
    "sites_TESTSITE": {
        "hosts": [
            "maplcmdb01",
            "maplcmdb02",
            "maplvault01",
            "testdevice"
        ]
    },
    "tags_vault": {
        "hosts": [
            "maplvault01"
        ]
    }
}
```
Testdevice is an actual device, the other 3 are virtual machines.
The Netbox version running on the system is v2.4.6