### PR TITLE
Adds hasattr checks for rpc calls used in network_cli plugins

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -294,8 +294,11 @@ class Connection(NetworkConnectionBase):
 
         self._play_context = play_context
 
-        self.reset_history()
-        self.disable_response_logging()
+        if hasattr(self, 'reset_history'):
+            self.reset_history()
+        if hasattr(self, 'disable_response_logging'):
+            self.disable_response_logging()
+
         return messages
 
     def _connect(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Network platforms that don't have cliconf plugin will fail when
sending rpc calls for the reset_history and disable_response_logging
functions because those are defined in cliconf exclusively at this
time.

This patch adds checks for those attributes before making the call

Fixes: #47589 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
networking modules

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
