### PR TITLE
Use `state: latest` for `dpkg_selections` test.

### DIFF
--- a/test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml
+++ b/test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml
@@ -19,7 +19,9 @@
 
 - name: attempt to upgrade hello
   apt:
-    upgrade: dist
+    name: hello
+    state: latest
+  ignore_errors: yes
 
 - name: check hello version
   shell: dpkg -s hello | grep Version | awk '{print $2}'
@@ -37,7 +39,8 @@
 
 - name: upgrade hello
   apt:
-    upgrade: dist
+    name: hello
+    state: latest
 
 - name: check hello version
   shell: dpkg -s hello | grep Version | awk '{print $2}'


### PR DESCRIPTION
##### SUMMARY

Use `state: latest` for `dpkg_selections` test.

We don't need to test with `upgrade: dist`, since we're not trying to test the `apt` module. We just need to make sure the hold set by the `dpkg_selections` module is working.

This change will avoid updating all the packages on the system, which is slow, unnecessary, and can cause the installed python to be changed.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

dpkg_selections integration test
