### PR TITLE
Fix lastpass lookup error

### DIFF
--- a/lib/ansible/plugins/lookup/lastpass.py
+++ b/lib/ansible/plugins/lookup/lastpass.py
@@ -38,6 +38,7 @@ RETURN = """
 from subprocess import Popen, PIPE
 
 from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_bytes, to_text
 from ansible.plugins.lookup import LookupBase
 
 
@@ -61,11 +62,11 @@ class LPass(object):
 
     def _run(self, args, stdin=None, expected_rc=0):
         p = Popen([self.cli_path] + args, stdout=PIPE, stderr=PIPE, stdin=PIPE)
-        out, err = p.communicate(stdin)
+        out, err = p.communicate(to_bytes(stdin))
         rc = p.wait()
         if rc != expected_rc:
             raise LPassException(err)
-        return out, err
+        return to_text(out, errors='surrogate_or_strict'), to_text(err, errors='surrogate_or_strict')
 
     def _build_args(self, command, args=None):
         if args is None:


### PR DESCRIPTION
##### SUMMARY
The lastpass lookup plugin fails with
```
An unhandled exception occurred while running the lookup plugin 'lastpass'. Error was a <class 'TypeError'>, original message: memoryview: a bytes-like object is required, not 'str'"
```

Fixes #42062.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lastpass

##### ADDITIONAL INFORMATION
Due to my limited Python experience this fix is primarily based on the way similar stuff is done in the onepass plugin (and testing of course).