### PR TITLE
Clarify volume unit in the ec2_vol module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vol.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vol.py
@@ -34,7 +34,7 @@ options:
     version_added: "1.6"
   volume_size:
     description:
-      - size of volume (in GB) to create.
+      - size of volume (in GiB) to create.
   volume_type:
     description:
       - Type of EBS volume; standard (magnetic), gp2 (SSD), io1 (Provisioned IOPS), st1 (Throughput Optimized HDD), sc1 (Cold HDD).


### PR DESCRIPTION

##### SUMMARY
"GiB" is more appropriate than "GB" since the volume size in AWS is
expressed in gibibytes.


##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vol
