### PR TITLE
Reboot - Fix errors when using Paramiko connection

### DIFF
--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -171,6 +171,11 @@ class ActionModule(ActionBase):
                     display.debug('%s: %s success' % (self._task.action, action_desc))
                 return
             except Exception as e:
+                if isinstance(e, AnsibleConnectionFailure):
+                    try:
+                        self._connection.reset()
+                    except AnsibleConnectionFailure:
+                        pass
                 # Use exponential backoff with a max timout, plus a little bit of randomness
                 random_int = random.randint(0, 1000) / 1000
                 fail_sleep = 2 ** fail_count + random_int
@@ -178,8 +183,12 @@ class ActionModule(ActionBase):
 
                     fail_sleep = max_fail_sleep + random_int
                 if action_desc:
+                    try:
+                        error = to_text(e).splitlines()[-1]
+                    except TypeError as e:
+                        error = to_text(e)
                     display.debug("{0}: {1} fail '{2}', retrying in {3:.4} seconds...".format(self._task.action, action_desc,
-                                                                                              to_text(e).splitlines()[-1], fail_sleep))
+                                                                                              error, fail_sleep))
                 fail_count += 1
                 time.sleep(fail_sleep)
 

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -528,6 +528,10 @@ class Connection(ConnectionBase):
 
         f.close()
 
+    def reset(self):
+        self.close()
+        self._connect()
+
     def close(self):
         ''' terminate the connection '''
 
@@ -585,7 +589,7 @@ class Connection(ConnectionBase):
 
                 os.rename(tmp_keyfile.name, self.keyfile)
 
-            except:
+            except Exception:
 
                 # unable to save keys, including scenario when key was invalid
                 # and caught earlier
@@ -593,3 +597,4 @@ class Connection(ConnectionBase):
             fcntl.lockf(KEY_LOCK, fcntl.LOCK_UN)
 
         self.ssh.close()
+        self._connected = False


### PR DESCRIPTION
##### SUMMARY
Different connection plugins return different data when throwing exceptions. The Paramiko connection plugin does not return a text string, which caused an exception.

The ssh connection plugin returns multi-line errors, which makes the debug logs harder to read. Only return the last line in that case in order to make the logs more readable.

Fixes #48948 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`reboot.py`
