### PR TITLE
sysctl: Rename ignoreerrors to ignore_unknown_keys

### DIFF
--- a/changelogs/fragments/49253-sysctl-rename-ignorerrors-to-ignore-unknown-keys.yml
+++ b/changelogs/fragments/49253-sysctl-rename-ignorerrors-to-ignore-unknown-keys.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "sysctl: ignoreerrors was renamed to ignore_unknown_keys; ignoreerrors is still supported as an alias"

--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -36,7 +36,7 @@ options:
             - Whether the entry should be present or absent in the sysctl file.
         choices: [ "present", "absent" ]
         default: present
-    ignore_errors:
+    ignore_unknown_keys:
         description:
             - Use this option to ignore errors about unknown keys.
         type: bool
@@ -242,13 +242,13 @@ class SysctlModule(object):
             thiscmd = "%s %s=%s" % (self.sysctl_cmd, token, value)
         elif self.platform == 'freebsd':
             ignore_missing = ''
-            if self.args['ignore_errors']:
+            if self.args['gnore_unknown_keys']:
                 ignore_missing = '-i'
             # freebsd doesn't accept -w, but since it's not needed, just drop it
             thiscmd = "%s %s %s=%s" % (self.sysctl_cmd, ignore_missing, token, value)
         else:
             ignore_missing = ''
-            if self.args['ignore_errors']:
+            if self.args['ignore_unknown_keys']:
                 ignore_missing = '-e'
             thiscmd = "%s %s -w %s=%s" % (self.sysctl_cmd, ignore_missing, token, value)
         rc, out, err = self.module.run_command(thiscmd)
@@ -277,7 +277,7 @@ class SysctlModule(object):
         else:
             # system supports reloading via the -p flag to sysctl, so we'll use that
             sysctl_args = [self.sysctl_cmd, '-p', self.sysctl_file]
-            if self.args['ignore_errors']:
+            if self.args['ignore_unknown_keys']:
                 sysctl_args.insert(1, '-e')
 
             rc, out, err = self.module.run_command(sysctl_args)
@@ -369,7 +369,7 @@ def main():
             state=dict(default='present', choices=['present', 'absent']),
             reload=dict(default=True, type='bool'),
             sysctl_set=dict(default=False, type='bool'),
-            ignore_errors=dict(aliases=['ignoreerrors'], default=False, type='bool'),
+            ignore_unknown_keys=dict(aliases=['ignoreerrors'], default=False, type='bool'),
             sysctl_file=dict(default='/etc/sysctl.conf', type='path')
         ),
         supports_check_mode=True,

--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -36,11 +36,12 @@ options:
             - Whether the entry should be present or absent in the sysctl file.
         choices: [ "present", "absent" ]
         default: present
-    ignoreerrors:
+    ignore_errors:
         description:
             - Use this option to ignore errors about unknown keys.
         type: bool
         default: 'no'
+        aliases: [ 'ignoreerrors' ]
     reload:
         description:
             - If C(yes), performs a I(/sbin/sysctl -p) if the C(sysctl_file) is
@@ -241,13 +242,13 @@ class SysctlModule(object):
             thiscmd = "%s %s=%s" % (self.sysctl_cmd, token, value)
         elif self.platform == 'freebsd':
             ignore_missing = ''
-            if self.args['ignoreerrors']:
+            if self.args['ignore_errors']:
                 ignore_missing = '-i'
             # freebsd doesn't accept -w, but since it's not needed, just drop it
             thiscmd = "%s %s %s=%s" % (self.sysctl_cmd, ignore_missing, token, value)
         else:
             ignore_missing = ''
-            if self.args['ignoreerrors']:
+            if self.args['ignore_errors']:
                 ignore_missing = '-e'
             thiscmd = "%s %s -w %s=%s" % (self.sysctl_cmd, ignore_missing, token, value)
         rc, out, err = self.module.run_command(thiscmd)
@@ -276,7 +277,7 @@ class SysctlModule(object):
         else:
             # system supports reloading via the -p flag to sysctl, so we'll use that
             sysctl_args = [self.sysctl_cmd, '-p', self.sysctl_file]
