### PR TITLE
Filter split list

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -446,6 +446,7 @@ def flatten(mylist, levels=None):
 
     return ret
 
+
 def subelements(obj, subelements, skip_missing=False):
     '''Accepts a dict or list of dicts, and a dotted accessor and produces a product
     of the element and the results of the dotted accessor

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -446,7 +446,6 @@ def flatten(mylist, levels=None):
 
     return ret
 
-
 def subelements(obj, subelements, skip_missing=False):
     '''Accepts a dict or list of dicts, and a dotted accessor and produces a product
     of the element and the results of the dotted accessor
@@ -491,6 +490,28 @@ def subelements(obj, subelements, skip_missing=False):
             results.append((element, value))
 
     return results
+
+
+def split_list(lst, max_sublist_elements=None):
+    '''Accepts a list and returns a list of lists, with each sublist containing
+    no more than <max_sublist_elements> items.
+    '''
+
+    if not isinstance(lst, list):
+        raise AnsibleFilterError('split_list requires a list, but got %s instead.' % type(lst))
+
+    if not max_sublist_elements or len(lst) <= max_sublist_elements:
+        return([lst])
+
+    subcount = int(len(lst) / max_sublist_elements) + (len(lst) % max_sublist_elements > 0)
+
+    lists = []
+
+    for i in range(0, subcount):
+        lists.append(lst[i*max_sublist_elements:(i+1)*max_sublist_elements])
+
+
+    return(lists)
 
 
 def dict_to_list_of_dict_key_value_elements(mydict, key_name='key', value_name='value'):
@@ -640,6 +661,7 @@ class FilterModule(object):
             'dict2items': dict_to_list_of_dict_key_value_elements,
             'items2dict': list_of_dict_key_value_elements_to_dict,
             'subelements': subelements,
+            'split_list': split_list,
 
             # Misc
             'random_mac': random_mac,

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -509,8 +509,7 @@ def split_list(lst, max_sublist_elements=None):
     lists = []
 
     for i in range(0, subcount):
-        lists.append(lst[i*max_sublist_elements:(i+1)*max_sublist_elements])
-
+        lists.append(lst[i * max_sublist_elements:(i + 1) * max_sublist_elements])
 
     return(lists)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds a new filter to core that allows for splitting a single list into a list of sublists of configurable size.  For example, a list of 100 dictionaries could be turned into a list containing 5 sublists of 20 dictionaries each.

I see this largely benefiting templates, and my use case was for improving readability of generated configs for Juniper switches by breaking long as-paths and prefix lists into multiple sublists; however, it could also be used for chunked processing of items in task loops.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
split_list

##### ADDITIONAL INFORMATION
Example:
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
    - debug:
        msg: '{{ ["a","b","c","d","e"]|split_list(3) }}'

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [debug] **********************************************************************************************************
ok: [localhost] => {
    "msg": [
        [
            "a",
            "b",
            "c"
        ],
        [
            "d",
            "e"
        ]
    ]
}

```
