### PR TITLE
[stable-2.6] -Change: set the 'canonical_url' theme option to enable rendering of canonical urls, promoting the 'latest' docs to search engines. (#49190)

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -127,6 +127,10 @@ html_theme_path = ['../_themes']
 html_theme = 'sphinx_rtd_theme'
 html_short_title = 'Ansible Documentation'
 
+html_theme_options = {
+    'canonical_url': "https://docs.ansible.com/ansible/latest/",
+}
+
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths
 # given in html_static_path.


### PR DESCRIPTION
##### SUMMARY
Backport of #49190

(cherry picked from commit 59e7a9442e0fbb9c827f6c4d58ea7aebf5b04b02)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Docs
