### PR TITLE
aix_chsec module

### DIFF
--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: aix_chsec
+
+short_description: modify aix stanza files
+
+version_added: "0.1"
+
+description:
+    - "adds stanzas to aix config files using the chsec command. see "man chsec" for additional infos"
+
+options:
+    path:
+        description:
+            - Path to the stanza file
+        required: true
+    stanza:
+        description:
+            - name of stanza
+        required: true
+    options:
+         description:
+             - comman separated key/value pairs eg. key=val,key=val
+    state:
+         description:
+            - If set to C(absent) the whole stanza incl. all given options will be removed.
+            - If set to C(present) stanza incl.options will be added.
+            - To remove an option from the stanza set to C(present) and set key to an empty value (key=).
+            - All rules/allowed file-stanza combos/allowed files for the chsec command also applies here, so once again, read "man chsec"!
+         choices: [ absent, present ]
+         default: present
+
+extends_documentation_fragment:
+    - files
+
+author:
+    - Christian Tremel (@flynn1973)
+'''
+
+EXAMPLES = '''
+- name: add ldap user stanza
+  aix_chsec:
+    path: /etc/security/user
+    stanza: ldapuser
+    options: SYSTEM=LDAP,registry=LDAP
+    state: present
+    mode: 0644
+
+- name: change login times for user
+  aix_chsec:
+    path: /etc/security/user
+    stanza: ldapuser
+    options: logintimes=:0800-1700
+    state: present
+
+- name: remove registry option from stanza 
+  aix_chsec:
+    path: /etc/security/user
+    stanza: ldapuser
+    options: SYSTEM=LDAP,registry=
+    state: present
+'''
+
+
+from ansible.module_utils.basic import *
+
+
+
+def do_stanza(module, filename, stanza, options, state='present'):
+
+    chsec_command = module.get_bin_path('chsec', True)
+
+    def arguments_generator(options):
+        for element in options:
+                yield '-a'
+                yield element
+
+    command = [chsec_command, '-f', filename, '-s', '%s' % stanza]
+    options = list(arguments_generator(options))
+
+    if state == 'present':
+        command += options
+        rc, package_result, err = module.run_command(command)
+        if rc != 0:
+            module.fail_json(msg='Failed to run chsec command (present).', rc=rc, err=err)
+        else:
+            msg='stanza added'
+            changed=True
+    elif state == 'absent':
+        # remove values from keys to enable chsec delete mode 
+        command += [s[:1+s.find('=')] or s for s in options]
+        rc, package_result, err = module.run_command(command)
+        if rc != 0:
+             module.fail_json(msg='Failed to run chsec command (absent).', rc=rc, err=err)
+        else:
+             msg='stanza removed'
+             changed=True
+
+    return (changed, msg)
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            path=dict(type='path', required=True, aliases=['dest']),
+            stanza=dict(type='str', required=True),
+            options=dict(type='list', required=True),
+            state=dict(type='str', default='present', choices=['absent', 'present'])
+        ),
+        supports_check_mode=False,
+    )
+
+    path = module.params['path']
+    stanza = module.params['stanza']
+    options = module.params['options']
+    state = module.params['state']
+
+    (changed, msg) = do_stanza(module, path, stanza, options, state)
+
+
+    results = dict(
+        changed=changed,
+        msg=msg,
+        path=path
+    )
+
+    # Mission complete
+    module.exit_json(**results)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -30,7 +30,7 @@ options:
         required: true
     stanza:
         description:
-            - name of stanza
+            - Name of stanza.
         required: true
     options:
          description:

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -59,7 +59,7 @@ EXAMPLES = '''
     stanza: ldapuser
     options: SYSTEM=LDAP,registry=LDAP
     state: present
-    mode: 0644
+    mode: '0644'
 
 - name: Change login times for user
   aix_chsec:

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -20,7 +20,9 @@ short_description: Modify AIX stanza files
 version_added: '2.8'
 
 description:
-    - "adds stanzas to aix config files using the chsec command. see "man chsec" for additional infos"
+    - Modify stanzas to AIX config files using the chsec command.
+notes:
+    - See `man chsec` for additional information.
 
 options:
     path:

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -52,7 +52,7 @@ author:
 '''
 
 EXAMPLES = '''
-- name: add ldap user stanza
+- name: Add an LDAP user stanza
   aix_chsec:
     path: /etc/security/user
     stanza: ldapuser

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -25,7 +25,8 @@ description:
 options:
     path:
         description:
