### PR TITLE
adds hint about simplestreams protocol

### DIFF
--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -62,8 +62,9 @@ options:
                     "mode": "pull",
                     "server": "https://images.linuxcontainers.org",
                     "protocol": "lxd",
-                    "alias": "ubuntu/xenial/amd64" }).
-            See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1)'
+                    "alias": "ubuntu/xenial/amd64" }).'
+          - 'See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1) for complete API documentation.'
+          - 'Note that C(protocol) accepts two choices: C(lxd) or C(simplestreams)'
         required: false
     state:
         choices:
@@ -151,7 +152,7 @@ EXAMPLES = '''
           type: image
           mode: pull
           server: https://images.linuxcontainers.org
-          protocol: lxd
+          protocol: lxd # if you get a 404, try setting protocol: simplestreams
           alias: ubuntu/xenial/amd64
         profiles: ["default"]
         wait_for_ipv4_addresses: true


### PR DESCRIPTION
##### SUMMARY
Supersedes #34373. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lxd_container module
docs.ansible.com

##### ADDITIONAL INFORMATION
To fix this properly, the `lxd_container` module should document all sub-options. If this module's maintainers and/or community users want to improve the module documentation, that would be awesome. Meanwhile, this PR adds a hint for users.

Example of full sub-option documentation: see the "Rules" section of https://docs.ansible.com/ansible/latest/modules/azure_rm_securitygroup_module.html. 
Source for that documentation:  https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py#L54. 
