### PR TITLE
docker_* tests: use force_kill instead of stop_timeout to make tests run faster

### DIFF
--- a/test/integration/targets/docker_container/tasks/main.yml
+++ b/test/integration/targets/docker_container/tasks/main.yml
@@ -20,7 +20,7 @@
     docker_container:
       name: "{{ item }}"
       state: absent
-      stop_timeout: 1
+      force_kill: yes
     with_items: "{{ cnames }}"
   - name: "Make sure all networks are removed"
     docker_network:

--- a/test/integration/targets/docker_container/tasks/tests/comparisons.yml
+++ b/test/integration/targets/docker_container/tasks/tests/comparisons.yml
@@ -26,6 +26,7 @@
     name: "{{ cname }}"
     state: started
     hostname: example.org
+    force_kill: yes
     comparisons:
       hostname: ignore
   register: value_2
@@ -37,7 +38,7 @@
     name: "{{ cname }}"
     state: started
     hostname: example.org
-    stop_timeout: 1
+    force_kill: yes
     comparisons:
       hostname: strict
   register: value_3
@@ -46,7 +47,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -77,6 +78,7 @@
     state: started
     dns_servers:
     - 9.9.9.9
+    force_kill: yes
     comparisons:
       dns_servers: ignore
   register: list_2
@@ -89,16 +91,16 @@
     state: started
     dns_servers:
     - 9.9.9.9
+    force_kill: yes
     comparisons:
       dns_servers: strict
-    stop_timeout: 1
   register: list_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -131,6 +133,7 @@
     - 1010
     - 1011
     - 1012
+    force_kill: yes
     comparisons:
       groups: ignore
   register: set_2
@@ -145,9 +148,9 @@
     - 1010
     - 1011
     - 1012
+    force_kill: yes
     comparisons:
       groups: allow_more_present
-    stop_timeout: 1
   register: set_3
 
 - name: set (change, allow_more_present)
@@ -159,9 +162,9 @@
     groups:
     - 1010
     - 1012
+    force_kill: yes
     comparisons:
       groups: allow_more_present
-    stop_timeout: 1
   register: set_4
 
 - name: set (change, strict)
@@ -173,16 +176,16 @@
     groups:
     - 1010
     - 1012
+    force_kill: yes
     comparisons:
       groups: strict
-    stop_timeout: 1
   register: set_5
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -217,6 +220,7 @@
     - "/dev/random:/dev/virt-random:rwm"
     - "/dev/urandom:/dev/virt-urandom:rwm"
     - "/dev/null:/dev/virt-null:rwm"
+    force_kill: yes
     comparisons:
       devices: ignore
   register: set_dict_2
@@ -231,9 +235,9 @@
     - "/dev/random:/dev/virt-random:rwm"
     - "/dev/urandom:/dev/virt-urandom:rwm"
     - "/dev/null:/dev/virt-null:rwm"
+    force_kill: yes
     comparisons:
       devices: allow_more_present
-    stop_timeout: 1
   register: set_dict_3
 
 - name: set(dict) (change, allow_more_present)
@@ -245,9 +249,9 @@
     devices:
     - "/dev/random:/dev/virt-random:rwm"
     - "/dev/null:/dev/virt-null:rwm"
+    force_kill: yes
     comparisons:
       devices: allow_more_present
-    stop_timeout: 1
   register: set_dict_4
 
 - name: set(dict) (change, strict)
@@ -259,16 +263,16 @@
     devices:
     - "/dev/random:/dev/virt-random:rwm"
     - "/dev/null:/dev/virt-null:rwm"
+    force_kill: yes
     comparisons:
       devices: strict
-    stop_timeout: 1
   register: set_dict_5
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -303,6 +307,7 @@
       ansible.test.1: hello
       ansible.test.2: world
       ansible.test.3: ansible
+    force_kill: yes
     comparisons:
       labels: ignore
   register: dict_2
@@ -317,9 +322,9 @@
       ansible.test.1: hello
       ansible.test.2: world
       ansible.test.3: ansible
+    force_kill: yes
     comparisons:
       labels: allow_more_present
