### PR TITLE
[WIP] digital_ocean_tag_facts - Fix KeyError problems

### DIFF
--- a/lib/ansible/module_utils/digital_ocean.py
+++ b/lib/ansible/module_utils/digital_ocean.py
@@ -128,7 +128,7 @@ class DigitalOceanHelper:
         status_code = None
         response = None
         while has_next or status_code != expected_status_code:
-            required_url = "{0}page={1}&per_page={2}".format(base_url, page, data_per_page)
+            required_url = "{0}?page={1}&per_page={2}".format(base_url, page, data_per_page)
             response = self.get(required_url)
             status_code = response.status_code
             # stop if any error during pagination

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag_facts.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag_facts.py
@@ -84,7 +84,7 @@ def core(module):
     tag_name = module.params.get('tag_name', None)
     rest = DigitalOceanHelper(module)
 
-    base_url = 'tags?'
+    base_url = 'tags'
     if tag_name is not None:
         response = rest.get("%s/%s" % (base_url, tag_name))
         status_code = response.status_code

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag_facts.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag_facts.py
@@ -95,7 +95,7 @@ def core(module):
         resp_json = response.json
         tag = resp_json['tag']
     else:
-        tag = rest.get_paginated_data(base_url=base_url, data_key_name='tags')
+        tag = rest.get_paginated_data(base_url="{0}?".format(base_url), data_key_name='tags')
 
     module.exit_json(changed=False, data=tag)
 


### PR DESCRIPTION
##### SUMMARY
- `base_url` shouldn't always have `?` after it.
- Move `?` to pagination method where it likely is always needed.
- I assume this will break other modules though. Really, test the heck out of this.

Fixes #49030 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
digital_ocean_tag_facts