### PR TITLE
ec2_metadata_facts: Handle missing identity_document_region

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
@@ -532,7 +532,8 @@ class Ec2Metadata(object):
         data = self.fix_invalid_varnames(data)
 
         # Maintain old key for backwards compatibility
-        data['ansible_ec2_placement_region'] = data['ansible_ec2_instance_identity_document_region']
+        if 'ansible_ec2_instance_identity_document_region' in data:
+          data['ansible_ec2_placement_region'] = data['ansible_ec2_instance_identity_document_region']
         return data
 
 

--- a/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
@@ -533,7 +533,7 @@ class Ec2Metadata(object):
 
         # Maintain old key for backwards compatibility
         if 'ansible_ec2_instance_identity_document_region' in data:
-          data['ansible_ec2_placement_region'] = data['ansible_ec2_instance_identity_document_region']
+            data['ansible_ec2_placement_region'] = data['ansible_ec2_instance_identity_document_region']
         return data
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

If `ansible_ec2_instance_identity_document_region` is not set by the metadata this module fails. It fails simply because it tries to set legacy value `ansible_ec2_placement_region`.

On a real AWS instance this value would always set (or someone would have raised an issue by now!), however there are also other cloud providers (Openstack) that emulate the EC2 metadata service and do not always implement the `identity_document_region`. There is no reason to fail because of that.

This PR simply adds a check for the first value. This should impact on existing behaviour. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

ec2_metadata_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
# ansible -m ec2_metadata_facts host-01
host-01 | FAILED! => {
    "changed": false, 
    "module_stderr": "Shared connection to 10.131.0.4 closed.\r\n", 
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_mDFTA7/ansible_module_ec2_metadata_facts.py\", line 554, in <module>\r\n    main()\r\n  File \"/tmp/ansible_mDFTA7/ansible_module_ec2_metadata_facts.py\", line 54
7, in main\r\n    ec2_metadata_facts = Ec2Metadata(module).run()\r\n  File \"/tmp/ansible_mDFTA7/ansible_module_ec2_metadata_facts.py\", line 534, in run\r\n    data['ansible_ec2_placement_region'] = data['ansible_ec2_instance_identity_document
_region']\r\nKeyError: 'ansible_ec2_instance_identity_document_region'\r\n",
    "msg": "MODULE FAILURE", 
    "rc": 1
}
```
After
```
# ansible -m ec2_metadata_facts host-01
host-01 | SUCCESS => {
    "ansible_facts": {
        "ansible_ec2_None": "None", 
        "ansible_ec2_ami_id": "ami-00000087", 
        "ansible_ec2_ami_launch_index": "0", 
        "ansible_ec2_ami_manifest_path": "FIXME", 
        "ansible_ec2_block_device_mapping_ami": "vda", 
        "ansible_ec2_block_device_mapping_ebs0": "/dev/vdb", 
        "ansible_ec2_block_device_mapping_root": "/dev/vda", 
        "ansible_ec2_hostname": "host-01.novalocal", 
        "ansible_ec2_instance_action": "none", 
        "ansible_ec2_instance_id": "i-00000df5", 
        "ansible_ec2_instance_type": "gp_2xlarge_8cpu_32gb", 
        "ansible_ec2_local_hostname": "host-01.novalocal", 
        "ansible_ec2_local_ipv4": "10.131.0.4", 
        "ansible_ec2_placement_availability_zone": "akl01-a", 
        "ansible_ec2_public_hostname": "host-01.novalocal", 
        "ansible_ec2_public_ipv4": "", 
        "ansible_ec2_public_key": "ssh-rsa AAAAB3...\n",
        "ansible_ec2_reservation_id": "r-muhvvm3h", 
        "ansible_ec2_security_groups": "default-sg", 
        "ansible_ec2_user_data": ""
    }, 
    "changed": false
}
```

Hope this is sufficient information. Thanks in advance.