### PR TITLE
Adds hasattr checks for rpc calls used in network_cli plugins (#49173)

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -281,8 +281,11 @@ class Connection(NetworkConnectionBase):
 
         self._play_context = play_context
 
-        self.reset_history()
-        self.disable_response_logging()
+        if hasattr(self, 'reset_history'):
+            self.reset_history()
+        if hasattr(self, 'disable_response_logging'):
+            self.disable_response_logging()
+
         return messages
 
     def _connect(self):


### PR DESCRIPTION
Network platforms that don't have cliconf plugin will fail when
sending rpc calls for the reset_history and disable_response_logging
functions because those are defined in cliconf exclusively at this
time.

This patch adds checks for those attributes before making the call

(cherry picked from commit 0b5b5e69d867e3cd835a8c52f27ac07da26114ca)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
