### PR TITLE
Incorrect parsing of media type in OpenBSD

### DIFF
--- a/lib/ansible/module_utils/facts/network/openbsd.py
+++ b/lib/ansible/module_utils/facts/network/openbsd.py
@@ -36,6 +36,30 @@ class OpenBSDNetwork(GenericBsdIfconfigNetwork):
         current_if['macaddress'] = words[1]
         current_if['type'] = 'ether'
 
+    def get_media_select(self, media_string):
+        last = media_string.find('(')
+        media_select = media_string[:last].rstrip() if last != -1 else media_string
+        return media_select
+
+    def get_media_type_and_options(self, media_string):
+        first = media_string.find('(') + 1
+        media_type_opts = media_string[first::].rstrip(')') if first else ''
+        return media_type_opts
+
+    def parse_media_line(self, words, current_if, ips):
+        # not sure if this is useful - we also drop information
+        current_if['media'] = words[1]
+
+        media_string = ' '.join(words[2:])
+        if len(words) > 2:
+            current_if['media_select'] = self.get_media_select(media_string)
+
+        if len(words) > 3:
+            media_type_opts_list = self.get_media_type_and_options(media_string).split(' ')
+            current_if['media_type'] = media_type_opts_list[0]
+            if len(media_type_opts_list) > 1:
+                current_if['media_options'] = media_type_opts_list[1].split(',')
+
 
 class OpenBSDNetworkCollector(NetworkCollector):
     _fact_class = OpenBSDNetwork


### PR DESCRIPTION
##### SUMMARY
Fixes #49051

Based on the issue, there is a possibility that the output of ifconfig for OpenBSD is similar to below which would cause to show a closing parenthesis for media_type.
```
$ ifconfig -Aa 
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 32768
        index 3 priority 0 llprio 3
        groups: lo
        inet6 ::1 prefixlen 128
        inet6 fe80::1%lo0 prefixlen 64 scopeid 0x3
        inet 127.0.0.1 netmask 0xff000000
vmx0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 1500
        lladdr 00:50:56:ba:d4:2e
        index 1 priority 0 llprio 3
        groups: egress
        media: Ethernet autoselect (10GbaseT)
        status: active
        inet 192.168.XXX.YYY netmask 0xffffff00 broadcast 192.168.XXX.YYY
enc0: flags=0<>
        index 2 priority 0 llprio 3
        groups: enc
        status: active
pflog0: flags=141<UP,RUNNING,PROMISC> mtu 33136
        index 4 priority 0 llprio 3
        groups: pflog
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
generic_bsd.py

