### PR TITLE
Use virtualenv in pip test to remove distribute.

### DIFF
--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -501,10 +501,22 @@
     state: absent
 
 # https://github.com/ansible/ansible/issues/47198
+- name: make sure the virtualenv does not exist
+  file:
+    state: absent
+    name: "{{ output_dir }}/pipenv"
+
+- name: install distribute in the virtualenv
+  pip:
+    name: distribute
+    virtualenv: "{{ output_dir }}/pipenv"
+    state: present
+
 - name: try to remove distribute
   pip:
     state: "absent"
     name: "distribute"
+    virtualenv: "{{ output_dir }}/pipenv"
   ignore_errors: yes
   register: remove_distribute
 


### PR DESCRIPTION
##### SUMMARY

Use virtualenv in pip test to remove distribute.

This fixes the test first introduced in https://github.com/ansible/ansible/pull/47403, which was causing the uri tests to fail on centos6 after distribute was removed.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

pip integration test
