### PR TITLE
Bug fixes for na_ontap_fcp

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_fcp.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_fcp.py
@@ -111,9 +111,12 @@ class NetAppOntapFCP(object):
         try:
             self.server.invoke_successfully(netapp_utils.zapi.NaElement('fcp-service-start'), True)
         except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error starting FCP %s' %
-                                      (to_native(error)),
-                                  exception=traceback.format_exc())
+            # Error 13013 denotes fcp service already started.
+            if to_native(error.code) == "13013":
+                return None
+            else:
+                self.module.fail_json(msg='Error starting FCP %s' % (to_native(error)),
+                                      exception=traceback.format_exc())
 
     def stop_fcp(self):
         """
@@ -164,6 +167,9 @@ class NetAppOntapFCP(object):
                                   exception=traceback.format_exc())
 
     def apply(self):
+        results = netapp_utils.get_cserver(self.server)
+        cserver = netapp_utils.setup_na_ontap_zapi(module=self.module, vserver=results)
+        netapp_utils.ems_log_event("na_ontap_fcp", cserver)
         exists = self.get_fcp()
         changed = False
         if self.parameters['state'] == 'present':
@@ -180,6 +186,8 @@ class NetAppOntapFCP(object):
                 self.create_fcp()
                 if self.parameters['status'] == 'up':
                     self.start_fcp()
+                elif self.parameters['status'] == 'down':
+                    self.stop_fcp()
                 changed = True
         else:
             if exists:


### PR DESCRIPTION
##### SUMMARY
Handle 13013 error without failing (13013 denote fcp has already started and no need to fail on this).
Fix case where users want to create an fcp in the down state. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- na_ontap_fcp

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
  config file = None
  configured module search path = [u'/Users/chrisarchibald/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chrisarchibald/Code/github/ansible/lib/ansible
  executable location = /Users/chrisarchibald/Code/github/ansible/bin/ansible
  python version = 2.7.15 (default, Oct  2 2018, 12:50:38) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
