### PR TITLE
Add session tracing support for network_cli, netconf, httapi connection

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -119,6 +119,10 @@ class ConnectionProcess(object):
             self.fd.close()
 
     def run(self):
+        invoke_log_message = False
+        if hasattr(self.connection, '_log_messages') and self.connection.get_option('persistent_log_messages'):
+            invoke_log_message = True
+
         try:
             while self.connection.connected:
                 signal.signal(signal.SIGALRM, self.connect_timeout)
@@ -128,17 +132,20 @@ class ConnectionProcess(object):
                 self.exception = None
                 (s, addr) = self.sock.accept()
                 signal.alarm(0)
-
                 signal.signal(signal.SIGALRM, self.command_timeout)
                 while True:
                     data = recv_data(s)
                     if not data:
                         break
+                    if invoke_log_message:
+                        self.connection._log_messages("jsonrpc request: %s" % data)
 
                     signal.alarm(self.connection.get_option('persistent_command_timeout'))
                     resp = self.srv.handle_request(data)
                     signal.alarm(0)
 
+                    if invoke_log_message:
+                        self.connection._log_messages("jsonrpc response: %s" % resp)
                     send_data(s, to_bytes(resp))
 
                 s.close()

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -99,6 +99,61 @@ Because the log files are verbose, you can use grep to look for specific informa
 
   grep "p=28990" $ANSIBLE_LOG_PATH
 
+
+Enabling Networking device interaction logging
+----------------------------------------------
+
+**Platforms:** Any
+
+Ansible 2.8 features added logging of device interaction in log file to help diagnose and troubleshoot
+issues regarding Ansible Networking modules. The messages are logged in file pointed by ``log_path`` configuration
+option in Ansible configuration file or by set :envvar:`ANSIBLE_LOG_PATH` as mentioned in above section.
+The device interaction messages consist of command executed on target device and the returned response, as this
+log data can contain sensitive information including passwords in plain text it is disabled by default. Be sure
+to fully understand the security implications of enabling this option. The device interaction logging can be enabled
+either globally by setting in configuration file or by setting environment or enabled on per task basis by passing
+special variable to task.
+
+Before running ``ansible-playbook`` run the following commands to enable logging::
+
+   # Specify the location for the log file
+   export ANSIBLE_LOG_PATH=~/ansible.log
+
+
+Enable device interaction logging for a given task
+
+.. code-block:: yaml
+
+  - name: get version information
+    ios_command:
+      commands:
+        - show version
+    vars:
+      ansible_persistent_log_messages: True
+
+
+To make this a global setting, add the following to your ``ansible.cfg`` file:
+
+.. code-block:: ini
+
+   [persistent_connection]
+   log_messages = True
+
+or enable :envvar:`ANSIBLE_PERSISTENT_LOG_MESSAGES`
+
+   # Enable device interaction logging
+   export ANSIBLE_PERSISTENT_LOG_MESSAGES=True
+
+If the task is failing at the time on connection initialization itself it is recommended to enable this option
+globally else if an individual task is failing intermittently this option can be enabled for that task itself to
+find the root cause.
+
+After Ansible has finished running you can inspect the log file which has been created on the ansible-controller
+
+.. note:: Be sure to fully understand the security implications of enabling this option as it can log sensitive
+          information in log file thus creating security vulnerability.
+
+
 Isolating an error
 ------------------
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -139,7 +139,7 @@ To make this a global setting, add the following to your ``ansible.cfg`` file:
    [persistent_connection]
    log_messages = True
 
-or enable :envvar:`ANSIBLE_PERSISTENT_LOG_MESSAGES`
+or enable environment variable `ANSIBLE_PERSISTENT_LOG_MESSAGES`
 
    # Enable device interaction logging
    export ANSIBLE_PERSISTENT_LOG_MESSAGES=True

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -374,3 +374,7 @@ class NetworkConnectionBase(ConnectionBase):
         if os.path.exists(socket_path):
             self._connected = True
             self._socket_path = socket_path
+
+    def _log_messages(self, message):
+        if self.get_option('persistent_log_messages'):
+            display.display("%s" % message, log_only=True)

--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -143,6 +143,22 @@ options:
       - name: ANSIBLE_PERSISTENT_COMMAND_TIMEOUT
     vars:
       - name: ansible_command_timeout
+  persistent_log_messages:
+    type: boolean
+    description:
+      - This flag will enable logging the command executed and response received from
+        target device in the ansible log file. For this option to work 'log_path' ansible
+        configuration option is required to be set to a file path with write access.
+      - Be sure to fully understand the security implications of enabling this
+        option as it could create a security vulnerability by logging sensitive information in log file.
+    default: False
+    ini:
+      - section: persistent_connection
+        key: log_messages
+    env:
+      - name: ANSIBLE_PERSISTENT_LOG_MESSAGES
+    vars:
+      - name: ansible_persistent_log_messages
 """
 
 from io import BytesIO
@@ -261,7 +277,9 @@ class Connection(NetworkConnectionBase):
             url_kwargs['url_password'] = self.get_option('password')
 
         try:
-            response = open_url(self._url + path, data=data, **url_kwargs)
+            url = self._url + path
+            self._log_messages("send url '%s' with data '%s' and kwargs '%s'" % (url, data, url_kwargs))
+            response = open_url(url, data=data, **url_kwargs)
         except HTTPError as exc:
             is_handled = self.handle_httperror(exc)
             if is_handled is True:
@@ -274,7 +292,9 @@ class Connection(NetworkConnectionBase):
             raise AnsibleConnectionFailure('Could not connect to {0}: {1}'.format(self._url + path, exc.reason))
 
         response_buffer = BytesIO()
-        response_buffer.write(response.read())
+        resp_data = response.read()
+        self._log_messages("received response: '%s'" % resp_data)
+        response_buffer.write(resp_data)
 
         # Try to assign a new auth token if one is given
         self._auth = self.update_auth(response, response_buffer) or self._auth

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -170,6 +170,22 @@ options:
     vars:
       - name: ansible_netconf_ssh_config
         version_added: '2.7'
+  persistent_log_messages:
+    type: boolean
+    description:
+      - This flag will enable logging the command executed and response received from
+        target device in the ansible log file. For this option to work 'log_path' ansible
+        configuration option is required to be set to a file path with write access.
+      - Be sure to fully understand the security implications of enabling this
+        option as it could create a security vulnerability by logging sensitive information in log file.
+    default: False
+    ini:
+      - section: persistent_connection
+        key: log_messages
+    env:
+      - name: ANSIBLE_PERSISTENT_LOG_MESSAGES
+    vars:
+      - name: ansible_persistent_log_messages
 """
 
 import os

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -172,6 +172,22 @@ options:
       - name: ANSIBLE_PERSISTENT_BUFFER_READ_TIMEOUT
     vars:
       - name: ansible_buffer_read_timeout
