### PR TITLE
Add new param "ignore_selinux_state" to seport, sefcontext, seboolean

### DIFF
--- a/lib/ansible/modules/system/seboolean.py
+++ b/lib/ansible/modules/system/seboolean.py
@@ -16,7 +16,7 @@ module: seboolean
 short_description: Toggles SELinux booleans
 description:
      - Toggles SELinux booleans.
-version_added: "2.8"
+version_added: "0.7"
 options:
   name:
     description:
@@ -37,6 +37,7 @@ options:
     - Run independent of selinux runtime state
     type: bool
     default: 'no'
+    version_added: '2.8'
 notes:
    - Not tested on any Debian based system.
 requirements:
@@ -71,7 +72,12 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import binary_type
 from ansible.module_utils._text import to_bytes, to_text
-from ansible.modules.system.selinux import get_runtime_status
+
+try:
+    from .selinux import get_runtime_status
+    HAVE_RUNTIME_STATUS = True
+except ImportError:
+    HAVE_RUNTIME_STATUS = False
 
 
 def has_boolean_value(module, name):
@@ -279,6 +285,9 @@ def main():
 
     if not HAVE_SEMANAGE:
         module.fail_json(msg="This module requires libsemanage-python support")
+
+    if not HAVE_RUNTIME_STATUS:
+        module.fail_json(msg="This module requires the runtime status")
 
     force = module.params['force']
 

--- a/lib/ansible/modules/system/seboolean.py
+++ b/lib/ansible/modules/system/seboolean.py
@@ -16,7 +16,7 @@ module: seboolean
 short_description: Toggles SELinux booleans
 description:
      - Toggles SELinux booleans.
-version_added: "0.8"
+version_added: "2.8"
 options:
   name:
     description:

--- a/lib/ansible/modules/system/seboolean.py
+++ b/lib/ansible/modules/system/seboolean.py
@@ -32,6 +32,11 @@ options:
       - Desired boolean value
     type: bool
     required: true
+  force:
+    description:
+    - Run independent of selinux runtime state
+    type: bool
+    default: 'no'
 notes:
    - Not tested on any Debian based system.
 requirements:
@@ -66,7 +71,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import binary_type
 from ansible.module_utils._text import to_bytes, to_text
-
+from ansible.modules.system.selinux import get_runtime_status
 
 def has_boolean_value(module, name):
     bools = []
@@ -260,6 +265,7 @@ def set_boolean_value(module, name, state):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
+            force=dict(type='bool', default=False),
             name=dict(type='str', required=True),
             persistent=dict(type='bool', default=False),
             state=dict(type='bool', required=True),
@@ -273,7 +279,9 @@ def main():
     if not HAVE_SEMANAGE:
         module.fail_json(msg="This module requires libsemanage-python support")
 
-    if not selinux.is_selinux_enabled():
+    force = module.params['force']
+
+    if not get_runtime_status(force):
         module.fail_json(msg="SELinux is disabled on this host.")
 
     name = module.params['name']

--- a/lib/ansible/modules/system/seboolean.py
+++ b/lib/ansible/modules/system/seboolean.py
@@ -16,7 +16,7 @@ module: seboolean
 short_description: Toggles SELinux booleans
 description:
      - Toggles SELinux booleans.
-version_added: "0.7"
+version_added: "0.8"
 options:
   name:
     description:
@@ -72,6 +72,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import binary_type
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.modules.system.selinux import get_runtime_status
+
 
 def has_boolean_value(module, name):
     bools = []

--- a/lib/ansible/modules/system/seboolean.py
+++ b/lib/ansible/modules/system/seboolean.py
@@ -36,7 +36,7 @@ options:
     description:
     - Run independent of selinux runtime state
     type: bool
-    default: 'no'
+    default: false
     version_added: '2.8'
 notes:
    - Not tested on any Debian based system.

--- a/lib/ansible/modules/system/seboolean.py
+++ b/lib/ansible/modules/system/seboolean.py
@@ -73,11 +73,9 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import binary_type
 from ansible.module_utils._text import to_bytes, to_text
 
