### PR TITLE
templar: ensure that exceptions are handled, fix 'AttributeError'

### DIFF
--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -107,7 +107,7 @@ class AnsibleJ2Vars(Mapping):
             except AnsibleUndefinedVariable:
                 raise
             except Exception as e:
-                msg = getattr(e, 'message') or to_native(e)
+                msg = getattr(e, 'message', None) or to_native(e)
                 raise AnsibleError("An unhandled exception occurred while templating '%s'. "
                                    "Error was a %s, original message: %s" % (to_native(variable), type(e), msg))
 

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -50,6 +50,7 @@ class BaseTemplar(object):
             some_unsafe_var=wrap_var("unsafe_blip"),
             some_static_unsafe_var=wrap_var("static_unsafe_blip"),
             some_unsafe_keyword=wrap_var("{{ foo }}"),
+            str_with_error="{{ 'str' | from_json }}",
         )
         self.fake_loader = DictDataLoader({
             "/path/to/my_file.txt": "foo\n",
@@ -182,6 +183,10 @@ class TestTemplarTemplate(BaseTemplar, unittest.TestCase):
                                 'template error while templating string',
                                 self.templar.template,
                                 data)
+
+    def test_template_with_error(self):
+        """Check that AnsibleError is raised, fail if an unhandled exception is raised"""
+        self.assertRaises(AnsibleError, self.templar.template, "{{ str_with_error }}")
 
 
 class TestTemplarMisc(BaseTemplar, unittest.TestCase):


### PR DESCRIPTION
##### SUMMARY

Fix `AttributeError`:
```
The full traceback is:
Traceback (most recent call last):
  File "ansible/lib/ansible/template/vars.py", line 106, in __getitem__
    value = self._templar.template(variable)
  File "ansible/lib/ansible/template/__init__.py", line 430, in template
    disable_lookups=disable_lookups,
  File "ansible/lib/ansible/template/__init__.py", line 678, in do_template
    res = j2_concat(rf)
  File "<template>", line 11, in root
  File "/usr/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "ansible/lib/ansible/executor/task_executor.py", line 144, in run
    res = self._execute()
  File "ansible/lib/ansible/executor/task_executor.py", line 535, in _execute
    self._task.post_validate(templar=templar)
  File "ansible/lib/ansible/playbook/task.py", line 271, in post_validate
    super(Task, self).post_validate(templar)
  File "ansible/lib/ansible/playbook/base.py", line 364, in post_validate
    value = templar.template(getattr(self, name))
  File "ansible/lib/ansible/template/__init__.py", line 475, in template
    disable_lookups=disable_lookups,
  File "ansible/lib/ansible/template/__init__.py", line 430, in template
    disable_lookups=disable_lookups,
  File "ansible/lib/ansible/template/__init__.py", line 678, in do_template
    res = j2_concat(rf)
  File "<template>", line 9, in root
  File "ansible/lib/ansible/template/__init__.py", line 236, in resolve_or_missing
    val = super(AnsibleContext, self).resolve_or_missing(key)
  File "lib/python3.7/site-packages/jinja2/runtime.py", line 217, in resolve_or_missing
    return resolve_or_missing(self, key)
  File "lib/python3.7/site-packages/jinja2/runtime.py", line 129, in resolve_or_missing
    return context.parent[key]
  File "ansible/lib/ansible/template/vars.py", line 110, in __getitem__
    msg = getattr(e, 'message') or to_native(e)
AttributeError: 'JSONDecodeError' object has no attribute 'message'
```

Unit test provided.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/template/vars.py

##### ADDITIONAL INFORMATION

Simple reproducer:

```paste below
- hosts: localhost
  vars:
    not_json: "{{ 'test str' | from_json }}"
  tasks:
    - command: "echo {{ not_json }}"
```
