### PR TITLE
Workaround for problems parsing the timezone

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_device_facts.py
+++ b/lib/ansible/modules/network/f5/bigip_device_facts.py
@@ -11302,7 +11302,15 @@ class SoftwareImagesParameters(BaseParameters):
         """
         if self._values['build_date'] is None:
             return None
-        result = datetime.datetime.strptime(self._values['build_date'], '%a %b %d %H %M %S PDT %Y').isoformat()
+
+        d = self._values['build_date'].split(' ')
+
+        # This removes the timezone portion from the string. This is done
+        # because Python has awfule tz parsing and strptime doesnt work with
+        # all timezones in %Z; it only uses the timezones found in time.tzname
+        d.pop(6)
+
+        result = datetime.datetime.strptime(' '.join(d), '%a %b %d %H %M %S %Y').isoformat()
         return result
 
     @property


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Device facts gets a time with a timezone back from the builddate.
Unfortunately, python cannot correctly parse timezones by default.
This hacks around the problem.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bigip_device_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.7 (default, Oct 24 2018, 22:47:56) [GCC 6.3.0 20170516]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
