### PR TITLE
[stable-2.7] Always use /proc/sys/kernel/random/boot_id to confirm reboot on Linux

### DIFF
--- a/changelogs/fragments/reboot-change-default-boot-command.yaml
+++ b/changelogs/fragments/reboot-change-default-boot-command.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - reboot - change default reboot time command to prevent hanging on certain systems (https://github.com/ansible/ansible/issues/46562)

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -35,7 +35,7 @@ class ActionModule(ActionBase):
     DEFAULT_PRE_REBOOT_DELAY = 0
     DEFAULT_POST_REBOOT_DELAY = 0
     DEFAULT_TEST_COMMAND = 'whoami'
-    DEFAULT_BOOT_TIME_COMMAND = 'who -b'
+    DEFAULT_BOOT_TIME_COMMAND = 'cat /proc/sys/kernel/random/boot_id'
     DEFAULT_REBOOT_MESSAGE = 'Reboot initiated by Ansible'
     DEFAULT_SHUTDOWN_COMMAND = 'shutdown'
     DEFAULT_SUDOABLE = True
@@ -43,15 +43,18 @@ class ActionModule(ActionBase):
     DEPRECATED_ARGS = {}
 
     BOOT_TIME_COMMANDS = {
-        'openbsd': "/sbin/sysctl kern.boottime",
+        'openbsd': '/sbin/sysctl kern.boottime',
+        'freebsd': '/sbin/sysctl kern.boottime',
+        'sunos': 'who -b',
+        'darwin': 'who -b',
     }
 
     SHUTDOWN_COMMANDS = {
         'linux': DEFAULT_SHUTDOWN_COMMAND,
         'freebsd': DEFAULT_SHUTDOWN_COMMAND,
+        'openbsd': DEFAULT_SHUTDOWN_COMMAND,
         'sunos': '/usr/sbin/shutdown',
         'darwin': '/sbin/shutdown',
-        'openbsd': DEFAULT_SHUTDOWN_COMMAND,
     }
 
     SHUTDOWN_COMMAND_ARGS = {
@@ -109,22 +112,6 @@ class ActionModule(ActionBase):
 
         boot_time_command = self.BOOT_TIME_COMMANDS.get(distribution, self.DEFAULT_BOOT_TIME_COMMAND)
         command_result = self._low_level_execute_command(boot_time_command, sudoable=self.DEFAULT_SUDOABLE)
-
-        # For single board computers, e.g., Raspberry Pi, that lack a real time clock and are using fake-hwclock
-        # launched by systemd, the update of utmp/wtmp is not done correctly.
-        # Fall back to using uptime -s for those systems.
-        # https://github.com/systemd/systemd/issues/6057
-        if '1970-01-01 00:00' in command_result['stdout']:
-            stdout += command_result['stdout']
-            stderr += command_result['stderr']
-            command_result = self._low_level_execute_command('uptime -s', sudoable=self.DEFAULT_SUDOABLE)
-
-        # This is a last resort for bare Linux systems (e.g. OpenELEC) where 'who -b' or 'uptime -s' are not supported.
-        # Other options like parsing /proc/uptime or default uptime output are less reliable than this
-        if command_result['rc'] != 0:
-            stdout += command_result['stdout']
-            stderr += command_result['stderr']
-            command_result = self._low_level_execute_command('cat /proc/sys/kernel/random/boot_id', sudoable=self.DEFAULT_SUDOABLE)
 
         if command_result['rc'] != 0:
             stdout += command_result['stdout']


### PR DESCRIPTION
`/proc/sys/kernel/random/boot_id` is available since kernel 2.3.16 and
should be safe to rely on.

The previously used method by checking the system boot time using `who -b`
turned out to be unreliable. Some systems lacking an RTC report the Unix
epoch as boot time, but the code trying to detect that did't always
work.

- change `DEFAULT_BOOT_TIME_COMMAND`
- add `BOOT_TIME_COMMANDS` for BSD, Solaris, and macOS
