### PR TITLE
Update guide_packet.rst

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_packet.rst
+++ b/docs/docsite/rst/scenario_guides/guide_packet.rst
@@ -178,7 +178,7 @@ The following playbook will create an SSH key, 3 Packet servers, and then wait u
           port: 22
           state: started
           timeout: 500
-        loop: "{{ newhosts.devices }}"
+        loop: "{{ newhosts.results[0].devices }}"
 
 
 As with most Ansible modules, the default states of the Packet modules are idempotent, meaning the resources in your project will remain the same after re-runs of a playbook. Thus, we can keep the ``packet_sshkey`` module call in our playbook. If the public key is already in your Packet account, the call will have no effect.


### PR DESCRIPTION
Properly parses the returned data to get the device data and IP address. 


+label: docsite_pr

##### SUMMARY
The sample playbook in the documentation does not properly parse the returned result from the API. This change updates sample playbook in the documentation to run correctly.

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
Documentation

##### ADDITIONAL INFORMATION
Before this patch, the sample playbook would fail with:

fatal: [localhost]: FAILED! => {"msg": "'dict object' has no attribute 'devices'"}
