### PR TITLE
fix py3 scope for unique filter errors, enable filters integration tests on rhel8 beta

### DIFF
--- a/changelogs/fragments/mathstuff-filter-py3-scope.yaml
+++ b/changelogs/fragments/mathstuff-filter-py3-scope.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "mattstuff filter - fix py3 scope for unique filter errors"

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -65,12 +65,12 @@ def unique(environment, a, case_sensitive=False, attribute=None):
             else:
                 c = list(c)
     except TypeError as e:
+        error = e
         _do_fail(e)
     except Exception as e:
+        error = e
         _do_fail(e)
         display.warning('Falling back to Ansible unique filter as Jinja2 one failed: %s' % to_text(e))
-    finally:
-        error = e
 
     if not HAS_UNIQUE or error:
 

--- a/test/integration/targets/filters/aliases
+++ b/test/integration/targets/filters/aliases
@@ -1,2 +1,1 @@
 shippable/posix/group2
-skip/rhel8.0


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix py3 scope for unique filter errors, enable filters integration tests on rhel8 beta
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/plugins/filter/mathstuff.py
test/integration/targets/filters/aliases
