### PR TITLE
[stable-2.6] Backport - Sysvinit - Enabling a service should use "defaults" if no runlevels are specified

### DIFF
--- a/changelogs/fragments/48808-sysvinit_defaults_if_no_runlevels.yaml
+++ b/changelogs/fragments/48808-sysvinit_defaults_if_no_runlevels.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sysvinit - enabling a service should use "defaults" if no runlevels are specified

--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -267,7 +267,7 @@ def main():
             # Perform enable/disable here
             if enabled:
                 if location.get('update-rc.d'):
-                    (rc, out, err) = module.run_command("%s %s enable" % (location['update-rc.d'], name))
+                    (rc, out, err) = module.run_command("%s %s defaults" % (location['update-rc.d'], name))
                 elif location.get('chkconfig'):
                     (rc, out, err) = module.run_command("%s %s on" % (location['chkconfig'], name))
             else:


### PR DESCRIPTION
##### SUMMARY
[stable-2.6] Backport
See: https://github.com/ansible/ansible/pull/48724
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sysvinit
