### PR TITLE
Clarify what recursive setting of attributes means

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -60,7 +60,7 @@ options:
       the Unix command C(ln -s SRC DEST) treats relative paths.
   recurse:
     description:
-    - Recursively set the specified file attributes.
+    - Recursively set the specified file attributes on directory contents.
     - This applies only to C(state=directory).
     type: bool
     default: no


### PR DESCRIPTION
##### SUMMARY

The existing language was ambiguous as to whether the recursive setting was on the parents or the children.

In my case, this led to smashing the file attributes on a large directory of user data, requiring a restore from backup. I had understood it to be more like `mkdir -p`, recursively creating and setting mode on parent dirs as necessary; it turns out it's more like `chmod -R`, setting mode on children.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
file