### PR TITLE
Relax ansible-test python version checking.

### DIFF
--- a/test/runner/versions.py
+++ b/test/runner/versions.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     pip = None
 
-print(sys.version)
+print('.'.join(u'%s' % i for i in sys.version_info))
 
 if pip:
     print('pip %s from %s' % (pip.__version__, os.path.dirname(pip.__file__)))


### PR DESCRIPTION
##### SUMMARY

Relax ansible-test python version checking.

This should allow the apt integration test to pass again, now that it is updating the python interpreter to a newer dated version of the same version number.

Ideally the test would not need to modify the interpreter, but that is a more complex fix. This should resolve the immediate problem without making the test completely useless.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
