### PR TITLE
Fix host type check for inventory plugins

### DIFF
--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -189,7 +189,7 @@ class InventoryData(object):
         ''' adds a host to inventory and possibly a group if not there already '''
 
         if host:
-            if not isinstance(group, string_types):
+            if not isinstance(host, string_types):
                 raise AnsibleError("Invalid host name supplied, expected a string but got %s for %s" % (type(host), host))
             g = None
             if group:


### PR DESCRIPTION
##### SUMMARY
Don't check group type when checking type of host

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory/data.py

##### ADDITIONAL INFORMATION

