### PR TITLE
Netbox secrets

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -198,7 +198,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             "device_roles": self.extract_device_role,
             "platforms": self.extract_platform,
             "device_types": self.extract_device_type,
-			"services": self.extract_services,
+            "services": self.extract_services,
             "manufacturers": self.extract_manufacturer
         }
 
@@ -448,3 +448,4 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self.group_by = self.get_option("group_by")
         self.query_filters = self.get_option("query_filters")
         self.main()
+

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -260,7 +260,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         try:
             url = urljoin(self.api_endpoint, "/api/ipam/services/?device=" + str(host["name"]))
             device_lookup = self._fetch_information(url)
-            return [device_lookup["results"]]
+            return device_lookup["results"]
         except Exception:
             return
 
@@ -370,13 +370,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def refresh_url(self):
         query_parameters = [("limit", 0)]
-        query_parameters.extend(filter(lambda x: x,
-                                       map(self.validate_query_parameters, self.query_filters)))
-        self.device_url = self.api_endpoint + "/api/dcim/devices/" + "?" + urlencode(query_parameters)
-        self.virtual_machines_url = "".join([self.api_endpoint,
-                                             "/api/virtualization/virtual-machines/",
-                                             "?",
-                                             urlencode(query_parameters)])
+        if self.query_filters:
+            query_parameters.extend(filter(lambda x: x,
+                                           map(self.validate_query_parameters, self.query_filters)))
+        self.device_url = urljoin(self.api_endpoint,
+                                  "/api/dcim/devices/?" + urlencode(query_parameters))
+        self.virtual_machines_url = urljoin(self.api_endpoint,
+                                            "/api/virtualization/virtual-machines/?" + urlencode(query_parameters))
 
     def fetch_hosts(self):
         return chain(

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -252,7 +252,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             return [self.manufacturers_lookup[host["device_type"]["manufacturer"]["id"]]]
         except Exception:
             return
-			
+
     def extract_services(self, host):
         try:
             url = urljoin(self.api_endpoint, "/api/ipam/services/?device=" + str(host["name"]))
@@ -260,7 +260,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             return device_lookup["results"]
         except Exception:
             return
-			
+
     def extract_primary_ip(self, host):
         try:
             address = host["primary_ip"]["address"]
@@ -448,4 +448,3 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self.group_by = self.get_option("group_by")
         self.query_filters = self.get_option("query_filters")
         self.main()
-

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -198,7 +198,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             "device_roles": self.extract_device_role,
             "platforms": self.extract_platform,
             "device_types": self.extract_device_type,
-            "services": self.extract_services,
             "manufacturers": self.extract_manufacturer
         }
 
@@ -250,14 +249,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     def extract_manufacturer(self, host):
         try:
             return [self.manufacturers_lookup[host["device_type"]["manufacturer"]["id"]]]
-        except Exception:
-            return
-
-    def extract_services(self, host):
-        try:
-            url = urljoin(self.api_endpoint, "/api/ipam/services/?device=" + str(host["name"]))
-            device_lookup = self._fetch_information(url)
-            return device_lookup["results"]
         except Exception:
             return
 

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -198,8 +198,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             "device_roles": self.extract_device_role,
             "platforms": self.extract_platform,
             "device_types": self.extract_device_type,
-            "config_context": self.extract_config_context,
-            "services": self.extract_services,
+			"services": self.extract_services,
             "manufacturers": self.extract_manufacturer
         }
 
@@ -248,14 +247,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         except Exception:
             return
 
-    def extract_config_context(self, host):
+    def extract_manufacturer(self, host):
         try:
-            url = urljoin(self.api_endpoint, "/api/dcim/devices/" + str(host["id"]))
-            device_lookup = self._fetch_information(url)
-            return [device_lookup["config_context"]]
+            return [self.manufacturers_lookup[host["device_type"]["manufacturer"]["id"]]]
         except Exception:
             return
-
+			
     def extract_services(self, host):
         try:
             url = urljoin(self.api_endpoint, "/api/ipam/services/?device=" + str(host["name"]))
@@ -263,13 +260,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             return device_lookup["results"]
         except Exception:
             return
-
-    def extract_manufacturer(self, host):
-        try:
-            return [self.manufacturers_lookup[host["device_type"]["manufacturer"]["id"]]]
-        except Exception:
-            return
-
+			
     def extract_primary_ip(self, host):
         try:
             address = host["primary_ip"]["address"]

