### PR TITLE
Add support for ECR Lifecycle Policies to ecs_ecr

### DIFF
--- a/changelogs/fragments/48997-ecs_ecr-livecycle-policy.yml
+++ b/changelogs/fragments/48997-ecs_ecr-livecycle-policy.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ecr_ecs - add support for lifecycle policies
+  - ecr_ecs - delete_policy has been renamed to purge_policy (with an alias) and will be removed in 2.14

--- a/hacking/aws_config/testing_policies/container-policy.json
+++ b/hacking/aws_config/testing_policies/container-policy.json
@@ -14,6 +14,9 @@
             "Sid": "SpecifiedCodeRepositories",
             "Effect": "Allow",
             "Action": [
+                "ecr:GetLifecyclePolicy",
+                "ecr:PutLifecyclePolicy",
+                "ecr:DeleteLifecyclePolicy",
                 "ecr:GetRepositoryPolicy",
                 "ecr:SetRepositoryPolicy",
                 "ecr:DeleteRepository",

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -295,10 +295,21 @@ def run(ecr, params, verbosity):
         registry_id = params['registry_id']
         force_set_policy = params['force_set_policy']
 
-        # If a policy was given, parse it
-        policy = policy_text and json.loads(policy_text)
-        lifecycle_policy = \
-            lifecycle_policy_text and json.loads(lifecycle_policy_text)
+        # Parse policies, if they are given
+        try:
+            policy = policy_text and json.loads(policy_text)
+        except ValueError:
+            result['policy'] = policy_text
+            result['msg'] = 'Could not parse policy'
+            return False, result
+
+        try:
+            lifecycle_policy = \
+                lifecycle_policy_text and json.loads(lifecycle_policy_text)
+        except ValueError:
+            result['lifecycle_policy'] = lifecycle_policy_text
+            result['msg'] = 'Could not parse lifecycle_policy'
+            return False, result
 
         result['state'] = state
         result['created'] = False

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -47,7 +47,7 @@ options:
     delete_policy:
         description:
             - deprecated. Use I(purge_policy) instead. To be removed in
-              Ansible 2.12
+              Ansible 2.13
         required: false
         default: false
     purge_policy:
@@ -56,7 +56,7 @@ options:
         required: false
         default: false
         type: bool
-        version_added: '2.8'
+        version_added: '2.9'
     image_tag_mutability:
         description:
             - Configure whether repository should be mutable (ie. an already existing tag can be overwritten) or not.
@@ -69,13 +69,13 @@ options:
         description:
             - JSON or dict that represents the new lifecycle policy
         required: false
-        version_added: '2.8'
+        version_added: '2.9'
     purge_lifecycle_policy:
         description:
             - if yes, remove the lifecycle policy from the repository
         required: false
         default: false
-        version_added: '2.8'
+        version_added: '2.9'
     state:
         description:
             - Create or destroy the repository.

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -311,7 +311,7 @@ def sort_lists_of_strings(policy):
     return policy
 
 
-def run(ecr, params, verbosity):
+def run(ecr, params):
     # type: (EcsEcr, dict, int) -> Tuple[bool, dict]
     result = {}
     try:
@@ -360,11 +360,7 @@ def run(ecr, params, verbosity):
                 original_lifecycle_policy = \
                     ecr.get_lifecycle_policy(registry_id, name)
 
-                if verbosity >= 2:
-                    result['lifecycle_policy'] = None
-
-                if verbosity >= 3:
-                    result['original_lifecycle_policy'] = original_lifecycle_policy
+                result['lifecycle_policy'] = None
 
                 if original_lifecycle_policy:
                     ecr.delete_lifecycle_policy(registry_id, name)
@@ -373,18 +369,14 @@ def run(ecr, params, verbosity):
             elif lifecycle_policy_text is not None:
                 try:
                     lifecycle_policy = sort_json_policy_dict(lifecycle_policy)
-                    if verbosity >= 2:
-                        result['lifecycle_policy'] = lifecycle_policy
+                    result['lifecycle_policy'] = lifecycle_policy
+
                     original_lifecycle_policy = ecr.get_lifecycle_policy(
                         registry_id, name)
 
                     if original_lifecycle_policy:
                         original_lifecycle_policy = sort_json_policy_dict(
                             original_lifecycle_policy)
-
-                    if verbosity >= 3:
-                        result['original_lifecycle_policy'] = \
-                            original_lifecycle_policy
 
                     if original_lifecycle_policy != lifecycle_policy:
                         ecr.put_lifecycle_policy(registry_id, name,
@@ -399,11 +391,7 @@ def run(ecr, params, verbosity):
             if purge_policy:
                 original_policy = ecr.get_repository_policy(registry_id, name)
 
-                if verbosity >= 2:
-                    result['policy'] = None
-
-                if verbosity >= 3:
-                    result['original_policy'] = original_policy
+                result['policy'] = None
 
                 if original_policy:
                     ecr.delete_repository_policy(registry_id, name)
@@ -414,16 +402,12 @@ def run(ecr, params, verbosity):
                     # Sort any lists containing only string types
                     policy = sort_lists_of_strings(policy)
 
-                    if verbosity >= 2:
-                        result['policy'] = policy
+                    result['policy'] = policy
+
                     original_policy = ecr.get_repository_policy(
                         registry_id, name)
-
                     if original_policy:
                         original_policy = sort_lists_of_strings(original_policy)
-
-                    if verbosity >= 3:
-                        result['original_policy'] = original_policy
 
                     if compare_policies(original_policy, policy):
                         ecr.set_repository_policy(
@@ -467,7 +451,8 @@ def main():
                    default='present'),
         force_set_policy=dict(required=False, type='bool', default=False),
         policy=dict(required=False, type='json'),
-        delete_policy=dict(required=False, type='bool', removed_in_version='2.5'),
+        delete_policy=dict(required=False, type='bool',
+                           removed_in_version='2.5'),
         purge_policy=dict(required=False, type='bool'),
         lifecycle_policy=dict(required=False, type='json'),
         purge_lifecycle_policy=dict(required=False, type='bool')))
