### PR TITLE
rabbitmq_user: Specify key to use while sorting permissions

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
@@ -117,6 +117,7 @@ EXAMPLES = '''
         write_priv: .*
     state: present
 '''
+import operator
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -230,7 +231,8 @@ class RabbitMqUser(object):
         return set(self.tags) != set(self._tags)
 
     def has_permissions_modifications(self):
-        return sorted(self._permissions) != sorted(self.permissions)
+        sort_key_fetch = operator.itemgetter('vhost')
+        return sorted(self._permissions, key=sort_key_fetch) != sorted(self.permissions, key=sort_key_fetch)
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Without specifying the dictionary key to use while sorting it will fail
in Python 3 environments due to simplifying Python's rules for ordering
comparisons: https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons

Fixes #49120 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rabbitmq_user

##### ADDITIONAL INFORMATION
The basic idea is to use the `vhost` dictionary key for sorting, which should be unique in the list according to https://www.rabbitmq.com/access-control.html#permissions ("Permissions are expressed as a triple of regular expressions - one each for configure, write and read - **on per-vhost basis**.").

I didn't find a unit test file I could extend, so no tests added. Please let me know if I just didn't look hard enough.

My Python is a bit rusty, so please let me know if I can improve it or feel free to base a new patch for #49120 on it.
