### PR TITLE
nmcli example: modern way to install packages

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -314,15 +314,13 @@ EXAMPLES = '''
   tasks:
 
   - name: install needed network manager libs
-    yum:
-      name: '{{ item }}'
+    package:
+      name:
+        - NetworkManager-glib
+        - nm-connection-editor
+        - libsemanage-python
+        - policycoreutils-python
       state: installed
-    with_items:
-      - NetworkManager-glib
-      - libnm-qt-devel.x86_64
-      - nm-connection-editor.x86_64
-      - libsemanage-python
-      - policycoreutils-python
 
 ##### Working with all cloud nodes - Teaming
   - name: try nmcli add team - conn_name only & ip4 gw4


### PR DESCRIPTION
##### SUMMARY

- use the generic `package` module, this way it will cover dnf and yum
- to not specify the x86_64 arch, the package manager will pull the fine
  version anyway
- with_items with package is deprecated
  See: https://docs.ansible.com/ansible/2.7/porting_guides/porting_guide_2.7.html#using-a-loop-on-a-package-module-via-squash-actions

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

- net_tools/nmcli.py