### PR TITLE
[2.7] vultr_server_facts: fixed facts gathering fails if firewall is enabled.

### DIFF
--- a/changelogs/fragments/48342-vultr_server_facts-fix-firewall-group.yml
+++ b/changelogs/fragments/48342-vultr_server_facts-fix-firewall-group.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vultr_server_facts - fixed facts gathering fails if firewall is enabled.

--- a/lib/ansible/modules/cloud/vultr/vultr_server_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_server_facts.py
@@ -114,7 +114,7 @@ class AnsibleVultrServerFacts(Vultr):
 
         self.returns = {
             "APPID": dict(key='application', convert_to='int', transform=self._get_application_name),
-            "FIREWALLGROUPID": dict(key='firewallgroup', convert_to='int', transform=self._get_firewallgroup_name),
+            "FIREWALLGROUPID": dict(key='firewallgroup', transform=self._get_firewallgroup_name),
             "SUBID": dict(key='id', convert_to='int'),
             "VPSPLANID": dict(key='plan', convert_to='int', transform=self._get_plan_name),
             "allowed_bandwidth_gb": dict(convert_to='int'),

--- a/test/legacy/roles/vultr_server_facts/tasks/main.yml
+++ b/test/legacy/roles/vultr_server_facts/tasks/main.yml
@@ -19,12 +19,17 @@
     that:
     - ansible_facts.vultr_server_facts | count == 0
 
-- name: Create the server
+- name: setup firewall group
+  vultr_firewall_group:
+    name: test_vultr_server_facts
+
+- name: setup create the server
   vultr_server:
     name: '{{ vultr_server_name }}'
     os: '{{ vultr_server_os }}'
     plan: '{{ vultr_server_plan }}'
     region: '{{ vultr_server_region }}'
+    firewall_group: test_vultr_server_facts
 
 - name: test gather vultr server facts in check mode
   vultr_server_facts:
@@ -47,7 +52,12 @@
   pause:
     minutes: 5
 
-- name: Delete the server
+- name: cleanup the server
   vultr_server:
     name: '{{ vultr_server_name }}'
+    state: absent
+
+- name: cleanup firewall group
+  vultr_firewall_group:
+    name: test_vultr_server_facts
     state: absent


### PR DESCRIPTION
##### SUMMARY
backport of #48342 and #48411


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vultr_server_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.7
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
