### PR TITLE
Aws waf region

### DIFF
--- a/hacking/aws_config/testing_policies/security-policy.json
+++ b/hacking/aws_config/testing_policies/security-policy.json
@@ -53,6 +53,12 @@
             "Resource": [
                 "arn:aws:logs:{{aws_region}}:{{aws_account}}:log-group:ansible-testing*"
             ]
+        },
+        {
+            "Sid": "AllowWAFRegionalusage",
+            "Action": "waf-regional:*",
+            "Effect": "Allow",
+            "Resource": "*"
         }
     ]
 }

--- a/lib/ansible/module_utils/aws/waf.py
+++ b/lib/ansible/module_utils/aws/waf.py
@@ -180,7 +180,6 @@ def list_web_acls_with_backoff(client):
 
 @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
 def list_regional_web_acls_with_backoff(client):
-    import ipdb; ipdb.set_trace()
     resp = client.list_web_acls()
     acls = []
     while resp:

--- a/lib/ansible/module_utils/aws/waf.py
+++ b/lib/ansible/module_utils/aws/waf.py
@@ -141,6 +141,11 @@ def get_web_acl_with_backoff(client, web_acl_id):
     return client.get_web_acl(WebACLId=web_acl_id)['WebACL']
 
 
+@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+def get_regional_web_acl_with_backoff(client, web_acl_id):
+    return client.get_web_acl(WebACLId=web_acl_id)['WebACL']
+
+
 def get_web_acl(client, module, web_acl_id):
     try:
         web_acl = get_web_acl_with_backoff(client, web_acl_id)
@@ -174,11 +179,24 @@ def list_web_acls_with_backoff(client):
     return paginator.paginate().build_full_result()['WebACLs']
 
 
+@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+def list_regional_web_acls_with_backoff(client):
+    # TODO: Implement manual pagination. This only returns the first 100 ACLs
+    return client.list_web_acls()['WebACLs']
+
+
 def list_web_acls(client, module):
     try:
         return list_web_acls_with_backoff(client)
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Couldn't obtain web acls")
+
+
+# def list_regional_web_acls(client, module):
+#    try:
+#        return list_regional_web_acls_with_backoff(client)
+#    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+#        module.fail_json_aws(e, msg="Couldn't obtain web acls")
 
 
 def get_change_token(client, module):

--- a/lib/ansible/module_utils/aws/waf.py
+++ b/lib/ansible/module_utils/aws/waf.py
@@ -163,6 +163,12 @@ def list_rules_with_backoff(client):
 
 
 @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+def list_regional_rules_with_backoff(client):
+    # TODO: Implement manual pagination. This only returns the first 100 results
+    return client.list_rules()['Rules']
+
+
+@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
 def list_web_acls_with_backoff(client):
     paginator = client.get_paginator('list_web_acls')
     return paginator.paginate().build_full_result()['WebACLs']

--- a/lib/ansible/module_utils/aws/waf.py
+++ b/lib/ansible/module_utils/aws/waf.py
@@ -190,7 +190,10 @@ def list_regional_web_acls_with_backoff(client):
 
 def list_web_acls(client, module):
     try:
-        return list_web_acls_with_backoff(client)
+        if type(client).__name__ == 'WAF':
+            return list_web_acls_with_backoff(client)
+        elif type(client).__name__ == 'WAFRegional':
+            return list_regional_web_acls_with_backoff(client)
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Couldn't obtain web acls")
 

--- a/lib/ansible/module_utils/aws/waf.py
+++ b/lib/ansible/module_utils/aws/waf.py
@@ -141,11 +141,6 @@ def get_web_acl_with_backoff(client, web_acl_id):
     return client.get_web_acl(WebACLId=web_acl_id)['WebACL']
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
-def get_regional_web_acl_with_backoff(client, web_acl_id):
-    return client.get_web_acl(WebACLId=web_acl_id)['WebACL']
-
-
 def get_web_acl(client, module, web_acl_id):
     try:
         web_acl = get_web_acl_with_backoff(client, web_acl_id)
@@ -185,11 +180,12 @@ def list_web_acls_with_backoff(client):
 
 @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
 def list_regional_web_acls_with_backoff(client):
+    import ipdb; ipdb.set_trace()
     resp = client.list_web_acls()
     acls = []
     while resp:
         acls += resp['WebACLs']
-        resp = client.list_rules(NextMarker=resp['NextMarker']) if 'NextMarker' in resp else None
+        resp = client.list_web_acls(NextMarker=resp['NextMarker']) if 'NextMarker' in resp else None
     return acls
 
 

--- a/lib/ansible/module_utils/aws/waf.py
+++ b/lib/ansible/module_utils/aws/waf.py
@@ -190,9 +190,9 @@ def list_regional_web_acls_with_backoff(client):
 
 def list_web_acls(client, module):
     try:
-        if type(client).__name__ == 'WAF':
+        if client.__class__.__name__ == 'WAF':
             return list_web_acls_with_backoff(client)
-        elif type(client).__name__ == 'WAFRegional':
+        elif client.__class__.__name__ == 'WAFRegional':
             return list_regional_web_acls_with_backoff(client)
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Couldn't obtain web acls")

--- a/lib/ansible/module_utils/aws/waiters.py
+++ b/lib/ansible/module_utils/aws/waiters.py
@@ -305,6 +305,12 @@ waiters_by_name = {
         core_waiter.NormalizedOperationMethod(
             waf.get_change_token_status
         )),
