### PR TITLE
[2.7] docker_* tests: check API version

### DIFF
--- a/test/integration/targets/docker_container/tasks/main.yml
+++ b/test/integration/targets/docker_container/tasks/main.yml
@@ -31,3 +31,6 @@
     when: docker_py_version is version('1.10.0', '>=')
 
   when: docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')
+
+- fail: msg="Too old docker / docker-py version to run all docker_container tests!"
+  when: not(docker_py_version is version('3.5.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_image/tasks/main.yml
+++ b/test/integration/targets/docker_image/tasks/main.yml
@@ -47,5 +47,7 @@
       stop_timeout: 1
     with_items: "{{ cnames }}"
 
-  # Skip for CentOS 6
-  when: ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6
+  when: docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')
+
+- fail: msg="Too old docker / docker-py version to run docker_image tests!"
+  when: not(docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_image_facts/tasks/main.yml
+++ b/test/integration/targets/docker_image_facts/tasks/main.yml
@@ -48,5 +48,7 @@
       - "'hello-world:latest' in result.images[0].RepoTags"
       - "'alpine:3.8' in result.images[1].RepoTags"
 
-  # Skip for CentOS 6
-  when: ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6
+  when: docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')
+
+- fail: msg="Too old docker / docker-py version to run docker_image_facts tests!"
+  when: not(docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_network/tasks/main.yml
+++ b/test/integration/targets/docker_network/tasks/main.yml
@@ -27,5 +27,7 @@
       force: yes
     loop: "{{ dnetworks }}"
 
-  # Skip for CentOS 6
-  when: ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6
+  when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.20', '>=')  # FIXME: find out API version!
+
+- fail: msg="Too old docker / docker-py version to run docker_network tests!"
+  when: not(docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.20', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_secret/handlers/main.yml
+++ b/test/integration/targets/docker_secret/handlers/main.yml
@@ -1,3 +1,0 @@
-- name: disable_swarm 
-  command: docker swarm leave --force
-  ignore_errors: yes

--- a/test/integration/targets/docker_secret/tasks/main.yml
+++ b/test/integration/targets/docker_secret/tasks/main.yml
@@ -1,2 +1,7 @@
 - include_tasks: test_secrets.yml
-  when: ansible_os_family != 'RedHat' or ansible_distribution_major_version != '6'
+  # Maximum of 2.1.0 (docker-py version for docker_secrets) and 2.6.0 (docker-py version for docker_swarm) is 2.6.0
+  # Maximum of 1.25 (docker API version for docker_secrets) and 1.35 (docker API version for docker_swarm) is 1.35
+  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')
+
+- fail: msg="Too old docker / docker-py version to run docker_secrets tests!"
+  when: not(docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_secret/tasks/test_secrets.yml
+++ b/test/integration/targets/docker_secret/tasks/test_secrets.yml
@@ -1,97 +1,105 @@
-- name: Check if already in swarm
-  shell: docker node ls 2>&1 | grep 'docker swarm init'
-  register: output
-  ignore_errors: yes 
+---
+- block:
+  - name: Make sure we're not already using Docker swarm
+    docker_swarm:
+      state: absent
+      force: true
 
-- name: Enable swarm mode
-  command: docker swarm init
-  when: output.rc == 0
-  notify: disable_swarm 
+  - name: Create a Swarm cluster
+    docker_swarm:
+      state: present
+      advertise_addr: "{{ansible_default_ipv4.address}}"
 
-- name: Parameter name should be required
-  docker_secret:
-    state: present
-  ignore_errors: yes
-  register: output
+  - name: Parameter name should be required
+    docker_secret:
+      state: present
+    ignore_errors: yes
+    register: output
 
-- name: assert failure when called with no name
-  assert:
-    that:
-       - 'output.failed'
-       - 'output.msg == "missing required arguments: name"'
+  - name: assert failure when called with no name
+    assert:
+      that:
+         - 'output.failed'
+         - 'output.msg == "missing required arguments: name"'
 
-- name: Test parameters
-  docker_secret:
-    name: foo
-    state: present
-  ignore_errors: yes
-  register: output
+  - name: Test parameters
+    docker_secret:
+      name: foo
+      state: present
+    ignore_errors: yes
+    register: output
 
-- name: assert failure when called with no data
-  assert:
-    that:
-       - 'output.failed'
-       - 'output.msg == "state is present but all of the following are missing: data"'
+  - name: assert failure when called with no data
+    assert:
+      that:
+         - 'output.failed'
+         - 'output.msg == "state is present but all of the following are missing: data"'
 
-- name: Create secret
-  docker_secret:
-    name: db_password
-    data: opensesame!
-    state: present
-  register: output
+  - name: Create secret
+    docker_secret:
+      name: db_password
+      data: opensesame!
+      state: present
+    register: output
 
-- name: Create variable secret_id 
-  set_fact:
-    secret_id: "{{ output.secret_id }}"
+  - name: Create variable secret_id
+    set_fact:
+      secret_id: "{{ output.secret_id }}"
 
-- name: Inspect secret
-  command: "docker secret inspect {{ secret_id }}"
-  register: inspect
+  - name: Inspect secret
+    command: "docker secret inspect {{ secret_id }}"
+    register: inspect
 
-- debug: var=inspect
+  - debug: var=inspect
 
-- name: assert secret creation succeeded
-  assert:
-    that:
-       - "'db_password' in inspect.stdout"
-       - "'ansible_key' in inspect.stdout"
+  - name: assert secret creation succeeded
+    assert:
+      that:
+         - "'db_password' in inspect.stdout"
+         - "'ansible_key' in inspect.stdout"
 
-- name: Create secret again
-  docker_secret:
-    name: db_password
-    data: opensesame!
-    state: present
-  register: output
+  - name: Create secret again
+    docker_secret:
+      name: db_password
+      data: opensesame!
+      state: present
+    register: output
 
-- name: assert create secret is idempotent
-  assert:
-    that:
-       - not output.changed
+  - name: assert create secret is idempotent
+    assert:
+      that:
+         - not output.changed
 
-- name: Update secret
-  docker_secret:
-    name: db_password
-    data: newpassword!
-    state: present
-  register: output
+  - name: Update secret
+    docker_secret:
+      name: db_password
+      data: newpassword!
+      state: present
+    register: output
 
-- name: assert secret was updated
-  assert:
-    that:
-       - output.changed
-       - output.secret_id != secret_id
+  - name: assert secret was updated
+    assert:
+      that:
+         - output.changed
+         - output.secret_id != secret_id
 
-- name: Remove secret
-  docker_secret:
-    name: db_password
-    state: absent
+  - name: Remove secret
+    docker_secret:
+      name: db_password
+      state: absent
 
-- name: Check that secret is removed
-  command: "docker secret inspect {{ secret_id }}"
-  register: output
-  ignore_errors: yes
+  - name: Check that secret is removed
+    command: "docker secret inspect {{ secret_id }}"
+    register: output
+    ignore_errors: yes
 
-- name: assert secret was removed 
-  assert:
-    that:
-      - output.failed 
+  - name: assert secret was removed
+    assert:
+      that:
+        - output.failed
+
+  always:
+  - name: Remove Swarm cluster
+    docker_swarm:
+      state: absent
+      force: true

--- a/test/integration/targets/docker_swarm/tasks/main.yml
+++ b/test/integration/targets/docker_swarm/tasks/main.yml
@@ -1,2 +1,5 @@
 - include_tasks: test_swarm.yml
-  when: ansible_os_family != 'RedHat' or ansible_distribution_major_version != '6'
+  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')
+
+- fail: msg="Too old docker / docker-py version to run docker_swarm tests!"
+  when: not(docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_swarm/tasks/test_swarm.yml
+++ b/test/integration/targets/docker_swarm/tasks/test_swarm.yml
@@ -1,53 +1,61 @@
-- name: Make sure we're not already using Docker swarm
-  docker_swarm:
-    state: absent
-    force: true
+---
+- block:
+  - name: Make sure we're not already using Docker swarm
+    docker_swarm:
+      state: absent
+      force: true
 
-- name: Test parameters with state=join
-  docker_swarm:
-    state: join
-  ignore_errors: yes
-  register: output
+  - name: Test parameters with state=join
+    docker_swarm:
+      state: join
+    ignore_errors: yes
+    register: output
 
-- name: assert failure when called with state=join and no advertise_addr,remote_addrs,join_token
-  assert:
-    that:
-       - 'output.failed'
-       - 'output.msg == "state is join but all of the following are missing: advertise_addr, remote_addrs, join_token"'
+  - name: assert failure when called with state=join and no advertise_addr,remote_addrs,join_token
+    assert:
+      that:
+         - 'output.failed'
+         - 'output.msg == "state is join but all of the following are missing: advertise_addr, remote_addrs, join_token"'
 
-- name: Test parameters with state=remove
-  docker_swarm:
-    state: remove
-  ignore_errors: yes
-  register: output
+  - name: Test parameters with state=remove
+    docker_swarm:
+      state: remove
+    ignore_errors: yes
+    register: output
 
-- name: assert failure when called with state=remove and no node_id
-  assert:
-    that:
-       - 'output.failed'
-       - 'output.msg == "state is remove but all of the following are missing: node_id"'
+  - name: assert failure when called with state=remove and no node_id
+    assert:
+      that:
+         - 'output.failed'
+         - 'output.msg == "state is remove but all of the following are missing: node_id"'
 
-- name: Create a Swarm cluster
-  docker_swarm:
-    state: present
-  register: output
+  - name: Create a Swarm cluster
+    docker_swarm:
+      state: present
+    register: output
 
-- name: assert changed when create a new swarm cluster
-  assert:
-    that:
-       - 'output.changed'
-       - 'output.actions[0] | regex_search("New Swarm cluster created: ")'
-       - 'output.swarm_facts.JoinTokens.Manager'
-       - 'output.swarm_facts.JoinTokens.Worker'
+  - name: assert changed when create a new swarm cluster
+    assert:
+      that:
+         - 'output.changed'
+         - 'output.actions[0] | regex_search("New Swarm cluster created: ")'
+         - 'output.swarm_facts.JoinTokens.Manager'
+         - 'output.swarm_facts.JoinTokens.Worker'
 
-- name: Remove a Swarm cluster
-  docker_swarm:
-    state: absent
-    force: true
-  register: output
+  - name: Remove a Swarm cluster
+    docker_swarm:
+      state: absent
+      force: true
+    register: output
 
-- name: assert changed when remove a swarm cluster
-  assert:
-    that:
-       - 'output.changed'
-       - 'output.actions[0] == "Node has leaved the swarm cluster"'
+  - name: assert changed when remove a swarm cluster
+    assert:
+      that:
+         - 'output.changed'
+         - 'output.actions[0] == "Node has leaved the swarm cluster"'
+
+  always:
+  - name: Cleanup
+    docker_swarm:
+      state: absent
+      force: true

--- a/test/integration/targets/docker_volume/tasks/main.yml
+++ b/test/integration/targets/docker_volume/tasks/main.yml
@@ -20,5 +20,7 @@
       force: yes
     with_items: "{{ vnames }}"
 
-  # Skip for CentOS 6
-  when: ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6
+  when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.20', '>=')  # FIXME: find out API version!
+
+- fail: msg="Too old docker / docker-py version to run docker_volume tests!"
+  when: not(docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.20', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)


### PR DESCRIPTION
##### SUMMARY
Backport of #48620: improves tests by adding an API version check. This makes the tests fail with a more helpful error message in case only a too old docker daemon is available.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
docker_image
docker_image_facts
docker_network
docker_secret
docker_swarm
docker_volume
