### PR TITLE
Update git example

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -187,7 +187,7 @@ EXAMPLES = '''
 
 # Example read-write git checkout from github
 - git:
-    repo: ssh://git@github.com/mylogin/hello.git
+    repo: git@github.com/mylogin/hello.git
     dest: /home/mylogin/hello
 
 # Example just ensuring the repo checkout exists

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -187,7 +187,7 @@ EXAMPLES = '''
 
 # Example read-write git checkout from github
 - git:
-    repo: git@github.com/mylogin/hello.git
+    repo: git@github.com:mylogin/hello.git
     dest: /home/mylogin/hello
 
 # Example just ensuring the repo checkout exists


### PR DESCRIPTION
##### SUMMARY
Fixes the git clone docs example.

Once I removed the prefix ssh:// it worked as expected.

Since the default URL from GitHub for example uses an URL in a different format, the documentation can be a bit misleading.
I think using an example most compatible with most common use case that is going to GitHub and copy the URL.

<img width="460" alt="github-url-example" src="https://user-images.githubusercontent.com/1537510/48979251-c3387400-f0af-11e8-8b0e-c8d1af25679c.png">



##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

source_control git module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Was getting this error msg:
```
ssh: Could not resolve hostname bitbucket.org:BernardoSilva: Name or service not known\r\nfatal: The remote end hung up unexpectedly
```


<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

```yml
- name: 'Checkout project into {{ deploy_path }}'
  git:
    repo: ssh://git@bitbucket.org:BernardoSilva/my-project.git
    dest: '{{ deploy_path }}'
    accept_hostkey: yes
    ssh_opts: '-o StrictHostKeyChecking=no'
bitbucket.org:BernardoSilva/my-project.git
```

Ran in verbose mode and saw that this was happening:
```
"cmd": "/usr/bin/git clone --origin origin 'ssh:********@bitbucket.org:BernardoSilva/my-project.git'
```


<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:

```
TASK [app : Checkout project into /my-deploy-path/] ****************************************************************************************************************************************
fatal: [xxx.xxx.xxx.xxx]: FAILED! => {"changed": false, "cmd": "/usr/bin/git clone --origin origin 'ssh:********@bitbucket.org:BernardoSilva/my-project.git' /my-deploy-path", "msg": "ssh: Could not resolve hostname bitbucket.org:BernardoSilva: Name or service not known\r\nfatal: The remote end hung up unexpectedly", "rc": 128, "stderr": "ssh: Could not resolve hostname bitbucket.org:BernardoSilva: Name or service not known\r\nfatal: The remote end hung up unexpectedly\n", "stderr_lines": ["ssh: Could not resolve hostname bitbucket.org:BernardoSilva: Name or service not known", "fatal: The remote end hung up unexpectedly"], "stdout": "Initialized empty Git repository in /my-deploy-path/.git/\n", "stdout_lines": ["Initialized empty Git repository in /my-deploy-path/.git/"]}
	to retry, use: --limit webserver.retry
```

After:
```
TASK [app : Checkout project into /my-deploy-path] ****************************************************************************************************************************************
changed: [xxx.xxx.xxx.xxx] => {"after": "6d77099c3d56d7eed9aec90c2fd72a61bb9af9bf", "before": null, "changed": true}
```