-    stop_timeout: 1
   register: dict_3
 
 - name: dict (change, allow_more_present)
@@ -331,9 +336,9 @@
     labels:
       ansible.test.1: hello
       ansible.test.3: ansible
+    force_kill: yes
     comparisons:
       labels: allow_more_present
-    stop_timeout: 1
   register: dict_4
 
 - name: dict (change, strict)
@@ -345,16 +350,16 @@
     labels:
       ansible.test.1: hello
       ansible.test.3: ansible
+    force_kill: yes
     comparisons:
       labels: strict
-    stop_timeout: 1
   register: dict_5
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -399,6 +404,7 @@
     labels:
       ansible.test.1: hello
       ansible.test.4: ignore
+    force_kill: yes
     comparisons:
       '*': ignore
   register: wildcard_2
@@ -415,6 +421,7 @@
       ansible.test.1: hello
       ansible.test.2: world
       ansible.test.3: ansible
+    force_kill: yes
     comparisons:
       '*': strict
   register: wildcard_3
@@ -431,6 +438,7 @@
       ansible.test.1: hello
       ansible.test.2: world
       ansible.test.3: ansible
+    force_kill: yes
     comparisons:
       '*': strict
   register: wildcard_4
@@ -439,7 +447,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:

--- a/test/integration/targets/docker_container/tasks/tests/image-ids.yml
+++ b/test/integration/targets/docker_container/tasks/tests/image-ids.yml
@@ -34,6 +34,7 @@
     image: "{{ image_facts.images[0].Id }}"
     name: "{{ cname }}"
     state: present
+    force_kill: yes
   register: create_1
 
 - name: Create container with hello-world image via ID (idempotent)
@@ -41,6 +42,7 @@
     image: "{{ image_facts.images[0].Id }}"
     name: "{{ cname }}"
     state: present
+    force_kill: yes
   register: create_2
 
 - name: Create container with alpine image via ID
@@ -48,6 +50,7 @@
     image: "{{ image_facts.images[1].Id }}"
     name: "{{ cname }}"
     state: present
+    force_kill: yes
   register: create_3
 
 - name: Create container with alpine image via ID (idempotent)
@@ -55,13 +58,14 @@
     image: "{{ image_facts.images[1].Id }}"
     name: "{{ cname }}"
     state: present
+    force_kill: yes
   register: create_4
 
 - name: Cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -88,14 +88,14 @@
     name: "{{ cname }}"
     state: started
     blkio_weight: 234
-    stop_timeout: 1
+    force_kill: yes
   register: blkio_weight_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -152,14 +152,14 @@
     - setgid
     cap_drop:
     - all
-    stop_timeout: 1
+    force_kill: yes
   register: capabilities_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -194,14 +194,14 @@
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: command_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -238,14 +238,14 @@
     name: "{{ cname }}"
     cpu_period: 50000
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: cpu_period_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -282,14 +282,14 @@
     name: "{{ cname }}"
     cpu_quota: 50000
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: cpu_quota_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -326,14 +326,14 @@
     name: "{{ cname }}"
     cpu_shares: 1100
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: cpu_shares_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -370,7 +370,7 @@
     name: "{{ cname }}"
     cpuset_cpus: 1
     state: started
-    stop_timeout: 1
+    force_kill: yes
   # This will fail if the system the test is run on doesn't have
   # multiple CPUs/cores available.
   ignore_errors: yes
@@ -380,7 +380,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -417,7 +417,7 @@
     name: "{{ cname }}"
     cpuset_mems: 1
     state: started
-    stop_timeout: 1
+    force_kill: yes
   # This will fail if the system the test is run on doesn't have
   # multiple MEMs available.
   ignore_errors: yes
@@ -427,7 +427,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -460,7 +460,7 @@
     image: alpine:3.8
     name: "{{ cname }}"
     state: stopped
-    stop_timeout: 1
+    force_kill: yes
     debug: yes
   register: debug_3
 
@@ -469,7 +469,7 @@
     name: "{{ cname }}"
     state: absent
     debug: yes
-    stop_timeout: 1
+    force_kill: yes
   register: debug_4
 
 - assert:
