### PR TITLE
AWS: Add support for available db types

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds_param_group.py
+++ b/lib/ansible/modules/cloud/amazon/rds_param_group.py
@@ -44,35 +44,8 @@ options:
   engine:
     description:
       - The type of database for this group. Required for state=present.
-    choices:
-        - 'aurora5.6'
-        - 'mariadb10.0'
-        - 'mariadb10.1'
-        - 'mysql5.1'
-        - 'mysql5.5'
-        - 'mysql5.6'
-        - 'mysql5.7'
-        - 'oracle-ee-11.2'
-        - 'oracle-ee-12.1'
-        - 'oracle-se-11.2'
-        - 'oracle-se-12.1'
-        - 'oracle-se1-11.2'
-        - 'oracle-se1-12.1'
-        - 'postgres9.3'
-        - 'postgres9.4'
-        - 'postgres9.5'
-        - 'postgres9.6'
-        - 'sqlserver-ee-10.5'
-        - 'sqlserver-ee-11.0'
-        - 'sqlserver-ex-10.5'
-        - 'sqlserver-ex-11.0'
-        - 'sqlserver-ex-12.0'
-        - 'sqlserver-se-10.5'
-        - 'sqlserver-se-11.0'
-        - 'sqlserver-se-12.0'
-        - 'sqlserver-web-10.5'
-        - 'sqlserver-web-11.0'
-        - 'sqlserver-web-12.0'
+      - Please use following command to get list of all supported db engines and their respective versions.
+      - '# aws rds describe-db-engine-versions --query "DBEngineVersions[].DBParameterGroupFamily"'
   immediate:
     description:
       - Whether to apply the changes immediately, or after the next reboot of any associated instances.
@@ -162,38 +135,6 @@ try:
     import botocore
 except ImportError:
     pass  # caught by imported HAS_BOTO3
-
-
-VALID_ENGINES = [
-    'aurora5.6',
-    'mariadb10.0',
-    'mariadb10.1',
-    'mysql5.1',
-    'mysql5.5',
-    'mysql5.6',
-    'mysql5.7',
-    'oracle-ee-11.2',
-    'oracle-ee-12.1',
-    'oracle-se-11.2',
-    'oracle-se-12.1',
-    'oracle-se1-11.2',
-    'oracle-se1-12.1',
-    'postgres9.3',
-    'postgres9.4',
-    'postgres9.5',
-    'postgres9.6',
-    'sqlserver-ee-10.5',
-    'sqlserver-ee-11.0',
-    'sqlserver-ex-10.5',
-    'sqlserver-ex-11.0',
-    'sqlserver-ex-12.0',
-    'sqlserver-se-10.5',
-    'sqlserver-se-11.0',
-    'sqlserver-se-12.0',
-    'sqlserver-web-10.5',
-    'sqlserver-web-11.0',
-    'sqlserver-web-12.0',
-]
 
 INT_MODIFIERS = {
     'K': 1024,

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -78,7 +78,6 @@ lib/ansible/modules/cloud/amazon/lambda_event.py E317
 lib/ansible/modules/cloud/amazon/rds.py E322
 lib/ansible/modules/cloud/amazon/rds.py E327
 lib/ansible/modules/cloud/amazon/rds_param_group.py E324
-lib/ansible/modules/cloud/amazon/rds_param_group.py E326
 lib/ansible/modules/cloud/amazon/rds_subnet_group.py E324
 lib/ansible/modules/cloud/amazon/redshift.py E322
 lib/ansible/modules/cloud/amazon/redshift.py E325


### PR DESCRIPTION
##### SUMMARY
Add several database types which are supported by AWS in valid engine type.

Fixes: #48623

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/rds_param_group.py
