### PR TITLE
Add integration tests for docker_image options

### DIFF
--- a/test/integration/targets/docker_image/files/Dockerfile
+++ b/test/integration/targets/docker_image/files/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+ENV foo /bar
+WORKDIR ${foo}

--- a/test/integration/targets/docker_image/files/MyDockerfile
+++ b/test/integration/targets/docker_image/files/MyDockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.7
+ENV INSTALL_PATH /newdata
+RUN mkdir -p $INSTALL_PATH
+
+WORKDIR $INSTALL_PATH

--- a/test/integration/targets/docker_image/tasks/tests/options.yml
+++ b/test/integration/targets/docker_image/tasks/tests/options.yml
@@ -103,6 +103,49 @@
     - dockerfile_1['image']['Config']['WorkingDir'] == '/newdata'
 
 ####################################################################
+## repository ######################################################
+####################################################################
+
+- name: Make sure image is not there
+  docker_image:
+    name: "{{ registry_address }}/test/{{ iname }}:latest"
+    state: absent
+
+- name: repository
+  docker_image:
+    name: "{{ iname }}"
+    path: "{{ role_path }}/files"
+    repository: "{{ registry_address }}/test/{{ iname }}"
+  register: repository_1
+
+- name: repository (idempotent)
+  docker_image:
+    name: "{{ iname }}"
+    path: "{{ role_path }}/files"
+    repository: "{{ registry_address }}/test/{{ iname }}"
+  register: repository_2
+
+- assert:
+    that:
+    - repository_1 is changed
+    - repository_2 is not changed
+
+- name: Get facts of image
+  docker_image_facts:
+    name: "{{ registry_address }}/test/{{ iname }}:latest"
+  register: facts_1
+
+- name: cleanup
+  docker_image:
+    name: "{{ registry_address }}/test/{{ iname }}:latest"
+    state: absent
+    force: yes
+
+- assert:
+    that:
+    - facts_1.images | length == 1
+
+####################################################################
 ## force ###########################################################
 ####################################################################
 

--- a/test/integration/targets/docker_image/tasks/tests/options.yml
+++ b/test/integration/targets/docker_image/tasks/tests/options.yml
@@ -149,17 +149,24 @@
 ## force ###########################################################
 ####################################################################
 
-- name: force
+- name: Build an image
   docker_image:
     path: "{{ role_path }}/files"
     name: "{{ iname }}"
-    force: yes
-  register: force_1
 
 - name: force (changed)
   docker_image:
     path: "{{ role_path }}/files"
     name: "{{ iname }}"
+    dockerfile: "MyDockerfile"
+    force: yes
+  register: force_1
+
+- name: force (unchanged)
+  docker_image:
+    path: "{{ role_path }}/files"
+    name: "{{ iname }}"
+    dockerfile: "MyDockerfile"
     force: yes
   register: force_2
 
@@ -171,7 +178,7 @@
 - assert:
     that:
     - force_1 is changed
-    - force_2 is changed
+    - force_2 is not changed
 
 ####################################################################
 ## load path #######################################################

