### PR TITLE
Meraki util - Add method to encode parameters in the URL

### DIFF
--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -153,7 +153,6 @@ class MerakiModule(object):
                     is_changed = True
         return is_changed
 
-
     def get_orgs(self):
         """Downloads all organizations for a user."""
         response = self.request('/organizations', method='GET')

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -249,7 +249,24 @@ class MerakiModule(object):
                 return template['id']
         self.fail_json(msg='No configuration template named {0} found'.format(name))
 
-    def construct_path(self, action, function=None, org_id=None, net_id=None, org_name=None, custom=None):
+    def encode_url_params(self, params):
+        """Encodes key value pairs for URL"""
+        param_string = "?"
+        for i, (k, v) in enumerate(params.items()):
+            if i == len(params)-1:
+                param_string += "{0}={1}".format(k, v)
+            else:
+                param_string += "{0}={1}%".format(k, v)
+        return param_string
+
+    def construct_path(self,
+                       action,
+                       function=None,
+                       org_id=None,
+                       net_id=None,
+                       org_name=None,
+                       custom=None,
+                       params=None):
         """Build a path from the URL catalog.
 
         Uses function property from class for catalog lookup.
@@ -265,6 +282,8 @@ class MerakiModule(object):
             built_path = built_path.format(org_id=org_id, net_id=net_id, **custom)
         else:
             built_path = built_path.format(org_id=org_id, net_id=net_id)
+        if params:
+            built_path += self.encode_url_params(params)
         return built_path
 
     def request(self, path, method=None, payload=None):

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -253,7 +253,7 @@ class MerakiModule(object):
         """Encodes key value pairs for URL"""
         param_string = "?"
         for i, (k, v) in enumerate(params.items()):
-            if i == len(params)-1:
+            if i == len(params) - 1:
                 param_string += "{0}={1}".format(k, v)
             else:
                 param_string += "{0}={1}%".format(k, v)

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -153,6 +153,17 @@ class MerakiModule(object):
                     is_changed = True
         return is_changed
 
+    def construct_params_list(self, keys, aliases=None):
+        args_list = []
+        for key in keys:
+            item = (aliases[key], self.module.params[key])
+            args_list.append(item)
+        return args_list
+
+    def encode_url_params(self, params):
+        """Encodes key value pairs for URL"""
+        return "?{0}".format(urlencode(params))
+
     def get_orgs(self):
         """Downloads all organizations for a user."""
         response = self.request('/organizations', method='GET')

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -32,6 +32,7 @@
 import os
 from ansible.module_utils.basic import AnsibleModule, json, env_fallback
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils._text import to_native, to_bytes, to_text
 
 
@@ -256,8 +257,8 @@ class MerakiModule(object):
             if i == len(params) - 1:
                 param_string += "{0}={1}".format(k, v)
             else:
-                param_string += "{0}={1}%".format(k, v)
-        return param_string
+                param_string += "{0}={1}&".format(k, v)
+        return urlencode(param_string)
 
     def construct_path(self,
                        action,

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -153,16 +153,6 @@ class MerakiModule(object):
                     is_changed = True
         return is_changed
 
-    def construct_params_list(self, keys, aliases=None):
-        args_list = []
-        for key in keys:
-            item = (aliases[key], self.module.params[key])
-            args_list.append(item)
-        return args_list
-
-    def encode_url_params(self, params):
-        """Encodes key value pairs for URL"""
-        return "?{0}".format(urlencode(params))
 
     def get_orgs(self):
         """Downloads all organizations for a user."""

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -261,15 +261,18 @@ class MerakiModule(object):
                 return template['id']
         self.fail_json(msg='No configuration template named {0} found'.format(name))
 
+    def construct_params_list(self, keys, aliases=None):
+        qs = {}
+        for key in keys:
+            if key in aliases:
+                qs[aliases[key]] = self.module.params[key]
+            else:
+                qs[key] = self.module.params[key]
+        return qs
+
     def encode_url_params(self, params):
         """Encodes key value pairs for URL"""
-        param_string = "?"
-        for i, (k, v) in enumerate(params.items()):
-            if i == len(params) - 1:
-                param_string += "{0}={1}".format(k, v)
-            else:
-                param_string += "{0}={1}&".format(k, v)
-        return urlencode(param_string)
+        return "?{0}".format(urlencode(params))
 
     def construct_path(self,
                        action,
@@ -280,7 +283,6 @@ class MerakiModule(object):
                        custom=None,
                        params=None):
         """Build a path from the URL catalog.
-
         Uses function property from class for catalog lookup.
         """
         built_path = None


### PR DESCRIPTION
##### SUMMARY
Some of the Meraki endpoints require parameters to be passed via the URL instead of in the body. A new method was created in the module utility format the parameter string and append to the URL. Also, a new parameter was added to the construct_path() method to allow passing the parameters, which are handled automatically.

Note, I am not actually doing any real encoding, just concatenating. If there is an Ansible method which already does this, please let me know and I'll use that instead.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
meraki

##### VERSION
ansible 2.8.0.dev0 (meraki/util_url_params cb6cdf4dab) last updated 2018/11/21 21:28:56 (GMT -500)
  config file = None
  configured module search path = ['/Users/kbreit/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kbreit/Documents/Programming/ansible/lib/ansible
  executable location = /Users/kbreit/Documents/Programming/ansible/bin/ansible
  python version = 3.5.4 (default, Feb 25 2018, 14:56:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
