### PR TITLE
Update postgresql_ext connection methods

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -38,6 +38,26 @@ options:
     description:
       - Host running the database
     default: localhost
+  login_unix_socket:
+    description:
+      - Path to a Unix domain socket for local connections.
+    version_added: '2.8'
+  ssl_mode:
+    description:
+      - Determines whether or with what priority a secure SSL TCP/IP connection
+        will be negotiated with the server.
+      - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
+        more information on the modes.
+      - Default of C(prefer) matches libpq default.
+    default: prefer
+    choices: ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
+    version_added: '2.8'
+  ssl_rootcert:
+    description:
+      - Specifies the name of a file containing SSL certificate authority (CA)
+        certificate(s). If the file exists, the server's certificate will be
+        verified to be signed by one of these authorities.
+    version_added: '2.8'
   port:
     description:
       - Database port to connect to.
@@ -54,7 +74,9 @@ notes:
      on the remote host. For Ubuntu-based systems, install the C(postgresql), C(libpq-dev), and C(python-psycopg2) packages on the remote host before using
      this module.
 requirements: [ psycopg2 ]
-author: "Daniel Schep (@dschep)"
+author:
+    - "Daniel Schep (@dschep)"
+    - "Thomas O'Donnell (@andytom)"
 '''
 
 EXAMPLES = '''
@@ -74,6 +96,7 @@ else:
     postgresqldb_found = True
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
 
 
@@ -119,10 +142,14 @@ def main():
             login_user=dict(default="postgres"),
             login_password=dict(default="", no_log=True),
             login_host=dict(default=""),
+            login_unix_socket=dict(default=""),
             port=dict(default="5432"),
             db=dict(required=True),
             ext=dict(required=True, aliases=['name']),
             state=dict(default="present", choices=["absent", "present"]),
+            ssl_mode=dict(default='prefer', choices=[
+                          'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
+            ssl_rootcert=dict(default=None),
         ),
         supports_check_mode=True
     )
@@ -133,6 +160,7 @@ def main():
     db = module.params["db"]
     ext = module.params["ext"]
     state = module.params["state"]
+    sslrootcert = module.params["ssl_rootcert"]
     changed = False
 
     # To use defaults values, keyword arguments must be absent, so
@@ -142,12 +170,24 @@ def main():
         "login_host": "host",
         "login_user": "user",
         "login_password": "password",
-        "port": "port"
+        "port": "port",
+        "db": "database",
+        "ssl_mode": "sslmode",
+        "ssl_rootcert": "sslrootcert"
     }
-    kw = dict((params_map[k], v) for (k, v) in module.params.items()
-              if k in params_map and v != '')
+    kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
+              if k in params_map and v != "" and v is not None)
+
+    # If a login_unix_socket is specified, incorporate it here.
+    is_localhost = "host" not in kw or kw["host"] == "" or kw["host"] == "localhost"
+    if is_localhost and module.params["login_unix_socket"] != "":
+        kw["host"] = module.params["login_unix_socket"]
+
+    if psycopg2.__version__ < '2.4.3' and sslrootcert is not None:
+        module.fail_json(msg='psycopg2 must be at least 2.4.3 in order to user the ssl_rootcert parameter')
+
     try:
-        db_connection = psycopg2.connect(database=db, **kw)
+        db_connection = psycopg2.connect(**kw)
         # Enable autocommit so we can create databases
         if psycopg2.__version__ >= '2.4.2':
             db_connection.autocommit = True
@@ -157,6 +197,13 @@ def main():
                                               .ISOLATION_LEVEL_AUTOCOMMIT)
         cursor = db_connection.cursor(
             cursor_factory=psycopg2.extras.DictCursor)
+
+    except TypeError as e:
+        if 'sslrootcert' in e.args[0]:
+            module.fail_json(
+                msg='Postgresql server must be at least version 8.4 to support sslrootcert')
+        module.fail_json(msg="unable to connect to database: %s" % to_native(e), exception=traceback.format_exc())
+
     except Exception as e:
         module.fail_json(msg="unable to connect to database: %s" % to_native(e), exception=traceback.format_exc())
 


### PR DESCRIPTION
##### SUMMARY

Have added some extra arguments to the postgresql_ext module to allow
configuring an SSL connection to the postgresql server and explicit
support for connecting via a unix socket. The arguments and method used
here for the connection are the same as used by the postgresql_database
module.

Related to: #39906 and #42988
Fixes  #42988

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
postgresql_ext

##### ANSIBLE VERSION
```paste below
2.6.0
```

##### ADDITIONAL INFORMATION

You can now use the same ssl configuration and unix socket arguments as the postgresql_database module for the postgresql_ext module. For example:

```yaml
# Connect via SSL
- name: Ensure acme db has the postgis extension installed
  postgresql_ext:
    login_host: psql.example.com
    login_user: example_user
    login_password: super-secret-password
    ssl_rootcert: /path/to/ssl/cert
    ssl_mode: verify-full

    name: postgis
    db: acme
```
and
```yaml
# Connect via unix socket
- name: Ensure acme db has the postgis extension installed
  postgresql_ext:
    login_unix_socket: '/var/run/postgres'
 
    name: postgis
    db: acme
```