### PR TITLE
Add timeout information into async failure message

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -806,7 +806,7 @@ class TaskExecutor:
 
         if int(async_result.get('finished', 0)) != 1:
             if async_result.get('_ansible_parsed'):
-                return dict(failed=True, msg="async task did not complete within the requested time")
+                return dict(failed=True, msg="async task did not complete within the requested time - %ss" % self._task.async_val)
             else:
                 return dict(failed=True, msg="async task produced unparseable results", async_result=async_result)
         else:


### PR DESCRIPTION
##### SUMMARY
Add some extra information to an async failure message to reflect the
actually timeout value of the failure.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_executor.py

##### ADDITIONAL INFORMATION
resurrected from https://github.com/ansible/ansible/pull/16333