### PR TITLE
docker: don't jsonify after and before on diff return

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -680,10 +680,7 @@ class DifferenceTracker(object):
         for item in self._diff:
             before[item['name']] = item['active']
             after[item['name']] = item['parameter']
-        return (
-            jsonify(before, sort_keys=True, indent=2),
-            jsonify(after, sort_keys=True, indent=2),
-        )
+        return before, after
 
     def get_legacy_docker_container_diffs(self):
         '''


### PR DESCRIPTION
##### SUMMARY
The current `DifferenceTracker` implementation in `module_utils/docker_common` creates `before` and `after` by running `jsonify()` on internal data structures. When I implemented that, I didn't knew that Ansible will do that itself if the internal data structures are returned directly. This is in particular important if other callback plugins are used; for example, for the YAML callback plugin, the diff is made using the YAML dump of `before` and `after` (if they are `dict`s); see #48794.

Not including changelog since this is a new 2.8 feature which is only slightly modified (and not in a way which affects the existing changelog).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/docker_common.py
