### PR TITLE
mail: restore module working with python 2.7

### DIFF
--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -211,6 +211,7 @@ from email.header import Header
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
+from ansible.module_utils.six import PY3
 
 
 def main():
@@ -264,7 +265,11 @@ def main():
     try:
         if secure != 'never':
             try:
-                smtp = smtplib.SMTP_SSL(host=host, port=port, timeout=timeout)
+                params = dict(timeout=timeout)
+                if PY3:
+                    params['host'] = host
+                    params['port'] = port
+                smtp = smtplib.SMTP_SSL(**params)
                 code, smtpmessage = smtp.connect(host, port)
                 secure_state = True
             except ssl.SSLError as e:
@@ -275,7 +280,11 @@ def main():
                 pass
 
         if not secure_state:
-            smtp = smtplib.SMTP(host=host, port=port, timeout=timeout)
+            params = dict(timeout=timeout)
+            if PY3:
+                params['host'] = host
+                params['port'] = port
+            smtp = smtplib.SMTP(**params)
             code, smtpmessage = smtp.connect(host, port)
 
     except smtplib.SMTPException as e:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Try to fix `mail` module for Python 2.7 & Python 3.7

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

mail

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.7.2
  config file = /home/k0ste/.ansible.cfg
  configured module search path = ['/home/k0ste/ansible/my_modules', '/home/k0ste/ceph-ansible/library']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.1 (default, Oct 22 2018, 10:41:28) [GCC 8.2.1 20180831]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Resolve #48785.