### PR TITLE
win_security_policy - add warning when using this module ot edit rights

### DIFF
--- a/changelogs/fragments/win_security_policy-rights.yaml
+++ b/changelogs/fragments/win_security_policy-rights.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_security_policy - warn users to use win_user_right instead when editing ``Privilege Rights``

--- a/lib/ansible/modules/windows/win_security_policy.ps1
+++ b/lib/ansible/modules/windows/win_security_policy.ps1
@@ -134,6 +134,10 @@ Function ConvertFrom-Ini($file_path) {
     return $ini
 }
 
+if ($section -eq "Privilege Rights") {
+    Add-Warning -obj $result -message "Using this module to edit rights and privileges is error-prone, use the win_user_right module instead"
+}
+
 $will_change = $false
 $secedit_ini = Export-SecEdit
 if (-not ($secedit_ini.ContainsKey($section))) {

--- a/lib/ansible/modules/windows/win_security_policy.py
+++ b/lib/ansible/modules/windows/win_security_policy.py
@@ -36,6 +36,8 @@ options:
     - Example sections to use are 'Account Policies', 'Local Policies',
       'Event Log', 'Restricted Groups', 'System Services', 'Registry' and
       'File System'
+    - If wanting to edit the C(Privilege Rights) section, use the
+      M(win_user_right) module instead.
     required: yes
   key:
     description:


### PR DESCRIPTION
##### SUMMARY
Add warning when trying to use win_security_policy to edit user rights/privileges. The win_user_right module is better suited for that task.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_security_policy