### PR TITLE
Fixes unit tests for bigip_device_auth that were broken in 2.8

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_device_auth.py
+++ b/lib/ansible/modules/network/f5/bigip_device_auth.py
@@ -790,8 +790,9 @@ def main():
         supports_check_mode=spec.supports_check_mode,
     )
 
+    client = F5RestClient(**module.params)
+
     try:
-        client = F5RestClient(**module.params)
         mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)

--- a/test/units/modules/network/f5/test_bigip_device_auth.py
+++ b/test/units/modules/network/f5/test_bigip_device_auth.py
@@ -8,16 +8,12 @@ __metaclass__ = type
 
 import os
 import json
-import pytest
 import sys
 
 from nose.plugins.skip import SkipTest
 if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
-from units.compat import unittest
-from units.compat.mock import Mock
-from units.compat.mock import patch
 from ansible.module_utils.basic import AnsibleModule
 
 try:
@@ -26,8 +22,13 @@ try:
     from library.modules.bigip_device_auth import TacacsManager
     from library.modules.bigip_device_auth import ModuleManager
     from library.modules.bigip_device_auth import ArgumentSpec
-    from library.module_utils.network.f5.common import F5ModuleError
-    from test.unit.modules.utils import set_module_args
+
+    # In Ansible 2.8, Ansible changed import paths.
+    from test.units.compat import unittest
+    from test.units.compat.mock import Mock
+    from test.units.compat.mock import patch
+
+    from test.units.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_sys_auth import TacacsApiParameters
@@ -35,7 +36,12 @@ except ImportError:
         from ansible.modules.network.f5.bigip_sys_auth import TacacsManager
         from ansible.modules.network.f5.bigip_sys_auth import ModuleManager
         from ansible.modules.network.f5.bigip_sys_auth import ArgumentSpec
-        from ansible.module_utils.network.f5.common import F5ModuleError
+
+        # Ansible 2.8 imports
+        from units.compat import unittest
+        from units.compat.mock import Mock
+        from units.compat.mock import patch
+
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes unit tests for bigip_device_auth that were broken in 2.8

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bigip_device_auth

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.7 (default, Oct 24 2018, 22:47:56) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
