### PR TITLE
Update docs with rhsm note

### DIFF
--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -22,6 +22,7 @@ description:
 version_added: "1.2"
 author: James Laska
 notes:
+    - This is for older Red Hat products. You probably want the redhat_subscription module instead.
     - In order to register a system, rhnreg_ks requires either a username and password, or an activationkey.
 requirements:
     - rhnreg_ks

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -22,7 +22,7 @@ description:
 version_added: "1.2"
 author: James Laska
 notes:
-    - This is for older Red Hat products. You probably want the redhat_subscription module instead.
+    - This is for older Red Hat products. You probably want the M(redhat_subscription) module instead.
     - In order to register a system, rhnreg_ks requires either a username and password, or an activationkey.
 requirements:
     - rhnreg_ks


### PR DESCRIPTION
redhat_subscription is the module for handling registration of modern Red Hat systems. This commit adds a note indicating that unless people are using RHEL 5 etc, they probably want that module instead.

+label: docsite_pr

##### SUMMARY
Users are landing on this module through google-fu and trying to use it rather than redhat_subscription so it would be good to enhance the docs to indicate they probably need to use that instead.

##### ISSUE TYPE
- Docs Pull Request
