### PR TITLE
Azure NIC Change Create with Default Security Group Parameter

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -441,7 +441,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             location=dict(type='str'),
             enable_accelerated_networking=dict(type='bool', default=False),
             create_with_default_security_group=dict(type='bool', default=True,
-                aliases=['create_with_security_group']),
+                                                    aliases=['create_with_security_group']),
             security_group=dict(type='raw', aliases=['security_group_name']),
             state=dict(default='present', choices=['present', 'absent']),
             private_ip_address=dict(type='str'),

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -164,12 +164,14 @@ options:
         type: bool
         version_added: 2.7
         default: False
-    create_with_security_group:
+    create_with_default_security_group:
         description:
             - Specifies whether a default security group should be be created with the NIC. Only applies when creating a new NIC.
         type: bool
         version_added: 2.6
         default: True
+        aliases:
+            - create_with_security_group
     security_group:
         description:
             - An existing security group with which to associate the network interface. If not provided, a
@@ -438,7 +440,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             name=dict(type='str', required=True),
             location=dict(type='str'),
             enable_accelerated_networking=dict(type='bool', default=False),
-            create_with_security_group=dict(type='bool', default=True),
+            create_with_default_security_group=dict(type='bool', default=True, aliases=['create_with_security_group']),
             security_group=dict(type='raw', aliases=['security_group_name']),
             state=dict(default='present', choices=['present', 'absent']),
             private_ip_address=dict(type='str'),

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -457,6 +457,8 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             dns_servers=dict(type='list'),
         )
 
+        mutually_exclusive = [('create_with_default_security_group', 'security_group')]
+
         required_if = [
             ('state', 'present', ['subnet_name', 'virtual_network'])
         ]
@@ -489,7 +491,8 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
 
         super(AzureRMNetworkInterface, self).__init__(derived_arg_spec=self.module_arg_spec,
                                                       supports_check_mode=True,
-                                                      required_if=required_if)
+                                                      required_if=required_if,
+                                                      mutually_exclusive=mutually_exclusive)
 
     def exec_module(self, **kwargs):
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -440,7 +440,8 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             name=dict(type='str', required=True),
             location=dict(type='str'),
             enable_accelerated_networking=dict(type='bool', default=False),
-            create_with_default_security_group=dict(type='bool', default=True, aliases=['create_with_security_group']),
+            create_with_default_security_group=dict(type='bool', default=True,
+                aliases=['create_with_security_group']),
             security_group=dict(type='raw', aliases=['security_group_name']),
             state=dict(default='present', choices=['present', 'absent']),
             private_ip_address=dict(type='str'),
@@ -457,7 +458,9 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             dns_servers=dict(type='list'),
         )
 
