### PR TITLE
Support skip of platforms by version in tests.

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
@@ -44,6 +44,11 @@ Aliases can be used to skip platforms using one of the following:
 - ``skip/rhel`` - Skip tests on RHEL.
 - ``skip/docker`` - Skip tests when running on a Docker container
 
+Platform versions, as specified using the ``--remote`` option with ``/`` removed, can also be skipped:
+
+- ``skip/freebsd11.1`` - Skip tests on FreeBSD 11.1.
+- ``skip/rhel7.6`` - Skip tests on RHEL 7.6.
+
 Aliases can be used to skip Python major versions using one of the following:
 
 - ``skip/python2`` - Skip tests on Python 2.x.

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1632,6 +1632,13 @@ def get_integration_remote_filter(args, targets):
         display.warning('Excluding tests marked "%s" which are not supported on %s: %s'
                         % (skip.rstrip('/'), platform, ', '.join(skipped)))
 
+    skip = 'skip/%s/' % args.remote.replace('/', '')
+    skipped = [target.name for target in targets if skip in target.aliases]
+    if skipped:
+        exclude.append(skip)
+        display.warning('Excluding tests marked "%s" which are not supported on %s: %s'
+                        % (skip.rstrip('/'), platform, ', '.join(skipped)))
+
     python_version = 2  # remotes are expected to default to python 2
 
     skip = 'skip/python%d/' % python_version


### PR DESCRIPTION
##### SUMMARY

Support skip of platforms by version in tests.

Previously a remote platform could be skipped completely using the alias:

`skip/{platform}` such as `skip/rhel`

Now a specific platform version can be skipped using the alias:

`skip/{platform}{version}` such as `skip/rhel7.6`

This feature is available for platforms specified with the `--remote` option.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test