### PR TITLE
fix constructed functionality in openstack inventory plugin

### DIFF
--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -240,7 +240,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             # create composite vars
             self._set_composite_vars(
-                self._config_data.get('compose'), hostvars, host)
+                self._config_data.get('compose'), hostvars[host], host)
 
             # actually update inventory
             for key in hostvars[host]:
@@ -248,7 +248,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             # constructed groups based on conditionals
             self._add_host_to_composed_groups(
-                self._config_data.get('groups'), hostvars, host)
+                self._config_data.get('groups'), hostvars[host], host)
+
+            # constructed groups based on jinja expressions
+            self._add_host_to_keyed_groups(
+                self._config_data.get('keyed_groups'), hostvars[host], host)
 
         for group_name, group_hosts in groups.items():
             self.inventory.add_group(group_name)

--- a/test/units/plugins/inventory/test_openstack.py
+++ b/test/units/plugins/inventory/test_openstack.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 Lars Kellogg-Stedman <lars@redhat.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible.plugins.inventory.openstack import InventoryModule
+from ansible.inventory.data import InventoryData
+from ansible.template import Templar
+
+
+config_data = {
+    'plugin': 'openstack',
+    'compose': {
+        'composed_var': '"testvar-" + testvar',
+    },
+    'groups': {
+        'testgroup': '"host" in inventory_hostname',
+    },
+    'keyed_groups':
+    [{
+        'prefix': 'keyed',
+        'key': 'testvar',
+    }]
+}
+
+hostvars = {
+    'host0': {
+        'inventory_hostname': 'host0',
+        'testvar': '0',
+    },
+    'host1': {
+        'inventory_hostname': 'host1',
+        'testvar': '1',
+    },
+}
+
+
+@pytest.fixture(scope="module")
+def inventory():
+    inventory = InventoryModule()
+    inventory._config_data = config_data
+    inventory.inventory = InventoryData()
+    inventory.templar = Templar(loader=None)
+
+    for host in hostvars:
+        inventory.inventory.add_host(host)
+
+    return inventory
+
+
+def test_simpel_groups(inventory):
+    inventory._set_variables(hostvars, {})
+    groups = inventory.inventory.get_groups_dict()
+    assert 'testgroup' in groups
+    assert len(groups['testgroup']) == len(hostvars)
+
+
+def test_keyed_groups(inventory):
+    inventory._set_variables(hostvars, {})
+    assert 'keyed_0' in inventory.inventory.groups
+    assert 'keyed_1' in inventory.inventory.groups
+
+
+def test_composed_vars(inventory):
+    inventory._set_variables(hostvars, {})
+
+    for host in hostvars:
+        assert host in inventory.inventory.hosts
+        host = inventory.inventory.get_host(host)
+        assert host.vars['composed_var'] == 'testvar-{testvar}'.format(**hostvars[host.name])

--- a/test/units/plugins/inventory/test_openstack.py
+++ b/test/units/plugins/inventory/test_openstack.py
@@ -68,7 +68,7 @@ def inventory():
     return inventory
 
 
-def test_simpel_groups(inventory):
+def test_simple_groups(inventory):
     inventory._set_variables(hostvars, {})
     groups = inventory.inventory.get_groups_dict()
     assert 'testgroup' in groups


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The compose, groups, and keyed_groups functionality of the openstack
inventory plugin was broken:

- the plugin was not passing the correct variables to the
  Constructable methods for compose and groups
- the plugin was simply never calling the appropriate method for
  implementing keyed_groups

This commit fixes both issues.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openstack inventory plugin