-            if self.args['ignoreerrors']:
+            if self.args['ignore_errors']:
                 sysctl_args.insert(1, '-e')
 
             rc, out, err = self.module.run_command(sysctl_args)
@@ -368,7 +369,7 @@ def main():
             state=dict(default='present', choices=['present', 'absent']),
             reload=dict(default=True, type='bool'),
             sysctl_set=dict(default=False, type='bool'),
-            ignoreerrors=dict(default=False, type='bool'),
+            ignore_errors=dict(aliases=['ignoreerrors'], default=False, type='bool'),
             sysctl_file=dict(default='/etc/sysctl.conf', type='path')
         ),
         supports_check_mode=True,

--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -242,7 +242,7 @@ class SysctlModule(object):
             thiscmd = "%s %s=%s" % (self.sysctl_cmd, token, value)
         elif self.platform == 'freebsd':
             ignore_missing = ''
-            if self.args['gnore_unknown_keys']:
+            if self.args['ignore_unknown_keys']:
                 ignore_missing = '-i'
             # freebsd doesn't accept -w, but since it's not needed, just drop it
             thiscmd = "%s %s %s=%s" % (self.sysctl_cmd, ignore_missing, token, value)

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -171,3 +171,31 @@
     that:
       - sysctl_no_value is failed
       - "sysctl_no_value.msg == 'value cannot be None'"
+
+## 
+## sysctl - sysctl_set with ignore_errors and ignoreerrors (to ensure backward compatibility) 
+## 
+
+- name: set value for fictional key with ignore_errors
+  sysctl: 
+    name: k.doesnotexist
+    value: 1 
+    ignore_errors: yes
+  register: sysctl_ignore_errors0
+  
+- name: validate success of set operation with ignore_errors
+  assert: 
+    that: 
+      - sysctl_ignore_errors0 is success
+
+- name: set value for fictional key with ignoreerrors
+  sysctl: 
+    name: k.doesnotexist
+    value: 1 
+    ignoreerrors: yes
+  register: sysctl_ignore_errors1
+  
+- name: validate success of set operation with ignoreerrors
+  assert: 
+    that: 
+      - sysctl_ignore_errors1 is success

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -176,34 +176,34 @@
 ## sysctl - sysctl_set with ignore_errors and ignoreerrors (to ensure backward compatibility) 
 ## 
 
-- name: set value for fictional key with ignore_errors
+- name: set value for fictional key with ignore_unknown_keys
   sysctl: 
     name: k.doesnotexist
     value: 1 
-    ignore_errors: yes
-  register: sysctl_ignore_errors0
+    ignore_unknown_keys: yes
+  register: sysctl_ignore_unknown_keys0
   
 - debug:
-    var: sysctl_ignore_errors0
+    var: sysctl_ignore_unknown_keys0
     verbosity: 1
 
-- name: validate success of set operation with ignore_errors
+- name: validate success of set operation with ignore_unknown_keys
   assert: 
     that: 
-      - sysctl_ignore_errors0 is success
+      - sysctl_ignore_unknown_keys0 is success
 
 - name: set value for fictional key with ignoreerrors
   sysctl: 
     name: k.doesnotexist
     value: 1 
     ignoreerrors: yes
-  register: sysctl_ignore_errors1
+  register: sysctl_ignoreerrors0
   
 - debug:
-    var: sysctl_ignore_errors1
+    var: sysctl_ignoreerrors0
     verbosity: 1
 
 - name: validate success of set operation with ignoreerrors
   assert: 
     that: 
-      - sysctl_ignore_errors1 is success
+      - sysctl_ignoreerrors0 is success

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -183,6 +183,10 @@
     ignore_errors: yes
   register: sysctl_ignore_errors0
   
+- debug:
+    var: sysctl_ignore_errors0
+    verbosity: 1
+
 - name: validate success of set operation with ignore_errors
   assert: 
     that: 
@@ -195,6 +199,10 @@
     ignoreerrors: yes
   register: sysctl_ignore_errors1
   