@@ -589,14 +589,14 @@
     devices:
     - "/dev/random:/dev/virt-random:rwm"
     - "/dev/null:/dev/virt-null:rwm"
-    stop_timeout: 1
+    force_kill: yes
   register: devices_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -660,7 +660,7 @@
         rate: 10M
       - path: /dev/urandom
         rate: 5K
-    stop_timeout: 1
+    force_kill: yes
   register: device_read_bps_4
   ignore_errors: yes
 
@@ -668,7 +668,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -738,7 +738,7 @@
         rate: 30
       - path: /dev/urandom
         rate: 50
-    stop_timeout: 1
+    force_kill: yes
   register: device_read_iops_4
   ignore_errors: yes
 
@@ -746,7 +746,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -807,7 +807,7 @@
     device_write_iops:
       - path: /dev/urandom
         rate: 100
-    stop_timeout: 1
+    force_kill: yes
   register: device_write_limit_3
   ignore_errors: yes
 
@@ -815,7 +815,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -877,7 +877,7 @@
     dns_opts:
     - "timeout:10"
     - no-check-names
-    stop_timeout: 1
+    force_kill: yes
   register: dns_opts_4
   ignore_errors: yes
 
@@ -885,7 +885,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -946,14 +946,14 @@
     dns_search_domains:
     - ansible.com
     - example.com
-    stop_timeout: 1
+    force_kill: yes
   register: dns_search_domains_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1008,14 +1008,14 @@
     dns_servers:
     - 8.8.8.8
     - 9.9.9.9
-    stop_timeout: 1
+    force_kill: yes
   register: dns_servers_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1053,14 +1053,14 @@
     name: "{{ cname }}"
     domainname: example.org
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: domainname_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1117,7 +1117,7 @@
     - "'sleep 10m'"
     name: "{{ cname }}"
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: entrypoint_4
 
 - name: entrypoint (other parameters)
@@ -1129,14 +1129,14 @@
     - "'sleep 5m'"
     name: "{{ cname }}"
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: entrypoint_5
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1191,14 +1191,14 @@
     env:
       TEST1: val1
       TEST3: val3
-    stop_timeout: 1
+    force_kill: yes
   register: env_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1233,7 +1233,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1285,14 +1285,14 @@
     etc_hosts:
       example.com: 1.2.3.4
       example.us: 1.2.3.5
-    stop_timeout: 1
+    force_kill: yes
   register: etc_hosts_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1346,14 +1346,14 @@
     exposed_ports:
     - 1234
     - 1235
-    stop_timeout: 1
+    force_kill: yes
   register: exposed_ports_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1413,14 +1413,14 @@
     groups:
     - 1234
     - 2345
-    stop_timeout: 1
+    force_kill: yes
   register: groups_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1447,7 +1447,7 @@
       timeout: 2s
       interval: 0h0m2s3ms4us
       retries: 2
-    stop_timeout: 1
+    force_kill: yes
   register: healthcheck_1
   ignore_errors: yes
 
@@ -1465,7 +1465,7 @@
       timeout: 2s
       interval: 0h0m2s3ms4us
       retries: 2
-    stop_timeout: 1
+    force_kill: yes
   register: healthcheck_2
   ignore_errors: yes
 
@@ -1483,7 +1483,7 @@
       timeout: 3s
       interval: 0h1m2s3ms4us
       retries: 3
-    stop_timeout: 1
+    force_kill: yes
   register: healthcheck_3
   ignore_errors: yes
 
@@ -1493,7 +1493,7 @@
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: healthcheck_4
   ignore_errors: yes
 
@@ -1506,7 +1506,7 @@
     healthcheck:
       test:
       - NONE
-    stop_timeout: 1
+    force_kill: yes
   register: healthcheck_5
   ignore_errors: yes
 
@@ -1519,7 +1519,7 @@
     healthcheck:
       test:
       - NONE
-    stop_timeout: 1
+    force_kill: yes
   register: healthcheck_6
   ignore_errors: yes
 
@@ -1531,7 +1531,7 @@
     state: started
     healthcheck:
       test: "sleep 1"
