### PR TITLE
docker_network: only pass ipam parameter to create_network() when needed

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -424,12 +424,17 @@ class DockerNetworkManager(object):
                     else:
                         ipam_pools.append(utils.create_ipam_pool(**ipam_pool))
 
-            if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:
-                params['ipam'] = IPAMConfig(driver=self.parameters.ipam_driver,
-                                            pool_configs=ipam_pools)
-            else:
-                params['ipam'] = utils.create_ipam_config(driver=self.parameters.ipam_driver,
-                                                          pool_configs=ipam_pools)
+            if self.parameters.ipam_driver or ipam_pools:
+                # Only add ipam parameter if a driver was specified or if IPAM parameters
+                # were specified. Leaving this parameter away can significantly speed up
+                # creation; on my machine creation with this option needs ~15 seconds,
+                # and without just a few seconds.
+                if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:
+                    params['ipam'] = IPAMConfig(driver=self.parameters.ipam_driver,
+                                                pool_configs=ipam_pools)
+                else:
+                    params['ipam'] = utils.create_ipam_config(driver=self.parameters.ipam_driver,
+                                                              pool_configs=ipam_pools)
 
             if self.parameters.enable_ipv6 is not None:
                 params['enable_ipv6'] = self.parameters.enable_ipv6


### PR DESCRIPTION
##### SUMMARY
On my machine, creating a network with `docker_network` takes considerably longer than with `docker network create`. I've tracked this down to the `ipam` argument to `client.create_network()`. Even if I don't specify any options to the module which result in a non-trivial `ipam` parameter, creation takes ~15 seconds, while direct creation via command line takes < 1 second. When leaving the parameter away, also `docker_network` needs < 1 second.

This PR only adds the `ipam` parameter when a driver is specified or IPAM config(s) are specified.

I'm labelling this as a bugfix since I consider it one, since it wastes a lot of time (CI and my personal time when waiting for test results) :)

Actually, on my machine, the `docker_network` tests needed 4:49 minutes before this PR, and 2:46 minutes after this PR.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_network
