### PR TITLE
Updated docs for the k8s module to mention how to avoid SSL certificate validation errors

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/k8s_auth_options.py
+++ b/lib/ansible/utils/module_docs_fragments/k8s_auth_options.py
@@ -56,8 +56,8 @@ options:
       variable.
   ssl_ca_cert:
     description:
-    - Path to a CA certificate used to authenticate with the API. Can also be specified via K8S_AUTH_SSL_CA_CERT
-      environment variable.
+    - Path to a CA certificate used to authenticate with the API. The full certificate chain must be provided to
+      avoid certificate validation errors. Can also be specified via K8S_AUTH_SSL_CA_CERT environment variable.
   verify_ssl:
     description:
     - "Whether or not to verify the API server's SSL certificates. Can also be specified via K8S_AUTH_VERIFY_SSL
@@ -68,4 +68,7 @@ notes:
   - "The OpenShift Python client wraps the K8s Python client, providing full access to
     all of the APIS and models available on both platforms. For API version details and
     additional information visit https://github.com/openshift/openshift-restclient-python"
+  - "To avoid SSL certificate validation errors when C(verify_ssl) is I(True), the full
+    certificate chain for the API server must be provided via C(ssl_ca_cert) or in the
+    kubeconfig file."
 '''


### PR DESCRIPTION
##### SUMMARY

Updated documentation for the `k8s` module to mention how to avoid SSL certificate validation errors.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

k8s

##### ANSIBLE VERSION

```
ansible 2.7.1
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/bincyber/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.1 (default, Nov  5 2018, 14:07:04) [GCC 8.2.1 20181011 (Red Hat 8.2.1-4)]
```