-try:
-    from .selinux import get_runtime_status
-    HAVE_RUNTIME_STATUS = True
-except ImportError:
-    HAVE_RUNTIME_STATUS = False
+
+def get_runtime_status(force=False):
+    return True if force is True else selinux.is_selinux_enabled()
 
 
 def has_boolean_value(module, name):
@@ -285,9 +283,6 @@ def main():
 
     if not HAVE_SEMANAGE:
         module.fail_json(msg="This module requires libsemanage-python support")
-
-    if not HAVE_RUNTIME_STATUS:
-        module.fail_json(msg="This module requires the runtime status")
 
     force = module.params['force']
 

--- a/lib/ansible/modules/system/seboolean.py
+++ b/lib/ansible/modules/system/seboolean.py
@@ -32,7 +32,7 @@ options:
       - Desired boolean value
     type: bool
     required: true
-  force:
+  ignore_selinux_state:
     description:
     - Run independent of selinux runtime state
     type: bool
@@ -74,8 +74,8 @@ from ansible.module_utils.six import binary_type
 from ansible.module_utils._text import to_bytes, to_text
 
 
-def get_runtime_status(force=False):
-    return True if force is True else selinux.is_selinux_enabled()
+def get_runtime_status(ignore_selinux_state=False):
+    return True if ignore_selinux_state is True else selinux.is_selinux_enabled()
 
 
 def has_boolean_value(module, name):
@@ -270,7 +270,7 @@ def set_boolean_value(module, name, state):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            force=dict(type='bool', default=False),
+            ignore_selinux_state=dict(type='bool', default=False),
             name=dict(type='str', required=True),
             persistent=dict(type='bool', default=False),
             state=dict(type='bool', required=True),
@@ -284,9 +284,9 @@ def main():
     if not HAVE_SEMANAGE:
         module.fail_json(msg="This module requires libsemanage-python support")
 
-    force = module.params['force']
+    ignore_selinux_state = module.params['ignore_selinux_state']
 
-    if not get_runtime_status(force):
+    if not get_runtime_status(ignore_selinux_state):
         module.fail_json(msg="SELinux is disabled on this host.")
 
     name = module.params['name']

--- a/lib/ansible/modules/system/seboolean.py
+++ b/lib/ansible/modules/system/seboolean.py
@@ -34,7 +34,7 @@ options:
     required: true
   ignore_selinux_state:
     description:
-    - Run independent of selinux runtime state
+    - Useful for scenarios (chrooted environment) that you can't get the real SELinux state.
     type: bool
     default: false
     version_added: '2.8'

--- a/lib/ansible/modules/system/sefcontext.py
+++ b/lib/ansible/modules/system/sefcontext.py
@@ -106,12 +106,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 try:
-    from .selinux import get_runtime_status
-    HAVE_RUNTIME_STATUS = True
-except ImportError:
-    HAVE_RUNTIME_STATUS = False
-
-try:
     import selinux
     HAVE_SELINUX = True
 except ImportError:
@@ -147,6 +141,10 @@ option_to_file_type_str = dict(
     p='named pipe',
     s='socket file',
 )
+
+
+def get_runtime_status(force=False):
+    return True if force is True else selinux.is_selinux_enabled()
 
 
 def semanage_fcontext_exists(sefcontext, target, ftype):
@@ -263,9 +261,6 @@ def main():
 
     if not HAVE_SEOBJECT:
         module.fail_json(msg="This module requires policycoreutils-python")
-
-    if not HAVE_RUNTIME_STATUS:
-        module.fail_json(msg="This module requires the runtime status")
 
     force = module.params['force']
 

--- a/lib/ansible/modules/system/sefcontext.py
+++ b/lib/ansible/modules/system/sefcontext.py
@@ -17,7 +17,7 @@ short_description: Manages SELinux file context mapping definitions
 description:
 - Manages SELinux file context mapping definitions.
 - Similar to the C(semanage fcontext) command.
