### PR TITLE
Add warning when later roles are overridden

### DIFF
--- a/changelogs/fragments/role-override-warning.yaml
+++ b/changelogs/fragments/role-override-warning.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- A warning is emitted when roles are ignored due to preceeding roles in the path with the same name.

--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -392,6 +392,8 @@ Ansible will search for roles in the following way:
 
 In Ansible 1.4 and later you can configure an additional roles_path to search for roles.  Use this to check all of your common roles out to one location, and share them easily between multiple playbook projects.  See :ref:`intro_configuration` for details about how to set this up in ansible.cfg.
 
+Note that when roles have the same name, the first role that matches it in the search path will be used and the later occurences will be ignored.  This can lead to confusion over which role is in use during a task, and it is suggested to use appropriate naming to avoid this.
+
 Ansible Galaxy
 ``````````````
 

--- a/test/integration/targets/include_import/override_role/override_role/tasks/main.yml
+++ b/test/integration/targets/include_import/override_role/override_role/tasks/main.yml
@@ -1,0 +1,2 @@
+- debug:
+    msg: In role1 override

--- a/test/integration/targets/include_import/override_role/override_role/vars/main.yml
+++ b/test/integration/targets/include_import/override_role/override_role/vars/main.yml
@@ -1,0 +1,1 @@
+where_am_i_defined: role1 vars/main.yml

--- a/test/integration/targets/include_import/override_role/override_role/vars/role1vars.yml
+++ b/test/integration/targets/include_import/override_role/override_role/vars/role1vars.yml
@@ -1,0 +1,1 @@
+where_am_i_defined: role1 vars/main.yml

--- a/test/integration/targets/include_import/test_role_override.yml
+++ b/test/integration/targets/include_import/test_role_override.yml
@@ -1,0 +1,5 @@
+- name: >-
+    verify we override roles from earlier in path
+  hosts: testhost
+  roles:
+    - override_role

--- a/test/integration/targets/include_import/to_override/to_override/tasks/main.yml
+++ b/test/integration/targets/include_import/to_override/to_override/tasks/main.yml
@@ -1,0 +1,2 @@
+- debug:
+    msg: Role to be overridden

--- a/test/integration/targets/include_import/to_override/to_override/vars/main.yml
+++ b/test/integration/targets/include_import/to_override/to_override/vars/main.yml
@@ -1,0 +1,1 @@
+where_am_i_defined: role1 vars/main.yml

--- a/test/integration/targets/include_import/to_override/to_override/vars/role1vars.yml
+++ b/test/integration/targets/include_import/to_override/to_override/vars/role1vars.yml
@@ -1,0 +1,1 @@
+where_am_i_defined: role1 vars/main.yml


### PR DESCRIPTION
##### SUMMARY

You currently don't get any sort of help diagnosing a situation where
a role in a later entry of ANSIBLE_ROLES_PATH is overriden by a role
with the same name earlier in the path.  Although you can pick things
out of the task paths from when it's running, since the names are the
same (kind of the point :) it can be very confusing as to what's
happening.

This continues the path walk when importing the roles, and warns if
you have later roles that are being ignored due to earlier matches.

The documentation is enhanced to discuss the role import precedence.

An integration test is added to match the new behaviour.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```playbook/role```

##### ADDITIONAL INFORMATION

This situation arose because we moved a role in our git tree.  This particular role had a ``filter_plugin`` so it actually left behind a ``__pycache__``  directory and ``.pyc`` file from when it had run.  This meant we had essentially a blank role -- no tasks, variables or anything else in the role -- but it was still being picked up and "run".  With no tasks it just appeared that the role was being read (I mean, the ``role: -roleinquestion`` was not giving a not found error) but somehow doing nothing at all.  This was even more vexing, as "git status" usually ignores ``.pyc`` files so it was completely opaque as to what was going on, and it had only moved up a directory so you can very easily miss this in long paths.

Of course, when it is explained, it all becomes rather obvious.  However, I feel a warning like this would have made it much clearer much sooner.  I think a warning is justified as it is best practice to avoid pointing guns at your foot by giving roles the same name.