### PR TITLE
PR to support commit check to confirm commits with JunOS

### DIFF
--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -125,7 +125,7 @@ options:
   check_commit:
     description:
       - This argument will check correctness of syntax; do not apply changes.
-        NOTE: This argument can be used to confirm verified configuration done via commit confirmed operation
+    note: This argument can be used to confirm verified configuration done via commit confirmed operation
     type: bool
     default: 'no'
     version_added: "2.8"

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -125,7 +125,7 @@ options:
   check_commit:
     description:
       - This argument will check correctness of syntax; do not apply changes.
-    note: This argument can be used to confirm verified configuration done via commit confirmed operation
+      - Note that this argument can be used to confirm verified configuration done via commit confirmed operation
     type: bool
     default: 'no'
     version_added: "2.8"

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -125,6 +125,7 @@ options:
   check_commit:
     description:
       - This argument will check correctness of syntax; do not apply changes.
+        NOTE: This argument can be used to confirm verified configuration done via commit confirmed operation
     type: bool
     default: 'no'
     version_added: "2.8"
@@ -403,10 +404,7 @@ def main():
                         result['diff'] = {'prepared': diff}
 
         elif module.params['check_commit']:
-            kwargs = {
-                'check': True
-            }
-            commit_configuration(module, **kwargs)
+            commit_configuration(module, check=True)
 
         elif module.params['confirm_commit']:
             with locked_config(module):

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -122,6 +122,12 @@ options:
     type: bool
     default: 'no'
     version_added: "2.4"
+  check_commit:
+    description:
+      - This argument will check correctness of syntax; do not apply changes.
+    type: bool
+    default: 'no'
+    version_added: "2.8"
 requirements:
   - ncclient (>=v0.5.2)
 notes:
@@ -156,6 +162,10 @@ EXAMPLES = """
       - set vlans vlan01 vlan-id 1
       - set interfaces irb unit 10 family inet address 10.0.0.1/24
       - set vlans vlan01 l3-interface irb.10
+
+- name: Check correctness of commit configuration
+  junos_config:
+    check_commit: yes
 
 - name: rollback the configuration to id 10
   junos_config:
@@ -313,6 +323,7 @@ def main():
         confirm=dict(default=0, type='int'),
         comment=dict(default=DEFAULT_COMMENT),
         confirm_commit=dict(type='bool', default=False),
+        check_commit=dict(type='bool', default=False),
 
         # config operations
         backup=dict(type='bool', default=False),
@@ -390,6 +401,12 @@ def main():
 
                     if module._diff:
                         result['diff'] = {'prepared': diff}
+
+        elif module.params['check_commit']:
+            kwargs = {
+                'check': True
+            }
+            commit_configuration(module, **kwargs)
 
         elif module.params['confirm_commit']:
             with locked_config(module):


### PR DESCRIPTION
Signed-off-by: Sumit Jaiswal <sjaiswal@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR is raised to resolve the feature support requested in issue #47740, and now with this support for `commit check` support is added via `junos_config` module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
junos_config
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
