### PR TITLE
[stable-2.7] Update win_scheduled_task.py (#46720)

### DIFF
--- a/lib/ansible/modules/windows/win_scheduled_task.py
+++ b/lib/ansible/modules/windows/win_scheduled_task.py
@@ -186,9 +186,22 @@ options:
         - Allows you to define the repetition action of the trigger that defines how often the task is run and how long the repetition pattern is repeated
           after the task is started.
         - It takes in the following keys, C(duration), C(interval), C(stop_at_duration_end)
-        - C(duration) is how long the pattern is repeated and is written in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S).
-        - C(interval) is the amount of time between earch restart of the task and is written in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S).
-        - C(stop_at_duration_end) is a boolean value that indicates if a running instance of the task is stopped at the end of the repetition pattern.
+        suboptions:
+          duration:
+            description:
+            - Defines how long the pattern is repeated.
+            - The value is in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S).
+            - By default this is not set which means it will repeat indefinitely.
+            type: str
+          interval:
+            description:
+            - The amount of time between each restart of the task.
+            - The value is written in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S).
+            type: str
+          stop_at_duration_end:
+            description:
+            - Whether a running instance of the task is stopped at the end of the repetition pattern.
+            type: bool
     version_added: '2.5'
 
   # Principal options

--- a/test/sanity/validate-modules/schema.py
+++ b/test/sanity/validate-modules/schema.py
@@ -60,7 +60,7 @@ suboption_schema = Schema(
         'version_added': Any(float, *string_types),
         'default': Any(None, float, int, bool, list, dict, *string_types),
         # Note: Types are strings, not literal bools, such as True or False
-        'type': Any(None, "bool"),
+        'type': Any(None, 'str', 'list', 'dict', 'bool', 'int', 'float', 'path', 'raw', 'jsonarg', 'json', 'bytes', 'bits'),
         # Recursive suboptions
         'suboptions': Any(None, *list({str_type: Self} for str_type in string_types)),
     },
@@ -81,7 +81,7 @@ option_schema = Schema(
         'default': Any(None, float, int, bool, list, dict, *string_types),
         'suboptions': Any(None, *list_dict_suboption_schema),
         # Note: Types are strings, not literal bools, such as True or False
-        'type': Any(None, 'str', 'list', 'dict', 'bool', 'int', 'float', 'path', 'raw', 'jsonarg', 'json', 'bytes', 'bits')
+        'type': Any(None, 'str', 'list', 'dict', 'bool', 'int', 'float', 'path', 'raw', 'jsonarg', 'json', 'bytes', 'bits'),
     },
     extra=PREVENT_EXTRA
 )


### PR DESCRIPTION
* Update win_scheduled_task.py to document that the duration of a task trigger can be null, which will cause it to run indefinitely - docs update makes use of suboptions

* Add a fix for the validate-modules schema
(cherry picked from commit 0bc5b79)

Co-authored-by: Justin England <justengland@gmail.com>


##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
docs for win_scheduled_task and changes to the tests that documentation matches parameters.

##### ADDITIONAL INFORMATION
The updates to the test infrastructure is needed for https://github.com/ansible/ansible/pull/48895  it has been cleared for backporting by jborean and sivel.  /cc @acozine If you could give your okay as well, I'll get this merged.