-version_added: '2.8'
+version_added: '2.2'
 options:
   target:
     description:
@@ -69,6 +69,7 @@ options:
     - Run independent of selinux runtime state
     type: bool
     default: 'no'
+    version_added: '2.8'
 notes:
 - The changes are persistent across reboots.
 - The M(sefcontext) module does not modify existing files to the new
@@ -103,7 +104,12 @@ RETURN = r'''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible.modules.system.selinux import get_runtime_status
+
+try:
+    from .selinux import get_runtime_status
+    HAVE_RUNTIME_STATUS = True
+except ImportError:
+    HAVE_RUNTIME_STATUS = False
 
 try:
     import selinux
@@ -257,6 +263,9 @@ def main():
 
     if not HAVE_SEOBJECT:
         module.fail_json(msg="This module requires policycoreutils-python")
+
+    if not HAVE_RUNTIME_STATUS:
+        module.fail_json(msg="This module requires the runtime status")
 
     force = module.params['force']
 

--- a/lib/ansible/modules/system/sefcontext.py
+++ b/lib/ansible/modules/system/sefcontext.py
@@ -66,7 +66,7 @@ options:
     default: 'yes'
   ignore_selinux_state:
     description:
-    - Run independent of selinux runtime state
+    - Useful for scenarios (chrooted environment) that you can't get the real SELinux state.
     type: bool
     default: false
     version_added: '2.8'

--- a/lib/ansible/modules/system/sefcontext.py
+++ b/lib/ansible/modules/system/sefcontext.py
@@ -68,7 +68,7 @@ options:
     description:
     - Run independent of selinux runtime state
     type: bool
-    default: 'no'
+    default: false
     version_added: '2.8'
 notes:
 - The changes are persistent across reboots.

--- a/lib/ansible/modules/system/sefcontext.py
+++ b/lib/ansible/modules/system/sefcontext.py
@@ -64,7 +64,7 @@ options:
     - Note that this does not apply SELinux file contexts to existing files.
     type: bool
     default: 'yes'
-  force:
+  ignore_selinux_state:
     description:
     - Run independent of selinux runtime state
     type: bool
@@ -143,8 +143,8 @@ option_to_file_type_str = dict(
 )
 
 
-def get_runtime_status(force=False):
-    return True if force is True else selinux.is_selinux_enabled()
+def get_runtime_status(ignore_selinux_state=False):
+    return True if ignore_selinux_state is True else selinux.is_selinux_enabled()
 
 
 def semanage_fcontext_exists(sefcontext, target, ftype):
@@ -245,7 +245,7 @@ def semanage_fcontext_delete(module, result, target, ftype, do_reload, sestore='
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            force=dict(type='bool', default=False),
+            ignore_selinux_state=dict(type='bool', default=False),
             target=dict(required=True, aliases=['path']),
             ftype=dict(type='str', default='a', choices=option_to_file_type_str.keys()),
             setype=dict(type='str', required=True),
@@ -262,9 +262,9 @@ def main():
     if not HAVE_SEOBJECT:
         module.fail_json(msg="This module requires policycoreutils-python")
 
-    force = module.params['force']
+    ignore_selinux_state = module.params['ignore_selinux_state']
 
-    if not get_runtime_status(force):
+    if not get_runtime_status(ignore_selinux_state):
         module.fail_json(msg="SELinux is disabled on this host.")
 
     target = module.params['target']

--- a/lib/ansible/modules/system/sefcontext.py
+++ b/lib/ansible/modules/system/sefcontext.py
@@ -103,7 +103,7 @@ RETURN = r'''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible.mobules.system.selinux import get_runtime_status
+from ansible.modules.system.selinux import get_runtime_status
 
 try:
     import selinux

--- a/lib/ansible/modules/system/sefcontext.py
+++ b/lib/ansible/modules/system/sefcontext.py
@@ -17,7 +17,7 @@ short_description: Manages SELinux file context mapping definitions
 description:
 - Manages SELinux file context mapping definitions.
 - Similar to the C(semanage fcontext) command.
