### PR TITLE
Spotinst - adding support for instance health check validation

### DIFF
--- a/changelogs/fragments/spotinst-instance-health-check-validation.yml
+++ b/changelogs/fragments/spotinst-instance-health-check-validation.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - spotinst - Added Instance Health Check Validation on creation of Elastigroup if "health_check_type" parameter set in playbook 
+  - spotinst - Added "SPOTINST_ACCOUNT_ID" or "ACCOUNT" env var 

--- a/lib/ansible/modules/cloud/spotinst/spotinst_aws_elastigroup.py
+++ b/lib/ansible/modules/cloud/spotinst/spotinst_aws_elastigroup.py
@@ -21,7 +21,6 @@ description:
     token = <YOUR TOKEN>
     Full documentation available at https://help.spotinst.com/hc/en-us/articles/115003530285-Ansible-
 requirements:
-  - spotinst >= 1.0.21
   - python >= 2.7
   - spotinst_sdk >= 1.0.38
 options:
@@ -754,8 +753,8 @@ import time
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    import spotinst
-    from spotinst import SpotinstClientException
+    import spotinst_sdk as spotinst
+    from spotinst_sdk import SpotinstClientException
 
     HAS_SPOTINST_SDK = True
 
@@ -958,6 +957,7 @@ def handle_elastigroup(client, module):
                     )
                     roll_response = client.roll_group(group_roll=eg_roll, group_id=group_id)
                     message = 'Updated and started rolling the group successfully.'
+
             except SpotinstClientException as exc:
                 message = 'Updated group successfully, but failed to perform roll. Error:' + str(exc)
             has_changed = True
@@ -981,6 +981,8 @@ def retrieve_group_instances(client, module, group_id):
     wait_timeout = module.params.get('wait_timeout')
     wait_for_instances = module.params.get('wait_for_instances')
 
+    health_check_type = module.params.get('health_check_type')
+
     if wait_timeout is None:
         wait_timeout = 300
 
@@ -995,12 +997,22 @@ def retrieve_group_instances(client, module, group_id):
         while is_amount_fulfilled is False and wait_timeout > time.time():
             instances = list()
             amount_of_fulfilled_instances = 0
-            active_instances = client.get_elastigroup_active_instances(group_id=group_id)
 
-            for active_instance in active_instances:
-                if active_instance.get('private_ip') is not None:
-                    amount_of_fulfilled_instances += 1
-                    instances.append(active_instance)
+            if health_check_type is not None:
+                healthy_instances = client.get_instance_healthiness(group_id=group_id)
+
+                for healthy_instance in healthy_instances:
+                    if(healthy_instance.get('healthStatus') == 'HEALTHY'):
+                        amount_of_fulfilled_instances += 1
+                        instances.append(healthy_instance)
+
+            else:
+                active_instances = client.get_elastigroup_active_instances(group_id=group_id)
+
+                for active_instance in active_instances:
+                    if active_instance.get('private_ip') is not None:
+                        amount_of_fulfilled_instances += 1
+                        instances.append(active_instance)
 
             if amount_of_fulfilled_instances >= target:
                 is_amount_fulfilled = True
@@ -1463,7 +1475,7 @@ def main():
     module = AnsibleModule(argument_spec=fields)
 
     if not HAS_SPOTINST_SDK:
-        module.fail_json(msg="the Spotinst SDK library is required. (pip install spotinst)")
+        module.fail_json(msg="the Spotinst SDK library is required. (pip install spotinst_sdk)")
 
     # Retrieve creds file variables
     creds_file_loaded_vars = dict()
@@ -1489,7 +1501,7 @@ def main():
 
     account = module.params.get('account_id')
     if not account:
-        account = os.environ.get('ACCOUNT')
+        account = os.environ.get('SPOTINST_ACCOUNT_ID') or os.environ.get('ACCOUNT')
     if not account:
         account = creds_file_loaded_vars.get("account")
 


### PR DESCRIPTION
##### SUMMARY
Adding option to wait for instances to return healthy signal when creating or updating spotinst elastigroup

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Spotinst Module

##### ADDITIONAL INFORMATION
If the variable `health_check_type` is set and `wait_for_instances` is True when running a Spotinst Playbook, then we will wait until the target number of instances all return a HEALTHY signal

```
ok: [localhost] => {
    "result": {
        "changed": true, 
        "failed": false, 
        "group_id": "sig-20520f40", 
        "instances": [], 
        "message": "Created group Successfully."
    }
}
```
