### PR TITLE
sysctl module with spaces around = - see #48727

### DIFF
--- a/changelogs/fragments/48729-sysctl-module-with-spaces-around-equal-sign.yaml
+++ b/changelogs/fragments/48729-sysctl-module-with-spaces-around-equal-sign.yaml
@@ -1,2 +1,2 @@
 minor_changes: 
-  - Sysctl keys are written with a space before and after the '=' sign per default. This can be prevented by using 'no_extra_spaces: yes'  
+- "Sysctl keys are written with a space before and after the '=' sign per default. This can be prevented by using 'no_extra_spaces: yes'"

--- a/changelogs/fragments/48729-sysctl-module-with-spaces-around-equal-sign.yaml
+++ b/changelogs/fragments/48729-sysctl-module-with-spaces-around-equal-sign.yaml
@@ -1,0 +1,2 @@
+minor_changes: 
+  - Sysctl keys are written with a space before and after the '=' sign per default. This can be prevented by using 'no_extra_spaces: yes'  

--- a/changelogs/fragments/48729-sysctl-module-with-spaces-around-equal-sign.yaml
+++ b/changelogs/fragments/48729-sysctl-module-with-spaces-around-equal-sign.yaml
@@ -1,2 +1,2 @@
 minor_changes: 
-- "Sysctl keys are written with a space before and after the '=' sign per default. This can be prevented by using 'no_extra_spaces: yes'"
+- "Sysctl keys are written with a space before and after the '=' symbol per default. This can be prevented by using 'space_wrap_assignment_operator: no'"

--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -328,14 +328,14 @@ class SysctlModule(object):
                 checked.append(k)
                 if k == self.args['name']:
                     if self.args['state'] == "present":
-                        new_line = "%s=%s\n" % (k, self.args['value'])
+                        new_line = "%s = %s\n" % (k, self.args['value'])
                         self.fixed_lines.append(new_line)
                 else:
-                    new_line = "%s=%s\n" % (k, v)
+                    new_line = "%s = %s\n" % (k, v)
                     self.fixed_lines.append(new_line)
 
         if self.args['name'] not in checked and self.args['state'] == "present":
-            new_line = "%s=%s\n" % (self.args['name'], self.args['value'])
+            new_line = "%s = %s\n" % (self.args['name'], self.args['value'])
             self.fixed_lines.append(new_line)
 
     # Completely rewrite the sysctl file

--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -41,6 +41,7 @@ options:
            - Do not insert spaces before and after '=' symbol
         type: bool
         default: 'no'
+        version_added: 2.8
     ignoreerrors:
         description:
             - Use this option to ignore errors about unknown keys.

--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -36,11 +36,11 @@ options:
             - Whether the entry should be present or absent in the sysctl file.
         choices: [ "present", "absent" ]
         default: present
-    no_extra_spaces:
+    space_wrap_assignment_operator:
         description:
-           - Do not insert spaces before and after '=' symbol
+           - Whether the '=' symbol should be wrapped in spaces or not. 
         type: bool
-        default: 'no'
+        default: 'yes'
         version_added: 2.8
     ignoreerrors:
         description:
@@ -105,7 +105,7 @@ EXAMPLES = '''
 - sysctl:
     name: vm.overcommit_memory
     value: 1
-    no_extra_spaces: yes
+    space_wrap_assignment_operator: no
     sysctl_file: /etc/sysctl.conf
 '''
 
@@ -329,7 +329,7 @@ class SysctlModule(object):
     def fix_lines(self):
         checked = []
         self.fixed_lines = []
-        if self.args['no_extra_spaces']:
+        if self.args['space_wrap_assignment_operator']:
             key_value_separator = "="
         else:
             key_value_separator = " = "
@@ -384,7 +384,7 @@ def main():
             name=dict(aliases=['key'], required=True),
             value=dict(aliases=['val'], required=False, type='str'),
             state=dict(default='present', choices=['present', 'absent']),