+- debug:
+    var: sysctl_ignore_errors1
+    verbosity: 1
+
 - name: validate success of set operation with ignoreerrors
   assert: 
     that: 

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -30,7 +30,7 @@
     state: directory
 
 - name: check if sysctl command is available
-  shell: command -v sysctl
+  shell: sysctl -w net.ipv4.ip_forward=0
   register: sysctl_command_test
   ignore_errors: yes
 

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -205,6 +205,9 @@
 ## 
 ## sysctl - sysctl_set with ignore_unknown_keys and ignoreerrors (to ensure backward compatibility) 
 ## 
+- debug: 
+    var: ansible_os_family 
+    verbosity: 1
 
 - name: set value for fictional key with ignore_unknown_keys
   sysctl: 

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -35,11 +35,11 @@
   ignore_errors: yes
 
 - set_fact:
-    reload_supported: yes
+    sysctl_cmd_supported: yes
   when: sysctl_command_test.rc == 0
 
 - set_fact:
-    reload_supported: no
+    sysctl_cmd_supported: no
   when: sysctl_command_test.rc != 0
 
 
@@ -139,15 +139,18 @@
     value: 1
     sysctl_set: yes
     reload: no
+  when: sysctl_cmd_supported 
   register: sysctl_test3
 
 - name: check with sysctl command
   shell: sysctl net.ipv4.ip_forward
+  when: sysctl_cmd_supported
   register: sysctl_check3
 
 - debug:
     var: item
     verbosity: 1
+  when: sysctl_cmd_supported
   with_items:
     - "{{ sysctl_test3 }}"
     - "{{ sysctl_check3 }}"
@@ -157,6 +160,7 @@
     that:
       - sysctl_test3 is changed
       - 'sysctl_check3.stdout_lines == ["net.ipv4.ip_forward = 1"]'
+  when: sysctl_cmd_supported
 
 - name: Try sysctl with no name
   sysctl:
@@ -164,6 +168,7 @@
     value: 1
     sysctl_set: yes
   ignore_errors: True
+  when: sysctl_cmd_supported
   register: sysctl_no_name
 
 - name: validate nameless results
@@ -171,6 +176,7 @@
     that:
       - sysctl_no_name is failed
       - "sysctl_no_name.msg == 'name cannot be None'"
+  when: sysctl_cmd_supported
 
 - name: Try sysctl with no value
   sysctl:
@@ -178,6 +184,7 @@
     value:
     sysctl_set: yes
   ignore_errors: True
+  when: sysctl_cmd_supported
   register: sysctl_no_value
 
 - name: validate nameless results
@@ -185,6 +192,7 @@
     that:
       - sysctl_no_value is failed
       - "sysctl_no_value.msg == 'value cannot be None'"
+  when: sysctl_cmd_supported
 
 ## 
 ## sysctl - sysctl_set with ignore_errors and ignoreerrors (to ensure backward compatibility) 
@@ -195,7 +203,7 @@
     name: k.doesnotexist
     value: 1 
     ignore_unknown_keys: yes
-    reload: "{{ reload_supported }}"
+    reload: "{{ sysctl_cmd_supported }}"
   register: sysctl_ignore_unknown_keys0
   
 - debug:
@@ -212,7 +220,7 @@
     name: k.doesnotexist
     value: 1 
     ignoreerrors: yes
-    reload: "{{ reload_supported }}"
+    reload: "{{ sysctl_cmd_supported }}"
   register: sysctl_ignoreerrors0
   
 - debug:

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -203,7 +203,7 @@
   when: sysctl_cmd_supported
 
 ## 
-## sysctl - sysctl_set with ignore_errors and ignoreerrors (to ensure backward compatibility) 
+## sysctl - sysctl_set with ignore_unknown_keys and ignoreerrors (to ensure backward compatibility) 
 ## 
 
 - name: set value for fictional key with ignore_unknown_keys
@@ -213,15 +213,18 @@
     ignore_unknown_keys: yes
     reload: "{{ sysctl_cmd_supported }}"
   register: sysctl_ignore_unknown_keys0
