### PR TITLE
Improve log message in paramiko_ssh connection plugin

### DIFF
--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -302,7 +302,7 @@ class Connection(ConnectionBase):
             raise AnsibleError("paramiko is not installed")
 
         port = self._play_context.port or 22
-        display.vvv("ESTABLISH CONNECTION FOR USER: %s on PORT %s TO %s" % (self._play_context.remote_user, port, self._play_context.remote_addr),
+        display.vvv("ESTABLISH PARAMIKO SSH CONNECTION FOR USER: %s on PORT %s TO %s" % (self._play_context.remote_user, port, self._play_context.remote_addr),
                     host=self._play_context.remote_addr)
 
         ssh = paramiko.SSHClient()


### PR DESCRIPTION
##### SUMMARY
This is the only connection plugin that does not state its name in `vvv` logs. Add the connection plugin name to the log message to aid in debugging.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
`paramiko_ssh.py`

##### ADDITIONAL INFORMATION

```
lib/ansible/plugins/connection/local.py
51:  display.vvv(u"ESTABLISH LOCAL CONNECTION FOR USER: {0}".format(self._play_context.remote_user), host=self._play_context.remote_addr)

lib/ansible/plugins/connection/paramiko_ssh.py
305:  display.vvv("ESTABLISH CONNECTION FOR USER: %s on PORT %s TO %s" % (self._play_context.remote_user, port, self._play_context.remote_addr),

lib/ansible/plugins/connection/jail.py
98:  display.vvv(u"ESTABLISH JAIL CONNECTION FOR USER: {0}".format(self._play_context.remote_user), host=self.jail)

lib/ansible/plugins/connection/docker.py
197:  display.vvv(u"ESTABLISH DOCKER CONNECTION FOR USER: {0}".format(

lib/ansible/plugins/connection/psrp.py
213:  display.vvv("ESTABLISH PSRP CONNECTION FOR USER: %s ON PORT %s TO %s" %

lib/ansible/plugins/connection/lxd.py
65:            self._display.vvv(u"ESTABLISH LXD CONNECTION FOR USER: root", host=self._host)

lib/ansible/plugins/connection/ssh.py
1059:  display.vvv(u"ESTABLISH SSH CONNECTION FOR USER: {0}".format(self._play_context.remote_user), host=self._play_context.remote_addr)

lib/ansible/plugins/connection/kubectl.py
255:  display.vvv(u"ESTABLISH {0} CONNECTION".format(self.transport), host=self._play_context.remote_addr)

lib/ansible/plugins/connection/winrm.py
362:  display.vvv("ESTABLISH WINRM CONNECTION FOR USER: %s on PORT %s TO %s" %

```