### PR TITLE
support project parameter in os_nova_flavor

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
@@ -67,6 +67,7 @@ options:
    project:
      description:
         - Project name or ID containing the flavor (name admin-only)
+     version_added: "2.8"
    availability_zone:
      description:
        - Ignored. Present for backwards compatibility

--- a/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
@@ -241,31 +241,21 @@ def main():
                 flavor = None
 
             if not flavor:
+                kwargs = {
+                    'name': name,
+                    'ram': module.params['ram'],
+                    'vcpus': module.params['vcpus'],
+                    'disk': module.params['disk'],
+                    'flavorid': module.params['flavorid'],
+                    'ephemeral': module.params['ephemeral'],
+                    'swap': module.params['swap'],
+                    'rxtx_factor': module.params['rxtx_factor'],
+                    'is_public': module.params['is_public']
+                }
                 if project_id is not None:
-                    flavor = cloud.create_flavor(
-                        name=name,
-                        ram=module.params['ram'],
-                        vcpus=module.params['vcpus'],
-                        disk=module.params['disk'],
-                        flavorid=module.params['flavorid'],
-                        ephemeral=module.params['ephemeral'],
-                        swap=module.params['swap'],
-                        rxtx_factor=module.params['rxtx_factor'],
-                        is_public=module.params['is_public'],
-                        project=module.params['project']
-                    )
-                else:
-                  flavor = cloud.create_flavor(
-                      name=name,
-                      ram=module.params['ram'],
-                      vcpus=module.params['vcpus'],
-                      disk=module.params['disk'],
-                      flavorid=module.params['flavorid'],
-                      ephemeral=module.params['ephemeral'],
-                      swap=module.params['swap'],
-                      rxtx_factor=module.params['rxtx_factor'],
-                      is_public=module.params['is_public']
-                  )
+                    kwargs['project'] = module.params['project']
+
+                flavor = cloud.create_flavor(**kwargs)
                 changed = True
             else:
                 changed = False


### PR DESCRIPTION
##### SUMMARY

Adds support for `project` parameter when creating openstack flavors. This enables cloud admins to create flavors within a customer project.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- cloud / openstack / os_nova_flavor

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7.1
```

##### ADDITIONAL INFORMATION

```paste below
ansible -m os_nova_flavor -a 'name=my_flavor vcpus=1 ram=512 disk=10 project=my_proj'
```
