### PR TITLE
docker_container: fix tests and idempotency for init and shm_size

### DIFF
--- a/changelogs/fragments/48551-docker_container-idempotency.yml
+++ b/changelogs/fragments/48551-docker_container-idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - ``init`` and ``shm_size`` are now checked for idempotency."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1720,8 +1720,7 @@ class Container(DockerBaseClass):
             read_only=host_config.get('ReadonlyRootfs'),
             restart_policy=restart_policy.get('Name'),
             runtime=host_config.get('Runtime'),
-            # Cannot test shm_size, as shm_size is not included in container inspection results.
-            # shm_size=host_config.get('ShmSize'),
+            shm_size=host_config.get('ShmSize'),
             security_opts=host_config.get("SecurityOpt"),
             stop_signal=config.get("StopSignal"),
             tmpfs=host_config.get('Tmpfs'),

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1692,6 +1692,7 @@ class Container(DockerBaseClass):
             hostname=config.get('Hostname'),
             user=config.get('User'),
             detach=detach,
+            init=host_config.get('Init'),
             interactive=config.get('OpenStdin'),
             capabilities=host_config.get('CapAdd'),
             cap_drop=host_config.get('CapDrop'),

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -216,7 +216,7 @@
 - name: cpu_period
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_period: 90000
     state: started
