### PR TITLE
Extended cloudfront_facts module to have a predictable return value…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -225,7 +225,7 @@ summary:
     returned: as default or if summary is true
     type: dict
 result:
-    description:i >
+    description: >
         Result dict not nested under the cloudfront id to access results of module without the knowledge of that id
         as figuring out the DistributionId is usually the reason one uses this module in the first place.
     returned: always

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -224,6 +224,10 @@ summary:
     description: Gives a summary of distributions, streaming distributions and origin access identities.
     returned: as default or if summary is true
     type: dict
+DistributionId:
+    description: Returns id of found distribution
+    returned: always
+    type: string
 '''
 
 from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, boto3_conn, HAS_BOTO3

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -224,10 +224,12 @@ summary:
     description: Gives a summary of distributions, streaming distributions and origin access identities.
     returned: as default or if summary is true
     type: dict
-DistributionId:
-    description: Returns id of found distribution
+result:
+    description:i >
+        Result dict not nested under the cloudfront id to access results of module without the knowledge of that id
+        as figuring out the DistributionId is usually the reason one uses this module in the first place.
     returned: always
-    type: string
+    type: dict
 '''
 
 from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, boto3_conn, HAS_BOTO3

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -531,6 +531,10 @@ class CloudFrontServiceManager:
 
 def set_facts_for_distribution_id_and_alias(details, facts, distribution_id, aliases):
     facts[distribution_id].update(details)
+    # also have a fixed key for accessing results/details returned
+    facts['result'] = details
+    facts['result']['DistributionId'] = distribution_id
+
     for alias in aliases:
         facts[alias].update(details)
     return facts


### PR DESCRIPTION
…for getting results without needing to know the CloudFront id. If you are actually searching for Cloudfront distributions to get the ID this quite helpful in my opinion. WDYT?

##### SUMMARY
Additional return value field `result` containing the cloudfront facts without being hidden behind a dict key.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cloudfront_facts module

##### ADDITIONAL INFORMATION

There is obviously ways to work arround that in yaml code too but they tend to get messy. So I think a 2 line addition to the module is probably a better solution.
