### PR TITLE
Remove CI platform: freebsd/10.4

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -47,7 +47,6 @@ matrix:
 
     - env: T=osx/10.11/1
     - env: T=rhel/7.6/1
-    - env: T=freebsd/10.4/1
     - env: T=freebsd/11.1/1
     - env: T=linux/centos6/1
     - env: T=linux/centos7/1
@@ -60,7 +59,6 @@ matrix:
 
     - env: T=osx/10.11/2
     - env: T=rhel/7.6/2
-    - env: T=freebsd/10.4/2
     - env: T=freebsd/11.1/2
     - env: T=linux/centos6/2
     - env: T=linux/centos7/2
@@ -73,7 +71,6 @@ matrix:
 
     - env: T=osx/10.11/3
     - env: T=rhel/7.6/3
-    - env: T=freebsd/10.4/3
     - env: T=freebsd/11.1/3
     - env: T=linux/centos6/3
     - env: T=linux/centos7/3

--- a/test/runner/completion/remote.txt
+++ b/test/runner/completion/remote.txt
@@ -1,4 +1,3 @@
-freebsd/10.4
 freebsd/11.1
 osx/10.11
 rhel/7.6


### PR DESCRIPTION
##### SUMMARY

Remove the `freebsd/10.4` platform from the test matrix.

FreeBSD 10.4 reached end-of-life on October 31st, 2018.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

shippable.yml