### PR TITLE
Let EC2 inventory unreachable/private hosts

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -47,6 +47,23 @@ destination_variable = public_dns_name
 # vpc_destination_variable = private_ip_address
 vpc_destination_variable = ip_address
 
+# If 'include_private_hosts' is True, then this variable will be used
+# to determine the destination address of a host. This should usually
+# be 'private_ip_address' since private DNS names rarely make sense.
+private_destination_variable = private_ip_address
+
+# If this is True, then the inventory will include hosts that cannot
+# be directly reached from the machine running Ansible. This is useful
+# if you plan to run Ansible through an SSH proxy.
+include_private_hosts = False
+
+# If 'include_private_hosts' is True, then all private/unreachable
+# hosts will be added to this group. This makes it easy to create a
+# group variable file that includes the appropriate
+# 'ansible_ssh_common_args' to make connections go through an SSH
+# proxy.
+private_host_group = ec2_private_host
+
 # The following two settings allow flexible ansible host naming based on a
 # python format string and a comma-separated list of ec2 tags.  Note that:
 #


### PR DESCRIPTION
This adds options to make it possible to inventory EC2 hosts that
aren't directly reachable, in case the user wants to run ansible on
those hosts via an SSH proxy.

##### SUMMARY

The existing EC2 inventory script silently ignores hosts that don't have public addresses, because it assumes that they're unreachable. But they may be entirely reachable via an SSH proxy, so we should at least provide the option to include them.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

EC2 dynamic inventory script

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (ec2-inventory-tag-exclude f33b0f73d8) last updated 2018/11/09 13:03:50 (GMT -500)
  config file = None
  configured module search path = [u'/home/stpierre/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/stpierre/devel/ansible/lib/ansible
  executable location = /home/stpierre/devel/ansible/bin/ansible
  python version = 2.7.15 (default, Oct 15 2018, 15:24:06) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
