### PR TITLE
Added track option for nxos_static_route module

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_static_route.py
+++ b/lib/ansible/modules/network/nxos/nxos_static_route.py
@@ -64,6 +64,10 @@ options:
   aggregate:
     description: List of static route definitions
     version_added: 2.5
+  track:
+    description:
+      - Track value (range 1 - 512). Track must already be configured on the device before adding the route.
+    version_added: "2.8"
   state:
     description:
       - Manage the state of the resource.
@@ -89,7 +93,7 @@ commands:
 import re
 from copy import deepcopy
 
-from ansible.module_utils.network.nxos.nxos import get_config, load_config
+from ansible.module_utils.network.nxos.nxos import get_config, load_config, run_commands
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.config import CustomNetworkConfig
@@ -100,7 +104,7 @@ def reconcile_candidate(module, candidate, prefix, w):
     netcfg = CustomNetworkConfig(indent=2, contents=get_config(module))
     state = w['state']
 
-    set_command = set_route_command(prefix, w)
+    set_command = set_route_command(prefix, w, module)
     remove_command = remove_route_command(prefix, w)
 
     parents = []
@@ -144,9 +148,31 @@ def remove_route_command(prefix, w):
     return 'no ip route {0} {1}'.format(prefix, w['next_hop'])
 
 
-def set_route_command(prefix, w):
+def get_configured_track(module, ctrack):
+    check_track = '{0}'.format(ctrack)
+    track_exists = False
+    command = 'show track'
+    try:
+        body = run_commands(module, [command])
+        match = re.findall(r'Track\s+(\d+)', body[0])
+    except IndexError:
+        return None
+    if check_track in match:
+        track_exists = True
+    return track_exists
+
+
+def set_route_command(prefix, w, module):
     route_cmd = 'ip route {0} {1}'.format(prefix, w['next_hop'])
 
+    if w['track']:
+        if w['track'] in range(1, 512):
+            if get_configured_track(module, w['track']):
+                route_cmd += ' track {0}'.format(w['track'])
+            else:
+                module.fail_json(msg='Track {0} not configured on device'.format(w['track']))
+        else:
+            module.fail_json(msg='Invalid track number, valid range is 1-512.')
     if w['route_name'] and w['route_name'] != 'default':
         route_cmd += ' name {0}'.format(w['route_name'])
     if w['tag']:
@@ -233,7 +259,8 @@ def map_params_to_obj(module):
             'tag': module.params['tag'],
             'route_name': module.params['route_name'],
             'pref': module.params['pref'],
-            'state': module.params['state']
+            'state': module.params['state'],
+            'track': module.params['track']
         })
 
     return obj
@@ -248,6 +275,7 @@ def main():
         route_name=dict(type='str'),
         pref=dict(type='str', aliases=['admin_distance']),
         state=dict(choices=['absent', 'present'], default='present'),
+        track=dict(type='int'),
     )
 
     aggregate_spec = deepcopy(element_spec)

--- a/test/integration/targets/nxos_static_route/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_static_route/tests/common/sanity.yaml
@@ -4,8 +4,14 @@
   when: ansible_connection == "local"
 
 - block:
+  - name: configure track
+    nxos_config:
+      lines:
+        - track 1 ip sla 1
+      provider: "{{ connection }}"
+
   - name: create static route
-    nxos_static_route: &configure
+    nxos_static_route: &configure_static
       prefix: "192.168.20.64/24"
       next_hop: "192.0.2.3"
       route_name: testing
@@ -20,8 +26,8 @@
       that:
         - "result.changed == true"
 
-  - name: "Conf Idempotence"
-    nxos_static_route: *configure
+  - name: "Conf static Idempotence"
+    nxos_static_route: *configure_static
     with_items: "{{ vrfs }}"
     register: result
 
@@ -30,7 +36,7 @@
         - "result.changed == false"
 
   - name: change static route
-    nxos_static_route: &configure1
+    nxos_static_route: &change_static
       prefix: "192.168.20.64/24"
       next_hop: "192.0.2.3"
       route_name: default
@@ -43,15 +49,55 @@
 
   - assert: *true
 
-  - name: "Conf1 Idempotence"
-    nxos_static_route: *configure1
+  - name: "Change Idempotence"
+    nxos_static_route: *change_static
     with_items: "{{ vrfs }}"
     register: result
 
   - assert: *false
 
+  - name: configure static route with track
+    nxos_static_route: &config_static_track
+      prefix: "192.168.20.64/24"
+      next_hop: "192.0.2.3"
+      route_name: default
+      pref: 10
+      tag: default
+      track: 1
+      vrf: "{{ item }}"
+      provider: "{{ connection }}"
+    with_items: "{{ vrfs }}"
+    register: result
+
+  - assert: *true
+
+  - name: "Config track Idempotence"
+    nxos_static_route: *config_static_track
+    with_items: "{{ vrfs }}"
+    register: result
+
+  - assert: *false
+
+  - name: configure static route with not configured track
+    nxos_static_route: &config_static_track
+      prefix: "192.168.20.64/24"
+      next_hop: "192.0.2.3"
+      route_name: default
+      pref: 10
+      tag: default
+      track: 2
+      vrf: "{{ item }}"
+      provider: "{{ connection }}"
+    with_items: "{{ vrfs }}"
+    register: result
+    ignore_errors: yes
+
+  - assert:
+      that:
+        - "result.failed == True"
+
   - name: remove static route
-    nxos_static_route: &remove
+    nxos_static_route: &remove_static
       prefix: "192.168.20.64/24"
       next_hop: "192.0.2.3"
       route_name: testing
@@ -65,7 +111,7 @@
   - assert: *true
 
   - name: "Remove Idempotence"
-    nxos_static_route: *remove
+    nxos_static_route: *remove_static
     with_items: "{{ vrfs }}"
     register: result
 
@@ -79,17 +125,13 @@
       provider: "{{ connection }}"
     register: result
 
-  - assert:
-      that:
-        - "result.changed == true"
+  - assert: *true
 
   - name: configure static route aggregate(Idempotence)
     nxos_static_route: *conf_agg
     register: result
 
-  - assert:
-      that:
-        - "result.changed == false"
+  - assert: *false
 
   - name: remove static route aggregate
     nxos_static_route: &remove_agg
@@ -100,19 +142,22 @@
       state: absent
     register: result
 
-  - assert:
-      that:
-        - "result.changed == true"
+  - assert: *true
 
   - name: remove static route aggregate(Idempotence)
     nxos_static_route: *remove_agg
     register: result
 
-  - assert:
-      that:
-        - "result.changed == false"
+  - assert: *false
 
   always:
+  - name: remove track
+    nxos_config:
+      lines:
+        - no track 1
+      provider: "{{ connection }}"
+    ignore_errors: yes
+
   - name: remove static route
     nxos_static_route:
       prefix: "192.168.20.64/24"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding track option for static routes when using nxos_static_route module
Fixes #47148

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_static_route

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This PR adds extra network parameter mentioned in #47148
Tested on 93180YC-EX running NXOS: version 7.0(3)I6(1)
Added documentation and test cases as well.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
