### PR TITLE
meraki - Rewrite update requirement check

### DIFF
--- a/changelogs/fragments/48394-meraki-idempotency-change.yml
+++ b/changelogs/fragments/48394-meraki-idempotency-change.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "meraki_* - Idempotency check has been rewritten. The new version is more thorough."

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -70,7 +70,7 @@ class MerakiModule(object):
         self.original = None
         self.proposed = dict()
         self.merged = None
-        self.ignored_keys = ('id', 'organizationId')
+        self.ignored_keys = ['id', 'organizationId']
 
         # debug output
         self.filter_string = ''
@@ -129,12 +129,23 @@ class MerakiModule(object):
         else:
             self.params['protocol'] = 'http'
 
+    def sanitize(self, original, proposed):
+        """Determine which keys are unique to original"""
+        keys = []
+        for k, v in original.items():
+            try:
+                if proposed[k] and k not in self.ignored_keys:
+                    pass
+            except KeyError:
+                keys.append(k)
+        return keys
+
     def filter_items(self, d):
         ''' Filter out keys when returning items() '''
         l = []
         # Ensure we return sorted tuples
         for k, v in sorted(d.items()):
-            if k not in self.ignored_keys:
+            if k not in self.ignored_keys and v is not None:
                 l.append((k, v))
         return l
 

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -140,42 +140,6 @@ class MerakiModule(object):
                 keys.append(k)
         return keys
 
-    # def filter_items(self, d):
-    #     ''' Filter out keys when returning items() '''
-    #     l = []
-    #     # Ensure we return sorted tuples
-    #     for k, v in sorted(d.items()):
-    #         if k not in self.ignored_keys and v is not None:
-    #             l.append((k, v))
-    #     return l
-
-    # Option 1 - Bidirectional check
-    # def is_update_required(self, original, proposed, optional_ignore=None):
-    #     ''' Compare two data-structures '''
-    #     if optional_ignore:
-    #         self.ignored_keys = self.ignored_keys + optional_ignore
-
-    #     if type(original) != type(proposed):
-    #         # print("Datatypes don't match: {0} vs {1}".format(type(original), type(proposed)))
-    #         return True
-    #     if isinstance(original, list) or isinstance(original, tuple):
-    #         if len(original) != len(proposed):
-    #             # print("Lengths don't match: {0} vs {1}".format(len(original), len(proposed)))
-    #             return True
-    #         for a, b in zip(original, proposed):
-    #             if self.is_update_required(a, b):
-    #                 return True
-    #     elif isinstance(original, dict):
-    #         # Turn dictionaries into list of tuples, and re-evaluate
-    #         if self.is_update_required(self.filter_items(original), self.filter_items(proposed)):
-    #             return True
-    #     else:  # Works for sets, integers, strings, ...
-    #         if original != proposed:
-    #             # print("Values don't match: {0} vs {1}".format(original, proposed))
-    #             return True
-    #     return False
-
-    # Option 2 - Unidirectional (proposed -> original ) check
     def is_update_required(self, original, proposed, optional_ignore=None):
         ''' Compare two data-structures '''
         self.ignored_keys.append('net_id')

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -149,6 +149,8 @@ class MerakiModule(object):
                 l.append((k, v))
         return l
 
+
+    # Option 1 - Bidirectional check
     def is_update_required(self, original, proposed, optional_ignore=None):
         ''' Compare two data-structures '''
         if optional_ignore:
@@ -173,6 +175,34 @@ class MerakiModule(object):
                 # print("Values don't match: {0} vs {1}".format(original, proposed))
                 return True
         return False
+
+    # Option 2 - Unidirectional (proposed -> original ) check
+    # def is_update_required(self, original, proposed, optional_ignore=None):
+    #     ''' Compare two data-structures '''
+    #     self.ignored_keys = ['net_id']
+    #     if optional_ignore is not None:
+    #         self.ignored_keys = self.ignored_keys + optional_ignore
+
+    #     if type(original) != type(proposed):
+    #         return True
+    #     if isinstance(original, list):
+    #         if len(original) != len(proposed):
+    #             return True
+    #         for a, b in zip(original, proposed):
+    #             if self.is_update_required(a, b):
+    #                 return True
+    #     elif isinstance(original, dict):
+    #         for k, v in proposed.items():
+    #             if k not in self.ignored_keys:
+    #                 if k in original:
+    #                     if self.is_update_required(original[k], proposed[k]):
+    #                         return True
+    #                 else:
+    #                     return True
+    #     else:
+    #         if original != proposed:
+    #             return True
+    #     return False
 
     def get_orgs(self):
         """Downloads all organizations for a user."""

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -175,20 +175,23 @@ class MerakiModule(object):
     #             return True
     #     return False
 
