### PR TITLE
ec2_metadata_facts: Revert back to getting the AWS role name from the URI

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
@@ -467,8 +467,9 @@ class Ec2Metadata(object):
         new_fields = {}
         for key, value in fields.items():
             split_fields = key[len(uri):].split('/')
-            if len(split_fields) == 2 and split_fields[0:2] == ['iam', 'info_instanceprofilearn']:
-                new_fields[self._prefix % "iam-instance-profile-role"] = value.split('/')[1]
+            # Parse out the IAM role name (which is _not_ the same as the instance profile name)
+            if len(split_fields) == 3 and split_fields[0:2] == ['iam', 'security-credentials'] and ':' not in split_fields[2]:
+                new_fields[self._prefix % "iam-instance-profile-role"] = split_fields[2]
             if len(split_fields) > 1 and split_fields[1]:
                 new_key = "-".join(split_fields)
                 new_fields[self._prefix % new_key] = value
@@ -504,7 +505,7 @@ class Ec2Metadata(object):
                         dict = json.loads(content)
                         self._data['%s' % (new_uri)] = content
                         for (key, value) in dict.items():
-                            self._data['%s_%s' % (new_uri, key.lower())] = value
+                            self._data['%s:%s' % (new_uri, key.lower())] = value
                     except:
                         self._data['%s' % (new_uri)] = content  # not a stringifed JSON string
 


### PR DESCRIPTION
##### SUMMARY
- The role name and instance profile name _can_ be different, the change made in #45534 gets the instance profile name, not the role name
- Change the delimiter to `:` for keys that are discovered through the JSON parsing (which is not a valid delimiter for AWS IAM role names), this delimiter is still converted to underscore
- Now checks for the existence of that delimiter to remove the cases where the JSON keys are appended to the role name to find the role name

_Actually_ fixes #45228

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_metadata_facts

##### ADDITIONAL INFORMATION
Before:
```
"ansible_ec2_iam_instance_profile_role": "<instance profile name>"
```
After:
```
"ansible_ec2_iam_instance_profile_role": "<role name>"
```

See https://github.com/ansible/ansible/pull/45534#issuecomment-439918305 for an explanation for what the real world behavior looks like. The [CLI example](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#create-iam-role) that AWS provides for EC2 instance profile creation _does_ have a different name for the role name and instance profile name. When creating instance profiles through the AWS console, the role name and the instance profile name are the _same_, which is why this issue didn't manifest itself through my previous testing.
