### PR TITLE
cs_template: fix KeyError on state=extracted

### DIFF
--- a/changelogs/fragments/48675-cs_template-fix-keyerror-state-extracted.yml
+++ b/changelogs/fragments/48675-cs_template-fix-keyerror-state-extracted.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cs_template - Fixed a KeyError on state=extracted.

--- a/lib/ansible/modules/cloud/cloudstack/cs_template.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_template.py
@@ -243,78 +243,78 @@ EXAMPLES = '''
 RETURN = '''
 ---
 id:
-  description: UUID of the template.
+  description: UUID of the template or extracted object.
   returned: success
   type: string
   sample: a6f7a5fc-43f8-11e5-a151-feff819cdc9f
 name:
-  description: Name of the template.
+  description: Name of the template or extracted object.
   returned: success
   type: string
   sample: Debian 7 64-bit
 display_text:
   description: Display text of the template.
-  returned: success
+  returned: if available
   type: string
   sample: Debian 7.7 64-bit minimal 2015-03-19
 checksum:
   description: MD5 checksum of the template.
-  returned: success
+  returned: if available
   type: string
   sample: 0b31bccccb048d20b551f70830bb7ad0
 status:
-  description: Status of the template.
+  description: Status of the template or extracted object.
   returned: success
   type: string
   sample: Download Complete
 is_ready:
   description: True if the template is ready to be deployed from.
-  returned: success
+  returned: if available
   type: boolean
   sample: true
 is_public:
   description: True if the template is public.
-  returned: success
+  returned: if available
   type: boolean
   sample: true
 is_featured:
   description: True if the template is featured.
-  returned: success
+  returned: if available
   type: boolean
   sample: true
 is_extractable:
   description: True if the template is extractable.
-  returned: success
+  returned: if available
   type: boolean
   sample: true
 format:
   description: Format of the template.
-  returned: success
+  returned: if available
   type: string
   sample: OVA
 os_type:
-  description: Typo of the OS.
-  returned: success
+  description: Type of the OS.
+  returned: if available
   type: string
   sample: CentOS 6.5 (64-bit)
 password_enabled:
   description: True if the reset password feature is enabled, false otherwise.
-  returned: success
+  returned: if available
   type: boolean
   sample: false
 sshkey_enabled:
   description: true if template is sshkey enabled, false otherwise.
-  returned: success
+  returned: if available
   type: boolean
   sample: false
 cross_zones:
   description: true if the template is managed across all zones, false otherwise.
-  returned: success
+  returned: if available
   type: boolean
   sample: false
 template_type:
   description: Type of the template.
-  returned: success
+  returned: if available
   type: string
   sample: USER
 created:
@@ -324,32 +324,32 @@ created:
   sample: 2015-03-29T14:57:06+0200
 template_tag:
   description: Template tag related to this template.
-  returned: success
+  returned: if available
   type: string
   sample: special
 hypervisor:
   description: Hypervisor related to this template.
-  returned: success
+  returned: if available
   type: string
   sample: VMware
 mode:
   description: Mode of extraction
-  returned: success
+  returned: on state=extracted
   type: string
   sample: http_download
 state:
   description: State of the extracted template
-  returned: success
+  returned: on state=extracted
   type: string
   sample: DOWNLOAD_URL_CREATED
 url:
   description: Url to which the template is extracted to
-  returned: success
+  returned: on state=extracted
   type: string
   sample: "http://1.2.3.4/userdata/eb307f13-4aca-45e8-b157-a414a14e6b04.ova"
 tags:
   description: List of resource tags associated with the template.
-  returned: success
+  returned: if available
   type: dict
   sample: '[ { "key": "foo", "value": "bar" } ]'
 zone:
@@ -664,9 +664,12 @@ class AnsibleCloudStackTemplate(AnsibleCloudStack):
     def get_result(self, template):
         super(AnsibleCloudStackTemplate, self).get_result(template)
         if template:
-            self.result['is_extractable'] = True if template['isextractable'] else False
-            self.result['is_featured'] = True if template['isfeatured'] else False
-            self.result['is_public'] = True if template['ispublic'] else False
+            if 'isextractable' in template:
+                self.result['is_extractable'] = True if template['isextractable'] else False
+            if 'isfeatured' in template:
+                self.result['is_featured'] = True if template['isfeatured'] else False
+            if 'ispublic' in template:
+                self.result['is_public'] = True if template['ispublic'] else False
         return self.result
 
 


### PR DESCRIPTION
##### SUMMARY
Reported by @onitake : 

~~~yaml
- name: extract new templates
   cs_template:
     name: mytemplate
     state: extracted
~~~

produces:
~~~
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'isextractable'
fatal: [Linux-CentOS-6-64bit-20GB]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 113, in <module>\n  File \"<stdin>\", line 105, in _ansiballz_main\n  File \"<stdin>\", line 48, in invoke_module\n  File \"/tmp/ansible_cs_template_payload_8ya2tZ/__main__.py\", line 737, in <module>\n  File \"/tmp/ansible_cs_template_payload_8ya2tZ/__main__.py\", line 731, in main\n  File \"/tmp/ansible_cs_template_payload_8ya2tZ/__main__.py\", line 667, in get_result\nKeyError: 'isextractable'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
~~~

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cs_template

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
needs backport to 2.7 but not 2.6