### PR TITLE
DC virtual interface - support DC gateway

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
+++ b/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
@@ -484,7 +484,7 @@ def main():
                                            ['public', True, ['amazon_address']],
                                            ['public', True, ['customer_address']],
                                            ['public', True, ['cidr']]],
-                              mutually_exclusive=[['virtual_gateway_id','direct_connect_gateway_id']])
+                              mutually_exclusive=[['virtual_gateway_id', 'direct_connect_gateway_id']])
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     connection = boto3_conn(module, conn_type='client', resource='directconnect', region=region, endpoint=ec2_url, **aws_connect_kwargs)

--- a/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
+++ b/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
@@ -65,6 +65,7 @@ options:
     description:
       - The direct connect gateway ID mutually exclusive with the virtual_gateway_id for creating a private virtual interface.
         We must specify either a virtual gateway ID or a direct connect gateway ID.
+    version_added: "2.5"
   virtual_interface_id:
     description:
       - The virtual interface ID.

--- a/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
+++ b/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
@@ -163,8 +163,16 @@ direct_connect_gateway_id:
   description: Direct connect gateway id
   returned: always
   type: string
+<<<<<<< HEAD
   sample: fa407c39-6fb7-4e78-92d8-f95339a3186a
 >>>>>>> DC virtual interface - support DC gateway
+=======
+direct_connect_gateway_id:
+  description: Direct connect gateway id
+  returned: always
+  type: string
+  sample: fa407c39-6fb7-4e78-92d8-f95339a3186a
+>>>>>>> 8f168cf17d7340a074ba3e067124d36ac842e6ff
 location:
   description: Where the connection is located.
   returned: always

--- a/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
+++ b/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
@@ -65,7 +65,7 @@ options:
     description:
       - The direct connect gateway ID mutually exclusive with the virtual_gateway_id for creating a private virtual interface.
         We must specify either a virtual gateway ID or a direct connect gateway ID.
-    version_added: "2.5"
+    version_added: "2.8"
   virtual_interface_id:
     description:
       - The virtual interface ID.

--- a/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
+++ b/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
@@ -65,7 +65,7 @@ options:
     description:
       - The direct connect gateway ID mutually exclusive with the virtual_gateway_id for creating a private virtual interface.
         We must specify either a virtual gateway ID or a direct connect gateway ID.
-    version_added: "2.8"
+    version_added: "2.9"
   virtual_interface_id:
     description:
       - The virtual interface ID.

--- a/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
+++ b/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
@@ -155,24 +155,12 @@ customer_address:
 customer_router_config:
   description: Information for generating the customer router configuration.
   returned: always
-<<<<<<< HEAD
   type: str
-=======
-  type: string
 direct_connect_gateway_id:
   description: Direct connect gateway id
   returned: always
-  type: string
-<<<<<<< HEAD
+  type: str
   sample: fa407c39-6fb7-4e78-92d8-f95339a3186a
->>>>>>> DC virtual interface - support DC gateway
-=======
-direct_connect_gateway_id:
-  description: Direct connect gateway id
-  returned: always
-  type: string
-  sample: fa407c39-6fb7-4e78-92d8-f95339a3186a
->>>>>>> 8f168cf17d7340a074ba3e067124d36ac842e6ff
 location:
   description: Where the connection is located.
   returned: always

--- a/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
+++ b/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
@@ -59,12 +59,14 @@ options:
       - A list of route filter prefix CIDRs with which to create the public virtual interface.
   virtual_gateway_id:
     description:
-      - The virtual gateway ID mutually exclusive with the direct_connect_gateway_id for creating a private virtual interface.
-        We must specify either a virtual gateway ID or a direct connect gateway ID.
+      - The virtual gateway ID for creating a private virtual interface.
+      - To create a private virtual interface I(virtual_gateway_id) or I(direct_connect_gateway_id) is required.
+        These options are mutually exclusive.
   direct_connect_gateway_id:
     description:
-      - The direct connect gateway ID mutually exclusive with the virtual_gateway_id for creating a private virtual interface.
-        We must specify either a virtual gateway ID or a direct connect gateway ID.
+      - The direct connect gateway ID for creating a private virtual interface.
+      - To create a private virtual interface I(virtual_gateway_id) or I(direct_connect_gateway_id) is required.
+        These options are mutually exclusive.
     version_added: "2.9"
   virtual_interface_id:
     description:


### PR DESCRIPTION
##### SUMMARY
The current module aws_direct_connect_virtual_interface does not currently support the
create of a virtual interace linking a direct connect gateway with a connection.

This commit add the ability to do it.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
aws_direct_connect_virtual_interface


This my firt contribution to ansible module so please be indulgent ;)