@@ -482,7 +467,7 @@ def main():
         module.fail_json(msg='boto3 required for this module')
 
     ecr = EcsEcr(module)
-    passed, result = run(ecr, module.params, module._verbosity)
+    passed, result = run(ecr, module.params)
 
     if passed:
         module.exit_json(**result)

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -47,7 +47,7 @@ options:
     delete_policy:
         description:
             - deprecated. Use I(purge_policy) instead. To be removed in
-              Ansible 2.9
+              Ansible 2.12
         required: false
         default: false
     purge_policy:
@@ -56,7 +56,7 @@ options:
         required: false
         default: false
         type: bool
-        version_added: '2.5'
+        version_added: '2.8'
     image_tag_mutability:
         description:
             - Configure whether repository should be mutable (ie. an already existing tag can be overwritten) or not.
@@ -69,13 +69,13 @@ options:
         description:
             - JSON or dict that represents the new lifecycle policy
         required: false
-        version_added: '2.5'
+        version_added: '2.8'
     purge_lifecycle_policy:
         description:
             - if yes, remove the lifecycle policy from the repository
         required: false
         default: false
-        version_added: '2.5'
+        version_added: '2.8'
     state:
         description:
             - Create or destroy the repository.

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -47,7 +47,7 @@ options:
     delete_policy:
         description:
             - deprecated. Use I(purge_policy) instead. To be removed in
-              Ansible 2.6
+              Ansible 2.9
         required: false
         default: false
     purge_policy:
@@ -452,7 +452,7 @@ def main():
         force_set_policy=dict(required=False, type='bool', default=False),
         policy=dict(required=False, type='json'),
         delete_policy=dict(required=False, type='bool',
-                           removed_in_version='2.5'),
+                           removed_in_version='2.9'),
         purge_policy=dict(required=False, type='bool'),
         lifecycle_policy=dict(required=False, type='json'),
         purge_lifecycle_policy=dict(required=False, type='bool')))

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -56,6 +56,7 @@ options:
         required: false
         default: false
         type: bool
