### PR TITLE
Changes to redfish-based parameters

### DIFF
--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -39,6 +39,7 @@ options:
     required: true
     description:
       - User for authentication with OOB controller
+    version_added: "2.8"
   password:
     required: true
     description:
@@ -47,18 +48,22 @@ options:
     required: false
     description:
       - ID of user to add/delete/modify
+    version_added: "2.8"
   new_username:
     required: false
     description:
       - name of user to add/delete/modify
+    version_added: "2.8"
   new_password:
     required: false
     description:
       - password of user to add/delete/modify
+    version_added: "2.8"
   roleid:
     required: false
     description:
       - role of user to add/delete/modify
+    version_added: "2.8"
   bootdevice:
     required: false
     description:

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -35,7 +35,7 @@ options:
     required: true
     description:
       - Base URI of OOB controller
-  user:
+  username:
     required: true
     description:
       - User for authentication with OOB controller
@@ -43,19 +43,19 @@ options:
     required: true
     description:
       - Password for authentication with OOB controller
-  userid:
+  id:
     required: false
     description:
       - ID of user to add/delete/modify
-  username:
+  new_username:
     required: false
     description:
       - name of user to add/delete/modify
-  userpswd:
+  new_password:
     required: false
     description:
       - password of user to add/delete/modify
-  userrole:
+  roleid:
     required: false
     description:
       - role of user to add/delete/modify
@@ -73,7 +73,7 @@ EXAMPLES = '''
       category: Systems
       command: PowerGracefulRestart
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 
   - name: Set one-time boot device to {{ bootdevice }}
@@ -82,7 +82,7 @@ EXAMPLES = '''
       command: SetOneTimeBoot
       bootdevice: "{{ bootdevice }}"
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 
   - name: Add and enable user
@@ -90,38 +90,38 @@ EXAMPLES = '''
       category: Accounts
       command: AddUser,EnableUser
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
-      password: "{{ password }}"
-      userid: "{{ userid }}"
       username: "{{ username }}"
-      userpswd: "{{ userpswd }}"
-      userrole: "{{ userrole }}"
+      password: "{{ password }}"
+      id: "{{ id }}"
+      new_username: "{{ new_username }}"
+      new_password: "{{ new_password }}"
+      roleid: "{{ roleid }}"
 
   - name: Disable and delete user
     redfish_command:
       category: Accounts
       command: ["DisableUser", "DeleteUser"]
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
-      userid: "{{ userid }}"
+      id: "{{ id }}"
 
   - name: Update user password
     redfish_command:
       category: Accounts
       command: UpdateUserPassword
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
-      userid: "{{ userid }}"
-      userpswd: "{{ userpswd }}"
+      id: "{{ id }}"
+      new_password: "{{ new_password }}"
 
   - name: Clear Manager Logs
     redfish_command:
       category: Manager
       command: ClearLogs
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 '''
 
@@ -156,12 +156,12 @@ def main():
             category=dict(required=True),
             command=dict(required=True, type='list'),
             baseuri=dict(required=True),
-            user=dict(required=True),
+            username=dict(required=True),
             password=dict(required=True, no_log=True),
-            userid=dict(),
-            username=dict(),
-            userpswd=dict(no_log=True),
-            userrole=dict(),
+            id=dict(),
+            new_username=dict(),
+            new_password=dict(no_log=True),
+            roleid=dict(),
             bootdevice=dict(),
         ),
         supports_check_mode=False
@@ -171,14 +171,14 @@ def main():
     command_list = module.params['command']
 
     # admin credentials used for authentication
