### PR TITLE
Document the tests that are currently run on documentation pull requests.

### DIFF
--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -163,6 +163,19 @@ For example:
 
   sphinx-build -b html -c rst/ rst/dev_guide/ _build/html/dev_guide/ rst/dev_guide/developing_modules_documenting.rst
 
+Running the final tests
+^^^^^^^^^^^^^^^^^^^^^^^
+
+When you submit a documentation pull request, automated tests are run. Those same tests can be run locally. To do so, navigate to the repository's top directory and run:
+
+.. code-block:: bash
+
+  make clean &&
+  bin/ansible-test sanity --test docs-build &&
+  bin/ansible-test sanity --test rstcheck
+
+Unfortunately, leftover rST-files from previous document-generating can occasionally confuse these tests. It is therefore safest to run them on a clean copy of the repository, which is the purpose of ``make clean``. If you type these three lines one at a time and manually check the success of each, you do not need the ``&&``.
+                
 Joining the documentation working group
 =======================================
 


### PR DESCRIPTION
##### SUMMARY

I submitted the doc pull request #48416 after building it locally and checking that it built
and that the result looked ok -- or at least better than what was there before. I would have wished
I had known beforehand how the automated pull requests tests work. So the next person doesn't
have that problem, I suggest this should be documented. This pull request documents it.

##### ISSUE TYPE

Docs Pull Request

##### ADDITIONAL INFORMATION

Apparently, the present test does not always rebuild (or delete?) module rST files if it finds them in the build directory, being left over from previous experimentation, from another branch. I suppose this is not a problem in automated builds. I had a test failure with this change proposed here, deleted leftover files from some version of #48416, and then the tests came through nicely. So I decided to include a pertinent warning.