### PR TITLE
Fix Pacman regex for unmatched Arch package name

### DIFF
--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -197,7 +197,7 @@ def upgrade(module, pacman_path):
         # Match lines of `pacman -Qu` output of the form:
         #   (package name) (before version-release) -> (after version-release)
         # e.g., "ansible 2.7.1-1 -> 2.7.2-1"
-        regex = re.compile(r'([\w+\-.@]+) ((?:\S+)-(?:\S+)) -> ((?:\S+)-(?:\S+))')
+        regex = re.compile(r'([\w+\-.@]+) (\S+-\S+) -> (\S+-\S+)')
         for p in data:
             m = regex.search(p)
             packages.append(m.group(1))

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -194,7 +194,7 @@ def upgrade(module, pacman_path):
     }
 
     if rc == 0:
-        regex = re.compile(r'([\w-]+) ((?:\S+)-(?:\S+)) -> ((?:\S+)-(?:\S+))')
+        regex = re.compile(r'([\w+\-.@]+) ((?:\S+)-(?:\S+)) -> ((?:\S+)-(?:\S+))')
         for p in data:
             m = regex.search(p)
             packages.append(m.group(1))

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -194,6 +194,9 @@ def upgrade(module, pacman_path):
     }
 
     if rc == 0:
+        # Match lines of `pacman -Qu` output of the form:
+        #   (package name) (before version-release) -> (after version-release)
+        # e.g., "ansible 2.7.1-1 -> 2.7.2-1"
         regex = re.compile(r'([\w+\-.@]+) ((?:\S+)-(?:\S+)) -> ((?:\S+)-(?:\S+))')
         for p in data:
             m = regex.search(p)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`ansible -m pacman -a upgrade=yes $(hostname)` failed due to not accounting for the `+` character in the `pacman -Qu` output line:

    libsigc++ 2.10.0-1 -> 2.10.1-1

[Per the Arch wiki][package-names], package names can contain alphanumeric characters, and any of {`@`, `.`, `_`, `+`, `-`}.

The existing `re` covered `_` (part of `\w` in Python), and `-` (explicitly included). This change adds `@`, `.`, and `+` (in ASCII-betical order).

[package-names]: https://wiki.archlinux.org/index.php/Arch_package_guidelines#Package_naming

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

pacman

##### ANSIBLE VERSION
<!-- Paste verbatim output from "ansible - - version" between quotes -->

Affected:

```
ansible 2.8.0.dev0 (devel 9a848ca883) last updated 2018/11/12 05:29:16 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/bhaskell/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/bhaskell/git/ansible/lib/ansible
  executable location = bin/ansible
  python version = 3.7.1 (default, Oct 22 2018, 10:41:28) [GCC 8.2.1 20180831]
```

Fixed:

```
ansible 2.8.0.dev0 (fix-pacman-upgrade-package-name-regex 82162c4ab6) last updated 2018/11/12 05:29:00 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/bhaskell/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/bhaskell/git/ansible/lib/ansible
  executable location = bin/ansible
  python version = 3.7.1 (default, Oct 22 2018, 10:41:28) [GCC 8.2.1 20180831]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before change (using `devel`, full version listed above):

```sh
$ archhost=bhaskell-asus
$ . hacking/env-setup >/dev/null 2>&1
$ bin/ansible -i $archhost, -m shell -a 'pacman -Qu | grep sigc' $archhost
bhaskell-asus | CHANGED | rc=0 >>
libsigc++ 2.10.0-1 -> 2.10.1-1

$ bin/ansible -i $archhost, -m pacman -a upgrade=yes -C $archhost 2>&1 |
… sed -e 1d -e '2i\{' |
… jq -r .msg
MODULE FAILURE
See stdout/stderr for the exact error
$
```

After change (using head of PR branch):

```sh
$ archhost=bhaskell-asus
$ . hacking/env-setup >/dev/null 2>&1
$ bin/ansible -i $archhost, -m shell -a 'pacman -Qu | grep sigc' $archhost
bhaskell-asus | CHANGED | rc=0 >>
libsigc++ 2.10.0-1 -> 2.10.1-1

$ bin/ansible -i $archhost, -m pacman -a upgrade=yes -C $archhost 2>&1 |
… sed -e 1d -e '2i\{' |
… jq '.packages|=(["..."]+map(select(contains("libsigc")))+["..."])'
{
  "changed": true,
  "msg": "618 package(s) would be upgraded",
  "packages": [
    "...",
    "libsigc++",
    "..."
  ]
}
$
```