### PR TITLE
k8s: Fix error where pod has error and no containers

### DIFF
--- a/lib/ansible/plugins/inventory/k8s.py
+++ b/lib/ansible/plugins/inventory/k8s.py
@@ -236,6 +236,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable, K8sAnsibleM
             else:
                 pod_labels = {}
 
+            if not pod.status.containerStatuses:
+                continue
+
             for container in pod.status.containerStatuses:
                 # add each pod_container to the namespace group, and to each label_value group
                 container_name = '{0}_{1}'.format(pod.metadata.name, container.name)


### PR DESCRIPTION
##### SUMMARY
This fixes a scenario where the inventory plugin was throwing an error, preventing it from being used, when a pod was in some kind of degenerate state.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/k8s.py

##### ADDITIONAL INFORMATION
Without this, I was getting:

```paste below
 [WARNING]:  * Failed to parse /Users/alancoding/Documents/repos/tower-qa/openshift.yml with yaml plugin: Plugin configuration YAML file, not YAML inventory


 [WARNING]:  * Failed to parse /Users/alancoding/Documents/repos/tower-qa/openshift.yml with ini plugin: Invalid host pattern 'plugin:' supplied, ending in ':' is
not allowed, this character is reserved to provide a port.

  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/plugins/inventory/ini.py", line 136, in parse
    self._parse(path, data)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/plugins/inventory/ini.py", line 214, in _parse
    hosts, port, variables = self._parse_host_definition(line)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/plugins/inventory/ini.py", line 306, in _parse_host_definition
    (hostnames, port) = self._expand_hostpattern(tokens[0])
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/plugins/inventory/ini.py", line 328, in _expand_hostpattern
    hostpattern)

 [WARNING]:  * Failed to parse /Users/alancoding/Documents/repos/tower-qa/openshift.yml with auto plugin: 'NoneType' object is not iterable

  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/inventory/manager.py", line 267, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/plugins/inventory/auto.py", line 55, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/plugins/inventory/k8s.py", line 147, in parse
    self.setup(config_data, cache, cache_key)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/plugins/inventory/k8s.py", line 165, in setup
    self.fetch_objects(connections)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/plugins/inventory/openshift.py", line 125, in fetch_objects
    super(InventoryModule, self).fetch_objects(connections)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/plugins/inventory/k8s.py", line 184, in fetch_objects
    self.get_pods_for_namespace(client, name, namespace)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/plugins/inventory/k8s.py", line 241, in get_pods_for_namespace
    for container in getattr(pod.status, 'containerStatuses', ()):

 [WARNING]: Unable to parse /Users/alancoding/Documents/repos/tower-qa/openshift.yml as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

{
    "_meta": {
        "hostvars": {}
    }, 
    "all": {
        "children": [
            "ungrouped"
        ]
    }
}
```

When I looked into the "status" entry of the pod which was giving trouble, I saw:

```python
u'status': {u'message': u'The node was low on resource: imagefs.',
```