### PR TITLE
[stable-2.7] Fix the changelog links to porting guide to be anonymous

### DIFF
--- a/packaging/release/Makefile
+++ b/packaging/release/Makefile
@@ -26,7 +26,7 @@ summary:
 	@printf '%s\n%s\n%s\n' \
 	'release_summary: |' \
 	'   | Release Date: $(shell date '+%Y-%m-%d')' \
-	'   | `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_' > \
+	'   | `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`__' > \
 	../../changelogs/fragments/v${version}_summary.yaml
 
 .PHONY: changelog


### PR DESCRIPTION
Prevents duplicate reference errors.
(cherry picked from commit 0070928)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
