### PR TITLE
changed documented default value for url

### DIFF
--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -24,7 +24,7 @@ DOCUMENTATION = '''
         choices: ['foreman']
       url:
         description: url to foreman
-        default: 'http://localhost:300'
+        default: 'http://localhost:3000'
       user:
         description: foreman authentication user
         required: True


### PR DESCRIPTION
the Default Value for url  port is 3000, so there was a mistake in the documentation

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
changed the documentated Default Value fur url to the correct Port
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```