### PR TITLE
Improve release `make summary` shell compatibility.

### DIFF
--- a/packaging/release/Makefile
+++ b/packaging/release/Makefile
@@ -23,9 +23,10 @@ version:
 
 .PHONY: summary
 summary:
-	@echo 'release_summary: |\n\
-	   | Release Date: $(shell date '+%Y-%m-%d')\n\
-	   | `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_' > \
+	@printf '%s\n%s\n%s\n' \
+	'release_summary: |' \
+	'   | Release Date: $(shell date '+%Y-%m-%d')' \
+	'   | `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_' > \
 	../../changelogs/fragments/v${version}_summary.yaml
 
 .PHONY: changelog


### PR DESCRIPTION
##### SUMMARY

Improve release `make summary` shell compatibility.

This should work with at least bash, dash and zsh.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

packaging/release/Makefile