+        version_added: '2.5'
     image_tag_mutability:
         description:
             - Configure whether repository should be mutable (ie. an already existing tag can be overwritten) or not.

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -52,7 +52,6 @@ options:
         default: false
         type: bool
         aliases: [ delete_policy ]
-        version_added: '2.10'
     image_tag_mutability:
         description:
             - Configure whether repository should be mutable (ie. an already existing tag can be overwritten) or not.

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -382,7 +382,7 @@ def run(ecr, params):
                         ecr.put_lifecycle_policy(registry_id, name,
                                                  lifecycle_policy_text)
                         result['changed'] = True
-                except:
+                except Exception:
                     # Some failure w/ the policy. It's helpful to know what the
                     # policy is.
                     result['lifecycle_policy'] = lifecycle_policy_text

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -47,7 +47,7 @@ options:
     delete_policy:
         description:
             - deprecated. Use I(purge_policy) instead. To be removed in
-              Ansible 2.13
+              Ansible 2.14
         required: false
         default: false
     purge_policy:
@@ -56,7 +56,7 @@ options:
         required: false
         default: false
         type: bool
-        version_added: '2.9'
+        version_added: '2.10'
     image_tag_mutability:
         description:
             - Configure whether repository should be mutable (ie. an already existing tag can be overwritten) or not.
@@ -69,13 +69,13 @@ options:
         description:
             - JSON or dict that represents the new lifecycle policy
         required: false
-        version_added: '2.9'
+        version_added: '2.10'
     purge_lifecycle_policy:
         description:
             - if yes, remove the lifecycle policy from the repository
         required: false
         default: false
-        version_added: '2.9'
+        version_added: '2.10'
     state:
         description:
             - Create or destroy the repository.

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -44,18 +44,14 @@ options:
         required: false
         default: false
         type: bool
-    delete_policy:
-        description:
-            - deprecated. Use I(purge_policy) instead. To be removed in
-              Ansible 2.14
-        required: false
-        default: false
     purge_policy:
         description:
             - If yes, remove the policy from the repository.
+            - Alias C(delete_policy) has been deprecated and will be removed in Ansible 2.14
         required: false
         default: false
         type: bool
+        aliases: [ delete_policy ]
         version_added: '2.10'
     image_tag_mutability:
         description:
@@ -362,7 +358,7 @@ def run(ecr, params):
         name = params['name']
         state = params['state']
         policy_text = params['policy']
-        purge_policy = params['purge_policy'] or params['delete_policy']
+        purge_policy = params['purge_policy']
         registry_id = params['registry_id']
         force_set_policy = params['force_set_policy']
         lifecycle_policy_text = params['lifecycle_policy']
@@ -495,9 +491,7 @@ def main():
                    default='present'),
         force_set_policy=dict(required=False, type='bool', default=False),
         policy=dict(required=False, type='json'),
-        delete_policy=dict(required=False, type='bool',
-                           removed_in_version='2.9'),
-        purge_policy=dict(required=False, type='bool'),
+        purge_policy=dict(required=False, type='bool', aliases=['delete_policy']),
         lifecycle_policy=dict(required=False, type='json'),
         purge_lifecycle_policy=dict(required=False, type='bool')))
 
@@ -506,6 +500,11 @@ def main():
                            mutually_exclusive=[
                                ['policy', 'delete_policy', 'purge_policy'],
                                ['lifecycle_policy', 'purge_lifecycle_policy']])
+    if module.params.get('delete_policy'):
+        module.deprecate(
+            'The alias "delete_policy" has been deprecated and will be removed, '
+            'use "purge_policy" instead',
+            version='2.14')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')

--- a/test/integration/targets/ecs_ecr/defaults/main.yml
+++ b/test/integration/targets/ecs_ecr/defaults/main.yml
@@ -8,3 +8,15 @@ policy:
         - ecr:GetDownloadUrlForLayer
         - ecr:BatchGetImage
         - ecr:BatchCheckLayerAvailability