-    Option 2 - Unidirectional (proposed -> original ) check
+    # Option 2 - Unidirectional (proposed -> original ) check
     def is_update_required(self, original, proposed, optional_ignore=None):
         ''' Compare two data-structures '''
-        self.ignored_keys = ['net_id']
+        self.ignored_keys.append('net_id')
         if optional_ignore is not None:
             self.ignored_keys = self.ignored_keys + optional_ignore
 
         if type(original) != type(proposed):
+            # self.fail_json(msg="Types don't match")
             return True
         if isinstance(original, list):
             if len(original) != len(proposed):
+                # self.fail_json(msg="Length of lists don't match")
                 return True
             for a, b in zip(original, proposed):
                 if self.is_update_required(a, b):
+                    # self.fail_json(msg="List doesn't match", a=a, b=b)
                     return True
         elif isinstance(original, dict):
             for k, v in proposed.items():
@@ -197,9 +200,11 @@ class MerakiModule(object):
                         if self.is_update_required(original[k], proposed[k]):
                             return True
                     else:
+                        # self.fail_json(msg="Key not in original", k=k)
                         return True
         else:
             if original != proposed:
+                # self.fail_json(msg="Fallback", original=original, proposed=proposed)
                 return True
         return False
 

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -129,7 +129,6 @@ class MerakiModule(object):
         else:
             self.params['protocol'] = 'http'
 
-
     def filter_items(self, d):
         ''' Filter out keys when returning items() '''
         l = []

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -140,69 +140,68 @@ class MerakiModule(object):
                 keys.append(k)
         return keys
 
-    def filter_items(self, d):
-        ''' Filter out keys when returning items() '''
-        l = []
-        # Ensure we return sorted tuples
-        for k, v in sorted(d.items()):
-            if k not in self.ignored_keys and v is not None:
-                l.append((k, v))
-        return l
-
+    # def filter_items(self, d):
+    #     ''' Filter out keys when returning items() '''
+    #     l = []
+    #     # Ensure we return sorted tuples
+    #     for k, v in sorted(d.items()):
+    #         if k not in self.ignored_keys and v is not None:
+    #             l.append((k, v))
+    #     return l
 
     # Option 1 - Bidirectional check
-    def is_update_required(self, original, proposed, optional_ignore=None):
-        ''' Compare two data-structures '''
-        if optional_ignore:
-            self.ignored_keys = self.ignored_keys + optional_ignore
-
-        if type(original) != type(proposed):
-            # print("Datatypes don't match: {0} vs {1}".format(type(original), type(proposed)))
-            return True
-        if isinstance(original, list) or isinstance(original, tuple):
-            if len(original) != len(proposed):
-                # print("Lengths don't match: {0} vs {1}".format(len(original), len(proposed)))
-                return True
-            for a, b in zip(original, proposed):
-                if self.is_update_required(a, b):
-                    return True
-        elif isinstance(original, dict):
-            # Turn dictionaries into list of tuples, and re-evaluate
-            if self.is_update_required(self.filter_items(original), self.filter_items(proposed)):
-                return True
-        else:  # Works for sets, integers, strings, ...
-            if original != proposed:
-                # print("Values don't match: {0} vs {1}".format(original, proposed))
-                return True
-        return False
-
-    # Option 2 - Unidirectional (proposed -> original ) check
     # def is_update_required(self, original, proposed, optional_ignore=None):
     #     ''' Compare two data-structures '''
-    #     self.ignored_keys = ['net_id']
-    #     if optional_ignore is not None:
+    #     if optional_ignore:
     #         self.ignored_keys = self.ignored_keys + optional_ignore
 
     #     if type(original) != type(proposed):
+    #         # print("Datatypes don't match: {0} vs {1}".format(type(original), type(proposed)))
     #         return True
