### PR TITLE
prepend 'ANSIBLE' to overlooked variables, define DEFAULT_VERBOSITY constant

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1314,7 +1314,7 @@ DISPLAY_SKIPPED_HOSTS:
   name: Show skipped results
   default: True
   description: "Toggle to control displaying skipped task/host entries in a task in the default callback"
-  env: [{name: DISPLAY_SKIPPED_HOSTS}]
+  env: [{name: ANSIBLE_DISPLAY_SKIPPED_HOSTS}]
   ini:
   - {key: display_skipped_hosts, section: defaults}
   type: boolean
@@ -1463,7 +1463,7 @@ NETWORK_GROUP_MODULES:
   name: Network module families
   default: [eos, nxos, ios, iosxr, junos, enos, ce, vyos, sros, dellos9, dellos10, dellos6, asa, aruba, aireos, bigip, ironware, onyx, netconf]
   description: 'TODO: write it'
-  env: [{name: NETWORK_GROUP_MODULES}]
+  env: [{name: ANSIBLE_NETWORK_GROUP_MODULES}]
   ini:
   - {key: network_group_modules, section: defaults}
   type: list

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -103,6 +103,7 @@ DEFAULT_SUDO_PASS = None
 DEFAULT_REMOTE_PASS = None
 DEFAULT_SUBSET = None
 DEFAULT_SU_PASS = None
+DEFAULT_VERBOSITY = 0
 # FIXME: expand to other plugins, but never doc fragments
 CONFIGURABLE_PLUGINS = ('cache', 'callback', 'connection', 'inventory', 'lookup', 'shell', 'cliconf', 'httpapi')
 # NOTE: always update the docs/docsite/Makefile to match


### PR DESCRIPTION
##### SUMMARY
a simple grep turned up settings that didn't have ANSIBLE_ prepended to the environment variable. Also trying to use ANSIBLE_VERBOSITY=N failed during parser.add_option() because the constant was not defined.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Config
