### PR TITLE
Change port to allow strings too

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_gtm_monitor_bigip.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_monitor_bigip.py
@@ -614,7 +614,7 @@ class ArgumentSpec(object):
             name=dict(required=True),
             parent=dict(default='/Common/bigip'),
             ip=dict(),
-            port=dict(type='int'),
+            port=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),
             ignore_down_response=dict(type='bool'),

--- a/lib/ansible/modules/network/f5/bigip_gtm_monitor_external.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_monitor_external.py
@@ -659,7 +659,7 @@ class ArgumentSpec(object):
             parent=dict(default='/Common/external'),
             arguments=dict(),
             ip=dict(),
-            port=dict(type='int'),
+            port=dict(),
             external_program=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),

--- a/lib/ansible/modules/network/f5/bigip_gtm_monitor_firepass.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_monitor_firepass.py
@@ -733,7 +733,7 @@ class ArgumentSpec(object):
             name=dict(required=True),
             parent=dict(default='/Common/firepass_gtm'),
             ip=dict(),
-            port=dict(type='int'),
+            port=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),
             ignore_down_response=dict(type='bool'),

--- a/lib/ansible/modules/network/f5/bigip_gtm_monitor_http.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_monitor_http.py
@@ -779,7 +779,7 @@ class ArgumentSpec(object):
             send=dict(),
             receive=dict(),
             ip=dict(),
-            port=dict(type='int'),
+            port=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),
             ignore_down_response=dict(type='bool'),

--- a/lib/ansible/modules/network/f5/bigip_gtm_monitor_https.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_monitor_https.py
@@ -895,7 +895,7 @@ class ArgumentSpec(object):
             send=dict(),
             receive=dict(),
             ip=dict(),
-            port=dict(type='int'),
+            port=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),
             ignore_down_response=dict(type='bool'),

--- a/lib/ansible/modules/network/f5/bigip_gtm_monitor_tcp.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_monitor_tcp.py
@@ -747,7 +747,7 @@ class ArgumentSpec(object):
             send=dict(),
             receive=dict(),
             ip=dict(),
-            port=dict(type='int'),
+            port=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),
             ignore_down_response=dict(type='bool'),

--- a/lib/ansible/modules/network/f5/bigip_gtm_monitor_tcp_half_open.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_monitor_tcp_half_open.py
@@ -654,7 +654,7 @@ class ArgumentSpec(object):
             name=dict(required=True),
             parent=dict(default='/Common/tcp_half_open'),
             ip=dict(),
-            port=dict(type='int'),
+            port=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),
             probe_interval=dict(type='int'),

--- a/lib/ansible/modules/network/f5/bigip_monitor_dns.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_dns.py
@@ -960,7 +960,7 @@ class ArgumentSpec(object):
             receive=dict(),
             ip=dict(),
             description=dict(),
-            port=dict(type='int'),
+            port=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),
             manual_resume=dict(type='bool'),

--- a/lib/ansible/modules/network/f5/bigip_monitor_external.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_external.py
@@ -696,7 +696,7 @@ class ArgumentSpec(object):
             description=dict(),
             arguments=dict(),
             ip=dict(),
-            port=dict(type='int'),
+            port=dict(),
             external_program=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),

--- a/lib/ansible/modules/network/f5/bigip_monitor_http.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_http.py
@@ -698,7 +698,7 @@ class ArgumentSpec(object):
             receive=dict(),
             receive_disable=dict(required=False),
             ip=dict(),
-            port=dict(type='int'),
+            port=dict(),
             interval=dict(type='int'),
             reverse=dict(type='bool'),
             timeout=dict(type='int'),

--- a/lib/ansible/modules/network/f5/bigip_monitor_https.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_https.py
@@ -56,7 +56,7 @@ options:
       - Port address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'. Note that if specifying an IP address, a value between 1 and 65535
-        must be specified
+        must be specified.
   interval:
     description:
       - The interval specifying how frequently the monitor instance of this
@@ -667,7 +667,7 @@ class ArgumentSpec(object):
             receive=dict(),
             receive_disable=dict(required=False),
             ip=dict(),
-            port=dict(type='int'),
+            port=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),
             time_until_up=dict(type='int'),

--- a/lib/ansible/modules/network/f5/bigip_monitor_ldap.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_ldap.py
@@ -756,7 +756,7 @@ class ArgumentSpec(object):
             parent=dict(default='/Common/ldap'),
             ip=dict(),
             description=dict(),
-            port=dict(type='int'),
+            port=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),
             target_username=dict(),

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp.py
@@ -621,7 +621,7 @@ class ArgumentSpec(object):
             send=dict(),
             receive=dict(),
             ip=dict(),
