### PR TITLE
Fix grafana_dashboard py2/3 compatibility

### DIFF
--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -183,7 +183,7 @@ def get_grafana_version(module, grafana_url, headers):
     if info['status'] == 200:
         try:
             settings = json.loads(r.read())
-            grafana_version = str.split(settings['buildInfo']['version'], '.')[0]
+            grafana_version = settings['buildInfo']['version'].split('.')[0]
         except Exception as e:
             raise GrafanaAPIException(e)
     else:

--- a/lib/ansible/modules/monitoring/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana_dashboard.py
@@ -140,6 +140,7 @@ import json
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_text
 
 __metaclass__ = type
 
@@ -182,8 +183,10 @@ def get_grafana_version(module, grafana_url, headers):
     r, info = fetch_url(module, '%s/api/frontend/settings' % grafana_url, headers=headers, method='GET')
     if info['status'] == 200:
         try:
-            settings = json.loads(r.read())
+            settings = json.loads(to_text(r.read()))
             grafana_version = settings['buildInfo']['version'].split('.')[0]
+        except UnicodeError as e:
+            raise GrafanaAPIException('Unable to decode version string to Unicode')
         except Exception as e:
             raise GrafanaAPIException(e)
     else:


### PR DESCRIPTION
##### SUMMARY
Fix grafana_dashboard Python 2 compatibility

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`grafana_dashboard`

##### ADDITIONAL INFORMATION

Merge request #47708 added a regression with Python 2, causing the following error:

```failed: [grafana-infra-000] (item=['node_exporter.json', 'prometheus-infra-000']) => {"changed": false, "item": ["node_exporter.json", "prometheus-infra-000"], "msg": "error : descriptor 'split' requires a 'str' object but received a 'unicode'"}```

Issue was the `json.loads` in the Grafana version check returned a `unicode` variable, incompatible with `str.split`.

I switched to using the split method from the returned object, either `str.split` or `unicode.split` depending on the type. The integer cast at the end of the function works with either type and normalizes the function output.

I also got the following error testing this fix for Python 3, also in the Grafana version check, and tried to correct it too:

```failed: [grafana-infra-000] (item=['node_exporter.json', 'prometheus-infra-000']) => {"changed": false, "item": ["node_exporter.json", "prometheus-infra-000"], "msg": "error : the JSON object must be str, not 'bytes'"}```

This time, it was the `json.loads` that was choking on a `bytes` object. I added a call to the `to_text` function to handle this issue, and added a case for `UnicodeError` in the exception handling.

Some data on my environment:

```
ansible 2.8.0.dev0 (fix_grafana_py2 7008e1bb47) last updated 2018/11/27 16:42:11 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/johann/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/johann/src/ansible/lib/ansible
  executable location = /home/johann/src/ansible/bin/ansible
  python version = 3.7.1 (default, Oct 22 2018, 10:41:28) [GCC 8.2.1 20180831]
```