### PR TITLE
Backport/2.7/48580: Do not require TTY for 'apt-key' operations

### DIFF
--- a/changelogs/fragments/48580-apt_key-no-tty.yaml
+++ b/changelogs/fragments/48580-apt_key-no-tty.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - apt_key - Disable TTY requirement in GnuPG for the module to work correctly
+    when SSH pipelining is enabled (https://github.com/ansible/ansible/pull/48580)

--- a/lib/ansible/modules/packaging/os/apt_key.py
+++ b/lib/ansible/modules/packaging/os/apt_key.py
@@ -214,9 +214,9 @@ def download_key(module, url):
 
 def import_key(module, keyring, keyserver, key_id):
     if keyring:
-        cmd = "%s --keyring %s adv --keyserver %s --recv %s" % (apt_key_bin, keyring, keyserver, key_id)
+        cmd = "%s --keyring %s adv --no-tty --keyserver %s --recv %s" % (apt_key_bin, keyring, keyserver, key_id)
     else:
-        cmd = "%s adv --keyserver %s --recv %s" % (apt_key_bin, keyserver, key_id)
+        cmd = "%s adv --no-tty --keyserver %s --recv %s" % (apt_key_bin, keyserver, key_id)
     for retry in range(5):
         lang_env = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
         (rc, out, err) = module.run_command(cmd, environ_update=lang_env)


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/48580 into the `stable-2.7` branch.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt_key