### PR TITLE
use explict conversion instead of as_dict

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_appserviceplan.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_appserviceplan.py
@@ -160,7 +160,7 @@ def appserviceplan_to_dict(plan):
         is_linux=plan.reserved,
         provisioning_state=plan.provisioning_state,
         status=plan.status,
-        target_woker_count=plan.target_woker_count,
+        target_worker_count=plan.target_worker_count,
         sku=dict(
             name=plan.sku.name,
             size=plan.sku.size,

--- a/lib/ansible/modules/cloud/azure/azure_rm_appserviceplan.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_appserviceplan.py
@@ -150,6 +150,30 @@ def get_sku_name(tier):
         return None
 
 
+def appserviceplan_to_dict(plan):
+    return dict(
+        id=plan.id,
+        name=plan.name,
+        kind=plan.kind,
+        location=plan.location,
+        reserved=plan.reserved,
+        is_linux=plan.reserved,
+        provisioning_state=plan.provisioning_state,
+        status=plan.status,
+        target_woker_count=plan.target_woker_count,
+        sku=dict(
+            name=plan.sku.name,
+            size=plan.sku.size,
+            tier=plan.sku.tier,
+            family=plan.sku.family,
+            capacity=plan.sku.capacity
+        ),
+        resource_group=plan.resource_group,
+        number_of_sites=plan.number_of_sites,
+        tags=plan.tags if plan.tags else None
+    )
+
+
 class AzureRMAppServicePlans(AzureRMModuleBase):
     """Configuration class for an Azure RM App Service Plan resource"""
 
@@ -294,7 +318,7 @@ class AzureRMAppServicePlans(AzureRMModuleBase):
             self.log("Response : {0}".format(response))
             self.log("App Service Plan : {0} found".format(response.name))
 
-            return response.as_dict()
+            return appserviceplan_to_dict(response)
         except CloudError as ex:
             self.log("Didn't find app service plan {0} in resource group {1}".format(self.name, self.resource_group))
 
@@ -323,7 +347,7 @@ class AzureRMAppServicePlans(AzureRMModuleBase):
 
             self.log("Response : {0}".format(response))
 
-            return response.as_dict()
+            return appserviceplan_to_dict(response)
         except CloudError as ex:
             self.fail("Failed to create app service plan {0} in resource group {1}: {2}".format(self.name, self.resource_group, str(ex)))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix  app service plan test `id` key not exist error to use explicit object conversion instead  of as_dict
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