+
+lifecycle_policy:
+  rules:
+    - rulePriority: 1
+      description: new policy
+      selection:
+        tagStatus: untagged
+        countType: sinceImagePushed
+        countUnit: days
+        countNumber: 365
+      action:
+        type: expire

--- a/test/integration/targets/ecs_ecr/tasks/main.yml
+++ b/test/integration/targets/ecs_ecr/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - set_fact:
-    ecr_name: '{{ resource_prefix }}-ecr'
+    ecr_name: '{{ resource_prefix | lower }}-ecr'
 
 - block:
 

--- a/test/integration/targets/ecs_ecr/tasks/main.yml
+++ b/test/integration/targets/ecs_ecr/tasks/main.yml
@@ -215,7 +215,6 @@
         that:
           - result is not changed
 
-
     - name: When omitting policy on a repository that has a policy
       ecs_ecr:
         region: '{{ ec2_region }}'
@@ -229,7 +228,6 @@
       assert:
         that:
           - result is not changed
-
 
     - name: When specifying both policy and delete_policy
       ecs_ecr:
@@ -253,7 +251,180 @@
       ecs_ecr:
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
-        policy_text: "Ceci n'est pas une JSON"
+        policy: "Ceci n'est pas une JSON"
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: result
+      ignore_errors: true
+
+    - name: it should fail
+      assert:
+        that:
+          - result|failed
+
+
+    - name: When in check mode, and deleting a lifecycle policy that does not exists
+      ecs_ecr:
+        region: '{{ ec2_region }}'
+        name: '{{ ecr_name }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        delete_lifecycle_policy: yes
+      register: result
+      check_mode: yes
+
+    - name: it should not skip and not change
+      assert:
+        that:
+          - not result|skipped
+          - not result|changed
+
+
+    - name: When in check mode, setting lifecyle policy on a repository that has no policy
+      ecs_ecr:
+        region: '{{ ec2_region }}'
+        name: '{{ ecr_name }}'
+        lifecycle_policy: '{{ lifecycle_policy }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: result
+      check_mode: yes
+
+    - name: it should skip, change and not create
+      assert:
+        that:
+          - result|skipped
+          - result|changed
+          - not result.created
+
+
+    - name: When setting lifecycle policy on a repository that has no policy
+      ecs_ecr:
+        region: '{{ ec2_region }}'
+        name: '{{ ecr_name }}'
+        lifecycle_policy: '{{ lifecycle_policy }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: result
+
+    - name: it should change and not create
+      assert:
+        that:
+          - result|changed
+          - not result.created
+
+
+    - name: When in check mode, and deleting a lifecyle policy that exists
+      ecs_ecr:
+        region: '{{ ec2_region }}'
+        name: '{{ ecr_name }}'
+        delete_lifecycle_policy: yes
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: result
+      check_mode: yes
+
+    - name: it should skip, change but not create
+      assert:
+        that:
+          - result|skipped
+          - result|changed
+          - not result.created
+
+
+    - name: When deleting a lifecycle policy that exists
+      ecs_ecr:
+        region: '{{ ec2_region }}'
+        name: '{{ ecr_name }}'
+        delete_lifecycle_policy: yes
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: result
+
+    - name: it should change and not create
+      assert:
+        that:
+          - result|changed
+          - not result.created
+
+
+    - name: When setting a lifecyle policy as a string
+      ecs_ecr:
+        region: '{{ ec2_region }}'
+        name: '{{ ecr_name }}'
+        lifecycle_policy: '{{ lifecycle_policy | to_json }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: result
+
+    - name: it should change and not create
+      assert:
+        that:
+          - result|changed
+          - not result.created
+
+
+    - name: When setting a lifecycle policy to its current value
+      ecs_ecr:
+        region: '{{ ec2_region }}'
+        name: '{{ ecr_name }}'
+        lifecycle_policy: '{{ lifecycle_policy }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: result
+
+    - name: it should not change
+      assert:
+        that:
+          - not result|changed
+
+
+    - name: When omitting lifecycle policy on a repository that has a policy
+      ecs_ecr:
+        region: '{{ ec2_region }}'
+        name: '{{ ecr_name }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: result
+
+    - name: it should not change
+      assert:
+        that:
+          - not result|changed
+
+
+    - name: When specifying both lifecycle_policy and delete_lifecycle_policy
+      ecs_ecr:
+        region: '{{ ec2_region }}'
+        name: '{{ ecr_name }}'
+        lifecycle_policy: '{{ lifecycle_policy }}'
+        delete_lifecycle_policy: yes
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: result
+      ignore_errors: true
+
+    - name: it should fail
+      assert:
+        that:
+          - result|failed
+
+
+    - name: When specifying invalid JSON for lifecycle policy
+      ecs_ecr:
+        region: '{{ ec2_region }}'
+        name: '{{ ecr_name }}'
+        lifecycle_policy: "Ceci n'est pas une JSON"
         ec2_access_key: '{{ec2_access_key}}'
         ec2_secret_key: '{{ec2_secret_key}}'
         security_token: '{{security_token}}'

