### PR TITLE
Catch per loop label templating exceptions

### DIFF
--- a/changelogs/fragments/loop-control-label-template-error.yaml
+++ b/changelogs/fragments/loop-control-label-template-error.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+- loop_control - Catch exceptions when templating label individually for loop
+  iterations which caused the templating failure as the full
+  result. This instead only registers the templating exception for a single
+  loop result (https://github.com/ansible/ansible/issues/48879)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -361,7 +361,13 @@ class TaskExecutor:
             res['_ansible_ignore_errors'] = task_fields.get('ignore_errors')
 
             # gets templated here unlike rest of loop_control fields, depends on loop_var above
-            res['_ansible_item_label'] = templar.template(label, cache=False)
+            try:
+                res['_ansible_item_label'] = templar.template(label, cache=False)
+            except AnsibleUndefinedVariable as e:
+                res.update({
+                    'failed': True,
+                    'msg': 'Failed to template loop_control.label: %s' % to_text(e)
+                })
 
             self._final_q.put(
                 TaskResult(


### PR DESCRIPTION
##### SUMMARY
Catch per loop label templating exceptions. Fixes #48879 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_executor.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```