### PR TITLE
Correct ansible-test injector python behavior.

### DIFF
--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -248,15 +248,6 @@ def get_coverage_path(args, version, interpreter):
     shutil.copytree(src, os.path.join(coverage_path, 'coverage'))
     shutil.copy('.coveragerc', os.path.join(coverage_path, 'coverage', '.coveragerc'))
 
-    injector = os.path.join(coverage_path, 'coverage', 'injector.py')
-
-    with open(injector, 'r+') as injector_fd:
-        code = injector_fd.read()
-        code = re.sub(r'^#!.*', '#!%s' % interpreter, code, count=1)
-        injector_fd.seek(0)
-        injector_fd.write(code)
-        injector_fd.truncate()
-
     for root, dir_names, file_names in os.walk(coverage_path):
         for name in dir_names + file_names:
             os.chmod(os.path.join(root, name), stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
@@ -264,6 +255,8 @@ def get_coverage_path(args, version, interpreter):
     for directory in 'output', 'logs':
         os.mkdir(os.path.join(coverage_path, directory))
         os.chmod(os.path.join(coverage_path, directory), stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)
+
+    os.symlink(interpreter, os.path.join(coverage_path, 'coverage', 'python'))
 
     if not COVERAGE_PATHS:
         atexit.register(cleanup_coverage_dirs)


### PR DESCRIPTION
##### SUMMARY

Correct ansible-test injector python behavior.

Inject a symlink to the correct python into the copied injector directory instead of altering the shebang of the injector. This has the side-effect of also intercepting `python` for integration tests which simplifies cases where it needs to be directly invoked without collecting code coverage.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
