### PR TITLE
Avoid duplicated recursive calls in inventory CLI

### DIFF
--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -324,6 +324,8 @@ class InventoryCLI(CLI):
 
     def json_inventory(self, top):
 
+        seen = set()
+
         def format_group(group):
             results = {}
             results[group.name] = {}
@@ -332,7 +334,9 @@ class InventoryCLI(CLI):
             results[group.name]['children'] = []
             for subgroup in sorted(group.child_groups, key=attrgetter('name')):
                 results[group.name]['children'].append(subgroup.name)
-                results.update(format_group(subgroup))
+                if subgroup.name not in seen:
+                    results.update(format_group(subgroup))
+                    seen.add(subgroup.name)
             if self.options.export:
                 results[group.name]['vars'] = self._get_group_variables(group)
 


### PR DESCRIPTION
##### SUMMARY
Ansible inventory CLI was taking too long with 17 groups, and becoming un-runnable with 20 groups, if those groups were arranged in a dense structure.

This fixes the issue so that it can run with 200 dense groups in ~7 seconds, and in general has non-factorial / non-combinatorial scaling with number of edges.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/inventory.py

##### ANSIBLE VERSION
current devel
```paste below
$ ansible --version
ansible 2.8.0.dev0
  config file = None
  configured module search path = [u'/Users/alancoding/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible
  executable location = /Users/alancoding/.virtualenvs/ansible/bin/ansible
  python version = 2.7.11 (default, Oct 17 2016, 14:59:40) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```

##### ADDITIONAL INFORMATION
Example:

inventory file:

```
$ cat scripts/connections/dag_max.py
#!/usr/bin/env python
# -*- coding: utf-8 -*-
import json
import os

"""
Maximum number of edges in group relationships

N = (N-1)*N/2
example of 5
N = 4*5/2 = 20/2 = 10

https://stackoverflow.com/questions/11699095/how-many-edges-can-there-be-in-a-dag
"""

r = {
    '_meta': {
        'hostvars': {}
    }
}

N = int(os.getenv('NUMBER_GROUPS'))

for i in range(N):
    group_name = 'g{}'.format(i)
    r[group_name] = {
        'hosts': [],
        'children': ['g{}'.format(j) for j in range(i)]
    }

print json.dumps(r)
```

pre-fix:

```
$ time NUMBER_GROUPS=17 ansible-inventory -i scripts/connections/dag_max.py --list --export > /dev/null 

real	0m20.501s
user	0m14.171s
sys	0m6.189s
```

post-fix:

```
$ time NUMBER_GROUPS=200 ansible-inventory -i scripts/connections/dag_max.py --list --export > /dev/null 

real	0m6.704s
user	0m5.625s
sys	0m0.365s
```

This is what AWX / Ansible Tower uses for inventory imports, so we need this fix if inventories of this structure are to be importable.