-    creds = {'user': module.params['user'],
+    creds = {'user': module.params['username'],
              'pswd': module.params['password']}
 
     # user to add/modify/delete
-    user = {'userid': module.params['userid'],
-            'username': module.params['username'],
-            'userpswd': module.params['userpswd'],
-            'userrole': module.params['userrole']}
+    user = {'userid': module.params['id'],
+            'username': module.params['new_username'],
+            'userpswd': module.params['new_password'],
+            'userrole': module.params['roleid']}
 
     # Build root URI
     root_uri = "https://" + module.params['baseuri']

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -38,6 +38,7 @@ options:
     required: true
     description:
       - User for authentication with OOB controller
+    version_added: "2.8"
   password:
     required: true
     description:
@@ -47,21 +48,25 @@ options:
     description:
       - name of BIOS attribute to update
     default: 'null'
+    version_added: "2.8"
   bios_attribute_value:
     required: false
     description:
       - value of BIOS attribute to update
     default: 'null'
+    version_added: "2.8"
   manager_attribute_name:
     required: false
     description:
       - name of Manager attribute to update
     default: 'null'
+    version_added: "2.8"
   manager_attribute_value:
     required: false
     description:
       - value of Manager attribute to update
     default: 'null'
+    version_added: "2.8"
 
 author: "Jose Delarosa (github: jose-delarosa)"
 '''

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -34,7 +34,7 @@ options:
     required: true
     description:
       - Base URI of OOB controller
-  user:
+  username:
     required: true
     description:
       - User for authentication with OOB controller
@@ -42,22 +42,22 @@ options:
     required: true
     description:
       - Password for authentication with OOB controller
-  bios_attr_name:
+  bios_attribute_name:
     required: false
     description:
       - name of BIOS attribute to update
     default: 'null'
-  bios_attr_value:
+  bios_attribute_value:
     required: false
     description:
       - value of BIOS attribute to update
     default: 'null'
-  mgr_attr_name:
+  manager_attribute_name:
     required: false
     description:
       - name of Manager attribute to update
     default: 'null'
-  mgr_attr_value:
+  manager_attribute_value:
     required: false
     description:
       - value of Manager attribute to update
@@ -71,30 +71,30 @@ EXAMPLES = '''
     redfish_config:
       category: Systems
       command: SetBiosAttributes
-      bios_attr_name: BootMode
-      bios_attr_value: Uefi
+      bios_attribute_name: BootMode
+      bios_attribute_value: Uefi
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 
   - name: Set BootMode to Legacy BIOS
     redfish_config:
       category: Systems
       command: SetBiosAttributes
-      bios_attr_name: BootMode
-      bios_attr_value: Bios
+      bios_attribute_name: BootMode
+      bios_attribute_value: Bios
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 
   - name: Enable PXE Boot for NIC1
     redfish_config:
       category: Systems
       command: SetBiosAttributes
-      bios_attr_name: PxeDev1EnDis
-      bios_attr_value: Enabled
+      bios_attribute_name: PxeDev1EnDis
+      bios_attribute_value: Enabled
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 
   - name: Set BIOS default settings
@@ -102,37 +102,37 @@ EXAMPLES = '''
       category: Systems
       command: SetBiosDefaultSettings
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 
   - name: Enable NTP in the OOB Controller
     redfish_config:
       category: Manager
       command: SetManagerAttributes
-      mgr_attr_name: NTPConfigGroup.1.NTPEnable
-      mgr_attr_value: Enabled
+      manager_attribute_name: NTPConfigGroup.1.NTPEnable
+      manager_attribute_value: Enabled
       baseuri: "{{ baseuri }}"
-      user: "{{ user}}"
+      username: "{{ username}}"
       password: "{{ password }}"
 
   - name: Set NTP server 1 to {{ ntpserver1 }} in the OOB Controller
     redfish_config:
       category: Manager
       command: SetManagerAttributes
-      mgr_attr_name: NTPConfigGroup.1.NTP1
-      mgr_attr_value: "{{ ntpserver1 }}"
+      manager_attribute_name: NTPConfigGroup.1.NTP1
+      manager_attribute_value: "{{ ntpserver1 }}"
       baseuri: "{{ baseuri }}"
-      user: "{{ user}}"
+      username: "{{ username}}"
       password: "{{ password }}"
 
   - name: Set Timezone to {{ timezone }} in the OOB Controller
     redfish_config:
       category: Manager
       command: SetManagerAttributes
-      mgr_attr_name: Time.1.Timezone
-      mgr_attr_value: "{{ timezone }}"
+      manager_attribute_name: Time.1.Timezone
+      manager_attribute_value: "{{ timezone }}"
       baseuri: "{{ baseuri }}"
-      user: "{{ user}}"
+      username: "{{ username}}"
       password: "{{ password }}"
 '''
 
@@ -163,12 +163,12 @@ def main():
             category=dict(required=True),
             command=dict(required=True, type='list'),
             baseuri=dict(required=True),
-            user=dict(required=True),
+            username=dict(required=True),
             password=dict(required=True, no_log=True),
-            mgr_attr_name=dict(default='null'),
-            mgr_attr_value=dict(default='null'),
-            bios_attr_name=dict(default='null'),
-            bios_attr_value=dict(default='null'),
+            manager_attribute_name=dict(default='null'),
+            manager_attribute_value=dict(default='null'),
+            bios_attribute_name=dict(default='null'),
+            bios_attribute_value=dict(default='null'),
         ),
         supports_check_mode=False
     )
