### PR TITLE
Add connection_timeout option to paramiko_ssh connection plugin

### DIFF
--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -123,8 +123,16 @@ DOCUMENTATION = """
         ini:
           - section: defaults
             key: use_persistent_connections
-# TODO:
-#timeout=self._play_context.timeout,
+      connection_timeout:
+        description: 'Sets the connection timeout in seconds.'
+        type: int
+        default:
+        env:
+          - name: ANSIBLE_PARAMIKO_CONNECTION_TIMEOUT
+        ini:
+          - section: paramiko_connection
+            key: timeout
+            version_added: '2.8'
 """
 
 import warnings
@@ -354,7 +362,7 @@ class Connection(ConnectionBase):
                 look_for_keys=self.get_option('look_for_keys'),
                 key_filename=key_filename,
                 password=self._play_context.password,
-                timeout=self._play_context.timeout,
+                timeout=self.get_option("connection_timeout", self._play_context.timeout),
                 port=port,
                 **ssh_connect_kwargs
             )


### PR DESCRIPTION
##### SUMMARY
Adds an option to set the timeout for `paramiko_ssh`. I'm not entirely sure this is done correctly, so I would appreciate a review.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
`paramiko_ssh.py`