--- a/test/integration/targets/docker_image/tasks/tests/options.yml
+++ b/test/integration/targets/docker_image/tasks/tests/options.yml
@@ -1,0 +1,162 @@
+---
+- name: Registering image name
+  set_fact:
+    iname: "{{ name_prefix ~ '-options' }}"
+    iname_1: "{{ name_prefix ~ '-options-1' }}"
+
+- name: Registering image name
+  set_fact:
+    inames: "{{ inames }} + [iname, iname_1]"
+
+####################################################################
+## buildargs #######################################################
+####################################################################
+
+- name: buildargs
+  docker_image:
+    path: "{{ role_path }}/files"
+    name: "{{ iname }}"
+    buildargs:
+      TEST1: val1
+      TEST2: val2
+      TEST3: "True"
+  register: buildargs_1
+
+- name: buildargs (idempotency)
+  docker_image:
+    path: "{{ role_path }}/files"
+    name: "{{ iname }}"
+    buildargs:
+      TEST1: val1
+      TEST2: val2
+      TEST3: "True"
+  register: buildargs_2
+
+- name: cleanup
+  docker_image:
+    name: "{{ iname }}"
+    state: absent
+
+- assert:
+    that:
+    - buildargs_1 is changed
+    - buildargs_2 is not changed
+  when: docker_py_version is version('1.6.0', '>=')
+
+- assert:
+    that:
+    - buildargs_1 is failed
+    - buildargs_2 is failed
+  when: docker_py_version is version('1.6.0', '<')
+
+####################################################################
+## container_limits ################################################
+####################################################################
+
+- name: container_limits (Failed due to min memory limit)
+  docker_image:
+    path: "{{ role_path }}/files"
+    name: "{{ iname }}"
+    container_limits:
+      memory: 4000
+  ignore_errors: yes
+  register: container_limits_1
+
+- name: container_limits
+  docker_image:
+    path: "{{ role_path }}/files"
+    name: "{{ iname }}"
+    container_limits:
+      memory: 5000000
+      memswap: 7000000
+  register: container_limits_2
+
+- name: cleanup
+  docker_image:
+    name: "{{ iname }}"
+    state: absent
+
+- assert:
+    that:
+    - "('Minimum memory limit allowed is 4MB') in container_limits_1.msg"
+    - container_limits_2 is changed
+
+####################################################################
+## dockerfile ######################################################
+####################################################################
+
+- name: dockerfile
+  docker_image:
+    path: "{{ role_path }}/files"
+    name: "{{ iname }}"
+    dockerfile: "MyDockerfile"
+  register: dockerfile_1
+
+- name: cleanup
+  docker_image:
+    name: "{{ iname }}"
+    state: absent
+
+- assert:
+    that:
+    - dockerfile_1 is changed
+    - dockerfile_1['image']['Config']['WorkingDir'] == '/newdata'
+
+####################################################################
+## load path #######################################################
+####################################################################
+
+- name: Archive image
+  docker_image:
+    name: "hello-world:latest"
+    archive_path: image.tar
+  register: archive_image
+
+- name: remove image
+  docker_image:
+    name: "hello-world:latest"
+    state: absent
+
+- name: load image (changed)
+  docker_image:
+    name: "hello-world:latest"
+    load_path: image.tar
+  register: load_image
+
+- name: load image (idempotency)
+  docker_image:
+    name: "hello-world:latest"
+    load_path: image.tar
+  register: load_image_1
+
+- assert:
+    that:
+    - load_image is changed
+    - load_image_1 is not changed
+    - archive_image['image']['Id'] == load_image['image']['Id']
+
+####################################################################
+## path ############################################################
+####################################################################
+
+- name: Build image
+  docker_image:
+    name: "{{ iname }}"
+    path: "{{ role_path }}/files"
+  register: path_1
+
+- name: Build image(idempotency)
+  docker_image:
+    name: "{{ iname }}"
+    path: "{{ role_path }}/files"
+  register: path_2
+
+- name: cleanup
+  docker_image:
+    name: "{{ iname }}"
+    state: absent
+
+- assert:
+    that:
+      - path_1 is changed
+      - path_2 is not changed

--- a/test/integration/targets/docker_image/tasks/tests/options.yml
+++ b/test/integration/targets/docker_image/tasks/tests/options.yml
@@ -103,6 +103,34 @@
     - dockerfile_1['image']['Config']['WorkingDir'] == '/newdata'
 
 ####################################################################
+## force ###########################################################
+####################################################################
+
+- name: force
+  docker_image:
+    path: "{{ role_path }}/files"
+    name: "{{ iname }}"
+    force: yes
+  register: force_1
+
+- name: force (changed)
+  docker_image:
+    path: "{{ role_path }}/files"
+    name: "{{ iname }}"
+    force: yes
+  register: force_2
+
+- name: cleanup
+  docker_image:
+    name: "{{ iname }}"
+    state: absent
+
+- assert:
+    that:
+    - force_1 is changed
+    - force_2 is changed
+
+####################################################################
 ## load path #######################################################
 ####################################################################
 


### PR DESCRIPTION
Tests for available options in docker_image module

##### SUMMARY
This adds integration test for existing options in docker_image module

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_image

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (docker_image-options-test 30670e3787) last updated 2018/11/12 23:43:13 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/source/ansible/lib/ansible
  executable location = /home/user/source/ansible/bin/ansible
  python version = 3.6.6 (default, Jul 19 2018, 14:25:17) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
```

##### ADDITIONAL INFORMATION
This helps to check functionality of docker_image options.