### PR TITLE
In the Makefile useful target list, mention "clean" and "webdocs".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 # Makefile for Ansible
 #
 # useful targets:
+#   make clean ---------------- clean up
+#   make webdocs -------------- produce ansible doc at docs/docsite/_build/html
 #   make sdist ---------------- produce a tarball
 #   make srpm ----------------- produce a SRPM
 #   make rpm  ----------------- produce RPMs


### PR DESCRIPTION
##### SUMMARY

The top-level `Makefile` has a list of useful targets.

I consider both the `clean` and `webdocs` target useful,
and they are also both mentioned in the [contribution guidelines](https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/community/documentation_contributions.rst).

This pull request is about adding those two to the list.

##### ISSUE TYPE
- Docs Pull Request
