### PR TITLE
Fix incorrect 'installed' status setting in dnf.py

### DIFF
--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -340,11 +340,10 @@ class DnfModule(YumDnf):
         result['nevra'] = '{epoch}:{name}-{version}-{release}.{arch}'.format(
             **result)
 
-        # Added for YUM3/YUM4 compat
-        if package.repoid == 'installed':
-            result['yumstate'] = 'installed'
-        else:
+        if package.installtime == 0:
             result['yumstate'] = 'available'
+        else:
+            result['yumstate'] = 'installed'
 
         return result
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The 'yumstate' field (installed/available) is incorrect in the return value of the dnf module, using the list parameter and a package name.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/packaging/os/dnf.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The dnf module was comparing the repoid to 'installed' to check whether a package is installed (in function _package_dict).

This does not work correctly on my Fedora 28 VM, 'available' is returned for all package matches, instead of 'installed' for the version that is indeed installed. It seems the repoid is now set to '@System' when the package is installed.

In the DNF API documentation a field 'installtime' is available which can be used to check whether a package is installed. When it is not installed, 'installtime' will be 0. I tested this on Fedora 28 and Fedora 22 (First release of Fedora with DNF). Using the 'installtime' field works for both Fedora versions.

I am now using the 'installtime' field to determine whether a package is installed.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
before:
ok: [localhost] => {
    "ansible_facts": {
        "pkg_mgr": "dnf"
    }, 
    "changed": false, 
    "invocation": {
        "module_args": {
            "allow_downgrade": false, 
            "autoremove": false, 
            "bugfix": false, 
            "conf_file": null, 
            "disable_excludes": null, 
            "disable_gpg_check": false, 
            "disable_plugin": [], 
            "disablerepo": [], 
            "download_only": false, 
            "enable_plugin": [], 
            "enablerepo": [], 
            "exclude": [], 
            "install_repoquery": true, 
            "installroot": "/", 
            "list": "chrony", 
            "name": [], 
            "releasever": null, 
            "security": false, 
            "skip_broken": false, 
            "state": "present", 
            "update_cache": false, 
            "update_only": false, 
            "validate_certs": true
        }
    }, 
    "msg": "", 
    "results": [
        {
            "arch": "x86_64", 
            "epoch": "0", 
            "name": "chrony", 
            "nevra": "0:chrony-3.4-1.fc28.x86_64", 
            "release": "1.fc28", 
            "repo": "@System", 
            "version": "3.4", 
            "yumstate": "available"
        }, 
        {
            "arch": "x86_64", 
            "epoch": "0", 
            "name": "chrony", 
            "nevra": "0:chrony-3.3-1.fc28.x86_64", 
            "release": "1.fc28", 
            "repo": "fedora", 
            "version": "3.3", 
            "yumstate": "available"
        }, 
        {
            "arch": "x86_64", 
            "epoch": "0", 
            "name": "chrony", 
            "nevra": "0:chrony-3.4-1.fc28.x86_64", 
            "release": "1.fc28", 
            "repo": "updates", 
            "version": "3.4", 
            "yumstate": "available"
        }
    ]
}

after:
ok: [localhost] => {
    "ansible_facts": {
        "pkg_mgr": "dnf"
    }, 
    "changed": false, 
    "invocation": {
        "module_args": {
            "allow_downgrade": false, 
            "autoremove": false, 
            "bugfix": false, 
            "conf_file": null, 
            "disable_excludes": null, 
            "disable_gpg_check": false, 
            "disable_plugin": [], 
            "disablerepo": [], 
            "download_only": false, 
            "enable_plugin": [], 
            "enablerepo": [], 
            "exclude": [], 
            "install_repoquery": true, 
            "installroot": "/", 
            "list": "chrony", 
            "name": [], 
            "releasever": null, 
            "security": false, 
            "skip_broken": false, 
            "state": "present", 
            "update_cache": false, 
            "update_only": false, 
            "validate_certs": true
        }
    }, 
    "msg": "", 
    "results": [
        {
            "arch": "x86_64", 
            "epoch": "0", 
            "name": "chrony", 
            "nevra": "0:chrony-3.4-1.fc28.x86_64", 
            "release": "1.fc28", 
            "repo": "@System", 
            "version": "3.4", 
            "yumstate": "installed"
        }, 
        {
            "arch": "x86_64", 
            "epoch": "0", 
            "name": "chrony", 
            "nevra": "0:chrony-3.3-1.fc28.x86_64", 
            "release": "1.fc28", 
            "repo": "fedora", 
            "version": "3.3", 
            "yumstate": "available"
        }, 
        {
            "arch": "x86_64", 
            "epoch": "0", 
            "name": "chrony", 
            "nevra": "0:chrony-3.4-1.fc28.x86_64", 
            "release": "1.fc28", 
            "repo": "updates", 
            "version": "3.4", 
            "yumstate": "available"
        }
    ]
}
```