@@ -225,7 +225,7 @@
 - name: cpu_period (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_period: 90000
     state: started
@@ -260,7 +260,7 @@
 - name: cpu_quota
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_quota: 150000
     state: started
@@ -269,7 +269,7 @@
 - name: cpu_quota (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_quota: 150000
     state: started
@@ -304,7 +304,7 @@
 - name: cpu_shares
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_shares: 900
     state: started
@@ -313,7 +313,7 @@
 - name: cpu_shares (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_shares: 900
     state: started
@@ -348,7 +348,7 @@
 - name: cpuset_cpus
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_cpus: 0
     state: started
@@ -357,7 +357,7 @@
 - name: cpuset_cpus (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_cpus: 0
     state: started
@@ -395,7 +395,7 @@
 - name: cpuset_mems
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_mems: 0
     state: started
@@ -404,7 +404,7 @@
 - name: cpuset_mems (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_mems: 0
     state: started
@@ -1031,7 +1031,7 @@
 - name: domainname
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     domainname: example.com
     state: started
@@ -1040,7 +1040,7 @@
 - name: domainname (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     domainname: example.com
     state: started
@@ -1577,7 +1577,7 @@
 - name: hostname
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     hostname: me.example.com
     state: started
@@ -1586,7 +1586,7 @@
 - name: hostname (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     hostname: me.example.com
     state: started
@@ -1621,7 +1621,7 @@
 - name: init
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     init: yes
     state: started
@@ -1631,7 +1631,7 @@
 - name: init (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     init: yes
     state: started
@@ -1674,7 +1674,7 @@
 - name: interactive
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     interactive: yes
     state: started
@@ -1683,7 +1683,7 @@
 - name: interactive (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     interactive: yes
     state: started
@@ -1773,7 +1773,7 @@
 - name: start helpers
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ container_name }}"
     state: started
   loop:
@@ -1835,7 +1835,7 @@
 - name: kernel_memory
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     kernel_memory: 8M
     state: started
@@ -1844,7 +1844,7 @@
 - name: kernel_memory (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     kernel_memory: 8M
     state: started
@@ -1946,7 +1946,7 @@
 - name: start helpers
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ container_name }}"
     state: started
   loop:
@@ -2136,7 +2136,7 @@
 - name: mac_address
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     mac_address: 92:d0:c6:0a:29:33
     state: started
@@ -2145,7 +2145,7 @@
 - name: mac_address (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     mac_address: 92:d0:c6:0a:29:33
     state: started
@@ -2180,7 +2180,7 @@
 - name: memory
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory: 64M
     state: started
@@ -2189,7 +2189,7 @@
 - name: memory (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory: 64M
     state: started
@@ -2224,7 +2224,7 @@
 - name: memory_reservation
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_reservation: 64M
     state: started
@@ -2233,7 +2233,7 @@
 - name: memory_reservation (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_reservation: 64M
     state: started
@@ -2268,7 +2268,7 @@
 - name: memory_swap
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     # Docker daemon does not accept memory_swap if memory is not specified
     memory: 32M
@@ -2280,7 +2280,7 @@
 - name: memory_swap (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     # Docker daemon does not accept memory_swap if memory is not specified
     memory: 32M
@@ -2330,7 +2330,7 @@
 - name: memory_swappiness
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_swappiness: 40
     state: started
@@ -2339,7 +2339,7 @@
 - name: memory_swappiness (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_swappiness: 40
     state: started
@@ -2497,7 +2497,7 @@
 - name: oom_killer
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_killer: yes
     state: started
@@ -2507,7 +2507,7 @@
 - name: oom_killer (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_killer: yes
     state: started
@@ -2550,7 +2550,7 @@
 - name: oom_score_adj
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_score_adj: 5
     state: started
@@ -2560,7 +2560,7 @@
 - name: oom_score_adj (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_score_adj: 5
     state: started
@@ -2633,7 +2633,7 @@
 - name: paused (continue)
   docker_container:
     image: alpine:3.8
-    command: "/bin/sh -c 'sleep 1s ; yes'"
+    command: "/bin/sh -c 'sleep 10m'"
     name: "{{ cname }}"
     state: started
     paused: no
@@ -2665,7 +2665,7 @@
 - name: start helpers
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname_h1 }}"
     state: started
   register: pid_mode_helper
@@ -2733,7 +2733,7 @@
 - name: privileged
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     privileged: yes
     state: started
@@ -2742,7 +2742,7 @@
 - name: privileged (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     privileged: yes
     state: started
@@ -2844,7 +2844,7 @@
 - name: read_only
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     read_only: yes
     state: started
@@ -2853,7 +2853,7 @@
 - name: read_only (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     read_only: yes
     state: started
@@ -2888,7 +2888,7 @@
 - name: recreate (created)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
     stop_timeout: 1
@@ -2897,7 +2897,7 @@
 - name: recreate (created, recreate)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     recreate: yes
     state: present
@@ -2907,7 +2907,7 @@
 - name: recreate (started)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
     stop_timeout: 1
@@ -2916,7 +2916,7 @@
 - name: recreate (started, recreate)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     recreate: yes
     state: started
@@ -2951,7 +2951,7 @@
 - name: restart
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
     stop_timeout: 1
@@ -2960,7 +2960,7 @@
 - name: restart (restart)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart: yes
     state: started
@@ -2989,7 +2989,7 @@
 - name: restart_policy
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: always
     state: started
@@ -2998,7 +2998,7 @@
 - name: restart_policy (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: always
     state: started
@@ -3033,7 +3033,7 @@
 - name: restart_retries
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: on-failure
     restart_retries: 5
@@ -3043,7 +3043,7 @@
 - name: restart_retries (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: on-failure
     restart_retries: 5
@@ -3080,7 +3080,7 @@
 - name: runtime
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     runtime: runc
     state: started
@@ -3090,7 +3090,7 @@
 - name: runtime (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     runtime: runc
     state: started
@@ -3198,7 +3198,7 @@
 - name: shm_size
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     shm_size: 96M
     state: started
@@ -3207,7 +3207,7 @@
 - name: shm_size (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     shm_size: 96M
     state: started
@@ -3242,7 +3242,7 @@
 - name: stop_signal
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_signal: 30
     state: started
@@ -3251,7 +3251,7 @@
 - name: stop_signal (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_signal: 30
     state: started
@@ -3478,7 +3478,7 @@
 - name: tty
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     tty: yes
     state: started
@@ -3487,7 +3487,7 @@
 - name: tty (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     tty: yes
     state: started
@@ -3583,7 +3583,7 @@
 - name: user
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     user: nobody
     state: started
@@ -3592,7 +3592,7 @@
 - name: user (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     user: nobody
     state: started
@@ -3627,7 +3627,7 @@
 - name: userns_mode
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     userns_mode: host
     state: started
@@ -3637,7 +3637,7 @@
 - name: userns_mode (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     userns_mode: host
     state: started
@@ -3680,7 +3680,7 @@
 - name: uts
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     uts: host
     state: started
@@ -3690,7 +3690,7 @@
 - name: uts (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     uts: host
     state: started
@@ -3739,7 +3739,7 @@
 - name: volume_driver
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     volume_driver: local
     state: started
@@ -3748,7 +3748,7 @@
 - name: volume_driver (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     volume_driver: local
     state: started
@@ -3857,7 +3857,7 @@
 - name: start helpers
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ container_name }}"
     state: started
     volumes:
@@ -3921,7 +3921,7 @@
 - name: working_dir
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     working_dir: /tmp
     state: started
@@ -3930,7 +3930,7 @@
 - name: working_dir (idempotency)
   docker_container:
     image: alpine:3.8
-    command: '/bin/sh -v -c "sleep 10m"'
+    command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     working_dir: /tmp
     state: started


### PR DESCRIPTION
##### SUMMARY
There unfortunately was a copy'n'paste problem with some of the integration idempotency tests, which did force some change because `command` changed. After fixing this, it turned out that `init` and `shm_size` have no idempotency checks.

(Extracted from #48546)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
2.8.0
```
