### PR TITLE
win_chocolatey - move over to AnsibleModule and add allow_multiple

### DIFF
--- a/changelogs/fragments/win_chocolatey-allow-multiple.yaml
+++ b/changelogs/fragments/win_chocolatey-allow-multiple.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- win_chocolatey - added the allow_multiple module option to allow side by side installs of the same package
+- win_chocolatey - support bootstrapping Chocolatey from other URLs with any PS script that ends with ``.ps1``, originally this script had to be ``install.ps1``

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -33,6 +33,14 @@ options:
     type: bool
     default: 'no'
     version_added: '2.2'
+  allow_multiple:
+    description:
+    - Allow the installation of multiple packages when I(version) is specified.
+    - Having multiple packages at different versions can cause issues if the
+      package doesn't support this. Use at your own risk.
+    type: bool
+    default: no
+    version_added: '2.8'
   allow_prerelease:
     description:
     - Allow the installation of pre-release packages.
@@ -194,7 +202,8 @@ options:
   version:
     description:
     - Specific version of the package to be installed.
-    - Ignored when I(state) is set to C(absent).
+    - When I(state) is set to C(absent), will uninstall the specific version
+      otherwise all versions of that package will be removed.
     type: str
 notes:
 - Provide the C(version) parameter value as a string (e.g. C('6.1')), otherwise it

--- a/lib/ansible/modules/windows/win_chocolatey_facts.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey_facts.ps1
@@ -87,7 +87,7 @@ Function Get-ChocolateyPackages {
 
     param($choco_app)
 
-    $command = Argv-ToString -arguments $choco_app.Path, "list", "--local-only", "-r"
+    $command = Argv-ToString -arguments $choco_app.Path, "list", "--local-only", "--limit-output", "--all-versions"
     $res = Run-Command -command $command
     if ($res.rc -ne 0) {
         $result.stdout = $res.stdout
@@ -97,7 +97,7 @@ Function Get-ChocolateyPackages {
     }
 
     $packages_info = [System.Collections.ArrayList]@()
-    $res.stdout -split "`r`n" | Where-Object { $_ -ne "" } | ForEach-Object {
+    $res.stdout.Split("`r`n", [System.StringSplitOptions]::RemoveEmptyEntries) | ForEach-Object {
         $packages_split = $_ -split "\|"
         $package_info = @{
             package = $packages_split[0]

--- a/test/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/test/integration/targets/win_chocolatey/tasks/tests.yml
@@ -270,7 +270,7 @@
     state: present
     version: 0.1.0
   register: fail_multiple_versions
-  failed_when: fail_multiple_versions.msg != "Chocolatey package '" + test_choco_package1 + "' is already installed at version '0.0.1' but was expecting '0.1.0'. Either change the expected version, set state=latest, or set force=yes to continue"
+  failed_when: fail_multiple_versions.msg != "Chocolatey package '" + test_choco_package1 + "' is already installed with version(s) '0.0.1' but was expecting '0.1.0'. Either change the expected version, set state=latest, set allow_multiple=yes, or set force=yes to continue"
 
 - name: force the upgrade of an existing version
   win_chocolatey:
@@ -450,3 +450,43 @@
     that:
     - all_latest is changed
     - all_latest_actual.stdout_lines == [test_choco_package1 + "|0.1.0"]
+
+- name: install newer version of package
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: present
+
+- name: install older package with allow_multiple
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: present
+    allow_multiple: True
+    version: '0.0.1'
+  register: allow_multiple
+
+- name: get result of install older package with allow_multiple
+  win_command: choco.exe list --local-only --limit-output --all-versions --exact {{ test_choco_package1|quote }}
+  register: allow_multiple_actual
+
+- name: assert install older package with allow_multiple
+  assert:
+    that:
+    - allow_multiple is changed
+    - allow_multiple_actual.stdout == "ansible|0.1.0\r\nansible|0.0.1\r\n"
+
+- name: uninstall specific version installed with allow_multiple
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: absent
+    version: '0.0.1'
+  register: remove_multiple
+
+- name: get result of uninstall specific version installed with allow_multiple
+  win_command: choco.exe list --local-only --limit-output --all-versions --exact {{ test_choco_package1|quote }}
+  register: remove_multiple_actual
+
+- name: assert uninstall specific version installed with allow_multiple
+  assert:
+    that:
+    - remove_multiple is changed
+    - remove_multiple_actual.stdout == "ansible|0.1.0\r\n"


### PR DESCRIPTION
##### SUMMARY
Adds to `win_chocolatey`:

* New module option `allow_multiple` that allows the installation of the same package at different versions
* Uses the new AnsibleModule util
* Changes the bootstrap script to use `source` when it ends with `.ps1` instead of just `install.ps1`

Also updates `win_chocolatey_facts` to support reporting multiple package versions.

Fixes https://github.com/ansible/ansible/issues/38535

Replaces https://github.com/ansible/ansible/pull/47876
Replaces https://github.com/ansible/ansible/pull/47746

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_chocolatey
win_chocolatey_facts

##### ANSIBLE VERSION
```paste below
devel
```