-    stop_timeout: 1
+    force_kill: yes
   register: healthcheck_7
   ignore_errors: yes
 
@@ -1543,7 +1543,7 @@
     state: started
     healthcheck:
       test: "sleep 1"
-    stop_timeout: 1
+    force_kill: yes
   register: healthcheck_8
   ignore_errors: yes
 
@@ -1551,7 +1551,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1599,14 +1599,14 @@
     name: "{{ cname }}"
     hostname: me.example.org
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: hostname_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1645,7 +1645,7 @@
     name: "{{ cname }}"
     init: no
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: init_3
   ignore_errors: yes
 
@@ -1653,7 +1653,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1696,14 +1696,14 @@
     name: "{{ cname }}"
     interactive: no
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: interactive_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1750,14 +1750,14 @@
     image: hello-world
     name: "{{ cname }}"
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: image_change
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1808,14 +1808,14 @@
     name: "{{ cname }}"
     state: started
     ipc_mode: private
-    stop_timeout: 1
+    force_kill: yes
   register: ipc_mode_3
 
 - name: cleanup
   docker_container:
     name: "{{ container_name }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
   loop:
   - "{{ cname }}"
   - "{{ cname_h1 }}"
@@ -1857,14 +1857,14 @@
     name: "{{ cname }}"
     kernel_memory: 6M
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: kernel_memory_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1923,14 +1923,14 @@
     labels:
       ansible.test.1: hello
       ansible.test.3: ansible
-    stop_timeout: 1
+    force_kill: yes
   register: labels_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -1997,14 +1997,14 @@
     links:
     - "{{ cname_h1 }}:test1"
     - "{{ cname_h3 }}:test3"
-    stop_timeout: 1
+    force_kill: yes
   register: links_4
 
 - name: cleanup
   docker_container:
     name: "{{ container_name }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
   loop:
   - "{{ cname }}"
   - "{{ cname_h1 }}"
@@ -2049,14 +2049,14 @@
     name: "{{ cname }}"
     state: started
     log_driver: syslog
-    stop_timeout: 1
+    force_kill: yes
   register: log_driver_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -2113,14 +2113,14 @@
     log_options:
       labels: production_status
       max-file: 1
-    stop_timeout: 1
+    force_kill: yes
   register: log_options_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -2158,14 +2158,14 @@
     name: "{{ cname }}"
     mac_address: 92:d0:c6:0a:29:44
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: mac_address_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -2202,14 +2202,14 @@
     name: "{{ cname }}"
     memory: 48M
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: memory_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -2246,14 +2246,14 @@
     name: "{{ cname }}"
     memory_reservation: 48M
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: memory_reservation_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -2298,7 +2298,7 @@
     memory: 32M
     memory_swap: 48M
     state: started
-    stop_timeout: 1
+    force_kill: yes
     debug: yes
   register: memory_swap_3
 
@@ -2306,7 +2306,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -2352,14 +2352,14 @@
     name: "{{ cname }}"
     memory_swappiness: 60
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: memory_swappiness_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -2396,14 +2396,14 @@
     name: "{{ cname }}"
     state: started
     network_mode: none
-    stop_timeout: 1
+    force_kill: yes
   register: network_mode_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -2471,14 +2471,14 @@
       networks:
       - name: bridge
       - name: "{{ nname_2 }}"
-      stop_timeout: 1
+      force_kill: yes
     register: networks_5
 
   - name: cleanup
     docker_container:
       name: "{{ cname }}"
       state: absent
-      stop_timeout: 1
+      force_kill: yes
 
   - assert:
       that:
@@ -2521,7 +2521,7 @@
     name: "{{ cname }}"
     oom_killer: no
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: oom_killer_3
   ignore_errors: yes
 
@@ -2529,7 +2529,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -2574,7 +2574,7 @@
     name: "{{ cname }}"
     oom_score_adj: 7
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: oom_score_adj_3
   ignore_errors: yes
 
@@ -2582,7 +2582,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -2613,7 +2613,7 @@
     name: "{{ cname }}"
     state: started
     paused: yes
-    stop_timeout: 1
+    force_kill: yes
   register: paused_1
 
 - name: inspect paused