-version_added: '2.3'
+version_added: '2.8'
 options:
   target:
     description:

--- a/lib/ansible/modules/system/sefcontext.py
+++ b/lib/ansible/modules/system/sefcontext.py
@@ -17,7 +17,7 @@ short_description: Manages SELinux file context mapping definitions
 description:
 - Manages SELinux file context mapping definitions.
 - Similar to the C(semanage fcontext) command.
-version_added: '2.2'
+version_added: '2.3'
 options:
   target:
     description:

--- a/lib/ansible/modules/system/selinux.py
+++ b/lib/ansible/modules/system/selinux.py
@@ -165,10 +165,6 @@ def set_config_policy(module, policy, configfile):
     module.atomic_move(tmpfile, configfile)
 
 
-def get_runtime_status(force=False):
-    return True if force is True else selinux.is_selinux_enabled()
-
-
 def main():
     module = AnsibleModule(
         argument_spec=dict(

--- a/lib/ansible/modules/system/selinux.py
+++ b/lib/ansible/modules/system/selinux.py
@@ -21,7 +21,7 @@ module: selinux
 short_description: Change policy and state of SELinux
 description:
   - Configures the SELinux mode and policy. A reboot may be required after usage. Ansible will not issue this reboot but will let you know when it is required.
-version_added: "0.8"
+version_added: "0.7"
 options:
   policy:
     description:

--- a/lib/ansible/modules/system/selinux.py
+++ b/lib/ansible/modules/system/selinux.py
@@ -21,7 +21,7 @@ module: selinux
 short_description: Change policy and state of SELinux
 description:
   - Configures the SELinux mode and policy. A reboot may be required after usage. Ansible will not issue this reboot but will let you know when it is required.
-version_added: "0.7"
+version_added: "0.8"
 options:
   policy:
     description:
@@ -164,8 +164,10 @@ def set_config_policy(module, policy, configfile):
 
     module.atomic_move(tmpfile, configfile)
 
+
 def get_runtime_status(force=False):
     return True if force is True else selinux.is_selinux_enabled()
+
 
 def main():
     module = AnsibleModule(

--- a/lib/ansible/modules/system/selinux.py
+++ b/lib/ansible/modules/system/selinux.py
@@ -164,6 +164,8 @@ def set_config_policy(module, policy, configfile):
 
     module.atomic_move(tmpfile, configfile)
 
+def get_runtime_status(force=False):
+    return True if force is True else selinux.is_selinux_enabled()
 
 def main():
     module = AnsibleModule(

--- a/lib/ansible/modules/system/seport.py
+++ b/lib/ansible/modules/system/seport.py
@@ -107,11 +107,9 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule, HAVE_SELINUX
 from ansible.module_utils._text import to_native
 
-try:
-    from .selinux import get_runtime_status
-    HAVE_RUNTIME_STATUS = True
-except ImportError:
-    HAVE_RUNTIME_STATUS = False
+
+def get_runtime_status(force=False):
+    return True if force is True else selinux.is_selinux_enabled()
 
 
 def semanage_port_get_ports(seport, setype, proto):
@@ -267,9 +265,6 @@ def main():
 
     if not HAVE_SEOBJECT:
         module.fail_json(msg="This module requires policycoreutils-python")
-
-    if not HAVE_RUNTIME_STATUS:
-        module.fail_json(msg="This module requires the runtime status")
 
     force = module.params['force']
 

--- a/lib/ansible/modules/system/seport.py
+++ b/lib/ansible/modules/system/seport.py
@@ -16,7 +16,7 @@ module: seport
 short_description: Manages SELinux network port type definitions
 description:
     - Manages SELinux network port type definitions.
-version_added: "2.0"
+version_added: "2.1"
 options:
   ports:
     description:

--- a/lib/ansible/modules/system/seport.py
+++ b/lib/ansible/modules/system/seport.py
@@ -16,7 +16,7 @@ module: seport
 short_description: Manages SELinux network port type definitions
 description:
     - Manages SELinux network port type definitions.
-version_added: "2.8"
+version_added: "2.0"
 options:
   ports:
     description:
@@ -47,6 +47,7 @@ options:
     - Run independent of selinux runtime state
     type: bool
     default: 'no'
+    version_added: '2.8'
 notes:
    - The changes are persistent across reboots.
    - Not tested on any debian based system.

--- a/lib/ansible/modules/system/seport.py
+++ b/lib/ansible/modules/system/seport.py
@@ -46,7 +46,7 @@ options:
     description:
     - Run independent of selinux runtime state
     type: bool
-    default: 'no'
+    default: false
     version_added: '2.8'
 notes:
    - The changes are persistent across reboots.

--- a/lib/ansible/modules/system/seport.py
+++ b/lib/ansible/modules/system/seport.py
@@ -42,7 +42,7 @@ options:
       - Reload SELinux policy after commit.
     type: bool
     default: 'yes'
-  force:
+  ignore_selinux_state:
     description:
     - Run independent of selinux runtime state
     type: bool
@@ -108,8 +108,8 @@ from ansible.module_utils.basic import AnsibleModule, HAVE_SELINUX
 from ansible.module_utils._text import to_native
 
 
-def get_runtime_status(force=False):
-    return True if force is True else selinux.is_selinux_enabled()
+def get_runtime_status(ignore_selinux_state=False):
+    return True if ignore_selinux_state is True else selinux.is_selinux_enabled()
 
 
 def semanage_port_get_ports(seport, setype, proto):
@@ -250,7 +250,7 @@ def semanage_port_del(module, ports, proto, setype, do_reload, sestore=''):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            force=dict(type='bool', default=False),
+            ignore_selinux_state=dict(type='bool', default=False),
             ports=dict(type='list', required=True),
             proto=dict(type='str', required=True, choices=['tcp', 'udp']),
             setype=dict(type='str', required=True),
@@ -266,9 +266,9 @@ def main():
     if not HAVE_SEOBJECT:
         module.fail_json(msg="This module requires policycoreutils-python")
 
-    force = module.params['force']
+    ignore_selinux_state = module.params['ignore_selinux_state']
 
-    if not get_runtime_status(force):
+    if not get_runtime_status(ignore_selinux_state):
         module.fail_json(msg="SELinux is disabled on this host.")
 
     ports = module.params['ports']

--- a/lib/ansible/modules/system/seport.py
+++ b/lib/ansible/modules/system/seport.py
@@ -16,7 +16,7 @@ module: seport
 short_description: Manages SELinux network port type definitions
 description:
     - Manages SELinux network port type definitions.
-version_added: "2.1"
+version_added: "2.8"
 options:
   ports:
     description:
@@ -105,7 +105,12 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule, HAVE_SELINUX
 from ansible.module_utils._text import to_native
-from ansible.modules.system.selinux import get_runtime_status
+
+try:
+    from .selinux import get_runtime_status
+    HAVE_RUNTIME_STATUS = True
+except ImportError:
+    HAVE_RUNTIME_STATUS = False
 
 
 def semanage_port_get_ports(seport, setype, proto):
@@ -261,6 +266,9 @@ def main():
 
     if not HAVE_SEOBJECT:
         module.fail_json(msg="This module requires policycoreutils-python")
+
+    if not HAVE_RUNTIME_STATUS:
+        module.fail_json(msg="This module requires the runtime status")
 
     force = module.params['force']
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added a new parameter "force" to SELinux module components: seport, seboolean and sefcontext.

The rationale to make this change is that when you are running this module in a chrooted environment it's not capable to respond with the correct SELinux state.

So, with the force option the task just ignores the real SELinux state and force it running.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
selinux

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
I needed this change because I'm running hashicorp's packer to make new AWS AMIs. 
And when I used the selinux module to make my ansible role idempotent it didn't work anymore with packer on option amazon-chroot.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```