### PR TITLE
Fix reboot plugin not working in Illumos/Solaris

### DIFF
--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -56,7 +56,7 @@ class ActionModule(ActionBase):
     SHUTDOWN_COMMAND_ARGS = {
         'linux': '-r {delay_min} "{message}"',
         'freebsd': '-r +{delay_sec}s "{message}"',
-        'sunos': '-y -g {delay_sec} -r "{message}"',
+        'sunos': '-i 6 -y -g {delay_sec} "{message}"',
         'darwin': '-r +{delay_min} "{message}"',
         'openbsd': '-r +{delay_min} "{message}"',
     }


### PR DESCRIPTION
##### SUMMARY
Using the reboot plugin under OpenIndiana results in the following error:

"msg": "Shutdown command failed. Error was /usr/sbin/shutdown: -r: unknown option\r\nUsage: /usr/sbin/shutdown [ -y ] [ -g<grace> ] [ -i<initstate> ] [ message ], Shared connection to 192.168.122.146 closed.",

The issue is that the command being called is wrong (`shutdown -y -g {delay_sec} -r "{message}"`) for Solaris/Illumos based system.
As specified here https://docs.oracle.com/cd/E23824_01/html/821-1451/gldpm.html and the manpages for OpenIndiana, there is no "-r" argument for shutdown. Also, based on the manpages, -i (init-state) defaults to single user mode, which means that the system would fail to start again.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
reboot.py

##### ADDITIONAL INFORMATION
By default, there is no `whoami` installed in OpenIndiana. This would make the DEFAULT_TEST_COMMAND to fail. Should I file an issue for this? Or could I fix this here?
