### PR TITLE
Add IPv6 support to ec2_vpc_route_table

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -422,8 +422,18 @@ def route_spec_matches_route(route_spec, route):
     if route_spec.get('GatewayId') and 'nat-' in route_spec['GatewayId']:
         route_spec['NatGatewayId'] = route_spec.pop('GatewayId')
     if route_spec.get('GatewayId') and 'vpce-' in route_spec['GatewayId']:
-        if route_spec.get('DestinationCidrBlock', '').startswith('pl-'):
-            route_spec['DestinationPrefixListId'] = route_spec.pop('DestinationCidrBlock')
+        try:
+            dest_block = route_spec.get('DestinationIpv6CidrBlock')
+        except KeyError:
+            dest_block = route_spec.get('DestinationCidrBlock', '')
+
+        if dest_block.startswith('pl-'):
+            try:
+                spec = route_spec.pop('DestinationCidrBlock')
+            except KeyError:
+                spec = route_spec.pop('DestinationIpv6CidrBlock')
+
+            route_spec['DestinationPrefixListId'] = spec
 
     return set(route_spec.items()).issubset(route.items())
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -660,6 +660,8 @@ def create_route_spec(connection, module, vpc_id):
             route_spec['gateway_id'] = igw
         if route_spec.get('gateway_id') and route_spec['gateway_id'].startswith('nat-'):
             rename_key(route_spec, 'gateway_id', 'nat_gateway_id')
+        if route_spec.get('gateway_id') and route_spec['gateway_id'].startswith('eigw-'):
+            rename_key(route_spec, 'gateway_id', 'egress_only_internet_gateway_id')
 
     return snake_dict_to_camel_dict(routes, capitalize_first=True)
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -56,8 +56,9 @@ options:
     description: The ID of the route table to update or delete.
   routes:
     description: List of routes in the route table.
-        Routes are specified as dicts containing the keys 'dest' and one of 'gateway_id',
-        'instance_id', 'network_interface_id', or 'vpc_peering_connection_id'.
+        Routes are specified as dicts containing the the following keys: either 'dest' or 'dest6',
+        and one of 'gateway_id', 'instance_id', 'network_interface_id', or
+        'vpc_peering_connection_id'.
         If 'gateway_id' is specified, you can refer to the VPC's IGW by using the value 'igw'.
         Routes are required for present states.
   state:
@@ -97,6 +98,8 @@ EXAMPLES = '''
     routes:
       - dest: 0.0.0.0/0
         gateway_id: "{{ igw.gateway_id }}"
+      - dest6: ::/0
+        gateway_id: "{{ egress_gw.gateway_id }}"
   register: public_route_table
 
 - name: Set up NAT-protected route table
@@ -176,9 +179,14 @@ route_table:
       contains:
         destination_cidr_block:
           description: CIDR block of destination
-          returned: always
+          returned: when the route is IPv4
           type: string
           sample: 10.228.228.0/22
+        destination_ipv6_cidr_block:
+          description: IPv6 CIDR block of destination
+          returned: when the route is IPv6
+          type: string
+          sample: 2001:db8:abcd:ef00::/56
         gateway_id:
           description: ID of the gateway
           returned: when gateway is local or internet gateway

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -56,11 +56,11 @@ options:
     description: The ID of the route table to update or delete.
   routes:
     description: List of routes in the route table.
-        Routes are specified as dicts containing the the following keys: either 'dest' or 'dest6',
-        and one of 'gateway_id', 'instance_id', 'network_interface_id', or
-        'vpc_peering_connection_id'.
-        If 'gateway_id' is specified, you can refer to the VPC's IGW by using the value 'igw'.
-        Routes are required for present states.
+      Routes are specified as dicts containing the the following keys: either 'dest' or 'dest6',
+      and one of 'gateway_id', 'instance_id', 'network_interface_id', or
+      'vpc_peering_connection_id'.
+      If 'gateway_id' is specified, you can refer to the VPC's IGW by using the value 'igw'.
+      Routes are required for present states.
   state:
     description: Create or destroy the VPC route table
     default: present

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -439,7 +439,14 @@ def route_spec_matches_route(route_spec, route):
 
 
 def route_spec_matches_route_cidr(route_spec, route):
-    return route_spec['DestinationCidrBlock'] == route.get('DestinationCidrBlock')
+    try:
+        key = 'DestinationCidrBlock'
+        match = route_spec[key] == route.get(key)
+    except KeyError:
+        key = 'DestinationIpv6CidrBlock'
+        match = route_spec[key] == route.get(key)
+
+    return match
 
 
 def rename_key(d, old_key, new_key):


### PR DESCRIPTION
##### SUMMARY
Add fully backwards-compatible IPv6 support to `ec2_vpc_route_table`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2_vpc_route_table

##### ANSIBLE VERSION
```
ansible 2.7.1
  config file = /home/styopa/.ansible.cfg
  configured module search path = [u'/home/styopa/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15+ (default, Aug 31 2018, 11:56:52) [GCC 8.2.0]
```

##### ADDITIONAL INFORMATION
Currently, `ec2_vpc_route_table` offers no IPv6 support. This patch adds such support without breaking the existing interface.

Example playbook:
```
    - name: Configure route tables
      ec2_vpc_route_table:
        vpc_id: vpc-1234abcd
        region: us-east-1
        subnets: subnet-5678abcd
        routes:
          - dest: 0.0.0.0/0
            gateway_id: igw-9876cdef
          - dest6: ::/0
            gateway_id: eigw-0123abcd4567cdef
        tags:
          Name: PublicAccess
```
