### PR TITLE
make compatible with both python 2 and 3 by setting the encoding

### DIFF
--- a/lib/ansible/module_utils/network/nso/nso.py
+++ b/lib/ansible/module_utils/network/nso/nso.py
@@ -21,6 +21,7 @@
 
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.urls import open_url
+from ansible.module_utils._text import to_text
 
 import json
 import re
@@ -244,7 +245,7 @@ class JsonRpc(object):
             raise NsoException(
                 'NSO returned HTTP code {0}, expected 200'.format(resp.status), {})
 
-        resp_body = resp.read().decode('utf8')
+        resp_body = to_text(resp.read())
         resp_json = json.loads(resp_body)
 
         if 'error' in resp_json:

--- a/lib/ansible/module_utils/network/nso/nso.py
+++ b/lib/ansible/module_utils/network/nso/nso.py
@@ -244,7 +244,7 @@ class JsonRpc(object):
             raise NsoException(
                 'NSO returned HTTP code {0}, expected 200'.format(resp.status), {})
 
-        resp_body = resp.read()
+        resp_body = resp.read().decode('utf8')
         resp_json = json.loads(resp_body)
 
         if 'error' in resp_json:


### PR DESCRIPTION
##### SUMMARY
Fixes working with Python3 (3.5) by setting the encoding.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
networking module nso that provides communications with Cisco Network Services Orchestrator (NSO).

##### ADDITIONAL INFORMATION
The documentation implies that it is only supported in Python2, but it was not very difficult to make work with both Python2 and Python3 with this small change.  Without change, the failure includes:
```
TypeError: the JSON object must be str, not 'bytes'\n"
```
 Tested change in virtualenv with python2 and python3.  
```
            raise NsoException(
                'NSO returned HTTP code {0}, expected 200'.format(resp.status), {})
         resp_body = resp.read()
        resp_body = resp.read().decode('utf8')
        resp_json = json.loads(resp_body)
         if 'error' in resp_json:

```