### PR TITLE
Let EC2 inventory script use r53 hostname as ansible_host

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -66,6 +66,10 @@ route53 = False
 # set to True.
 # route53_hostnames = .example.com
 
+# To use Route53 hostnames as the 'ansible_host' (i.e., to SSH to the
+# r53 hostname), set to True.
+route53_hostname_as_destination = False
+
 # To exclude RDS instances from the inventory, uncomment and set to False.
 #rds = False
 

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -233,6 +233,7 @@ DEFAULTS = {
     'route53': 'False',
     'route53_excluded_zones': '',
     'route53_hostnames': '',
+    'route53_hostname_as_destination': 'False',
     'stack_filters': 'False',
     'vpc_destination_variable': 'ip_address'
 }
@@ -387,6 +388,7 @@ class Ec2Inventory(object):
         # Route53
         self.route53_enabled = config.getboolean('ec2', 'route53')
         self.route53_hostnames = config.get('ec2', 'route53_hostnames')
+        self.route53_hostname_as_destination = config.getboolean('ec2', 'route53_hostname_as_destination')
 
         self.route53_excluded_zones = []
         self.route53_excluded_zones = [a for a in config.get('ec2', 'route53_excluded_zones').split(',') if a]
@@ -1079,7 +1081,10 @@ class Ec2Inventory(object):
         self.push(self.inventory, 'ec2', hostname)
 
         self.inventory["_meta"]["hostvars"][hostname] = self.get_host_info_dict_from_instance(instance)
-        self.inventory["_meta"]["hostvars"][hostname]['ansible_host'] = dest
+        if self.route53_enabled and self.route53_hostname_as_destination:
+            self.inventory["_meta"]["hostvars"][hostname]['ansible_host'] = hostname
+        else:
+            self.inventory["_meta"]["hostvars"][hostname]['ansible_host'] = dest
 
     def add_rds_instance(self, instance, region):
         ''' Adds an RDS instance to the inventory and index, as long as it is


### PR DESCRIPTION
##### SUMMARY
This lets the user SSH to the r53 hostname, which, depending on domain
topology, may be easier to manage SSH configs for.

For instance, our hosts all have `*.compute-1.amazonaws.com` as their public hostname, but a sensible CNAME in route53. Using that CNAME makes the configurations in `~/.ssh/config` work, even across subdomains (which are expressed through the r53 CNAME records).

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

EC2 dynamic inventory script

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (ec2-inventory-r53-hostname-as-dest 49908c42c6) last updated 2018/11/09 13:39:59 (GMT -500)
  config file = None
  configured module search path = [u'/home/stpierre/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/stpierre/devel/ansible/lib/ansible
  executable location = /home/stpierre/devel/ansible/bin/ansible
  python version = 2.7.15 (default, Oct 15 2018, 15:24:06) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