+  persistent_log_messages:
+    type: boolean
+    description:
+      - This flag will enable logging the command executed and response received from
+        target device in the ansible log file. For this option to work 'log_path' ansible
+        configuration option is required to be set to a file path with write access.
+      - Be sure to fully understand the security implications of enabling this
+        option as it could create a security vulnerability by logging sensitive information in log file.
+    default: False
+    ini:
+      - section: persistent_connection
+        key: log_messages
+    env:
+      - name: ANSIBLE_PERSISTENT_LOG_MESSAGES
+    vars:
+      - name: ansible_persistent_log_messages
 """
 
 import getpass
@@ -376,6 +392,7 @@ class Connection(NetworkConnectionBase):
         buffer_read_timeout = self.get_option('persistent_buffer_read_timeout')
         self._validate_timeout_value(buffer_read_timeout, "persistent_buffer_read_timeout")
 
+        self._log_messages("command: %s" % command)
         while True:
             if command_prompt_matched:
                 try:
@@ -383,6 +400,7 @@ class Connection(NetworkConnectionBase):
                     signal.setitimer(signal.ITIMER_REAL, buffer_read_timeout)
                     data = self._ssh_shell.recv(256)
                     signal.alarm(0)
+                    self._log_messages("response-%s: %s" % (window_count+1, data))
                     # if data is still received on channel it indicates the prompt string
                     # is wrongly matched in between response chunks, continue to read
                     # remaining response.
@@ -396,7 +414,7 @@ class Connection(NetworkConnectionBase):
                     return self._command_response
             else:
                 data = self._ssh_shell.recv(256)
-
+                self._log_messages("response-%s: %s" % (window_count+1, data))
             # when a channel stream is closed, received data will be empty
             if not data:
                 break
@@ -490,6 +508,9 @@ class Connection(NetworkConnectionBase):
         for index, regex in enumerate(prompts_regex):
             match = regex.search(resp)
             if match:
+                self._matched_cmd_prompt = match.group()
+                self._log_messages("matched command prompt: %s" % self._matched_cmd_prompt)
+
                 # if prompt_retry_check is enabled to check if same prompt is
                 # repeated don't send answer again.
                 if not prompt_retry_check:
@@ -497,7 +518,8 @@ class Connection(NetworkConnectionBase):
                     self._ssh_shell.sendall(b'%s' % prompt_answer)
                     if newline:
                         self._ssh_shell.sendall(b'\r')
-                self._matched_cmd_prompt = match.group()
+                        prompt_answer += '\r'
+                    self._log_messages("matched command prompt answer: %s" % self.prompt_answer)
                 if check_all and prompts and not single_prompt:
                     prompts.pop(0)
                     answer.pop(0)
@@ -533,6 +555,7 @@ class Connection(NetworkConnectionBase):
                         errored_response = response
                         self._matched_pattern = regex.pattern
                         self._matched_prompt = match.group()
+                        self._log_messages("matched error regex '%s' from response '%s'" % (self._matched_pattern, errored_response))
                         break
 
         if not is_error_message:
@@ -541,6 +564,7 @@ class Connection(NetworkConnectionBase):
                 if match:
                     self._matched_pattern = regex.pattern
                     self._matched_prompt = match.group()
+                    self._log_messages("matched cli prompt '%s' with regex '%s' from response '%s'" % (self._matched_prompt, self._matched_pattern, response))
                     if not errored_response:
                         return True
 

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -400,7 +400,7 @@ class Connection(NetworkConnectionBase):
                     signal.setitimer(signal.ITIMER_REAL, buffer_read_timeout)
                     data = self._ssh_shell.recv(256)
                     signal.alarm(0)
-                    self._log_messages("response-%s: %s" % (window_count+1, data))
+                    self._log_messages("response-%s: %s" % (window_count + 1, data))
                     # if data is still received on channel it indicates the prompt string
                     # is wrongly matched in between response chunks, continue to read
                     # remaining response.
@@ -414,7 +414,7 @@ class Connection(NetworkConnectionBase):
                     return self._command_response
             else:
                 data = self._ssh_shell.recv(256)
-                self._log_messages("response-%s: %s" % (window_count+1, data))
+                self._log_messages("response-%s: %s" % (window_count + 1, data))
             # when a channel stream is closed, received data will be empty
             if not data:
                 break


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes https://github.com/ansible/ansible/issues/34997

*  Add `persistent_log_messages` configuration option to log device inteaction
   in the log file for network_cli, netconf and httapi connection
   type
*  Log jsonrpc request and response in the log file if the configuration option
   is enabled
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bin/ansible-connection
network_cli
netconf
httpapi

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
