### PR TITLE
ovirt_storage_connection: comparing passwords breaks idempotency in update_check

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_connection.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_connection.py
@@ -176,7 +176,6 @@ class StorageConnectionModule(BaseModule):
             equal(self.param('nfs_timeout'), entity.nfs_timeo) and
             equal(self.param('nfs_retrans'), entity.nfs_retrans) and
             equal(self.param('mount_options'), entity.mount_options) and
-            equal(self.param('password'), entity.password) and
             equal(self.param('username'), entity.username) and
             equal(self.param('port'), entity.port) and
             equal(self.param('target'), entity.target) and


### PR DESCRIPTION
##### SUMMARY
Comparing provided password parameter against returned entity password breaks idempotency as storage_connections_service() returns passwords as NoneType.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ovirt_storage_connection

