### PR TITLE
win_mapped_drive - refactor module and docs

### DIFF
--- a/changelogs/fragments/win_mapped_drive-fixes.yaml
+++ b/changelogs/fragments/win_mapped_drive-fixes.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_mapped_drive - Updated win_mapped_drive to use the proper Win32 APIs and updated documentation for proper usage

--- a/lib/ansible/modules/windows/win_mapped_drive.ps1
+++ b/lib/ansible/modules/windows/win_mapped_drive.ps1
@@ -3,117 +3,347 @@
 # Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#Requires -Module Ansible.ModuleUtils.AddType
 
-$ErrorActionPreference = 'Stop'
+$spec = @{
+    options = @{
+        letter = @{ type = "str"; required = $true }
+        path = @{ type = "path"; }
+        state = @{ type = "str"; default = "present"; choices = "absent", "present" }
+        username = @{ type = "str" }
+        password = @{ type = "str"; no_log = $true }
+    }
+    required_if = @(
+        ,@("state", "present", @("path"))
+    )
+    supports_check_mode = $true
+}
 
-$params = Parse-Args $args -supports_check_mode $true
-$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
-$diff_mode = Get-AnsibleParam -obj $params -name "_ansible_diff" -type "bool" -default $false
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 
-$letter = Get-AnsibleParam -obj $params -name "letter" -type "str" -failifempty $true
-$path = Get-AnsibleParam -obj $params -name "path" -type "path"
-$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "absent","present"
-$username = Get-AnsibleParam -obj $params -name "username" -type "str"
-$password = Get-AnsibleParam -obj $params -name "password" -type "str"
+$letter = $module.Params.letter
+$path = $module.Params.path
+$state = $module.Params.state
+$username = $module.Params.username
+$password = $module.Params.password
 
 $result = @{
     changed = $false
 }
 
-if ($diff_mode) {
-    $result.diff = @{}
-}
-
 if ($letter -notmatch "^[a-zA-z]{1}$") {
-    Fail-Json $result "letter must be a single letter from A-Z, was: $letter"
+    $module.FailJson("letter must be a single letter from A-Z, was: $letter")
 }
 
