### PR TITLE
Fix lookup_passwordstore test skipping.

### DIFF
--- a/test/integration/targets/lookup_passwordstore/aliases
+++ b/test/integration/targets/lookup_passwordstore/aliases
@@ -1,3 +1,3 @@
 shippable/posix/group2
 destructive
-skip/rhel8.0
+skip/rhel

--- a/test/integration/targets/lookup_passwordstore/tasks/main.yml
+++ b/test/integration/targets/lookup_passwordstore/tasks/main.yml
@@ -3,4 +3,4 @@
     - include: "tests.yml"
   when:
     - not (ansible_distribution == 'RedHat')  # requires EPEL
-    - not (ansible_distribution == 'CentOS' and ansible_distribution_version | version_compare('7', '<'))
+    - not (ansible_distribution == 'CentOS' and ansible_distribution_version is version_compare('7', '<'))

--- a/test/integration/targets/lookup_passwordstore/tasks/main.yml
+++ b/test/integration/targets/lookup_passwordstore/tasks/main.yml
@@ -1,4 +1,6 @@
-- include: "package.yml"
-  when: "ansible_distribution_version not in passwordstore_skip_os.get(ansible_distribution, [])"
-- include: "tests.yml"
-  when: "ansible_distribution_version not in passwordstore_skip_os.get(ansible_distribution, [])"
+- block:
+    - include: "package.yml"
+    - include: "tests.yml"
+  when:
+    - not (ansible_distribution == 'RedHat')  # requires EPEL
+    - not (ansible_distribution == 'CentOS' and ansible_distribution_version | version_compare('7', '<'))

--- a/test/integration/targets/lookup_passwordstore/vars/main.yml
+++ b/test/integration/targets/lookup_passwordstore/vars/main.yml
@@ -56,7 +56,3 @@ passwordstore_privkey: |
   SxHTvI2pKk+gx0FB8wWhd/CocAHJpx9oNUs/7A==
   =ZF3O
   -----END PGP PRIVATE KEY BLOCK-----
-passwordstore_skip_os:
-  Ubuntu: ['12.04']
-  RedHat: ['7.4']
-  CentOS: ['6.9', '6.10']


### PR DESCRIPTION
##### SUMMARY

Fix lookup_passwordstore test skipping.

Skip all of RHEL instead of specific versions.
Skip all of CentOS < 7 instead of specific versions.

This makes the test more robust when testing newer versions.

Tests could be executed on RHEL if EPEL was installed during the test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lookup_passwordstore integration test
