### PR TITLE
Removes the f5-sdk from bigip_routedomain

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_routedomain.py
+++ b/lib/ansible/modules/network/f5/bigip_routedomain.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2016 F5 Networks Inc.
+# Copyright: (c) 2016, F5 Networks Inc.
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -87,9 +87,14 @@ options:
   vlans:
     description:
       - VLANs for the system to use in the route domain.
+  fw_enforced_policy:
+    description:
+      - Specifies AFM policy to be attached to route domain.
+    version_added: 2.8
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
+  - Wojciech Wypior (@wojtek0806)
 '''
 
 EXAMPLES = r'''
@@ -167,35 +172,38 @@ service_policy:
   returned: changed
   type: string
   sample: /Common-my-service-policy
+fw_enforced_policy:
+  description: Specfies AFM policy to be attached to route domain.
+  returned: changed
+  type: string
+  sample: /Common/afm-blocking-policy
 '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
 
 try:
-    from library.module_utils.network.f5.bigip import HAS_F5SDK
-    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
     from library.module_utils.network.f5.common import fq_name
+    from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    try:
-        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
+    from library.module_utils.network.f5.common import exit_json
+    from library.module_utils.network.f5.common import fail_json
+    from library.module_utils.network.f5.compare import cmp_simple_list
 except ImportError:
-    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
-    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
     from ansible.module_utils.network.f5.common import fq_name
+    from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    try:
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
+    from ansible.module_utils.network.f5.common import exit_json
+    from ansible.module_utils.network.f5.common import fail_json
+    from ansible.module_utils.network.f5.compare import cmp_simple_list
 
 
 class Parameters(AnsibleF5Parameters):
@@ -204,7 +212,9 @@ class Parameters(AnsibleF5Parameters):
         'servicePolicy': 'service_policy',
         'bwcPolicy': 'bwc_policy',
         'flowEvictionPolicy': 'flow_eviction_policy',
-        'routingProtocol': 'routing_protocol'
+        'routingProtocol': 'routing_protocol',
+        'fwEnforcedPolicy': 'fw_enforced_policy',
+        'fwEnforcedPolicyReference': 'fw_policy_link',
     }
 
     api_attributes = [
@@ -217,7 +227,9 @@ class Parameters(AnsibleF5Parameters):
         'flowEvictionPolicy',
         'routingProtocol',
         'vlans',
-        'id'
+        'id',
+        'fwEnforcedPolicy',
+        'fwEnforcedPolicyReference',
     ]
 
     returnables = [
@@ -230,7 +242,7 @@ class Parameters(AnsibleF5Parameters):
         'routing_protocol',
         'vlans',
         'connection_limit',
-        'id'
+        'id',
     ]
 
     updatables = [
@@ -243,7 +255,9 @@ class Parameters(AnsibleF5Parameters):
         'routing_protocol',
         'vlans',
         'connection_limit',
-        'id'
+        'id',
+        'fw_enforced_policy',
+        'fw_policy_link',
     ]
 
     @property
@@ -271,12 +285,26 @@ class ApiParameters(Parameters):
     @property
     def domains(self):
         domains = self.read_domains_from_device()
-        result = [x.fullPath for x in domains]
+        result = [x['fullPath'] for x in domains['items']]
         return result
 
     def read_domains_from_device(self):
-        collection = self.client.api.tm.net.route_domains.get_collection()
-        return collection
+        uri = "https://{0}:{1}/mgmt/tm/net/route-domain/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return response
 
 
 class ModuleParameters(Parameters):
@@ -326,6 +354,24 @@ class ModuleParameters(Parameters):
         if len(self._values['routing_protocol']) == 1 and self._values['routing_protocol'][0] in ['', 'none']:
             return ''
         return self._values['routing_protocol']
