### PR TITLE
Add common files for ONTAP and SOLIDFIRE unit tests

### DIFF
--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -27,10 +27,7 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
+import json
 
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.urls import open_url
@@ -40,17 +37,26 @@ try:
 except ImportError:
     ansible_version = 'unknown'
 
+# Ugly patch to bypass relative import issue with Python 3
+# TODO: redo this once netapp-lib is fixed in pypi
+import inspect
 import os
-import ssl
-
-HAS_NETAPP_LIB = False
+import sys
+sys_path_len = len(sys.path)
 try:
+    import netapp_lib.api.zapi
+    sys.path.insert(0, os.path.dirname(inspect.getfile(netapp_lib.api.zapi)))
     from netapp_lib.api.zapi import zapi
-    from netapp_lib.api.zapi import errors as zapi_errors
     HAS_NETAPP_LIB = True
-except:
+except ImportError:
     HAS_NETAPP_LIB = False
+if sys_path_len < len(sys.path):
+    # restore original path
+    sys.path.pop(0)
+del sys_path_len
+# end of patch
 
+import ssl
 
 HAS_SF_SDK = False
 SF_BYTE_MAP = dict(
@@ -65,6 +71,20 @@ SF_BYTE_MAP = dict(
     eb=1000 ** 6,
     zb=1000 ** 7,
     yb=1000 ** 8
+)
+
+POW2_BYTE_MAP = dict(
+    # Here, 1 kb = 1024
+    bytes=1,
+    b=1,
+    kb=1024,
+    mb=1024 ** 2,
+    gb=1024 ** 3,
+    tb=1024 ** 4,
+    pb=1024 ** 5,
+    eb=1024 ** 6,
+    zb=1024 ** 7,
+    yb=1024 ** 8
 )
 
 try:
@@ -93,7 +113,8 @@ def na_ontap_host_argument_spec():
         password=dict(required=True, type='str', aliases=['pass'], no_log=True),
         https=dict(required=False, type='bool', default=False),
         validate_certs=dict(required=False, type='bool', default=True),
-        http_port=dict(required=False, type='int')
+        http_port=dict(required=False, type='int'),
+        ontapi=dict(required=False, type='int')
     )
 
 
@@ -128,6 +149,7 @@ def setup_na_ontap_zapi(module, vserver=None):
     https = module.params['https']
     validate_certs = module.params['validate_certs']
     port = module.params['http_port']
+    version = module.params['ontapi']
 
     if HAS_NETAPP_LIB:
         # set up zapi
@@ -136,8 +158,11 @@ def setup_na_ontap_zapi(module, vserver=None):
         server.set_password(password)
         if vserver:
             server.set_vserver(vserver)
-        # Todo : Replace hard-coded values with configurable parameters.
-        server.set_api_version(major=1, minor=110)
+        if version:
+            minor = version
+        else:
+            minor = 110
+        server.set_api_version(major=1, minor=minor)
         # default is HTTP
         if https:
             if port is None:

--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -28,6 +28,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+import os
 
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.urls import open_url
@@ -37,24 +38,11 @@ try:
 except ImportError:
     ansible_version = 'unknown'
 
-# Ugly patch to bypass relative import issue with Python 3
-# TODO: redo this once netapp-lib is fixed in pypi
-import inspect
-import os
-import sys
-sys_path_len = len(sys.path)
 try:
-    import netapp_lib.api.zapi
-    sys.path.insert(0, os.path.dirname(inspect.getfile(netapp_lib.api.zapi)))
     from netapp_lib.api.zapi import zapi
     HAS_NETAPP_LIB = True
 except ImportError:
     HAS_NETAPP_LIB = False
-if sys_path_len < len(sys.path):
-    # restore original path
-    sys.path.pop(0)
-del sys_path_len
-# end of patch
 
 import ssl
 

--- a/lib/ansible/utils/module_docs_fragments/netapp.py
+++ b/lib/ansible/utils/module_docs_fragments/netapp.py
@@ -61,12 +61,17 @@ options:
       description:
       - Override the default port (80 or 443) with this port
       type: int
+  ontapi:
+      description:
+      - The ontap api version to use
+      type: int
 
 
 requirements:
-  - A physical or virtual clustered Data ONTAP system. The modules were developed with Clustered Data ONTAP 9.3
+  - A physical or virtual clustered Data ONTAP system. The modules support Data ONTAP 9.1 and onward
   - Ansible 2.6
-  - netapp-lib (2017.10.30). Install using 'pip install netapp-lib'
+  - Python2 netapp-lib (2017.10.30) or later. Install using 'pip install netapp-lib'
+  - Python3 netapp-lib (2018.11.13) or later. Install using 'pip install netapp-lib'
   - To enable http on the cluster you must run the following commands 'set -privilege advanced;' 'system services web modify -http-enabled true;'
 
 notes:

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -18,6 +18,8 @@ setuptools > 0.6 # pytest-xdist installed via requirements does not work with ve
 unittest2 ; python_version < '2.7'
 netaddr
 ipaddress
