### PR TITLE
Correct usage in RDS Group name in example

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds_param_group.py
+++ b/lib/ansible/modules/cloud/amazon/rds_param_group.py
@@ -103,7 +103,7 @@ EXAMPLES = '''
 # Add or change a parameter group, in this case setting auto_increment_increment to 42 * 1024
 - rds_param_group:
       state: present
-      name: norwegian_blue
+      name: norwegian-blue
       description: 'My Fancy Ex Parrot Group'
       engine: 'mysql5.6'
       params:
@@ -115,7 +115,7 @@ EXAMPLES = '''
 # Remove a parameter group
 - rds_param_group:
       state: absent
-      name: norwegian_blue
+      name: norwegian-blue
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY
RDS Group name in `describe_db_parameter_groups` does not accept
underscore in name. Replacing underscore with hypen which is allowed.

Fixes: #30127

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/rds_param_group.py

