### PR TITLE
[stable-2.7] Fix pip idempotence in check mode

### DIFF
--- a/changelogs/fragments/pip-fix-idempotence-in-check-mode.yaml
+++ b/changelogs/fragments/pip-fix-idempotence-in-check-mode.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "pip - idempotence in check mode now works correctly."

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -340,10 +340,11 @@ def _is_present(module, req, installed_pkgs, pkg_command):
     for pkg in installed_pkgs:
         if '==' in pkg:
             pkg_name, pkg_version = pkg.split('==')
+            pkg_name = Package.canonicalize_name(pkg_name)
         else:
             continue
 
-        if pkg_name.lower() == req.package_name and req.is_satisfied_by(pkg_version):
+        if pkg_name == req.package_name and req.is_satisfied_by(pkg_version):
             return True
 
     return False
@@ -489,6 +490,8 @@ class Package:
     test whether a package is already satisfied.
     """
 
+    _CANONICALIZE_RE = re.compile(r'[-_.]+')
+
     def __init__(self, name_string, version_string=None):
         self._plain_package = False
         self.package_name = name_string
@@ -505,7 +508,7 @@ class Package:
                 self.package_name = "setuptools"
                 self._requirement.project_name = "setuptools"
             else:
-                self.package_name = self._requirement.project_name
+                self.package_name = Package.canonicalize_name(self._requirement.project_name)
             self._plain_package = True
         except ValueError as e:
             pass
@@ -528,6 +531,11 @@ class Package:
                 op_dict[op](version_to_test, LooseVersion(ver))
                 for op, ver in self._requirement.specs
             )
+
+    @staticmethod
+    def canonicalize_name(name):
+        # This is taken from PEP 503.
+        return Package._CANONICALIZE_RE.sub("-", name).lower()
 
     def __str__(self):
         if self._plain_package:

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -213,6 +213,27 @@
     that:
       - "not (q_check_mode is changed)"
 
+# Case with package name that has a different package name case and an
+# underscore instead of a hyphen
+- name: check for Junit-XML package
+  pip:
+    name: Junit-XML
+    virtualenv: "{{ output_dir }}/pipenv"
+    state: present
+
+- name: check for Junit-XML package in check_mode
+  pip:
+    name: Junit-XML
+    virtualenv: "{{ output_dir }}/pipenv"
+    state: present
+  check_mode: True
+  register: diff_case_check_mode
+
+- name: make sure Junit-XML in check_mode doesn't report changed
+  assert:
+    that:
+      - "diff_case_check_mode is not changed"
+
 # ansible#23204
 - name: ensure is a fresh virtualenv
   file:


### PR DESCRIPTION
Backport of #44396.

PIP package names must be case insensitive, and must consider hyphens
and underscores to be equivalent
(https://www.python.org/dev/peps/pep-0426/#name), because of this the
module didn't work correctly in check mode. For example if the passed
package name had a different case or an underscore instead of a hyphen
(or the other way around) compared to the installed package, check mode
reported as changed, even though packages were installed. Now the module
ignores case and hyphens/underscores in package names, so check mode
works correctly.
(cherry picked from commit b89b688)

Co-authored-by: Strahinja Kustudic <kustodian@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7.0-2.7.1
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
