### PR TITLE
clarify what `strict` means for the `version` test

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -84,8 +84,7 @@ The ``version`` test accepts the following operators::
 
     <, lt, <=, le, >, gt, >=, ge, ==, =, eq, !=, <>, ne
 
-This test also accepts a 3rd parameter, ``strict`` which defines if strict version parsing should
-be used.  The default is ``False``, but this setting as ``True`` uses more strict version parsing::
+This test also accepts a 3rd parameter, ``strict`` which defines if strict version parsing as defined by ``distutils.version.StrictVersion`` should be used.  The default is ``False`` (using ``distutils.version.LooseVersion``), ``True`` enables strict version parsing::
 
     {{ sample_version_var is version('1.0', operator='lt', strict=True) }}
 


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
Just saying `strict` will make things `strict` without explaining what exactly will be stricter is not helpful to the user. Reference the fact that we use the `StrictVersion` parser instead of `LooseVersion` from `distutils` in this case.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`version`