### PR TITLE
Fix fact ansible_distribution_version for AIX

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -490,8 +490,11 @@ class Distribution(object):
         rc, out, err = self.module.run_command("/usr/bin/oslevel")
         data = out.split('.')
         aix_facts['distribution_major_version'] = data[0]
-        aix_facts['distribution_version'] = '%s.%s' % (data[0], data[1])
-        aix_facts['distribution_release'] = data[1]
+        if len(data) > 1:
+            aix_facts['distribution_version'] = '%s.%s' % (data[0], data[1])
+            aix_facts['distribution_release'] = data[1]
+        else:
+            aix_facts['distribution_version'] = data[0]
         return aix_facts
 
     def get_distribution_HPUX(self):

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -490,7 +490,7 @@ class Distribution(object):
         rc, out, err = self.module.run_command("/usr/bin/oslevel")
         data = out.split('.')
         aix_facts['distribution_major_version'] = data[0]
-        aix_facts['distribution_version'] = data[0]
+        aix_facts['distribution_version'] = '%s.%s' % (data[0], data[1])
         aix_facts['distribution_release'] = data[1]
         return aix_facts
 


### PR DESCRIPTION
##### SUMMARY
Fact `ansible_distribution_version` contains for AIX system only the major version (e.g. `7`) and not the full version (e.g. `7.2`) like for other distributions.

Before:
```
        "ansible_distribution": "AIX", 
        "ansible_distribution_major_version": "7", 
        "ansible_distribution_release": "2", 
        "ansible_distribution_version": "7", 
```
After:
```
        "ansible_distribution": "AIX", 
        "ansible_distribution_major_version": "7", 
        "ansible_distribution_release": "2", 
        "ansible_distribution_version": "7.2", 
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/module_utils/facts/system/distribution.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
