### PR TITLE
Add new facts for list of loaded kernel modules

### DIFF
--- a/lib/ansible/module_utils/facts/compat.py
+++ b/lib/ansible/module_utils/facts/compat.py
@@ -66,7 +66,7 @@ def ansible_facts(module, gather_subset=None):
 
     minimal_gather_subset = frozenset(['apparmor', 'caps', 'cmdline', 'date_time',
                                        'distribution', 'dns', 'env', 'fips', 'local',
-                                       'lsb', 'pkg_mgr', 'platform', 'python', 'selinux',
+                                       'lsb', 'lsmod', 'pkg_mgr', 'platform', 'python', 'selinux',
                                        'service_mgr', 'ssh_pub_keys', 'user'])
 
     all_collector_classes = default_collectors.collectors

--- a/lib/ansible/module_utils/facts/default_collectors.py
+++ b/lib/ansible/module_utils/facts/default_collectors.py
@@ -43,6 +43,7 @@ from ansible.module_utils.facts.system.dns import DnsFactCollector
 from ansible.module_utils.facts.system.fips import FipsFactCollector
 from ansible.module_utils.facts.system.local import LocalFactCollector
 from ansible.module_utils.facts.system.lsb import LSBFactCollector
+from ansible.module_utils.facts.system.lsmod import LsmodFactCollector
 from ansible.module_utils.facts.system.pkg_mgr import PkgMgrFactCollector
 from ansible.module_utils.facts.system.pkg_mgr import OpenBSDPkgMgrFactCollector
 from ansible.module_utils.facts.system.platform import PlatformFactCollector
@@ -112,7 +113,8 @@ _general = [
     DateTimeFactCollector,
     EnvFactCollector,
     SshPubKeyFactCollector,
-    UserFactCollector
+    UserFactCollector,
+    LsmodFactCollector
 ]
 
 # virtual, this might also limit hardware/networking

--- a/lib/ansible/module_utils/facts/system/lsmod.py
+++ b/lib/ansible/module_utils/facts/system/lsmod.py
@@ -1,0 +1,56 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+from ansible.module_utils.facts.utils import get_file_lines
+from ansible.module_utils.facts.collector import BaseFactCollector
+
+
+class LsmodFactCollector(BaseFactCollector):
+    name = 'lsmod'
+    _fact_ids = set()
+
+    def _get_proc_modules(self):
+        if os.path.exists("/proc/modules") and os.access('/proc/modules', os.R_OK):
+            return get_file_lines('/proc/modules')
+
+    def _parse_proc_modules(self, modules):
+        loaded_kernel_modules = []
+        for mod in modules:
+            module_dict = {}
+            data = mod.split(" ", 5)
+            module_dict['name'] = data[0]
+            module_dict['size'] = data[1]
+            module_dict['instances'] = data[2]
+            if data[3] != "-":
+                module_dict['dependencies'] = data[3].rstrip(',')
+            else:
+                module_dict['dependencies'] = ""
+            module_dict['state'] = data[4]
+            loaded_kernel_modules.append(module_dict)
+        return loaded_kernel_modules
+
+    def collect(self, module=None, collected_facts=None):
+        lsmod_facts = {}
+        modules = self._get_proc_modules()
+
+        if not modules:
+            return lsmod_facts
+
+        lsmod_facts['loaded_kernel_modules'] = self._parse_proc_modules(modules)
+        return lsmod_facts

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -158,7 +158,7 @@ def main():
     #       some tweaking on how gather_subset operations are performed
     minimal_gather_subset = frozenset(['apparmor', 'caps', 'cmdline', 'date_time',
                                        'distribution', 'dns', 'env', 'fips', 'local',
-                                       'lsb', 'pkg_mgr', 'platform', 'python', 'selinux',
+                                       'lsb', 'lsmod', 'pkg_mgr', 'platform', 'python', 'selinux',
                                        'service_mgr', 'ssh_pub_keys', 'user'])
 
     all_collector_classes = default_collectors.collectors


### PR DESCRIPTION
New fact: _ansible_loaded_kernel_modules_, a list of dicts
Based upon the content of /proc/modules
Included in the default collectors and minimal_gather_subset
Each module has the following attributes:
-     name: name of the kernel module
-     size: memory size of the module in bytes
-     instances: number of instances of the module currently loaded
-     dependencies: other modules this depends upon in order to run
-     state: current state (either Live, Loading or Unloading)

Also included: _ansible_builtin_kernel_modules_, a list of modules that are compiled into the kernel (from the content of modules.builtin)