-        mutually_exclusive = [('create_with_default_security_group', 'security_group')]
+        mutually_exclusive = [
+            ('create_with_default_security_group', 'security_group')
+        ]
 
         required_if = [
             ('state', 'present', ['subnet_name', 'virtual_network'])

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -175,7 +175,7 @@ options:
     security_group:
         description:
             - An existing security group with which to associate the network interface. If not provided, a
-              default security group will be created when C(create_with_security_group) is true.
+              default security group will be created when C(create_with_default_security_group) is true.
             - It can be the name of security group.
             - Make sure the security group is in the same resource group when you only give its name.
             - It can be the resource id.
@@ -229,7 +229,7 @@ EXAMPLES = '''
         resource_group: Testing
         virtual_network: vnet001
         subnet_name: subnet001
-        create_with_security_group: False
+        create_with_default_security_group: False
         ip_configurations:
           - name: ipconfig1
             primary: True
@@ -469,7 +469,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
         self.resource_group = None
         self.name = None
         self.location = None
-        self.create_with_security_group = None
+        self.create_with_default_security_group = None
         self.enable_accelerated_networking = None
         self.security_group = None
         self.private_ip_address = None
@@ -550,7 +550,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                 if update_tags:
                     changed = True
 
-                if self.create_with_security_group != bool(results.get('network_security_group')):
+                if self.create_with_default_security_group != bool(results.get('network_security_group')):
                     self.log("CHANGED: add or remove network interface {0} network security group".format(self.name))
                     changed = True
 
@@ -646,7 +646,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                                                         self.location,
                                                         self.security_group['name'],
                                                         self.os_type,
-                                                        self.open_ports) if self.create_with_security_group else None
+                                                        self.open_ports) if self.create_with_default_security_group else None
 
                 self.log('Creating or updating network interface {0}'.format(self.name))
                 nic = self.network_models.NetworkInterface(

--- a/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
+++ b/test/integration/targets/azure_rm_networkinterface/tasks/main.yml
@@ -495,3 +495,127 @@
     name: "pip{{ rpfx }}"
     resource_group: '{{ resource_group }}'
     state: absent
+
+- name: create a network security group
+  azure_rm_securitygroup:
+    name: "nsg{{ rpfx }}"
+    resource_group: '{{ resource_group }}'
+
+- name: create a NIC with an existing NSG
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}nsg"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      security_group:
+        name: "nsg{{ rpfx }}"
+        resource_group: "{{ resource_group }}"
+  register: output
+
+- assert:
+    that:
+      - output.changed
+      - output.state.network_security_group.name == 'nsg{{ rpfx }}'
+      
+
+- name: create a NIC with an existing NSG (idempotent)
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}nsg"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+      security_group: "nsg{{ rpfx }}"
+  register: output
+
+- assert:
+    that:
+      - not output.changed
+      - output.state.network_security_group.name == 'nsg{{ rpfx }}'
+
+- name: create a NIC to add an existing NSG to
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "tn{{ rpfx }}nsgadd"
+      virtual_network: "{{ vn.state.id }}"
+      subnet: "tn{{ rpfx }}"
+  register: output
+
+- assert:
+    that:
+      - output.changed
+
+- name: add an existing NSG to an existing NIC
+  azure_rm_networkinterface:
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}nsgadd"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    security_group: "nsg{{ rpfx }}"
+  register: output
+
+- assert:
+    that:
+      - output.changed
+      - output.state.network_security_group.name == 'nsg{{ rpfx }}'
+
+- name: add an existing NSG to an existing NIC (idempotent)
+  azure_rm_networkinterface:
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}nsgadd"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+    security_group:
+      name: "nsg{{ rpfx }}"
+      resource_group: "{{ resource_group }}"
+  register: output
+
+- assert:
+    that:
+      - not output.changed
+      - output.state.network_security_group.name == 'nsg{{ rpfx }}'
+
+- name: disassociate an NSG from a NIC
+  azure_rm_networkinterface:
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}nsg"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+  register: output
+
+- assert:
+    that:
+      - output.changed
+      - not output.state.network_security_group
+
+- name: disassociate an NSG from a NIC (idempotent)
+  azure_rm_networkinterface:
+    resource_group: "{{ resource_group }}"
+    name: "tn{{ rpfx }}nsg"
+    virtual_network: "{{ vn.state.id }}"
+    subnet: "tn{{ rpfx }}"
+  register: output
+
+- assert:
+    that:
+      - not output.changed
+      - not output.state.network_security_group
+
+- name: Delete the NICs
+  azure_rm_networkinterface:
+      resource_group: "{{ resource_group }}"
+      name: "{{ item }}"
+      state: absent
+  with_items:
+    - "tn{{ rpfx }}nsgadd"
+    - "tn{{ rpfx }}nsg"
+  register: output
+
+- assert:
+    that:
+      - output.changed
+
+- name: Delete the NSG
+  azure_rm_securitygroup:
+    name: "nsg{{ rpfx }}"
+    resource_group: '{{ resource_group }}'
+    state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Update the `create_with_security_group` variable to be `create_with_default_security_group` for clarity
- Sets `create_with_default_security_group` and `security_group` to be mutually exclusive
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_network_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
$ ansible --version
ansible 2.8.0.dev0 (feature/mutually-exclusive-security-group-azure-nic 074e25c8e3) last updated 2018/11/10 20:39:21 (GMT +000)
  config file = None
  configured module search path = [u'/home/marc/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/marc/github/marc-sensenich/ansible/lib/ansible
  executable location = /home/marc/.pyenv/versions/ansible-development/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