+    ('WAFRegional', 'change_token_in_sync'): lambda waf: core_waiter.Waiter(
+        'change_token_in_sync',
+        waf_model('ChangeTokenInSync'),
+        core_waiter.NormalizedOperationMethod(
+            waf.get_change_token_status
+        )),
     ('EKS', 'cluster_active'): lambda eks: core_waiter.Waiter(
         'cluster_active',
         eks_model('ClusterActive'),

--- a/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
@@ -62,7 +62,7 @@ options:
         default: false
         required: no
         type: bool
-        version_added: 2.8
+        version_added: 2.9
     state:
         description: Whether the condition should be C(present) or C(absent).
         choices:

--- a/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
@@ -57,11 +57,11 @@ options:
         - Whether to remove existing filters from a condition if not passed in I(filters).
         default: False
         type: bool
-        description: Whether to remove existing filters from a condition if not passed in I(filters). Defaults to false.
     waf_regional:
         description: Wether to use waf_regional module. Defaults to false.
         default: false
         required: no
+        type: bool
         version_added: 2.8
     state:
         description: Whether the condition should be C(present) or C(absent).

--- a/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
@@ -59,9 +59,9 @@ options:
         default: False
         type: bool
         description: Whether to remove existing filters from a condition if not passed in I(filters). Defaults to false.
-    cloudfront:
-        description: Wether to use CloudFront WAF. Defaults to true
-        default: true
+    waf_regional:
+        description: Wether to use waf_regional module. Defaults to true
+        default: false
         required: no
     state:
         description: Whether the condition should be C(present) or C(absent).
@@ -651,10 +651,8 @@ def main():
     state = module.params.get('state')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-    if module.params.get('cloudfront'):
-        client = boto3_conn(module, conn_type='client', resource='waf', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-    elif not module.params.get('cloudfront'):
-        client = boto3_conn(module, conn_type='client', resource='waf-regional', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    resource = 'waf' if not module.params['waf_regional'] else 'waf-regional'
+    client = boto3_conn(module, conn_type='client', resource=resource, region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
     condition = Condition(client, module)
 

--- a/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
@@ -63,6 +63,7 @@ options:
         description: Wether to use waf_regional module. Defaults to true
         default: false
         required: no
+        version_added: 2.8
     state:
         description: Whether the condition should be C(present) or C(absent).
         choices:
@@ -525,9 +526,9 @@ class Condition(object):
     def find_condition_in_rules(self, condition_set_id):
         rules_in_use = []
         try:
-            if type(self.client).__name__ == 'WAF':
+            if self.client.__class__.__name__ == 'WAF':
                 all_rules = list_rules_with_backoff(self.client)
-            elif type(self.client).__name__ == 'WAFRegional':
+            elif self.client.__class__.__name__ == 'WAFRegional':
                 all_rules = list_regional_rules_with_backoff(self.client)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self.module.fail_json_aws(e, msg='Could not list rules')

--- a/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
@@ -53,14 +53,13 @@ options:
         - I(target_string) is a maximum of 50 bytes.
         - I(regex_pattern) is a dict with a C(name) key and C(regex_strings) list of strings to match.
     purge_filters:
-<<<<<<< HEAD
         description:
         - Whether to remove existing filters from a condition if not passed in I(filters).
         default: False
         type: bool
         description: Whether to remove existing filters from a condition if not passed in I(filters). Defaults to false.
     waf_regional:
-        description: Wether to use waf_regional module. Defaults to true
+        description: Wether to use waf_regional module. Defaults to false.
         default: false
         required: no
         version_added: 2.8

--- a/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
@@ -642,7 +642,7 @@ def main():
             type=dict(required=True, choices=['byte', 'geo', 'ip', 'regex', 'size', 'sql', 'xss']),
             filters=dict(type='list'),
             purge_filters=dict(type='bool', default=False),
-            cloudfront=dict(type='bool', default=True),
+            waf_regional=dict(type='bool', default=False),
             state=dict(default='present', choices=['present', 'absent']),
         ),
     )

--- a/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
@@ -53,10 +53,16 @@ options:
         - I(target_string) is a maximum of 50 bytes.
         - I(regex_pattern) is a dict with a C(name) key and C(regex_strings) list of strings to match.
     purge_filters:
+<<<<<<< HEAD
         description:
         - Whether to remove existing filters from a condition if not passed in I(filters).
         default: False
         type: bool
+        description: Whether to remove existing filters from a condition if not passed in I(filters). Defaults to false.
+    cloudfront:
+        description: Wether to use CloudFront WAF. Defaults to true
+        default: true
+        required: no
     state:
         description: Whether the condition should be C(present) or C(absent).
         choices:
@@ -636,6 +642,7 @@ def main():
             type=dict(required=True, choices=['byte', 'geo', 'ip', 'regex', 'size', 'sql', 'xss']),
             filters=dict(type='list'),
             purge_filters=dict(type='bool', default=False),
+            cloudfront=dict(type='bool', default=True),
             state=dict(default='present', choices=['present', 'absent']),
         ),
     )
