### PR TITLE
nxos: Make sure config ends with a linefeed

### DIFF
--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -145,7 +145,7 @@ class Cli:
             except ConnectionError as exc:
                 self._module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
 
-            cfg = to_text(out, errors='surrogate_then_replace').strip()
+            cfg = to_text(out, errors='surrogate_then_replace').strip() + '\n'
             self._device_configs[cmd] = cfg
             return cfg
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The config parser on NX-OS does not deal with configs that do not end with a linefeed correctly which leads to various issues when the config is loaded from startup-config upon reboot. Therefore, ensure that the config returned is terminated by a linefeed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (nxos-config f4194fb767) last updated 2018/11/10 08:11:21 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/paul/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/paul/ansible-dev/ansible/lib/ansible
  executable location = /home/paul/ansible-dev/ansible/bin/ansible
  python version = 3.7.1 (default, Oct 22 2018, 10:41:28) [GCC 8.2.1 20180831]
```

##### ADDITIONAL INFORMATION
###### Steps to reproduce
1. Save config gathered from nxos_facts
2. Upload saved config onto device's startup-config
3. reboot

The expected result would be to have the exact config as saved on the device. As the config parser in NX-OS seems to have problems with the last line not being terminated correctly, make sure the linefeed is there which achieves the desired result.