@@ -177,15 +177,15 @@ def main():
     command_list = module.params['command']
 
     # admin credentials used for authentication
-    creds = {'user': module.params['user'],
+    creds = {'username': module.params['username'],
              'pswd': module.params['password']}
 
     # Manager attributes to update
-    mgr_attributes = {'mgr_attr_name': module.params['mgr_attr_name'],
-                      'mgr_attr_value': module.params['mgr_attr_value']}
+    mgr_attributes = {'mgr_attr_name': module.params['manager_attribute_name'],
+                      'mgr_attr_value': module.params['manager_attribute_value']}
     # BIOS attributes to update
-    bios_attributes = {'bios_attr_name': module.params['bios_attr_name'],
-                       'bios_attr_value': module.params['bios_attr_value']}
+    bios_attributes = {'bios_attr_name': module.params['bios_attribute_name'],
+                       'bios_attr_value': module.params['bios_attribute_value']}
 
     # Build root URI
     root_uri = "https://" + module.params['baseuri']

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -182,7 +182,7 @@ def main():
     command_list = module.params['command']
 
     # admin credentials used for authentication
-    creds = {'username': module.params['username'],
+    creds = {'user': module.params['username'],
              'pswd': module.params['password']}
 
     # Manager attributes to update

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -34,7 +34,7 @@ options:
     required: true
     description:
       - Base URI of OOB controller
-  user:
+  username:
     required: true
     description:
       - User for authentication with OOB controller
@@ -52,7 +52,7 @@ EXAMPLES = '''
       category: Systems
       command: GetCpuInventory
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 
   - name: Get fan inventory
@@ -60,13 +60,13 @@ EXAMPLES = '''
       category: Chassis
       command: GetFanInventory
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 
   - name: Get default inventory information
     redfish_facts:
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 
   - name: Get several inventories
@@ -74,21 +74,21 @@ EXAMPLES = '''
       category: Systems
       command: GetNicInventory,GetPsuInventory,GetBiosAttributes
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 
   - name: Get default system inventory and user information
     redfish_facts:
       category: Systems,Accounts
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 
   - name: Get default system, user and firmware information
     redfish_facts:
       category: ["Systems", "Accounts", "Update"]
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 
   - name: Get all information available in the Manager category
@@ -96,7 +96,7 @@ EXAMPLES = '''
       category: Manager
       command: all
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 
   - name: Get all information available in all categories
@@ -104,7 +104,7 @@ EXAMPLES = '''
       category: all
       command: all
       baseuri: "{{ baseuri }}"
-      user: "{{ user }}"
+      username: "{{ username }}"
       password: "{{ password }}"
 '''
 
@@ -147,14 +147,14 @@ def main():
             category=dict(type='list', default=['Systems']),
             command=dict(type='list'),
             baseuri=dict(required=True),
-            user=dict(required=True),
+            username=dict(required=True),
             password=dict(required=True, no_log=True),
         ),
         supports_check_mode=False
     )
 
     # admin credentials used for authentication
-    creds = {'user': module.params['user'],
+    creds = {'user': module.params['username'],
              'pswd': module.params['password']}
 
     # Build root URI

--- a/lib/ansible/modules/remote_management/redfish/redfish_facts.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_facts.py
@@ -38,6 +38,7 @@ options:
     required: true
     description:
       - User for authentication with OOB controller
+    version_added: "2.8"
   password:
     required: true
     description:


### PR DESCRIPTION
Corrected redfish parameters to their Schematic counterparts

##### SUMMARY
Changes all playbook related variables to counterparts related to their Redfish terminology as best as possible, in order to maintain a similar vocabulary between the playbooks and Redfish.  In the event of conflicting terms, prefix with appropriate information.

user -> username
userid -> id
username -> new_username
password -> new_password
userrole -> roleid
bios_attr_name -> bios_attribute_name
mgr_attr_name -> manager_attribute_name
bios_attr_name -> bios_attribute_name
mgr_attr_name -> manager_attribute_name

Fixes #46549

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/remote_management/redfish

##### ADDITIONAL INFORMATION
No changed behavior.