@@ -2627,7 +2627,7 @@
     name: "{{ cname }}"
     state: started
     paused: yes
-    stop_timeout: 1
+    force_kill: yes
   register: paused_3
 
 - name: paused (continue)
@@ -2637,7 +2637,7 @@
     name: "{{ cname }}"
     state: started
     paused: no
-    stop_timeout: 1
+    force_kill: yes
   register: paused_4
 
 - name: inspect paused
@@ -2648,7 +2648,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -2699,14 +2699,14 @@
     name: "{{ cname }}"
     state: started
     pid_mode: host
-    stop_timeout: 1
+    force_kill: yes
   register: pid_mode_3
 
 - name: cleanup
   docker_container:
     name: "{{ container_name }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
   loop:
   - "{{ cname }}"
   - "{{ cname_h1 }}"
@@ -2755,14 +2755,14 @@
     name: "{{ cname }}"
     privileged: no
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: privileged_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -2815,14 +2815,14 @@
     published_ports:
     - 1234
     - 2345
-    stop_timeout: 1
+    force_kill: yes
   register: published_ports_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -2866,14 +2866,14 @@
     name: "{{ cname }}"
     read_only: no
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: read_only_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -2891,7 +2891,7 @@
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
-    stop_timeout: 1
+    force_kill: yes
   register: recreate_1
 
 - name: recreate (created, recreate)
@@ -2901,7 +2901,7 @@
     name: "{{ cname }}"
     recreate: yes
     state: present
-    stop_timeout: 1
+    force_kill: yes
   register: recreate_2
 
 - name: recreate (started)
@@ -2910,7 +2910,7 @@
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: recreate_3
 
 - name: recreate (started, recreate)
@@ -2920,14 +2920,14 @@
     name: "{{ cname }}"
     recreate: yes
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: recreate_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - debug: var=recreate_1
 - debug: var=recreate_2
@@ -2954,7 +2954,7 @@
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: restart_1
 
 - name: restart (restart)
@@ -2964,14 +2964,14 @@
     name: "{{ cname }}"
     restart: yes
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: restart_2
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - debug: var=restart_1
 - debug: var=restart_2
@@ -3011,14 +3011,14 @@
     name: "{{ cname }}"
     restart_policy: unless-stopped
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: restart_policy_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3058,14 +3058,14 @@
     restart_policy: on-failure
     restart_retries: 2
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: restart_retries_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3101,7 +3101,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3175,14 +3175,14 @@
     security_opts:
     - "label:disable"
     - "no-new-privileges"
-    stop_timeout: 1
+    force_kill: yes
   register: security_opts_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3220,14 +3220,14 @@
     name: "{{ cname }}"
     shm_size: 75M
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: shm_size_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3264,14 +3264,14 @@
     name: "{{ cname }}"
     stop_signal: 9
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: stop_signal_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3315,7 +3315,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3381,7 +3381,7 @@
     sysctls:
       net.ipv4.icmp_echo_ignore_all: 1
       net.ipv6.conf.default.accept_redirects: 0
-    stop_timeout: 1
+    force_kill: yes
   register: sysctls_4
   ignore_errors: yes
 
@@ -3389,7 +3389,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3449,14 +3449,14 @@
     tmpfs:
     - "/test1:rw,noexec,nosuid,size=65536k"
     - "/test3:rw,noexec,nosuid,size=65536k"
-    stop_timeout: 1
+    force_kill: yes
   register: tmpfs_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3500,14 +3500,14 @@
     name: "{{ cname }}"
     tty: no
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: tty_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3560,14 +3560,14 @@
     ulimits:
     - "nofile:1234:1234"
     - "sigpending:100:200"
-    stop_timeout: 1
+    force_kill: yes
   register: ulimits_4
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3605,14 +3605,14 @@
     name: "{{ cname }}"
     user: root
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: user_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3651,7 +3651,7 @@
     name: "{{ cname }}"
     userns_mode: ""
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: userns_mode_3
   ignore_errors: yes
 
@@ -3659,7 +3659,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3704,7 +3704,7 @@
     name: "{{ cname }}"
     uts: ""
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: uts_3
   ignore_errors: yes
 
