### PR TITLE
Add `--raw` option to ansible-test shell command.

### DIFF
--- a/test/runner/lib/cli.py
+++ b/test/runner/lib/cli.py
@@ -409,6 +409,10 @@ def parse_args():
     shell.set_defaults(func=command_shell,
                        config=ShellConfig)
 
+    shell.add_argument('--raw',
+                       action='store_true',
+                       help='direct to shell with no setup')
+
     add_environments(shell, tox_version=True)
     add_extra_docker_options(shell)
     add_httptester_options(shell, argparse)

--- a/test/runner/lib/config.py
+++ b/test/runner/lib/config.py
@@ -134,6 +134,11 @@ class ShellConfig(EnvironmentConfig):
         """
         super(ShellConfig, self).__init__(args, 'shell')
 
+        self.raw = args.raw  # type: bool
+
+        if self.raw:
+            self.httptester = False
+
 
 class SanityConfig(TestConfig):
     """Configuration for the sanity command."""

--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -334,9 +334,11 @@ def delegate_remote(args, exclude, require, integration_targets):
 
     core_ci = AnsibleCoreCI(args, platform, version, stage=args.remote_stage, provider=args.remote_provider)
     success = False
+    raw = False
 
     if isinstance(args, ShellConfig):
         use_httptester = args.httptester
+        raw = args.raw
     else:
         use_httptester = args.httptester and any('needs/httptester/' in target.aliases for target in integration_targets)
 
@@ -359,6 +361,9 @@ def delegate_remote(args, exclude, require, integration_targets):
             # Windows doesn't need the ansible-test fluff, just run the SSH command
             manage = ManageWindowsCI(core_ci)
             cmd = ['powershell.exe']
+        elif raw:
+            manage = ManagePosixCI(core_ci)
+            cmd = create_shell_command(['bash'])
         else:
             options = {
                 '--remote': 1,
@@ -384,6 +389,7 @@ def delegate_remote(args, exclude, require, integration_targets):
             manage = ManagePosixCI(core_ci)
 
         manage.setup()
+
         if isinstance(args, IntegrationConfig):
             cloud_platforms = get_cloud_providers(args)
 
@@ -394,7 +400,16 @@ def delegate_remote(args, exclude, require, integration_targets):
             manage.ssh(cmd, ssh_options)
             success = True
         finally:
+            download = False
+
             if platform != 'windows':
+                download = True
+
+            if isinstance(args, ShellConfig):
+                if args.raw:
+                    download = False
+
+            if download:
                 manage.ssh('rm -rf /tmp/results && cp -a ansible/test/results /tmp/results && chmod -R a+r /tmp/results')
                 manage.download('/tmp/results', 'test')
     finally:

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -161,6 +161,10 @@ def install_command_requirements(args, python_version=None):
     :type args: EnvironmentConfig
     :type python_version: str | None
     """
+    if isinstance(args, ShellConfig):
+        if args.raw:
+            return
+
     generate_egg_info(args)
 
     if not args.requirements:

--- a/test/runner/lib/manage_ci.py
+++ b/test/runner/lib/manage_ci.py
@@ -24,6 +24,10 @@ from lib.ansible_util import (
     ansible_environment,
 )
 
+from lib.config import (
+    ShellConfig,
+)
+
 
 class ManageWindowsCI(object):
     """Manage access to a Windows instance provided by Ansible Core CI."""
@@ -203,6 +207,11 @@ class ManagePosixCI(object):
     def setup(self):
         """Start instance and wait for it to become ready and respond to an ansible ping."""
         self.wait()
+
+        if isinstance(self.core_ci.args, ShellConfig):
+            if self.core_ci.args.raw:
+                return
+
         self.configure()
         self.upload_source()
 


### PR DESCRIPTION
##### SUMMARY

Add `--raw` option to ansible-test shell command.

It is currently supported only with the `--remote` option.

This makes it easier to troubleshoot new instances which are not yet supported by the setup scripts used by ansible-test.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test