### PR TITLE
Support for NIOS modules to use environment variables in provider

### DIFF
--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -58,17 +58,17 @@ NIOS_TXT_RECORD = 'record:txt'
 NIOS_NSGROUP = 'nsgroup'
 
 NIOS_PROVIDER_SPEC = {
-    'host': dict(),
-    'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
-    'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
-    'ssl_verify': dict(type='bool', default=False),
+    'host': dict(fallback=(env_fallback, ['INFOBLOX_HOST'])),
+    'username': dict(fallback=(env_fallback, ['INFOBLOX_USERNAME'])),
+    'password': dict(fallback=(env_fallback, ['INFOBLOX_PASSWORD']), no_log=True),
+    'ssl_verify': dict(type='bool', default=False, fallback=(env_fallback, ['INFOBLOX_SSL_VERIFY'])),
     'silent_ssl_warnings': dict(type='bool', default=True),
-    'http_request_timeout': dict(type='int', default=10),
+    'http_request_timeout': dict(type='int', default=10, fallback=(env_fallback, ['INFOBLOX_HTTP_REQUEST_TIMEOUT'])),
     'http_pool_connections': dict(type='int', default=10),
     'http_pool_maxsize': dict(type='int', default=10),
-    'max_retries': dict(type='int', default=3),
-    'wapi_version': dict(default='2.1'),
-    'max_results': dict(type='int', default=1000)
+    'max_retries': dict(type='int', default=3, fallback=(env_fallback, ['INFOBLOX_MAX_RETRIES'])),
+    'wapi_version': dict(default='2.1', fallback=(env_fallback, ['INFOBLOX_WAP_VERSION'])),
+    'max_results': dict(type='int', default=1000, fallback=(env_fallback, ['INFOBLOX_MAX_RETRIES']))
 }
 
 

--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -31,6 +31,7 @@ from functools import partial
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_text
+from ansible.module_utils.basic import env_fallback
 
 try:
     from infoblox_client.connector import Connector
@@ -58,8 +59,8 @@ NIOS_NSGROUP = 'nsgroup'
 
 NIOS_PROVIDER_SPEC = {
     'host': dict(),
-    'username': dict(),
-    'password': dict(no_log=True),
+    'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
+    'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
     'ssl_verify': dict(type='bool', default=False),
     'silent_ssl_warnings': dict(type='bool', default=True),
     'http_request_timeout': dict(type='int', default=10),

--- a/lib/ansible/utils/module_docs_fragments/nios.py
+++ b/lib/ansible/utils/module_docs_fragments/nios.py
@@ -70,7 +70,7 @@ options:
           - Specifies the version of WAPI to use
           - Value can also be specified using C(INFOBLOX_WAP_VERSION) environment
             variable.
-          - Default Wapi version is updated in ansible version 2.8
+          - Until ansible 2.8 the default WAPI was 1.4
         default: 2.1
       max_results:
         description:

--- a/lib/ansible/utils/module_docs_fragments/nios.py
+++ b/lib/ansible/utils/module_docs_fragments/nios.py
@@ -70,7 +70,7 @@ options:
           - Specifies the version of WAPI to use
           - Value can also be specified using C(INFOBLOX_WAP_VERSION) environment
             variable.
-        default: 1.4
+        default: 2.1
       max_results:
         description:
           - Specifies the maximum number of objects to be returned,

--- a/lib/ansible/utils/module_docs_fragments/nios.py
+++ b/lib/ansible/utils/module_docs_fragments/nios.py
@@ -70,6 +70,7 @@ options:
           - Specifies the version of WAPI to use
           - Value can also be specified using C(INFOBLOX_WAP_VERSION) environment
             variable.
+          - Default Wapi version is updated in ansible version 2.8
         default: 2.1
       max_results:
         description:


### PR DESCRIPTION
Signed-off-by: Sumit Jaiswal <sjaiswal@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR fixes the bug raised in issue #48697, and now environment variables can be set for username/password and used in provider making NIOS modules in sync with other network modules of using the environment variable for provider values.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nios/api.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
