### PR TITLE
Ansible.Basic.cs - fix check mode run with nested spec

### DIFF
--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -700,7 +700,8 @@ namespace Ansible.Basic
             // initially parse the params and check for unsupported ones and set internal vars
             CheckUnsupportedArguments(param, legalInputs);
 
-            if (CheckMode && !(bool)spec["supports_check_mode"])
+            // Only run this check if we are at the root argument (optionsContext.Count == 0)
+            if (CheckMode && !(bool)spec["supports_check_mode"] && optionsContext.Count == 0)
             {
                 Result["skipped"] = true;
                 Result["msg"] = String.Format("remote module ({0}) does not support check mode", ModuleName);

--- a/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
@@ -1352,6 +1352,28 @@ test_no_log - Invoked with:
         $actual.invocation | Assert-DictionaryEquals -Expected @{module_args = @{option_key = "abc"}}
     }
 
+    "Check mode with suboption without supports_check_mode" = {
+        $spec = @{
+            options = @{
+                sub_options = @{
+                    # This tests the situation where a sub key doesn't set supports_check_mode, the logic in
+                    # Ansible.Basic automatically sets that to $false and we want it to ignore it for a nested check
+                    type = "dict"
+                    options = @{
+                        sub_option = @{ type = "str"; default = "value" }
+                    }
+                }
+            }
+            supports_check_mode = $true
+        }
+        $complex_args = @{
+            _ansible_check_mode = $true
+        }
+
+        $m = [Ansible.Basic.AnsibleModule]::Create(@(), $spec)
+        $m.CheckMode | Assert-Equals -Expected $true
+    }
+
     "Type conversion error" = {
         $spec = @{
             options = @{


### PR DESCRIPTION
##### SUMMARY
Fix issue where Ansible.Basic was always validating `supports_check_mode` for nested specs. This is an issue as `supports_check_mode` defaults to `False` and causes a module to exit early.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/csharp/Ansible.Basic.cs