### PR TITLE
[Backport 2.6] Fix type in ansible-galaxy info output

### DIFF
--- a/changelogs/fragments/49096-ansible-galaxy-fix_info_typo.yaml
+++ b/changelogs/fragments/49096-ansible-galaxy-fix_info_typo.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Fixed typo in ansible-galaxy info command.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -276,7 +276,7 @@ class GalaxyCLI(CLI):
             install_info = gr.install_info
             if install_info:
                 if 'version' in install_info:
-                    install_info['intalled_version'] = install_info['version']
+                    install_info['installed_version'] = install_info['version']
                     del install_info['version']
                 role_info.update(install_info)
 


### PR DESCRIPTION
##### SUMMARY
Changed from 'intalled_version' to 'installed_version'

(cherry picked from commit 12a573a7db45e5b8cd514dd3df43361053e6f7d4)

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/49096-ansible-galaxy-fix_info_typo.yaml
lib/ansible/cli/galaxy.py
