### PR TITLE
docker_swarm_service: ensure idempotency when the user parameter is None

### DIFF
--- a/changelogs/fragments/49235-docker_swarm_service-user-default.yaml
+++ b/changelogs/fragments/49235-docker_swarm_service-user-default.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - 'fix: fails because of default "user: root" (https://github.com/ansible/ansible/issues/49199)'
+minor_changes:
+  - 'docker_swarm_service: use docker defaults for the C(user) parameter if it is set to None'

--- a/changelogs/fragments/49235-docker_swarm_service-user-default.yaml
+++ b/changelogs/fragments/49235-docker_swarm_service-user-default.yaml
@@ -2,4 +2,4 @@
 bugfixes:
   - 'docker_swarm_service: fails because of default "user: root" (https://github.com/ansible/ansible/issues/49199)'
 minor_changes:
-  - 'docker_swarm_service: use docker defaults for the C(user) parameter if it is set to C(null)'
+  - 'docker_swarm_service: use docker defaults for the ``user`` parameter if it is set to ``null``'

--- a/changelogs/fragments/49235-docker_swarm_service-user-default.yaml
+++ b/changelogs/fragments/49235-docker_swarm_service-user-default.yaml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
-  - 'fix: fails because of default "user: root" (https://github.com/ansible/ansible/issues/49199)'
+  - 'docker_swarm_service: fails because of default "user: root" (https://github.com/ansible/ansible/issues/49199)'
 minor_changes:
-  - 'docker_swarm_service: use docker defaults for the C(user) parameter if it is set to None'
+  - 'docker_swarm_service: use docker defaults for the C(user) parameter if it is set to C(null)'

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -271,7 +271,10 @@ options:
   user:
     required: false
     default: root
-    description: username or UID
+    description:
+    - username or UID.
+    - "If set to C(none) the docker daemon default value (or the one already
+       set for the service) will be used"
 extends_documentation_fragment:
 - docker
 requirements:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -273,7 +273,7 @@ options:
     default: root
     description:
     - username or UID.
-    - "If set to C(none) the docker daemon default value (or the one already
+    - "If set to C(null) the image provided value (or the one already
        set for the service) will be used"
 extends_documentation_fragment:
 - docker

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -720,7 +720,7 @@ class DockerService(DockerBaseClass):
             differences.add('update_order', parameter=self.update_order, active=os.update_order)
         if self.image != os.image.split('@')[0]:
             differences.add('image', parameter=self.image, active=os.image.split('@')[0])
-        if self.user != os.user:
+        if self.user and self.user != os.user:
             differences.add('user', parameter=self.user, active=os.user)
         if self.dns != os.dns:
             differences.add('dns', parameter=self.dns, active=os.dns)


### PR DESCRIPTION
##### SUMMARY
This solves the idempotency issue reported in  #49199, when `user` parameter is `None`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm_service.py

##### ADDITIONAL INFORMATION
