### PR TITLE
BOTMETA: remove hekonsek from team_scaleway

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -125,6 +125,8 @@ files:
   $modules/cloud/profitbricks/: baldwinSPC
   $modules/cloud/rackspace/:
     ignored: sivel angstwad
+  $modules/cloud/scaleway/scaleway_volume.py:
+    ignored: hekonsek
   $modules/cloud/univention/: 2-B
   $modules/cloud/vmware/:
     maintainers: $team_vmware
@@ -1144,7 +1146,7 @@ macros:
   team_rabbitmq: chrishoffman manuel-sousa hyperized
   team_redfish: jose-delarosa mraineri tomasg2012 billdodd
   team_rhn: alikins barnabycourt flossware vritant
-  team_scaleway: sieben hekonsek Spredzy abarbare anthony25 pilou-
+  team_scaleway: sieben Spredzy abarbare anthony25 pilou-
   team_tower: ghjm jlaska matburt wwitzel3 simfarm ryanpetrello rooftopcellist AlanCoding
   team_ucs: dsoper2 johnamcdonough SDBrett vallard vvb dagwieers
   team_e_spirit: MatrixCrawler getjack


### PR DESCRIPTION
##### SUMMARY

[As requested](https://github.com/ansible/ansible/pull/48671#issuecomment-438755239):
* remove `hekonsek` contributor from `team_scaleway`
* don't notify contributor anymore.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml