### PR TITLE
New module - meraki/meraki_syslog

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_syslog.py
+++ b/lib/ansible/modules/network/meraki/meraki_syslog.py
@@ -1,0 +1,247 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Kevin Breit (@kbreit) <kevin.breit@kevinbreit.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = r'''
+---
+module: meraki_syslog
+short_description: Manage syslog server settings in the Meraki cloud.
+version_added: "2.8"
+description:
+- Allows for creation and management of Syslog servers within Meraki.
+
+options:
+    auth_key:
+        description:
+        - Authentication key provided by the dashboard. Required if environmental variable MERAKI_KEY is not set.
+    state:
+        description:
+        - Create or modify an organization.
+        choices: [absent, present, query]
+        default: present
+    net_name:
+        description:
+        - Name of a network.
+        aliases: [name, network]
+    net_id:
+        description:
+        - ID number of a network.
+    org_name:
+        description:
+        - Name of organization associated to a network.
+    org_id:
+        description:
+        - ID of organization associated to a network.
+    server:
+        description:
+        - Syslog server settings
+        suboptions:
+            host:
+                description:
+                - IP address or hostname of Syslog server.
+            port:
+                description:
+                - Port number Syslog server is listening on.
+            roles:
+                description:
+                - List of applicable Syslog server roles.
+                choices: ['Wireless event log',
+                          'Appliance event log',
+                          'Switch event log',
+                          'Air Marshal events',
+                          'Flows',
+                          'URLs',
+                          'IDS alerts',
+                          'Security events']
+
+author:
+    - Kevin Breit (@kbreit)
+extends_documentation_fragment: meraki
+'''
+
+EXAMPLES = r'''
+- name: Query Syslog configurations on network named MyNet in the YourOrg organization
+  meraki_snmp:
+    auth_key: abc12345
+    status: query
+    org_name: YourOrg
+    net_name: MyNet
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+data:
+    description: Information about the created or manipulated object.
+    returned: info
+    type: complex
+    contains:
+      host:
+        description: Hostname or IP address of Syslog server.
+        returned: success
+        type: string
+        sample: 192.0.1.1
+      port:
+        description: Port number for Syslog communication.
+        returned: success
+        type: int
+        sample: 443
+      roles:
+        description: Organization ID which owns the network.
+        returned: success
+        type: list
+        sample: "Wireless event log", "URLs"
+'''
+
+import os
+from ansible.module_utils.basic import AnsibleModule, json, env_fallback
+from ansible.module_utils.urls import fetch_url
+from ansible.module_utils._text import to_native
+from ansible.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
+
+
+def is_net_valid(meraki, net_name, data):
+    for n in data:
+        if n['name'] == net_name:
+            return True
+    return False
+
+
+def construct_tags(tags):
+    ''' Assumes tags are a comma separated list '''
+    if tags is not None:
+        tags = tags.replace(' ', '')
+        tags = tags.split(',')
+        tag_list = str()
+        for t in tags:
+            tag_list = tag_list + " " + t
+        tag_list = tag_list + " "
+        return tag_list
+    return None
+
+def validate_roles(meraki, data):
+    ''' Validates whether provided rules are valid '''
+    valid_roles = ['WIRELESS EVENT LOG',
+                   'APPLIANCE EVENT LOG',
+                   'SWITCH EVENT LOG',
+                   'AIR MARSHAL EVENTS',
+                   'FLOWS',
+                   'URLS',
+                   'IDS ALERTS',
+                   'SECURITY EVENTS']
+    for server in data:
+        for role in server:
+            if role.upper() not in valid_roles:
+                meraki.fail_json(msg='{role} is not a valid Syslog role.'.format(role=role))
+
+def main():
+
+    # define the available arguments/parameters that a user can pass to
+    # the module
+
+    server_arg_spec = dict(host=dict(type='str'),
+                           port=dict(type='int'),
+                           roles=dict(type='list'),
+                           )
+
+    argument_spec = meraki_argument_spec()
+    argument_spec.update(
+        net_id=dict(type='str'),
+        servers=dict(type='list', element='dict', options=server_arg_spec)
+    )
+
+    # the AnsibleModule object will be our abstraction working with Ansible
+    # this includes instantiation, a couple of common attr would be the
+    # args/params passed to the execution, as well as if the module
+    # supports check mode
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=False,
+                           )
+
+    meraki = MerakiModule(module, function='syslog')
+    module.params['follow_redirects'] = 'all'
+    payload = None
+
+    syslog_urls = {'syslog': '/networks/{net_id}/syslogServers'}
+    meraki.url_catalog['query_update'] = syslog_urls
+
+    if not meraki.params['org_name'] and not meraki.params['org_id']:
+        meraki.fail_json(msg='org_name or org_id parameters are required')
+    if meraki.params['state'] != 'query':
+        if not meraki.params['net_name'] or meraki.params['net_id']:
+            meraki.fail_json(msg='net_name or net_id is required for present or absent states')
+    if meraki.params['net_name'] and meraki.params['net_id']:
+        meraki.fail_json(msg='net_name and net_id are mutually exclusive')
+
+    # if the user is working with this module in only check mode we do not
+    # want to make any changes to the environment, just return the current
+    # state with no modifications
+    if module.check_mode:
+        return meraki.result
+
+
+    # manipulate or modify the state as needed (this is going to be the
+    # part where your module will do what it needs to do)
+
+    org_id = meraki.params['org_id']
+    if not org_id:
+        org_id = meraki.get_org_id(meraki.params['org_name'])
+    nets = meraki.get_nets(org_id=org_id)
+    net_id = meraki.get_netid(net_name=meraki.params['net_name'], data=nets)
+
+    if meraki.params['state'] == 'query':
+        path = meraki.construct_path('query_update', net_id=net_id)
+        r = meraki.request(path, METHOD='GET')
+        if meraki.status == 200:
+            meraki.result['data'] = r
+    elif meraki.params['state'] == 'present':
+        # Construct payload
+        payload = dict()
+        payload['servers'] = meraki.params['servers']
+
+        path = meraki.construct_path('query_update', net_id=net_id)
+        r = meraki.request(path, METHOD='GET')
+        if meraki.status == 200:
+            original = r
+
+        validate_roles(meraki, payload)
+        if meraki.is_update_required(original, payload):
+            path = meraki.construct_path('query_update', net_id=net_id)
+            r = meraki.request(path, METHOD='PUT', payload=payload)
+            if meraki.status == 200:
+                meraki.result['data'] = r
+                meraki.result['changed'] = True
+    elif meraki.params['state'] == 'absent':
+        # Construct payload
+        payload = dict()
+
+        path = meraki.construct_path('query_update', net_id=net_id)
+        r = meraki.request(path, METHOD='GET')
+        if meraki.status == 200:
+            original = r
+
+        if meraki.is_update_required(original, payload):
+            path = meraki.construct_path('query_update', net_id=net_id)
+            r = meraki.request(path, METHOD='PUT', payload=payload)
+            if meraki.status == 200:
+                meraki.result['data'] = r
+                meraki.result['changed'] = True        
+
+
+    # in the event of a successful module execution, you will want to
+    # simple AnsibleModule.exit_json(), passing the key/value results
+    meraki.exit_json(**meraki.result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/meraki/meraki_syslog.py
+++ b/lib/ansible/modules/network/meraki/meraki_syslog.py
@@ -27,25 +27,31 @@ options:
     auth_key:
         description:
         - Authentication key provided by the dashboard. Required if environmental variable MERAKI_KEY is not set.
+        type: str
     state:
         description:
         - Query or edit syslog servers
         - To delete a syslog server, do not include server in list of servers
         choices: [present, query]
         default: present
+        type: str
     net_name:
         description:
         - Name of a network.
         aliases: [name, network]
+        type: str
     net_id:
         description:
         - ID number of a network.
+        type: str
     org_name:
         description:
         - Name of organization associated to a network.
+        type: str
     org_id:
         description:
         - ID of organization associated to a network.
+        type: str
     servers:
         description:
         - List of syslog server settings
@@ -188,7 +194,7 @@ def main():
     # the module
 
     server_arg_spec = dict(host=dict(type='str'),
-                           port=dict(type='str', default="514"),
+                           port=dict(type='int', default="514"),
                            roles=dict(type='list', choices=['Wireless Event log',
                                                             'Appliance event log',
                                                             'Switch event log',

--- a/lib/ansible/modules/network/meraki/meraki_syslog.py
+++ b/lib/ansible/modules/network/meraki/meraki_syslog.py
@@ -205,7 +205,6 @@ def main():
     if module.check_mode:
         return meraki.result
 
-
     # manipulate or modify the state as needed (this is going to be the
     # part where your module will do what it needs to do)
 

--- a/lib/ansible/modules/network/meraki/meraki_syslog.py
+++ b/lib/ansible/modules/network/meraki/meraki_syslog.py
@@ -75,12 +75,43 @@ extends_documentation_fragment: meraki
 '''
 
 EXAMPLES = r'''
-- name: Query Syslog configurations on network named MyNet in the YourOrg organization
-  meraki_snmp:
+- name: Query syslog configurations on network named MyNet in the YourOrg organization
+  meraki_syslog:
     auth_key: abc12345
     status: query
     org_name: YourOrg
     net_name: MyNet
+  delegate_to: localhost
+
+- name: Add single syslog server with Appliance event log role
+  meraki_syslog:
+    auth_key: abc12345
+    status: query
+    org_name: YourOrg
+    net_name: MyNet
+    servers:
+      - host: 192.0.1.2
+        port: 514
+        roles:
+          - Appliance event log
+  delegate_to: localhost
+
+- name: Add multiple syslog servers
+  meraki_syslog:
+    auth_key: abc12345
+    status: query
+    org_name: YourOrg
+    net_name: MyNet
+    servers:
+      - host: 192.0.1.2
+        port: 514
+        roles:
+          - Appliance event log
+      - host: 192.0.1.3
+        port: 514
+        roles:
+          - Appliance event log
+          - Flows
   delegate_to: localhost
 '''
 

--- a/lib/ansible/modules/network/meraki/meraki_syslog.py
+++ b/lib/ansible/modules/network/meraki/meraki_syslog.py
@@ -21,8 +21,8 @@ version_added: "2.8"
 description:
 - Allows for creation and management of Syslog servers within Meraki.
 notes:
-- Changes to existing syslog servers replaces existing configuration. If you need to add to an existing configuration \
-perform a C(state: query) to gather the existing configuration and then modify or add.
+- Changes to existing syslog servers replaces existing configuration. If you need to add to an
+  existing configuration set state to query to gather the existing configuration and then modify or add.
 options:
     auth_key:
         description:
@@ -46,9 +46,9 @@ options:
     org_id:
         description:
         - ID of organization associated to a network.
-    server:
+    servers:
         description:
-        - Syslog server settings
+        - List of syslog server settings
         suboptions:
             host:
                 description:
@@ -56,7 +56,7 @@ options:
             port:
                 description:
                 - Port number Syslog server is listening on.
-                default: 514
+                default: "514"
             roles:
                 description:
                 - List of applicable Syslog server roles.
@@ -122,20 +122,20 @@ data:
     type: complex
     contains:
       host:
-        description: Hostname or IP address of Syslog server.
+        description: Hostname or IP address of syslog server.
         returned: success
         type: string
         sample: 192.0.1.1
       port:
-        description: Port number for Syslog communication.
+        description: Port number for syslog communication.
         returned: success
         type: string
         sample: 443
       roles:
-        description: Organization ID which owns the network.
+        description: List of roles assigned to syslog server.
         returned: success
         type: list
-        sample: "Wireless event log", "URLs"
+        sample: "Wireless event log, URLs"
 '''
 
 import os

--- a/test/integration/targets/meraki_syslog/tasks/main.yml
+++ b/test/integration/targets/meraki_syslog/tasks/main.yml
@@ -1,0 +1,87 @@
+# Test code for the Meraki Organization module
+# Copyright: (c) 2018, Kevin Breit (@kbreit)
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+# - name: Test an API key is provided
+#   fail:
+#     msg: Please define an API key
+#   when: auth_key is not defined
+  
+# - name: Use an invalid domain
+#   meraki_switchport:
+#     auth_key: '{{ auth_key }}'
+#     host: marrrraki.com
+#     state: query
+#     serial: Q2HP-2C6E-GTLD
+#     org_name: IntTestOrg
+#   delegate_to: localhost
+#   register: invaliddomain
+#   ignore_errors: yes
+  
+# - name: Disable HTTP
+#   meraki_switchport:
+#     auth_key: '{{ auth_key }}'
+#     use_https: false
+#     state: query
+#     serial: Q2HP-2C6E-
+#     output_level: debug
+#   delegate_to: localhost
+#   register: http
+#   ignore_errors: yes
+
+# - name: Connection assertions
+#   assert:
+#     that:
+#       - '"Failed to connect to" in invaliddomain.msg'
+#       - '"http" in http.url'
+
+# - name: Query syslog settings
+#   meraki_syslog:
+#     auth_key: '{{auth_key}}'
+#     org_name: '{{test_org_name}}'
+#     net_name: '{{test_net_name}}'
+#     state: query
+#   delegate_to: localhost
+#   register: query_all
+
+# - debug:
+#     msg: '{{query_all}}'
+
+- name: Set syslog server
+  meraki_syslog:
+    auth_key: '{{auth_key}}'
+    org_name: '{{test_org_name}}'
+    net_name: '{{test_net_name}}'
+    state: present
+    servers:
+      - host: 192.0.1.2
+        port: 514
+        roles:
+          - Appliance event log
+  delegate_to: localhost
+  register: create_server
+
+- debug:
+    msg: '{{create_server}}'
+
+- assert:
+    that:
+      - create_server['servers'][0]['host'] == "192.0.1.2"
+
+- name: Set syslog server with idempotency
+  meraki_syslog:
+    auth_key: '{{auth_key}}'
+    org_name: '{{test_org_name}}'
+    net_name: '{{test_net_name}}'
+    state: present
+    servers:
+      - host: 192.0.1.2
+        port: 514
+        roles:
+          - Appliance event log
+  delegate_to: localhost
+  register: create_server_idempotency
+
+- debug:
+    msg: '{{create_server_idempotency}}'

--- a/test/integration/targets/meraki_syslog/tasks/main.yml
+++ b/test/integration/targets/meraki_syslog/tasks/main.yml
@@ -4,44 +4,50 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - block:
-  - name: Test an API key is provided
-    fail:
-      msg: Please define an API key
-    when: auth_key is not defined
+  # - name: Test an API key is provided
+  #   fail:
+  #     msg: Please define an API key
+  #   when: auth_key is not defined
     
-  - name: Use an invalid domain
-    meraki_switchport:
-      auth_key: '{{ auth_key }}'
-      host: marrrraki.com
-      state: query
-      serial: Q2HP-2C6E-GTLD
-      org_name: IntTestOrg
-    delegate_to: localhost
-    register: invaliddomain
-    ignore_errors: yes
+  # - name: Use an invalid domain
+  #   meraki_switchport:
+  #     auth_key: '{{ auth_key }}'
+  #     host: marrrraki.com
+  #     state: query
+  #     serial: Q2HP-2C6E-GTLD
+  #     org_name: IntTestOrg
+  #   delegate_to: localhost
+  #   register: invaliddomain
+  #   ignore_errors: yes
     
-  - name: Disable HTTP
-    meraki_switchport:
-      auth_key: '{{ auth_key }}'
-      use_https: false
-      state: query
-      serial: Q2HP-2C6E-
-      output_level: debug
-    delegate_to: localhost
-    register: http
-    ignore_errors: yes
+  # - name: Disable HTTP
+  #   meraki_switchport:
+  #     auth_key: '{{ auth_key }}'
+  #     use_https: false
+  #     state: query
+  #     serial: Q2HP-2C6E-
+  #     output_level: debug
+  #   delegate_to: localhost
+  #   register: http
+  #   ignore_errors: yes
 
-  - name: Connection assertions
-    assert:
-      that:
-        - '"Failed to connect to" in invaliddomain.msg'
-        - '"http" in http.url'
+  # - name: Connection assertions
+  #   assert:
+  #     that:
+  #       - '"Failed to connect to" in invaliddomain.msg'
+  #       - '"http" in http.url'
 
   - set_fact:
       syslog_test_net_name: 'syslog_{{test_net_name}}'
 
-  - debug:
-      msg: syslog_test_net_name
+  - name: Create network with type appliance and no timezone
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: '{{syslog_test_net_name}}'
+      type: appliance
+    delegate_to: localhost
 
   - name: Query syslog settings
     meraki_syslog:
@@ -70,11 +76,11 @@
     register: create_server
 
   - debug:
-      msg: '{{create_server}}'
+      msg: '{{create_server.data}}'
 
   - assert:
       that:
-        - create_server['servers'][0]['host'] == "192.0.1.2"
+        - create_server['data'][0]['host'] == "192.0.1.2"
 
   - name: Set syslog server with idempotency
     meraki_syslog:
@@ -95,9 +101,9 @@
 
   - assert:
       that:
-        - create_server_idempotency.changed is False
+        - create_server_idempotency.changed == False
 
-  - name: Set multiple syslog servers
+  - name: Set multiple syslog servers  # Broken
     meraki_syslog:
       auth_key: '{{auth_key}}'
       org_name: '{{test_org_name}}'
@@ -111,12 +117,12 @@
         - host: 192.0.1.4
           port: 514
           roles:
-            - Appliance event log
-            - Air Marshal events
+            - Appliance Event log
+            - Flows
         - host: 192.0.1.5
           port: 514
           roles:
-            - Air Marshal events   
+            - Flows
     delegate_to: localhost
     register: create_multiple_servers
 
@@ -125,14 +131,16 @@
 
   - assert:
       that:
-        - create_multiple_servers['servers'][0]['host'] == "192.0.1.2"
-        - create_multiple_servers['servers'][1]['host'] == "192.0.1.3"
-        - create_multiple_servers['servers'][2]['host'] == "192.0.1.4"
-        - create_multiple_servers['servers'][3]['host'] == "192.0.1.5"
-        - create_multiple_servers['servers'] | length == 4
+        - create_multiple_servers['data'][0]['host'] == "192.0.1.3"
+        - create_multiple_servers['data'][1]['host'] == "192.0.1.4"
+        - create_multiple_servers['data'][2]['host'] == "192.0.1.5"
+        - create_multiple_servers['data'] | length == 3
 
   - name: Create syslog server with bad name
     meraki_syslog:
+      auth_key: '{{auth_key}}'
+      org_name: '{{test_org_name}}'
+      net_name: '{{syslog_test_net_name}}'      
       state: present
       servers:
         - host: 192.0.1.6
@@ -143,14 +151,14 @@
     register: invalid_role
     ignore_errors: yes
 
-  - debug:
-      msg: '{{invalid_role}}'
+  # - debug:
+  #     msg: '{{invalid_role.body.errors.0}}'
 
   - assert:
       that:
-        - '"is not a valid Syslog role" in invalid_role.msg'
+        - '"Please select at least one valid role" in invalid_role.body.errors.0'
 
-  - name: Add role to existing syslog server
+  - name: Add role to existing syslog server  # Adding doesn't work, just creation
     meraki_syslog:
       auth_key: '{{auth_key}}'
       org_name: '{{test_org_name}}'
@@ -165,11 +173,12 @@
     register: add_role
 
   - debug:
-      msg: '{{add_role}}'
+      msg: '{{add_role.data.0.roles}}'
 
   - assert:
       that:
-        - add_role[0].roles[1] == 'Flows'
+        - add_role.data.0.roles.0 == 'Flows'
+        # - add_role.data.0.roles | length == 2
 
   always:
     - name: Delete syslog test network

--- a/test/integration/targets/meraki_syslog/tasks/main.yml
+++ b/test/integration/targets/meraki_syslog/tasks/main.yml
@@ -3,85 +3,181 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-# - name: Test an API key is provided
-#   fail:
-#     msg: Please define an API key
-#   when: auth_key is not defined
-  
-# - name: Use an invalid domain
-#   meraki_switchport:
-#     auth_key: '{{ auth_key }}'
-#     host: marrrraki.com
-#     state: query
-#     serial: Q2HP-2C6E-GTLD
-#     org_name: IntTestOrg
-#   delegate_to: localhost
-#   register: invaliddomain
-#   ignore_errors: yes
-  
-# - name: Disable HTTP
-#   meraki_switchport:
-#     auth_key: '{{ auth_key }}'
-#     use_https: false
-#     state: query
-#     serial: Q2HP-2C6E-
-#     output_level: debug
-#   delegate_to: localhost
-#   register: http
-#   ignore_errors: yes
+- block:
+  - name: Test an API key is provided
+    fail:
+      msg: Please define an API key
+    when: auth_key is not defined
+    
+  - name: Use an invalid domain
+    meraki_switchport:
+      auth_key: '{{ auth_key }}'
+      host: marrrraki.com
+      state: query
+      serial: Q2HP-2C6E-GTLD
+      org_name: IntTestOrg
+    delegate_to: localhost
+    register: invaliddomain
+    ignore_errors: yes
+    
+  - name: Disable HTTP
+    meraki_switchport:
+      auth_key: '{{ auth_key }}'
+      use_https: false
+      state: query
+      serial: Q2HP-2C6E-
+      output_level: debug
+    delegate_to: localhost
+    register: http
+    ignore_errors: yes
 
-# - name: Connection assertions
-#   assert:
-#     that:
-#       - '"Failed to connect to" in invaliddomain.msg'
-#       - '"http" in http.url'
+  - name: Connection assertions
+    assert:
+      that:
+        - '"Failed to connect to" in invaliddomain.msg'
+        - '"http" in http.url'
 
-# - name: Query syslog settings
-#   meraki_syslog:
-#     auth_key: '{{auth_key}}'
-#     org_name: '{{test_org_name}}'
-#     net_name: '{{test_net_name}}'
-#     state: query
-#   delegate_to: localhost
-#   register: query_all
+  - set_fact:
+      syslog_test_net_name: 'syslog_{{test_net_name}}'
 
-# - debug:
-#     msg: '{{query_all}}'
+  - debug:
+      msg: syslog_test_net_name
 
-- name: Set syslog server
-  meraki_syslog:
-    auth_key: '{{auth_key}}'
-    org_name: '{{test_org_name}}'
-    net_name: '{{test_net_name}}'
-    state: present
-    servers:
-      - host: 192.0.1.2
-        port: 514
-        roles:
-          - Appliance event log
-  delegate_to: localhost
-  register: create_server
+  - name: Query syslog settings
+    meraki_syslog:
+      auth_key: '{{auth_key}}'
+      org_name: '{{test_org_name}}'
+      net_name: '{{syslog_test_net_name}}'
+      state: query
+    delegate_to: localhost
+    register: query_all
 
-- debug:
-    msg: '{{create_server}}'
+  - debug:
+      msg: '{{query_all}}'
 
-- assert:
-    that:
-      - create_server['servers'][0]['host'] == "192.0.1.2"
+  - name: Set syslog server
+    meraki_syslog:
+      auth_key: '{{auth_key}}'
+      org_name: '{{test_org_name}}'
+      net_name: '{{syslog_test_net_name}}'
+      state: present
+      servers:
+        - host: 192.0.1.2
+          port: 514
+          roles:
+            - Appliance event log
+    delegate_to: localhost
+    register: create_server
 
-- name: Set syslog server with idempotency
-  meraki_syslog:
-    auth_key: '{{auth_key}}'
-    org_name: '{{test_org_name}}'
-    net_name: '{{test_net_name}}'
-    state: present
-    servers:
-      - host: 192.0.1.2
-        port: 514
-        roles:
-          - Appliance event log
-  delegate_to: localhost
-  register: create_server_idempotency
+  - debug:
+      msg: '{{create_server}}'
 
-- debug:
-    msg: '{{create_server_idempotency}}'
+  - assert:
+      that:
+        - create_server['servers'][0]['host'] == "192.0.1.2"
+
+  - name: Set syslog server with idempotency
+    meraki_syslog:
+      auth_key: '{{auth_key}}'
+      org_name: '{{test_org_name}}'
+      net_name: '{{syslog_test_net_name}}'
+      state: present
+      servers:
+        - host: 192.0.1.2
+          port: 514
+          roles:
+            - Appliance event log
+    delegate_to: localhost
+    register: create_server_idempotency
+
+  - debug:
+      msg: '{{create_server_idempotency}}'
+
+  - assert:
+      that:
+        - create_server_idempotency.changed is False
+
+  - name: Set multiple syslog servers
+    meraki_syslog:
+      auth_key: '{{auth_key}}'
+      org_name: '{{test_org_name}}'
+      net_name: '{{syslog_test_net_name}}'
+      state: present
+      servers:
+        - host: 192.0.1.3
+          port: 514
+          roles:
+            - Appliance event log
+        - host: 192.0.1.4
+          port: 514
+          roles:
+            - Appliance event log
+            - Air Marshal events
+        - host: 192.0.1.5
+          port: 514
+          roles:
+            - Air Marshal events   
+    delegate_to: localhost
+    register: create_multiple_servers
+
+  - debug:
+      msg: '{{create_multiple_servers}}'
+
+  - assert:
+      that:
+        - create_multiple_servers['servers'][0]['host'] == "192.0.1.2"
+        - create_multiple_servers['servers'][1]['host'] == "192.0.1.3"
+        - create_multiple_servers['servers'][2]['host'] == "192.0.1.4"
+        - create_multiple_servers['servers'][3]['host'] == "192.0.1.5"
+        - create_multiple_servers['servers'] | length == 4
+
+  - name: Create syslog server with bad name
+    meraki_syslog:
+      state: present
+      servers:
+        - host: 192.0.1.6
+          port: 514
+          roles:
+            - Invalid role
+    delegate_to: localhost
+    register: invalid_role
+    ignore_errors: yes
+
+  - debug:
+      msg: '{{invalid_role}}'
+
+  - assert:
+      that:
+        - '"is not a valid Syslog role" in invalid_role.msg'
+
+  - name: Add role to existing syslog server
+    meraki_syslog:
+      auth_key: '{{auth_key}}'
+      org_name: '{{test_org_name}}'
+      net_name: '{{syslog_test_net_name}}'
+      state: present
+      servers:
+        - host: 192.0.1.2
+          port: 514
+          roles:
+            - flows
+    delegate_to: localhost
+    register: add_role
+
+  - debug:
+      msg: '{{add_role}}'
+
+  - assert:
+      that:
+        - add_role[0].roles[1] == 'Flows'
+
+  always:
+    - name: Delete syslog test network
+      meraki_network:
+        auth_key: '{{ auth_key }}'
+        state: absent
+        org_name: '{{test_org_name}}'
+        net_name: '{{syslog_test_net_name}}'
+      delegate_to: localhost
+      register: delete_all
+      ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
Allows Ansible to create syslog servers with proper roles for Meraki networks

Fixes #48609

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
meraki_syslog

##### ADDITIONAL INFORMATION
This heavily relies on the API for error information and changes. I am not merging old configurations with new configurations so any changes provided by a playbook completely overwrite the existing configuration.