### PR TITLE
Ansible.Basic - fix deprecate return value

### DIFF
--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -242,7 +242,7 @@ namespace Ansible.Basic
 
         public void Deprecate(string message, string version)
         {
-            deprecations.Add(new Dictionary<string, string>() { { "message", message }, { "version", version } });
+            deprecations.Add(new Dictionary<string, string>() { { "msg", message }, { "version", version } });
             LogEvent(String.Format("[DEPRECATION WARNING] {0} {1}", message, version));
         }
 

--- a/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
@@ -655,7 +655,7 @@ test_no_log - Invoked with:
             }
             deprecations = @(
                 @{
-                    message = "Param 'removed1' is deprecated. See the module docs for more information"
+                    msg = "Param 'removed1' is deprecated. See the module docs for more information"
                     version = "2.1"
                 }
             )
@@ -710,7 +710,7 @@ test_no_log - Invoked with:
                 module_args = @{}
             }
             warnings = @("warning")
-            deprecations = @(@{message = "message"; version = "2.8"})
+            deprecations = @(@{msg = "message"; version = "2.8"})
         }
         $actual | Assert-DictionaryEquals -Expected $expected
     }


### PR DESCRIPTION
##### SUMMARY
When using `Deprecate` the return message is put under the `message` key when Ansible expects it under `msg`. Fix this and updated the tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.Basic.cs