### PR TITLE
[Backport 2.7] k8s_facts: fix handling of unknown resource types

### DIFF
--- a/changelogs/fragments/k8s_facts_fix.yaml
+++ b/changelogs/fragments/k8s_facts_fix.yaml
@@ -1,3 +1,4 @@
 ---
 bugfixes:
 - k8s_facts now returns a resources key in all situations
+- "k8s_facts: fix handling of unknown resource types"

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -198,6 +198,8 @@ class K8sAnsibleMixin(object):
 
     def kubernetes_facts(self, kind, api_version, name=None, namespace=None, label_selectors=None, field_selectors=None):
         resource = self.find_resource(kind, api_version)
+        if not resource:
+            return dict(resources=[])
         try:
             result = resource.get(name=name,
                                   namespace=namespace,


### PR DESCRIPTION
##### SUMMARY
(cherry picked from commit a5c8e952e8dbea9c9b5140e0b1c8680b2a1cdbf7)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/k8s_facts_fix.yaml
lib/ansible/module_utils/k8s/common.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
Stable-2.7
```