### PR TITLE
Fixed support for user macros with context and added missing validate_cer…

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -77,8 +77,8 @@ try:
     # Extend the ZabbixAPI
     # Since the zabbix-api python module too old (version 1.0, no higher version so far).
     class ZabbixAPIExtends(ZabbixAPI):
-        def __init__(self, server, timeout, user, passwd, **kwargs):
-            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd)
+        def __init__(self, server, timeout, user, passwd, validate_certs, **kwargs):
+            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd, validate_certs=validate_certs)
 
     HAS_ZABBIX_API = True
 except ImportError:
@@ -121,7 +121,7 @@ class HostMacro(object):
             if self._module.check_mode:
                 self._module.exit_json(changed=True)
             self._zapi.usermacro.create({'hostid': host_id, 'macro': '{$' + macro_name + '}', 'value': macro_value})
-            self._module.exit_json(changed=True, result="Successfully added host macro %s " % macro_name)
+            self._module.exit_json(changed=True, result="Successfully added host macro %s" % macro_name)
         except Exception as e:
             self._module.fail_json(msg="Failed to create host macro %s: %s" % (macro_name, e))
 
@@ -134,9 +134,9 @@ class HostMacro(object):
             if self._module.check_mode:
                 self._module.exit_json(changed=True)
             self._zapi.usermacro.update({'hostmacroid': host_macro_id, 'value': macro_value})
-            self._module.exit_json(changed=True, result="Successfully updated host macro %s " % macro_name)
+            self._module.exit_json(changed=True, result="Successfully updated host macro %s" % macro_name)
         except Exception as e:
-            self._module.fail_json(msg="Failed to updated host macro %s: %s" % (macro_name, e))
+            self._module.fail_json(msg="Failed to update host macro %s: %s" % (macro_name, e))
 
     # delete host macro
     def delete_host_macro(self, host_macro_obj, macro_name):
@@ -145,7 +145,7 @@ class HostMacro(object):
             if self._module.check_mode:
                 self._module.exit_json(changed=True)
             self._zapi.usermacro.delete([host_macro_id])
-            self._module.exit_json(changed=True, result="Successfully deleted host macro %s " % macro_name)
+            self._module.exit_json(changed=True, result="Successfully deleted host macro %s" % macro_name)
         except Exception as e:
             self._module.fail_json(msg="Failed to delete host macro %s: %s" % (macro_name, e))
 
@@ -179,11 +179,16 @@ def main():
     http_login_password = module.params['http_login_password']
     validate_certs = module.params['validate_certs']
     host_name = module.params['host_name']
-    macro_name = (module.params['macro_name']).upper()
+    macro_name = (module.params['macro_name'])
     macro_value = module.params['macro_value']
     state = module.params['state']
     timeout = module.params['timeout']
     force = module.params['force']
+
+    if ':' in macro_name:
+        macro_name = ':'.join([macro_name.split(':')[0].upper(), macro_name.split(':')[1]])
+    else:
+        macro_name = macro_name.upper()
 
     zbx = None
     # login to zabbix


### PR DESCRIPTION
…ts attribute

##### SUMMARY
Fixes #46953 #47611

* due to module converting whole `macro_name` to upper space characters, user macros with context  ended up being created wrong (e.g. `LOW_SPACE_LIMIT:/home` was converted to `LOW_SPACE_LIMIT:/HOME`). Credits to @HampusLundqvist for proposed changes

* module didn't properly implement `validate_certs` option, attribute was never passed to ZabbixAPI object, thus not allowing SSL connections to be made with untrusted certificates. Credits to @tifennlegoff

* some minor grammar fixes

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_hostmacro.py

##### ADDITIONAL INFORMATION
User macros in zabbix are using same syntax as [trigger expressions](https://www.zabbix.com/documentation/3.0/manual/config/triggers/expression), thus it is fairly safe to assume that there will be just one colon present in the expression when using `.split()`.

Tested against all LTS releases of zabbix-server (2.2, 3.0, 4.0).