### PR TITLE
Sysvinit - Enabling a service should use "defaults" if no runlevels are specified

### DIFF
--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -267,7 +267,7 @@ def main():
             # Perform enable/disable here
             if enabled:
                 if location.get('update-rc.d'):
-                    (rc, out, err) = module.run_command("%s %s enable" % (location['update-rc.d'], name))
+                    (rc, out, err) = module.run_command("%s %s defaults" % (location['update-rc.d'], name))
                 elif location.get('chkconfig'):
                     (rc, out, err) = module.run_command("%s %s on" % (location['chkconfig'], name))
             else:


### PR DESCRIPTION
##### SUMMARY
Starting from ansible 2.5, the new `sysvinit` module is used under the hood by the good old `service` module when necessary.
Unfortunately, both don't handle `enabled` status the same way if no runlevels are specified.

In `service`, `/usr/sbin/update-rc.d [service] defaults` is used (see: https://github.com/ansible/ansible/blob/617372f8c0103c0f508f640bbb2f9f4a1fc85957/lib/ansible/modules/system/service.py#L815)
In `sysvinit`, `/usr/sbin/update-rc.d [service] enable` is used (see: https://github.com/ansible/ansible/blob/617372f8c0103c0f508f640bbb2f9f4a1fc85957/lib/ansible/modules/system/sysvinit.py#L270)

The `sysvinit` documentation is pretty clear about runlevels:
> Use this to override the *defaults set by the package or init script itself*.

According to the update-rc.d documentation, "defaults" is 
> using "runlevel and dependency information from the init.d script LSB comment header

See: http://manpages.ubuntu.com/manpages/xenial/man8/update-rc.d.8.html#installing%20init%20script%20links

According to my recent playbook failures and my related tests, this is true :)

Btw, update-rc.d enable command ha no real interests without runlevels defined, always complaining on stderr that "error: no runlevel symlinks to modify, aborting!"

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sysvinit
