### PR TITLE
Backport/2.6/44726 Fix calling deprecate with correct arguments

### DIFF
--- a/changelogs/fragments/44726-correct_deprecate_call.yaml
+++ b/changelogs/fragments/44726-correct_deprecate_call.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix calling deprecate with correct arguments (https://github.com/ansible/ansible/pull/46062).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2352,6 +2352,8 @@ class AnsibleModule(object):
                 for d in kwargs['deprecations']:
                     if isinstance(d, SEQUENCETYPE) and len(d) == 2:
                         self.deprecate(d[0], version=d[1])
+                    elif isinstance(d, Mapping):
+                        self.deprecate(d['msg'], version=d.get('version', None))
                     else:
                         self.deprecate(d)
             else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport 46062 - Fix calling deprecate with correct arguments to 2.6
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
basic.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.6.7
```
