### PR TITLE
Remove f5-sdk from bigip_device_trust

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_device_trust.py
+++ b/lib/ansible/modules/network/f5/bigip_device_trust.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017 F5 Networks Inc.
+# Copyright: (c) 2017, F5 Networks Inc.
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
@@ -77,13 +78,14 @@ author:
 EXAMPLES = r'''
 - name: Add trusts for all peer devices to Active device
   bigip_device_trust:
-    server: lb.mydomain.com
-    user: admin
-    password: secret
     peer_server: "{{ item.ansible_host }}"
     peer_hostname: "{{ item.inventory_hostname }}"
     peer_user: "{{ item.bigip_username }}"
     peer_password: "{{ item.bigip_password }}"
+    provider:
+      server: lb.mydomain.com
+      user: admin
+      password: secret
   loop: hostvars
   when: inventory_hostname in groups['master']
   delegate_to: localhost
@@ -107,29 +109,19 @@ import re
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    from library.module_utils.network.f5.bigip import HAS_F5SDK
-    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.ipaddress import is_valid_ip
-    try:
-        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
 except ImportError:
-    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
-    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
-    try:
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -142,7 +134,12 @@ class Parameters(AnsibleF5Parameters):
     }
 
     api_attributes = [
-        'name', 'caDevice', 'device', 'deviceName', 'username', 'password'
+        'name',
+        'caDevice',
+        'device',
+        'deviceName',
+        'username',
+        'password'
     ]
 
     returnables = [
@@ -207,13 +204,10 @@ class ModuleManager(object):
         result = dict()
         state = self.want.state
 
-        try:
-            if state == "present":
-                changed = self.present()
-            elif state == "absent":
-                changed = self.absent()
-        except iControlUnexpectedHTTPError as e:
-            raise F5ModuleError(str(e))
+        if state == "present":
+            changed = self.present()
+        elif state == "absent":
+            changed = self.absent()
 
         changes = self.changes.to_return()
         result.update(**changes)
@@ -272,27 +266,72 @@ class ModuleManager(object):
         return True
 
     def exists(self):
-        result = self.client.api.tm.cm.devices.get_collection()
-        for device in result:
+        uri = "https://{0}:{1}/mgmt/tm/cm/device".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        for device in response['items']:
             try:
-                if device.managementIp == self.want.peer_server:
+                if device['managementIp'] == self.want.peer_server:
                     return True
-            except AttributeError:
+            except KeyError:
                 pass
         return False
 
     def create_on_device(self):
         params = self.want.api_params()
-        self.client.api.tm.cm.add_to_trust.exec_cmd(
-            'run',
-            name='Root',
-            **params
+        params.update({
+            "command": "run",
+            "name": 'Root',
+        })
+        uri = "https://{0}:{1}/mgmt/tm/cm/add-to-trust/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port']
         )
+        resp = self.client.api.post(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
     def remove_from_device(self):
-        self.client.api.tm.cm.remove_from_trust.exec_cmd(
-            'run', deviceName=self.want.peer_hostname, name=self.want.peer_hostname
+        params = self.want.api_params()
+        params.update({
+            "command": "run",
+            "deviceName": self.want.peer_hostname,
+            "name": self.want.peer_hostname,
+        })
+        uri = "https://{0}:{1}/mgmt/tm/cm/remove-from-trust/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port']
         )
+        resp = self.client.api.post(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
 
 class ArgumentSpec(object):
@@ -324,11 +363,10 @@ def main():
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode
     )
-    if not HAS_F5SDK:
-        module.fail_json(msg="The python f5-sdk module is required")
+
+    client = F5RestClient(**module.params)
 
     try:
-        client = F5Client(**module.params)
         mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)

--- a/test/units/modules/network/f5/test_bigip_device_trust.py
+++ b/test/units/modules/network/f5/test_bigip_device_trust.py
@@ -14,9 +14,6 @@ from nose.plugins.skip import SkipTest
 if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
-from units.compat import unittest
-from units.compat.mock import Mock
-from units.compat.mock import patch
 from ansible.module_utils.basic import AnsibleModule
 
 try:
@@ -24,26 +21,29 @@ try:
     from library.modules.bigip_device_trust import ModuleManager
     from library.modules.bigip_device_trust import ArgumentSpec
     from library.modules.bigip_device_trust import HAS_F5SDK
-    from library.modules.bigip_device_trust import HAS_NETADDR
-    from library.module_utils.network.f5.common import F5ModuleError
-    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    from test.unit.modules.utils import set_module_args
+
+    # In Ansible 2.8, Ansible changed import paths.
+    from test.units.compat import unittest
+    from test.units.compat.mock import Mock
+    from test.units.compat.mock import patch
+
+    from test.units.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_device_trust import Parameters
         from ansible.modules.network.f5.bigip_device_trust import ModuleManager
         from ansible.modules.network.f5.bigip_device_trust import ArgumentSpec
         from ansible.modules.network.f5.bigip_device_trust import HAS_F5SDK
-        from ansible.modules.network.f5.bigip_device_trust import HAS_NETADDR
-        from ansible.module_utils.network.f5.common import F5ModuleError
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+
+        # Ansible 2.8 imports
+        from units.compat import unittest
+        from units.compat.mock import Mock
+        from units.compat.mock import patch
+
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 
-    from ansible.modules.network.f5.bigip_device_trust import HAS_NETADDR
-    if not HAS_NETADDR:
-        raise SkipTest("F5 Ansible modules require the netaddr Python library")
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Remove f5-sdk from bigip_device_trust

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bigip_device_trust

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.7 (default, Oct 24 2018, 22:47:56) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
