### PR TITLE
docker_container: fix init option idempotency with old docker-py versions

### DIFF
--- a/changelogs/fragments/49078-docker_container-min-version-fix.yml
+++ b/changelogs/fragments/49078-docker_container-min-version-fix.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "docker_container - fix idempotency problems with docker-py caused by previous ``init`` idempotency fix."
+- "docker_container - fix interplay of docker-py version check with argument_spec validation improvements."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2293,7 +2293,7 @@ class ContainerManager(DockerBaseClass):
                 if image_different:
                     self.diff['image_different'] = True
                 self.log("differences")
-                self.log(differences, pretty_print=True)
+                self.log(differences.get_legacy_docker_container_diffs(), pretty_print=True)
                 image_to_use = self.parameters.image
                 if not image_to_use and container and container.Image:
                     image_to_use = container.Image

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1854,6 +1854,9 @@ class Container(DockerBaseClass):
 
         differences = DifferenceTracker()
         for key, value in config_mapping.items():
+            minimal_version = self.parameters.client.option_minimal_versions.get(key, {})
+            if not minimal_version.get('supported', True):
+                continue
             compare = self.parameters.client.comparisons[self.parameters_map.get(key, key)]
             self.log('check differences %s %s vs %s (%s)' % (key, getattr(self.parameters, key), str(value), compare))
             if getattr(self.parameters, key, None) is not None:

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2743,7 +2743,7 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
         # Helper function to detect whether any specified network uses ipv4_address or ipv6_address
         def detect_ipvX_address_usage():
             for network in self.module.params.get("networks") or []:
-                if 'ipv4_address' in network or 'ipv6_address' in network:
+                if network.get('ipv4_address') is not None or network.get('ipv6_address') is not None:
                     return True
             return False
 


### PR DESCRIPTION
##### SUMMARY
As reported in #49070, older versions of docker-py have idempotency problems because of the `init` option. Since idempotency checking for `init` was only added recently (#48551), I didn't notice this after implementing #48074, I didn't again ran the tests against all supported docker-py versions.

Fixes #49070.

I'll test this against all docker-py versions; if I find more problems, I'll add them to this PR, and remove the WIP tag once I'm done.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
