### PR TITLE
VMware: add VBS configuration support for Windows 10

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -149,7 +149,9 @@ options:
           version then no action is taken. version_added: 2.6'
     - ' - C(boot_firmware) (string): Choose which firmware should be used to boot the virtual machine.
           Allowed values are "bios" and "efi". version_added: 2.7'
-
+    - ' - C(virt_based_security) (bool): Enable Virtualization Based Security feature for Windows 10.
+          (Support from Virtual machine hardware version 14, Guest OS Windows 10 64 bit, Windows Server 2016)'
+  
   guest_id:
     description:
     - Set the guest ID.
@@ -1104,6 +1106,33 @@ class PyVmomiHelper(PyVmomi):
                     except vim.fault.AlreadyUpgraded:
                         # Don't fail if VM is already upgraded.
                         pass
+
+            if 'virt_based_security' in self.params['hardware']:
+                host_version = self.select_host().summary.config.product.version
+                if int(host_version.split('.')[0]) < 6 or (int(host_version.split('.')[0]) == 6 and int(host_version.split('.')[1]) < 7):
+                    self.module.fail_json(msg="ESXi version %s not support VBS." % host_version)
+                guest_ids = ['windows9_64Guest', 'windows9Server64Guest']
+                if vm_obj is None:
+                    guestid = self.configspec.guestId
+                else:
+                    guestid = vm_obj.summary.config.guestId
+                if guestid not in guest_ids:
+                    self.module.fail_json(msg="Guest '%s' not support VBS." % guestid)
+                if (vm_obj is None and int(self.configspec.version.split('-')[1]) >= 14) or \
+                        (vm_obj and int(vm_obj.config.version.split('-')[1]) >= 14 and (vm_obj.runtime.powerState == vim.VirtualMachinePowerState.poweredOff)):
+                    self.configspec.flags = vim.vm.FlagInfo()
+                    self.configspec.flags.vbsEnabled = bool(self.params['hardware']['virt_based_security'])
+                    if bool(self.params['hardware']['virt_based_security']):
+                        self.configspec.flags.vvtdEnabled = True
+                        self.configspec.nestedHVEnabled = True
+                        if (vm_obj is None and self.configspec.firmware == 'efi') or \
+                                (vm_obj and vm_obj.config.firmware == 'efi'):
+                            self.configspec.bootOptions = vim.vm.BootOptions()
+                            self.configspec.bootOptions.efiSecureBootEnabled = True
+                        else:
+                            self.module.fail_json(msg="Not support VBS when firmware is BIOS.")
+                    if vm_obj is None or self.configspec.flags.vbsEnabled != vm_obj.config.flags.vbsEnabled:
+                        self.change_detected = True
 
     def get_device_by_type(self, vm=None, type=None):
         if vm is None or type is None:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -151,7 +151,7 @@ options:
           Allowed values are "bios" and "efi". version_added: 2.7'
     - ' - C(virt_based_security) (bool): Enable Virtualization Based Security feature for Windows 10.
           (Support from Virtual machine hardware version 14, Guest OS Windows 10 64 bit, Windows Server 2016)'
-  
+
   guest_id:
     description:
     - Set the guest ID.

--- a/test/integration/targets/vmware_guest/tasks/windows_vbs_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/windows_vbs_d1_c1_f0.yml
@@ -1,0 +1,122 @@
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/killall' }}"
+- name: start vcsim with no folders
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=0' }}"
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of Clusters from vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=CCR' }}"
+  register: clusterlist
+
+- debug: var=vcsim_instance
+- debug: var=clusterlist
+
+- name: Create Windows 10 VM with VBS enabled
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    name: vbs-Test
+    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    cluster: "{{ clusterlist['json'][0] }}"
+    resource_pool: Resources
+    guest_id: windows9_64Guest
+    hardware:
+      memory_mb: 1024
+      num_cpus: 1
+      virt_based_security: True
+      version: 14
+      boot_firmware: efi
+      scsi: paravirtual
+    disk:
+    - size_mb: 128
+      type: thin
+      datastore: LocalDS_0
+    cdrom:
+      type: client
+  register: vbs_vm
+
+- debug: var=vbs_vm
+
+- name: assert the VM was created
+  assert:
+    that:
+      - "vbs_vm.failed == false"
+      - "vbs_vm.changed == true"
+
+- name: Create Windows Server 2016 VM without VBS enabled
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    name: vbs-Test2
+    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    cluster: "{{ clusterlist['json'][0] }}"
+    resource_pool: Resources
+    guest_id: windows9Server64Guest
+    hardware:
+      memory_mb: 1024
+      num_cpus: 1
+      version: 14
+      boot_firmware: efi
+      scsi: paravirtual
+    disk:
+    - size_mb: 128
+      type: thin
+      datastore: LocalDS_0
+    cdrom:
+      type: client
+  register: vbs_vm
+
+- debug: var=vbs_vm
+
+- name: assert the VM was created
+  assert:
+    that:
+      - "vbs_vm.failed == false"
+      - "vbs_vm.changed == true"
+
+- name: Enable VBS for Windows Server 2016 VM
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    name: vbs-Test2
+    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    disk:
+    - size_mb: 256
+      type: thin
+      datastore: LocalDS_0
+    hardware:
+      virt_based_security: True
+    state: present
+  register: vbs_vm
+
+- debug: var=vbs_vm
+
+- name: assert the VM was changed
+  assert:
+    that:
+      - "vbs_vm.failed == false"
+      - "vbs_vm.changed == true"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add a new parameter under 'hardware', named 'virt_based_security', stands for "Virtualization based security" feature of Windows 10 and Windows Server 2016 on ESXi 6.7.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #48334 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.8.0.dev0 (fix_pr48334 1ef4e41294) last updated 2018/11/13 17:37:45 (GMT +800)
  config file = /root/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/ansible/lib/ansible
  executable location = /root/ansible/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Support guest IDs are: "windows9_64Guest" and "windows9Server64Guest"
Support hardware version: 14
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
    guest_id: windows9_64Guest
    hardware:
      memory_mb: 1024
      num_cpus: 1
      virt_based_security: True
      version: 14
      boot_firmware: efi
      scsi: paravirtual
```