--- a/test/integration/targets/ecs_ecr/tasks/main.yml
+++ b/test/integration/targets/ecs_ecr/tasks/main.yml
@@ -266,7 +266,7 @@
           - result is failed
 
 
-    - name: When in check mode, deleting a policy that exists
+    - name: When in check mode, deleting a repository that exists
       ecs_ecr:
         name: '{{ ecr_name }}'
         region: '{{ ec2_region }}'
@@ -285,7 +285,7 @@
           - not result.created
 
 
-    - name: When deleting a policy that exists
+    - name: When deleting a repository that exists
       ecs_ecr:
         name: '{{ ecr_name }}'
         region: '{{ ec2_region }}'
@@ -301,7 +301,7 @@
           - result is changed
 
 
-    - name: When in check mode, deleting a policy that does not exist
+    - name: When in check mode, deleting a repository that does not exist
       ecs_ecr:
         name: '{{ ecr_name }}'
         region: '{{ ec2_region }}'
@@ -319,7 +319,7 @@
           - result is not changed
 
 
-    - name: When deleting a policy that does not exist
+    - name: When deleting a repository that does not exist
       ecs_ecr:
         name: '{{ ecr_name }}'
         region: '{{ ec2_region }}'

--- a/test/integration/targets/ecs_ecr/tasks/main.yml
+++ b/test/integration/targets/ecs_ecr/tasks/main.yml
@@ -160,8 +160,8 @@
     - name: it should skip, change but not create, no deprecations
       assert:
         that:
-          - result|skipped
-          - result|changed
+          - result is skipped
+          - result is changed
           - not result.created
           - result.deprecations is not defined
 
@@ -243,7 +243,7 @@
     - name: it should fail
       assert:
         that:
-          - result|failed
+          - result is failed
 
 
     - name: When in check mode, and purging a lifecycle policy that does not exists
@@ -257,8 +257,8 @@
     - name: it should not skip and not change
       assert:
         that:
-          - not result|skipped
-          - not result|changed
+          - not result is skipped
+          - not result is changed
 
 
     - name: When in check mode, setting lifecyle policy on a repository that has no policy
@@ -272,8 +272,8 @@
     - name: it should skip, change and not create
       assert:
         that:
-          - result|skipped
-          - result|changed
+          - result is skipped
+          - result is changed
           - not result.created
 
 
@@ -287,7 +287,7 @@
     - name: it should change and not create
       assert:
         that:
-          - result|changed
+          - result is changed
           - not result.created
 
 
@@ -302,8 +302,8 @@
     - name: it should skip, change but not create
       assert:
         that:
-          - result|skipped
-          - result|changed
+          - result is skipped
+          - result is changed
           - not result.created
 
 
@@ -317,7 +317,7 @@
     - name: it should change and not create
       assert:
         that:
-          - result|changed
+          - result is changed
           - not result.created
 
 
@@ -331,7 +331,7 @@
     - name: it should change and not create
       assert:
         that:
-          - result|changed
+          - result is changed
           - not result.created
 
 
@@ -345,7 +345,7 @@
     - name: it should not change
       assert:
         that:
