### PR TITLE
win_reboot: Use a less error-prone command to get uptime

### DIFF
--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -29,7 +29,7 @@ class ActionModule(RebootActionModule, ActionBase):
         'reboot_timeout', 'reboot_timeout_sec', 'shutdown_timeout', 'shutdown_timeout_sec', 'test_command',
     ))
 
-    DEFAULT_BOOT_TIME_COMMAND = "(Get-WmiObject -ClassName Win32_OperatingSystem).LastBootUpTime"
+    DEFAULT_BOOT_TIME_COMMAND = "wmic os get lastbootuptime"
     DEFAULT_CONNECT_TIMEOUT = 5
     DEFAULT_PRE_REBOOT_DELAY = 2
     DEFAULT_SHUTDOWN_COMMAND_ARGS = '/r /t %d /c "%s"'


### PR DESCRIPTION
##### SUMMARY
The powershell command used to get the system uptime can cause errors in some corner cases, due to special characters in the dot notation.
The proposed change uses a special-character-free command which should cover those corner cases too without compromising the logic


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_reboot