-    #     if isinstance(original, list):
+    #     if isinstance(original, list) or isinstance(original, tuple):
     #         if len(original) != len(proposed):
+    #             # print("Lengths don't match: {0} vs {1}".format(len(original), len(proposed)))
     #             return True
     #         for a, b in zip(original, proposed):
     #             if self.is_update_required(a, b):
     #                 return True
     #     elif isinstance(original, dict):
-    #         for k, v in proposed.items():
-    #             if k not in self.ignored_keys:
-    #                 if k in original:
-    #                     if self.is_update_required(original[k], proposed[k]):
-    #                         return True
-    #                 else:
-    #                     return True
-    #     else:
+    #         # Turn dictionaries into list of tuples, and re-evaluate
+    #         if self.is_update_required(self.filter_items(original), self.filter_items(proposed)):
+    #             return True
+    #     else:  # Works for sets, integers, strings, ...
     #         if original != proposed:
+    #             # print("Values don't match: {0} vs {1}".format(original, proposed))
     #             return True
     #     return False
+
+    Option 2 - Unidirectional (proposed -> original ) check
+    def is_update_required(self, original, proposed, optional_ignore=None):
+        ''' Compare two data-structures '''
+        self.ignored_keys = ['net_id']
+        if optional_ignore is not None:
+            self.ignored_keys = self.ignored_keys + optional_ignore
+
+        if type(original) != type(proposed):
+            return True
+        if isinstance(original, list):
+            if len(original) != len(proposed):
+                return True
+            for a, b in zip(original, proposed):
+                if self.is_update_required(a, b):
+                    return True
+        elif isinstance(original, dict):
+            for k, v in proposed.items():
+                if k not in self.ignored_keys:
+                    if k in original:
+                        if self.is_update_required(original[k], proposed[k]):
+                            return True
+                    else:
+                        return True
+        else:
+            if original != proposed:
+                return True
+        return False
 
     def get_orgs(self):
         """Downloads all organizations for a user."""

--- a/lib/ansible/modules/network/meraki/meraki_device.py
+++ b/lib/ansible/modules/network/meraki/meraki_device.py
@@ -331,9 +331,12 @@ def main():
                 path = meraki.construct_path('get_all', net_id=net_id)
                 devices = meraki.request(path, method='GET')
                 for unit in devices:
-                    if unit['name'] == meraki.params['hostname']:
-                        device.append(unit)
-                        meraki.result['data'] = device
+                    try:
+                        if unit['name'] == meraki.params['hostname']:
+                            device.append(unit)
+                            meraki.result['data'] = device
+                    except KeyError:
+                        pass
             elif meraki.params['model']:
                 path = meraki.construct_path('get_all', net_id=net_id)
                 devices = meraki.request(path, method='GET')
@@ -372,6 +375,7 @@ def main():
                 query_path = meraki.construct_path('get_device', net_id=net_id) + meraki.params['serial']
                 device_data = meraki.request(query_path, method='GET')
                 ignore_keys = ['lanIp', 'serial', 'mac', 'model', 'networkId', 'moveMapMarker', 'wan1Ip', 'wan2Ip']
+                # meraki.fail_json(msg="Compare", original=device_data, payload=payload, ignore=ignore_keys)
                 if meraki.is_update_required(device_data, payload, optional_ignore=ignore_keys):
                     path = meraki.construct_path('update', net_id=net_id) + meraki.params['serial']
                     updated_device = []

--- a/lib/ansible/modules/network/meraki/meraki_snmp.py
+++ b/lib/ansible/modules/network/meraki/meraki_snmp.py
@@ -201,7 +201,7 @@ def set_snmp(meraki, org_id):
         full_compare['v2cEnabled'] = False
     path = meraki.construct_path('create', org_id=org_id)
     snmp = get_snmp(meraki, org_id)