-          - not result|changed
+          - not result is changed
 
 
     - name: When omitting lifecycle policy on a repository that has a policy
@@ -357,7 +357,7 @@
     - name: it should not change
       assert:
         that:
-          - not result|changed
+          - not result is changed
 
 
     - name: When specifying both lifecycle_policy and purge_lifecycle_policy
@@ -372,7 +372,7 @@
     - name: it should fail
       assert:
         that:
-          - result|failed
+          - result is failed
 
 
     - name: When specifying invalid JSON for lifecycle policy
@@ -402,7 +402,7 @@
     - name: it should fail
       assert:
         that:
-          - result|failed
+          - result is failed
 
 
     - name: When in check mode, deleting a repository that exists

--- a/test/integration/targets/ecs_ecr/tasks/main.yml
+++ b/test/integration/targets/ecs_ecr/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - set_fact:
-    ecr_name: '{{ resource_prefix | lower }}-ecr'
+    ecr_name: '{{ resource_prefix }}-ecr'
 
 - block:
 
@@ -289,6 +289,8 @@
         that:
           - result is changed
           - not result.created
+          - result.lifecycle_policy is defined
+          - result.lifecycle_policy|from_json|selectattr("rules")|length == 1
 
 
     - name: When in check mode, and purging a lifecyle policy that exists

--- a/test/integration/targets/ecs_ecr/tasks/main.yml
+++ b/test/integration/targets/ecs_ecr/tasks/main.yml
@@ -100,7 +100,7 @@
         ec2_access_key: '{{ec2_access_key}}'
         ec2_secret_key: '{{ec2_secret_key}}'
         security_token: '{{security_token}}'
-        delete_policy: yes
+        purge_policy: yes
       register: result
       check_mode: yes
 
@@ -158,19 +158,40 @@
       register: result
       check_mode: yes
 
-    - name: it should skip, change but not create
+    - name: it should skip, change but not create, have deprecations
       assert:
         that:
           - result is skipped
           - result is changed
           - not result.created
+          - result.deprecations
 
 
-    - name: When deleting a policy that exists
+    - name: When in check mode, and purging a policy that exists
       ecs_ecr:
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
-        delete_policy: yes
+        purge_policy: yes
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: result
+      check_mode: yes
+
+    - name: it should skip, change but not create, no deprecations
+      assert:
+        that:
+          - result|skipped
+          - result|changed
+          - not result.created
+          - result.deprecations is not defined
+
+
+    - name: When purging a policy that exists
+      ecs_ecr:
+        region: '{{ ec2_region }}'
+        name: '{{ ecr_name }}'
+        purge_policy: yes
         ec2_access_key: '{{ec2_access_key}}'
         ec2_secret_key: '{{ec2_secret_key}}'
         security_token: '{{security_token}}'
@@ -229,12 +250,12 @@
         that:
           - result is not changed
 
-    - name: When specifying both policy and delete_policy
+    - name: When specifying both policy and purge_policy
       ecs_ecr:
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy }}'
-        delete_policy: yes
+        purge_policy: yes
         ec2_access_key: '{{ec2_access_key}}'
         ec2_secret_key: '{{ec2_secret_key}}'
         security_token: '{{security_token}}'
@@ -264,14 +285,14 @@
           - result|failed
 
 
-    - name: When in check mode, and deleting a lifecycle policy that does not exists
+    - name: When in check mode, and purging a lifecycle policy that does not exists
       ecs_ecr:
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         ec2_access_key: '{{ec2_access_key}}'
         ec2_secret_key: '{{ec2_secret_key}}'
         security_token: '{{security_token}}'
-        delete_lifecycle_policy: yes
+        purge_lifecycle_policy: yes
       register: result
       check_mode: yes
 
@@ -318,11 +339,11 @@
           - not result.created
 
 
-    - name: When in check mode, and deleting a lifecyle policy that exists
+    - name: When in check mode, and purging a lifecyle policy that exists
       ecs_ecr:
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
-        delete_lifecycle_policy: yes
+        purge_lifecycle_policy: yes
         ec2_access_key: '{{ec2_access_key}}'
         ec2_secret_key: '{{ec2_secret_key}}'
         security_token: '{{security_token}}'
