### PR TITLE
FreeIPA: Fix ipa_user password option

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -301,6 +301,7 @@ Noteworthy module changes
   <https://galaxy.ansible.com/PaloAltoNetworks/paloaltonetworks>`_.  Contributions to the role can be made
   `here <https://github.com/PaloAltoNetworks/ansible-pan>`_.
 
+* The ``ipa_user`` module originally always sent ``password`` to FreeIPA regardless of whether the password changed. Now the module only sends ``password`` if ``update_password`` is set to ``always``, which is the default.
 
 Plugins
 =======

--- a/lib/ansible/modules/identity/ipa/ipa_user.py
+++ b/lib/ansible/modules/identity/ipa/ipa_user.py
@@ -24,9 +24,10 @@ options:
   update_password:
     description:
     - Set password for a user.
+    type: str
     default: 'always'
-    version_added: 2.8
     choices: [ always, on_create ]
+    version_added: 2.8
   givenname:
     description: First name
   krbpasswordexpiration:
@@ -286,7 +287,7 @@ def ensure(module, client):
             if not module.check_mode:
                 ipa_user = client.user_add(name=name, item=module_user)
         else:
-            if update_password == "on_create":
+            if update_password == 'on_create':
                 module_user.pop('userpassword', None)
             diff = get_user_diff(client, ipa_user, module_user)
             if len(diff) > 0:


### PR DESCRIPTION
##### SUMMARY

This adds a new option `force_password` to the `ipa_user` module, defaulting to `no`. When set to `no` the `password` will not be sent to FreeIPA. When set to `yes` the `password` will be sent, and will maintain the current module behavior.

Fixes #41582

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ipa_user

##### ANSIBLE VERSION

```
ansible 2.8.0.dev0 (fix-ipa-password 9b4c41e8fb) last updated 2018/11/09 23:07:44 (GMT -400)
  config file = /media/sf_Development/configuration-management/ansible.cfg
  configured module search path = ['/home/madmin/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/madmin/Development/ansible/lib/ansible
  executable location = /home/madmin/Development/ansible/bin/ansible
  python version = 3.6.6 (default, Sep 12 2018, 18:26:19) [GCC 8.0.1 20180414 (experimental) [trunk revision 259383]]
```

##### ADDITIONAL INFORMATION
The current `ipa_user` module will overwrite a FreeIPA user's password if `password` is specified, most likely due to the FreeIPA API not exposing passwords for security reasons, preventing a comparison and always marking the run as `changed`.

This adds a new option `force_password`, defaulted to `no`. If it is set to `no`, the password will not be overwritten by removing it from the data it sends to the FreeIPA API. If nothing else changes with the other data, the module returns `ok`, and if data does change, it returns `changed`. 

If the `force_password` option is set to `yes`, it will still send the password and will FreeIPA will reset the user's password every run, and return `changed`. 

Note that this changes the current behavior. I believe that is acceptable due to the new method being most people's expected behavior, and the module being flagged as `preview` which does not guarantee a backwards compatibly interface. I did update the porting guide noting this change.
