### PR TITLE
[stable-2.7] pip: Fix the mistake replacement from 'distribute' to 'setuptools' (#47403)

### DIFF
--- a/changelogs/fragments/47198-fix-setuptools-distutils.yaml
+++ b/changelogs/fragments/47198-fix-setuptools-distutils.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "pip module - fix setuptools/distutils replacement (https://github.com/ansible/ansible/issues/47198)"

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -503,8 +503,8 @@ class Package:
             name_string = separator.join((name_string, version_string))
         try:
             self._requirement = Requirement.parse(name_string)
-            # old pkg_resource will replace 'setuptools' with 'distribute' when it already installed
-            if self._requirement.project_name == "distribute":
+            # old pkg_resource will replace 'setuptools' with 'distribute' when it's already installed
+            if self._requirement.project_name == "distribute" and "setuptools" in name_string:
                 self.package_name = "setuptools"
                 self._requirement.project_name = "setuptools"
             else:

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -499,3 +499,15 @@
   pip:
     name: "{{ pip_test_packages }}"
     state: absent
+
+# https://github.com/ansible/ansible/issues/47198
+- name: try to remove distribute
+  pip:
+    state: "absent"
+    name: "distribute"
+  ignore_errors: yes
+  register: remove_distribute
+
+- name: inspect the cmd
+  assert:
+    that: "'distribute' in remove_distribute.cmd"


### PR DESCRIPTION
* Fix the mistake replace from distribute to setuptools

* Add a testcase for this bug
(cherry picked from commit 93c5781)

Co-authored-by: Zhikang Zhang <zzhang63@ncsu.edu>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Backport Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pip

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
