### PR TITLE
split PS wrapper and payload (CVE-2018-16859)

### DIFF
--- a/changelogs/fragments/ps_sb_logging.yaml
+++ b/changelogs/fragments/ps_sb_logging.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Windows - prevent sensitive content from appearing in scriptblock logging (CVE 2018-16859)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -912,7 +912,8 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
         # FUTURE: smuggle this back as a dict instead of serializing here; the connection plugin may need to modify it
         module_json = json.dumps(exec_manifest)
 
-        b_module_data = exec_wrapper.replace(b"$json_raw = ''", b"$json_raw = @'\r\n%s\r\n'@" % to_bytes(module_json))
+        # delimit the payload JSON from the wrapper to keep sensitive contents out of scriptblocks (which can be logged)
+        b_module_data = to_bytes(exec_wrapper) + b'\0\0\0\0' + to_bytes(module_json)
 
     elif module_substyle == 'jsonargs':
         module_args_json = to_bytes(json.dumps(module_args))

--- a/lib/ansible/executor/powershell/bootstrap_wrapper.ps1
+++ b/lib/ansible/executor/powershell/bootstrap_wrapper.ps1
@@ -1,0 +1,7 @@
+&chcp.com 65001 > $null
+$exec_wrapper_str = $input | Out-String
+$split_parts = $exec_wrapper_str.Split(@("`0`0`0`0"), 2, [StringSplitOptions]::RemoveEmptyEntries)
+If (-not $split_parts.Length -eq 2) { throw "invalid payload" }
+Set-Variable -Name json_raw -Value $split_parts[1]
+$exec_wrapper = [ScriptBlock]::Create($split_parts[0])
+&$exec_wrapper

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -278,6 +278,7 @@ class Connection(ConnectionBase):
             # starting a new interpreter to save on time
             b_command = base64.b64decode(cmd.split(" ")[-1])
             script = to_text(b_command, 'utf-16-le')
+            in_data = to_text(in_data, errors="surrogate_or_strict", nonstring="passthru")
             display.vvv("PSRP: EXEC %s" % script, host=self._psrp_host)
         else:
             # in other cases we want to execute the cmd as the script

--- a/test/integration/targets/win_become/tasks/main.yml
+++ b/test/integration/targets/win_become/tasks/main.yml
@@ -1,7 +1,7 @@
 - set_fact:
     become_test_username: ansible_become_test
     become_test_admin_username: ansible_become_admin
-    gen_pw: password123! + {{ lookup('password', '/dev/null chars=ascii_letters,digits length=8') }}
+    gen_pw: "{{ 'password123!' + lookup('password', '/dev/null chars=ascii_letters,digits length=8') }}"
 
 - name: create unprivileged user
   win_user:
@@ -28,6 +28,10 @@
   - SeNetworkLogonRight
   - SeInteractiveLogonRight
   - SeBatchLogonRight
+
+- name: fetch current target date/time for log filtering
+  raw: '[datetime]::now | Out-String'
+  register: test_starttime
 
 - name: execute tests and ensure that test user is deleted regardless of success/failure
   block:
@@ -199,6 +203,7 @@
     assert:
       that:
       - whoami_out is successful
+      - become_test_username in whoami_out.stdout
 
   - name: test failure with string become invalid key
     vars: *become_vars
@@ -311,6 +316,18 @@
       - nonascii_output.stdout_lines|count == 1
       - nonascii_output.stdout_lines[0] == 'über den Fußgängerübergang gehen'
       - nonascii_output.stderr == ''
+
+  - name: get PS events containing password or module args created since test start
+    raw: |
+      $dt=[datetime]"{{ test_starttime.stdout|trim }}"
+      (Get-WinEvent -LogName Microsoft-Windows-Powershell/Operational |
+      ? { $_.TimeCreated -ge $dt -and $_.Message -match "{{ gen_pw }}|whoami" }).Count
+    register: ps_log_count
+
+  - name: assert no PS events contain password or module args
+    assert:
+      that:
+      - ps_log_count.stdout | int == 0
 
 # FUTURE: test raw + script become behavior once they're running under the exec wrapper again
 # FUTURE: add standalone playbook tests to include password prompting and play become keywords


### PR DESCRIPTION
##### SUMMARY
backport of https://github.com/ansible/ansible/pull/49142
* addresses CVE-2018-16859
* prevent scriptblock logging from logging payload contents
* added tests to verify no payload contents in PS Operational event log
* fix script action to send split-aware wrapper
* fix CLIXML error parser (return to -EncodedCommand exposed problems with it)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
powershell.py

##### ADDITIONAL INFORMATION
