### PR TITLE
2.7: Warn about falling back to jinja2_native=false (#49063)

### DIFF
--- a/changelogs/fragments/jinja2_native-fallback-warning.yaml
+++ b/changelogs/fragments/jinja2_native-fallback-warning.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add warning about falling back to jinja2_native=false when Jinja2 version is lower than 2.10.

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -77,6 +77,11 @@ if C.DEFAULT_JINJA2_NATIVE:
     except ImportError:
         from jinja2 import Environment
         from jinja2.utils import concat as j2_concat
+        from jinja2 import __version__ as j2_version
+        display.warning(
+            'jinja2_native requires Jinja 2.10 and above. '
+            'Version detected: %s. Falling back to default.' % j2_version
+        )
 else:
     from jinja2 import Environment
     from jinja2.utils import concat as j2_concat


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/49063

(cherry picked from commit abdf46803b3021b184ebcd9ea52bf6772355196a)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/template/__init__.py`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->