### PR TITLE
apt: disable deb repos to not change test env

### DIFF
--- a/test/integration/targets/apt/defaults/main.yml
+++ b/test/integration/targets/apt/defaults/main.yml
@@ -1,2 +1,1 @@
 apt_foreign_arch: i386
-hello_old_version: 2.6-1

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -16,6 +16,14 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - block:
+  - include: 'apt.yml'
+
+  - include: 'apt-multiarch.yml'
+    when:
+      - ansible_userspace_architecture != apt_foreign_arch
+
+  - include: 'apt-builddep.yml'
+
   - block:
       - include: 'repo.yml'
     always:
@@ -25,53 +33,6 @@
       - file:
           name: "{{ repodir }}"
           state: absent
-
-  - include: 'apt.yml'
-
-  - include: 'apt-multiarch.yml'
-    when:
-      - ansible_userspace_architecture != apt_foreign_arch
-
-  - include: 'apt-builddep.yml'
-
-  - include: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type=dist force_apt_get={{ False | bool }}"
-
-  - name: Check if aptitude is installed
-    command: dpkg-query --show --showformat='${db:Status-Abbrev}' aptitude
-    register: aptitude_status
-
-  - name: Remove aptitude, if installed, to test fall-back to apt-get
-    apt:
-      pkg: aptitude
-      state: absent
-    when:
-      - aptitude_status.stdout.find('ii') != -1
-
-  - include: "upgrade.yml aptitude_present={{ False | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
-    with_items:
-      - { upgrade_type: safe, force_apt_get: False }
-      - { upgrade_type: full, force_apt_get: False }
-      - { upgrade_type: safe, force_apt_get: True }
-      - { upgrade_type: full, force_apt_get: True }
-
-  - name: (Re-)Install aptitude, run same tests again
-    apt:
-      pkg: aptitude
-      state: present
-
-  - include: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
-    with_items:
-      - { upgrade_type: safe, force_apt_get: False }
-      - { upgrade_type: full, force_apt_get: False }
-      - { upgrade_type: safe, force_apt_get: True }
-      - { upgrade_type: full, force_apt_get: True }
-
-  - name: Remove aptitude if not originally present
-    apt:
-      pkg: aptitude
-      state: absent
-    when:
-      - aptitude_status.stdout.find('ii') == -1
 
   when:
     - ansible_distribution in ('Ubuntu', 'Debian')

--- a/test/integration/targets/apt/tasks/repo.yml
+++ b/test/integration/targets/apt/tasks/repo.yml
@@ -33,12 +33,64 @@
         - "apt_result is success"
         - "dpkg_result is success"
         - "'1.0.1' in dpkg_result.stdout"
+  always:
+    - name: Clean up
+      apt:
+        name: foo
+        state: absent
+        allow_unauthenticated: yes
 
-  # https://github.com/ansible/ansible/issues/35900
-  - name: Clean up
+
+# https://github.com/ansible/ansible/issues/30638
+- block:
+  - name: Fail to install foo=1.0.1 since foo is not installed and only_upgrade is set
     apt:
-      name: foo
-      state: absent
+      name: foo=1.0.1
+      state: installed
+      only_upgrade: yes
+      allow_unauthenticated: yes
+    ignore_errors: yes
+    register: apt_result
+
+  - name: Check that foo was not upgraded
+    assert:
+      that:
+        - "apt_result is not changed"
+
+  - apt:
+      name: foo=1.0.0
+      allow_unauthenticated: yes
+
+  - name: Upgrade foo to 1.0.1
+    apt:
+      name: foo=1.0.1
+      state: installed
+      only_upgrade: yes
+      allow_unauthenticated: yes
+    register: apt_result
+
+  - name: Check install with dpkg
+    shell: dpkg-query -l foo
+    register: dpkg_result
+
+  - name: Check if install was successful
+    assert:
+      that:
+        - "apt_result is success"
+        - "dpkg_result is success"
+        - "'1.0.1' in dpkg_result.stdout"
+  always:
+    - name: Clean up
+      apt:
+        name: foo
+        state: absent
+        allow_unauthenticated: yes
+
+
+# https://github.com/ansible/ansible/issues/35900
+- block:
+  - name: Disable ubuntu repos so system packages are not upgraded and do not change testing env
+    command: mv /etc/apt/sources.list /etc/apt/sources.list.backup
 
   - name: Install foobar, installs foo as a dependency
     apt:
