### PR TITLE
Fix getheaders regression with open_url in Scaleway dynamic inventory

### DIFF
--- a/changelogs/fragments/scaleway-getheaders.yaml
+++ b/changelogs/fragments/scaleway-getheaders.yaml
@@ -1,2 +1,3 @@
 ---
-bugfixes: Fix response.getheaders regression
+bugfixes:
+- scaleway inventory plugin - Fix response.getheaders regression (https://github.com/ansible/ansible/pull/48671)

--- a/changelogs/fragments/scaleway-getheaders.yaml
+++ b/changelogs/fragments/scaleway-getheaders.yaml
@@ -1,0 +1,2 @@
+---
+bugfixes: Fix response.getheaders regression

--- a/lib/ansible/plugins/inventory/scaleway.py
+++ b/lib/ansible/plugins/inventory/scaleway.py
@@ -113,7 +113,7 @@ def _fetch_information(token, url):
         except KeyError:
             raise AnsibleError("Incorrect format from the Scaleway API response")
 
-        link = response.getheader('Link')
+        link = response.headers['Link']
         if not link:
             return results
         relations = parse_pagination_link(link)


### PR DESCRIPTION
##### SUMMARY

It seems that the response object does not have a `getheader` but it got a `headers` attribute.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- Scaleway dynamic inventory
