### PR TITLE
Add options to EC2 inventory to exclude by tag

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -155,6 +155,16 @@ group_by_elasticache_replication_group = True
 # If you want to exclude any hosts that match a certain regular expression
 # pattern_exclude = staging-*
 
+# If you only want to include hosts with a particular tag. If you
+# provide a comma-separated list of tags, then *any* matching tag
+# results in the host being included.
+# tag_include = tag1=value1,tag2
+
+# If you want to exclude any hosts with a particular tag. If you
+# provide a comma-separated list of tags, then *any* matching tag
+# results in the host being excluded.
+# tag_exclude = tag1=value1,tag2
+
 # Instance filters can be used to control which instances are retrieved for
 # inventory. For the full list of possible filters, please read the EC2 API
 # docs: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeInstances.html#query-DescribeInstances-filters


### PR DESCRIPTION
##### SUMMARY

This adds `tag_exclude` and `tag_include` options to let the EC2 dynamic inventory script include/exclude hosts based on the tags they have.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

EC2 dynamic inventory script
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (ec2-inventory-tag-exclude f33b0f73d8) last updated 2018/11/09 13:03:50 (GMT -500)
  config file = None
  configured module search path = [u'/home/stpierre/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/stpierre/devel/ansible/lib/ansible
  executable location = /home/stpierre/devel/ansible/bin/ansible
  python version = 2.7.15 (default, Oct 15 2018, 15:24:06) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
