### PR TITLE
Fix grafana_datasource fails when name with spaces

### DIFF
--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -280,6 +280,7 @@ import json
 import base64
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves.urllib.parse import quote_plus
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 from ansible.module_utils._text import to_text
 
@@ -310,7 +311,7 @@ def grafana_headers(module, data):
 def grafana_datasource_exists(module, grafana_url, name, headers):
     datasource_exists = False
     ds = {}
-    r, info = fetch_url(module, '%s/api/datasources/name/%s' % (grafana_url, name), headers=headers, method='GET')
+    r, info = fetch_url(module, '%s/api/datasources/name/%s' % (grafana_url, quote_plus(name)), headers=headers, method='GET')
     if info['status'] == 200:
         datasource_exists = True
         ds = json.loads(to_text(r.read(), errors='surrogate_or_strict'))
@@ -468,7 +469,7 @@ def grafana_delete_datasource(module, data):
     result = {}
     if datasource_exists is True:
         # delete
-        r, info = fetch_url(module, '%s/api/datasources/name/%s' % (data['grafana_url'], data['name']), headers=headers, method='DELETE')
+        r, info = fetch_url(module, '%s/api/datasources/name/%s' % (data['grafana_url'], quote_plus(data['name'])), headers=headers, method='DELETE')
         if info['status'] == 200:
             res = json.loads(to_text(r.read(), errors='surrogate_or_strict'))
             result['msg'] = "Datasource %s deleted : %s" % (data['name'], res['message'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #44154
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
grafana_datasource
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```
