### PR TITLE
meraki_network - Parameter change for combined network type

### DIFF
--- a/changelogs/fragments/49160-meraki_network-combined-type-change.yml
+++ b/changelogs/fragments/49160-meraki_network-combined-type-change.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "meraki_network - type parameter no longer accepts combined. Instead, the network types should be specified in a list."

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -47,6 +47,7 @@ options:
         description:
         - Type of network device network manages.
         - Required when creating a network.
+        - As of Ansible 2.8, combined type has moved to the types parameter.
         choices: [appliance, switch, wireless]
         aliases: [net_type]
     types:
@@ -200,7 +201,7 @@ def main():
     argument_spec = meraki_argument_spec()
     argument_spec.update(
         net_id=dict(type='str'),
-        type=dict(type='str', choices=['wireless', 'switch', 'appliance', 'combined'], aliases=['net_type']),
+        type=dict(type='str', choices=['wireless', 'switch', 'appliance'], aliases=['net_type']),
         types=dict(type='list', aliases=['net_types']),
         tags=dict(type='str'),
         timezone=dict(type='str'),

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2018, Kevin Breit (@kbreit) <kevin.breit@kevinbreit.net>
+# Copyright: (c) 2018, 2019 Kevin Breit (@kbreit) <kevin.breit@kevinbreit.net>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -51,6 +51,10 @@ options:
         choices: [ appliance, switch, wireless ]
         aliases: [net_type]
         type: list
+    tags:
+        type: list
+        description:
+        - Comma delimited list of tags to assign to network.
     timezone:
         description:
         - Timezone associated to network.

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -48,13 +48,15 @@ options:
         - Type of network device network manages.
         - Required when creating a network.
         - As of Ansible 2.8, C(combined) type is no longer accepted.
+        - As of Ansible 2.8, changes to this parameter are no longer idempotent.
         choices: [ appliance, switch, wireless ]
         aliases: [net_type]
         type: list
     tags:
         type: list
         description:
-        - Comma delimited list of tags to assign to network.
+        - List of tags to assign to network.
+        - C(tags) name conflicts with the tags parameter in Ansible. Indentation problems may cause unexpected behaviors.
     timezone:
         description:
         - Timezone associated to network.

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -48,7 +48,7 @@ options:
         - Type of network device network manages.
         - Required when creating a network.
         - As of Ansible 2.8, combined type has moved to the types parameter.
-        choices: [appliance, switch, wireless]
+        choices: [ appliance, switch, wireless ]
         aliases: [net_type]
     types:
         description:

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -47,18 +47,10 @@ options:
         description:
         - Type of network device network manages.
         - Required when creating a network.
-        - As of Ansible 2.8, combined type has moved to the types parameter.
+        - As of Ansible 2.8, C(combined) type is no longer accepted.
         choices: [ appliance, switch, wireless ]
         aliases: [net_type]
-    types:
-        description:
-        - Type of network device network manages.
-        - Identical to type, but used when multiple network types are needed in a single network.
-        aliases: ['net_types']
-        version_added: '2.8'
-    tags:
-        description:
-        - Comma delimited list of tags to assign to network.
+        type: list
     timezone:
         description:
         - Timezone associated to network.
@@ -105,7 +97,7 @@ EXAMPLES = r'''
     state: present
     org_name: YourOrg
     net_name: MyNet
-    types:
+    type:
       - switch
       - appliance
     timezone: America/Chicago
@@ -190,7 +182,7 @@ def list_to_string(data):
             new_string += i
         else:
             new_string = "{0}{1} ".format(new_string, item)
-    return new_string
+    return new_string.strip()
 
 
 def main():
@@ -201,8 +193,7 @@ def main():
     argument_spec = meraki_argument_spec()
     argument_spec.update(
         net_id=dict(type='str'),
-        type=dict(type='str', choices=['wireless', 'switch', 'appliance'], aliases=['net_type']),
-        types=dict(type='list', aliases=['net_types']),
+        type=dict(type='list', choices=['wireless', 'switch', 'appliance'], aliases=['net_type']),
         tags=dict(type='str'),
         timezone=dict(type='str'),
         net_name=dict(type='str', aliases=['name', 'network']),
@@ -249,9 +240,7 @@ def main():
         if meraki.params['net_name']:
             payload['name'] = meraki.params['net_name']
         if meraki.params['type']:
-            payload['type'] = meraki.params['type']
-        elif meraki.params['types']:
-            payload['type'] = list_to_string(meraki.params['types'])
+            payload['type'] = list_to_string(meraki.params['type'])
         if meraki.params['tags']:
             payload['tags'] = construct_tags(meraki.params['tags'])
         if meraki.params['timezone']:

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -126,7 +126,9 @@
       net_name: IntTestNetworkTags
       type: switch
       timezone: America/Chicago
-      tags: first_tag, second_tag
+      tags: 
+        - first_tag
+        - second_tag
     delegate_to: localhost
     register: create_net_tags
 
@@ -141,7 +143,10 @@
       net_name: IntTestNetworkTags
       type: switch
       timezone: America/Chicago
-      tags: first_tag, second_tag, third_tag
+      tags: 
+        - first_tag
+        - second_tag
+        - third_tag
     delegate_to: localhost
     register: create_net_modified
 
@@ -153,7 +158,10 @@
       net_name: IntTestNetworkTags
       type: switch
       timezone: America/Chicago
-      tags: first_tag, second_tag, third_tag
+      tags: 
+        - first_tag
+        - second_tag
+        - third_tag
     delegate_to: localhost
     register: create_net_modified_idempotent
 

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -83,7 +83,7 @@
     meraki_network:
       auth_key: '{{ auth_key }}'
       state: present
-      org_name: '{{test_org_name}}'
+      org_name: '{{ test_org_name }}'
       net_name: IntTestNetworkCombined
       types:
         - appliance

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -85,7 +85,7 @@
       state: present
       org_name: '{{ test_org_name }}'
       net_name: IntTestNetworkCombined
-      types:
+      type:
         - appliance
         - switch
       timezone: America/Chicago

--- a/test/integration/targets/meraki_network/tasks/main.yml
+++ b/test/integration/targets/meraki_network/tasks/main.yml
@@ -85,7 +85,9 @@
       state: present
       org_name: '{{test_org_name}}'
       net_name: IntTestNetworkCombined
-      type: combined
+      types:
+        - appliance
+        - switch
       timezone: America/Chicago
       disable_my_meraki: yes
     delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY
`meraki_network` used to have a network type of combined, but that hard coded the combined types. This pull request adds a new parameter, `types`, which allows the playbook author to apply a list of network types for greater flexibility

Fixes #49149
@ericdost - If you can, please test using my branch. Another option I have is to keep the `type` parameter as is and allow the playbook developer to specify the space delimited types. Let me know if you have a preference one way or another.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
meraki_network