-            port=dict(type='int'),
+            port=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),
             time_until_up=dict(type='int'),

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp_echo.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp_echo.py
@@ -38,8 +38,6 @@ options:
       - IP address part of the IP/port definition. If this parameter is not
         provided when creating a new monitor, then the default value will be
         '*'.
-      - If this value is an IP address, and the C(type) is C(tcp) (the default),
-        then a C(port) number must be specified.
   interval:
     description:
       - The interval specifying how frequently the monitor instance of this

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp_half_open.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp_half_open.py
@@ -606,7 +606,7 @@ class ArgumentSpec(object):
             parent=dict(default='/Common/tcp_half_open'),
             description=dict(),
             ip=dict(),
-            port=dict(type='int'),
+            port=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),
             time_until_up=dict(type='int'),

--- a/lib/ansible/modules/network/f5/bigip_monitor_udp.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_udp.py
@@ -616,7 +616,7 @@ class ArgumentSpec(object):
             receive=dict(),
             receive_disable=dict(required=False),
             ip=dict(),
-            port=dict(type='int'),
+            port=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),
             time_until_up=dict(type='int'),

--- a/test/units/modules/network/f5/test_bigip_gtm_monitor_bigip.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_monitor_bigip.py
@@ -29,20 +29,18 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_gtm_monitor_bigip import ApiParameters
-        from ansible.modules.network.f5.bigip_gtm_monitor_bigip import ModuleParameters
-        from ansible.modules.network.f5.bigip_gtm_monitor_bigip import ModuleManager
-        from ansible.modules.network.f5.bigip_gtm_monitor_bigip import ArgumentSpec
+    from ansible.modules.network.f5.bigip_gtm_monitor_bigip import ApiParameters
+    from ansible.modules.network.f5.bigip_gtm_monitor_bigip import ModuleParameters
+    from ansible.modules.network.f5.bigip_gtm_monitor_bigip import ModuleManager
+    from ansible.modules.network.f5.bigip_gtm_monitor_bigip import ArgumentSpec
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_gtm_monitor_external.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_monitor_external.py
@@ -29,20 +29,18 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_gtm_monitor_external import ApiParameters
-        from ansible.modules.network.f5.bigip_gtm_monitor_external import ModuleParameters
-        from ansible.modules.network.f5.bigip_gtm_monitor_external import ModuleManager
-        from ansible.modules.network.f5.bigip_gtm_monitor_external import ArgumentSpec
+    from ansible.modules.network.f5.bigip_gtm_monitor_external import ApiParameters
+    from ansible.modules.network.f5.bigip_gtm_monitor_external import ModuleParameters
+    from ansible.modules.network.f5.bigip_gtm_monitor_external import ModuleManager
+    from ansible.modules.network.f5.bigip_gtm_monitor_external import ArgumentSpec
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_gtm_monitor_firepass.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_monitor_firepass.py
@@ -29,20 +29,18 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_gtm_monitor_firepass import ApiParameters
-        from ansible.modules.network.f5.bigip_gtm_monitor_firepass import ModuleParameters
-        from ansible.modules.network.f5.bigip_gtm_monitor_firepass import ModuleManager
-        from ansible.modules.network.f5.bigip_gtm_monitor_firepass import ArgumentSpec
+    from ansible.modules.network.f5.bigip_gtm_monitor_firepass import ApiParameters
+    from ansible.modules.network.f5.bigip_gtm_monitor_firepass import ModuleParameters
+    from ansible.modules.network.f5.bigip_gtm_monitor_firepass import ModuleManager
+    from ansible.modules.network.f5.bigip_gtm_monitor_firepass import ArgumentSpec
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_gtm_monitor_http.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_monitor_http.py
@@ -29,20 +29,18 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_gtm_monitor_http import ApiParameters
-        from ansible.modules.network.f5.bigip_gtm_monitor_http import ModuleParameters
-        from ansible.modules.network.f5.bigip_gtm_monitor_http import ModuleManager
-        from ansible.modules.network.f5.bigip_gtm_monitor_http import ArgumentSpec
+    from ansible.modules.network.f5.bigip_gtm_monitor_http import ApiParameters
+    from ansible.modules.network.f5.bigip_gtm_monitor_http import ModuleParameters
+    from ansible.modules.network.f5.bigip_gtm_monitor_http import ModuleManager
+    from ansible.modules.network.f5.bigip_gtm_monitor_http import ArgumentSpec
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_gtm_monitor_https.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_monitor_https.py
@@ -29,20 +29,18 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_gtm_monitor_https import ApiParameters
-        from ansible.modules.network.f5.bigip_gtm_monitor_https import ModuleParameters
-        from ansible.modules.network.f5.bigip_gtm_monitor_https import ModuleManager
-        from ansible.modules.network.f5.bigip_gtm_monitor_https import ArgumentSpec
+    from ansible.modules.network.f5.bigip_gtm_monitor_https import ApiParameters
+    from ansible.modules.network.f5.bigip_gtm_monitor_https import ModuleParameters
+    from ansible.modules.network.f5.bigip_gtm_monitor_https import ModuleManager
+    from ansible.modules.network.f5.bigip_gtm_monitor_https import ArgumentSpec
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_gtm_monitor_tcp.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_monitor_tcp.py
@@ -29,20 +29,18 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_gtm_monitor_tcp import ApiParameters
-        from ansible.modules.network.f5.bigip_gtm_monitor_tcp import ModuleParameters
-        from ansible.modules.network.f5.bigip_gtm_monitor_tcp import ModuleManager
-        from ansible.modules.network.f5.bigip_gtm_monitor_tcp import ArgumentSpec
+    from ansible.modules.network.f5.bigip_gtm_monitor_tcp import ApiParameters
+    from ansible.modules.network.f5.bigip_gtm_monitor_tcp import ModuleParameters
+    from ansible.modules.network.f5.bigip_gtm_monitor_tcp import ModuleManager
+    from ansible.modules.network.f5.bigip_gtm_monitor_tcp import ArgumentSpec
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_gtm_monitor_tcp_half_open.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_monitor_tcp_half_open.py
@@ -29,20 +29,18 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_gtm_monitor_tcp_half_open import ApiParameters
-        from ansible.modules.network.f5.bigip_gtm_monitor_tcp_half_open import ModuleParameters
-        from ansible.modules.network.f5.bigip_gtm_monitor_tcp_half_open import ModuleManager
-        from ansible.modules.network.f5.bigip_gtm_monitor_tcp_half_open import ArgumentSpec
+    from ansible.modules.network.f5.bigip_gtm_monitor_tcp_half_open import ApiParameters
+    from ansible.modules.network.f5.bigip_gtm_monitor_tcp_half_open import ModuleParameters
+    from ansible.modules.network.f5.bigip_gtm_monitor_tcp_half_open import ModuleManager
+    from ansible.modules.network.f5.bigip_gtm_monitor_tcp_half_open import ArgumentSpec
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_monitor_dns.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_dns.py
@@ -29,20 +29,18 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_monitor_dns import ApiParameters
-        from ansible.modules.network.f5.bigip_monitor_dns import ModuleParameters
-        from ansible.modules.network.f5.bigip_monitor_dns import ModuleManager
-        from ansible.modules.network.f5.bigip_monitor_dns import ArgumentSpec
+    from ansible.modules.network.f5.bigip_monitor_dns import ApiParameters
+    from ansible.modules.network.f5.bigip_monitor_dns import ModuleParameters
+    from ansible.modules.network.f5.bigip_monitor_dns import ModuleManager
+    from ansible.modules.network.f5.bigip_monitor_dns import ArgumentSpec
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_monitor_external.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_external.py
@@ -29,20 +29,18 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_monitor_external import ApiParameters
-        from ansible.modules.network.f5.bigip_monitor_external import ModuleParameters
-        from ansible.modules.network.f5.bigip_monitor_external import ModuleManager
-        from ansible.modules.network.f5.bigip_monitor_external import ArgumentSpec
+    from ansible.modules.network.f5.bigip_monitor_external import ApiParameters
+    from ansible.modules.network.f5.bigip_monitor_external import ModuleParameters
+    from ansible.modules.network.f5.bigip_monitor_external import ModuleManager
+    from ansible.modules.network.f5.bigip_monitor_external import ArgumentSpec
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}
@@ -89,8 +87,6 @@ class TestParameters(unittest.TestCase):
         assert p.timeout == 30
 
 
