### PR TITLE
Fix man page template typo.

### DIFF
--- a/docs/templates/man.j2
+++ b/docs/templates/man.j2
@@ -100,7 +100,7 @@ FILES
 
 ~/.ansible.cfg -- User config file, overrides the default config if present
 
-./ansible.cfg -- Local config file (in current working direcotry) assumed to be 'project specific' and overrides the rest if present.
+./ansible.cfg -- Local config file (in current working directory) assumed to be 'project specific' and overrides the rest if present.
 
 As mentioned above, the ANSIBLE_CONFIG environment variable will override all others.
 


### PR DESCRIPTION
##### SUMMARY
Fixes a typo in the man page template (there's a place where "directory" is misspelled as "direcotry").

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
N/A

##### ANSIBLE VERSION
```
ansible 2.7.1                                                                                                                                                                                               
  config file = None                                                                                                                                                                                        
  configured module search path = ['/Users/brendangood/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']                                                                                     
  ansible python module location = /usr/local/Cellar/ansible/2.7.1/libexec/lib/python3.7/site-packages/ansible                                                                                              
  executable location = /usr/local/bin/ansible                                                                                                                                                              
  python version = 3.7.1 (default, Nov  7 2018, 20:37:11) [Clang 10.0.0 (clang-1000.11.45.5)]
```
