### PR TITLE
To ipv6 network

### DIFF
--- a/lib/ansible/module_utils/common/network.py
+++ b/lib/ansible/module_utils/common/network.py
@@ -79,6 +79,36 @@ def to_subnet(addr, mask, dotted_notation=False):
     return '%s/%s' % ('.'.join(network), cidr)
 
 
+def to_ipv6_subnet(addr):
+    """ IPv6 addresses are eight groupings. The first four groupings (64 bits) comprise the subnet address. """
+
+    # https://tools.ietf.org/rfc/rfc2374.txt
+
+    # Split by :: to identify omitted zeros
+    ipv6_prefix = addr.split('::')[0]
+
+    # Get the first four groups, or as many as are found + ::
+    found_groups = []
+    for group in ipv6_prefix.split(':'):
+        found_groups.append(group)
+        if len(found_groups) == 4:
+            break
+    if len(found_groups) < 4:
+        found_groups.append('::')
+
+    # Concatenate network address parts
+    network_addr = ''
+    for group in found_groups:
+        if group != '::':
+            network_addr += str(group)
+        network_addr += str(':')
+
+    # Ensure network address ends with ::
+    if not network_addr.endswith('::'):
+        network_addr += str(':')
+    return network_addr
+
+
 def to_ipv6_network(addr):
     """ IPv6 addresses are eight groupings. The first three groupings (48 bits) comprise the network address. """
 

--- a/lib/ansible/module_utils/network/common/utils.py
+++ b/lib/ansible/module_utils/network/common/utils.py
@@ -42,7 +42,7 @@ from ansible.module_utils.basic import AnsibleFallbackNotFound
 
 # Backwards compatibility for 3rd party modules
 from ansible.module_utils.common.network import (
-    to_bits, is_netmask, is_masklen, to_netmask, to_masklen, to_subnet, to_ipv6_network, VALID_MASKS
+    to_bits, is_netmask, is_masklen, to_netmask, to_masklen, to_subnet, to_ipv6_network, to_ipv6_subnet, VALID_MASKS
 )
 
 try:

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -301,7 +301,7 @@ from ansible.module_utils.aws.iam import get_aws_account_id
 from ansible.module_utils.aws.waiters import get_waiter
 from ansible.module_utils.ec2 import AWSRetry, camel_dict_to_snake_dict, compare_aws_tags
 from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_tag_list
-from ansible.module_utils.network.common.utils import to_ipv6_network, to_subnet
+from ansible.module_utils.network.common.utils import to_ipv6_subnet, to_subnet
 from ansible.module_utils._text import to_text
 from ansible.module_utils.six import string_types
 
@@ -724,7 +724,7 @@ def validate_ip(module, cidr_ip):
         try:
             ip = to_subnet(split_addr[0], split_addr[1])
         except ValueError:
-            ip = to_ipv6_network(split_addr[0]) + "/" + split_addr[1]
+            ip = to_ipv6_subnet(split_addr[0]) + "/" + split_addr[1]
         if ip != cidr_ip:
             module.warn("One of your CIDR addresses ({0}) has host bits set. To get rid of this warning, "
                         "check the network mask and make sure that only network bits are set: {1}.".format(cidr_ip, ip))

--- a/test/units/module_utils/network/common/test_utils.py
+++ b/test/units/module_utils/network/common/test_utils.py
@@ -204,3 +204,8 @@ def test_to_ipv6_network():
     assert '2001:db8::' == to_ipv6_network('2001:db8::')
     assert '2001:0db8:85a3::' == to_ipv6_network('2001:0db8:85a3:0000:0000:8a2e:0370:7334')
     assert '2001:0db8:85a3::' == to_ipv6_network('2001:0db8:85a3:0:0:8a2e:0370:7334')
+
+def test_to_ipv6_subnet():
+    assert '2001:db8::' == to_ipv6_subnet('2001:db8::')
+    assert '2001:0db8:85a3:4242::' == to_ipv6_subnet('2001:0db8:85a3:4242:0000:8a2e:0370:7334')
+    assert '2001:0db8:85a3:4242::' == to_ipv6_subnet('2001:0db8:85a3:4242:0:8a2e:0370:7334')


### PR DESCRIPTION
##### SUMMARY
Corrected `ec2_group` IPv6 handling: use subnet address in firewall rules, not just public site prefix.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`ec2_group`

##### ANSIBLE VERSION
Irrelevant to this patch:
```
ansible 2.7.1
  config file = /home/styopa/.ansible.cfg
  configured module search path = [u'/home/styopa/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15+ (default, Aug 31 2018, 11:56:52) [GCC 8.2.0]
```

##### ADDITIONAL INFORMATION
The function `to_ipv6_network` is used incorrectly in module `ec2_group`. The current implementation extracts public routable site address (48 bits) from the IPv6 address, not the subnet address (64 bits). Because of that, IPv6 subnets in EC2 firewall rules get chopped at 3 groups, e.g.:

`2001:db8:abcd:ef00::/56` (typical subnet allocated by Amazon)

becomes incorrectly chopped to:

`2001:db8:abcd::/56`

I added a similar function `to_ipv6_subnet`, and updated `ec2_group` module to call it. The old function is not used anywhere else in Ansible, but I kept it for compatibility in case any 3-rd party module relies on it (which is still incorrect behavior).