-@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
-       return_value=True)
 class TestManager(unittest.TestCase):
 
     def setUp(self):

--- a/test/units/modules/network/f5/test_bigip_monitor_http.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_http.py
@@ -31,21 +31,19 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_monitor_http import Parameters
-        from ansible.modules.network.f5.bigip_monitor_http import ModuleManager
-        from ansible.modules.network.f5.bigip_monitor_http import ArgumentSpec
+    from ansible.modules.network.f5.bigip_monitor_http import Parameters
+    from ansible.modules.network.f5.bigip_monitor_http import ModuleManager
+    from ansible.modules.network.f5.bigip_monitor_http import ArgumentSpec
 
-        from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import F5ModuleError
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_monitor_https.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_https.py
@@ -31,21 +31,19 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_monitor_https import Parameters
-        from ansible.modules.network.f5.bigip_monitor_https import ModuleManager
-        from ansible.modules.network.f5.bigip_monitor_https import ArgumentSpec
+    from ansible.modules.network.f5.bigip_monitor_https import Parameters
+    from ansible.modules.network.f5.bigip_monitor_https import ModuleManager
+    from ansible.modules.network.f5.bigip_monitor_https import ArgumentSpec
 
-        from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import F5ModuleError
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_monitor_ldap.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_ldap.py
@@ -29,20 +29,18 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_monitor_ldap import ApiParameters
-        from ansible.modules.network.f5.bigip_monitor_ldap import ModuleParameters
-        from ansible.modules.network.f5.bigip_monitor_ldap import ModuleManager
-        from ansible.modules.network.f5.bigip_monitor_ldap import ArgumentSpec
+    from ansible.modules.network.f5.bigip_monitor_ldap import ApiParameters
+    from ansible.modules.network.f5.bigip_monitor_ldap import ModuleParameters
+    from ansible.modules.network.f5.bigip_monitor_ldap import ModuleManager
+    from ansible.modules.network.f5.bigip_monitor_ldap import ArgumentSpec
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_monitor_snmp_dca.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_snmp_dca.py
@@ -28,19 +28,17 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_monitor_snmp_dca import Parameters
-        from ansible.modules.network.f5.bigip_monitor_snmp_dca import ModuleManager
-        from ansible.modules.network.f5.bigip_monitor_snmp_dca import ArgumentSpec
+    from ansible.modules.network.f5.bigip_monitor_snmp_dca import Parameters
+    from ansible.modules.network.f5.bigip_monitor_snmp_dca import ModuleManager
+    from ansible.modules.network.f5.bigip_monitor_snmp_dca import ArgumentSpec
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_monitor_tcp.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_tcp.py
@@ -31,21 +31,19 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_monitor_tcp import Parameters
-        from ansible.modules.network.f5.bigip_monitor_tcp import ModuleManager
-        from ansible.modules.network.f5.bigip_monitor_tcp import ArgumentSpec
+    from ansible.modules.network.f5.bigip_monitor_tcp import Parameters
+    from ansible.modules.network.f5.bigip_monitor_tcp import ModuleManager
+    from ansible.modules.network.f5.bigip_monitor_tcp import ArgumentSpec
 
