### PR TITLE
Added a bytes cast when checking for terminal response

### DIFF
--- a/lib/ansible/plugins/terminal/dellos6.py
+++ b/lib/ansible/plugins/terminal/dellos6.py
@@ -57,7 +57,7 @@ class TerminalModule(TerminalBase):
     terminal_inital_prompt_newline = False
 
     def on_become(self, passwd=None):
-        if self._get_prompt().endswith('#'):
+        if self._get_prompt().endswith(b'#'):
             return
 
         cmd = {u'command': u'enable'}


### PR DESCRIPTION
##### SUMMARY
The return object from _get_prompt is a `bytes` type and the chained call for `endswith` should take a `bytes` and not a `string`

Fixes #48426

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
dellos6_command

##### ANSIBLE VERSION

```
ansible 2.7.1
  config file = None
  configured module search path = ['/Users/jed.giblin/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jed.giblin/.pyenv/versions/3.5.6/lib/python3.5/site-packages/ansible
  executable location = /Users/jed.giblin/.pyenv/versions/3.5.6/bin/ansible
  python version = 3.5.6 (default, Oct 11 2018, 08:11:38) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
```

##### ADDITIONAL INFORMATION
This is an error in which data type to pass the method. 

I can't paste the output for security, but playbook recap changes
before
```
PLAY RECAP *********************************************************************************************************************************************************************************************************************************************************************
some-hostname          : ok=0    changed=0    unreachable=0    failed=1
```

After
```
PLAY RECAP *********************************************************************************************************************************************************************************************************************************************************************
some-hostname          : ok=1    changed=0    unreachable=0    failed=0
```
