### PR TITLE
fix typo in constants.py

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -96,7 +96,7 @@ BECOME_MISSING_STRINGS = {
 }  # FIXME: deal with i18n
 BLACKLIST_EXTS = ('.pyc', '.pyo', '.swp', '.bak', '~', '.rpm', '.md', '.txt', '.rst')
 BOOL_TRUE = BOOLEANS_TRUE
-CONTROLER_LANG = os.getenv('LANG', 'en_US.UTF-8')
+CONTROLLER_LANG = os.getenv('LANG', 'en_US.UTF-8')
 DEFAULT_BECOME_PASS = None
 DEFAULT_PASSWORD_CHARS = to_text(ascii_letters + digits + ".,:-_", errors='strict')  # characters included in auto-generated passwords
 DEFAULT_SUDO_PASS = None


### PR DESCRIPTION
* CONTROLER_LANG => CONTROLLER_LANG

##### SUMMARY
Fixed typo in variable CONTROLER_LANG in constants.py

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
core library