@@ -3712,7 +3712,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3761,14 +3761,14 @@
     name: "{{ cname }}"
     volume_driver: /
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: volume_driver_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3821,7 +3821,7 @@
     volumes:
     - "/tmp:/tmp"
     - "/tmp:/somewhereelse:ro,Z"
-    stop_timeout: 1
+    force_kill: yes
   register: volumes_4
 
 - name: volumes (different modes)
@@ -3833,14 +3833,14 @@
     volumes:
     - "/tmp:/tmp"
     - "/tmp:/somewhereelse:ro"
-    stop_timeout: 1
+    force_kill: yes
   register: volumes_5
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -3893,14 +3893,14 @@
     name: "{{ cname }}"
     state: started
     volumes_from: "{{ cname_h2 }}"
-    stop_timeout: 1
+    force_kill: yes
   register: volumes_from_3
 
 - name: cleanup
   docker_container:
     name: "{{ container_name }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
   loop:
   - "{{ cname }}"
   - "{{ cname_h1 }}"
@@ -3943,14 +3943,14 @@
     name: "{{ cname }}"
     working_dir: /
     state: started
-    stop_timeout: 1
+    force_kill: yes
   register: working_dir_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:

--- a/test/integration/targets/docker_container/tasks/tests/ports.yml
+++ b/test/integration/targets/docker_container/tasks/tests/ports.yml
@@ -18,7 +18,7 @@
     - 8081
     published_ports:
     - all
-    stop_timeout: 1
+    force_kill: yes
   register: published_ports_1
 
 - name: published_ports -- all (idempotency)
@@ -32,7 +32,7 @@
     - 8081
     published_ports:
     - all
-    stop_timeout: 1
+    force_kill: yes
   register: published_ports_2
 
 - name: published_ports -- all (writing out 'all')
@@ -47,7 +47,7 @@
     published_ports:
     - 8080
     - 8081
-    stop_timeout: 1
+    force_kill: yes
   register: published_ports_3
 
 - name: published_ports -- all (idempotency 2)
@@ -62,7 +62,7 @@
     published_ports:
     - 8080
     - 8081
-    stop_timeout: 1
+    force_kill: yes
   register: published_ports_4
 
 - name: published_ports -- all (switching back to 'all')
@@ -76,14 +76,14 @@
     - 8081
     published_ports:
     - all
-    stop_timeout: 1
+    force_kill: yes
   register: published_ports_5
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -109,7 +109,7 @@
     published_ports:
     - 8080:8080
     - 5000-5040:5000-5040
-    stop_timeout: 1
+    force_kill: yes
   register: published_ports_1
 
 - name: published_ports -- port range (idempotency)
@@ -124,7 +124,7 @@
     published_ports:
     - 8080:8080
     - 5000-5040:5000-5040
-    stop_timeout: 1
+    force_kill: yes
   register: published_ports_2
 
 - name: published_ports -- port range (different range)
@@ -139,14 +139,14 @@
     published_ports:
     - 8080:8080
     - 5010-5050:5010-5050
-    stop_timeout: 1
+    force_kill: yes
   register: published_ports_3
 
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:
@@ -166,7 +166,7 @@
     state: started
     published_ports:
     - "[::1]:8080:8080"
-    stop_timeout: 1
+    force_kill: yes
   register: published_ports_1
 
 - name: published_ports -- IPv6 (idempotency)
@@ -177,7 +177,7 @@
     state: started
     published_ports:
     - "[::1]:8080:8080"
-    stop_timeout: 1
+    force_kill: yes
   register: published_ports_2
 
 - name: published_ports -- IPv6 (different IP)
@@ -188,7 +188,7 @@
     state: started
     published_ports:
     - 127.0.0.1:8080:8080
-    stop_timeout: 1
+    force_kill: yes
   register: published_ports_3
 
 - name: published_ports -- IPv6 (hostname)
@@ -199,7 +199,7 @@
     state: started
     published_ports:
     - localhost:8080:8080
-    stop_timeout: 1
+    force_kill: yes
   register: published_ports_4
   ignore_errors: yes
 