-Function Get-MappedDriveTarget($letter) {
-    # Get-PSDrive and Get-CimInstance doesn't work through WinRM
-    $target = $null
-    if (Test-Path -Path HKCU:\Network\$letter) {
-        $target = (Get-ItemProperty -Path HKCU:\Network\$letter -Name RemotePath).RemotePath
+Add-CSharpType -AnsibleModule $module -References @'
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Ansible.MappedDrive
+{
+    internal class NativeHelpers
+    {
+        public enum ResourceScope : uint
+        {
+            Connected = 0x00000001,
+            GlobalNet = 0x00000002,
+            Remembered = 0x00000003,
+            Recent = 0x00000004,
+            Context = 0x00000005,
+        }
+
+        [Flags]
+        public enum ResourceType : uint
+        {
+            Any = 0x0000000,
+            Disk = 0x00000001,
+            Print = 0x00000002,
+            Reserved = 0x00000008,
+            Unknown = 0xFFFFFFFF,
+        }
+
+        public enum CloseFlags : uint
+        {
+            None = 0x00000000,
+            UpdateProfile = 0x00000001,
+        }
+
+        [Flags]
+        public enum ResourceUsage : uint
+        {
+            All = 0x00000000,
+            Connectable = 0x00000001,
+            Container = 0x00000002,
+            NoLocalDevice = 0x00000004,
+            Sibling = 0x00000008,
+            Attached = 0x00000010,
+        }
+
+        [Flags]
+        public enum AddFlags : uint
+        {
+            UpdateProfile = 0x00000001,
+            UpdateRecent = 0x00000002,
+            Temporary = 0x00000004,
+            Interactive = 0x00000008,
+            Prompt = 0x00000010,
+            Redirect = 0x00000080,
+            CurrentMedia = 0x00000200,
+            CommandLine = 0x00000800,
+            CmdSaveCred = 0x00001000,
+            CredReset = 0x00002000,
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct NETRESOURCEW
+        {
+            public ResourceScope dwScope;
+            public ResourceType dwType;
+            public UInt32 dwDisplayType;
+            public ResourceUsage dwUsage;
+            [MarshalAs(UnmanagedType.LPWStr)] public string lpLocalName;
+            [MarshalAs(UnmanagedType.LPWStr)] public string lpRemoteName;
+            [MarshalAs(UnmanagedType.LPWStr)] public string lpComment;
+            [MarshalAs(UnmanagedType.LPWStr)] public string lpProvider;
+        }
     }
 
-    return $target
-}
+    internal class NativeMethods
+    {
+        [DllImport("Mpr.dll", CharSet = CharSet.Unicode)]
+        public static extern UInt32 WNetAddConnection2W(
+            NativeHelpers.NETRESOURCEW lpNetResource,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpPassword,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpUserName,
+            NativeHelpers.AddFlags dwFlags);
 
-Function Remove-MappedDrive($letter) {
-    # Remove-PSDrive doesn't work through WinRM as it cannot view the mapped drives for the user
-    if (-not $check_mode) {
-        try {
-            &cmd.exe /c net use "$($letter):" /delete
-        } catch {
-            Fail-Json $result "failed to removed mapped drive $($letter): $($_.Exception.Message)"
+        [DllImport("Mpr.dll", CharSet = CharSet.Unicode)]
+        public static extern UInt32 WNetCancelConnection2W(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpName,
+            NativeHelpers.CloseFlags dwFlags,
+            bool fForce);
+
+        [DllImport("Mpr.dll")]
+        public static extern UInt32 WNetCloseEnum(
+            IntPtr hEnum);
+
+        [DllImport("Mpr.dll", CharSet = CharSet.Unicode)]
+        public static extern UInt32 WNetEnumResourceW(
+            IntPtr hEnum,
+            ref Int32 lpcCount,
+            IntPtr lpBuffer,
+            ref UInt32 lpBufferSize);
+
+        [DllImport("Mpr.dll", CharSet = CharSet.Unicode)]
+        public static extern UInt32 WNetOpenEnumW(
+            NativeHelpers.ResourceScope dwScope,
+            NativeHelpers.ResourceType dwType,
+            NativeHelpers.ResourceUsage dwUsage,
+            IntPtr lpNetResource,
+            out IntPtr lphEnum);
+    }
+
+    public class Win32Exception : System.ComponentModel.Win32Exception
+    {
+        private string _msg;
+        public Win32Exception(string message) : this(Marshal.GetLastWin32Error(), message) { }
+        public Win32Exception(int errorCode, string message) : base(errorCode)
+        {
+            _msg = String.Format("{0} ({1}, Win32ErrorCode {2})", message, base.Message, errorCode);
+        }
+        public override string Message { get { return _msg; } }
+        public static explicit operator Win32Exception(string message) { return new Win32Exception(message); }
+    }
+
+    public class DriveInfo
+    {
+        public string Drive;
+        public string Path;
+        public string Username;
+    }
+
+    public class Utils
+    {
+        private const UInt32 ERROR_SUCCESS = 0x00000000;
+        private const UInt32 ERROR_NO_MORE_ITEMS = 0x0000103;
+
+        public static void AddMappedDrive(string drive, string path, string username = null, string password = null)
+        {
+            NativeHelpers.NETRESOURCEW resource = new NativeHelpers.NETRESOURCEW
+            {
+                dwType = NativeHelpers.ResourceType.Disk,
+                lpLocalName = drive,
+                lpRemoteName = path,
+            };
+            NativeHelpers.AddFlags dwFlags = NativeHelpers.AddFlags.UpdateProfile;
+            UInt32 res = NativeMethods.WNetAddConnection2W(resource, password, username, dwFlags);
+            if (res != ERROR_SUCCESS)
+                throw new Win32Exception((int)res, String.Format("Failed to map {0} to '{1}' with WNetAddConnection2W()", drive, path));
+        }
+
+        public static List<DriveInfo> GetMappedDrives()
+        {
+            IntPtr enumPtr = IntPtr.Zero;
+            UInt32 res = NativeMethods.WNetOpenEnumW(NativeHelpers.ResourceScope.Remembered, NativeHelpers.ResourceType.Disk,
+                NativeHelpers.ResourceUsage.All, IntPtr.Zero, out enumPtr);
+            if (res != ERROR_SUCCESS)
+                throw new Win32Exception((int)res, "WNetOpenEnumW()");
+
+            List<DriveInfo> resources = new List<DriveInfo>();
+            try
+            {
+                // MS recommend a buffer size of 16 KiB
+                UInt32 bufferSize = 16384;
+                int lpcCount = -1;
+
+                // keep iterating the enum until ERROR_NO_MORE_ITEMS is returned
+                do
+                {
+                    IntPtr buffer = Marshal.AllocHGlobal((int)bufferSize);
+                    try
+                    {
+                        res = NativeMethods.WNetEnumResourceW(enumPtr, ref lpcCount, buffer, ref bufferSize);
+                        if (res != ERROR_SUCCESS && res != ERROR_NO_MORE_ITEMS)
+                            throw new Win32Exception((int)res, "WNetEnumResourceW()");
+
+                        NativeHelpers.NETRESOURCEW[] rawResources = new NativeHelpers.NETRESOURCEW[lpcCount];
+                        PtrToStructureArray(rawResources, buffer);
+                        foreach (NativeHelpers.NETRESOURCEW resource in rawResources)
+                        {
+                            DriveInfo currentDrive = new DriveInfo
+                            {
+                                Drive = resource.lpLocalName,
+                                Path = resource.lpRemoteName,
+                                Username = GetUsernameForDrive(resource.lpLocalName),
+                            };
+                            resources.Add(currentDrive);
+                        }
+                    }
+                    finally
+                    {
+                        Marshal.FreeHGlobal(buffer);
+                    }
+                }
+                while (res != ERROR_NO_MORE_ITEMS);
+            }
+            finally
+            {
+                NativeMethods.WNetCloseEnum(enumPtr);
+            }
+
+            return resources;
+        }
+
+        public static void RemoveMappedDrive(string drive)
+        {
+            UInt32 res = NativeMethods.WNetCancelConnection2W(drive, NativeHelpers.CloseFlags.UpdateProfile, true);
+            if (res != ERROR_SUCCESS)
+                throw new Win32Exception((int)res, String.Format("Failed to remove mapped drive {0} with WNetCancelConnection2W()", drive));
+        }
+
+        private static string GetUsernameForDrive(string drive)
+        {
+            // WNetGetUser only get's the user the provider will use and not what was configured, we will just
+            // go straight to the source to get the UserName that's configured.
+            using (RegistryKey key = Registry.CurrentUser.OpenSubKey(String.Format("Network\\{0}", drive.Substring(0, 1))))
+            {
+                string username = (string)key.GetValue("UserName", "");
+                // An empty string means no username is set, return null for PS comparison
+                return username == "" ? null : username;
+            }
+        }
+
+        private static void PtrToStructureArray<T>(T[] array, IntPtr ptr)
+        {
+            IntPtr ptrOffset = ptr;
+            for (int i = 0; i < array.Length; i++, ptrOffset = IntPtr.Add(ptrOffset, Marshal.SizeOf(typeof(T))))
+                array[i] = (T)Marshal.PtrToStructure(ptrOffset, typeof(T));
         }
     }
 }
+'@
 
-$existing_target = Get-MappedDriveTarget -letter $letter
+$letter_root = "$($letter):"
+$existing_targets = [Ansible.MappedDrive.Utils]::GetMappedDrives()
+$existing_target = $existing_targets | Where-Object { $_.Drive -eq $letter_root }
+
+$module.Diff.before = ""
+$module.Diff.after = ""
+if ($existing_target) {
+    $module.Diff.before = @{
+        letter = $letter
+        path = $existing_target.Path
+        username = $existing_target.Username
+    }
+}
 
 if ($state -eq "absent") {
     if ($existing_target -ne $null) {
-        if ($path -ne $null) {
-            if ($existing_target -eq $path) {
-                Remove-MappedDrive -letter $letter
+        if ($null -ne $path) {
+            if ($existing_target.Path -eq $path) {
+                if (-not $module.CheckMode) {
+                    [Ansible.MappedDrive.Utils]::RemoveMappedDrive($letter_root)
+                }
             } else {
-                Fail-Json $result "did not delete mapped drive $letter, the target path is pointing to a different location at $existing_target"
+                $module.FailJson("did not delete mapped drive $letter, the target path is pointing to a different location at $($existing_target.Path)")
             }
         } else {
-            Remove-MappedDrive -letter $letter
+            if (-not $module.CheckMode) {
+                [Ansible.MappedDrive.Utils]::RemoveMappedDrive($letter_root)
+            }
         }
 
-        $result.changed = $true
-        if ($diff_mode) {
-            $result.diff.prepared = "-$($letter): $existing_target"
-        }
+        $module.Result.changed = $true
     }
 } else {
-    if ($path -eq $null) {
-        Fail-Json $result "path must be set when creating a mapped drive"
-    }
-
-    $extra_args = @{}
-    if ($username -ne $null) {
-        $sec_password = ConvertTo-SecureString -String $password -AsPlainText -Force
-        $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $username, $sec_password
-        $extra_args.Credential = $credential
-    }
-
     $physical_drives = Get-PSDrive -PSProvider "FileSystem"
     if ($letter -in $physical_drives.Name) {
-        Fail-Json $result "failed to create mapped drive $letter, this letter is in use and is pointing to a non UNC path"
+        $module.FailJson("failed to create mapped drive $letter, this letter is in use and is pointing to a non UNC path")
     }
 
-    if ($existing_target -ne $null) {
-        if ($existing_target -ne $path -or ($username -ne $null)) {
-            # the source path doesn't match or we are putting in a credential
-            Remove-MappedDrive -letter $letter
-            $result.changed = $true
+    # PowerShell converts a $null value to "" when crossing the .NET marshaler, we need to convert the input
+    # to a missing value so it uses the defaults. We also need to Invoke it with MethodInfo.Invoke so the defaults
+    # are still used
+    $input_username = $username
+    if ($null -eq $username) {
+        $input_username = [Type]::Missing
+    }
+    $input_password = $password
+    if ($null -eq $password) {
+        $input_password = [Type]::Missing
+    }
+    $add_method = [Ansible.MappedDrive.Utils].GetMethod("AddMappedDrive")
 
-            try {
-                New-PSDrive -Name $letter -PSProvider "FileSystem" -root $path -Persist -WhatIf:$check_mode @extra_args | Out-Null
-            } catch {
-                Fail-Json $result "failed to create mapped drive $letter pointed to $($path): $($_.Exception.Message)"
+    if ($null -ne $existing_target) {
+        if ($existing_target.Path -ne $path) {
+            if (-not $module.CheckMode) {
+                [Ansible.MappedDrive.Utils]::RemoveMappedDrive($letter_root)
             }
+            $module.Result.changed = $true
 
-            if ($diff_mode) {
-                $result.diff.prepared = "-$($letter): $existing_target`n+$($letter): $path"
+            if (-not $module.CheckMode) {
+                $add_method.Invoke($null, [Object[]]@($letter_root, $path, $input_username, $input_password) )
             }
+        } elseif ($username -ne $existing_target.Username) {
+            Set-ItemProperty -Path HKCU:\Network\$letter -Name UserName -Value $username -WhatIf:$module.CheckMode
+            $module.Result.changed = $true
         }
     } else {
-        try {
-            New-PSDrive -Name $letter -PSProvider "FileSystem" -Root $path -Persist -WhatIf:$check_mode @extra_args | Out-Null
-        } catch {
-            Fail-Json $result "failed to create mapped drive $letter pointed to $($path): $($_.Exception.Message)"
+        if (-not $module.CheckMode) {
+            $add_method.Invoke($null, [Object[]]@($letter_root, $path, $input_username, $input_password) )
         }
 
-        $result.changed = $true
-        if ($diff_mode) {
-            $result.diff.prepared = "+$($letter): $path"
-        }
+        $module.Result.changed = $true
+    }
+    $module.Diff.after = @{
+        letter = $letter
+        path = $path
+        username = $username
     }
 }
 
-Exit-Json $result
+$module.ExitJson()

--- a/lib/ansible/modules/windows/win_mapped_drive.py
+++ b/lib/ansible/modules/windows/win_mapped_drive.py
@@ -44,9 +44,8 @@ options:
     description:
     - The password for C(username) that is used when testing the initial
       connection.
-    - This is never saved with a mapped drive, use the
-      M(win_credential_manager) module to persist a username and password for a
-      host.
+    - This is never saved with a mapped drive, use the M(win_credential) module
+      to persist a username and password for a host.
   path:
     description:
     - The UNC path to map the drive to.
@@ -65,13 +64,12 @@ options:
   username:
     description:
     - The username that is used when testing the initial connection.
-    - This is never saved with a mapped drive, the the
-      M(win_credential_manager) module to persist a username and password for a
-      host.
+    - This is never saved with a mapped drive, the the M(win_credential) module
+      to persist a username and password for a host.
     - This is required if the mapped drive requires authentication with
       custom credentials and become, or CredSSP cannot be used.
     - If become or CredSSP is used, any credentials saved with
-      M(win_credential_manager) will automatically be used instead.
+      M(win_credential) will automatically be used instead.
 author:
 - Jordan Borean (@jborean93)
 '''
@@ -96,7 +94,7 @@ EXAMPLES = r'''
 - name: Create mapped drive with credentials and save the username and password
   block:
   - name: Save the network credentials required for the mapped drive
-    win_credential_manager:
+    win_credential:
       name: server
       type: domain_password
       username: username@DOMAIN

--- a/lib/ansible/modules/windows/win_mapped_drive.py
+++ b/lib/ansible/modules/windows/win_mapped_drive.py
@@ -44,8 +44,9 @@ options:
     description:
     - The password for C(username) that is used when testing the initial
       connection.
-    - This is never saved with a mapped drive, use the C(cmdkey) executable
-      with become to persist a username and password for a host.
+    - This is never saved with a mapped drive, use the
+      M(win_credential_manager) module to persist a username and password for a
+      host.
   path:
     description:
     - The UNC path to map the drive to.
@@ -64,12 +65,13 @@ options:
   username:
     description:
     - The username that is used when testing the initial connection.
-    - This is never saved with a mapped drive, use the C(cmdkey) executable
-      with become to persist a username and password for a host.
+    - This is never saved with a mapped drive, the the
+      M(win_credential_manager) module to persist a username and password for a
+      host.
     - This is required if the mapped drive requires authentication with
       custom credentials and become, or CredSSP cannot be used.
-    - If become or CredSSP is used, any credentials saved with C(cmdkey) will
-      automatically be used instead.
+    - If become or CredSSP is used, any credentials saved with
+      M(win_credential_manager) will automatically be used instead.
 author:
 - Jordan Borean (@jborean93)
 '''
@@ -94,8 +96,12 @@ EXAMPLES = r'''
 - name: Create mapped drive with credentials and save the username and password
   block:
   - name: Save the network credentials required for the mapped drive
-    win_command: cmdkey.exe /add:server /user:username@DOMAIN /pass:Password01
-    no_log: True
+    win_credential_manager:
+      name: server
+      type: domain_password
+      username: username@DOMAIN
+      secret: Password01
+      state: present
 
   - name: Create a mapped drive that requires authentication
     win_mapped_drive:

--- a/test/integration/targets/win_mapped_drive/tasks/main.yml
+++ b/test/integration/targets/win_mapped_drive/tasks/main.yml
@@ -52,7 +52,7 @@
   # test cleanup
   always:
   - name: remove stored credential
-    win_credential_manager:
+    win_credential:
       name: '{{ ansible_hostname }}'
       type: domain_password
       state: absent

--- a/test/integration/targets/win_mapped_drive/tasks/main.yml
+++ b/test/integration/targets/win_mapped_drive/tasks/main.yml
@@ -52,8 +52,10 @@
   # test cleanup
   always:
   - name: remove stored credential
-    win_command: cmdkey.exe /delete:{{ansible_hostname}}
-    ignore_errors: yes
+    win_credential_manager:
+      name: '{{ ansible_hostname }}'
+      type: domain_password
+      state: absent
     vars:
       ansible_become: yes
       ansible_become_method: runas

--- a/test/integration/targets/win_mapped_drive/tasks/main.yml
+++ b/test/integration/targets/win_mapped_drive/tasks/main.yml
@@ -2,6 +2,7 @@
 # test setup
 - name: gather facts required by the tests
   setup:
+    gather_subset: platform
 
 - name: ensure mapped drive is deleted before test
   win_mapped_drive:
@@ -31,6 +32,19 @@
   - { name: '{{test_win_mapped_drive_path}}', path: '{{test_win_mapped_drive_local_path}}' }
   - { name: '{{test_win_mapped_drive_path2}}', path: '{{test_win_mapped_drive_local_path2}}' }
 
+# This ensures we test out the split token/become behaviour
+- name: ensure builtin Administrator has a split token
+  win_regedit:
+    path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+    name: FilterAdministratorToken
+    data: 1
+    type: dword
+  register: admin_uac
+
+- name: reboot to apply Admin approval mode setting
+  win_reboot:
+  when: admin_uac is changed
+
 - block:
   # tests
   - include_tasks: tests.yml
@@ -39,6 +53,7 @@
   always:
   - name: remove stored credential
     win_command: cmdkey.exe /delete:{{ansible_hostname}}
+    ignore_errors: yes
     vars:
       ansible_become: yes
       ansible_become_method: runas
@@ -68,3 +83,15 @@
     win_user:
       name: '{{test_win_mapped_drive_temp_user}}'
       state: absent
+
+  - name: disable Admin approval mode if changed in test
+    win_regedit:
+      path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+      name: FilterAdministratorToken
+      data: 0
+      type: dword
+    when: admin_uac is changed
+
+  - name: reboot to apply Admin approval mode setting
+    win_reboot:
+    when: admin_uac is changed

--- a/test/integration/targets/win_mapped_drive/tasks/main.yml
+++ b/test/integration/targets/win_mapped_drive/tasks/main.yml
@@ -37,6 +37,14 @@
 
   # test cleanup
   always:
+  - name: remove stored credential
+    win_command: cmdkey.exe /delete:{{ansible_hostname}}
+    vars:
+      ansible_become: yes
+      ansible_become_method: runas
+      ansible_become_user: '{{ ansible_user }}'
+      ansible_become_pass: '{{ ansible_password }}'
+
   - name: ensure mapped drive is deleted at the end of the test
     win_mapped_drive:
       letter: '{{test_win_mapped_drive_letter}}'

--- a/test/integration/targets/win_mapped_drive/tasks/tests.yml
+++ b/test/integration/targets/win_mapped_drive/tasks/tests.yml
@@ -273,7 +273,12 @@
     - delete_without_path_again is not changed
 
 - name: store credential for test network account
-  win_command: cmdkey.exe /add:{{ansible_hostname}} /user:{{test_win_mapped_drive_temp_user}} /pass:{{test_win_mapped_drive_temp_password}}
+  win_credential_manager:
+    name: '{{ ansible_hostname }}'
+    type: domain_password
+    username: '{{ test_win_mapped_drive_temp_user }}'
+    secret: '{{ test_win_mapped_drive_temp_password }}'
+    state: present
   vars: &become_vars
     ansible_become: yes
     ansible_become_method: runas

--- a/test/integration/targets/win_mapped_drive/tasks/tests.yml
+++ b/test/integration/targets/win_mapped_drive/tasks/tests.yml
@@ -211,7 +211,7 @@
     that:
     - map_with_credentials is changed
     - map_with_credentials_actual.rc == 0
-    - map_with_credential_actual_username.value == '{{ansible_hostname}}\\{{test_win_mapped_drive_temp_user}}'
+    - map_with_credential_actual_username.value == ''  # we explicitly remove the username part in the module
 
 - name: map drive with current credentials again
   win_mapped_drive:
@@ -337,4 +337,3 @@
   assert:
     that:
     - not map_with_stored_cred_again is changed
-

--- a/test/integration/targets/win_mapped_drive/tasks/tests.yml
+++ b/test/integration/targets/win_mapped_drive/tasks/tests.yml
@@ -273,7 +273,7 @@
     - delete_without_path_again is not changed
 
 - name: store credential for test network account
-  win_credential_manager:
+  win_credential:
     name: '{{ ansible_hostname }}'
     type: domain_password
     username: '{{ test_win_mapped_drive_temp_user }}'

--- a/test/integration/targets/win_mapped_drive/tasks/tests.yml
+++ b/test/integration/targets/win_mapped_drive/tasks/tests.yml
@@ -2,6 +2,7 @@
 - name: fail with invalid path
   win_mapped_drive:
     letter: invalid
+    state: absent
   register: fail_invalid_letter
   failed_when: "fail_invalid_letter.msg != 'letter must be a single letter from A-Z, was: invalid'"
 
@@ -10,7 +11,7 @@
     letter: '{{test_win_mapped_drive_letter}}'
     state: present
   register: fail_path_missing
-  failed_when: fail_path_missing.msg != 'path must be set when creating a mapped drive'
+  failed_when: "fail_path_missing.msg != 'state is present but all of the following are missing: path'"
 
 - name: fail when specifying letter with existing physical path
   win_mapped_drive:
@@ -224,7 +225,7 @@
 - name: assert map drive with current credentials again
   assert:
     that:
-    - map_with_credentials_again is changed # we expect a change as it will just delete and recreate if credentials are passed
+    - not map_with_credentials_again is changed
 
 - name: delete mapped drive without path check
   win_mapped_drive:
@@ -270,3 +271,70 @@
   assert:
     that:
     - delete_without_path_again is not changed
+
+- name: store credential for test network account
+  win_command: cmdkey.exe /add:{{ansible_hostname}} /user:{{test_win_mapped_drive_temp_user}} /pass:{{test_win_mapped_drive_temp_password}}
+  vars: &become_vars
+    ansible_become: yes
+    ansible_become_method: runas
+    ansible_become_user: '{{ ansible_user }}'
+    ansible_become_pass: '{{ ansible_password }}'
+
+- name: map drive with stored cred (check mode)
+  win_mapped_drive:
+    letter: '{{test_win_mapped_drive_letter}}'
+    path: \\{{ansible_hostname}}\{{test_win_mapped_drive_path}}
+    state: present
+  check_mode: yes
+  vars: *become_vars
+  register: map_with_stored_cred_check
+
+- name: get actual of map drive with stored cred (check mode)
+  win_command: 'net use {{test_win_mapped_drive_letter}}:'
+  register: map_with_stored_cred_actual_check
+  failed_when: False
+
+- name: assert map drive with stored cred (check mode)
+  assert:
+    that:
+    - map_with_stored_cred_check is changed
+    - map_with_stored_cred_actual_check.rc == 2
+
+- name: map drive with stored cred
+  win_mapped_drive:
+    letter: '{{test_win_mapped_drive_letter}}'
+    path: \\{{ansible_hostname}}\{{test_win_mapped_drive_path}}
+    state: present
+  vars: *become_vars
+  register: map_with_stored_cred
+
+- name: get actual of map drive with stored cred
+  win_command: 'net use {{test_win_mapped_drive_letter}}:'
+  register: map_with_stored_cred_actual
+
+- name: get username of mapped network drive with stored cred
+  win_reg_stat:
+    path: HKCU:\Network\{{test_win_mapped_drive_letter}}
+    name: UserName
+  register: map_with_stored_cred_actual_username
+
+- name: assert map drive with stored cred
+  assert:
+    that:
+    - map_with_stored_cred is changed
+    - map_with_stored_cred_actual.rc == 0
+    - map_with_stored_cred_actual_username.value == ''
+
+- name: map drive with stored cred again
+  win_mapped_drive:
+    letter: '{{test_win_mapped_drive_letter}}'
+    path: \\{{ansible_hostname}}\{{test_win_mapped_drive_path}}
+    state: present
+  vars: *become_vars
+  register: map_with_stored_cred_again
+
+- name: assert map drive with stored cred again
+  assert:
+    that:
+    - not map_with_stored_cred_again is changed
+


### PR DESCRIPTION
##### SUMMARY
Updated win_mapped_drive to use the new AnsibleModule wrapper but also to use the proper Win32 APIs to managed the mappings. This also updates the documentation to talk about how to properly create a mapped drive that requires credentials. Long story short is that the `username/password` parameters are meant to be for the initial connection but are not persisted. In reality a Windows credential should be added with `cmdkey.exe` beforehand and not `username`/`password` specified on the module.

Still todo:

* ~~Document [EnableLinkedConnections](https://support.microsoft.com/en-us/help/3035277/mapped-drives-are-not-available-from-an-elevated-prompt-when-uac-is-co)~~ - not necessary and outside the scope of thise module
* ~~Handle running with become as an elevated token when `EnableLinkedConnections` is set to 0~~ - done
* ~~Document and test running become with SYSTEM for a global map~~ - unable to easily test but this has been documented
* ~~Fix PInvoke code for non 2016~~ - done

This relies on https://github.com/ansible/ansible/pull/48840 to be merged first.

Fixes https://github.com/ansible/ansible/issues/46713

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_mapped_drive