### PR TITLE
[docker_network] Add handling for Python booleans in driver_options

### DIFF
--- a/changelogs/fragments/docker_network-driver_options.yaml
+++ b/changelogs/fragments/docker_network-driver_options.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "docker_network - ``driver_options`` containing Python booleans would cause Docker to throw exceptions."

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -192,6 +192,21 @@ def container_names_in_network(network):
     return [c['Name'] for c in network['Containers'].values()] if network['Containers'] else []
 
 
+def get_driver_options(driver_options):
+    result = dict()
+    if driver_options is not None:
+        for k, v in driver_options.items():
+            # Go doesn't like 'True' or 'False'
+            if v is True:
+                v = 'true'
+            elif v is False:
+                v = 'false'
+            else:
+                v = str(v)
+            result[str(k)] = v
+    return result
+
+
 class DockerNetworkManager(object):
 
     def __init__(self, client):
@@ -208,6 +223,9 @@ class DockerNetworkManager(object):
 
         if not self.parameters.connected and self.existing_network:
             self.parameters.connected = container_names_in_network(self.existing_network)
+
+        if self.parameters.driver_options:
+            self.parameters.driver_options = get_driver_options(self.parameters.driver_options)
 
         state = self.parameters.state
         if state == 'present':

--- a/test/integration/targets/docker_network/tasks/tests/options.yml
+++ b/test/integration/targets/docker_network/tasks/tests/options.yml
@@ -1,0 +1,60 @@
+---
+- name: Registering network name
+  set_fact:
+    nname_1: "{{ name_prefix ~ '-network-1' }}"
+- name: Registering network name
+  set_fact:
+    dnetworks: "{{ dnetworks }} + [nname_1]"
+
+####################################################################
+## driver_options ##################################################
+####################################################################
+
+- name: driver_options
+  docker_network:
+    name: "{{ nname_1 }}"
+    driver_options:
+      com.docker.network.bridge.enable_icc: 'false'
+  register: driver_options_1
+
+- name: driver_options (idempotency)
+  docker_network:
+    name: "{{ nname_1 }}"
+    driver_options:
+      com.docker.network.bridge.enable_icc: 'false'
+  register: driver_options_2
+
+- name: driver_options (idempotency with string translation)
+  docker_network:
+    name: "{{ nname_1 }}"
+    driver_options:
+      com.docker.network.bridge.enable_icc: False
+  register: driver_options_3
+
+- name: driver_options (change)
+  docker_network:
+    name: "{{ nname_1 }}"
+    driver_options:
+      com.docker.network.bridge.enable_icc: 'true'
+  register: driver_options_4
+
+- name: driver_options (idempotency with string translation)
+  docker_network:
+    name: "{{ nname_1 }}"
+    driver_options:
+      com.docker.network.bridge.enable_icc: True
+  register: driver_options_5
+
+- name: cleanup
+  docker_network:
+    name: "{{ nname_1 }}"
+    state: absent
+    force: yes
+
+- assert:
+    that:
+    - driver_options_1 is changed
+    - driver_options_2 is not changed
+    - driver_options_3 is not changed
+    - driver_options_4 is changed
+    - driver_options_5 is not changed


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/48105 to 2.7.

Fixes #26708

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_network

##### ADDITIONAL INFORMATION
`docker_network` integration tests passed in `ubuntu1604` image