##### SUMMARY
This is extremely useful to have as facts (enabling conditional behavior based on the system's modules, e.g.:
```
when: ansible_loaded_kernel_modules | selectattr('name','equalto','md_mod') | list | count > 0
```
The above task would only run on a machine with RAID.

I was surprised this was not already included! There are so many capabilities which may only be used in Linux if a kernel module has been loaded first.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
LsmodFactCollector, lsmod facts, ansible_loaded_kernel_modules, ansible_builtin_kernel_modules

##### ADDITIONAL INFORMATION
Let me know if you need any tests or documentation updates.

Example output (purposely truncated for length):
```
        "ansible_loaded_kernel_modules": [
            {
                "dependencies": "", 
                "instances": "2", 
                "name": "cifs", 
                "size": "909312", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "5", 
                "name": "fuse", 
                "size": "122880", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "vboxpci", 
                "size": "28672", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "vboxnetadp", 
                "size": "28672", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "vboxnetflt", 
                "size": "32768", 
                "state": "Live"
            }, 
            {
                "dependencies": "vboxpci,vboxnetadp,vboxnetflt", 
                "instances": "3", 
                "name": "vboxdrv", 
                "size": "483328", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "16", 
                "name": "lz4", 
                "size": "16384", 
                "state": "Live"
            }, 
            {
                "dependencies": "lz4", 
                "instances": "1", 
                "name": "lz4_compress", 
                "size": "32768", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "9", 
                "name": "nf_conntrack_ipv4", 
                "size": "16384", 
                "state": "Live"
            }, 
            {
                "dependencies": "ipt_MASQUERADE,nf_conntrack_netlink,xt_conntrack,nft_ct,nf_conntrack_ipv6,nf_nat_ipv6,nf_conntrack_ipv4,nf_nat_ipv4,nf_nat", 
                "instances": "9", 
                "name": "nf_conntrack", 
                "size": "155648", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "ip6_tables", 
                "size": "32768", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "1", 
                "name": "vfat", 
                "size": "24576", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "1", 
                "name": "snd_hda_codec_realtek", 
                "size": "110592", 
                "state": "Live"
            }, 
            {
                "dependencies": "snd_hda_codec_realtek", 
                "instances": "1", 
                "name": "snd_hda_codec_generic", 
                "size": "86016", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "12", 
                "name": "amdgpu", 
                "size": "3354624", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "snd_usb_audio", 
                "size": "249856", 
                "state": "Live"
            }, 
            {
                "dependencies": "snd_hda_codec_realtek,snd_hda_codec_generic,snd_hda_codec_hdmi,snd_hda_intel", 
                "instances": "4", 
                "name": "snd_hda_codec", 
                "size": "151552", 
                "state": "Live"
            }, 
            {
                "dependencies": "snd_hda_codec_realtek,snd_hda_codec_generic,snd_hda_codec_hdmi,snd_hda_intel,snd_hda_codec", 
                "instances": "5", 
                "name": "snd_hda_core", 
                "size": "94208", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "pcspkr", 
                "size": "16384", 
                "state": "Live"
            }, 
            {
                "dependencies": "snd_hda_codec_hdmi,snd_usb_audio,snd_hda_intel,snd_hda_codec,snd_hda_core,snd_pcm_oss", 
                "instances": "6", 
                "name": "snd_pcm", 
                "size": "118784", 
                "state": "Live"
            }, 
            {
                "dependencies": "efi_pstore", 
                "instances": "1", 
                "name": "efivars", 
                "size": "20480", 
                "state": "Live"
            }, 
            {
                "dependencies": "snd_hda_codec_realtek,snd_hda_codec_generic,snd_hda_codec_hdmi,snd_usb_audio,snd_hda_intel,snd_usbmidi_lib,snd_hda_codec,snd_rawmidi,snd_seq_device,snd_hwdep,snd_pcm_oss,snd_mixer_oss,snd_pcm,snd_timer", 
                "instances": "14", 
                "name": "snd", 
                "size": "94208", 
                "state": "Live"
            }, 
            {
                "dependencies": "snd", 
                "instances": "1", 
                "name": "soundcore", 
                "size": "16384", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "video", 
                "size": "45056", 
                "state": "Live"
            }, 

            {
                "dependencies": "", 
                "instances": "1", 
                "name": "binfmt_misc", 
                "size": "20480", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "bfq", 
                "size": "69632", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "lp", 
                "size": "20480", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "loop", 
                "size": "32768", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "1", 
                "name": "efivarfs", 
                "size": "16384", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "ip_tables", 
                "size": "28672", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "5", 
                "name": "ext4", 
                "size": "741376", 
                "state": "Live"
            },
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "crc32c_generic", 
                "size": "16384", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "raid1", 
                "size": "45056", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "raid0", 
                "size": "20480", 
                "state": "Live"
            }, 
            {
                "dependencies": "raid10,raid456,raid1,raid0,multipath,linear", 
                "instances": "6", 
                "name": "md_mod", 
                "size": "159744", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "hid_generic", 
                "size": "16384", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "usbhid", 
                "size": "57344", 
                "state": "Live"
            }, 
            {
                "dependencies": "hid_generic,usbhid", 
                "instances": "2", 
                "name": "hid", 
                "size": "135168", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "9", 
                "name": "crc32c_intel", 
                "size": "24576", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "4", 
                "name": "ahci", 
                "size": "40960", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "7", 
                "name": "aesni_intel", 
                "size": "200704", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "igb", 
                "size": "249856", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "xhci_pci", 
                "size": "16384", 
                "state": "Live"
            }, 
            {
                "dependencies": "aesni_intel", 
                "instances": "1", 
                "name": "aes_x86_64", 
                "size": "20480", 
                "state": "Live"
            }, 
            {
                "dependencies": "ahci", 
                "instances": "1", 
                "name": "libahci", 
                "size": "40960", 
                "state": "Live"
            }, 
            {
                "dependencies": "xhci_pci", 
                "instances": "1", 
                "name": "xhci_hcd", 
                "size": "270336", 
                "state": "Live"
            }, 
            {
                "dependencies": "ahci,libahci", 
                "instances": "2", 
                "name": "libata", 
                "size": "278528", 
                "state": "Live"
            }, 
            {
                "dependencies": "", 
                "instances": "0", 
                "name": "e1000e", 
                "size": "282624", 
                "state": "Live"
            }, 
            {
                "dependencies": "snd_usb_audio,snd_usbmidi_lib,usbhid,xhci_pci,xhci_hcd", 
                "instances": "5", 
                "name": "usbcore", 
                "size": "290816", 
                "state": "Live"
            }, 
            {
                "dependencies": "usbcore", 
                "instances": "1", 
                "name": "usb_common", 
                "size": "16384", 
                "state": "Live"
            }
        ], 

```