@@ -644,7 +651,10 @@ def main():
     state = module.params.get('state')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-    client = boto3_conn(module, conn_type='client', resource='waf', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    if module.params.get('cloudfront'):
+        client = boto3_conn(module, conn_type='client', resource='waf', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    elif not module.params.get('cloudfront'):
+        client = boto3_conn(module, conn_type='client', resource='waf-regional', region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
     condition = Condition(client, module)
 

--- a/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
@@ -341,7 +341,7 @@ from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry, compare_policies
 from ansible.module_utils.aws.waf import run_func_with_change_token_backoff, MATCH_LOOKUP
-from ansible.module_utils.aws.waf import get_rule_with_backoff, list_rules_with_backoff
+from ansible.module_utils.aws.waf import get_rule_with_backoff, list_rules_with_backoff, list_regional_rules_with_backoff
 
 
 class Condition(object):
@@ -525,7 +525,10 @@ class Condition(object):
     def find_condition_in_rules(self, condition_set_id):
         rules_in_use = []
         try:
-            all_rules = list_rules_with_backoff(self.client)
+            if type(self.client).__name__ == 'WAF':
+                all_rules = list_rules_with_backoff(self.client)
+            elif type(self.client).__name__ == 'WAFRegional':
+                all_rules = list_regional_rules_with_backoff(self.client)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self.module.fail_json_aws(e, msg='Could not list rules')
         for rule in all_rules:

--- a/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
@@ -58,7 +58,7 @@ options:
         default: False
         type: bool
     waf_regional:
-        description: Wether to use waf_regional module. Defaults to false.
+        description: Whether to use waf_regional module. Defaults to false.
         default: false
         required: no
         type: bool

--- a/lib/ansible/modules/cloud/amazon/aws_waf_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_facts.py
@@ -22,7 +22,7 @@ options:
       default: false
       required: no
       type: bool
-      version_added: "2.8"
+      version_added: "2.9"
 
 author:
   - Mike Mochan (@mmochan)

--- a/lib/ansible/modules/cloud/amazon/aws_waf_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_facts.py
@@ -17,10 +17,11 @@ options:
   name:
     description:
       - The name of a Web Application Firewall
-    waf_regional:
-        description: Wether to use waf_regional module. Defaults to true
-        default: false
-        required: no
+  waf_regional:
+      description: Wether to use waf_regional module. Defaults to true
+      default: false
+      required: no
+      version_added: "2.8"
 
 author:
   - Mike Mochan (@mmochan)
@@ -37,6 +38,11 @@ EXAMPLES = '''
 - name: obtain all facts for a single WAF
   aws_waf_facts:
     name: test_waf
+
+- name: obtain all facts for a single WAF Regional
+  aws_waf_facts:
+    name: test_waf
+    waf_regional: true
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/amazon/aws_waf_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_facts.py
@@ -17,6 +17,10 @@ options:
   name:
     description:
       - The name of a Web Application Firewall
+    cloudfront:
+        description: Wether to use CloudFront WAF. Defaults to true
+        default: true
+        required: no
 
 author:
   - Mike Mochan (@mmochan)
@@ -113,13 +117,16 @@ def main():
     argument_spec.update(
         dict(
             name=dict(required=False),
+            cloudfront=dict(type='bool', default=True),
         )
     )
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-    client = boto3_conn(module, conn_type='client', resource='waf', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-
+    if module.params.get('cloudfront'):
+        client = boto3_conn(module, conn_type='client', resource='waf', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    elif not module.params.get('cloudfront'):
+        client = boto3_conn(module, conn_type='client', resource='waf-regional', region=region, endpoint=ec2_url, **aws_connect_kwargs)
     web_acls = list_web_acls(client, module)
     name = module.params['name']
     if name:

--- a/lib/ansible/modules/cloud/amazon/aws_waf_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_facts.py
@@ -17,9 +17,9 @@ options:
   name:
     description:
       - The name of a Web Application Firewall
-    cloudfront:
-        description: Wether to use CloudFront WAF. Defaults to true
-        default: true
+    waf_regional:
+        description: Wether to use waf_regional module. Defaults to true
+        default: false
         required: no
 
 author:
@@ -117,16 +117,14 @@ def main():
     argument_spec.update(
         dict(
             name=dict(required=False),
-            cloudfront=dict(type='bool', default=True),
+            waf_regional=dict(type='bool', default=False),
         )
     )
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-    if module.params.get('cloudfront'):
-        client = boto3_conn(module, conn_type='client', resource='waf', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-    elif not module.params.get('cloudfront'):
-        client = boto3_conn(module, conn_type='client', resource='waf-regional', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    resource = 'waf' if not module.params['waf_regional'] else 'waf-regional'
+    client = boto3_conn(module, conn_type='client', resource=resource, region=region, endpoint=ec2_url, **aws_connect_kwargs)
     web_acls = list_web_acls(client, module)
     name = module.params['name']
     if name:

--- a/lib/ansible/modules/cloud/amazon/aws_waf_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_facts.py
@@ -21,6 +21,7 @@ options:
       description: Wether to use waf_regional module. Defaults to true
       default: false
       required: no
+      type: bool
       version_added: "2.8"
 
 author:

--- a/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
@@ -54,7 +54,7 @@ options:
         default: false
         required: no
         type: bool
-        version_added: "2.8"
+        version_added: "2.9"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
@@ -160,7 +160,7 @@ def list_rules(client, module):
         try:
             return list_regional_rules_with_backoff(client)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg='Could not list WAF rules')
+            module.fail_json_aws(e, msg='Could not list WAF Regional rules')
 
 
 def list_regional_rules(client, module):

--- a/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
@@ -50,7 +50,7 @@ options:
         default: false
         type: bool
     waf_regional:
-        description: Wether to use waf_regional module. Defaults to false
+        description: Whether to use waf_regional module. Defaults to false
         default: false
         required: no
         type: bool

--- a/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
@@ -315,17 +315,15 @@ def main():
             state=dict(default='present', choices=['present', 'absent']),
             conditions=dict(type='list'),
             purge_conditions=dict(type='bool', default=False),
-            cloudfront=dict(type='bool', default=True),
+            waf_regional=dict(type='bool', default=False),
         ),
     )
     module = AnsibleAWSModule(argument_spec=argument_spec)
     state = module.params.get('state')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-    if module.params.get('cloudfront'):
-        client = boto3_conn(module, conn_type='client', resource='waf', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-    elif not module.params.get('cloudfront'):
-        client = boto3_conn(module, conn_type='client', resource='waf-regional', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    resource = 'waf' if not module.params['waf_regional'] else 'waf-regional'
+    client = boto3_conn(module, conn_type='client', resource=resource, region=region, endpoint=ec2_url, **aws_connect_kwargs)
     if state == 'present':
         (changed, results) = ensure_rule_present(client, module)
     else:

--- a/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
@@ -56,6 +56,7 @@ options:
         description: Wether to use waf_regional module. Defaults to true
         default: false
         required: no
+        version_added: "2.8"
 '''
 
 EXAMPLES = '''
@@ -152,12 +153,12 @@ def get_rule(client, module, rule_id):
 
 
 def list_rules(client, module):
-    if type(client).__name__ == 'WAF':
+    if client.__class__.__name__ == 'WAF':
         try:
             return list_rules_with_backoff(client)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg='Could not list WAF rules')
-    elif type(client).__name__ == 'WAFRegional':
+    elif client.__class__.__name__ == 'WAFRegional':
         try:
             return list_regional_rules_with_backoff(client)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
@@ -280,9 +281,9 @@ def ensure_rule_present(client, module):
 def find_rule_in_web_acls(client, module, rule_id):
     web_acls_in_use = []
     try:
-        if type(client).__name__ == 'WAF':
+        if client.__class__.__name__ == 'WAF':
             all_web_acls = list_web_acls_with_backoff(client)
-        elif type(client).__name__ == 'WAFRegional':
+        elif client.__class__.__name__ == 'WAFRegional':
             all_web_acls = list_regional_web_acls_with_backoff(client)
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg='Could not list Web ACLs')

--- a/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
@@ -49,11 +49,8 @@ options:
           - Whether or not to remove conditions that are not passed when updating `conditions`.
         default: false
         type: bool
-    cloudfront:
-        description: Wether to use CloudFront WAF. Defaults to true
-        default: true
     waf_regional:
-        description: Wether to use waf_regional module. Defaults to true
+        description: Wether to use waf_regional module. Defaults to false
         default: false
         required: no
         version_added: "2.8"

--- a/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_rule.py
@@ -53,6 +53,7 @@ options:
         description: Wether to use waf_regional module. Defaults to false
         default: false
         required: no
+        type: bool
         version_added: "2.8"
 '''
 

--- a/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
@@ -169,7 +169,7 @@ def create_rule_lookup(client, module):
             rules = list_regional_rules_with_backoff(client)
             return dict((rule['Name'], rule) for rule in rules)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg='Could not list rules')
+            module.fail_json_aws(e, msg='Could not list regional rules')
 
 
 def get_web_acl(client, module, web_acl_id):

--- a/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
@@ -55,7 +55,7 @@ options:
         default: False
         type: bool
     waf_regional:
-        description: Wether to use waf_regional module. Defaults to false.
+        description: Whether to use waf_regional module. Defaults to false.
         default: false
         required: no
         type: bool

--- a/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
@@ -59,7 +59,7 @@ options:
         default: false
         required: no
         type: bool
-        version_added: "2.8"
+        version_added: "2.9"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
@@ -144,7 +144,8 @@ import re
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.aws.waiters import get_waiter
 from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict
-from ansible.module_utils.aws.waf import list_rules_with_backoff, list_web_acls_with_backoff, list_regional_web_acls_with_backoff, run_func_with_change_token_backoff, list_regional_rules_with_backoff
+from ansible.module_utils.aws.waf import list_rules_with_backoff, list_web_acls_with_backoff, list_regional_web_acls_with_backoff, \
+    run_func_with_change_token_backoff, list_regional_rules_with_backoff
 
 
 def get_web_acl_by_name(client, module, name):
@@ -156,7 +157,6 @@ def get_web_acl_by_name(client, module, name):
 
 
 def create_rule_lookup(client, module):
-    import ipdb; ipdb.set_trace()
     if type(client).__name__ == 'WAF':
         try:
             rules = list_rules_with_backoff(client)

--- a/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
@@ -58,6 +58,7 @@ options:
         description: Wether to use waf_regional module. Defaults to false.
         default: false
         required: no
+        type: bool
         version_added: "2.8"
 '''
 

--- a/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
@@ -55,9 +55,9 @@ options:
         default: False
         type: bool
         description: Whether to remove rules that aren't passed with C(rules). Defaults to false
-    cloudfront:
-        description: Wether to use CloudFront WAF. Defaults to true
-        default: true
+    waf_regional:
+        description: Wether to use waf_regional module. Defaults to true
+        default: false
         required: no
 '''
 
@@ -323,10 +323,8 @@ def main():
     state = module.params.get('state')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-    if module.params.get('cloudfront'):
-        client = boto3_conn(module, conn_type='client', resource='waf', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-    elif not module.params.get('cloudfront'):
-        client = boto3_conn(module, conn_type='client', resource='waf-regional', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    resource = 'waf' if not module.params['waf_regional'] else 'waf-regional'
+    client = boto3_conn(module, conn_type='client', resource=resource, region=region, endpoint=ec2_url, **aws_connect_kwargs)
     if state == 'present':
         (changed, results) = ensure_web_acl_present(client, module)
     else:

--- a/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
@@ -54,9 +54,8 @@ options:
         - Whether to remove rules that aren't passed with C(rules).
         default: False
         type: bool
-        description: Whether to remove rules that aren't passed with C(rules). Defaults to false
     waf_regional:
-        description: Wether to use waf_regional module. Defaults to true
+        description: Wether to use waf_regional module. Defaults to false.
         default: false
         required: no
         version_added: "2.8"

--- a/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
@@ -315,7 +315,7 @@ def main():
             state=dict(default='present', choices=['present', 'absent']),
             rules=dict(type='list'),
             purge_rules=dict(type='bool', default=False),
-            cloudfront=dict(type='bool', default=True),
+            waf_regional=dict(type='bool', default=False),
         ),
     )
     module = AnsibleAWSModule(argument_spec=argument_spec,

--- a/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
@@ -59,6 +59,7 @@ options:
         description: Wether to use waf_regional module. Defaults to true
         default: false
         required: no
+        version_added: "2.8"
 '''
 
 EXAMPLES = '''
@@ -157,13 +158,13 @@ def get_web_acl_by_name(client, module, name):
 
 
 def create_rule_lookup(client, module):
-    if type(client).__name__ == 'WAF':
+    if client.__class__.__name__ == 'WAF':
         try:
             rules = list_rules_with_backoff(client)
             return dict((rule['Name'], rule) for rule in rules)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg='Could not list rules')
-    elif type(client).__name__ == 'WAFRegional':
+    elif client.__class__.__name__ == 'WAFRegional':
         try:
             rules = list_regional_rules_with_backoff(client)
             return dict((rule['Name'], rule) for rule in rules)
@@ -179,12 +180,12 @@ def get_web_acl(client, module, web_acl_id):
 
 
 def list_web_acls(client, module,):
-    if type(client).__name__ == 'WAF':
+    if client.__class__.__name__ == 'WAF':
         try:
             return list_web_acls_with_backoff(client)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg='Could not get Web ACLs')
-    elif type(client).__name__ == 'WAFRegional':
+    elif client.__class__.__name__ == 'WAFRegional':
         try:
             return list_regional_web_acls_with_backoff(client)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:

--- a/test/integration/targets/aws_waf_web_acl/tasks/main.yml
+++ b/test/integration/targets/aws_waf_web_acl/tasks/main.yml
@@ -613,7 +613,7 @@
       region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
-    register: create_aws_regional_waf_rule
+    register: create_aws_waf_regional_waf_rule
 
   - name: check WAF Regional rule
     assert:

--- a/test/integration/targets/aws_waf_web_acl/tasks/main.yml
+++ b/test/integration/targets/aws_waf_web_acl/tasks/main.yml
@@ -613,7 +613,7 @@
       region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
-    register: create_aws_waf_regional_waf_rule
+    register: create_aws_waf_regional_rule
 
   - name: check WAF Regional rule
     assert:

--- a/test/integration/targets/aws_waf_web_acl/tasks/main.yml
+++ b/test/integration/targets/aws_waf_web_acl/tasks/main.yml
@@ -239,6 +239,7 @@
       filters:
         - ip_address: "10.0.0.0/8"
       type: ip
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: create_waf_regional_ip_condition
@@ -250,6 +251,7 @@
         - ip_address: "10.0.0.0/8"
         - ip_address: "192.168.0.0/24"
       type: ip
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: add_ip_address_to_waf_regional_condition
@@ -265,6 +267,7 @@
       filters:
         - ip_address: "192.168.10.0/24"
       type: ip
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: add_ip_address_to_waf_regional_condition_no_purge

--- a/test/integration/targets/aws_waf_web_acl/tasks/main.yml
+++ b/test/integration/targets/aws_waf_web_acl/tasks/main.yml
@@ -233,6 +233,242 @@
             recreate_waf_regex_condition.condition.regex_match_tuples[0].regex_pattern_set_id !=
             create_waf_regex_condition.condition.regex_match_tuples[0].regex_pattern_set_id
 
+  - name: create WAF Regional IP condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_ip_condition"
+      filters:
+        - ip_address: "10.0.0.0/8"
+      type: ip
+      waf_regional: true
+      <<: *aws_connection_info
+    register: create_waf_regional_ip_condition
+
+  - name: add an IP address to WAF Regional condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_ip_condition"
+      filters:
+        - ip_address: "10.0.0.0/8"
+        - ip_address: "192.168.0.0/24"
+      type: ip
+      waf_regional: true
+      <<: *aws_connection_info
+    register: add_ip_address_to_waf_regional_condition
+
+  - name: check expected WAF Regional filter length
+    assert:
+      that:
+        - add_ip_address_to_waf_regional_condition.condition.ip_set_descriptors|length == 2
+
+  - name: add an IP address to WAF Regional condition (rely on purge_filters defaulting to false)
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_ip_condition"
+      filters:
+        - ip_address: "192.168.10.0/24"
+      type: ip
+      waf_regional: true
+      <<: *aws_connection_info
+    register: add_ip_address_to_waf_regional_condition_no_purge
+
+  - name: check WAF Regional filter length has increased
+    assert:
+      that:
+        - add_ip_address_to_waf_regional_condition_no_purge.condition.ip_set_descriptors|length == 3
+        - add_ip_address_to_waf_regional_condition_no_purge.changed
+
+  - name: add an IP address to WAF Regional condition (set purge_filters)
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_ip_condition"
+      filters:
+        - ip_address: "192.168.20.0/24"
+      purge_filters: yes
+      type: ip
+      waf_regional: true
+      <<: *aws_connection_info
+    register: add_ip_address_to_waf_regional_condition_purge
+
+  - name: check WAF Regional filter length has reduced
+    assert:
+      that:
+        - add_ip_address_to_waf_regional_condition_purge.condition.ip_set_descriptors|length == 1
+        - add_ip_address_to_waf_regional_condition_purge.changed
+
+  - name: create WAF Regional byte condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_byte_condition"
+      filters:
+      - field_to_match: header
+        position: STARTS_WITH
+        target_string: Hello
+        header: Content-type
+      type: byte
+      waf_regional: true
+      <<: *aws_connection_info
+    register: create_waf_regional_byte_condition
+
+  - name: recreate WAF Regional byte condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_byte_condition"
+      filters:
+      - field_to_match: header
+        position: STARTS_WITH
+        target_string: Hello
+        header: Content-type
+      type: byte
+      waf_regional: true
+      <<: *aws_connection_info
+    register: recreate_waf_regional_byte_condition
+
+  - name: assert that no change was made
+    assert:
+      that:
+        - not recreate_waf_regional_byte_condition.changed
+
+  - name: create WAF Regional geo condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_geo_condition"
+      filters:
+        - country: US
+        - country: AU
+        - country: AT
+      type: geo
+      waf_regional: true
+      <<: *aws_connection_info
+    register: create_waf_regional_geo_condition
+
+  - name: create WAF Regional size condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_size_condition"
+      filters:
+        - field_to_match: query_string
+          size: 300
+          comparison: GT
+      type: size
+      waf_regional: true
+      <<: *aws_connection_info
+    register: create_waf_regional_size_condition
+
+  - name: create WAF Regional sql condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_sql_condition"
+      filters:
+        - field_to_match: query_string
+          transformation: url_decode
+      type: sql
+      waf_regional: true
+      <<: *aws_connection_info
+    register: create_waf_regional_sql_condition
+
+  - name: create WAF Regional xss condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_xss_condition"
+      filters:
+        - field_to_match: query_string
+          transformation: url_decode
+      type: xss
+      waf_regional: true
+      <<: *aws_connection_info
+    register: create_waf_regional_xss_condition
+
+  - name: create WAF Regional regex condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_regex_condition"
+      filters:
+        - field_to_match: query_string
+          regex_pattern:
+            name: greetings
+            regex_strings:
+              - '[hH]ello'
+              - '^Hi there'
+              - '.*Good Day to You'
+      type: regex
+      waf_regional: true
+      <<: *aws_connection_info
+    register: create_waf_regional_regex_condition
+
+  - name: create a second WAF Regional regex condition with the same regex
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_regex_condition_part_2"
+      filters:
+        - field_to_match: header
+          header: cookie
+          regex_pattern:
+            name: greetings
+            regex_strings:
+              - '[hH]ello'
+              - '^Hi there'
+              - '.*Good Day to You'
+      type: regex
+      waf_regional: true
+      <<: *aws_connection_info
+    register: create_second_waf_regional_regex_condition
+
+  - name: check that the pattern is shared
+    assert:
+      that:
+        - >
+            create_waf_regional_regex_condition.condition.regex_match_tuples[0].regex_pattern_set_id ==
+            create_second_waf_regional_regex_condition.condition.regex_match_tuples[0].regex_pattern_set_id
+        - create_second_waf_regional_regex_condition.changed
+
+
+  - name: delete first WAF Regional regex condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_regex_condition"
+      filters:
+        - field_to_match: query_string
+          regex_pattern:
+            name: greetings
+            regex_strings:
+              - '[hH]ello'
+              - '^Hi there'
+              - '.*Good Day to You'
+      type: regex
+      state: absent
+      waf_regional: true
+      <<: *aws_connection_info
+    register: delete_waf_regional_regex_condition
+
+  - name: delete second WAF Regional regex condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_regex_condition_part_2"
+      filters:
+        - field_to_match: header
+          header: cookie
+          regex_pattern:
+            name: greetings
+            regex_strings:
+              - '[hH]ello'
+              - '^Hi there'
+              - '.*Good Day to You'
+      type: regex
+      state: absent
+      waf_regional: true
+      <<: *aws_connection_info
+    register: delete_second_waf_regional_regex_condition
+
+  - name: create WAF Regional regex condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_regex_condition"
+      filters:
+        - field_to_match: query_string
+          regex_pattern:
+            name: greetings
+            regex_strings:
+              - '[hH]ello'
+              - '^Hi there'
+              - '.*Good Day to You'
+      type: regex
+      waf_regional: true
+      <<: *aws_connection_info
+    register: recreate_waf_regional_regex_condition
+
+  - name: check that a new pattern is created (because the first pattern should have been deleted once unused)
+    assert:
+      that:
+        - >
+            recreate_waf_regional_regex_condition.condition.regex_match_tuples[0].regex_pattern_set_id !=
+            create_waf_regional_regex_condition.condition.regex_match_tuples[0].regex_pattern_set_id
+
   ##################################################
   # aws_waf_rule tests
   ##################################################
@@ -335,6 +571,119 @@
       name: "{{ resource_prefix }}_size_condition"
       type: size
       state: absent
+      <<: *aws_connection_info
+    ignore_errors: yes
+    register: remove_in_use_condition
+
+  - name: check failure was sensible
+    assert:
+      that:
+        - remove_in_use_condition.failed
+        - "'Condition {{ resource_prefix }}_size_condition is in use' in remove_in_use_condition.msg"
+
+  - name: create WAF Regional rule
+    aws_waf_rule:
+      name: "{{ resource_prefix }}_rule"
+      conditions:
+        - name: "{{ resource_prefix }}_regex_condition"
+          type: regex
+          negated: no
+        - name: "{{ resource_prefix }}_geo_condition"
+          type: geo
+          negated: no
+        - name: "{{ resource_prefix }}_byte_condition"
+          type: byte
+          negated: no
+      purge_conditions: yes
+      waf_regional: true
+      <<: *aws_connection_info
+    register: create_aws_regional_waf_rule
+
+  - name: check WAF Regional rule
+    assert:
+      that:
+        - create_aws_waf_regional_rule.changed
+        - create_aws_waf_regional_rule.rule.predicates|length == 3
+
+  - name: recreate WAF Regional rule
+    aws_waf_rule:
+      name: "{{ resource_prefix }}_rule"
+      conditions:
+        - name: "{{ resource_prefix }}_regex_condition"
+          type: regex
+          negated: no
+        - name: "{{ resource_prefix }}_geo_condition"
+          type: geo
+          negated: no
+        - name: "{{ resource_prefix }}_byte_condition"
+          type: byte
+          negated: no
+      waf_regional: true
+      <<: *aws_connection_info
+    register: create_aws_waf_regional_rule
+
+  - name: check WAF Regional rule did not change
+    assert:
+      that:
+        - not create_aws_waf_regional_rule.changed
+        - create_aws_waf_regional_rule.rule.predicates|length == 3
+
+  - name: add further WAF Regional rules relying on purge_conditions defaulting to false
+    aws_waf_rule:
+      name: "{{ resource_prefix }}_rule"
+      conditions:
+        - name: "{{ resource_prefix }}_ip_condition"
+          type: ip
+          negated: yes
+        - name: "{{ resource_prefix }}_sql_condition"
+          type: sql
+          negated: no
+        - name: "{{ resource_prefix }}_xss_condition"
+          type: xss
+          negated: no
+      waf_regional: true
+      <<: *aws_connection_info
+    register: add_conditions_to_aws_waf_regional_rule
+
+  - name: check WAF Regional rule added rules
+    assert:
+      that:
+        - add_conditions_to_aws_waf_regional_rule.changed
+        - add_conditions_to_aws_waf_regional_rule.rule.predicates|length == 6
+
+  - name: remove some rules through purging conditions
+    aws_waf_rule:
+      name: "{{ resource_prefix }}_rule"
+      conditions:
+        - name: "{{ resource_prefix }}_ip_condition"
+          type: ip
+          negated: yes
+        - name: "{{ resource_prefix }}_xss_condition"
+          type: xss
+          negated: no
+        - name: "{{ resource_prefix }}_byte_condition"
+          type: byte
+          negated: no
+        - name: "{{ resource_prefix }}_size_condition"
+          type: size
+          negated: no
+      purge_conditions: yes
+      waf_regional: true
+      <<: *aws_connection_info
+    register: add_and_remove_waf_regional_rule_conditions
+
+  - name: check WAF Regional rules were updated as expected
+    assert:
+      that:
+        - add_and_remove_waf_regional_rule_conditions.changed
+        - add_and_remove_waf_regional_rule_conditions.rule.predicates|length == 4
+
+  - name: attempt to remove an WAF Regional in use condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_size_condition"
+      type: size
+      state: absent
+      waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes
     register: remove_in_use_condition
@@ -477,6 +826,147 @@
       state: absent
       <<: *aws_connection_info
 
+  - name: create WAF Regional web ACL
+    aws_waf_web_acl:
+      name: "{{ resource_prefix }}_web_acl"
+      rules:
+        - name: "{{ resource_prefix }}_rule"
+          priority: 1
+          action: block
+      default_action: block
+      purge_rules: yes
+      state: present
+      waf_regional: true
+      <<: *aws_connection_info
+    register: create_waf_regional_web_acl
+
+  - name: recreate WAF Regional web acl
+    aws_waf_web_acl:
+      name: "{{ resource_prefix }}_web_acl"
+      rules:
+        - name: "{{ resource_prefix }}_rule"
+          priority: 1
+          action: block
+      default_action: block
+      state: present
+      waf_regional: true
+      <<: *aws_connection_info
+    register: recreate_waf_regional_web_acl
+
+  - name: check WAF Regional web acl was not changed
+    assert:
+      that:
+        - not recreate_waf_regional_web_acl.changed
+        - recreate_waf_regional_web_acl.web_acl.rules|length == 1
+
+  - name: create a second WAF Regional rule
+    aws_waf_rule:
+      name: "{{ resource_prefix }}_rule_2"
+      conditions:
+        - name: "{{ resource_prefix }}_ip_condition"
+          type: ip
+          negated: yes
+        - name: "{{ resource_prefix }}_sql_condition"
+          type: sql
+          negated: no
+        - name: "{{ resource_prefix }}_xss_condition"
+          type: xss
+          negated: no
+      waf_regional: true
+      <<: *aws_connection_info
+
+  - name: add a new rule to the WAF Regional web acl
+    aws_waf_web_acl:
+      name: "{{ resource_prefix }}_web_acl"
+      rules:
+        - name: "{{ resource_prefix }}_rule_2"
+          priority: 2
+          action: allow
+      default_action: block
+      state: present
+      waf_regional: true
+      <<: *aws_connection_info
+    register: waf_regional_web_acl_add_rule
+
+  - name: check that rule was added to the WAF Regional web acl
+    assert:
+      that:
+        - waf_regional_web_acl_add_rule.changed
+        - waf_regional_web_acl_add_rule.web_acl.rules|length == 2
+
+  - name: use purge rules to remove the WAF Regional first rule
+    aws_waf_web_acl:
+      name: "{{ resource_prefix }}_web_acl"
+      rules:
+        - name: "{{ resource_prefix }}_rule_2"
+          priority: 2
+          action: allow
+      purge_rules: yes
+      default_action: block
+      state: present
+      waf_regional: true
+      <<: *aws_connection_info
+    register: waf_regional_web_acl_add_rule
+
+  - name: check that rule was removed from the WAF Regional web acl
+    assert:
+      that:
+        - waf_regional_web_acl_add_rule.changed
+        - waf_regional_web_acl_add_rule.web_acl.rules|length == 1
+
+  - name: swap two WAF Regional rules of same priority
+    aws_waf_web_acl:
+      name: "{{ resource_prefix }}_web_acl"
+      rules:
+        - name: "{{ resource_prefix }}_rule"
+          priority: 2
+          action: allow
+      purge_rules: yes
+      default_action: block
+      state: present
+      waf_regional: true
+      <<: *aws_connection_info
+    register: waf_regional_web_acl_swap_rule
+
+  - name: attempt to delete the WAF Regional inuse first rule
+    aws_waf_rule:
+      name: "{{ resource_prefix }}_rule"
+      state: absent
+      waf_regional: true
+      <<: *aws_connection_info
+    ignore_errors: yes
+    register: remove_waf_regional_inuse_rule
+
+  - name: check that removing WAF Regional in-use rule fails
+    assert:
+      that:
+        - remove_waf_regional_inuse_rule.failed
+
+  - name: delete the WAF Regional web acl
+    aws_waf_web_acl:
+      name: "{{ resource_prefix }}_web_acl"
+      state: absent
+      waf_regional: true
+      <<: *aws_connection_info
+    register: delete_waf_regional_web_acl
+
+  - name: check that WAF Regional web acl was deleted
+    assert:
+      that:
+        - delete_waf_regional_web_acl.changed
+        - not delete_waf_regional_web_acl.web_acl
+
+  - name: delete the no longer in use WAF Regional first rule
+    aws_waf_rule:
+      name: "{{ resource_prefix }}_rule"
+      state: absent
+      waf_regional: true
+      <<: *aws_connection_info
+
+  ##################################################
+  # TEARDOWN
+  ##################################################
+
   always:
   - debug:
       msg: "****** TEARDOWN STARTS HERE ******"
@@ -566,5 +1056,104 @@
       name: "{{ resource_prefix }}_regex_condition"
       type: regex
       state: absent
+      <<: *aws_connection_info
+    ignore_errors: yes
+
+  - name: delete the WAF Regional web acl
+    aws_waf_web_acl:
+      name: "{{ resource_prefix }}_web_acl"
+      state: absent
+      purge_rules: yes
+      waf_regional: true
+      <<: *aws_connection_info
+    ignore_errors: yes
+
+  - name: remove second WAF Regional rule
+    aws_waf_rule:
+      name: "{{ resource_prefix }}_rule_2"
+      state: absent
+      purge_conditions: yes
+      waf_regional: true
+      <<: *aws_connection_info
+    ignore_errors: yes
+
+  - name: remove WAF Regional rule
+    aws_waf_rule:
+      name: "{{ resource_prefix }}_rule"
+      state: absent
+      purge_conditions: yes
+      waf_regional: true
+      <<: *aws_connection_info
+    ignore_errors: yes
+
+  - name: remove WAF Regional XSS condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_xss_condition"
+      type: xss
+      state: absent
+      waf_regional: true
+      <<: *aws_connection_info
+    ignore_errors: yes
+
+  - name: remove WAF Regional SQL condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_sql_condition"
+      type: sql
+      state: absent
+      waf_regional: true
+      <<: *aws_connection_info
+    ignore_errors: yes
+
+  - name: remove WAF Regional size condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_size_condition"
+      type: size
+      state: absent
+      waf_regional: true
+      <<: *aws_connection_info
+    ignore_errors: yes
+
+  - name: remove WAF Regional geo condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_geo_condition"
+      type: geo
+      state: absent
+      waf_regional: true
+      <<: *aws_connection_info
+    ignore_errors: yes
+
+  - name: remove WAF Regional byte condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_byte_condition"
+      type: byte
+      state: absent
+      waf_regional: true
+      <<: *aws_connection_info
+    ignore_errors: yes
+
+  - name: remove WAF Regional ip address condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_ip_condition"
+      type: ip
+      state: absent
+      waf_regional: true
+      <<: *aws_connection_info
+    ignore_errors: yes
+
+  - name: remove WAF Regional regex part 2 condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_regex_condition_part_2"
+      type: regex
+      state: absent
+      waf_regional: true
+      <<: *aws_connection_info
+    ignore_errors: yes
+
+  - name: remove first WAF Regional regex condition
+    aws_waf_condition:
+      name: "{{ resource_prefix }}_regex_condition"
+      type: regex
+      state: absent
+      waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes

--- a/test/integration/targets/aws_waf_web_acl/tasks/main.yml
+++ b/test/integration/targets/aws_waf_web_acl/tasks/main.yml
@@ -285,6 +285,7 @@
         - ip_address: "192.168.20.0/24"
       purge_filters: yes
       type: ip
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: add_ip_address_to_waf_regional_condition_purge
@@ -304,6 +305,7 @@
         target_string: Hello
         header: Content-type
       type: byte
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: create_waf_regional_byte_condition
@@ -317,6 +319,7 @@
         target_string: Hello
         header: Content-type
       type: byte
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: recreate_waf_regional_byte_condition
@@ -334,6 +337,7 @@
         - country: AU
         - country: AT
       type: geo
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: create_waf_regional_geo_condition
@@ -346,6 +350,7 @@
           size: 300
           comparison: GT
       type: size
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: create_waf_regional_size_condition
@@ -357,6 +362,7 @@
         - field_to_match: query_string
           transformation: url_decode
       type: sql
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: create_waf_regional_sql_condition
@@ -368,6 +374,7 @@
         - field_to_match: query_string
           transformation: url_decode
       type: xss
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: create_waf_regional_xss_condition
@@ -384,6 +391,7 @@
               - '^Hi there'
               - '.*Good Day to You'
       type: regex
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: create_waf_regional_regex_condition
@@ -401,6 +409,7 @@
               - '^Hi there'
               - '.*Good Day to You'
       type: regex
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: create_second_waf_regional_regex_condition
@@ -427,6 +436,7 @@
               - '.*Good Day to You'
       type: regex
       state: absent
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: delete_waf_regional_regex_condition
@@ -445,6 +455,7 @@
               - '.*Good Day to You'
       type: regex
       state: absent
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: delete_second_waf_regional_regex_condition
@@ -461,6 +472,7 @@
               - '^Hi there'
               - '.*Good Day to You'
       type: regex
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: recreate_waf_regional_regex_condition
@@ -598,6 +610,7 @@
           type: byte
           negated: no
       purge_conditions: yes
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: create_aws_regional_waf_rule
@@ -621,6 +634,7 @@
         - name: "{{ resource_prefix }}_byte_condition"
           type: byte
           negated: no
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: create_aws_waf_regional_rule
@@ -644,6 +658,7 @@
         - name: "{{ resource_prefix }}_xss_condition"
           type: xss
           negated: no
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: add_conditions_to_aws_waf_regional_rule
@@ -671,6 +686,7 @@
           type: size
           negated: no
       purge_conditions: yes
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: add_and_remove_waf_regional_rule_conditions
@@ -686,6 +702,7 @@
       name: "{{ resource_prefix }}_size_condition"
       type: size
       state: absent
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes
@@ -839,6 +856,7 @@
       default_action: block
       purge_rules: yes
       state: present
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: create_waf_regional_web_acl
@@ -852,6 +870,7 @@
           action: block
       default_action: block
       state: present
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: recreate_waf_regional_web_acl
@@ -875,6 +894,7 @@
         - name: "{{ resource_prefix }}_xss_condition"
           type: xss
           negated: no
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
 
@@ -887,6 +907,7 @@
           action: allow
       default_action: block
       state: present
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: waf_regional_web_acl_add_rule
@@ -907,6 +928,7 @@
       purge_rules: yes
       default_action: block
       state: present
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: waf_regional_web_acl_add_rule
@@ -927,6 +949,7 @@
       purge_rules: yes
       default_action: block
       state: present
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: waf_regional_web_acl_swap_rule
@@ -935,6 +958,7 @@
     aws_waf_rule:
       name: "{{ resource_prefix }}_rule"
       state: absent
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes
@@ -949,6 +973,7 @@
     aws_waf_web_acl:
       name: "{{ resource_prefix }}_web_acl"
       state: absent
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     register: delete_waf_regional_web_acl
@@ -963,6 +988,7 @@
     aws_waf_rule:
       name: "{{ resource_prefix }}_rule"
       state: absent
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
 
@@ -1067,6 +1093,7 @@
       name: "{{ resource_prefix }}_web_acl"
       state: absent
       purge_rules: yes
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes
@@ -1076,6 +1103,7 @@
       name: "{{ resource_prefix }}_rule_2"
       state: absent
       purge_conditions: yes
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes
@@ -1085,6 +1113,7 @@
       name: "{{ resource_prefix }}_rule"
       state: absent
       purge_conditions: yes
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes
@@ -1094,6 +1123,7 @@
       name: "{{ resource_prefix }}_xss_condition"
       type: xss
       state: absent
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes
@@ -1103,6 +1133,7 @@
       name: "{{ resource_prefix }}_sql_condition"
       type: sql
       state: absent
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes
@@ -1112,6 +1143,7 @@
       name: "{{ resource_prefix }}_size_condition"
       type: size
       state: absent
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes
@@ -1121,6 +1153,7 @@
       name: "{{ resource_prefix }}_geo_condition"
       type: geo
       state: absent
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes
@@ -1130,6 +1163,7 @@
       name: "{{ resource_prefix }}_byte_condition"
       type: byte
       state: absent
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes
@@ -1139,6 +1173,7 @@
       name: "{{ resource_prefix }}_ip_condition"
       type: ip
       state: absent
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes
@@ -1148,6 +1183,7 @@
       name: "{{ resource_prefix }}_regex_condition_part_2"
       type: regex
       state: absent
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes
@@ -1157,6 +1193,7 @@
       name: "{{ resource_prefix }}_regex_condition"
       type: regex
       state: absent
+      region: "{{ aws_region }}"
       waf_regional: true
       <<: *aws_connection_info
     ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
Adds support for WAF Regional to the Ansible WAF Modules

Fixes #44767 #44896
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
aws_waf_condition
aws_waf_facts
aws_waf_rule
aws_waf_web_acl
module_utils/aws/waf
module_utils/aws/waiters

##### ADDITIONAL INFORMATION
There are two WAF modules in botocore. WAF and WAFRegional. They function largely in the same way. But there are differences. These changes add support for WAFRegional without changing the existing behavior of the module.

Previously WAF worked like:
```
- name: create IP address condition
  aws_waf_condition:
    name: "{{ resource_prefix }}_ip_condition"
    filters:
      - ip_address: "10.0.0.0/8"
      - ip_address: "192.168.0.0/24"
    type: ip
```

It now supports WAF Regional and takes the waf_regional bool parameter
```
- name: create IP address condition
  aws_waf_condition:
    name: "{{ resource_prefix }}_ip_condition"
    filters:
      - ip_address: "10.0.0.0/8"
      - ip_address: "192.168.0.0/24"
    type: ip
    waf_regional: true
    region: '{{ aws_region }}'
```

