### PR TITLE
Canonical url rendering on docs

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -127,6 +127,10 @@ html_theme_path = ['../_themes']
 html_theme = 'sphinx_rtd_theme'
 html_short_title = 'Ansible Documentation'
 
+html_theme_options = {
+    'canonical_url': "https://docs.ansible.com/ansible/latest/",
+}
+
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths
 # given in html_static_path.


### PR DESCRIPTION
This small config change to sphinx enables the rendering of canonical urls on all doc pages

##### SUMMARY
This is a variation on the suggestion made by @gundalow on #43562. Instead of using a javascript snippet to build a canonical URL, we use the theme's built-in support for generating canonical urls in its output, removing the need for a script to run.

This change should be back-portable down to 2.5 if needed, the theme used in 2.4 and below did not accommodate for this option.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Docs

##### ADDITIONAL INFORMATION
```paste below

```
