### PR TITLE
module_utils/vmware is support:community

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -614,7 +614,6 @@ files:
   $module_utils/utm_utils.py:
     maintainers: $team_e_spirit
   $module_utils/vmware:
-    support: core
     maintainers: $team_vmware
   $module_utils/memset.py:
     maintainers: analbeard


### PR DESCRIPTION
##### SUMMARY
jctanner & Dylan confirmed this is community, which is the default for module_utils

##### ISSUE TYPE
- Bugfix Pull Request
