### PR TITLE
Removed the proxmox_kvm.py filter that prevented update of a network …

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -334,7 +334,7 @@ options:
     description:
       - If C(yes), the VM will be update with new value.
       - Cause of the operations of the API and security reasons, I have disabled the update of the following parameters
-      - C(net, virtio, ide, sata, scsi). Per example updating C(net) update the MAC address and C(virtio) create always new disk...
+      - C(virtio, ide, sata, scsi). Per example updating C(virtio) create always new disk...
     type: bool
     default: 'no'
   validate_certs:
@@ -689,7 +689,7 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
             if p in kwargs:
                 del kwargs[p]
 
-    # If update, don't update disk (virtio, ide, sata, scsi) and network interface
+    # If update, don't update disk (virtio, ide, sata, scsi)
     if update:
         if 'virtio' in kwargs:
             del kwargs['virtio']
@@ -699,8 +699,6 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
             del kwargs['scsi']
         if 'ide' in kwargs:
             del kwargs['ide']
-        if 'net' in kwargs:
-            del kwargs['net']
 
     # Convert all dict in kwargs to elements. For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n]
     for k in kwargs.keys():


### PR DESCRIPTION
…interface

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The original author filtered out updates for networks in the proxmox_kvm module. The original documentation claimed that the MAC would be updated however the net parameter was ignored all together when `update: yes` was used.

This change allows updating of a network interface. It was tested with changing both MAC and the network device which caused no issues in Proxmox.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_kvm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Test playbooks used were:
```paste below
- name: Test update of VM
  hosts: host
  tasks:
  - name: Test VM
    proxmox_kvm:
      api_user: root@pam
      api_password: "{{ proxmox_pass }}"
      api_host: localhost
      node: deb-itc-hv01
      name: wsr-pvm-dc01
      net: '{"net0":"e1000=56:d3:b4:16:fc:f3,bridge=vmbr0"}'
```
```paste below
- name: Test update of VM
  hosts: host
  tasks:
  - name: Test VM
    proxmox_kvm:
      api_user: root@pam
      api_password: "{{ proxmox_pass }}"
      api_host: localhost
      node: deb-itc-hv01
      name: wsr-pvm-dc01
      net: '{"net0":"i82551=bc:d3:b4:16:fc:f4,bridge=vmbr0"}'
```
```paste below
- name: Test update of VM
  hosts: host
  tasks:
  - name: Test VM
    proxmox_kvm:
      api_user: root@pam
      api_password: "{{ proxmox_pass }}"
      api_host: localhost
      node: deb-itc-hv01
      name: wsr-pvm-dc01
      net: '{"net0":"e1000=bc:d3:b4:16:fc:f4,bridge=vmbr0"}'
```
