### PR TITLE
[backport 2.7] Do not reboot after updating BIOS configuration (#48317)

### DIFF
--- a/changelogs/fragments/48317-do-not-auto-reboot-with-redfish_config-bios-changes
+++ b/changelogs/fragments/48317-do-not-auto-reboot-with-redfish_config-bios-changes
@@ -1,0 +1,2 @@
+bugfixes:
+  - redfish_config - do not automatically reboot when scheduling a BIOS configuration job

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -745,7 +745,7 @@ class RedfishUtils(object):
         data = response['data']
         set_bios_attr_uri = data["@Redfish.Settings"]["SettingsObject"]["@odata.id"]
 
-        payload = {"TargetSettingsURI": set_bios_attr_uri, "RebootJobType": "PowerCycle"}
+        payload = {"TargetSettingsURI": set_bios_attr_uri}
         response = self.post_request(self.root_uri + self.manager_uri + "/" + jobs, payload, HEADERS)
         if response['ret'] is False:
             return response
@@ -753,7 +753,8 @@ class RedfishUtils(object):
         response_output = response['resp'].__dict__
         job_id = response_output["headers"]["Location"]
         job_id = re.search("JID_.+", job_id).group()
-        return {'ret': True, 'msg': 'Config job created', 'job_id': job_id}
+        # Currently not passing job_id back to user but patch is coming
+        return {'ret': True, 'msg': "Config job %s created" % job_id}
 
     def get_fan_inventory(self):
         result = {}


### PR DESCRIPTION
##### SUMMARY
Backport request of #48317.

Prior to this fix, making a BIOS config change via a `CreateBiosConfigJob` task with `redfish_config` module, the server would reboot.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redfish_utils

##### ANSIBLE VERSION
```
t$ ansible --version
ansible 2.7.1.post0 (backport/2.7/48317 bc4fc7eaee) last updated 2018/11/12 16:40:24 (GMT -400)
  config file = None
  configured module search path = [u'/Users/jacobyundt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jacobyundt/git/ansible/lib/ansible
  executable location = /Users/jacobyundt/git/ansible/bin/ansible
  python version = 2.7.15 (default, Jun 17 2018, 12:46:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)]
$ 
```

##### ADDITIONAL INFORMATION


cc @nlopez
