### PR TITLE
Improve include_vars examples

### DIFF
--- a/lib/ansible/modules/utilities/logic/include_vars.py
+++ b/lib/ansible/modules/utilities/logic/include_vars.py
@@ -92,6 +92,21 @@ EXAMPLES = """
       - "{{ ansible_os_family }}.yaml"
       - default.yaml
 
+- name: Additive loading of OS specific variables
+  include_vars: "{{ vars_item }}"
+  when: vars_item | length
+  vars:
+      vars_item: "{{ lookup('first_found', vars_search) }}"
+      vars_search:
+          files: "{{ item }}"
+          paths: vars
+          skip: true
+  loop:
+      - "{{ ansible_os_family | lower }}.yml"
+      - "{{ ansible_distribution | lower }}.yml"
+      - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
+      - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version.replace('.', '-') | lower }}.yml"
+
 - name: Bare include (free-form)
   include_vars: myvars.yaml
 


### PR DESCRIPTION
Adds example about loading multiple variable files based on comment
from https://github.com/ansible/ansible/issues/38227


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
include_vars

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.8.0
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```