### PR TITLE
[stable-2.7] Improve release `make summary` shell compatibility.

### DIFF
--- a/packaging/release/Makefile
+++ b/packaging/release/Makefile
@@ -23,9 +23,10 @@ version:
 
 .PHONY: summary
 summary:
-	@echo 'release_summary: |\n\
-	   | Release Date: $(shell date '+%Y-%m-%d')\n\
-	   | `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_' > \
+	@printf '%s\n%s\n%s\n' \
+	'release_summary: |' \
+	'   | Release Date: $(shell date '+%Y-%m-%d')' \
+	'   | `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_' > \
 	../../changelogs/fragments/v${version}_summary.yaml
 
 .PHONY: changelog


### PR DESCRIPTION
##### SUMMARY

[stable-2.7] Improve release `make summary` shell compatibility.

This should work with at least bash, dash and zsh.

(cherry picked from commit 0755f16f9a8c80b31da957d447df93c622a8fb77)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

packaging/release/Makefile
