### PR TITLE
amazon/service_discovery_namespace new_module

### DIFF
--- a/changelogs/fragments/48764-service-discovery-namespace.yml
+++ b/changelogs/fragments/48764-service-discovery-namespace.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - service_discovery_namespace - Add module for managing aws service discovery namespaces

--- a/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
+++ b/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
@@ -58,7 +58,6 @@ options:
              - if wait is false, this returns an operation ID
              - if wait is true, returns the namespace
         default: True
-
     creator_request_id:
         description:
             A unique string that identifies the request and that allows failed CreateService
@@ -80,7 +79,6 @@ EXAMPLES = '''
       name: "my-namespace"
       state: present
       type: "DNS_PRIVATE"
-
 '''
 
 RETURN = '''
@@ -121,7 +119,8 @@ namespace:
                 dns_properties:
                     type: complex
                     returned: always
-                    description: A complex type that contains the ID for the hosted zone that Route 53 creates when you create a namespace.
+                    description: A complex type that contains the ID for the hosted zone that Route 53 creates
+                                 when you create a namespace.
                     contains:
                         hosted_zone_id:
                             type: string
@@ -227,7 +226,7 @@ class ServiceDiscoveryNamespace:
 
     def create_public_dns_namespace(self, name, description, creator_request_id, wait):
         params = dict(Name=name)
-        # Createor request id and description are optional; only include if given
+        # Creator request id and description are optional; only include if given
         if creator_request_id:
             params['CreatorRequestId'] = creator_request_id
         if description:
@@ -250,9 +249,8 @@ class ServiceDiscoveryNamespace:
             return response
 
     def create_private_dns_namespace(self, name, description, creator_request_id, vpc_id, wait):
-        params = dict(Name=name,
-                      Vpc=vpc_id)
-        # Createor request id and description are optional; only include if given
+        params = dict(Name=name, Vpc=vpc_id)
+        # Creator request id and description are optional; only include if given
         if creator_request_id:
             params['CreatorRequestId'] = creator_request_id
         if description:
@@ -293,7 +291,6 @@ class ServiceDiscoveryNamespace:
                 if 'createdAt' in e:
                     e['createdAt'] = str(e['createdAt'])
         return service
-
 
 def main():
     argument_spec = ec2_argument_spec()

--- a/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
+++ b/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
@@ -1,0 +1,353 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: service_discovery_namespace
+short_description: thin wrap for boto servicediscovery client
+description:
+    - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/servicediscovery.html
+notes:
+     - nah.
+version_added: "2.8"
+author:
+    - "tad merchant @ezmac"
+
+requirements: [ json, botocore, boto3 ]
+options:
+    state:
+        description:
+          - The desired state of the service
+        required: true
+        choices: ["present", "absent"]
+    name:
+        description:
+          - The name of the service
+        required: true
+    type:
+        description:
+            - Type of namespace
+        choices: ["DNS_PRIVATE","DNS_PUBLIC"]
+        required: true
+    vpc_id:
+        description:
+             - id of vpc associated with DNS_PRIVATE namespaces
+        required: false
+    wait:
+        type: bool
+        description:
+             - Wait for creation to complete
+             - if wait is false, this returns an operation ID
+             - if wait is true, returns the namespace
+        default: True
+
+    creator_request_id:
+        description:
+            A unique string that identifies the request and that allows failed CreateService
+            requests to be retried without the risk of executing the operation twice.
+            CreatorRequestId can be any unique string, for example, a date/time stamp.
+            This field is autopopulated if not provided.
+        required: false
+    description:
+        description: Description for the namespace
+
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+  - service_discovery_namespace:
+      name: "my-namespace"
+      state: present
+      type: "DNS_PRIVATE"
+
+'''
+
+RETURN = '''
+namespace:
+    description: Details of created namespace.
+    returned: when creating a namespace with wait=true (default)
+    type: complex
+    contains:
+        id:
+            description: Identifier of service discovery namespace
+            returned: always
+            type: string
+        arn:
+            description: arn of namespace
+            returned: always
+            type: string
+        name:
+            description: name of service discovery service
+            returned: always
+            type: string
+        type:
+            description: The type of the namespace. Valid values are DNS_PUBLIC and DNS_PRIVATE .
+            type: string
+            returned: always
+        description:
+            description: Description of namespace
+            type: string
+            returned: always
+        service_count:
+            description: The number of services that are associated with the namespace.
+            type: integer
+            returned: if services are associated
+        properties:
+            type: complex
+            returned: always
+            description: A complex type that contains information that's specific to the type of the namespace.
+            contains:
+                dns_properties:
+                    type: complex
+                    returned: always
+                    description: A complex type that contains the ID for the hosted zone that Route 53 creates when you create a namespace.
+                    contains:
+                        hosted_zone_id:
+                            type: string
+                            returned: always
+                            description: The ID for the hosted zone that Route 53 creates when you create a namespace.
+        create_date:
+            type: datetime
+            returned: always
+            description: datetime of creation
+        creator_request_id:
+            type: string
+            returned: always
+            description:
+                A unique string that identifies the request and that allows failed requests to be
+                retried without the risk of executing an operation twice.
+
+
+operation_id:
+    description: operation id of the non-waited namespace create request
+    type: string
+    returned: when creating and wait=false
+
+'''
+import time
+
+DEPLOYMENT_CONFIGURATION_TYPE_MAP = {
+    'maximum_percent': 'int',
+    'minimum_healthy_percent': 'int'
+}
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible.module_utils.ec2 import ec2_argument_spec
+from ansible.module_utils.ec2 import snake_dict_to_camel_dict, map_complex_type, get_ec2_security_group_ids_from_names
+try:
+    from botocore import waiter as core_waiter
+except ImportError:
+    pass
+
+sd_waiter_config = {
+    "version": 2,
+    "waiters": {
+        "NamespaceCreated": {
+            "delay": 5,
+            "maxAttempts": 10,
+            "operation": "GetOperation",
+            "acceptors": [
+                {
+                    "state": "success",
+                    "matcher": "path",
+                    "argument": "Operation.Status",
+                    "expected": "SUCCESS"
+                }
+            ]
+        }
+    }
+}
+
+
+class ServiceDiscoveryNamespace:
+    """Handles servicediscovery namespaces"""
+
+    def __init__(self, module):
+        self.module = module
+        self.sd = module.client('servicediscovery')
+
+    def get_operation(self, operation_id):
+        operation = self.sd.get_operation(OperationId=operation_id)
+        return operation
+
+    def get_namespaces_by_name(self, namespace_name, type):
+        namespaces = self.list_namespaces(type)
+        if (not namespaces):
+            return None
+        matching_namespaces = []
+        for ns in namespaces['Namespaces']:
+            if ns['Name'] == namespace_name:
+                matching_namespaces.append(ns)
+        return matching_namespaces
+
+    def get_namespace(self, namespace_id):
+        namespace = self.sd.get_namespace(Id=namespace_id)['Namespace']
+        if not namespace:
+            return None
+        return self.jsonize(namespace)
+
+    def create_namespace(self, name, type, description, creator_request_id, vpc_id, wait):
+        if type == "DNS_PRIVATE":
+            namespace = self.create_private_dns_namespace(name,
+                                                          description,
+                                                          creator_request_id,
+                                                          vpc_id,
+                                                          wait)
+        if type == "DNS_PUBLIC":
+            namespace = self.create_public_dns_namespace(name,
+                                                         description,
+                                                         creator_request_id,
+                                                         wait)
+        return self.jsonize(namespace)
+
+    def list_namespaces(self, type):
+        if type:
+            filters = ansible_dict_to_boto3_filter_list({'TYPE': type})
+        else:
+            filters = []
+        return self.sd.list_namespaces(Filters=filters)
+
+    def create_public_dns_namespace(self, name, description, creator_request_id, wait):
+        params = dict(Name=name)
+        # Createor request id and description are optional; only include if given
+        if creator_request_id:
+            params['CreatorRequestId'] = creator_request_id
+        if description:
+            params['description'] = description
+        response = self.sd.create_public_dns_namespace(**params)
+
+        operation = response['OperationId']
+        if wait:
+            waiter_model = core_waiter.WaiterModel(waiter_config=sd_waiter_config).get_waiter("NamespaceCreated")
+            waiter = core_waiter.Waiter('namespace_created',
+                                        waiter_model,
+                                        self.sd.get_operation)
+
+            waiter.wait(OperationId=operation)
+            operationResponse = self.sd.get_operation(OperationId=operation)
+            namespace_id = operationResponse['Operation']['Targets']["NAMESPACE"]
+            created_namespace = self.sd.get_namespace(Id=namespace_id)['Namespace']
+            return created_namespace
+        else:
+            return response
+
+    def create_private_dns_namespace(self, name, description, creator_request_id, vpc_id, wait):
+        params = dict(Name=name,
+                      Vpc=vpc_id)
+        # Createor request id and description are optional; only include if given
+        if creator_request_id:
+            params['CreatorRequestId'] = creator_request_id
+        if description:
+            params['description'] = description
+        response = self.sd.create_private_dns_namespace(**params)
+
+        operation = response['OperationId']
+        if wait:
+            waiter_model = core_waiter.WaiterModel(waiter_config=sd_waiter_config).get_waiter("NamespaceCreated")
+            waiter = core_waiter.Waiter('namespace_created',
+                                        waiter_model,
+                                        self.sd.get_operation)
+            waiter.wait(OperationId=operation)
+            operationResponse = self.sd.get_operation(OperationId=operation)
+            namespace_id = operationResponse['Operation']['Targets']["NAMESPACE"]
+            created_namespace = self.sd.get_namespace(Id=namespace_id)['Namespace']
+            return created_namespace
+        else:
+            return response
+
+    def delete_namespace(self, id):
+        response = self.sd.delete_namespace(Id=id)
+        return response
+
+    def jsonize(self, service):
+        # some fields are datetime which is not JSON serializable
+        # make them strings
+        if 'createdAt' in service:
+            service['createdAt'] = str(service['createdAt'])
+        if 'deployments' in service:
+            for d in service['deployments']:
+                if 'createdAt' in d:
+                    d['createdAt'] = str(d['createdAt'])
+                if 'updatedAt' in d:
+                    d['updatedAt'] = str(d['updatedAt'])
+        if 'events' in service:
+            for e in service['events']:
+                if 'createdAt' in e:
+                    e['createdAt'] = str(e['createdAt'])
+        return service
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+        state=dict(required=True, choices=['present', 'absent']),
+        type=dict(choices=['DNS_PRIVATE', 'DNS_PUBLIC']),
+        name=dict(required=True, type='str'),
+        creator_request_id=dict(),
+        description=dict(),
+        wait=dict(required=False, type='bool', default=True),
+        vpc_id=dict()
+    ))
+
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              supports_check_mode=False,
+                              required_if=[('state', 'present', ['type']),
+                                           ('type', 'private', ['vpc_id'])])
+
+    sd_mgr = ServiceDiscoveryNamespace(module)
+
+    if module.params['state'] == 'present':
+        try:
+            existing = sd_mgr.get_namespaces_by_name(module.params['name'], module.params['type'])
+            if (len(existing) == 1):
+                namespace = sd_mgr.get_namespace(existing[0]['Id'])
+                module.exit_json(changed=False, namespace=camel_dict_to_snake_dict(namespace))
+
+            if (not existing):
+                namespace = sd_mgr.create_namespace(module.params['name'],
+                                                    module.params['type'],
+                                                    module.params['description'],
+                                                    module.params['creator_request_id'],
+                                                    module.params['vpc_id'],
+                                                    module.params['wait'])
+                module.exit_json(changed=True, namespace=camel_dict_to_snake_dict(namespace))
+
+        except Exception as e:
+            module.fail_json(msg="Exception '" + module.params['name'] + "': " + str(e))
+
+        module.exit_json(**existing)
+
+    if module.params['state'] == 'absent':
+        try:
+            existing = sd_mgr.get_namespaces_by_name(module.params['name'], module.params['type'])
+            sd_mgr.delete_namespace(existing[0]['Id'])
+            module.exit_json(changed=True)
+        except Exception as e:
+            module.fail_json(msg="Exception '" + module.params['name'] + "': " + str(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
+++ b/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
@@ -29,7 +29,7 @@ notes:
      - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/servicediscovery.html
 version_added: "2.8"
 author:
-    - "tad merchant @ezmac"
+    - "Tad Merchant (@ezmac)"
 
 requirements: [ json, botocore, boto3 ]
 options:

--- a/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
+++ b/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
@@ -24,9 +24,9 @@ DOCUMENTATION = '''
 module: service_discovery_namespace
 short_description: thin wrap for boto servicediscovery client
 description:
-    - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/servicediscovery.html
+    - works with service discovery namespaces
 notes:
-     - nah.
+     - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/servicediscovery.html
 version_added: "2.8"
 author:
     - "tad merchant @ezmac"

--- a/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
+++ b/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
@@ -145,12 +145,7 @@ operation_id:
     returned: when creating and wait=false
 
 '''
-import time
 
-DEPLOYMENT_CONFIGURATION_TYPE_MAP = {
-    'maximum_percent': 'int',
-    'minimum_healthy_percent': 'int'
-}
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict

--- a/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
+++ b/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
@@ -137,6 +137,9 @@ namespace:
                 A unique string that identifies the request and that allows failed requests to be
                 retried without the risk of executing an operation twice.
 
+'''
+
+RETURN = '''
 
 operation_id:
     description: operation id of the non-waited namespace create request
@@ -319,13 +322,18 @@ def main():
                 module.exit_json(changed=False, namespace=camel_dict_to_snake_dict(namespace))
 
             if (not existing):
+                # namespace might be either the namespace object or 
+                # the operation ID depending on wait
                 namespace = sd_mgr.create_namespace(module.params['name'],
                                                     module.params['type'],
                                                     module.params['description'],
                                                     module.params['creator_request_id'],
                                                     module.params['vpc_id'],
                                                     module.params['wait'])
-                module.exit_json(changed=True, namespace=camel_dict_to_snake_dict(namespace))
+                if module.params['wait']:
+                    module.exit_json(changed=True, namespace=camel_dict_to_snake_dict(namespace))
+                else:
+                    module.exit_json(changed=True, operation_id=namespace['OperationId'])
 
         except Exception as e:
             module.fail_json(msg="Exception '" + module.params['name'] + "': " + str(e))

--- a/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
+++ b/lib/ansible/modules/cloud/amazon/service_discovery_namespace.py
@@ -90,22 +90,22 @@ namespace:
         id:
             description: Identifier of service discovery namespace
             returned: always
-            type: string
+            type: str
         arn:
             description: arn of namespace
             returned: always
-            type: string
+            type: str
         name:
             description: name of service discovery service
             returned: always
-            type: string
+            type: str
         type:
             description: The type of the namespace. Valid values are DNS_PUBLIC and DNS_PRIVATE .
-            type: string
+            type: str
             returned: always
         description:
             description: Description of namespace
-            type: string
+            type: str
             returned: always
         service_count:
             description: The number of services that are associated with the namespace.
@@ -123,7 +123,7 @@ namespace:
                                  when you create a namespace.
                     contains:
                         hosted_zone_id:
-                            type: string
+                            type: str
                             returned: always
                             description: The ID for the hosted zone that Route 53 creates when you create a namespace.
         create_date:
@@ -131,7 +131,7 @@ namespace:
             returned: always
             description: datetime of creation
         creator_request_id:
-            type: string
+            type: str
             returned: always
             description:
                 A unique string that identifies the request and that allows failed requests to be
@@ -143,7 +143,7 @@ RETURN = '''
 
 operation_id:
     description: operation id of the non-waited namespace create request
-    type: string
+    type: str
     returned: when creating and wait=false
 
 '''
@@ -295,6 +295,7 @@ class ServiceDiscoveryNamespace:
                     e['createdAt'] = str(e['createdAt'])
         return service
 
+
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
@@ -322,7 +323,7 @@ def main():
                 module.exit_json(changed=False, namespace=camel_dict_to_snake_dict(namespace))
 
             if (not existing):
-                # namespace might be either the namespace object or 
+                # namespace might be either the namespace object or
                 # the operation ID depending on wait
                 namespace = sd_mgr.create_namespace(module.params['name'],
                                                     module.params['type'],

--- a/test/integration/targets/service_discovery/aliases
+++ b/test/integration/targets/service_discovery/aliases
@@ -1,0 +1,4 @@
+cloud/aws
+service_discovery
+service_discovery_namespace
+unsupported

--- a/test/integration/targets/service_discovery/playbooks/full_test.yml
+++ b/test/integration/targets/service_discovery/playbooks/full_test.yml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  connection: local
+
+  roles:
+    - service_discovery

--- a/test/integration/targets/service_discovery/playbooks/roles/service_discovery/defaults/main.yml
+++ b/test/integration/targets/service_discovery/playbooks/roles/service_discovery/defaults/main.yml
@@ -1,0 +1,1 @@
+namespace_name: "test-namespace"

--- a/test/integration/targets/service_discovery/playbooks/roles/service_discovery/tasks/main.yml
+++ b/test/integration/targets/service_discovery/playbooks/roles/service_discovery/tasks/main.yml
@@ -1,0 +1,67 @@
+---
+# tasks file for ecs_cluster
+
+- block:
+    # ============================================================
+    - name: set up aws connection info
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          aws_access_key: "{{ aws_access_key }}"
+          aws_secret_key: "{{ aws_secret_key }}"
+          security_token: "{{ security_token }}"
+          region: "{{ aws_region }}"
+      no_log: yes
+
+    - name: create a vpc to work in
+      ec2_vpc_net:
+        cidr_block: 10.0.0.0/16
+        state: present
+        name: '{{ resource_prefix }}_ecs_cluster'
+        resource_tags:
+          name: '{{ resource_prefix }}_ecs_cluster'
+        <<: *aws_connection_info
+      register: setup_vpc
+
+    - name: create private service discovery namespace
+      service_discovery_namespace:
+        name: "private-{{ namespace_name}}"
+        state: present
+        type: DNS_PRIVATE
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+        <<: *aws_connection_info
+      register: service_discovery_private_namespace
+
+    - name: check that service_discovery_private_namespace changed
+      assert:
+        that:
+          - service_discovery_private_namespace.changed
+    - name: check that service_discovery_private_namespace returns expected parameters
+      assert:
+        that:
+          - service_discovery_private_namespace.namespace.id is defined
+
+
+
+
+  always:
+    # tear down: registry, namespace, vpc
+    - name: announce teardown start
+      debug:
+        msg: "***** testing complete. commence teardown *****"
+
+    # ignore errors so that test repeats are more reliable
+    - name: remove private service_discovery_namespace
+      service_discovery_namespace:
+        name: "private-{{ namespace_name }}"
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes
+
+
+    - name: remove setup vpc
+      ec2_vpc_net:
+        cidr_block: 10.0.0.0/16
+        state: absent
+        name: '{{ resource_prefix }}_ecs_cluster'
+        <<: *aws_connection_info
+      ignore_errors: no

--- a/test/integration/targets/service_discovery/playbooks/roles/service_discovery/tasks/main.yml
+++ b/test/integration/targets/service_discovery/playbooks/roles/service_discovery/tasks/main.yml
@@ -40,9 +40,6 @@
         that:
           - service_discovery_private_namespace.namespace.id is defined
 
-
-
-
   always:
     # tear down: registry, namespace, vpc
     - name: announce teardown start

--- a/test/integration/targets/service_discovery/playbooks/roles/service_discovery/tasks/main.yml
+++ b/test/integration/targets/service_discovery/playbooks/roles/service_discovery/tasks/main.yml
@@ -21,6 +21,22 @@
           name: '{{ resource_prefix }}_ecs_cluster'
         <<: *aws_connection_info
       register: setup_vpc
+      
+    - name: create private service discovery namespace without wait
+      service_discovery_namespace:
+        name: "private-{{ namespace_name}}-nowait"
+        state: present
+        type: DNS_PRIVATE
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+        wait: false
+        <<: *aws_connection_info
+      register: service_discovery_private_namespace_nowait
+
+    - name: check that service_discovery_private_namespace_nowait returns an OperationId
+      assert:
+        that:
+          - service_discovery_private_namespace_nowait.operation_id is defined
+
 
     - name: create private service discovery namespace
       service_discovery_namespace:
@@ -50,6 +66,13 @@
     - name: remove private service_discovery_namespace
       service_discovery_namespace:
         name: "private-{{ namespace_name }}"
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes
+    # ignore errors so that test repeats are more reliable
+    - name: remove private service_discovery_namespace
+      service_discovery_namespace:
+        name: "private-{{ namespace_name }}-nowait"
         state: absent
         <<: *aws_connection_info
       ignore_errors: yes

--- a/test/integration/targets/service_discovery/runme.sh
+++ b/test/integration/targets/service_discovery/runme.sh
@@ -12,7 +12,7 @@ trap 'rm -rf "${MYTMPDIR}"' EXIT
 # but for the python3 tests we need virtualenv to use python3
 PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
 
-# servicediscovery has been touched in 3 botocore versions, 1.8.8, 1.9.8 1.8.38
+# servicediscovery has been touched in 3 botocore versions, 1.8.8, 1.9.8 1.9.38
 # looks like 1.9.8 added custom health check, so I'm ignoring previous versions
 # Run full test suite
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"

--- a/test/integration/targets/service_discovery/runme.sh
+++ b/test/integration/targets/service_discovery/runme.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# We don't set -u here, due to pypa/virtualenv#150
+set -ex
+
+MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
+
+trap 'rm -rf "${MYTMPDIR}"' EXIT
+
+# This is needed for the ubuntu1604py3 tests
+# Ubuntu patches virtualenv to make the default python2
+# but for the python3 tests we need virtualenv to use python3
+PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
+
+# servicediscovery has been touched in 3 botocore versions, 1.8.8, 1.9.8 1.8.38
+# looks like 1.9.8 added custom health check, so I'm ignoring previous versions
+# Run full test suite
+virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
+source "${MYTMPDIR}/botocore-recent/bin/activate"
+$PYTHON -m pip install 'botocore>=1.9.8' boto3
+ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/full_test.yml "$@"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add service_discovery_namespace module

This won't be very useful without service discovery "services" and ecs service support.  I have both done but can only PR for one module at a time (as stated here: https://github.com/ansible/ansible/pull/48321) and tests for each part depends on previous parts. Advice on how to do that appreciated.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
service_discovery_namespace