### PR TITLE
os_server: server.security_groups is a list of dicts

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -625,7 +625,7 @@ def _check_security_groups(module, cloud, server):
         return changed, server
 
     module_security_groups = set(module.params['security_groups'])
-    server_security_groups = set(sg.name for sg in server.security_groups)
+    server_security_groups = set(sg['name'] for sg in server.security_groups)
 
     add_sgs = module_security_groups - server_security_groups
     remove_sgs = server_security_groups - module_security_groups


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
os_server was trying to access `[sg.name for sg in server.security_groups]`, but the items in `server.security_groups` are dictionaries, so that should be `sg['name']`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_server module

##### ADDITIONAL INFORMATION

This is with ansible trunk (e9c91ebd09148e404cfa242b28f0fab24a4233d7) and python-openstacksdk trunk (openstack/python-openstacksdk@3cf6730a71d8fb448f24af8a5b4e82f2af749cea).