### PR TITLE
PR to fix the issue of keyerror in Nios api

### DIFF
--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -227,7 +227,7 @@ class WapiModule(WapiBase):
         if ib_obj_ref:
             if len(ib_obj_ref) > 1:
                 for each in ib_obj_ref:
-                    if each['ipv4addr'] == proposed_object['ipv4addr']:
+                    if ('ipv4addr' in each and proposed_object) and each['ipv4addr'] == proposed_object['ipv4addr']:
                         current_object = each
             else:
                 current_object = ib_obj_ref[0]

--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -227,7 +227,8 @@ class WapiModule(WapiBase):
         if ib_obj_ref:
             if len(ib_obj_ref) > 1:
                 for each in ib_obj_ref:
-                    if ('ipv4addr' in each and proposed_object) and each['ipv4addr'] == proposed_object['ipv4addr']:
+                    if ('ipv4addr' in each) and ('ipv4addr' in proposed_object)\
+                            and each['ipv4addr'] == proposed_object['ipv4addr']:
                         current_object = each
             else:
                 current_object = ib_obj_ref[0]


### PR DESCRIPTION
Signed-off-by: Sumit Jaiswal <sjaiswal@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR to fix the issue of `ipv4addr: keyerror` faced in shippable error: https://app.shippable.com/github/ansible/ansible/runs/94066/91/tests. Small patch fix
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nios/api.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
