### PR TITLE
2.7: Document lineinfile regexp gotcha

### DIFF
--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -42,11 +42,15 @@ options:
   regexp:
     aliases: [ 'regex' ]
     description:
-      - The regular expression to look for in every line of the file. For
-        C(state=present), the pattern to replace if found. Only the last line
-        found will be replaced. For C(state=absent), the pattern of the line(s)
-        to remove. Uses Python regular expressions.
-        See U(http://docs.python.org/2/library/re.html).
+      - The regular expression to look for in every line of the file.
+      - For C(state=present), the pattern to replace if found. Only the last line found will be replaced.
+      - For C(state=absent), the pattern of the line(s) to remove.
+      - If the regular expression is not matched, the line will be
+        added to the file in keeping with`insertbefore` or `insertafter`
+        settings.
+      - When modifying a line the regexp should typically match both the initial state of
+        the line as well as its state after replacement by C(line) to ensure idempotence.
+      - Uses Python regular expressions. See U(http://docs.python.org/2/library/re.html).
     version_added: '1.7'
   state:
     description:


### PR DESCRIPTION
… in PR 47912 due to deleted repository. As requested back port documentation change from devel(2.8) to stable-2.7

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
As requested merge documentation clarification for regexp parameter of lineinfile module originally submited in PR 47912 against devel(2.8), forked repo was unfortunately deleted so can't cleanly use cherry-pick documented workflow.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lineinfile

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.1.post0 (stable-2.7 c7c55f6e5f) last updated 2018/11/08 23:21:43 (GMT -700)
  config file = None
  configured module search path = [u'/Users/panisset/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/panisset/Documents/Personal/ansible/lib/ansible
  executable location = /Users/panisset/Documents/Personal/ansible/bin/ansible
  python version = 2.7.15 (default, Oct  2 2018, 11:47:18) [GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
