### PR TITLE
[ec2_group] fix comparison of determining which rules to purge

### DIFF
--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -1114,6 +1114,29 @@
           - 'result.changed'
       when: result.ip_permissions_egress[0].ip_ranges[0].description is undefined
 
+    # =========================================================================================
+    - name: add rules without descriptions ready for adding descriptions to existing rules
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        <<: *aws_connection_info
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        # purge the other rules so assertions work for the subsequent tests for rule descriptions
+        purge_rules_egress: true
+        purge_rules: true
+        state: present
+        rules:
+        - proto: "tcp"
+          ports:
+          - 8281
+          cidr_ipv6: 1001:d00::/24
+        rules_egress:
+        - proto: "tcp"
+          ports:
+          - 8282
+          cidr_ip: 2.2.2.2/32
+      register: result
+
     # ============================================================
     - name: test adding a rule and egress rule descriptions (expected changed=true)
       ec2_group:
@@ -1187,6 +1210,7 @@
       # compatibility with this feature.
       assert:
         that:
+          - 'result.ip_permissions | length > 0'
           - 'result.changed'
       when: result.ip_permissions_egress[0].ip_ranges[0].description is defined
 


### PR DESCRIPTION
Fix comparison of determining which rules to purge by ignoring descriptions

AWS uses rule type, protocol, port range, and source as an idempotent identifier.
There can only be one rule with that unique combination. Rules that differ only by description are allowed but overwritten by AWS.
Add a test

Co-authored-by: Will Thames <will@thames.id.au>

##### SUMMARY
Fixes #47904

See #48023 for an alternative, but I think this is safer to backport. The second reproducer playbook in #47904 fails with that patch, but succeeds with this one.

I think it's probably better to optimize this by consolidating the logic of the loop I've added with the loop in the function for updating rules, since it is a little redundant. Another thing that could be improved is sorting the list of rules that differ only by description so AWS produces a consistent result (and maybe adding a warning for the superfluous rules?).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_group.py

##### ANSIBLE VERSION
```
ansible 2.8.0.dev0
```