-        from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import F5ModuleError
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_monitor_tcp_echo.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_tcp_echo.py
@@ -31,21 +31,19 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_monitor_tcp_echo import Parameters
-        from ansible.modules.network.f5.bigip_monitor_tcp_echo import ModuleManager
-        from ansible.modules.network.f5.bigip_monitor_tcp_echo import ArgumentSpec
+    from ansible.modules.network.f5.bigip_monitor_tcp_echo import Parameters
+    from ansible.modules.network.f5.bigip_monitor_tcp_echo import ModuleManager
+    from ansible.modules.network.f5.bigip_monitor_tcp_echo import ArgumentSpec
 
-        from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import F5ModuleError
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_monitor_tcp_half_open.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_tcp_half_open.py
@@ -31,21 +31,19 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_monitor_tcp_half_open import Parameters
-        from ansible.modules.network.f5.bigip_monitor_tcp_half_open import ModuleManager
-        from ansible.modules.network.f5.bigip_monitor_tcp_half_open import ArgumentSpec
+    from ansible.modules.network.f5.bigip_monitor_tcp_half_open import Parameters
+    from ansible.modules.network.f5.bigip_monitor_tcp_half_open import ModuleManager
+    from ansible.modules.network.f5.bigip_monitor_tcp_half_open import ArgumentSpec
 
-        from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import F5ModuleError
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_monitor_udp.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_udp.py
@@ -31,21 +31,19 @@ try:
 
     from test.units.modules.utils import set_module_args
 except ImportError:
-    try:
-        from ansible.modules.network.f5.bigip_monitor_udp import Parameters
-        from ansible.modules.network.f5.bigip_monitor_udp import ModuleManager
-        from ansible.modules.network.f5.bigip_monitor_udp import ArgumentSpec
+    from ansible.modules.network.f5.bigip_monitor_udp import Parameters
+    from ansible.modules.network.f5.bigip_monitor_udp import ModuleManager
+    from ansible.modules.network.f5.bigip_monitor_udp import ArgumentSpec
 
-        from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import F5ModuleError
 
-        # Ansible 2.8 imports
-        from units.compat import unittest
-        from units.compat.mock import Mock
-        from units.compat.mock import patch
+    # Ansible 2.8 imports
+    from units.compat import unittest
+    from units.compat.mock import Mock
+    from units.compat.mock import patch
 
-        from units.modules.utils import set_module_args
-    except ImportError:
-        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
+    from units.modules.utils import set_module_args
+
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
The port technically supports an asterisk, but the argument spec was
requiring integers only.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
bigip monitor modules

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
