### PR TITLE
win_say: Port to use CSharpUtil AnsibleBasic 

### DIFF
--- a/changelogs/fragments/win-say-ansible-basic.yaml
+++ b/changelogs/fragments/win-say-ansible-basic.yaml
@@ -1,3 +1,4 @@
 minor_changes:
- - win_say - Ported code to use Ansible.Basic
- - win_say - If requested voice is not found a warning is now displayed
+ - win_say - Ported code to use Ansible.Basic.
+ - win_say - If requested voice is not found a warning is now displayed.
+ - win_say - Some error messages worded differently now that the module uses generic module parameter validation.

--- a/changelogs/fragments/win-say-ansible-basic.yaml
+++ b/changelogs/fragments/win-say-ansible-basic.yaml
@@ -1,3 +1,3 @@
 minor_changes:
- - port win_say to use Ansible.Basic
- - if requested voice is not found a warning is now displayed
+ - win_say: ported code to use Ansible.Basic
+ - win_say: if requested voice is not found a warning is now displayed

--- a/changelogs/fragments/win-say-ansible-basic.yaml
+++ b/changelogs/fragments/win-say-ansible-basic.yaml
@@ -1,3 +1,3 @@
 minor_changes:
- - win_say: ported code to use Ansible.Basic
- - win_say: if requested voice is not found a warning is now displayed
+ - win_say - Ported code to use Ansible.Basic
+ - win_say - If requested voice is not found a warning is now displayed

--- a/changelogs/fragments/win-say-ansible-basic.yaml
+++ b/changelogs/fragments/win-say-ansible-basic.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - port win_say to use Ansible.Basic
+ - if requested voice is not found a warning is now displayed

--- a/lib/ansible/modules/windows/win_say.ps1
+++ b/lib/ansible/modules/windows/win_say.ps1
@@ -33,34 +33,30 @@ $end_sound_path = $module.Params.end_sound_path
 $voice = $module.Params.voice
 $speech_speed = $module.Params.speech_speed
 
-$module.Result.changed = $false
-
-$words = $null
-
 if ($speech_speed -lt -10 -or $speech_speed -gt 10) {
    $module.FailJson("speech_speed needs to be an integer in the range -10 to 10.  The value $speech_speed is outside this range.")
 }
 
-if ($msg_file) {
-   if (Test-Path -Path $msg_file) {
-      $words = Get-Content $msg_file | Out-String
-   } else {
-      $module.FailJson("Message file $msg_file could not be found or opened.  Ensure you have specified the full path to the file, and the ansible windows user has permission to read the file.")
-   }
-}
+$words = $null
 
