### PR TITLE
Fix: Scaleway Compute managed reserved IP

### DIFF
--- a/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
@@ -372,7 +372,7 @@ def present_strategy(compute_api, wished_server):
         target_server = query_results[0]
 
     if server_or_ip_should_be_changed(compute_api=compute_api, target_server=target_server,
-                                           wished_server=wished_server):
+                                      wished_server=wished_server):
         changed = True
 
         if compute_api.module.check_mode:
@@ -436,7 +436,7 @@ def running_strategy(compute_api, wished_server):
         target_server = query_results[0]
 
     if server_or_ip_should_be_changed(compute_api=compute_api, target_server=target_server,
-                                           wished_server=wished_server):
+                                      wished_server=wished_server):
         changed = True
 
         if compute_api.module.check_mode:
@@ -480,7 +480,7 @@ def stop_strategy(compute_api, wished_server):
     compute_api.module.debug("stop_strategy: Servers are found.")
 
     if server_or_ip_should_be_changed(compute_api=compute_api, target_server=target_server,
-                                           wished_server=wished_server):
+                                      wished_server=wished_server):
         changed = True
 
         if compute_api.module.check_mode:
@@ -527,7 +527,7 @@ def restart_strategy(compute_api, wished_server):
         target_server = query_results[0]
 
     if server_or_ip_should_be_changed(compute_api=compute_api, target_server=target_server,
-                                           wished_server=wished_server):
+                                      wished_server=wished_server):
         changed = True
 
         if compute_api.module.check_mode:
@@ -584,6 +584,7 @@ def find(compute_api, wished_server, per_page=1):
     search_results = response.json["servers"]
 
     return search_results