@@ -207,7 +207,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - assert:
     that:

--- a/test/integration/targets/docker_container/tasks/tests/regression-45700-dont-parse-on-absent.yml
+++ b/test/integration/targets/docker_container/tasks/tests/regression-45700-dont-parse-on-absent.yml
@@ -17,7 +17,7 @@
 - name: Stop container with a lot of invalid options
   docker_container:
     name: "{{ cname }}"
-    stop_timeout: 1
+    force_kill: yes
     # Some options with "invalid" values, which would
     # have to be parsed. The values are "invalid" because
     # the containers and networks listed here do not exist.

--- a/test/integration/targets/docker_container/tasks/tests/start-stop.yml
+++ b/test/integration/targets/docker_container/tasks/tests/start-stop.yml
@@ -122,12 +122,13 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
 
 - name: Start container from scratch (check)
   docker_container:
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
+    stop_timeout: 1
     name: "{{ cname }}"
     state: started
   check_mode: yes
@@ -137,6 +138,7 @@
   docker_container:
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
+    stop_timeout: 1
     name: "{{ cname }}"
     state: started
   register: start_scratch_2
@@ -145,6 +147,7 @@
   docker_container:
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
+    stop_timeout: 1
     name: "{{ cname }}"
     state: started
   register: start_scratch_3
@@ -153,6 +156,7 @@
   docker_container:
     image: alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
+    stop_timeout: 1
     name: "{{ cname }}"
     state: started
   check_mode: yes
@@ -262,7 +266,7 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
   check_mode: yes
   register: remove_from_running_1
 
@@ -270,21 +274,21 @@
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
   register: remove_from_running_2
 
 - name: Remove container from running (idempotent)
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
   register: remove_from_running_3
 
 - name: Remove container from running (idempotent check)
   docker_container:
     name: "{{ cname }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
   check_mode: yes
   register: remove_from_running_4
 

--- a/test/integration/targets/docker_container_facts/tasks/main.yml
+++ b/test/integration/targets/docker_container_facts/tasks/main.yml
@@ -8,7 +8,7 @@
     docker_container:
       name: "{{ cname }}"
       state: absent
-      stop_timeout: 1
+      force_kill: yes
 
   - name: Inspect a non-present container
     docker_container_facts:
@@ -28,7 +28,7 @@
       command: '/bin/sh -c "sleep 10m"'
       state: started
       auto_remove: yes
-      stop_timeout: 1
+      force_kill: yes
 
   - name: Inspect a present container
     docker_container_facts:
@@ -49,7 +49,7 @@
     docker_container:
       name: "{{ cname }}"
       state: absent
-      stop_timeout: 1
+      force_kill: yes
 
   - assert:
       that:

--- a/test/integration/targets/docker_image/tasks/main.yml
+++ b/test/integration/targets/docker_image/tasks/main.yml
@@ -44,7 +44,7 @@
     docker_container:
       name: "{{ item }}"
       state: absent
-      stop_timeout: 1
+      force_kill: yes
     with_items: "{{ cnames }}"
 
   # Skip for CentOS 6

--- a/test/integration/targets/docker_network/tasks/main.yml
+++ b/test/integration/targets/docker_network/tasks/main.yml
@@ -18,7 +18,7 @@
     docker_container:
       name: "{{ item }}"
       state: absent
-      stop_timeout: 1
+      force_kill: yes
     loop: "{{ cnames }}"
   - name: "Make sure all networks are removed"
     docker_network:

--- a/test/integration/targets/docker_network/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_network/tasks/tests/basic.yml
@@ -125,7 +125,7 @@
   docker_container:
     name: "{{ container_name }}"
     state: absent
-    stop_timeout: 1
+    force_kill: yes
   loop:
   - "{{ cname_1 }}"
   - "{{ cname_2 }}"


### PR DESCRIPTION
##### SUMMARY
Especially during the `docker_container` tests, a lot of containers are started and stopped. So far, I used `stop_timeout: 1` to decrease the stop timeout from 10 seconds (or so, the default value) to 1 second, but now I noticed that using `force_kill: yes` is even faster.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
docker_container_facts
docker_image
docker_network
