### PR TITLE
add conditional checks for mysql8 compatibility

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -73,7 +73,6 @@ options:
       - Whether the user requires a SSL encrypted connection to connect.
     type: bool
     default: 'no'
-    version_added: "tba"
   sql_log_bin:
     description:
       - Whether binary logging should be enabled or disabled for the connection.

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -398,7 +398,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted, new_priv, append
                     if not scu.supports_pluggable_auth:
                         cursor.execute("SET PASSWORD FOR %s@%s = PASSWORD(%s)", (user, host, password))
                     else:
-                        cursor.execute("ALTER USER %s@%s IDENTIFIED WITH mysql_native_password BY %s", (user, host, password))
+                        cursor.execute("ALTER USER %s@%s IDENTIFIED WITH mysql_native_password AS %s", (user, host, password))
                     changed = True
 
         # Handle privileges

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -558,7 +558,7 @@ def privileges_unpack(priv, mode):
 
     # if we are only specifying something like REQUIRESSL and/or GRANT (=WITH GRANT OPTION) in *.*
     # we still need to add USAGE as a privilege to avoid syntax errors
-    if 'REQUIRESSL' in priv and not set(output['*.*']).difference({'GRANT', 'REQUIRESSL'}):
+    if 'REQUIRESSL' in priv and not set(output['*.*']).difference(set(['GRANT', 'REQUIRESSL'])):
         output['*.*'].append('USAGE')
 
     return output
@@ -625,7 +625,7 @@ def main():
             ssl_cert=dict(type='path'),
             ssl_key=dict(type='path'),
             ssl_ca=dict(type='path'),
-            require_ssl = dict(type='bool', default=False)
+            require_ssl=dict(type='bool', default=False)
         ),
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -395,7 +395,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted, new_priv, append
                 if current_pass_hash[0] != new_pass_hash[0]:
                     if module.check_mode:
                         return True
-                    if not scu.supports_pluggable_auth:
+                    if not scu.supports_pluggable_auth or (scu.vendor == 'mariadb' and scu.version < (10, 2)):
                         cursor.execute("SET PASSWORD FOR %s@%s = PASSWORD(%s)", (user, host, password))
                     else:
                         cursor.execute("ALTER USER %s@%s IDENTIFIED WITH mysql_native_password AS %s", (user, host, password))

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -73,6 +73,7 @@ options:
       - Whether the user requires a SSL encrypted connection to connect.
     type: bool
     default: 'no'
+    version_added: "2.8"
   sql_log_bin:
     description:
       - Whether binary logging should be enabled or disabled for the connection.


### PR DESCRIPTION
##### SUMMARY
The `mysql_user` module currently lacks support for MySQL 8.0 and higher (and won't work on those). Since the syntax of some SQL commands have changed, some changes in the module are required to provide support for newer MySQL versions, while maintaining full backward-compatibility with prior versions.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`mysql_user` module

##### ADDITIONAL INFORMATION
The change adds a helper class that can retrieve the server version and decide which features are available or unavailable on the actual server connection. Based on that information, it will change the syntax of the SQL commands sent to the server and adds some error testing. The helper class will cache the information, so its only retrieved once - regardless of how many operations are being performed after that.

It also adds a new boolean parameter called `require_ssl` which controls whether the mysql user requires SSL to connect (see it as a replacement for the `*.*:REQUIRESSL` privilege on prior server versions). Since the `REQUIRESSL` privilege is gone in MySQL 8, this change will instruct the functions to use the appropriate syntax when creating the user account.

Some further notable changes:
* The regex pattern in the `privileges_get` method has been updated to accept the non-ANSI quote in SQL output. Otherwise, the function will fail on MySQL 8 which seems to use the non-ANSI quotes instead of the previous single quote character.
* `InvalidPrivsError` is raised when trying to deploy `REQUIRESSL` privileges on MySQL 8.0 or higher.