@@ -61,14 +113,21 @@
       that:
         - "dpkg_result is failed"
 
-  # https://github.com/ansible/ansible/issues/26298
-  - name: Clean up
-    apt:
-      name: "{{ item }}"
-      state: absent
-    with_items:
-      - foo
-      - foobar
+  always:
+    - name: Clean up
+      apt:
+        pkg: foo,foobar
+        state: absent
+        autoclean: yes
+
+    - name: Restore ubuntu repos
+      command: mv /etc/apt/sources.list.backup /etc/apt/sources.list
+
+
+# https://github.com/ansible/ansible/issues/26298
+- block:
+  - name: Disable ubuntu repos so system packages are not upgraded and do not change testing env
+    command: mv /etc/apt/sources.list /etc/apt/sources.list.backup
 
   - name: Install foobar, installs foo as a dependency
     apt:
@@ -141,50 +200,54 @@
       that:
         - "autoclean_result is not changed"
 
-  # https://github.com/ansible/ansible/issues/30638
-  - name: Fail to install foo=1.0.1 since foo is not installed and only_upgrade is set
-    apt:
-      name: foo=1.0.1
-      state: installed
-      only_upgrade: yes
-      allow_unauthenticated: yes
-    ignore_errors: yes
-    register: apt_result
-
-  - name: Check that foo was not upgraded
-    assert:
-      that:
-        - "apt_result is not changed"
-
-  - apt:
-      name: foo=1.0.0
-      allow_unauthenticated: yes
-
-  - name: Upgrade foo to 1.0.1
-    apt:
-      name: foo=1.0.1
-      state: installed
-      only_upgrade: yes
-      allow_unauthenticated: yes
-    register: apt_result
-
-  - name: Check install with dpkg
-    shell: dpkg-query -l foo
-    register: dpkg_result
-
-  - name: Check if install was successful
-    assert:
-      that:
-        - "apt_result is success"
-        - "dpkg_result is success"
-        - "'1.0.1' in dpkg_result.stdout"
-
   always:
     - name: Clean up
       apt:
-        name: "{{ item }}"
+        pkg: foo,foobar
         state: absent
-        allow_unauthenticated: yes
+        autoclean: yes
+
+    - name: Restore ubuntu repos
+      command: mv /etc/apt/sources.list.backup /etc/apt/sources.list
+
+
+- name: Upgrades
+  block:
+    - include: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type=dist force_apt_get={{ False | bool }}"
+
+    - name: Check if aptitude is installed
+      command: dpkg-query --show --showformat='${db:Status-Abbrev}' aptitude
+      register: aptitude_status
+
+    - name: Remove aptitude, if installed, to test fall-back to apt-get
+      apt:
+        pkg: aptitude
+        state: absent
+      when:
+        - aptitude_status.stdout.find('ii') != -1
+
+    - include: "upgrade.yml aptitude_present={{ False | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
       with_items:
-        - foo
-        - foobar
+        - { upgrade_type: safe, force_apt_get: False }
+        - { upgrade_type: full, force_apt_get: False }
+        - { upgrade_type: safe, force_apt_get: True }
+        - { upgrade_type: full, force_apt_get: True }
+
+    - name: (Re-)Install aptitude, run same tests again
+      apt:
+        pkg: aptitude
+        state: present
+
+    - include: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
+      with_items:
+        - { upgrade_type: safe, force_apt_get: False }
+        - { upgrade_type: full, force_apt_get: False }
+        - { upgrade_type: safe, force_apt_get: True }
+        - { upgrade_type: full, force_apt_get: True }
+
+    - name: Remove aptitude if not originally present
+      apt:
+        pkg: aptitude
+        state: absent
+      when:
+        - aptitude_status.stdout.find('ii') == -1

--- a/test/integration/targets/apt/tasks/upgrade.yml
+++ b/test/integration/targets/apt/tasks/upgrade.yml
@@ -1,61 +1,72 @@
----
-#### Tests for upgrade/download functions in modules/packaging/os/apt.py ####
-- name: download and install old version of hello
-  apt: "deb=https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/apt/hello_{{ hello_old_version }}_amd64.deb"
+- block:
+  - name: Disable ubuntu repos so system packages are not upgraded and do not change testing env
+    command: mv /etc/apt/sources.list /etc/apt/sources.list.backup
 
