### PR TITLE
Properly handle FieldAttribute.default if callable

### DIFF
--- a/changelogs/fragments/48673-fix-omit-on-play-keywords.yaml
+++ b/changelogs/fragments/48673-fix-omit-on-play-keywords.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix using omit on play keywords (https://github.com/ansible/ansible/issues/48673)

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -363,7 +363,10 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
                 # if this evaluated to the omit value, set the value back to
                 # the default specified in the FieldAttribute and move on
                 if omit_value is not None and value == omit_value:
-                    setattr(self, name, attribute.default)
+                    if callable(attribute.default):
+                        setattr(self, name, attribute.default())
+                    else:
+                        setattr(self, name, attribute.default)
                     continue
 
                 # and make sure the attribute is of the type it should be
@@ -546,7 +549,10 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
             if name in data:
                 setattr(self, name, data[name])
             else:
-                setattr(self, name, attribute.default)
+                if callable(attribute.default):
+                    setattr(self, name, attribute.default())
+                else:
+                    setattr(self, name, attribute.default)
 
         # restore the UUID field
         setattr(self, '_uuid', data.get('uuid'))

--- a/test/integration/targets/omit/48673.yml
+++ b/test/integration/targets/omit/48673.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  serial: "{{ testing_omitted_variable | default(omit) }}"
+  tasks:
+    - debug:

--- a/test/integration/targets/omit/aliases
+++ b/test/integration/targets/omit/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group3

--- a/test/integration/targets/omit/runme.sh
+++ b/test/integration/targets/omit/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ansible-playbook 48673.yml -i ../../inventory -v "$@"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #48673
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Since https://github.com/ansible/ansible/pull/46833, `attribute.default` would be in the case of #48673 now `list`, as opposed to `[]` previously, which results in `exception TypeError: object of type 'type' has no len()`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/playbook/base.py

##### ADDITIONAL INFORMATION
