### PR TITLE
make it explicit that role dependencies can include conditionals

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -282,6 +282,13 @@ Role dependencies allow you to automatically pull in other roles when using a ro
           dbname: blarg
           other_parameter: 12
 
+Role dependencies may be conditional::
+
+    ---
+    dependencies:
+      - role: apache
+        when: need_apache|default(false)
+
 .. note::
     Role dependencies must use the classic role definition style.
 


### PR DESCRIPTION
the docs don't make it clear that when: can be applied to dependencies
in meta/main.yml.


##### SUMMARY
This adds verbage to user_guide/playbooks_reuse_roles.rst making
describing the use of when: in role dependencies.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs

##### ADDITIONAL INFORMATION
Per #ansible irc discussion 2018-11-20