### PR TITLE
Fix OpenNebula Deploy VM from template with id==0.

### DIFF
--- a/lib/ansible/modules/cloud/opennebula/one_vm.py
+++ b/lib/ansible/modules/cloud/opennebula/one_vm.py
@@ -1331,20 +1331,20 @@ def main():
     template_id = None
     if requested_template_id or requested_template_name:
         template_id = get_template_id(module, client, requested_template_id, requested_template_name)
-        if not template_id:
+        if template_id is None:
             if requested_template_id:
                 module.fail_json(msg='There is no template with template_id: ' + str(requested_template_id))
             elif requested_template_name:
                 module.fail_json(msg="There is no template with name: " + requested_template_name)
 
-    if exact_count and not template_id:
+    if exact_count and template_id is None:
         module.fail_json(msg='Option `exact_count` needs template_id or template_name')
 
     if exact_count is not None and not (count_attributes or count_labels):
         module.fail_json(msg='Either `count_attributes` or `count_labels` has to be specified with option `exact_count`.')
     if (count_attributes or count_labels) and exact_count is None:
         module.fail_json(msg='Option `exact_count` has to be specified when either `count_attributes` or `count_labels` is used.')
-    if template_id and state != 'present':
+    if template_id is not None and state != 'present':
         module.fail_json(msg="Only state 'present' is valid for the template")
 
     if memory:
@@ -1372,7 +1372,7 @@ def main():
                                                                                    count_attributes, labels, count_labels, disk_size,
                                                                                    networks, hard, wait, wait_timeout)
         vms = tagged_instances_list
-    elif template_id and state == 'present':
+    elif template_id is not None and state == 'present':
         # Deploy count VMs
         changed, instances_list, tagged_instances_list = create_count_of_vms(module, client, template_id, count,
                                                                              attributes, labels, disk_size, networks, wait, wait_timeout)


### PR DESCRIPTION
##### SUMMARY
Fix OpenNebula Deploy VM (one_vm) from template with id==0.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
one_vm
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.1
  config file = None
  configured module search path = ['~/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.7.1/libexec/lib/python3.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.7.0 (default, Oct  2 2018, 09:18:58) [Clang 10.0.0 (clang-1000.11.45.2)]
```

##### ADDITIONAL INFORMATION
[Existing OpenNebula VM Templates]
![screenshot_2018-11-09_17 53 28](https://user-images.githubusercontent.com/16351460/48273636-1375cc00-e44a-11e8-8e8a-52944c2473cd.png)

```paste below
TASK [opennebula-vm : Opennebula VM] *********************************************************************************************************************************************
fatal: [localhost]: FAILED! => changed=false
  msg: 'There is no template with name: Ubuntu-16.04'
```