### PR TITLE
Remove non-standard CreateBiosConfigJob command

### DIFF
--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -141,8 +141,7 @@ from ansible.module_utils._text import to_native
 # More will be added as module features are expanded
 CATEGORY_COMMANDS_ALL = {
     "Systems": ["PowerOn", "PowerForceOff", "PowerGracefulRestart",
-                "PowerGracefulShutdown", "SetOneTimeBoot",
-                "CreateBiosConfigJob"],
+                "PowerGracefulShutdown", "PowerReboot", "SetOneTimeBoot"],
     "Accounts": ["AddUser", "EnableUser", "DeleteUser", "DisableUser",
                  "UpdateUserRole", "UpdateUserPassword"],
     "Manager": ["GracefulRestart", "ClearLogs"],
@@ -225,12 +224,6 @@ def main():
                 result = rf_utils.manage_system_power(command)
             elif command == "SetOneTimeBoot":
                 result = rf_utils.set_one_time_boot_device(module.params['bootdevice'])
-            elif command == "CreateBiosConfigJob":
-                # execute only if we find a Managers resource
-                result = rf_utils._find_managers_resource(rf_uri)
-                if result['ret'] is False:
-                    module.fail_json(msg=to_native(result['msg']))
-                result = rf_utils.create_bios_config_job()
 
     elif category == "Manager":
         MANAGER_COMMANDS = {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Removed the non-standard `CreateBiosConfigJob` command because it uses a vendor-specific Oem function. Added a `PowerReboot` command that looks at the current power state and issues the appropriate reset command to achieve a reboot. If the power is On it issues a restart command (`GracefulRestart` or `ForceRestart`). If the power is not On it issues an `On` command. 

This allows for the standard approach for doing things like setting BIOS attributes and then doing a reboot in order for the attributes settings to be applied. 

Fixes #48364 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py
redfish_command.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Setting BIOS attributes can be achieved using a playbook like this:
```paste below
---
- hosts: myhosts
  connection: local
  name: Set BIOS attribute - choose below
  gather_facts: False

  # Updating BIOS settings requires creating a configuration job to implement,
  # which then reboots the system.

  # BIOS attributes that have been tested
  #
  # Name      Value
  # --------------------------------------------------
  # OsWatchdogTimer   Disabled / Enabled
  # ProcVirtualization    Disabled / Enabled
  # MemTest     Disabled / Enabled
  # SriovGlobalEnable   Disabled / Enabled

  vars:
  - attribute_name1: SriovGlobalEnable
  - attribute_value1: Disabled
  - attribute_name2: ProcVirtualization
  - attribute_value2: Enabled

  tasks:

  - name: Set BIOS attribute {{ attribute_name1 }} to {{ attribute_value1 }}
    redfish_config:
      category: Systems
      command: SetBiosAttributes
      bios_attr_name: "{{ attribute_name1 }}"
      bios_attr_value: "{{ attribute_value1 }}"
      baseuri: "{{ baseuri }}"
      user: "{{ user }}"
      password: "{{ password }}"

  - name: Set BIOS attribute {{ attribute_name2 }} to {{ attribute_value2 }}
    redfish_config:
      category: Systems
      command: SetBiosAttributes
      bios_attr_name: "{{ attribute_name2 }}"
      bios_attr_value: "{{ attribute_value2 }}"
      baseuri: "{{ baseuri }}"
      user: "{{ user }}"
      password: "{{ password }}"

  - name: Reboot
    redfish_command:
      category: Systems
      command: PowerReboot
      baseuri: "{{ baseuri }}"
      user: "{{ user }}"
      password: "{{ password }}"
```
