### PR TITLE
Adds bigip_dns_nameserver module

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_dns_nameserver.py
+++ b/lib/ansible/modules/network/f5/bigip_dns_nameserver.py
@@ -1,0 +1,471 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright: (c) 2018, F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'certified'}
+
+DOCUMENTATION = r'''
+---
+module: bigip_dns_nameserver
+short_description: Manage LTM DNS nameservers on a BIG-IP
+description:
+  - Manages LTM DNS nameservers on a BIG-IP. These nameservers form part of what is
+    known as DNS Express on a BIG-IP. This module does not configure GTM related
+    functionality, nor does it configure system-level name servers that affect the
+    base system's ability to resolve DNS names.
+version_added: 2.8
+options:
+  name:
+    description:
+      - Specifies the name of the nameserver.
+    required: True
+  address:
+    description:
+      - Specifies the IP address on which the DNS nameserver (client) or back-end DNS
+        authoritative server (DNS Express server) listens for DNS messages.
+      - When creating a new nameserver, if this value is not specified, the default
+        is C(127.0.0.1).
+  service_port:
+    description:
+      - Specifies the service port on which the DNS nameserver (client) or back-end DNS
+        authoritative server (DNS Express server) listens for DNS messages.
+      - When creating a new nameserver, if this value is not specified, the default
+        is C(53).
+  route_domain:
+    description:
+      - Specifies the local route domain that the DNS nameserver (client) or back-end
+        DNS authoritative server (DNS Express server) uses for outbound traffic.
+      - When creating a new nameserver, if this value is not specified, the default
+        is C(0).
+  tsig_key:
+    description:
+      - Specifies the TSIG key the system uses to communicate with this DNS nameserver
+        (client) or back-end DNS authoritative server (DNS Express server) for AXFR zone
+        transfers.
+      - If the nameserver is a client, then the system uses this TSIG key to verify the
+        request and sign the response.
+      - If this nameserver is a DNS Express server, then this TSIG key must match the
+        TSIG key for the zone on the back-end DNS authoritative server.
+  state:
+    description:
+      - When C(present), ensures that the resource exists.
+      - When C(absent), ensures the resource is removed.
+    default: present
+    choices:
+      - present
+      - absent
+  partition:
+    description:
+      - Device partition to manage resources on.
+    default: Common
+extends_documentation_fragment: f5
+author:
+  - Tim Rupp (@caphrim007)
+'''
+
+EXAMPLES = r'''
+- name: Create a nameserver
+  bigip_dns_nameserver:
+    name: foo
+    address: 10.10.10.10
+    service_port: 53
+    state: present
+    provider:
+      password: secret
+      server: lb.mydomain.com
+      user: admin
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+address:
+  description: Address which the nameserver listens for DNS messages.
+  returned: changed
+  type: string
+  sample: 127.0.0.1
+service_port:
+  description: Service port on which the nameserver listens for DNS messages.
+  returned: changed
+  type: int
+  sample: 53
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+
+try:
+    from library.module_utils.network.f5.bigip import F5RestClient
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import cleanup_tokens
+    from library.module_utils.network.f5.common import fq_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.common import exit_json
+    from library.module_utils.network.f5.common import fail_json
+    from library.module_utils.network.f5.common import transform_name
+except ImportError:
+    from ansible.module_utils.network.f5.bigip import F5RestClient
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import cleanup_tokens
+    from ansible.module_utils.network.f5.common import fq_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.common import exit_json
+    from ansible.module_utils.network.f5.common import fail_json
+    from ansible.module_utils.network.f5.common import transform_name
+
+
+class Parameters(AnsibleF5Parameters):
+    api_map = {
+        'routeDomain': 'route_domain',
+        'port': 'service_port',
+        'tsigKey': 'tsig_key'
+    }
+
+    api_attributes = [
+        'address',
+        'routeDomain',
+        'port',
+        'tsigKey'
+    ]
+
+    returnables = [
+        'address',
+        'service_port',
+        'route_domain',
+        'tsig_key',
+    ]
+
+    updatables = [
+        'address',
+        'service_port',
+        'route_domain',
+        'tsig_key',
+    ]
+
+
+class ApiParameters(Parameters):
+    pass
+
+
+class ModuleParameters(Parameters):
+    @property
+    def tsig_key(self):
+        if self._values['tsig_key'] in [None, '']:
+            return self._values['tsig_key']
+        return fq_name(self.partition, self._values['tsig_key'])
+
+    @property
+    def route_domain(self):
+        if self._values['route_domain'] is None:
+            return None
+        return fq_name(self.partition, self._values['route_domain'])
+
+    @property
+    def service_port(self):
+        if self._values['service_port'] is None:
+            return None
+        try:
+            return int(self._values['service_port'])
+        except ValueError:
+            # Reserving the right to add well-known ports
+            raise F5ModuleError(
+                "The 'service_port' must be in numeric form."
+            )
+
+
+class Changes(Parameters):
+    def to_return(self):
+        result = {}
+        try:
+            for returnable in self.returnables:
+                result[returnable] = getattr(self, returnable)
+            result = self._filter_params(result)
+        except Exception:
+            pass
+        return result
+
+
+class UsableChanges(Changes):
+    pass
+
+
+class ReportableChanges(Changes):
+    pass
+
+
+class Difference(object):
+    def __init__(self, want, have=None):
+        self.want = want
+        self.have = have
+
+    def compare(self, param):
+        try:
+            result = getattr(self, param)
+            return result
+        except AttributeError:
+            return self.__default(param)
+
+    def __default(self, param):
+        attr1 = getattr(self.want, param)
+        try:
+            attr2 = getattr(self.have, param)
+            if attr1 != attr2:
+                return attr1
+        except AttributeError:
+            return attr1
+
+    @property
+    def tsig_key(self):
+        if self.want.tsig_key is None:
+            return None
+        if self.have.tsig_key is None and self.want.tsig_key == '':
+            return None
+        if self.want.tsig_key != self.have.tsig_key:
+            return self.want.tsig_key
+
+
+class ModuleManager(object):
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = kwargs.get('client', None)
+        self.want = ModuleParameters(params=self.module.params)
+        self.have = ApiParameters()
+        self.changes = UsableChanges()
+
+    def _set_changed_options(self):
+        changed = {}
+        for key in Parameters.returnables:
+            if getattr(self.want, key) is not None:
+                changed[key] = getattr(self.want, key)
+        if changed:
+            self.changes = UsableChanges(params=changed)
+
+    def _update_changed_options(self):
+        diff = Difference(self.want, self.have)
+        updatables = Parameters.updatables
+        changed = dict()
+        for k in updatables:
+            change = diff.compare(k)
+            if change is None:
+                continue
+            else:
+                if isinstance(change, dict):
+                    changed.update(change)
+                else:
+                    changed[k] = change
+        if changed:
+            self.changes = UsableChanges(params=changed)
+            return True
+        return False
+
+    def should_update(self):
+        result = self._update_changed_options()
+        if result:
+            return True
+        return False
+
+    def exec_module(self):
+        changed = False
+        result = dict()
+        state = self.want.state
+
+        if state == "present":
+            changed = self.present()
+        elif state == "absent":
+            changed = self.absent()
+
+        reportable = ReportableChanges(params=self.changes.to_return())
+        changes = reportable.to_return()
+        result.update(**changes)
+        result.update(dict(changed=changed))
+        self._announce_deprecations(result)
+        return result
+
+    def _announce_deprecations(self, result):
+        warnings = result.pop('__warnings', [])
+        for warning in warnings:
+            self.client.module.deprecate(
+                msg=warning['msg'],
+                version=warning['version']
+            )
+
+    def present(self):
+        if self.exists():
+            return self.update()
+        else:
+            return self.create()
+
+    def exists(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/dns/nameserver/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError:
+            return False
+        if resp.status == 404 or 'code' in response and response['code'] == 404:
+            return False
+        return True
+
+    def update(self):
+        self.have = self.read_current_from_device()
+        if not self.should_update():
+            return False
+        if self.module.check_mode:
+            return True
+        self.update_on_device()
+        return True
+
+    def remove(self):
+        if self.module.check_mode:
+            return True
+        self.remove_from_device()
+        if self.exists():
+            raise F5ModuleError("Failed to delete the resource.")
+        return True
+
+    def create(self):
+        if self.want.address is None:
+            self.want.update({'address': '127.0.0.1'})
+        if self.want.service_port is None:
+            self.want.update({'service_port': '53'})
+        if self.want.route_domain is None:
+            self.want.update({'route_domain': '/Common/0'})
+        self._set_changed_options()
+        if self.module.check_mode:
+            return True
+        self.create_on_device()
+        return True
+
+    def create_on_device(self):
+        params = self.changes.api_params()
+        params['name'] = self.want.name
+        params['partition'] = self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/ltm/dns/nameserver/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port']
+        )
+        resp = self.client.api.post(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+
+    def update_on_device(self):
+        params = self.changes.api_params()
+        uri = "https://{0}:{1}/mgmt/tm/ltm/dns/nameserver/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.patch(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+
+    def absent(self):
+        if self.exists():
+            return self.remove()
+        return False
+
+    def remove_from_device(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/dns/nameserver/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        response = self.client.api.delete(uri)
+        if response.status == 200:
+            return True
+        raise F5ModuleError(response.content)
+
+    def read_current_from_device(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/dns/nameserver/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return ApiParameters(params=response)
+
+
+class ArgumentSpec(object):
+    def __init__(self):
+        self.supports_check_mode = True
+        argument_spec = dict(
+            name=dict(required=True),
+            address=dict(),
+            service_port=dict(),
+            route_domain=dict(),
+            tsig_key=dict(),
+            state=dict(
+                default='present',
+                choices=['present', 'absent']
+            ),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
+            )
+        )
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
+
+
+def main():
+    spec = ArgumentSpec()
+
+    module = AnsibleModule(
+        argument_spec=spec.argument_spec,
+        supports_check_mode=spec.supports_check_mode,
+    )
+
+    client = F5RestClient(**module.params)
+
+    try:
+        mm = ModuleManager(module=module, client=client)
+        results = mm.exec_module()
+        cleanup_tokens(client)
+        exit_json(module, results, client)
+    except F5ModuleError as ex:
+        cleanup_tokens(client)
+        fail_json(module, ex, client)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/f5/fixtures/load_ltm_dns_nameserver_1.json
+++ b/test/units/modules/network/f5/fixtures/load_ltm_dns_nameserver_1.json
@@ -1,0 +1,18 @@
+{
+    "kind": "tm:ltm:dns:nameserver:nameserverstate",
+    "name": "foo",
+    "partition": "Common",
+    "fullPath": "/Common/foo",
+    "generation": 8076,
+    "selfLink": "https://localhost/mgmt/tm/ltm/dns/nameserver/~Common~foo?ver=13.1.0.7",
+    "address": "127.0.0.1",
+    "port": 53,
+    "routeDomain": "/Common/0",
+    "routeDomainReference": {
+        "link": "https://localhost/mgmt/tm/net/route-domain/~Common~0?ver=13.1.0.7"
+    },
+    "tsigKey": "/Common/key1",
+    "tsigKeyReference": {
+        "link": "https://localhost/mgmt/tm/ltm/dns/tsig-key/~Common~key1?ver=13.1.0.7"
+    }
+}

--- a/test/units/modules/network/f5/test_bigip_dns_nameserver.py
+++ b/test/units/modules/network/f5/test_bigip_dns_nameserver.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright: (c) 2018, F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import sys
+
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from library.modules.bigip_dns_nameserver import ApiParameters
+    from library.modules.bigip_dns_nameserver import ModuleParameters
+    from library.modules.bigip_dns_nameserver import ModuleManager
+    from library.modules.bigip_dns_nameserver import ArgumentSpec
+
+    # In Ansible 2.8, Ansible changed import paths.
+    from test.units.compat import unittest
+    from test.units.compat.mock import Mock
+    from test.units.compat.mock import patch
+
+    from test.units.modules.utils import set_module_args
+except ImportError:
+    try:
+        from ansible.modules.network.f5.bigip_dns_nameserver import ApiParameters
+        from ansible.modules.network.f5.bigip_dns_nameserver import ModuleParameters
+        from ansible.modules.network.f5.bigip_dns_nameserver import ModuleManager
+        from ansible.modules.network.f5.bigip_dns_nameserver import ArgumentSpec
+
+        # Ansible 2.8 imports
+        from units.compat import unittest
+        from units.compat.mock import Mock
+        from units.compat.mock import patch
+
+        from units.modules.utils import set_module_args
+    except ImportError:
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+
+fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+fixture_data = {}
+
+
+def load_fixture(name):
+    path = os.path.join(fixture_path, name)
+
+    if path in fixture_data:
+        return fixture_data[path]
+
+    with open(path) as f:
+        data = f.read()
+
+    try:
+        data = json.loads(data)
+    except Exception:
+        pass
+
+    fixture_data[path] = data
+    return data
+
+
+class TestParameters(unittest.TestCase):
+    def test_module_parameters(self):
+        args = dict(
+            name='foo',
+            address='10.10.10.10',
+            service_port=80,
+            route_domain=20,
+            tsig_key='key1',
+            partition='Common'
+        )
+
+        p = ModuleParameters(params=args)
+        assert p.name == 'foo'
+        assert p.address == '10.10.10.10'
+        assert p.service_port == 80
+        assert p.route_domain == '/Common/20'
+        assert p.tsig_key == '/Common/key1'
+
+    def test_api_parameters(self):
+        args = load_fixture('load_ltm_dns_nameserver_1.json')
+
+        p = ApiParameters(params=args)
+        assert p.name == 'foo'
+        assert p.address == '127.0.0.1'
+        assert p.service_port == 53
+        assert p.route_domain == '/Common/0'
+        assert p.tsig_key == '/Common/key1'
+
+
+@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
+       return_value=True)
+class TestManager(unittest.TestCase):
+
+    def setUp(self):
+        self.spec = ArgumentSpec()
+
+    def test_create_monitor(self, *args):
+        set_module_args(dict(
+            name='foo',
+            address='10.10.10.10',
+            service_port=80,
+            route_domain=20,
+            tsig_key='key1',
+            partition='Common',
+            server='localhost',
+            password='password',
+            user='admin'
+        ))
+
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode
+        )
+
+        # Override methods in the specific type of manager
+        mm = ModuleManager(module=module)
+        mm.exists = Mock(side_effect=[False, True])
+        mm.create_on_device = Mock(return_value=True)
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This module can be used to manage DNS nameservers (usually used for
DNS express) functionality on a BIG-IP.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bigip_dns_nameserver

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.7 (default, Oct 24 2018, 22:47:56) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