@@ -337,11 +358,11 @@
           - not result.created
 
 
-    - name: When deleting a lifecycle policy that exists
+    - name: When purging a lifecycle policy that exists
       ecs_ecr:
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
-        delete_lifecycle_policy: yes
+        purge_lifecycle_policy: yes
         ec2_access_key: '{{ec2_access_key}}'
         ec2_secret_key: '{{ec2_secret_key}}'
         security_token: '{{security_token}}'
@@ -402,12 +423,12 @@
           - not result|changed
 
 
-    - name: When specifying both lifecycle_policy and delete_lifecycle_policy
+    - name: When specifying both lifecycle_policy and purge_lifecycle_policy
       ecs_ecr:
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         lifecycle_policy: '{{ lifecycle_policy }}'
-        delete_lifecycle_policy: yes
+        purge_lifecycle_policy: yes
         ec2_access_key: '{{ec2_access_key}}'
         ec2_secret_key: '{{ec2_secret_key}}'
         security_token: '{{security_token}}'
@@ -435,6 +456,25 @@
       assert:
         that:
           - result is failed
+
+
+    - name: When specifying an invalid document for lifecycle policy
+      ecs_ecr:
+        region: '{{ ec2_region }}'
+        name: '{{ ecr_name }}'
+        lifecycle_policy:
+          rules:
+            - invalid: "Ceci n'est pas une rule"
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: result
+      ignore_errors: true
+
+    - name: it should fail
+      assert:
+        that:
+          - result|failed
 
 
     - name: When in check mode, deleting a repository that exists

--- a/test/integration/targets/ecs_ecr/tasks/main.yml
+++ b/test/integration/targets/ecs_ecr/tasks/main.yml
@@ -290,7 +290,7 @@
           - result is changed
           - not result.created
           - result.lifecycle_policy is defined
-          - result.lifecycle_policy|from_json|selectattr("rules")|length == 1
+          - result.lifecycle_policy.rules|length == 1
 
 
     - name: When in check mode, and purging a lifecyle policy that exists

--- a/test/integration/targets/ecs_ecr/tasks/main.yml
+++ b/test/integration/targets/ecs_ecr/tasks/main.yml
@@ -4,13 +4,19 @@
 
 - block:
 
+    - name: set connection information for all tasks
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          aws_access_key: "{{ aws_access_key }}"
+          aws_secret_key: "{{ aws_secret_key }}"
+          security_token: "{{ security_token }}"
+          region: "{{ aws_region }}"
+      no_log: yes
+
     - name: When creating with check mode
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       check_mode: yes
 
@@ -26,10 +32,7 @@
       ecs_ecr:
         registry_id: 999999999999
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       ignore_errors: true
 
@@ -43,10 +46,7 @@
     - name: When creating a repository
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: it should change and create
@@ -64,10 +64,7 @@
     - name: When creating a repository that already exists in check mode
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       check_mode: yes
 
@@ -81,10 +78,7 @@
     - name: When creating a repository that already exists
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: it should not change
@@ -95,12 +89,9 @@
 
     - name: When in check mode, and deleting a policy that does not exist
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         purge_policy: yes
+        <<: *aws_connection_info
       register: result
       check_mode: yes
 
@@ -113,12 +104,9 @@
 
     - name: When in check mode, setting policy on a repository that has no policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       check_mode: yes
 
@@ -132,12 +120,9 @@
 
     - name: When setting policy on a repository that has no policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: it should change and not create
@@ -149,12 +134,9 @@
 
     - name: When in check mode, and deleting a policy that exists
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         delete_policy: yes
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       check_mode: yes
 
@@ -169,12 +151,9 @@
 
     - name: When in check mode, and purging a policy that exists
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         purge_policy: yes
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       check_mode: yes
 
