### PR TITLE
ec2_instance_facts: documentation: add example

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_instance_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance_facts.py
@@ -60,6 +60,12 @@ EXAMPLES = '''
 - ec2_instance_facts:
     filters:
       "tag:Name": Example
+
+# Gather facts about any instance in states "shutting-down", "stopping", "stopped"
+- ec2_instance_facts:
+    filters:
+      instance-state-name: [ "shutting-down", "stopping", "stopped" ]
+
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY
Add an example of using multiple states for instance-state-name in filters. It's not obvious how to make a multiple states filter.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ec2_instance_facts