-            no_extra_spaces=dict(default=False, type='bool'),
+            space_wrap_assignment_operator=dict(default=True, type='bool'),
             reload=dict(default=True, type='bool'),
             sysctl_set=dict(default=False, type='bool'),
             ignoreerrors=dict(default=False, type='bool'),

--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -330,9 +330,9 @@ class SysctlModule(object):
         checked = []
         self.fixed_lines = []
         if self.args['space_wrap_assignment_operator']:
-            key_value_separator = "="
-        else:
             key_value_separator = " = "
+        else:
+            key_value_separator = "="
 
         for line in self.file_lines:
             if not line.strip() or line.strip().startswith(("#", ";")) or "=" not in line:

--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -38,7 +38,7 @@ options:
         default: present
     space_wrap_assignment_operator:
         description:
-           - Whether the '=' symbol should be wrapped in spaces or not. 
+           - Whether the '=' symbol should be wrapped in spaces or not.
         type: bool
         default: 'yes'
         version_added: 2.8

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -73,7 +73,7 @@
       that:
         - sysctl_test0 is changed
         - sysctl_test1 is not changed
-        - 'sysctl_content0.stdout_lines[sysctl_content0.stdout_lines.index("vm.swappiness=5")] == "vm.swappiness=5"'
+        - 'sysctl_content0.stdout_lines[sysctl_content0.stdout_lines.index("vm.swappiness = 5")] == "vm.swappiness = 5"'
 
 - name: Remove kernel.panic
   sysctl:

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -75,6 +75,30 @@
       - sysctl_test1 is not changed
       - 'sysctl_content0.stdout_lines[sysctl_content0.stdout_lines.index("vm.swappiness = 5")] == "vm.swappiness = 5"'
 
+- name: set vm.swappiness to 10 (without extra spaces) 
+  sysctl:
+    name: vm.swappiness
+    value: 10
+    state: present
+    no_extra_spaces: true 
+    reload: no
+    sysctl_file: "{{ output_dir_test }}/sysctl.conf"
+  register: sysctl_test2
+
+- name: get file content (without extra spaces)
+  shell: "cat {{ output_dir_test }}/sysctl.conf | egrep -v ^\\#"
+  register: sysctl_content2
+
+- debug:
+    var: sysctl_content2
+    verbosity: 1
+
+- name: validate result without extra spaces 
+  assert: 
+    that: 
+      - sysctl_test2 is changed 
+      - 'sysctl_content2.stdout_lines[sysctl_content2.stdout_lines.index("vm.swappiness=10")] == "vm.swappiness=10"'
+
 - name: Remove kernel.panic
   sysctl:
     name: kernel.panic
@@ -82,24 +106,24 @@
     reload: no
     state: absent
     sysctl_file: "{{ output_dir_test }}/sysctl.conf"
-  register: sysctl_test2
+  register: sysctl_test3
 
 - name: get file content
   shell: "cat {{ output_dir_test }}/sysctl.conf | egrep -v ^\\#"
-  register: sysctl_content2
+  register: sysctl_content3
 
 - debug:
     var: item
     verbosity: 1
   with_items:
-    - "{{ sysctl_test2 }}"
-    - "{{ sysctl_content2 }}"
+    - "{{ sysctl_test3 }}"
+    - "{{ sysctl_content3 }}"
 
 - name: Validate results for key removal
   assert:
     that:
       - sysctl_test2 is changed
-      - "'kernel.panic' not in sysctl_content2.stdout_lines"
+      - "'kernel.panic' not in sysctl_content3.stdout_lines"
 
 - name: Test remove kernel.panic again
   sysctl:
@@ -108,12 +132,12 @@
     state: absent
     reload: no
     sysctl_file: "{{ output_dir_test }}/sysctl.conf"
-  register: sysctl_test2_change_test
+  register: sysctl_test3_change_test
 
 - name: Assert that no change was made
   assert:
     that:
-      - sysctl_test2_change_test is not changed
+      - sysctl_test3_change_test is not changed
 
 ##
 ## sysctl - sysctl_set