-            - Path to the stanza file
+            - Path to the stanza file.
+        type: path
         required: true
     stanza:
         description:

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# Copyright: (c) 2018, Christian Tremel (@flynn1973)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -11,49 +13,47 @@ ANSIBLE_METADATA = {
     'supported_by': 'community'
 }
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: aix_chsec
-
 short_description: Modify AIX stanza files
-
 version_added: '2.8'
-
 description:
-    - Modify stanzas to AIX config files using the chsec command.
-notes:
-    - See `man chsec` for additional information.
-
+- Modify stanzas to AIX config files using the C(chsec) command.
 options:
-    path:
-        description:
-            - Path to the stanza file.
-        type: path
-        required: true
-    stanza:
-        description:
-            - Name of stanza.
-        required: true
-    options:
-         description:
-             - A list of key/value pairs, e.g. `key=val,key=val`
-         type: list
-    state:
-         description:
-            - If set to C(absent) the whole stanza incl. all given options will be removed.
-            - If set to C(present) stanza incl.options will be added.
-            - To remove an option from the stanza set to C(present) and set key to an empty value (key=).
-            - All rules/allowed file-stanza combos/allowed files for the chsec command also applies here, so once again, read "man chsec"!
-         type: str
-         choices: [ absent, present ]
-         default: present
-
-
+  path:
+    description:
+    - Path to the stanza file.
+    type: path
+    required: true
+    aliases: [ dest ]
+  stanza:
+    description:
+    - Name of stanza.
+    type: str
+    required: true
+  options:
+     description:
+     - A list of key/value pairs, e.g. C(key=val,key=val).
+     type: list
+  state:
+     description:
+     - If set to C(absent) the whole stanza incl. all given options will be removed.
+     - If set to C(present) stanza incl.options will be added.
+     - To remove an option from the stanza set to C(present) and set key to an empty value (key=).
+     - All rules, allowed file-stanza combos or allowed files for the C(chsec) command also applies here.
+     type: str
+     choices: [ absent, present ]
+     default: present
+seealso:
+- name: The chsec manual page from the IBM Knowledge Center
+  description: Changes the attributes in the security stanza files.
+  link: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/com.ibm.aix.cmds1/chsec.htm
 author:
-    - Christian Tremel (@flynn1973)
+- Christian Tremel (@flynn1973)
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Add an LDAP user stanza
   aix_chsec:
     path: /etc/security/user
@@ -69,7 +69,7 @@ EXAMPLES = '''
     options: logintimes=:0800-1700
     state: present
 
-- name: Remove registry option from stanza 
+- name: Remove registry option from stanza
   aix_chsec:
     path: /etc/security/user
     stanza: ldapuser
@@ -79,9 +79,10 @@ EXAMPLES = '''
     state: present
 '''
 
+RETURN = r'''
+'''
 
 from ansible.module_utils.basic import AnsibleModule
-
 
 
 def do_stanza(module, filename, stanza, options, state='present'):
@@ -90,31 +91,31 @@ def do_stanza(module, filename, stanza, options, state='present'):
 
     def arguments_generator(options):
         for element in options:
-                yield '-a'
-                yield element
+            yield '-a'
+            yield element
 
     command = [chsec_command, '-f', filename, '-s', '%s' % stanza]
     options = list(arguments_generator(options))
 
     if state == 'present':
         command += options
-        rc, package_result, err = module.run_command(command)
+        rc, stdout, stderr = module.run_command(command)
         if rc != 0:
-            module.fail_json(msg='Failed to run chsec command (present).', rc=rc, err=err)
+            module.fail_json(msg='Failed to run chsec command (present).', rc=rc, stdout=stdout, stderr=stderr)
         else:
-            msg='stanza added'
-            changed=True
+            msg = 'stanza added'
+            changed = True
     elif state == 'absent':
-        # remove values from keys to enable chsec delete mode 
-        command += [s[:1+s.find('=')] or s for s in options]
-        rc, package_result, err = module.run_command(command)
+        # remove values from keys to enable chsec delete mode
+        command += [s[:1 + s.find('=')] or s for s in options]
+        rc, stdout, stderr = module.run_command(command)
         if rc != 0:
-             module.fail_json(msg='Failed to run chsec command (absent).', rc=rc, err=err)
+            module.fail_json(msg='Failed to run chsec command (absent).', rc=rc, stdout=stdout, stderr=stderr)
         else:
-             msg='stanza removed'
-             changed=True
+            msg = 'stanza removed'
+            changed = True
 
-    return (changed, msg)
+    return changed, msg
 
 
 def main():
@@ -124,7 +125,7 @@ def main():
             path=dict(type='path', required=True, aliases=['dest']),
             stanza=dict(type='str', required=True),
             options=dict(type='list', required=True),
-            state=dict(type='str', default='present', choices=['absent', 'present'])
+            state=dict(type='str', default='present', choices=['absent', 'present']),
         ),
         supports_check_mode=False,
     )
@@ -134,17 +135,15 @@ def main():
     options = module.params['options']
     state = module.params['state']
 
-    (changed, msg) = do_stanza(module, path, stanza, options, state)
-
-
     result = dict(
-        changed=changed,
-        msg=msg,
-        path=path,
+        changed=False,
     )
+
+    result['changed'], result['msg'] = do_stanza(module, path, stanza, options, state)
 
     # Mission complete
     module.exit_json(**result)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -68,7 +68,7 @@ EXAMPLES = '''
     options: logintimes=:0800-1700
     state: present
 
