### PR TITLE
[stable-2.7] Use virtualenv in pip test to remove distribute.

### DIFF
--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -501,10 +501,22 @@
     state: absent
 
 # https://github.com/ansible/ansible/issues/47198
+- name: make sure the virtualenv does not exist
+  file:
+    state: absent
+    name: "{{ output_dir }}/pipenv"
+
+- name: install distribute in the virtualenv
+  pip:
+    name: distribute
+    virtualenv: "{{ output_dir }}/pipenv"
+    state: present
+
 - name: try to remove distribute
   pip:
     state: "absent"
     name: "distribute"
+    virtualenv: "{{ output_dir }}/pipenv"
   ignore_errors: yes
   register: remove_distribute
 


### PR DESCRIPTION
##### SUMMARY

[stable-2.7] Use virtualenv in pip test to remove distribute.

(cherry picked from commit 6f29eafef4d8fc49645d2382c444e9416f8ab38d)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

pip integration test