+
+    @property
+    def fw_enforced_policy(self):
+        if self._values['fw_enforced_policy'] is None:
+            return None
+        if self._values['fw_enforced_policy'] in ['none', '']:
+            return None
+        name = self._values['fw_enforced_policy']
+        return fq_name(self.partition, name)
+
+    @property
+    def fw_policy_link(self):
+        policy = self.fw_enforced_policy
+        if policy is None:
+            return None
+        tmp = policy.split('/')
+        link = dict(link='https://localhost/mgmt/tm/security/firewall/policy/~{0}~{1}'.format(tmp[1], tmp[2]))
+        return link
 
 
 class Changes(Parameters):
@@ -383,33 +429,20 @@ class Difference(object):
 
     @property
     def routing_protocol(self):
-        if self.want.routing_protocol is None:
-            return None
-        if self.want.routing_protocol == '' and self.have.routing_protocol is None:
-            return None
-        if self.want.routing_protocol == '' and len(self.have.routing_protocol) > 0:
-            return []
-        if self.have.routing_protocol is None:
-            return self.want.routing_protocol
-        want = set(self.want.routing_protocol)
-        have = set(self.have.routing_protocol)
-        if want != have:
-            return list(want)
+        return cmp_simple_list(self.want.routing_protocol, self.have.routing_protocol)
 
     @property
     def vlans(self):
-        if self.want.vlans is None:
+        return cmp_simple_list(self.want.vlans, self.have.vlans)
+
+    @property
+    def fw_policy_link(self):
+        if self.want.fw_enforced_policy is None:
             return None
-        if self.want.vlans == '' and self.have.vlans is None:
+        if self.want.fw_enforced_policy == self.have.fw_enforced_policy:
             return None
-        if self.want.vlans == '' and len(self.have.vlans) > 0:
-            return []
-        if self.have.vlans is None:
-            return self.want.vlans
-        want = set(self.want.vlans)
-        have = set(self.have.vlans)
-        if want != have:
-            return list(want)
+        if self.want.fw_policy_link != self.have.fw_policy_link:
+            return self.want.fw_policy_link
 
 
 class ModuleManager(object):
@@ -457,13 +490,10 @@ class ModuleManager(object):
         result = dict()
         state = self.want.state
 
-        try:
-            if state == "present":
-                changed = self.present()
-            elif state == "absent":
-                changed = self.absent()
-        except iControlUnexpectedHTTPError as e:
-            raise F5ModuleError(str(e))
+        if state == "present":
+            changed = self.present()
+        elif state == "absent":
+            changed = self.absent()
 
         reportable = ReportableChanges(params=self.changes.to_return())
         changes = reportable.to_return()
@@ -486,12 +516,10 @@ class ModuleManager(object):
         else:
             return self.create()
 
-    def exists(self):
-        result = self.client.api.tm.net.route_domains.route_domain.exists(
-            name=self.want.name,
-            partition=self.want.partition
-        )
-        return result
+    def absent(self):
+        if self.exists():
+            return self.remove()
+        return False
 
     def update(self):
         self.have = self.read_current_from_device()
@@ -529,42 +557,112 @@ class ModuleManager(object):
         self.create_on_device()
         return True
 
+    def exists(self):
+        uri = "https://{0}:{1}/mgmt/tm/net/route-domain/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name),
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError:
+            return False
+        if resp.status == 404 or 'code' in response and response['code'] == 404:
+            return False
+        return True
+
     def create_on_device(self):
         params = self.changes.api_params()
-        self.client.api.tm.net.route_domains.route_domain.create(
-            name=self.want.name,
-            partition=self.want.partition,
-            **params
+        params['name'] = self.want.name
+        params['partition'] = self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/net/route-domain/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
         )
