### PR TITLE
terraform: use_unsafe_shell=True in run_command

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2710,7 +2710,7 @@ class AnsibleModule(object):
         :kw data: If given, information to write to the stdin of the command
         :kw binary_data: If False, append a newline to the data.  Default False
         :kw path_prefix: If given, additional path to find the command in.
-            This adds to the PATH environment vairable so helper commands in
+            This adds to the PATH environment variable so helper commands in
             the same directory can also be found
         :kw cwd: If given, working directory to run the command inside
         :kw use_unsafe_shell: See `args` parameter.  Default False

--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -177,7 +177,7 @@ def preflight_validation(bin_path, project_path, variables_args=None, plan_file=
     if not os.path.isdir(project_path):
         module.fail_json(msg="Path for Terraform project '{0}' doesn't exist on this host - check the path and try again please.".format(project_path))
 
-    rc, out, err = module.run_command([bin_path, 'validate'] + variables_args, cwd=project_path)
+    rc, out, err = module.run_command([bin_path, 'validate'] + variables_args, cwd=project_path, use_unsafe_shell=True)
     if rc != 0:
         module.fail_json(msg="Failed to validate Terraform configuration files:\r\n{0}".format(err))
 
@@ -246,12 +246,12 @@ def build_plan(bin_path, project_path, variables_args, state_file, targets, plan
 
     command = [bin_path, 'plan', '-input=false', '-no-color', '-detailed-exitcode', '-out', plan_path]
 
-    for t in (module.params.get('targets') or []):
+    for t in (targets or []):
         command.extend(['-target', t])
 
     command.extend(_state_args(state_file))
 
-    rc, out, err = module.run_command(command + variables_args, cwd=project_path)
+    rc, out, err = module.run_command(command + variables_args, cwd=project_path, use_unsafe_shell=True)
 
     if rc == 0:
         # no changes
@@ -320,7 +320,7 @@ def main():
     for k, v in variables.items():
         variables_args.extend([
             '-var',
-            shlex_quote('{0}={1}'.format(k, v))
+            '{0}={1}'.format(k, v)
         ])
     if variables_file:
         variables_args.extend(['-var-file', variables_file])


### PR DESCRIPTION
##### SUMMARY
When there are spaces in command args passed as a list,
then run_command and underlying subprocess fails.
This can be overcome by passing command as string rather than list.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py
lib/ansible/modules/cloud/misc/terraform.py