+
 
 OPTIONAL_SERVER_ATTRIBUTES = (
     "security_group",

--- a/test/legacy/roles/scaleway_compute/defaults/main.yml
+++ b/test/legacy/roles/scaleway_compute/defaults/main.yml
@@ -1,6 +1,6 @@
 # Below information has been taken from https://developer.scaleway.com/#servers
 ---
-scaleway_image_id: 89ee4018-f8c3-4dc4-a6b5-bca14f985ebe
+scaleway_image_id: 6a601340-19c1-4ca7-9c1c-0704bcc9f5fe
 scaleway_organization: '{{ scw_org }}'
 scaleway_region: ams1
 scaleway_commerial_type: START1-S

--- a/test/legacy/roles/scaleway_compute/tasks/ip.yml
+++ b/test/legacy/roles/scaleway_compute/tasks/ip.yml
@@ -199,3 +199,208 @@
     that:
       - server_destroy_task is success
       - server_destroy_task is changed
+
+# Reserved IP
+- name: Reserve public IPV4
+  scaleway_ip:
+    organization: '{{ scaleway_organization }}'
+    state: present
+    region: '{{ scaleway_region }}'
+  register: reserved_ip_1
+
+- name: Reserve public IPV4
+  scaleway_ip:
+    organization: '{{ scaleway_organization }}'
+    state: present
+    region: '{{ scaleway_region }}'
+  register: reserved_ip_2
+
+- name: Create a server reserved IP
+  scaleway_compute:
+    name: '{{ scaleway_name }}'
+    state: present
+    public_ip: '{{ reserved_ip_1.scaleway_ip.id }}'
+    image: '{{ scaleway_image_id }}'
+    organization: '{{ scaleway_organization }}'
+    region: '{{ scaleway_region }}'
+    commercial_type: '{{ scaleway_commerial_type }}'
+    wait: true
+
+  register: server_creation_reserved_task
+
+- debug: var=server_creation_reserved_task
+
+- assert:
+    that:
+      - server_creation_reserved_task is success
+      - server_creation_reserved_task is changed
+
+- name: Check server reserved IP
+  scaleway_compute:
+    name: '{{ scaleway_name }}'
+    state: present
+    public_ip: '{{ reserved_ip_1.scaleway_ip.id }}'
+    image: '{{ scaleway_image_id }}'
+    organization: '{{ scaleway_organization }}'
+    region: '{{ scaleway_region }}'
+    commercial_type: '{{ scaleway_commerial_type }}'
+    wait: true
+
+  register: server_creation_reserved_check_task
+
+- debug: var=server_creation_reserved_check_task
+
+- assert:
+    that:
+      - server_creation_reserved_check_task is success
+      - server_creation_reserved_check_task is not changed
+
+- name: Switch reserved IP
+  scaleway_compute:
+    name: '{{ scaleway_name }}'
+    state: present
+    public_ip: '{{ reserved_ip_2.scaleway_ip.id }}'
+    image: '{{ scaleway_image_id }}'
+    organization: '{{ scaleway_organization }}'
+    region: '{{ scaleway_region }}'
+    commercial_type: '{{ scaleway_commerial_type }}'
+    wait: true
+
+  register: server_switch_reserved_task
+
+- debug: var=server_switch_reserved_task
+
+- assert:
+    that:
+      - server_switch_reserved_task is success
+      - server_switch_reserved_task is changed
+
+- name: Switch to dynamic IP
+  scaleway_compute:
+    name: '{{ scaleway_name }}'
+    state: present
+    public_ip: 'dynamic'
+    image: '{{ scaleway_image_id }}'
+    organization: '{{ scaleway_organization }}'
+    region: '{{ scaleway_region }}'
+    commercial_type: '{{ scaleway_commerial_type }}'
+    wait: true
+
+  register: server_switch_dynamic_task
+
+- debug: var=server_switch_dynamic_task
+
+- assert:
+    that:
+      - server_switch_dynamic_task is success
+      - server_switch_dynamic_task is changed
+
+- name: Switch to reserved IP
+  scaleway_compute:
+    name: '{{ scaleway_name }}'
+    state: present
+    public_ip: '{{ reserved_ip_1.scaleway_ip.id }}'
+    image: '{{ scaleway_image_id }}'
+    organization: '{{ scaleway_organization }}'
+    region: '{{ scaleway_region }}'
+    commercial_type: '{{ scaleway_commerial_type }}'
+    wait: true
+
+  register: server_switch_reserved_task2
+
+- debug: var=server_switch_reserved_task2
+
+- assert:
+    that:
+      - server_switch_reserved_task2 is success
+      - server_switch_reserved_task2 is changed
+
+- name: Switch to no IP
+  scaleway_compute:
+    name: '{{ scaleway_name }}'
+    state: present
+    public_ip: 'absent'
+    image: '{{ scaleway_image_id }}'
+    organization: '{{ scaleway_organization }}'
+    region: '{{ scaleway_region }}'
+    commercial_type: '{{ scaleway_commerial_type }}'
+    wait: true
+
+  register: server_switch_absent_task
+
+- debug: var=server_switch_absent_task
+
+- assert:
+    that:
+      - server_switch_absent_task is success
+      - server_switch_absent_task is changed
+
+- name: Switch to reserved IP
+  scaleway_compute:
+    name: '{{ scaleway_name }}'
+    state: present
+    public_ip: '{{ reserved_ip_1.scaleway_ip.id }}'
+    image: '{{ scaleway_image_id }}'
+    organization: '{{ scaleway_organization }}'
+    region: '{{ scaleway_region }}'
+    commercial_type: '{{ scaleway_commerial_type }}'
+    wait: true
+
+  register: server_switch_reserved_task3
+
+- debug: var=server_switch_reserved_task3
+
+- assert:
+    that:
+      - server_switch_reserved_task3 is success
+      - server_switch_reserved_task3 is changed
+
+# Cleanup
+- name: Destroy it
+  scaleway_compute:
+    name: '{{ scaleway_name }}'
+    state: absent
+    image: '{{ scaleway_image_id }}'
+    organization: '{{ scaleway_organization }}'
+    region: '{{ scaleway_region }}'
+    commercial_type: '{{ scaleway_commerial_type }}'
+    wait: true
+
+  register: server_destroy_task
+
+- debug: var=server_destroy_task
+
+- assert:
+    that:
+      - server_destroy_task is success
+      - server_destroy_task is changed
+
+- name: Destroy IP
+  scaleway_ip:
+    state: absent
+    organization: '{{ scaleway_organization }}'
+    region: '{{ scaleway_region }}'
+    id: '{{ reserved_ip_1.scaleway_ip.id }}'
+  register: ip_destroy_task
+
+- debug: var=ip_destroy_task
+
+- assert:
+    that:
+      - ip_destroy_task is success
+      - ip_destroy_task is changed
+
+- name: Destroy IP
+  scaleway_ip:
+    state: absent
+    organization: '{{ scaleway_organization }}'
+    region: '{{ scaleway_region }}'
+    id: '{{ reserved_ip_2.scaleway_ip.id }}'
+  register: ip_destroy_task
+
+- debug: var=ip_destroy_task
+
+- assert:
+    that:
+      - ip_destroy_task is success
+      - ip_destroy_task is changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR intents is to fix the Scaleway compute module regarding the `public_ip` management.
It allows the user to specify a Scaleway `public_ip` id at server creation and update its state by changing the `public_ip` field during the server lifetime. 

It manage the following transitions:
`no ip`-> `dynamic ip`
`no ip` -> `reserved ip`
`dynamic ip` -> `reserved ip`
`dynamic ip` -> `no ip`
`reserved ip` -> `dynamic ip`
`reserved ip` -> `no ip`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
scaleway_compute

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.8.0.dev0 (scw-cp-ip e0d82ca548) last updated 2018/11/17 12:51:47 (GMT +200)
  config file = /Users/abarbare/.ansible.cfg
  configured module search path = [u'/Users/abarbare/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/abarbare/Documents/projets_info/ansible/lib/ansible
  executable location = /Users/abarbare/Documents/projets_info/ansible/bin/ansible
  python version = 2.7.15 (default, May  1 2018, 16:44:08) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
```
