### PR TITLE
[WIP] Add a new option to make all stdout look like debug stdout

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -533,6 +533,18 @@ DEFAULT_DEBUG:
   ini:
   - {key: debug, section: defaults}
   type: boolean
+DEFAULT_DEBUG_STDOUT:
+  name: Debug mode stdout format
+  default: False
+  description:
+    - "Toggles debug formatted output in Ansible for all lines. This is *very* verbose and can hinder
+      multiprocessing.  Debug output can also include secret information
+      despite no_log settings being enabled, which means debug mode should not be used in
+      production."
+  env: [{name: ANSIBLE_DEBUG_STDOUT}]
+  ini:
+  - {key: debug_stdout, section: defaults}
+  type: boolean
 DEFAULT_EXECUTABLE:
   name: Target shell executable
   default: /bin/sh

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -517,7 +517,9 @@ class Connection(ConnectionBase):
             b_command += [b'-b', b'-']
 
         if self._play_context.verbosity > 3:
-            b_command.append(b'-vvv')
+            #b_command.append(b'-vvv')
+            vs = u''.join(['v' for x in range(0, self._play_context.verbosity)])
+            b_command.append(b'-' + vs)
 
         #
         # Next, we add [ssh_connection]ssh_args from ansible.cfg.


### PR DESCRIPTION
##### SUMMARY

DO NOT MERGE! THIS IS A PROTOTYPE FOR TROUBLESHOOTING ISSUES.

All stdout from ansible can now resemble the debug stdout with `<pid> <time> [<host>]: <msg>`

It turns output like this ...

```
 41247 1541720389.17492: Loading ActionModule 'command' from /Users/jtanner/workspace/issues/AP-PRIO_HEALTH_PERF/ansible/lib/ansible/plugins/action/command.py
 41247 1541720389.17527: _low_level_execute_command(): starting
 41247 1541720389.17542: _low_level_execute_command(): executing: /bin/sh -c 'echo ~vagrant && sleep 0'
<el7host> ESTABLISH SSH CONNECTION FOR USER: vagrant
<el7host> SSH: EXEC ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o 'IdentityFile="/Users/jtanner/.ssh/id_rsa.corsair"' -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=vagrant -o ConnectTimeout=10 -o ControlPath=/Users/jtanner/.ansible/cp/332f4e80b1 el7host '/bin/sh -c '"'"'echo ~vagrant && sleep 0'"'"''
 41248 1541720389.18252: Loaded config def from plugin (connection/ssh)
 41246 1541720389.18900: stdout chunk (state=3):
>>>/home/vagrant
<<<
 41246 1541720389.18925: stderr chunk (state=3):
>>>debug3: mux_client_read_packet: read header failed: Broken pipe
debug2: Received exit status from master 0
<<<
 41246 1541720389.18959: stdout chunk (state=3):
>>><<<
 41246 1541720389.18975: stderr chunk (state=3):
>>><<<
<el7host> (0, '/home/vagrant\n', 'OpenSSH_7.6p1, LibreSSL 2.6.2\r\ndebug1: Reading configuration data /Users/jtanner/.ssh/config\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: /etc/ssh/ssh_config line 48: Applying options for *\r\ndebug1: auto-mux: Trying existing master\r\ndebug2: fd 3 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_session: entering\r\ndebug3: mux_client_request_alive: entering\r\ndebug3: mux_client_request_alive: done pid = 40614\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session: master session id: 2\r\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 0\r\n')
 41246 1541720389.19440: _low_level_execute_command() done: rc=0, stdout=/home/vagrant
, stderr=OpenSSH_7.6p1, LibreSSL 2.6.2
debug1: Reading configuration data /Users/jtanner/.ssh/config
debug1: Reading configuration data /etc/ssh/ssh_config
debug1: /etc/ssh/ssh_config line 48: Applying options for *
debug1: auto-mux: Trying existing master
debug2: fd 3 setting O_NONBLOCK
debug2: mux_client_hello_exchange: master version 4
debug3: mux_client_forwards: request forwardings: 0 local, 0 remote
```

into output like this ...

```
 40604 1541720308.57733 [None]: >>>OpenSSH_7.6p1, LibreSSL 2.6.2
 40604 1541720308.57733 [None]: debug1: Reading configuration data /Users/jtanner/.ssh/config
 40604 1541720308.57733 [None]: debug1: Reading configuration data /etc/ssh/ssh_config
 40604 1541720308.57733 [None]: debug1: /etc/ssh/ssh_config line 48: Applying options for *
 40604 1541720308.57733 [None]: debug1: auto-mux: Trying existing master
 40604 1541720308.57733 [None]: debug1: Control socket "/Users/jtanner/.ansible/cp/332f4e80b1" does not exist
 40604 1541720308.57733 [None]: debug2: resolving "el7host" port 22
 40604 1541720308.57733 [None]: debug2: ssh_connect_direct: needpriv 0
 40604 1541720308.57733 [None]: debug1: Connecting to el7host [10.0.0.107] port 22.
 40604 1541720308.57733 [None]: debug2: fd 5 setting O_NONBLOCK
 40604 1541720308.57733 [None]: debug1: fd 5 clearing O_NONBLOCK
 40604 1541720308.57733 [None]: debug1: Connection established.
 40604 1541720308.57733 [None]: debug3: timeout: 9963 ms remain after connect
 40604 1541720308.57733 [None]: debug1: identity file /Users/jtanner/.ssh/id_rsa.corsair type 0
 40604 1541720308.57733 [None]: debug1: key_load_public: No such file or directory
 40604 1541720308.57733 [None]: debug1: identity file /Users/jtanner/.ssh/id_rsa.corsair-cert type -1
 40604 1541720308.57733 [None]: debug1: Local version string SSH-2.0-OpenSSH_7.6
 40604 1541720308.57733 [None]: debug1: Remote protocol version 2.0, remote software version OpenSSH_7.4
 40604 1541720308.57733 [None]: debug1: match: OpenSSH_7.4 pat OpenSSH* compat 0x04000000
 40604 1541720308.57733 [None]: debug2: fd 5 setting O_NONBLOCK
 40604 1541720308.57733 [None]: debug1: Authenticating to el7host:22 as 'vagrant'
 40604 1541720308.57733 [None]: debug3: hostkeys_foreach: reading file "/Users/jtanner/.ssh/known_hosts"
 40604 1541720308.57733 [None]: debug3: record_hostkey: found key type ECDSA in file /Users/jtanner/.ssh/known_hosts:30
 40604 1541720308.57733 [None]: debug3: load_hostkeys: loaded 1 keys from el7host
 40604 1541720308.57733 [None]: debug3: order_hostkeyalgs: prefer hostkeyalgs: ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521
 40604 1541720308.57733 [None]: debug3: send packet: type 20
 40604 1541720308.57733 [None]: debug1: SSH2_MSG_KEXINIT sent
 40604 1541720308.57733 [None]: debug3: receive packet: type 20
 40604 1541720308.57733 [None]: debug1: SSH2_MSG_KEXINIT received
 40604 1541720308.57733 [None]: debug2: local client KEXINIT proposal
 40604 1541720308.57733 [None]: debug2: KEX algorithms: curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1,ext-info-c
```

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
display