@@ -189,12 +168,9 @@
 
     - name: When purging a policy that exists
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         purge_policy: yes
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: it should change and not create
@@ -206,12 +182,9 @@
 
     - name: When setting a policy as a string
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy | to_json }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: it should change and not create
@@ -223,12 +196,9 @@
 
     - name: When setting a policy to its current value
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: it should not change
@@ -238,11 +208,8 @@
 
     - name: When omitting policy on a repository that has a policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: it should not change
@@ -252,13 +219,10 @@
 
     - name: When specifying both policy and purge_policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy }}'
         purge_policy: yes
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       ignore_errors: true
 
@@ -270,12 +234,9 @@
 
     - name: When specifying invalid JSON for policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: "Ceci n'est pas une JSON"
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       ignore_errors: true
 
@@ -287,12 +248,9 @@
 
     - name: When in check mode, and purging a lifecycle policy that does not exists
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         purge_lifecycle_policy: yes
+        <<: *aws_connection_info
       register: result
       check_mode: yes
 
@@ -305,12 +263,9 @@
 
     - name: When in check mode, setting lifecyle policy on a repository that has no policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         lifecycle_policy: '{{ lifecycle_policy }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       check_mode: yes
 
@@ -324,12 +279,9 @@
 
     - name: When setting lifecycle policy on a repository that has no policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         lifecycle_policy: '{{ lifecycle_policy }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: it should change and not create
@@ -341,12 +293,9 @@
 
     - name: When in check mode, and purging a lifecyle policy that exists
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         purge_lifecycle_policy: yes
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       check_mode: yes
 
@@ -360,12 +309,9 @@
 
     - name: When purging a lifecycle policy that exists
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         purge_lifecycle_policy: yes
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: it should change and not create
@@ -377,12 +323,9 @@
 
     - name: When setting a lifecyle policy as a string
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         lifecycle_policy: '{{ lifecycle_policy | to_json }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: it should change and not create
@@ -394,12 +337,9 @@
 
     - name: When setting a lifecycle policy to its current value
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         lifecycle_policy: '{{ lifecycle_policy }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: it should not change
@@ -410,11 +350,8 @@
 
     - name: When omitting lifecycle policy on a repository that has a policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: it should not change
@@ -425,13 +362,10 @@
 
     - name: When specifying both lifecycle_policy and purge_lifecycle_policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         lifecycle_policy: '{{ lifecycle_policy }}'
         purge_lifecycle_policy: yes
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       ignore_errors: true
 
@@ -443,12 +377,9 @@
 
     - name: When specifying invalid JSON for lifecycle policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         lifecycle_policy: "Ceci n'est pas une JSON"
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       ignore_errors: true
 
@@ -460,14 +391,11 @@
 
     - name: When specifying an invalid document for lifecycle policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         lifecycle_policy:
           rules:
             - invalid: "Ceci n'est pas une rule"
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       ignore_errors: true
 
@@ -480,11 +408,8 @@
     - name: When in check mode, deleting a repository that exists
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
         state: absent
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       check_mode: yes
 
@@ -499,11 +424,8 @@
     - name: When deleting a repository that exists
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
         state: absent
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: it should change
@@ -515,11 +437,8 @@
     - name: When in check mode, deleting a repository that does not exist
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
         state: absent
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
       check_mode: yes
 
@@ -533,11 +452,8 @@
     - name: When deleting a repository that does not exist
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
         state: absent
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: it should not change
@@ -621,8 +537,5 @@
     - name: Delete lingering ECR repository
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
         state: absent
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info


### PR DESCRIPTION
##### SUMMARY

Add support for ECR Lifecycle Policies to ecs_ecr. Fixes #32003

##### ISSUE TYPE

    Feature Pull Request

##### COMPONENT NAME

ecs_ecr

##### ANSIBLE VERSION

ansible 2.4.0.0
  config file = /Users/dlee/.ansible.cfg
  configured module search path = [u'/Users/dlee/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.4.0.0/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]

##### ADDITIONAL INFORMATION

Integration tests provided, and they pass.

PLAY RECAP *********************************************************************
localhost                  : ok=55   changed=8    unreachable=0    failed=0