### PR TITLE
vmware_dvs_portgroup: use type list for vlan_id and alias vlan_ids

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -42,8 +42,10 @@ options:
     vlan_id:
         description:
             - The VLAN ID that should be configured with the portgroup, use 0 for no VLAN.
-            - 'If C(vlan_trunk) is configured to be I(true), this can be a combination of multiple ranges and numbers, example: 1-200, 205, 400-4094.'
+            - 'If C(vlan_trunk) is configured to be I(true), this can be a range, example: 1-4094.'
+            - Since version 2.8, it can be a list of multiple ranges and numbers also represented by the alias C(vlan_ids).
         required: True
+        aliases: [ vlan_ids ]
     num_ports:
         description:
             - The number of ports the portgroup should contain.
@@ -159,7 +161,10 @@ EXAMPLES = '''
     password: '{{ vcenter_password }}'
     portgroup_name: vlan-trunk-portrgoup
     switch_name: dvSwitch
-    vlan_id: 1-1000, 1005, 1100-1200
+    vlan_ids:
+        - 1-1000
+        - 1005
+        - 1100-1200
     vlan_trunk: True
     num_ports: 120
     portgroup_type: earlyBinding
@@ -258,7 +263,7 @@ class VMwareDvsPortgroup(PyVmomi):
         if self.module.params['vlan_trunk']:
             config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec()
             vlan_id_list = []
-            for vlan_id_splitted in self.module.params['vlan_id'].split(','):
+            for vlan_id_splitted in self.module.params['vlan_id']:
                 try:
                     vlan_id_start, vlan_id_end = vlan_id_splitted.split('-')
                     vlan_id_list.append(vim.NumericRange(start=int(vlan_id_start.strip()), end=int(vlan_id_end.strip())))
@@ -345,7 +350,7 @@ def main():
         dict(
             portgroup_name=dict(required=True, type='str'),
             switch_name=dict(required=True, type='str'),
-            vlan_id=dict(required=True, type='str'),
+            vlan_id=dict(required=True, type='list', aliases=['vlan_ids']),
             num_ports=dict(required=True, type='int'),
             portgroup_type=dict(required=True, choices=['earlyBinding', 'lateBinding', 'ephemeral'], type='str'),
             state=dict(required=True, choices=['present', 'absent'], type='str'),

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -43,7 +43,7 @@ options:
         description:
             - The VLAN ID that should be configured with the portgroup, use 0 for no VLAN.
             - 'If C(vlan_trunk) is configured to be I(true), this can be a range, example: 1-4094.'
-            - Since version 2.8, it can be a list of multiple ranges and numbers also represented by the alias C(vlan_ids).
+            - Since version 2.8, it can be a list of multiple ranges and numbers, also represented by the alias C(vlan_ids).
         required: True
         aliases: [ vlan_ids ]
     num_ports:

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -271,8 +271,10 @@ class VMwareDvsPortgroup(PyVmomi):
                     vlan_id_list.append(vim.NumericRange(start=int(vlan_id_splitted.strip()), end=int(vlan_id_splitted.strip())))
             config.defaultPortConfig.vlan.vlanId = vlan_id_list
         else:
+            if len(self.module.params['vlan_id']) > 1 or '-' in self.module.params['vlan_id'][0]:
+                self.module.fail_json(msg="Use vlan_trunk=true for VLAN ID ranges or multiple VLAN IDs")
             config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
-            config.defaultPortConfig.vlan.vlanId = int(self.module.params['vlan_id'])
+            config.defaultPortConfig.vlan.vlanId = int(self.module.params['vlan_id'][0])
         config.defaultPortConfig.vlan.inherited = False
         config.defaultPortConfig.securityPolicy = vim.dvs.VmwareDistributedVirtualSwitch.SecurityPolicy()
         config.defaultPortConfig.securityPolicy.allowPromiscuous = vim.BoolPolicy(value=self.module.params['network_policy']['promiscuous'])


### PR DESCRIPTION
##### SUMMARY
stumbled upon #46628, and suggest to extend it in a way to use type=list for vlan_id(s) support, but could not test. It is more "ansible" like.

/cc @Akasurde  and @MikeySmet

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_dvs_portgroup

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
