### PR TITLE
Improve docs for umask option of pip module. (#49146)

### DIFF
--- a/changelogs/fragments/49146-improve-pip-umask-docs.yaml
+++ b/changelogs/fragments/49146-improve-pip-umask-docs.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pip - Improve documentation for umask option. (https://github.com/ansible/ansible/issues/43256)

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -98,9 +98,12 @@ options:
     description:
       - The system umask to apply before installing the pip package. This is
         useful, for example, when installing on systems that have a very
-        restrictive umask by default (e.g., 0077) and you want to pip install
+        restrictive umask by default (e.g., "0077") and you want to pip install
         packages which are to be used by all users. Note that this requires you
-        to specify desired umask mode in octal, with a leading 0 (e.g., 0077).
+        to specify desired umask mode as an octal string, (e.g., "0022").
+        Specifying the mode as a decimal integer (e.g., 22) will also work, but
+        an octal integer (e.g., 0022) will be converted to decimal (18) before
+        evaluation, which is almost certainly not what was intended.
     version_added: "2.1"
 notes:
    - Please note that virtualenv (U(http://www.virtualenv.org/)) must be


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Note that the umask should be specified as an octal *string*, not an octal *integer*.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #43256 
Backport of #49146 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pip
