### PR TITLE
Backport/2.7/47938

### DIFF
--- a/changelogs/fragments/47938-docker_swarm_service-requirements.yaml
+++ b/changelogs/fragments/47938-docker_swarm_service-requirements.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm_service - The ``publish``.``mode`` parameter was being ignored if docker-py version was < 3.0.0. Added a parameter validation test."

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -110,6 +110,8 @@ BYTE_SUFFIXES = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
 
 
 if not HAS_DOCKER_PY:
+    docker_version = None
+
     # No docker-py. Create a place holder client to allow
     # instantiation of AnsibleModule and proper error handing
     class Client(object):

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -191,6 +191,7 @@ options:
     - List of dictionaries describing the service published ports.
     - Every item must be a dictionary exposing the keys published_port, target_port, protocol (defaults to 'tcp'), mode <ingress|host>, default to ingress.
     - Only used with api_version >= 1.25
+    - If api_version >= 1.32 and docker python library >= 3.0.0 attribute 'mode' can be set to 'ingress' or 'host' (default 'ingress').
   replicas:
     required: false
     default: -1
@@ -458,6 +459,7 @@ EXAMPLES = '''
 import time
 from ansible.module_utils.docker_common import DockerBaseClass
 from ansible.module_utils.docker_common import AnsibleDockerClient
+from ansible.module_utils.docker_common import docker_version
 from ansible.module_utils.basic import human_to_bytes
 from ansible.module_utils._text import to_text
 
@@ -1031,10 +1033,11 @@ class DockerServiceManager():
                          % (pv['param'], pv['min_version'])))
 
         for publish_def in self.client.module.params.get('publish', []):
-            if ('mode' in publish_def.keys() and
-                    (LooseVersion(self.client.version()['ApiVersion']) <
-                     LooseVersion('1.25'))):
-                self.client.module.fail_json(msg='publish.mode parameter supported only with api_version>=1.25')
+            if 'mode' in publish_def.keys():
+                if LooseVersion(self.client.version()['ApiVersion']) < LooseVersion('1.25'):
+                    self.client.module.fail_json(msg='publish.mode parameter supported only with api_version>=1.25')
+                if LooseVersion(docker_version) < LooseVersion('3.0.0'):
+                    self.client.module.fail_json(msg='publish.mode parameter requires docker python library>=3.0.0')
 
     def run(self):
         self.test_parameter_versions()

--- a/test/units/modules/cloud/docker/test_docker_volume.py
+++ b/test/units/modules/cloud/docker/test_docker_volume.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2018 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+import json
+
+import pytest
+
+from ansible.modules.cloud.docker import docker_volume
+from ansible.module_utils import docker_common
+
+pytestmark = pytest.mark.usefixtures('patch_ansible_module')
+
+TESTCASE_DOCKER_VOLUME = [
+    {
+        'name': 'daemon_config',
+        'state': 'present'
+    }
+]
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_DOCKER_VOLUME, indirect=['patch_ansible_module'])
+def test_create_volume_on_invalid_docker_version(mocker, capfd):
+    mocker.patch.object(docker_common, 'HAS_DOCKER_PY', True)
+    mocker.patch.object(docker_common, 'docker_version', '1.8.0')
+
+    with pytest.raises(SystemExit):
+        docker_volume.main()
+
+    out, dummy = capfd.readouterr()
+    results = json.loads(out)
+    assert results['failed']
+    assert 'Error: docker / docker-py version is 1.8.0. Minimum version required is 1.10.0.' in results['msg']


### PR DESCRIPTION
##### SUMMARY

Backport to 2.7 of #47938.

Cherry pick commits 89bcd3ff1edc082db659c8d646e4cdf9c71d4219 and c062f37984acbea54afa2a9a0d22251fd3958d4a (required for ci)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

docker_swarm_service
##### ANSIBLE VERSION

stable-2.7

##### ADDITIONAL INFORMATION
This PR also includes commit c062f37984acbea54afa2a9a0d22251fd3958d4a, whose changes are required to pass ci tests.