### PR TITLE
fix incorrect fact cache 'update' method

### DIFF
--- a/changelogs/fragments/vm_fix.yml
+++ b/changelogs/fragments/vm_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - fix issue with incorrect dict update in vars manager

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -609,8 +609,7 @@ class VariableManager:
         '''
         Clears the facts for a host
         '''
-        if hostname in self._fact_cache:
-            del self._fact_cache[hostname]
+        self._fact_cache.pop(hostname, None)
 
     def set_host_facts(self, host, facts):
         '''
@@ -620,13 +619,16 @@ class VariableManager:
         if not isinstance(facts, dict):
             raise AnsibleAssertionError("the type of 'facts' to set for host_facts should be a dict but is a %s" % type(facts))
 
-        if host.name not in self._fact_cache:
-            self._fact_cache[host.name] = facts
-        else:
+        try:
             try:
+                # this is a cache plugin, not a dictionary
+                self._fact_cache.update({host.name: facts})
+            except TypeError:
+                # this is here for backwards compatibilty for the time cache plugins were not 'dict compatible'
                 self._fact_cache.update(host.name, facts)
-            except KeyError:
-                self._fact_cache[host.name] = facts
+                display.deprecated("Your configured fact cache plugin is using a deprecated form of the 'update' method", version="2.12")
+        except KeyError:
+            self._fact_cache[host.name] = facts
 
     def set_nonpersistent_facts(self, host, facts):
         '''
@@ -636,13 +638,10 @@ class VariableManager:
         if not isinstance(facts, dict):
             raise AnsibleAssertionError("the type of 'facts' to set for nonpersistent_facts should be a dict but is a %s" % type(facts))
 
-        if host.name not in self._nonpersistent_fact_cache:
+        try:
+            self._nonpersistent_fact_cache[host.name].update(facts)
+        except KeyError:
             self._nonpersistent_fact_cache[host.name] = facts
-        else:
-            try:
-                self._nonpersistent_fact_cache[host.name].update(facts)
-            except KeyError:
-                self._nonpersistent_fact_cache[host.name] = facts
 
     def set_host_variable(self, host, varname, value):
         '''


### PR DESCRIPTION
The Cache plugins base update method was made incompatible with dictionaries a while back, this was never meant to be the case. Below is traceback from user that found that when the plugin fails to load the fallback to a dict does not work (since update methods are not compatible).

 - Also simplify the update functions.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vars manager

#### ADDITIONAL INFO
```      
     1890	<host.fqnd.com> (0, '\n{"invocation": {"module_args": {"name": "host"}}, "diff": {"after": "hostname = host\\n", "before": "hostname = hostprev.fqdn.com\\n"}, "changed": true, "ansible_facts": {"ansible_hostname": "host", "ansible_domain": "fqdn.com", "ansible_fqdn": "host.fqdn.com", "ansible_nodename": "host"}, "name": "host"}\n', 'OpenSSH_7.4p1, OpenSSL 1.0.2k-fips  26 Jan 2017\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: /etc/ssh/ssh_config line 1: Applying options for *\r\ndebug1: auto-mux: Trying existing master\r\ndebug2: fd 4 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_session: entering\r\ndebug3: mux_client_request_alive: entering\r\ndebug3: mux_client_request_alive: done pid = 28768\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session: master session id: 2\r\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 0\r\n')
      1891	NOTIFIED HANDLER setup_hostname : reboot system for host.fqdn.com
      1892	ERROR! Unexpected Exception, this is probably a bug: update expected at most 1 arguments, got 2
      1893	the full traceback was:
      1894	
      1895	Traceback (most recent call last):
      1896	  File "/usr/bin/ansible-playbook", line 118, in <module>
      1897	    exit_code = cli.run()
      1898	  File "/usr/lib/python2.7/site-packages/ansible/cli/playbook.py", line 122, in run
      1899	    results = pbex.run()
      1900	  File "/usr/lib/python2.7/site-packages/ansible/executor/playbook_executor.py", line 156, in run
      1901	    result = self._tqm.run(play=play)
      1902	  File "/usr/lib/python2.7/site-packages/ansible/executor/task_queue_manager.py", line 291, in run
      1903	    play_return = strategy.run(iterator, play_context)
      1904	  File "/usr/lib/python2.7/site-packages/ansible/plugins/strategy/linear.py", line 325, in run
      1905	    results += self._wait_on_pending_results(iterator)
      1906	  File "/usr/lib/python2.7/site-packages/ansible/plugins/strategy/__init__.py", line 712, in _wait_on_pending_results
      1907	    results = self._process_pending_results(iterator)
      1908	  File "/usr/lib/python2.7/site-packages/ansible/plugins/strategy/__init__.py", line 117, in inner
      1909	    results = func(self, iterator, one_pass=one_pass, max_passes=max_passes)
      1910	  File "/usr/lib/python2.7/site-packages/ansible/plugins/strategy/__init__.py", line 615, in _process_pending_results
      1911	    self._variable_manager.set_host_facts(target_host, result_item['ansible_facts'].copy())
      1912	  File "/usr/lib/python2.7/site-packages/ansible/vars/manager.py", line 626, in set_host_facts
      1913	    self._fact_cache.update(host.name, facts)
      1914	TypeError: update expected at most 1 arguments, got 2```