### PR TITLE
ansible octal

### DIFF
--- a/changelogs/fragments/octal.yml
+++ b/changelogs/fragments/octal.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Implement AnsibleOctal to deal with chmod/file modes sanely, also added !oct/!octal YAML tags for when we want to be explicit.

--- a/lib/ansible/parsing/yaml/constructor.py
+++ b/lib/ansible/parsing/yaml/constructor.py
@@ -23,7 +23,7 @@ from yaml.constructor import SafeConstructor, ConstructorError
 from yaml.nodes import MappingNode
 
 from ansible.module_utils._text import to_bytes
-from ansible.parsing.yaml.objects import AnsibleMapping, AnsibleSequence, AnsibleUnicode, AnsibleOctal, AnsibleHex
+from ansible.parsing.yaml.objects import AnsibleMapping, AnsibleSequence, AnsibleUnicode, AnsibleOctal
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 from ansible.utils.unsafe_proxy import wrap_var
 from ansible.parsing.vault import VaultLib

--- a/lib/ansible/parsing/yaml/constructor.py
+++ b/lib/ansible/parsing/yaml/constructor.py
@@ -23,6 +23,7 @@ from yaml.constructor import SafeConstructor, ConstructorError
 from yaml.nodes import MappingNode
 
 from ansible.module_utils._text import to_bytes
+from ansible.module_utils.six import PY3
 from ansible.parsing.yaml.objects import AnsibleMapping, AnsibleSequence, AnsibleUnicode, AnsibleOctal
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 from ansible.utils.unsafe_proxy import wrap_var
@@ -80,7 +81,7 @@ class AnsibleConstructor(SafeConstructor):
 
     def construct_ansible_int(self, node):
         value = self.construct_scalar(node)
-        if len(value) > 1 and value.startswith('0') and not value.startswith('0x'):
+        if PY3 and len(value) > 1 and value.startswith('0') and not value.startswith('0x'):
             ret = self.construct_yaml_octal(node)
         else:
             ret = self.construct_yaml_int(node)

--- a/lib/ansible/parsing/yaml/constructor.py
+++ b/lib/ansible/parsing/yaml/constructor.py
@@ -80,7 +80,7 @@ class AnsibleConstructor(SafeConstructor):
 
     def construct_ansible_int(self, node):
         value = self.construct_scalar(node)
-        if value.startswith('0') and not value.startswith('0x'):
+        if len(value) > 1 and value.startswith('0') and not value.startswith('0x'):
             ret = self.construct_yaml_octal(node)
         else:
             ret = self.construct_yaml_int(node)

--- a/lib/ansible/parsing/yaml/objects.py
+++ b/lib/ansible/parsing/yaml/objects.py
@@ -68,6 +68,16 @@ class AnsibleSequence(AnsibleBaseYAMLObject, list):
     pass
 
 
+class AnsibleOctal(AnsibleBaseYAMLObject, int):
+    ''' for using octal numbers in chmod/file operations to dwim and not return a decimal conversion '''
+
+    def __str__(self):
+        return to_text(oct(self).replace('o', ''))
+
+    def __repr__(self):
+        return repr(str(self))
+
+
 # Unicode like object that is not evaluated (decrypted) until it needs to be
 # TODO: is there a reason these objects are subclasses for YAMLObject?
 class AnsibleVaultEncryptedUnicode(yaml.YAMLObject, AnsibleBaseYAMLObject):

--- a/lib/ansible/parsing/yaml/objects.py
+++ b/lib/ansible/parsing/yaml/objects.py
@@ -75,7 +75,7 @@ class AnsibleOctal(AnsibleBaseYAMLObject, int):
         return to_text(oct(self).replace('o', ''))
 
     def __repr__(self):
-        return repr(str(self))
+        return repr(self.__str__())
 
 
 # Unicode like object that is not evaluated (decrypted) until it needs to be


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->


This now does what most people expect
```yaml
-  file:
      path: /whatever
      mode: !oct 0755 
```

with updated commit, you don't even need `!oct`, a leading 0 will suffice.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yaml