-    ignored_parameters = ('v3AuthPass', 'v3PrivPass', 'hostname', 'port', 'v2CommunityString', 'v3User')
+    ignored_parameters = ['v3AuthPass', 'v3PrivPass', 'hostname', 'port', 'v2CommunityString', 'v3User']
     if meraki.is_update_required(snmp, full_compare, optional_ignore=ignored_parameters):
         r = meraki.request(path,
                            method='PUT',

--- a/lib/ansible/modules/network/meraki/meraki_switchport.py
+++ b/lib/ansible/modules/network/meraki/meraki_switchport.py
@@ -377,7 +377,7 @@ def main():
         original = meraki.request(query_path, method='GET')
         if meraki.params['type'] == 'trunk':
             proposed['voiceVlan'] = original['voiceVlan']  # API shouldn't include voice VLAN on a trunk port
-        if meraki.is_update_required(original, proposed, optional_ignore=('number')):
+        if meraki.is_update_required(original, proposed, optional_ignore=['number']):
             path = meraki.construct_path('update', custom={'serial': meraki.params['serial'],
                                                            'number': meraki.params['number'],
                                                            })

--- a/test/integration/targets/meraki_config_template/tasks/main.yml
+++ b/test/integration/targets/meraki_config_template/tasks/main.yml
@@ -14,7 +14,7 @@
       auth_key: '{{ auth_key }}'
       host: marrrraki.com
       state: query
-      org_name: DevTestOrg
+      org_name: '{{test_org_name}}'
       output_level: debug
     delegate_to: localhost
     register: invalid_domain

--- a/test/integration/targets/meraki_device/tasks/main.yml
+++ b/test/integration/targets/meraki_device/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - block:
+  # This is commented out because a device cannot be unclaimed via API
   # - name: Claim a device into an organization
   #   meraki_device:
   #     auth_key: '{{auth_key}}'

--- a/test/integration/targets/meraki_switchport/tasks/main.yml
+++ b/test/integration/targets/meraki_switchport/tasks/main.yml
@@ -8,16 +8,16 @@
     msg: Please define an API key
   when: auth_key is not defined
   
-# - name: Use an invalid domain
-#   meraki_switchport:
-#     auth_key: '{{ auth_key }}'
-#     host: marrrraki.com
-#     state: query
-#     serial: Q2HP-2C6E-GTLD
-#     org_name: IntTestOrg
-#   delegate_to: localhost
-#   register: invaliddomain
-#   ignore_errors: yes
+- name: Use an invalid domain
+  meraki_switchport:
+    auth_key: '{{ auth_key }}'
+    host: marrrraki.com
+    state: query
+    serial: Q2HP-2C6E-GTLD
+    org_name: IntTestOrg
+  delegate_to: localhost
+  register: invaliddomain
+  ignore_errors: yes
   
 - name: Disable HTTP
   meraki_switchport:

--- a/test/integration/targets/meraki_switchport/tasks/main.yml
+++ b/test/integration/targets/meraki_switchport/tasks/main.yml
@@ -8,16 +8,16 @@
     msg: Please define an API key
   when: auth_key is not defined
   
-- name: Use an invalid domain
-  meraki_switchport:
-    auth_key: '{{ auth_key }}'
-    host: marrrraki.com
-    state: query
-    serial: Q2HP-2C6E-GTLD
-    org_name: IntTestOrg
-  delegate_to: localhost
-  register: invaliddomain
-  ignore_errors: yes
+# - name: Use an invalid domain
+#   meraki_switchport:
+#     auth_key: '{{ auth_key }}'
+#     host: marrrraki.com
+#     state: query
+#     serial: Q2HP-2C6E-GTLD
+#     org_name: IntTestOrg
+#   delegate_to: localhost
+#   register: invaliddomain
+#   ignore_errors: yes
   
 - name: Disable HTTP
   meraki_switchport:


### PR DESCRIPTION
##### SUMMARY
- Rewrite of the Meraki utility's idempotency check
- Check now operates recursively and works on multiple types
- Order of lists matter
- This will likely change behavior for some modules because there could be a change on whether the data structure is completely overwritten or if it's patched

###### Modules Tested Via Integration Tests
- [x] meraki_admin
- [x] meraki_config_template
- [x] meraki_content_filtering
- [x] meraki_device
- [x] meraki_mr_l3_firewall
- [x] meraki_mx_l3_firewall
- [x] meraki_network
- [x] meraki_organization
- [x] meraki_snmp
- [x] meraki_ssid
- [x] meraki_static_route
- [x] meraki_switchport
- [x] meraki_syslog
- [x] meraki_vlan



Fixes #48279

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0 (meraki/network_cleanup bb2aca9f4a) last updated 2018/11/08 20:20:56 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]

```