### PR TITLE
dnf to support modularity module appstream specs

### DIFF
--- a/changelogs/fragments/dnf-modularity.yaml
+++ b/changelogs/fragments/dnf-modularity.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "dnf properly support modularity appstream installation via overloaded group modifier syntax"

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -257,17 +257,17 @@ EXAMPLES = '''
 
 - name: install a modularity appstream with defined stream and profile
   dnf:
-    name: @postgresql:9.6/client
+    name: '@postgresql:9.6/client'
     state: present
 
 - name: install a modularity appstream with defined stream
   dnf:
-    name: @postgresql:9.6
+    name: '@postgresql:9.6'
     state: present
 
 - name: install a modularity appstream with defined profile
   dnf:
-    name: @postgresql/client
+    name: '@postgresql/client'
     state: present
 '''
 
@@ -764,9 +764,10 @@ class DnfModule(YumDnf):
                 if env:
                     env_specs.append(env.id)
 
-                mdl = self.module_base._get_modules(grp_env_mdl_candidate)
-                if mdl[0]:
-                    module_specs.append(grp_env_mdl_candidate)
+                if self.with_modules:
+                    mdl = self.module_base._get_modules(grp_env_mdl_candidate)
+                    if mdl[0]:
+                        module_specs.append(grp_env_mdl_candidate)
             else:
                 pkg_specs.append(name)
         return pkg_specs, grp_specs, env_specs, module_specs, filenames
@@ -831,7 +832,7 @@ class DnfModule(YumDnf):
             if nsv.stream in self.base._moduleContainer.getEnabledStream(nsv.name):
                 return True
 
-        return False # seems like a sane default
+        return False  # seems like a sane default
 
     def ensure(self):
         allow_erasing = False

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -38,3 +38,8 @@
   when:
     - ansible_distribution == 'Fedora'
     - ansible_distribution_major_version|int >= 23
+
+- import_tasks: 'modularity.yml'
+  when:
+    - ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 29
+    - ansible_distribution == 'RedHat' and ansible_distribution_major_version|int >= 8

--- a/test/integration/targets/dnf/tasks/modularity.yml
+++ b/test/integration/targets/dnf/tasks/modularity.yml
@@ -1,0 +1,48 @@
+- name: install "@postgresql:9.6/client" module
+  dnf:
+    name: "@postgresql:9.6/client"
+    state: present
+  register: dnf_result
+
+- name: verify installation of "@postgresql:9.6/client" module
+  assert:
+    that:
+        - "not dnf_result.failed"
+        - "dnf_result.changed"
+
+- name: install "@postgresql:9.6/client" module again
+  dnf:
+    name: "@postgresql:9.6/client"
+    state: present
+  register: dnf_result
+
+- name: verify installation of "@postgresql:9.6/client" module again
+  assert:
+    that:
+        - "not dnf_result.failed"
+        - "not dnf_result.changed"
+
+- name: uninstall "@postgresql:9.6/client" module
+  dnf:
+    name: "@postgresql:9.6/client"
+    state: absent
+  register: dnf_result
+
+- name: verify uninstallation of "@postgresql:9.6/client" module
+  assert:
+    that:
+        - "not dnf_result.failed"
+        - "dnf_result.changed"
+
+- name: uninstall "@postgresql:9.6/client" module again
+  dnf:
+    name: "@postgresql:9.6/client"
+    state: install
+  register: dnf_result
+
+- name: verify uninstallation of "@postgresql:9.6/client" module again
+  assert:
+    that:
+        - "not dnf_result.failed"
+        - "not dnf_result.changed"
+

--- a/test/integration/targets/dnf/tasks/modularity.yml
+++ b/test/integration/targets/dnf/tasks/modularity.yml
@@ -45,4 +45,3 @@
     that:
         - "not dnf_result.failed"
         - "not dnf_result.changed"
-


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #48743

Previously if you attempted to use the overloaded `@modularity:appstream/profile` syntax to install an appstream, you would get an error that the dnf comps group wasn't found.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dnf

