### PR TITLE
iosxr_command failure when ‘connection timed out’ is in the return output

### DIFF
--- a/lib/ansible/plugins/terminal/iosxr.py
+++ b/lib/ansible/plugins/terminal/iosxr.py
@@ -39,7 +39,7 @@ class TerminalModule(TerminalBase):
         re.compile(br"% ?This command is not authorized"),
         re.compile(br"invalid input", re.I),
         re.compile(br"(?:incomplete|ambiguous) command", re.I),
-        re.compile(br"connection timed out", re.I),
+        re.compile(br"(?<!\()connection timed out(?!\))", re.I),
         re.compile(br"[^\r\n]+ not found", re.I),
         re.compile(br"'[^']' +returned error code: ?\d+"),
         re.compile(br"Failed to commit", re.I)


### PR DESCRIPTION
##### SUMMARY
Fixes #47985

on IOSXR, I found at least one scenario where 'connection timed out' was a valid error string in command output e.g. when trying to copy a large file from tftp to router flash. In this context 'Connection timed out' error string should have been flagged as a valid error .So we can not just remove regex pattern 'connection timed out' . However if this is part of a show command, most probably it would be enclosed within a bracket () as we saw in PR #47985 . Long term fix would be to remove regex based error identification but for current release it might be worthwhile to fix it to ignore '(connection timed out)' to be flagged as an error.

Example when 'connection timed out' was a valid error 
```
RP/0/RP0/CPU0:ios#copy tftp://11.1.1.43:/home/vagrant/install.sh .
Fri Sep  7 00:43:26.653 UTC
Address or name of remote host [11.1.1.43]?
Destination filename [/disk0:/./install.sh]?
Accessing tftp://11.1.1.43/home/vagrant/install.sh
%Error copying tftp://11.1.1.43/home/vagrant/install.sh (Error opening source file): Connection timed out 
                                                                                       ^^^^^
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
iosxr_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8
```

