### PR TITLE
Revert "Relax ansible-test python version checking."

### DIFF
--- a/test/runner/versions.py
+++ b/test/runner/versions.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     pip = None
 
-print('.'.join(u'%s' % i for i in sys.version_info))
+print(sys.version)
 
 if pip:
     print('pip %s from %s' % (pip.__version__, os.path.dirname(pip.__file__)))


### PR DESCRIPTION
##### SUMMARY

Revert "Relax ansible-test python version checking."

This reverts commit d6cc3c41874b64e346639549fd18d8c41be0db8b.

No longer needed now that https://github.com/ansible/ansible/pull/48659 has been merged.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
