### PR TITLE
Backport/2.7/46044 Make puppet module useable on puppet 6

### DIFF
--- a/changelogs/fragments/46044-puppet-puppet6-fix.yaml
+++ b/changelogs/fragments/46044-puppet-puppet6-fix.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Puppet module remove ``--ignorecache`` to allow Puppet 6 support

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -216,7 +216,7 @@ def main():
 
     if not p['manifest'] and not p['execute']:
         cmd = ("%(base_cmd)s agent --onetime"
-               " --ignorecache --no-daemonize --no-usecacheonfailure --no-splay"
+               " --no-daemonize --no-usecacheonfailure --no-splay"
                " --detailed-exitcodes --verbose --color 0") % dict(base_cmd=base_cmd)
         if p['puppetmaster']:
             cmd += " --server %s" % pipes.quote(p['puppetmaster'])


### PR DESCRIPTION
##### SUMMARY
The unused ignorecache setting has been removed and so you
can't run puppet through this module anymore on puppet 6.

https://github.com/ansible/ansible/commit/475d69da69d81947c61b47902d198c40e3c72dce
##### ISSUE TYPE
- Bugfix Pull Request