@@ -125,24 +149,24 @@
     value: 1
     sysctl_set: yes
     reload: no
-  register: sysctl_test3
+  register: sysctl_test4
 
 - name: check with sysctl command
   shell: sysctl net.ipv4.ip_forward
-  register: sysctl_check3
+  register: sysctl_check4
 
 - debug:
     var: item
     verbosity: 1
   with_items:
-    - "{{ sysctl_test3 }}"
-    - "{{ sysctl_check3 }}"
+    - "{{ sysctl_test4 }}"
+    - "{{ sysctl_check4 }}"
 
-- name: validate results for test 3
+- name: validate results for test 4
   assert:
     that:
-      - sysctl_test3 is changed
-      - 'sysctl_check3.stdout_lines == ["net.ipv4.ip_forward = 1"]'
+      - sysctl_test4 is changed
+      - 'sysctl_check4.stdout_lines == ["net.ipv4.ip_forward = 1"]'
 
 - name: Try sysctl with no name
   sysctl:

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -61,19 +61,19 @@
 
 - name: Set vm.swappiness to 5 again
   sysctl:
-      name: vm.swappiness
-      value: 5
-      state: present
-      reload: no
-      sysctl_file: "{{ output_dir_test }}/sysctl.conf"
+    name: vm.swappiness
+    value: 5
+    state: present
+    reload: no
+    sysctl_file: "{{ output_dir_test }}/sysctl.conf"
   register: sysctl_test1
 
 - name: validate results
   assert:
-      that:
-        - sysctl_test0 is changed
-        - sysctl_test1 is not changed
-        - 'sysctl_content0.stdout_lines[sysctl_content0.stdout_lines.index("vm.swappiness = 5")] == "vm.swappiness = 5"'
+    that:
+      - sysctl_test0 is changed
+      - sysctl_test1 is not changed
+      - 'sysctl_content0.stdout_lines[sysctl_content0.stdout_lines.index("vm.swappiness = 5")] == "vm.swappiness = 5"'
 
 - name: Remove kernel.panic
   sysctl:

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -75,17 +75,17 @@
       - sysctl_test1 is not changed
       - 'sysctl_content0.stdout_lines[sysctl_content0.stdout_lines.index("vm.swappiness = 5")] == "vm.swappiness = 5"'
 
-- name: set vm.swappiness to 10 (without extra spaces) 
+- name: set vm.swappiness to 10 (without space wrapped '=' symbol) 
   sysctl:
     name: vm.swappiness
     value: 10
     state: present
-    no_extra_spaces: true 
+    space_wrap_assignment_operator: no
     reload: no
     sysctl_file: "{{ output_dir_test }}/sysctl.conf"
   register: sysctl_test2
 
-- name: get file content (without extra spaces)
+- name: get file content (without space wrapped '=' symbol)
   shell: "cat {{ output_dir_test }}/sysctl.conf | egrep -v ^\\#"
   register: sysctl_content2
 
@@ -93,7 +93,7 @@
     var: sysctl_content2
     verbosity: 1
 
-- name: validate result without extra spaces 
+- name: validate result without space wrapped '=' symbol
   assert: 
     that: 
       - sysctl_test2 is changed 


### PR DESCRIPTION
##### SUMMARY
Fixes #48727 and writes configuration files with spaces around the `=` to be compatible to security scanners and use the default style shipped with Linux. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
sysctl

##### ADDITIONAL INFORMATION
Before: 
```
net.ipv4.conf.all.accept_redirects=0
net.ipv4.conf.default.accept_redirects=0
net.ipv6.conf.all.accept_redirects=0
net.ipv6.conf.default.accept_redirects=0
```
After: 
```
net.ipv4.conf.all.accept_redirects = 0
net.ipv4.conf.default.accept_redirects = 0
net.ipv6.conf.all.accept_redirects = 0
net.ipv6.conf.default.accept_redirects = 0
```
