### PR TITLE
Bulk fix DOCUMENTATION.author (Part 3)

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attribute_defs.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attribute_defs.py
@@ -23,7 +23,7 @@ description:
     - This module can be used to add and remove custom attributes definitions for the given virtual machine from VMWare.
 version_added: 2.7
 author:
-    - Jimmy Conner
+    - Jimmy Conner (@cigamit)
     - Abhijeet Kasurde (@Akasurde)
 notes:
     - Tested on vSphere 6.5

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
@@ -25,7 +25,7 @@ description:
     - This module can be used to add, remove and update custom attributes for the given virtual machine.
 version_added: 2.7
 author:
-    - Jimmy Conner
+    - Jimmy Conner (@cigamit)
     - Abhijeet Kasurde (@Akasurde)
 notes:
     - Tested on vSphere 6.5

--- a/lib/ansible/modules/monitoring/pagerduty.py
+++ b/lib/ansible/modules/monitoring/pagerduty.py
@@ -24,7 +24,7 @@ author:
     - "Andrew Newdigate (@suprememoocow)"
     - "Dylan Silva (@thaumos)"
     - "Justin Johns"
-    - "Bruce Pennypacker"
+    - "Bruce Pennypacker (@bpennypacker)"
 requirements:
     - PagerDuty API access
 options:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -21,7 +21,7 @@ description:
    - manages Zabbix host macros, it can create, update or delete them.
 version_added: "2.0"
 author:
-    - "(@cave)"
+    - "Cove (@cove)"
     - Dean Hailin Song
 requirements:
     - "python >= 2.6"

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
@@ -21,7 +21,7 @@ description:
     - This module allows you to create, modify and delete Zabbix screens and associated graph data.
 version_added: "2.0"
 author:
-    - "(@cove)"
+    - "Cove (@cove)"
     - "Tony Minfei Ding"
     - "Harrison Gu (@harrisongu)"
 requirements:

--- a/lib/ansible/modules/packaging/language/pear.py
+++ b/lib/ansible/modules/packaging/language/pear.py
@@ -24,7 +24,7 @@ description:
     - Manage PHP packages with the pear package manager.
 version_added: 2.0
 author:
-    - "'jonathan.lestrelin' <jonathan.lestrelin@gmail.com>"
+    - Jonathan Lestrelin (@jle64) <jonathan.lestrelin@gmail.com>
 options:
     name:
         description:

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -23,7 +23,7 @@ version_added: "1.0"
 author:
     - Indrajit Raychaudhuri (@indrajitr)
     - Aaron Bull Schaefer (@elasticdog) <aaron@elasticdog.com>
-    - Afterburn
+    - Kevin Karsopawiro (@Afterburn)
     - Maxime de Roucy (@tchernomax)
 options:
     name:

--- a/lib/ansible/modules/source_control/git_config.py
+++ b/lib/ansible/modules/source_control/git_config.py
@@ -20,7 +20,7 @@ DOCUMENTATION = '''
 module: git_config
 author:
   - Matthew Gamble (@djmattyg007)
-  - Marius Gedminas
+  - Marius Gedminas (@mgedmin)
 version_added: 2.1
 requirements: ['git']
 short_description: Read and write git configuration

--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -129,7 +129,7 @@ requirements:
 author:
     - Dane Summers (@dsummersl)
     - Mike Grozak
-    - Patrick Callahan
+    - Patrick Callahan (@dirtyharrycallahan)
     - Evan Kaufman (@EvanK)
     - Luca Berruti (@lberruti)
 """


### PR DESCRIPTION
##### SUMMARY
Helps reduce `label/needs_maintainer` https://github.com/ansible/community/issues/406

* `cigamit` wasn't previously listed as they didn't want `@notifying`, they've been added to `ignore` in https://github.com/ansible/ansible/pull/48978
* It's `cove` (not `cave`)

##### ISSUE TYPE
- Bugfix Pull Request
