### PR TITLE
nxos_logging message fix

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_logging.py
+++ b/lib/ansible/modules/network/nxos/nxos_logging.py
@@ -74,7 +74,7 @@ options:
       - Link/trunk enable/default interface configuration logging
     choices: ['link-enable', 'link-default', 'trunk-enable', 'trunk-default']
     version_added: '2.8'
-  message:
+  interface_message:
     description:
       - Add interface description to interface syslogs.
         Does not work with version 6.0 images using nxapi as a transport.
@@ -163,7 +163,7 @@ EXAMPLES = """
     state: present
 - name: Configure logging message ethernet description
   nxos_logging:
-    message: add-interface-description
+    interface_message: add-interface-description
     state: present
 - name: Configure logging event link enable
   nxos_logging:
@@ -679,7 +679,7 @@ def map_params_to_obj(module):
             'state': module.params['state'],
             'facility_link_status': module.params['facility_link_status'],
             'event': module.params['event'],
-            'message': module.params['message'],
+            'message': module.params['interface_message'],
             'file_size': file_size,
             'timestamp': module.params['timestamp']
         })
@@ -728,7 +728,7 @@ def main():
         interface=dict(),
         facility_link_status=dict(choices=['link-down-notif', 'link-down-error', 'link-up-notif', 'link-up-error']),
         event=dict(choices=['link-enable', 'link-default', 'trunk-enable', 'trunk-default']),
-        message=dict(choices=['add-interface-description']),
+        interface_message=dict(choices=['add-interface-description']),
         file_size=dict(type='int'),
         timestamp=dict(choices=['microseconds', 'milliseconds', 'seconds']),
         state=dict(default='present', choices=['present', 'absent']),

--- a/test/integration/targets/nxos_logging/tasks/main.yaml
+++ b/test/integration/targets/nxos_logging/tasks/main.yaml
@@ -1,9 +1,8 @@
 ---
-# Use block to ensure that both cli and nxapi tests
-# will run even if there are failures or errors.
+# Use block to ensure that the baude rate gets set
+# back to 9600 even if there are failures or errors.
 - block:
   - { include: cli.yaml, tags: ['cli'] }
-  rescue:
   - { include: nxapi.yaml, tags: ['nxapi'] }
   always:
   - name: Set Baud Rate Back to 9600 so our tests don't break

--- a/test/integration/targets/nxos_logging/tasks/main.yaml
+++ b/test/integration/targets/nxos_logging/tasks/main.yaml
@@ -1,3 +1,14 @@
 ---
-- { include: cli.yaml, tags: ['cli'] }
-- { include: nxapi.yaml, tags: ['nxapi'] }
+# Use block to ensure that both cli and nxapi tests
+# will run even if there are failures or errors.
+- block:
+  - { include: cli.yaml, tags: ['cli'] }
+  rescue:
+  - { include: nxapi.yaml, tags: ['nxapi'] }
+  always:
+  - name: Set Baud Rate Back to 9600 so our tests don't break
+    nxos_config:
+      lines:
+        - speed 9600
+      parents: line console
+    connection: network_cli

--- a/test/integration/targets/nxos_logging/tests/common/basic.yaml
+++ b/test/integration/targets/nxos_logging/tests/common/basic.yaml
@@ -3,6 +3,15 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
+# This task is needed to clear out any previous logfile
+# size settings.
+- name: Workaround to clear logging logfile size
+  nxos_config:
+    lines:
+      - logging logfile test 1 size 4194304
+    provider: "{{ connection }}"
+  ignore_errors: yes
+
 - name: Purge logging configuration first
   nxos_logging:
     purge: true
@@ -51,7 +60,7 @@
 - name: Set Baud Rate to less than 38400
   nxos_config:
     lines:
-      - speed 9600
+      - speed 19200
     parents: line console
     provider: "{{ connection }}"
 
@@ -263,7 +272,7 @@
 - block:
   - name: Configure Logging message
     nxos_logging: &logm
-      message: add-interface-description
+      interface_message: add-interface-description
       state: present
       provider: "{{ connection }}"
     register: result
@@ -280,7 +289,7 @@
 
   - name: Remove Logging message
     nxos_logging:
-      message: add-interface-description
+      interface_message: add-interface-description
       state: absent
       provider: "{{ connection }}"
     register: result


### PR DESCRIPTION
##### SUMMARY
Fixes the following issues for the `nxos_logging` module:

* Changes the `message` parameter to `interface_message`.
  * We discovered a problem (detailed below) where using `message` conflicts with code in `module_utils/basic.py` on certain ansible controllers.
   * For example, it works fine on MacOs but fails on Ubuntu.
   * This should probably be fixed in module_utils at some point so other modules don't encounter this problem.
* Changes the speed setting on one of the tests to use `19200` instead of `9600`.  Some nxos image versions don't support the test at the lower speed setting.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_logging

##### ADDITIONAL INFORMATION
Here are details on the  `module_utils/basic.py` failure when we used `message:` as the parameter name.

```
279363:  The full traceback is:
279364:  Traceback (most recent call last):
279365:    File "/root/.ansible/tmp/ansible-local-2879ueVbR9/ansible-tmp-1542411755.75-1565106891704/AnsiballZ_nxos_logging.py", line 113, in <module>
279366:      _ansiballz_main()
279367:    File "/root/.ansible/tmp/ansible-local-2879ueVbR9/ansible-tmp-1542411755.75-1565106891704/AnsiballZ_nxos_logging.py", line 105, in _ansiballz_main
279368:      invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
279369:    File "/root/.ansible/tmp/ansible-local-2879ueVbR9/ansible-tmp-1542411755.75-1565106891704/AnsiballZ_nxos_logging.py", line 48, in invoke_module
279370:      imp.load_module('__main__', mod, module, MOD_DESC)
279371:    File "/tmp/ansible_nxos_logging_payload_OgR8b1/__main__.py", line 781, in <module>
279372:    File "/tmp/ansible_nxos_logging_payload_OgR8b1/__main__.py", line 746, in main
279373:    File "/tmp/ansible_nxos_logging_payload_OgR8b1/ansible_nxos_logging_payload.zip/ansible/module_utils/basic.py", line 907, in __init__
279374:    File "/tmp/ansible_nxos_logging_payload_OgR8b1/ansible_nxos_logging_payload.zip/ansible/module_utils/basic.py", line 2249, in _log_invocation
279375:    File "/tmp/ansible_nxos_logging_payload_OgR8b1/ansible_nxos_logging_payload.zip/ansible/module_utils/basic.py", line 2207, in log
279376:  TypeError: send() got multiple values for keyword argument 'MESSAGE'
```