+  when: ansible_os_family != 'RedHat'
   
 - debug:
     var: sysctl_ignore_unknown_keys0
     verbosity: 1
+  when: sysctl_cmd_supported and ansible_os_family != 'RedHat'
 
 - name: validate success of set operation with ignore_unknown_keys
   assert: 
     that: 
       - sysctl_ignore_unknown_keys0 is success
+  when: sysctl_cmd_supported and ansible_os_family != 'RedHat'
 
 - name: set value for fictional key with ignoreerrors
   sysctl: 
@@ -230,12 +233,15 @@
     ignoreerrors: yes
     reload: "{{ sysctl_cmd_supported }}"
   register: sysctl_ignoreerrors0
+  when: ansible_os_family != 'RedHat'
   
 - debug:
     var: sysctl_ignoreerrors0
     verbosity: 1
+  when: sysctl_cmd_supported and ansible_os_family != 'RedHat'
 
 - name: validate success of set operation with ignoreerrors
   assert: 
     that: 
       - sysctl_ignoreerrors0 is success
+  when: sysctl_cmd_supported and ansible_os_family != 'RedHat'

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -29,6 +29,20 @@
     path: "{{ output_dir_test }}"
     state: directory
 
+- name: check if sysctl command is available
+  shell: command -v sysctl
+  register: sysctl_command_test
+  ignore_errors: yes
+
+- set_fact:
+    reload_supported: yes
+  when: sysctl_command_test.rc == 0
+
+- set_fact:
+    reload_supported: no
+  when: sysctl_command_test.rc != 0
+
+
 ##
 ## sysctl - file manipulation
 ##
@@ -181,6 +195,7 @@
     name: k.doesnotexist
     value: 1 
     ignore_unknown_keys: yes
+    reload: "{{ reload_supported }}"
   register: sysctl_ignore_unknown_keys0
   
 - debug:
@@ -197,6 +212,7 @@
     name: k.doesnotexist
     value: 1 
     ignoreerrors: yes
+    reload: "{{ reload_supported }}"
   register: sysctl_ignoreerrors0
   
 - debug:

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -205,9 +205,6 @@
 ## 
 ## sysctl - sysctl_set with ignore_unknown_keys and ignoreerrors (to ensure backward compatibility) 
 ## 
-- debug: 
-    var: ansible_os_family 
-    verbosity: 1
 
 - name: set value for fictional key with ignore_unknown_keys
   sysctl: 

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -34,6 +34,10 @@
   register: sysctl_command_test
   ignore_errors: yes
 
+- debug:
+    var: sysctl_command_test
+    verbosity: 1
+
 - set_fact:
     sysctl_cmd_supported: yes
   when: sysctl_command_test.rc == 0
@@ -41,6 +45,10 @@
 - set_fact:
     sysctl_cmd_supported: no
   when: sysctl_command_test.rc != 0
+
+- debug:
+    var: sysctl_cmd_supported
+    verbosity: 1
 
 
 ##
@@ -139,7 +147,7 @@
     value: 1
     sysctl_set: yes
     reload: no
-  when: sysctl_cmd_supported 
+  when: sysctl_cmd_supported
   register: sysctl_test3
 
 - name: check with sysctl command


### PR DESCRIPTION
This PR renames ignoreerrors to ignore_errors and keeps backward compatibility with ignorerrors. 

It's basically to be consistent with all other modules.

The sysctl module is the only one where the attribute is called ignoreerrors and not ignore_errors.
The new parameter is called ignore_errors but supports ignoreerrors as an alias.
The alias ensures that backward compatibility is given and this is not a breaking change.

##### SUMMARY
With this PR ignore_errors is allowed, too. I found it a bit unintuitive because it is not consistent with all other modules where the parameter is called ignore_errors with an underscore. The alias is to ensure backward compatibility because this cosmetically change should not break any playbooks out there. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
sysctl

##### ADDITIONAL INFORMATION
Documentation was updated and 2 tests to test both, ignoreerrors and ignore_errors were added. 
