### PR TITLE
Remove unnecessary --recursive option to git clone

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -339,7 +339,7 @@ To install from source, clone the Ansible git repository:
 
 .. code-block:: bash
 
-    $ git clone https://github.com/ansible/ansible.git --recursive
+    $ git clone https://github.com/ansible/ansible.git
     $ cd ./ansible
 
 Once git has cloned the Ansible repository, setup the Ansible environment:


### PR DESCRIPTION
##### SUMMARY

Remove unnecessary --recursive option to git clone from the "Running from source" section. For two reasons:

1. Since the [repomerge](https://docs.ansible.com/ansible/2.6/dev_guide/repomerge.html) submodules aren't used and
2. Between [2.12.0] and [2.13.0] the `--recursive` syntax for initialising all sub-modules with `git clone` was dropped in favour of `--recurse-submodules`.

[2.12.0]: https://github.com/git/git/blob/v2.12.0/Documentation/git-clone.txt#L218
[2.13.0]: https://github.com/git/git/blob/v2.13.0/Documentation/git-clone.txt#L218

+label: docsite_pr

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

Installation guide

##### ANSIBLE VERSION

devel / 2.7

##### ADDITIONAL INFORMATION

None