### PR TITLE
add required state parameter to acme_certificate route53 example

### DIFF
--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -233,6 +233,7 @@ EXAMPLES = R'''
 #     record: "{{ sample_com_challenge.challenge_data['sample.com']['dns-01'].record }}"
 #     type: TXT
 #     ttl: 60
+#     state: present
 #     # Note: route53 requires TXT entries to be enclosed in quotes
 #     value: "{{ sample_com_challenge.challenge_data['sample.com']['dns-01'].resource_value }}"
 #     when: sample_com_challenge is changed
@@ -244,6 +245,7 @@ EXAMPLES = R'''
 #     record: "{{ item.key }}"
 #     type: TXT
 #     ttl: 60
+#     state: present
 #     # Note: item.value is a list of TXT entries, and route53
 #     # requires every entry to be enclosed in quotes
 #     value: "{{ item.value | map('regex_replace', '^(.*)$', '\'\\1\'' ) | list }}"

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -235,7 +235,7 @@ EXAMPLES = R'''
 #     ttl: 60
 #     state: present
 #     # Note: route53 requires TXT entries to be enclosed in quotes
-#     value: "{{ sample_com_challenge.challenge_data['sample.com']['dns-01'].resource_value }}"
+#     value: "{{ sample_com_challenge.challenge_data['sample.com']['dns-01'].resource_value | regex_replace('^(.*)$', '\"\\1\"') }}"
 #     when: sample_com_challenge is changed
 #
 # Alternative way:
@@ -248,7 +248,7 @@ EXAMPLES = R'''
 #     state: present
 #     # Note: item.value is a list of TXT entries, and route53
 #     # requires every entry to be enclosed in quotes
-#     value: "{{ item.value | map('regex_replace', '^(.*)$', '\'\\1\'' ) | list }}"
+#     value: "{{ item.value | map('regex_replace', '^(.*)$', '\"\\1\"' ) | list }}"
 #     loop: "{{ sample_com_challenge.challenge_data_dns | dictsort }}"
 #     when: sample_com_challenge is changed
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
route53 module state parameter is required (https://docs.ansible.com/ansible/latest/modules/route53_module.html#parameters), so the example is not working out of the box in ansible.

Required state parameters has been introduced in commit 698fa37a4496b44b32c2b851f0cf83bd664e8eda (https://github.com/ansible/ansible/commit/698fa37a4496b44b32c2b851f0cf83bd664e8eda)

Thank you!

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- `route53`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
