### PR TITLE
Amends #47040 - influxdb_user - Prevents potential accidental password changes to blank

### DIFF
--- a/changelogs/fragments/49084-influxdb_user-default-password-fix.yaml
+++ b/changelogs/fragments/49084-influxdb_user-default-password-fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - influxdb_user - An unspecified password now sets the password to blank, except on existing users. This previously caused an unhandled exception.

--- a/lib/ansible/modules/database/influxdb/influxdb_user.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_user.py
@@ -157,7 +157,7 @@ def main():
 
     state = module.params['state']
     user_name = module.params['user_name']
-    user_password = module.params['user_password'] or ''
+    user_password = module.params['user_password']
     admin = module.params['admin']
     influxdb = influx.InfluxDb(module)
     client = influxdb.connect_to_influxdb()
@@ -167,7 +167,7 @@ def main():
         if user:
             changed = False
 
-            if not check_user_password(module, client, user_name, user_password):
+            if not check_user_password(module, client, user_name, user_password) and user_password is not None:
                 set_user_password(module, client, user_name, user_password)
                 changed = True
 
@@ -183,6 +183,7 @@ def main():
 
             module.exit_json(changed=changed)
         else:
+            user_password = user_password or ''
             create_user(module, client, user_name, user_password, admin)
 
     if state == 'absent':


### PR DESCRIPTION
##### SUMMARY
Amends #47040

I'm concerned of the possibility that someone might mistakenly leave the user password unspecified on an existing user with a password and reset that user's password to a blank password.

This avoids that by not changing the password on an existing user if the attribute is unspecified. If they truly want to reset the password to blank, they can still do so by explicitly passing an empty string.

I've also added a changelog fragment to this PR.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
influxdb_user