--- a/lib/ansible/plugins/lookup/netbox_secrets.py
+++ b/lib/ansible/plugins/lookup/netbox_secrets.py
@@ -31,9 +31,8 @@ DOCUMENTATION = """
 """
 
 EXAMPLES = """
-- secret_name: use list directly with a socket
-  debug: msg="{{ lookup('redis', 'key1', 'key2', socket='/var/tmp/redis.sock') }}"
-
+- secret_name: lookup netbox secret
+  debug: mag={{ lookup("netbox_secrets", netbox_host="http://localhost:8000", private_key_file=".netbox-private-key.pem", token="[token]", device=[inventory_hostname], secret_name="[username]") }}
 """
 
 RETURN = """
@@ -70,11 +69,10 @@ class LookupModule(LookupBase):
         device = self.get_option('device')
 
         nb = pynetbox.api(
-          netbox_host,
-          private_key_file=private_key_file,
-          token=token
+            netbox_host,
+            private_key_file=private_key_file,
+            token=token
         )
+        conn = nb.secrets.secrets.get(device=device, name=secret_name).plaintext
 
-        conn = nb.secrets.secrets.get(device=device,name=secret_name).plaintext
-
-    return conn
+        return conn

--- a/lib/ansible/plugins/lookup/netbox_secrets.py
+++ b/lib/ansible/plugins/lookup/netbox_secrets.py
@@ -1,0 +1,87 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    lookup: netbox_secrets
+    author:
+      - Oliver Burkill (@ollybee) <ollybee(at)gmail.com>
+    short_description: fetch secrets from Netbox
+    description:
+      - This lookup returns a list of results from a Redis DB corresponding to a list of items given to it
+    requirements:
+      - pynetbox (Python API client library for Netbox https://github.com/digitalocean/pynetbox)
+    options:
+      device:
+        description: Device secret_name you want to fetch secrets for
+      netbox_host:
+        description: location of Netbox  host
+        default: '127.0.0.1'
+        env:
+          - secret_name: ANSIBLE_NETBOX_HOST
+      port:
+        description: port for Netox 
+        default: 8000
+        type: int
+        env:
+          - secret_name: ANSIBLE_NETBOX_PORT
+      private_key_file:
+        description: path to private key file for secrets authentication
+        type: path
+        env:
+          - secret_name: ANSIBLE_NETBOX_KEY
+      token:
+        description: Netbox API token (Read only is good)
+        env:
+          - secret_name: ANSIBLE_NETBOX_API_TOKEN
+      secret_name:
+        description: Name of the secret you want to retrieve 
+"""
+
+EXAMPLES = """
+- secret_name: use list directly with a socket
+  debug: msg="{{ lookup('redis', 'key1', 'key2', socket='/var/tmp/redis.sock') }}"
+
+"""
+
+RETURN = """
+_raw:
+  description: value(s) stored in Netbox
+"""
+
+import os
+
+HAVE_PYNETBOX = False
+try:
+    import pynetbox
+    HAVE_PYNETBOX = True
+except ImportError:
+    pass
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables, **kwargs):
+
+        if not HAVE_PYNETBOX:
+            raise AnsibleError("Module pynetbox is not installed")
+
+        self.set_options(direct=kwargs)
+
+        netbox_host = self.get_option('netbox_host')
+        token = self.get_option('token')
+        private_key_file = self.get_option('private_key_file')
+        secret_name = self.get_option('secret_name')
+        device = self.get_option('device')
+
+        nb = pynetbox.api(
+          netbox_host,
+          private_key_file=private_key_file,
+          token=token
+        )
+
+        conn = nb.secrets.secrets.get(device=device,name=secret_name).plaintext
+
+    return conn

