### PR TITLE
re-enable batch tests for script on Windows

### DIFF
--- a/test/integration/targets/win_script/files/fail.bat
+++ b/test/integration/targets/win_script/files/fail.bat
@@ -1,0 +1,1 @@
+bang-run-a-thing-that-doesnt-exist

--- a/test/integration/targets/win_script/tasks/main.yml
+++ b/test/integration/targets/win_script/tasks/main.yml
@@ -16,6 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: run setup to allow skipping OS-specific tests
+  setup:
+    gather_subset: min
+
 - name: get tempdir path
   raw: $env:TEMP
   register: tempdir
@@ -178,36 +182,50 @@
       - "test_script_removes_file_again_result is not changed"
       - "test_script_removes_file_again_result is skipped"
 
-# TODO: these tests fail on 2008 (not even R2) with no output. It's related to the default codepage being UTF8- if we force it back to 437, it works fine.
-# Need to figure out a sane place to do that under the new exec wrapper.
-#- name: run simple batch file
-#  script: test_script.bat
-#  register: test_batch_result
-#
-#- name: check that batch file ran
-#  assert:
-#    that:
-#      - "test_batch_result.rc == 0"
-#      - "test_batch_result.stdout"
-#      - "'batch' in test_batch_result.stdout"
-#      - "not test_batch_result.stderr"
-#      - "test_batch_result is not failed"
-#      - "test_batch_result is changed"
+- name: skip batch tests on 6.0 (UTF8 codepage prevents it from working, see https://github.com/ansible/ansible/issues/21915)
+  block:
+  - name: run simple batch file
+    script: test_script.bat
+    register: test_batch_result
 
+  - name: check that batch file ran
+    assert:
+      that:
+        - "test_batch_result.rc == 0"
+        - "test_batch_result.stdout"
+        - "'batch' in test_batch_result.stdout"
+        - "not test_batch_result.stderr"
+        - "test_batch_result is not failed"
+        - "test_batch_result is changed"
 
-#- name: run simple batch file with .cmd extension
-#  script: test_script.cmd
-#  register: test_cmd_result
-#
-#- name: check that batch file with .cmd extension ran
-#  assert:
-#    that:
-#      - "test_cmd_result.rc == 0"
-#      - "test_cmd_result.stdout"
-#      - "'cmd extension' in test_cmd_result.stdout"
-#      - "not test_cmd_result.stderr"
-#      - "test_cmd_result is not failed"
-#      - "test_cmd_result is changed"
+  - name: run simple batch file with .cmd extension
+    script: test_script.cmd
+    register: test_cmd_result
+
+  - name: check that batch file with .cmd extension ran
+    assert:
+      that:
+        - "test_cmd_result.rc == 0"
+        - "test_cmd_result.stdout"
+        - "'cmd extension' in test_cmd_result.stdout"
+        - "not test_cmd_result.stderr"
+        - "test_cmd_result is not failed"
+        - "test_cmd_result is changed"
+
+  - name: run simple batch file with .bat extension that fails
+    script: fail.bat
+    ignore_errors: true
+    register: test_batch_result
+
+  - name: check that batch file with .bat extension reported failure
+    assert:
+      that:
+        - test_batch_result.rc == 1
+        - test_batch_result.stdout
+        - test_batch_result.stderr
+        - test_batch_result is failed
+        - test_batch_result is changed
+  when: not ansible_distribution_version.startswith('6.0')
 
 - name: run test script that takes a boolean parameter
   script: test_script_bool.ps1 $false  # use false as that can pick up more errors


### PR DESCRIPTION
##### SUMMARY
* skipped on Server 2008 since batch interpreter is busted under UTF8 codepage
* see https://github.com/ansible/ansible/issues/21915 for more details

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
script

##### ADDITIONAL INFORMATION