+netapp-lib
+solidfire-sdk-python
 
 # requirements for F5 specific modules
 f5-sdk ; python_version >= '2.7'

--- a/test/units/modules/storage/netapp/test_netapp.py
+++ b/test/units/modules/storage/netapp/test_netapp.py
@@ -4,10 +4,7 @@
 ''' unit tests for module_utils netapp.py '''
 from __future__ import absolute_import, division, print_function
 
-try:
-    from ansible.module_utils.ansible_release import __version__ as ansible_version
-except ImportError:
-    ansible_version = 'unknown'
+from ansible.module_utils.ansible_release import __version__ as ansible_version
 
 import pytest
 import ansible.module_utils.netapp as netapp_utils
@@ -44,11 +41,14 @@ class MockONTAPConnection(object):
         xml.add_child_elem(attributes)
         return xml
 
+
 @pytest.fixture
 def has_zapi():
-     assert HAS_NETAPP_LIB, HAS_NETAPP_LIB_MSG
+    assert HAS_NETAPP_LIB, HAS_NETAPP_LIB_MSG
+
 
 pytestmark = pytest.mark.usefixtures("has_zapi")
+
 
 def test_ems_log_event_version():
     ''' validate Ansible version is correctly read '''
@@ -59,6 +59,7 @@ def test_ems_log_event_version():
     version = xml.get_child_content('app-version')
     assert version == ansible_version
     print("Ansible version: %s" % ansible_version)
+
 
 def test_get_cserver():
     ''' validate cluster vserser name is correctly retrieved '''

--- a/test/units/modules/storage/netapp/test_netapp.py
+++ b/test/units/modules/storage/netapp/test_netapp.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2018 NetApp
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+''' unit tests for module_utils netapp.py '''
+from __future__ import absolute_import, division, print_function
+
+try:
+    from ansible.module_utils.ansible_release import __version__ as ansible_version
+except ImportError:
+    ansible_version = 'unknown'
+
+import pytest
+import ansible.module_utils.netapp as netapp_utils
+
+HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()
+HAS_NETAPP_LIB_MSG = "pip install netapp_lib is required"
+
+
+class MockONTAPConnection(object):
+    ''' mock a server connection to ONTAP host '''
+
+    def __init__(self, kind=None, parm1=None):
+        ''' save arguments '''
+        self.type = kind
+        self.parm1 = parm1
+        self.xml_in = None
+        self.xml_out = None
+
+    def invoke_successfully(self, xml, enable_tunneling):  # pylint: disable=unused-argument
+        ''' mock invoke_successfully returning xml data '''
+        self.xml_in = xml
+        if self.type == 'vserver':
+            xml = self.build_vserver_info(self.parm1)
+        self.xml_out = xml
+        return xml
+
+    @staticmethod
+    def build_vserver_info(vserver):
+        ''' build xml data for vserser-info '''
+        xml = netapp_utils.zapi.NaElement('xml')
+        attributes = netapp_utils.zapi.NaElement('attributes-list')
+        attributes.add_node_with_children('vserver-info',
+                                          **{'vserver-name': vserver})
+        xml.add_child_elem(attributes)
+        return xml
+
+@pytest.fixture
+def has_zapi():
+     assert HAS_NETAPP_LIB, HAS_NETAPP_LIB_MSG
+
+pytestmark = pytest.mark.usefixtures("has_zapi")
+
+def test_ems_log_event_version():
+    ''' validate Ansible version is correctly read '''
+    source = 'unittest'
+    server = MockONTAPConnection()
+    netapp_utils.ems_log_event(source, server)
+    xml = server.xml_in
+    version = xml.get_child_content('app-version')
+    assert version == ansible_version
+    print("Ansible version: %s" % ansible_version)
+
+def test_get_cserver():
+    ''' validate cluster vserser name is correctly retrieved '''
+    svm_name = 'svm1'
+    server = MockONTAPConnection('vserver', svm_name)
+    cserver = netapp_utils.get_cserver(server)
+    assert cserver == svm_name


### PR DESCRIPTION
##### SUMMARY
Add common files for ONTAP and SOLIDFIRE unit tests, and documentation changes for python 3

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.8.0.dev0 (netapp-unittest2 5f3e5053c0) last updated 2018/11/15 10:24:07 (GMT -700)
  config file = None
  configured module search path = [u'/Users/chrisarchibald/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chrisarchibald/Code/github/ansible/lib/ansible
  executable location = /Users/chrisarchibald/Code/github/ansible/bin/ansible
  python version = 2.7.15 (default, Oct  2 2018, 12:50:38) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
