### PR TITLE
Update openstack.py for allowing users to set ansible_host_vars on metadata

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -48,8 +48,11 @@
 #                When set to False, the inventory will return hosts from
 #                whichever other clouds it can contact. (Default: True)
 #
-# Also it is possible to pass the correct user by setting an ansible_user: $myuser
-# metadata attribute.
+# Metadata-Usage with Ansible:
+# It is possible to pass the correct user by setting the metadata-attribute ansible_user, for example: ansible_user: $myuser
+# Also groups for Ansible can be prepared, using an attribute groups: $group1,$group2
+# Furthermore, Ansible Host specific variables can be set using the attribute ansible_host_vars, for example:
+# ansible_host_vars: ansible_python_interpreter=/usr/bin/env python3,dnsserver=mydns.example.com
 
 import argparse
 import collections
@@ -135,7 +138,12 @@ def append_hostvars(hostvars, groups, key, server, namegroup=False):
     metadata = server.get('metadata', {})
     if 'ansible_user' in metadata:
         hostvars[key]['ansible_user'] = metadata['ansible_user']
-
+        
+    if 'ansible_host_vars' in metadata:
+        for ansible_hostvars_kv in metadata['ansible_host_vars'].split(','):
+            ansible_key, ansible_value = ansible_hostvars_kv.split('=')
+            hostvars[key][ansible_key] = ansible_value
+            
     for group in get_groups_from_server(server, namegroup=namegroup):
         groups[group].append(key)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Host vars are needed for ansible to make use of the correct python environment on the target host. This can be easily added via OpenStack-metadata and therefore be fetched by the dynamic inventory script.
The feature interprets an optional set ansible_host_vars metadata attribute.
In addition this feature documents better understandable how to work with ansible dynamic inventory

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openstack dynamic inventory for ansible
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.7.0
  config file = /home/ansible_testing/ansible.cfg
  configured module search path = [u'/home/ansible_testing/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
