### PR TITLE
Last loaded handler with the same name wins

### DIFF
--- a/changelogs/fragments/last-loaded-handler-same-name-wins.yaml
+++ b/changelogs/fragments/last-loaded-handler-same-name-wins.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Last loaded handler with the same name is used

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -368,7 +368,7 @@ class StrategyBase:
                 return self._inventory.get_host(host_name)
 
         def search_handler_blocks_by_name(handler_name, handler_blocks):
-            for handler_block in handler_blocks:
+            for handler_block in reversed(handler_blocks):
                 for handler_task in handler_block.block:
                     if handler_task.name:
                         handler_vars = self._variable_manager.get_vars(play=iterator._play, task=handler_task)
@@ -394,7 +394,7 @@ class StrategyBase:
             return None
 
         def search_handler_blocks_by_uuid(handler_uuid, handler_blocks):
-            for handler_block in handler_blocks:
+            for handler_block in reversed(handler_blocks):
                 for handler_task in handler_block.block:
                     if handler_uuid == handler_task._uuid:
                         return handler_task

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -368,6 +368,7 @@ class StrategyBase:
                 return self._inventory.get_host(host_name)
 
         def search_handler_blocks_by_name(handler_name, handler_blocks):
+            # iterate in reversed order since last handler loaded with the same name wins
             for handler_block in reversed(handler_blocks):
                 for handler_task in handler_block.block:
                     if handler_task.name:
@@ -394,6 +395,7 @@ class StrategyBase:
             return None
 
         def search_handler_blocks_by_uuid(handler_uuid, handler_blocks):
+            # iterate in reversed order since last handler loaded with the same name wins
             for handler_block in reversed(handler_blocks):
                 for handler_task in handler_block.block:
                     if handler_uuid == handler_task._uuid:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Make loading handlers consistent with plugins.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Related https://github.com/ansible/ansible/issues/37512 and https://github.com/ansible/ansible/pull/41968#discussion_r237109663

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/strategy/__init__.py`

##### ADDITIONAL INFORMATION