### PR TITLE
Docker volume fix labels

### DIFF
--- a/changelogs/fragments/48536-docker_volume-labels.yml
+++ b/changelogs/fragments/48536-docker_volume-labels.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_volume - ``labels`` now work (and are a ``dict`` and no longer a ``list``)."

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -25,6 +25,7 @@ options:
     description:
       - Name of the volume to operate on.
     required: true
+    type: dict
     aliases:
       - volume_name
 
@@ -32,15 +33,18 @@ options:
     description:
       - Specify the type of volume. Docker provides the C(local) driver, but 3rd party drivers can also be used.
     default: local
+    type: str
 
   driver_options:
     description:
       - "Dictionary of volume settings. Consult docker docs for valid options and values:
         U(https://docs.docker.com/engine/reference/commandline/volume_create/#driver-specific-options)"
+    type: dict
 
   labels:
     description:
-      - List of labels to set for the volume
+      - Dictionary of label key/values to set for the volume
+    type: dict
 
   force:
     description:
@@ -185,8 +189,7 @@ class DockerVolumeManager(object):
                         differences.append('driver_options.%s' % key)
         if self.parameters.labels:
             existing_labels = self.existing_volume.get('Labels', {})
-            all_labels = set(self.parameters.labels) | set(existing_labels)
-            for label in all_labels:
+            for label in self.parameters.labels:
                 if existing_labels.get(label) != self.parameters.labels.get(label):
                     differences.append('labels.%s' % label)
 
@@ -247,7 +250,7 @@ def main():
         state=dict(type='str', default='present', choices=['present', 'absent']),
         driver=dict(type='str', default='local'),
         driver_options=dict(type='dict', default={}),
-        labels=dict(type='list'),
+        labels=dict(type='dict'),
         force=dict(type='bool', default=False),
         debug=dict(type='bool', default=False)
     )

--- a/test/integration/targets/docker_volume/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_volume/tasks/tests/basic.yml
@@ -99,31 +99,31 @@
   docker_volume:
     name: "{{ vname }}"
     labels:
-    - label1
-    - label2
+      ansible.test.1: hello
+      ansible.test.2: world
   register: driver_labels_1
 
 - name: Create a volume with labels (idempotency)
   docker_volume:
     name: "{{ vname }}"
     labels:
-    - label2
-    - label1
+      ansible.test.2: world
+      ansible.test.1: hello
   register: driver_labels_2
 
 - name: Create a volume with labels (less)
   docker_volume:
     name: "{{ vname }}"
     labels:
-    - label2
+      ansible.test.1: hello
   register: driver_labels_3
 
 - name: Create a volume with labels (more)
   docker_volume:
     name: "{{ vname }}"
     labels:
-    - label2
-    - label3
+      ansible.test.1: hello
+      ansible.test.3: ansible
   register: driver_labels_4
 
 - name: Cleanup

--- a/test/integration/targets/docker_volume/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_volume/tasks/tests/basic.yml
@@ -90,3 +90,50 @@
     - driver_options_1 is changed
     - driver_options_2 is not changed
     - driver_options_3 is changed
+
+####################################################################
+## labels ##########################################################
+####################################################################
+
+- name: Create a volume with labels
+  docker_volume:
+    name: "{{ vname }}"
+    labels:
+    - label1
+    - label2
+  register: driver_labels_1
+
+- name: Create a volume with labels (idempotency)
+  docker_volume:
+    name: "{{ vname }}"
+    labels:
+    - label2
+    - label1
+  register: driver_labels_2
+
+- name: Create a volume with labels (less)
+  docker_volume:
+    name: "{{ vname }}"
+    labels:
+    - label2
+  register: driver_labels_3
+
+- name: Create a volume with labels (more)
+  docker_volume:
+    name: "{{ vname }}"
+    labels:
+    - label2
+    - label3
+  register: driver_labels_4
+
+- name: Cleanup
+  docker_volume:
+    name: "{{ vname }}"
+    state: absent
+
+- assert:
+    that:
+    - driver_labels_1 is changed
+    - driver_labels_2 is not changed
+    - driver_labels_3 is not changed
+    - driver_labels_4 is changed


### PR DESCRIPTION
##### SUMMARY
Labels for docker_volume are currently declared as a `list` (and not as a `dict`). Using them makes the module fail (#36635). This PR fixes this problem as in #36638, a PR which hasn't been updated since February, and also updates the documentation and adds an integration test.

Fixes #36635; replaces #36638.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docker_volume

##### ANSIBLE VERSION
```
2.7.1
```
