### PR TITLE
pagerduty_updates

### DIFF
--- a/lib/ansible/modules/monitoring/pagerduty.py
+++ b/lib/ansible/modules/monitoring/pagerduty.py
@@ -119,6 +119,20 @@ EXAMPLES = '''
     user: example@example.com
     state: absent
     window_id: '{{ pd_window.result.maintenance_window.id }}'
+
+# Delete a maintenance window from a separate playbook than its creation, and if it is the only existing maintenance window.
+- pagerduty:
+    requester_id: XXXXXXX
+    token: yourtoken
+    state: ongoing
+  register: pd_window
+
+- pagerduty:
+    requester_id: XXXXXXX
+    token: yourtoken
+    state: absent
+    window_id: "{{ pd_window.result.maintenance_windows[0].id }}"
+
 '''
 
 import datetime


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Just adding example usage that took me a little while to figure out, to benefit others.  The example can be run from a standalone playbook, separate from the play that created the maintenance window.  It will find and list the only running maintenance window, and then delete it.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
/modules/monitoring/pagerduty.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.7.1
  config file = None
  configured module search path = ['/Users/username/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.7.1/libexec/lib/python3.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.7.0 (default, Nov  1 2018, 10:45:45) [Clang 10.0.0 (clang-1000.11.45.5)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Straightforward doc example to list and then delete the only active Maintenance Window.