+        resp = self.client.api.post(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        if self.want.fw_enforced_policy:
+            payload = dict(
+                fwEnforcedPolicy=self.want.fw_enforced_policy,
+                fwEnforcedPolicyReference=self.want.fw_policy_link
+            )
+            uri = "https://{0}:{1}/mgmt/tm/net/route-domain/{2}".format(
+                self.client.provider['server'],
+                self.client.provider['server_port'],
+                transform_name(self.want.partition, self.want.name),
+            )
+            resp = self.client.api.patch(uri, json=payload)
+
+            try:
+                response = resp.json()
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
+
+            if 'code' in response and response['code'] in [400, 403]:
+                if 'message' in response:
+                    raise F5ModuleError(response['message'])
+                else:
+                    raise F5ModuleError(resp.content)
+        return True
 
     def update_on_device(self):
         params = self.changes.api_params()
-        resource = self.client.api.tm.net.route_domains.route_domain.load(
-            name=self.want.name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/net/route-domain/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name),
         )
-        resource.modify(**params)
+        resp = self.client.api.patch(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
 
-    def absent(self):
-        if self.exists():
-            return self.remove()
-        return False
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
     def remove_from_device(self):
-        resource = self.client.api.tm.net.route_domains.route_domain.load(
-            name=self.want.name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/net/route-domain/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name),
         )
-        if resource:
-            resource.delete()
+        response = self.client.api.delete(uri)
+        if response.status == 200:
+            return True
+        raise F5ModuleError(response.content)
 
     def read_current_from_device(self):
-        resource = self.client.api.tm.net.route_domains.route_domain.load(
-            name=self.want.name,
-            partition=self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/net/route-domain/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name),
         )
-        result = resource.attrs
-        return ApiParameters(params=result, client=self.client)
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return ApiParameters(params=response, client=self.client)
 
 
 class ArgumentSpec(object):
@@ -585,6 +683,7 @@ class ArgumentSpec(object):
             connection_limit=dict(type='int'),
             flow_eviction_policy=dict(),
             service_policy=dict(),
+            fw_enforced_policy=dict(),
             partition=dict(
                 default='Common',
                 fallback=(env_fallback, ['F5_PARTITION'])
@@ -609,18 +708,17 @@ def main():
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode
     )
-    if not HAS_F5SDK:
-        module.fail_json(msg="The python f5-sdk module is required")
+
+    client = F5RestClient(**module.params)
 
     try:
-        client = F5Client(**module.params)
         mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        module.exit_json(**results)
+        exit_json(module, results, client)
     except F5ModuleError as ex:
         cleanup_tokens(client)
-        module.fail_json(msg=str(ex))
+        fail_json(module, ex, client)
 
 
 if __name__ == '__main__':

--- a/test/units/modules/network/f5/test_bigip_routedomain.py
+++ b/test/units/modules/network/f5/test_bigip_routedomain.py
@@ -8,16 +8,12 @@ __metaclass__ = type
 
 import os
 import json
-import pytest
 import sys
 
 from nose.plugins.skip import SkipTest
 if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
-from units.compat import unittest
-from units.compat.mock import Mock
-from units.compat.mock import patch
 from ansible.module_utils.basic import AnsibleModule
 
 try:
@@ -25,17 +21,25 @@ try:
     from library.modules.bigip_routedomain import ModuleParameters
     from library.modules.bigip_routedomain import ModuleManager
     from library.modules.bigip_routedomain import ArgumentSpec
-    from library.module_utils.network.f5.common import F5ModuleError
-    from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    from test.unit.modules.utils import set_module_args
+
+    # In Ansible 2.8, Ansible changed import paths.
+    from test.units.compat import unittest
+    from test.units.compat.mock import Mock
+    from test.units.compat.mock import patch
+
+    from test.units.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_routedomain import ApiParameters
         from ansible.modules.network.f5.bigip_routedomain import ModuleParameters
         from ansible.modules.network.f5.bigip_routedomain import ModuleManager
         from ansible.modules.network.f5.bigip_routedomain import ArgumentSpec
-        from ansible.module_utils.network.f5.common import F5ModuleError
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
+
+        # Ansible 2.8 imports
+        from units.compat import unittest
+        from units.compat.mock import Mock
+        from units.compat.mock import patch
+
         from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Removes the f5-sdk from bigip_routedomain

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bigip_routedomain

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.7 (default, Oct 24 2018, 22:47:56) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