-if ($start_sound_path) {
-   if (Test-Path -Path $start_sound_path) {
-      if (-not $module.CheckMode) {
-         (new-object Media.SoundPlayer $start_sound_path).playSync()
-      }
-   } else {
-      $module.FailJson("Start sound file $start_sound_path could not be found or opened.  Ensure you have specified the full path to the file, and the ansible windows user has permission to read the file.")
-   }
+if ($msg_file) {
+   if (-not (Test-Path -Path $msg_file)) {
+      $module.FailJson("Message file $msg_file could not be found or opened.  Ensure you have specified the full path to the file, and the ansible windows user has permission to read the file.")
+   } 
+   $words = Get-Content $msg_file | Out-String
 }
 
 if ($msg) {
    $words = $msg
+}
+
+if ($start_sound_path) {
+   if (-not (Test-Path -Path $start_sound_path)) {
+      $module.FailJson("Start sound file $start_sound_path could not be found or opened.  Ensure you have specified the full path to the file, and the ansible windows user has permission to read the file.")
+   } 
+   if (-not $module.CheckMode) {
+      (new-object Media.SoundPlayer $start_sound_path).playSync()
+   }
 }
 
 if ($words) {
@@ -80,18 +76,17 @@ if ($words) {
       $tts.Rate = $speech_speed
    }
    if (-not $module.CheckMode) {
-       $tts.Speak($words)
+      $tts.Speak($words)
    }
    $tts.Dispose()
 }
 
 if ($end_sound_path) {
-   if (Test-Path -Path $end_sound_path) {
-      if (-not $module.CheckMode) {
-         (new-object Media.SoundPlayer $end_sound_path).playSync()
-      }
-   } else {
+   if (-not (Test-Path -Path $end_sound_path)) {
       $module.FailJson("End sound file $start_sound_path could not be found or opened.  Ensure you have specified the full path to the file, and the ansible windows user has permission to read the file.")
+   } 
+   if (-not $module.CheckMode) {
+      (new-object Media.SoundPlayer $end_sound_path).playSync()
    }
 }
 

--- a/lib/ansible/modules/windows/win_say.ps1
+++ b/lib/ansible/modules/windows/win_say.ps1
@@ -20,12 +20,12 @@ $spec = @{
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 
 
-$msg = $module.params.msg
-$msg_file = $module.params.msg_file
-$start_sound_path = $module.params.start_sound_path
-$end_sound_path = $module.params.end_sound_path
-$voice = $module.params.voice
-$speech_speed = $module.params.speech_speed
+$msg = $module.Params.msg
+$msg_file = $module.Params.msg_file
+$start_sound_path = $module.Params.start_sound_path
+$end_sound_path = $module.Params.end_sound_path
+$voice = $module.Params.voice
+$speech_speed = $module.Params.speech_speed
 
 $module.Result.changed = $false
 

--- a/lib/ansible/modules/windows/win_say.ps1
+++ b/lib/ansible/modules/windows/win_say.ps1
@@ -90,6 +90,6 @@ if ($end_sound_path) {
    }
 }
 
-$module.Result.message_text = $words
+$module.Result.message_text = $words.ToString()
 
 $module.ExitJson()

--- a/lib/ansible/modules/windows/win_say.ps1
+++ b/lib/ansible/modules/windows/win_say.ps1
@@ -14,6 +14,12 @@ $spec = @{
       voice = @{ type = "str"  }
       speech_speed = @{ type = "int"; default = 0  }
    }
+   mutually_exclusive = @(
+     ,@('msg', 'msg_file')
+   )
+   required_one_of = @(
+     ,@('msg', 'msg_file', 'start_sound_path', 'end_sound_path')
+   )
    supports_check_mode = $true
 }
 
@@ -33,14 +39,6 @@ $words = $null
 
 if ($speech_speed -lt -10 -or $speech_speed -gt 10) {
    $module.FailJson("speech_speed needs to be an integer in the range -10 to 10.  The value $speech_speed is outside this range.")
-}
-
-if ($msg_file -and $msg) {
-   $module.FailJson("Please specify either msg_file or msg parameters, not both")
-}
-
-if (-not $msg_file -and -not $msg -and -not $start_sound_path -and -not $end_sound_path) {
-   $module.FailJson("No msg_file, msg, start_sound_path, or end_sound_path parameters have been specified.  Please specify at least one so the module has something to do")
 }
 
 if ($msg_file) {

--- a/test/integration/targets/win_say/tasks/main.yml
+++ b/test/integration/targets/win_say/tasks/main.yml
@@ -4,21 +4,21 @@
 - name: Warn of impending deployment
   win_say:
     msg: Warning, deployment commencing in 5 minutes, please log out.
-  check_mode: yes
+  check_mode: "{{ win_say_check_mode |default('yes') }}"
 
-- name: Using a different voice and a start sound
+- name: Using a specified voice and a start sound
   win_say:
     msg: Warning, deployment commencing in 5 minutes, please log out.
     start_sound_path: C:\Windows\Media\ding.wav
     voice: Microsoft Hazel Desktop
-  check_mode: yes
+  check_mode: "{{ win_say_check_mode |default('yes') }}"
 
 - name: Example with start and end sound
   win_say:
     msg: New software installed
     start_sound_path: C:\Windows\Media\Windows Balloon.wav
     end_sound_path: C:\Windows\Media\chimes.wav
-  check_mode: yes
+  check_mode: "{{ win_say_check_mode |default('yes') }}"
 
 - name: Create message file
   win_copy:
@@ -30,15 +30,15 @@
     msg_file: C:\Windows\Temp\win_say_message.txt
     start_sound_path: C:\Windows\Media\Windows Balloon.wav
     end_sound_path: C:\Windows\Media\chimes.wav
-  check_mode: yes
+  check_mode: "{{ win_say_check_mode |default('yes') }}"
 
 - name: Remove message file
   win_file:
     path: C:\Windows\Temp\win_say_message.txt
     state: absent
 
-- name: Different spech peed
+- name: Different speech speed
   win_say:
     speech_speed: 5
     msg: Stay calm and proceed to the closest fire exit.
-  check_mode: yes
+  check_mode: "{{ win_say_check_mode |default('yes') }}"


### PR DESCRIPTION
Also add warning when requested voice not found (will use the default voice which is not a change in behaviour)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Switch win_say to use AnsibleBasic to take advantage of having arg specification.

Also added a warning if the selected voice is not found.  Previously if this happened, it was just returned in the 'voice_info' return parameter, as I think windows modules did not support having warnings at the time win_say was first created.

I have left the 'voice_info' return field for now but it could be deprecated/removed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_say
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (ansible-basic-win-say 7754df4366) last updated 2018/11/08 08:20:11 (GMT +100)
  config file = None
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

(warning is new, otherwise output is the same)

after

$ time ansible 10, -m win_say -a "msg=Hello voice=goat"
 [WARNING]: Could not load voice 'goat', using system default voice.

TENSY | SUCCESS => {
    "changed": false,
    "message_text": "Hello",
    "voice": "Microsoft Hazel Desktop",
    "voice_info": "Could not load voice 'goat', using system default voice."
}

real    0m7.958s
user    0m1.000s
sys     0m2.719s

```
