### PR TITLE
fix typo in ansible-galaxy info output

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -283,7 +283,7 @@ class GalaxyCLI(CLI):
             install_info = gr.install_info
             if install_info:
                 if 'version' in install_info:
-                    install_info['intalled_version'] = install_info['version']
+                    install_info['installed_version'] = install_info['version']
                     del install_info['version']
                 role_info.update(install_info)
 


### PR DESCRIPTION
##### SUMMARY
Fix a typo in the `ansible-galaxy info` output.   Current example:
```
$ ansible-galaxy info triplepoint.unifi | cat

Role: triplepoint.unifi
	description: The Ubiquiti Unifi controller service
	active: True
	commit: 7ff3aa1d86566dc7cbdf193dc21b4e7d7dd52441
        {redacted}
	install_date: Tue Sep 25 06:08:39 2018
	intalled_version: 1.0.2
        {truncated}
```
note the `intalled_version` typo.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy CLI tool
