### PR TITLE
Fix n3k power supply facts

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -734,9 +734,13 @@ class Legacy(FactsBase):
         ('psmodel', 'model'),
         ('psnum', 'number'),
         ('ps_status', 'status'),
+        ('ps_status_3k', 'status'),
         ('actual_out', 'actual_output'),
         ('actual_in', 'actual_in'),
-        ('total_capa', 'total_capacity')
+        ('total_capa', 'total_capacity'),
+        ('input_type', 'input_type'),
+        ('watts', 'watts'),
+        ('amps', 'amps')
     ])
 
     def populate(self):


### PR DESCRIPTION
##### SUMMARY
This PR fixes an issue where the structured output for power supply information is not presented the same way on different N3k platforms.



##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_facts

##### ADDITIONAL INFORMATION

Power supply information can be presented in different ways depending on the platform.

**Example 1:**
```json
    "powersup": {
        "TABLE_psinfo": {
            "ROW_psinfo": [
                {
                    "psnum": "1", 
                    "psmodel": "NXA-PAC-650W-PE", 
                    "actual_out": "0 W", 
                    "actual_input": "0 W", 
                    "tot_capa": "0 W", 
                    "ps_status": "Shutdown"
                }, 
                {
                    "psnum": "2", 
                    "psmodel": "NXA-PAC-650W-PE", 
                    "actual_out": "94 W", 
                    "actual_input": "106 W", 
                    "tot_capa": "650 W", 
                    "ps_status": "Ok"
                }
            ]
        }, 
```

**Example 2:**
```json
    "powersup": {
        "TABLE_psinfo": [
            {
                "ROW_psinfo": {
                    "psmodel": "N2200-PAC-400W", 
                    "input_type": "AC", 
                    "watts": "396.00", 
                    "amps": "33.00", 
                    "ps_status_3k": "ok"
                }
            }, 
            {
                "ROW_psinfo": {
                    "psmodel": "--", 
                    "input_type": "--", 
                    "watts": "--", 
                    "amps": "--", 
                    "ps_status_3k": "fail/not-powered-up"
                }
            }
        ], 
```

Here is the failure seen before this change.

```
ASK [Get the NX-OS version] ************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'unicode' object has no attribute 'get'
fatal: [31108-1]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_jX14Xg/ansible_module_nxos_facts.py\", line 602, in <module>\n    main()\n  File \"/tmp/ansible_jX14Xg/ansible_module_nxos_facts.py\", line 585, in main\n    inst.populate()\n  File \"/tmp/ansible_jX14Xg/ansible_module_nxos_facts.py\", line 233, in populate\n    if data.get('sys_ver_str'):\nAttributeError: 'unicode' object has no attribute 'get'\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: list indices must be integers, not str
fatal: [3064-1]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_nxmyNb/ansible_module_nxos_facts.py\", line 602, in <module>\n    main()\n  File \"/tmp/ansible_nxmyNb/ansible_module_nxos_facts.py\", line 585, in main\n    inst.populate()\n  File \"/tmp/ansible_nxmyNb/ansible_module_nxos_facts.py\", line 476, in populate\n    self.facts['_power_supply_info'] = self.parse_power_supply_info(data)\n  File \"/tmp/ansible_nxmyNb/ansible_module_nxos_facts.py\", line 516, in parse_power_supply_info\n    data = data['powersup']['TABLE_psinfo']['ROW_psinfo']\nTypeError: list indices must be integers, not str\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: list indices must be integers, not str
fatal: [3048-1]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_r8ISSI/ansible_module_nxos_facts.py\", line 602, in <module>\n    main()\n  File \"/tmp/ansible_r8ISSI/ansible_module_nxos_facts.py\", line 585, in main\n    inst.populate()\n  File \"/tmp/ansible_r8ISSI/ansible_module_nxos_facts.py\", line 476, in populate\n    self.facts['_power_supply_info'] = self.parse_power_supply_info(data)\n  File \"/tmp/ansible_r8ISSI/ansible_module_nxos_facts.py\", line 516, in parse_power_supply_info\n    data = data['powersup']['TABLE_psinfo']['ROW_psinfo']\nTypeError: list indices must be integers, not str\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
```

**With the fix:**
```json
       "power_supply_info": [
            {
                "amps": "33.00", 
                "input_type": "AC", 
                "model": "N2200-PAC-400W", 
                "status": "ok", 
                "watts": "396.00"
            }, 
            {
                "amps": "--", 
                "input_type": "--", 
                "model": "--", 
                "status": "fail/not-powered-up", 
                "watts": "--"
            }
        ], 
```