-- name: check hello version
-  shell: dpkg -s hello | grep Version | awk '{print $2}'
-  register: hello_version
+  - name: install foo-1.0.0
+    apt:
+      name: foo=1.0.0
+      state: present
+      allow_unauthenticated: yes
 
-- name: ensure the correct version of hello has been installed
-  assert:
-    that:
-      - "{{ hello_version.stdout }}=={{ hello_old_version }}"
+  - name: check foo version
+    shell: dpkg -s foo | grep Version | awk '{print $2}'
+    register: foo_version
 
-- name: "(upgrade type: {{upgrade_type}}) upgrade packages to latest version, force_apt_get: {{force_apt_get}}"
-  apt:
-    upgrade: "{{ upgrade_type }}"
-    force_apt_get: "{{ force_apt_get }}"
-  register: upgrade_result
+  - name: ensure the correct version of foo has been installed
+    assert:
+      that:
+        - "'1.0.0' in foo_version.stdout"
 
-- name: check hello version
-  shell: dpkg -s hello | grep Version | awk '{print $2}'
-  register: hello_version
+  - name: "(upgrade type: {{upgrade_type}}) upgrade packages to latest version, force_apt_get: {{force_apt_get}}"
+    apt:
+      upgrade: "{{ upgrade_type }}"
+      force_apt_get: "{{ force_apt_get }}"
+      force: yes
+    register: upgrade_result
 
-- name: check that warning is not given when force_apt_get set
-  assert:
-    that:
-      - "'warnings' not in upgrade_result"
-  when:
-    - force_apt_get
+  - name: check foo version
+    shell: dpkg -s foo | grep Version | awk '{print $2}'
+    register: foo_version
 
-- name: check that warning is given when aptitude not found and force_apt_get not set
-  assert:
-    that:
-      - "'Could not find aptitude. Using apt-get instead' in upgrade_result.warnings[0]"
-  when:
-    - not aptitude_present
-    - not force_apt_get
+  - name: check that warning is not given when force_apt_get set
+    assert:
+      that:
+        - "'warnings' not in upgrade_result"
+    when:
+      - force_apt_get
 
-- name: check that old version upgraded correctly
-  assert:
-    that:
-      - "{{ hello_version.stdout }}!={{ hello_old_version }}"
-      - "{{ hello_version.changed }}"
+  - name: check that warning is given when aptitude not found and force_apt_get not set
+    assert:
+      that:
+        - "'Could not find aptitude. Using apt-get instead' in upgrade_result.warnings[0]"
+    when:
+      - not aptitude_present
+      - not force_apt_get
 
-- name: "(upgrade type: {{upgrade_type}}) upgrade packages to latest version (Idempotant)"
-  apt:
-    upgrade: "{{ upgrade_type }}"
-    force_apt_get: "{{ force_apt_get }}"
-  register: second_upgrade_result
+  - name: check that old version upgraded correctly
+    assert:
+      that:
+        - "'1.0.0' not in foo_version.stdout"
+        - "{{ foo_version.changed }}"
 
-- name: check that nothing has changed (Idempotant)
-  assert:
-    that:
-      - "second_upgrade_result.changed == false"
+  - name: "(upgrade type: {{upgrade_type}}) upgrade packages to latest version (Idempotant)"
+    apt:
+      upgrade: "{{ upgrade_type }}"
+      force_apt_get: "{{ force_apt_get }}"
+      force: yes
+    register: second_upgrade_result
 
-- name: remove hello
-  apt:
-    pkg: hello
-    state: absent
-    autoclean: yes
+  - name: check that nothing has changed (Idempotant)
+    assert:
+      that:
+        - "second_upgrade_result.changed == false"
+
+  always:
+    - name: Clean up
+      apt:
+        pkg: foo,foobar
+        state: absent
+        autoclean: yes
+
+    - name: Restore ubuntu repos
+      command: mv /etc/apt/sources.list.backup /etc/apt/sources.list


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This isolates `apt upgrade` tests by disabling deb repos and using just "fake" testing repo created in `setup-deb-repo`. This way upgrades do not change testing environment. It's also way faster, obviously.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt integration tests

##### ADDITIONAL INFORMATION