-- name: remove registry option from stanza 
+- name: Remove registry option from stanza 
   aix_chsec:
     path: /etc/security/user
     stanza: ldapuser

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -72,7 +72,9 @@ EXAMPLES = '''
   aix_chsec:
     path: /etc/security/user
     stanza: ldapuser
-    options: SYSTEM=LDAP,registry=
+    options:
+    - SYSTEM=LDAP
+    - registry=
     state: present
 '''
 

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -143,7 +143,7 @@ def main():
     )
 
     # Mission complete
-    module.exit_json(**results)
+    module.exit_json(**result)
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -44,7 +44,6 @@ options:
          default: present
 
 extends_documentation_fragment:
-    - files
 
 author:
     - Christian Tremel (@flynn1973)

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -15,7 +15,7 @@ DOCUMENTATION = '''
 ---
 module: aix_chsec
 
-short_description: modify aix stanza files
+short_description: Modify AIX stanza files
 
 version_added: "0.1"
 

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -42,6 +42,7 @@ options:
             - If set to C(present) stanza incl.options will be added.
             - To remove an option from the stanza set to C(present) and set key to an empty value (key=).
             - All rules/allowed file-stanza combos/allowed files for the chsec command also applies here, so once again, read "man chsec"!
+         type: str
          choices: [ absent, present ]
          default: present
 

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -136,7 +136,7 @@ def main():
     (changed, msg) = do_stanza(module, path, stanza, options, state)
 
 
-    results = dict(
+    result = dict(
         changed=changed,
         msg=msg,
         path=path,

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -61,7 +61,7 @@ EXAMPLES = '''
     state: present
     mode: 0644
 
-- name: change login times for user
+- name: Change login times for user
   aix_chsec:
     path: /etc/security/user
     stanza: ldapuser

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -17,7 +17,7 @@ module: aix_chsec
 
 short_description: Modify AIX stanza files
 
-version_added: "0.1"
+version_added: '2.8'
 
 description:
     - "adds stanzas to aix config files using the chsec command. see "man chsec" for additional infos"

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -80,7 +80,7 @@ EXAMPLES = '''
 '''
 
 
-from ansible.module_utils.basic import *
+from ansible.module_utils.basic import AnsibleModule
 
 
 

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -139,7 +139,7 @@ def main():
     results = dict(
         changed=changed,
         msg=msg,
-        path=path
+        path=path,
     )
 
     # Mission complete

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -34,7 +34,8 @@ options:
         required: true
     options:
          description:
-             - comman separated key/value pairs eg. key=val,key=val
+             - A list of key/value pairs, e.g. `key=val,key=val`
+         type: list
     state:
          description:
             - If set to C(absent) the whole stanza incl. all given options will be removed.

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -46,7 +46,6 @@ options:
          choices: [ absent, present ]
          default: present
 
-extends_documentation_fragment:
 
 author:
     - Christian Tremel (@flynn1973)


### PR DESCRIPTION
##### SUMMARY
adds stanzas to aix config files using the chsec command.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
aix_chsec

##### ADDITIONAL INFORMATION
example plays:
```yaml
- name: add ldap user stanza
  aix_chsec:
    path: /etc/security/user
    stanza: ldapuser
    options: SYSTEM=LDAP,registry=LDAP
    state: present
    mode: 0644

- name: change login times for user
  aix_chsec:
    path: /etc/security/user
    stanza: ldapuser
    options: logintimes=:0800-1700
    state: present

- name: remove registry option from stanza
  aix_chsec:
    path: /etc/security/user
    stanza: ldapuser
    options: SYSTEM=LDAP,registry=
    state: present
```