### PR TITLE
Add extra_exec_args to win_shell

### DIFF
--- a/lib/ansible/modules/windows/win_shell.ps1
+++ b/lib/ansible/modules/windows/win_shell.ps1
@@ -47,6 +47,7 @@ $executable = Get-AnsibleParam -obj $params -name "executable" -type "path"
 $creates = Get-AnsibleParam -obj $params -name "creates" -type "path"
 $removes = Get-AnsibleParam -obj $params -name "removes" -type "path"
 $stdin = Get-AnsibleParam -obj $params -name "stdin" -type "str"
+$extra_exec_args = Get-AnsibleParam -obj $params -name "extra_exec_args" -type "str"
 
 $raw_command_line = $raw_command_line.Trim()
 
@@ -73,10 +74,12 @@ If(-not $executable -or $executable -eq "powershell") {
     # Base64 encode the command so we don't have to worry about the various levels of escaping
     $encoded_command = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($raw_command_line))
 
-    if ($stdin) {
-        $exec_args = "-encodedcommand $encoded_command"
-    } else {
-        $exec_args = "-noninteractive -encodedcommand $encoded_command"
+    $exec_args = "-encodedcommand $encoded_command"
+    if (-not $stdin) {
+        $exec_args = "-noninteractive $exec_args"
+    }
+    if ($extra_exec_args) {
+        $exec_args = "$extra_exec_args $exec_args"
     }
 }
 Else {
@@ -86,6 +89,9 @@ Else {
         $exec_application = "$($exec_application).exe"
     }
     $exec_args = "/c $raw_command_line"
+    if ($extra_exec_args) {
+        $exec_args = "$extra_exec_args $exec_args"
+    }
 }
 
 $command = "$exec_application $exec_args"

--- a/lib/ansible/modules/windows/win_shell.py
+++ b/lib/ansible/modules/windows/win_shell.py
@@ -41,6 +41,11 @@ options:
       - Change the shell used to execute the command (eg, C(cmd)).
       - The target shell must accept a C(/c) parameter followed by the raw command line to be executed.
     type: path
+  extra_exec_args:
+    description:
+      - Additional options used to launch the shell
+      - Useful for powershell to add the -noprofile option
+    version_added: '2.8'
   stdin:
     description:
     - Set the stdin of the command directly to the specified value.

--- a/test/integration/targets/win_shell/tasks/main.yml
+++ b/test/integration/targets/win_shell/tasks/main.yml
@@ -257,3 +257,37 @@
     - nonascii_output.stdout_lines|count == 1
     - nonascii_output.stdout_lines[0] == 'über den Fußgängerübergang gehen'
     - nonascii_output.stderr == ''
+
+- name: execute a cmd.exe shell task
+  win_shell: 'Echo hello from Ansible'
+  args:
+    executable: cmd.exe
+  register: shellout
+
+- name: validate result
+  assert:
+    that:
+    - shellout is successful
+    - shellout is changed
+    - shellout.cmd == 'Echo hello from Ansible'
+    - shellout.delta is match('^\d:(\d){2}:(\d){2}.(\d){6}$')
+    - shellout.end is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
+    - shellout.rc == 0
+    - shellout.start is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
+    - shellout.stdout == "hello from Ansible\r\n"
+    - shellout.stdout_lines == ["hello from Ansible"]
+
+- name: execute a powershell with extra_exec_args
+  win_shell: "[System.Environment]::CommandLine"
+  args:
+    extra_exec_args: -noprofile
+  register: shellout
+
+- name: validate result
+  assert:
+    that:
+    - shellout is successful
+    - shellout is changed
+    - shellout.cmd == "[System.Environment]::CommandLine"
+    - shellout.rc == 0
+    - shellout.stdout is match('^powershell.exe -noprofile -noninteractive -encodedcommand')


### PR DESCRIPTION
##### SUMMARY
Windows systems can have powershell profiles, if the powershell profiles send any output to stdout/stderr pretty much all the current integration tests fail, and trying to return output from commandlets become impossible.  Adding `extra_exec_args` allows adding `-noprofile` or other arguments if required.

Issue #37756

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_shell
