### PR TITLE
Fix win_nssm credentials quoting

### DIFF
--- a/changelogs/fragments/48728-win_nssm-credential-quoting.yml
+++ b/changelogs/fragments/48728-win_nssm-credential-quoting.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "win_nssm - Switched to Argv-ToString for escaping NSSM credentials (https://github.com/ansible/ansible/issues/48728)"

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -403,7 +403,7 @@ Function Nssm-Update-Credentials
             }
 
             If ($nssm_result.stdout.split("`n`r")[0] -ne $fullUser) {
-                $cmd = "set ""$name"" ObjectName $fullUser '$password'"
+                $cmd = "set ""$name"" ObjectName $fullUser ""$password"""
                 $nssm_result = Nssm-Invoke $cmd
 
                 if ($nssm_result.rc -ne 0)

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -403,7 +403,7 @@ Function Nssm-Update-Credentials
             }
 
             If ($nssm_result.stdout.split("`n`r")[0] -ne $fullUser) {
-                $cmd = "set ""$name"" ObjectName $fullUser ""$password"""
+                $cmd = Argv-ToString @("set", $name, "ObjectName", $fullUser, $password)
                 $nssm_result = Nssm-Invoke $cmd
 
                 if ($nssm_result.rc -ne 0)


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible/ansible/issues/48728

The problem is with the escaping of the `$password` variable with single quotes (introduced by PR #26228) which worked in <=2.7.0 when `Invoke-Expression` was being used to invoke nssm. With 2.7.1, nssm is being invoked differently and the escaping no longer works properly. Escaping with double double quotes fixes the issue.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
win_nssm

##### ADDITIONAL INFORMATION
None

