### PR TITLE
[2.7] add required state parameter to acme_certificate route53 example

### DIFF
--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -234,7 +234,7 @@ EXAMPLES = R'''
 #     type: TXT
 #     ttl: 60
 #     # Note: route53 requires TXT entries to be enclosed in quotes
-#     value: "{{ sample_com_challenge.challenge_data['sample.com']['dns-01'].resource_value }}"
+#     value: "{{ sample_com_challenge.challenge_data['sample.com']['dns-01'].resource_value | regex_replace('^(.*)$', '\"\\1\"') }}"
 #     when: sample_com_challenge is changed
 #
 # Alternative way:
@@ -246,7 +246,7 @@ EXAMPLES = R'''
 #     ttl: 60
 #     # Note: item.value is a list of TXT entries, and route53
 #     # requires every entry to be enclosed in quotes
-#     value: "{{ item.value | map('regex_replace', '^(.*)$', '\'\\1\'' ) | list }}"
+#     value: "{{ item.value | map('regex_replace', '^(.*)$', '\"\\1\"' ) | list }}"
 #     with_dict: sample_com_challenge.challenge_data_dns
 #     when: sample_com_challenge is changed
 

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -233,6 +233,7 @@ EXAMPLES = R'''
 #     record: "{{ sample_com_challenge.challenge_data['sample.com']['dns-01'].record }}"
 #     type: TXT
 #     ttl: 60
+#     state: present
 #     # Note: route53 requires TXT entries to be enclosed in quotes
 #     value: "{{ sample_com_challenge.challenge_data['sample.com']['dns-01'].resource_value | regex_replace('^(.*)$', '\"\\1\"') }}"
 #     when: sample_com_challenge is changed
@@ -244,6 +245,7 @@ EXAMPLES = R'''
 #     record: "{{ item.key }}"
 #     type: TXT
 #     ttl: 60
+#     state: present
 #     # Note: item.value is a list of TXT entries, and route53
 #     # requires every entry to be enclosed in quotes
 #     value: "{{ item.value | map('regex_replace', '^(.*)$', '\"\\1\"' ) | list }}"


### PR DESCRIPTION
##### SUMMARY
Backport of #49031 to stable-2.7: fixes DNS auth examples (usage of route53 module).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
acme_certificate
