### PR TITLE
Do not require TTY for 'apt-key' operations

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_key.py
+++ b/lib/ansible/modules/packaging/os/apt_key.py
@@ -216,9 +216,9 @@ def download_key(module, url):
 
 def import_key(module, keyring, keyserver, key_id):
     if keyring:
-        cmd = "%s --keyring %s adv --keyserver %s --recv %s" % (apt_key_bin, keyring, keyserver, key_id)
+        cmd = "%s --keyring %s adv --no-tty --keyserver %s --recv %s" % (apt_key_bin, keyring, keyserver, key_id)
     else:
-        cmd = "%s adv --keyserver %s --recv %s" % (apt_key_bin, keyserver, key_id)
+        cmd = "%s adv --no-tty --keyserver %s --recv %s" % (apt_key_bin, keyserver, key_id)
     for retry in range(5):
         lang_env = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
         (rc, out, err) = module.run_command(cmd, environ_update=lang_env)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
The 'gpg' command supports the '--no-tty' option, which disables any use
of a TTY during its execution. This parameter is sometimes required for
non-interactive operation to avoid any questions for the user.

The 'apt-key adv' command can pass additional parameters to the
underlying 'gpg' command. This patch adds the '--no-tty' option to avoid
issues with APT key imports when Ansible pipelining active, which
disables the use of a dedicated TTY.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt_key