### PR TITLE
AWS: ec2_ami_facts now allows nonstrings(boolean and numbers) as filter arguments. 

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -32,7 +32,9 @@ import re
 from ansible.module_utils.ansible_release import __version__
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.cloud import CloudRetry
-from ansible.module_utils.six import string_types, binary_type, text_type
+from ansible.module_utils.six import (
+    string_types, binary_type, text_type, integer_types
+)
 from ansible.module_utils.common.dict_transformations import (
     camel_dict_to_snake_dict, snake_dict_to_camel_dict,
     _camel_to_snake, _snake_to_camel,
@@ -387,7 +389,11 @@ def ansible_dict_to_boto3_filter_list(filters_dict):
     filters_list = []
     for k, v in filters_dict.items():
         filter_dict = {'Name': k}
-        if isinstance(v, string_types):
+        if isinstance(v, bool):
+            filter_dict['Values'] = [str(v).lower()]
+        elif isinstance(v, integer_types):
+            filter_dict['Values'] = [str(v)]
+        elif isinstance(v, string_types):
             filter_dict['Values'] = [v]
         else:
             filter_dict['Values'] = v


### PR DESCRIPTION
##### SUMMARY
module ec2_ami_facts now allows nonstrings(boolean and numbers) as filter arguments.
Fixes: #43570

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible/lib/ansible/modules/cloud/amazon/ec2_ami_facts.py
lib/ansible/module_utils/ec2.py


##### Ansible Version
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.8.0.dev0 
```