--- a/lib/ansible/plugins/lookup/netbox_secrets.py
+++ b/lib/ansible/plugins/lookup/netbox_secrets.py
@@ -14,16 +14,9 @@ DOCUMENTATION = """
       device:
         description: Device secret_name you want to fetch secrets for
       netbox_host:
-        description: location of Netbox  host
-        default: '127.0.0.1'
+        description: URL of Netbox  host
         env:
           - secret_name: ANSIBLE_NETBOX_HOST
-      port:
-        description: port for Netox 
-        default: 8000
-        type: int
-        env:
-          - secret_name: ANSIBLE_NETBOX_PORT
       private_key_file:
         description: path to private key file for secrets authentication
         type: path


### PR DESCRIPTION
##### SUMMARY
A lookup plugin to fetch secrets from Netbox
Fixes #48354

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
netbox-secrets

##### ANSIBLE VERSION
```paste below
ansible 2.7.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/monitoring/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION


```paste below
    - name: query  for Netbox secret
      debug: msg={{ lookup("netbox_secrets", netbox_host="https://netbox.hyperslice.net:443", private_key_file=".netbox-private-key.pem", token="<redacted>", device="someserver", secret_name="test_username")}}


~/ansible$ ansible-playbook lookup.yml -i ./netbox_inventory.yml --connection=local --limit someserver -vvvv
ansible-playbook 2.7.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/monitoring/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
Using /etc/ansible/ansible.cfg as config file
setting up inventory plugins
/home/monitoring/ansible/netbox_inventory.yml did not meet host_list requirements, check plugin documentation if this is unexpected
/home/monitoring/ansible/netbox_inventory.yml did not meet virtualbox requirements, check plugin documentation if this is unexpected
Fetching: https://netboxdev.hyperslice.net/api/dcim/regions/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/tenancy/tenants/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/racks/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/sites/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/device-roles/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/device-types/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/manufacturers/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/devices/?limit=0&name=someserver
Fetching: https://netboxdev.hyperslice.net/api/virtualization/virtual-machines/?limit=0&name=someserver
Parsed /home/monitoring/ansible/netbox_inventory.yml inventory source with netbox plugin
Loading callback plugin default of type stdout, v2.0 from /usr/lib/python2.7/dist-packages/ansible/plugins/callback/default.pyc

PLAYBOOK: lookup.yml ********************************************************************************************************************************************************************************************************************************************************************************************************
1 plays in lookup.yml

PLAY [all] ******************************************************************************************************************************************************************************************************************************************************************************************************************
META: ran handlers

TASK [query  for Netbox secret] *********************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/monitoring/ansible/lookup.yml:8
fatal: [someserver]: FAILED! => {
    "msg": "lookup plugin (netbox_secrets) not found"
}
        to retry, use: --limit @/home/monitoring/ansible/lookup.retry

PLAY RECAP ******************************************************************************************************************************************************************************************************************************************************************************************************************
someserver                 : ok=0    changed=0    unreachable=0    failed=1

~/ansible$ ansible-playbook lookup.yml -i ./netbox_inventory.yml --connection=local --limit someserver -vvvv
ansible-playbook 2.7.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/monitoring/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
Using /etc/ansible/ansible.cfg as config file
setting up inventory plugins
/home/monitoring/ansible/netbox_inventory.yml did not meet host_list requirements, check plugin documentation if this is unexpected
/home/monitoring/ansible/netbox_inventory.yml did not meet virtualbox requirements, check plugin documentation if this is unexpected
Fetching: https://netboxdev.hyperslice.net/api/dcim/sites/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/regions/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/tenancy/tenants/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/device-roles/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/device-types/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/racks/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/manufacturers/?limit=0
Fetching: https://netboxdev.hyperslice.net/api/dcim/devices/?limit=0&name=someserver
Fetching: https://netboxdev.hyperslice.net/api/virtualization/virtual-machines/?limit=0&name=someserver
Parsed /home/monitoring/ansible/netbox_inventory.yml inventory source with netbox plugin
Loading callback plugin default of type stdout, v2.0 from /usr/lib/python2.7/dist-packages/ansible/plugins/callback/default.pyc

PLAYBOOK: lookup.yml ********************************************************************************************************************************************************************************************************************************************************************************************************
1 plays in lookup.yml

PLAY [all] ******************************************************************************************************************************************************************************************************************************************************************************************************************
META: ran handlers

TASK [query  for Netbox secret] *********************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/monitoring/ansible/lookup.yml:8
ok: [someserver] => {
    "msg": "hunter2"
}
META: ran handlers
META: ran handlers

PLAY RECAP ******************************************************************************************************************************************************************************************************************************************************************************************************************
someserver                 : ok=1    changed=0    unreachable=0    failed=0


```
