### PR TITLE
Disable docker_swarm teset when docker_api_version is not high enough

### DIFF
--- a/test/integration/targets/docker_swarm/tasks/main.yml
+++ b/test/integration/targets/docker_swarm/tasks/main.yml
@@ -1,2 +1,9 @@
+- debug:
+    var: docker_api_version
+- debug:
+    msg: '{{ docker_api_version is version("1.35", ">=") }}'
+- debug:
+    msg: 'Conditional failed to work'
+  when: ansible_os_family != 'RedHat' or ansible_distribution_major_version != '6' and docker_api_version is version('1.35', '>=')
 - include_tasks: test_swarm.yml
   when: ansible_os_family != 'RedHat' or ansible_distribution_major_version != '6' and docker_api_version is version('1.35', '>=')

--- a/test/integration/targets/docker_swarm/tasks/main.yml
+++ b/test/integration/targets/docker_swarm/tasks/main.yml
@@ -1,2 +1,2 @@
 - include_tasks: test_swarm.yml
-  when: ansible_os_family != 'RedHat' or ansible_distribution_major_version != '6'
+  when: ansible_os_family != 'RedHat' or ansible_distribution_major_version != '6' and docker_api_version is version('1.35', '>=')


### PR DESCRIPTION
##### SUMMARY

docker_swarm cannot be used without docker >= 1.35 and shippable seems to be using 1.30.  Disable the tests until mattclay can figure out how to get us a new enough docker version.

!bot_skip

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
stable-2.7
```