### PR TITLE
correctly detect pkg_mgr on fedora/rhel/centos rpm-ostree installed

### DIFF
--- a/changelogs/fragments/49184-facts-rpm-ostree-pkgmgr.yml
+++ b/changelogs/fragments/49184-facts-rpm-ostree-pkgmgr.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "facts - properly detect package manager for a Fedora/RHEL/CentOS system that has rpm-ostree installed"

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -75,22 +75,21 @@ class PkgMgrFactCollector(BaseFactCollector):
         if collected_facts['ansible_distribution'] == 'Fedora':
             if os.path.exists('/run/ostree-booted'):
                 return "atomic_container"
-            else:
-                try:
-                    if int(collected_facts['ansible_distribution_major_version']) < 23:
-                        for yum in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'yum']:
-                            if os.path.exists(yum['path']):
-                                pkg_mgr_name = 'yum'
-                                break
-                    else:
-                        for dnf in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'dnf']:
-                            if os.path.exists(dnf['path']):
-                                pkg_mgr_name = 'dnf'
-                                break
-                except ValueError:
-                    # If there's some new magical Fedora version in the future,
-                    # just default to dnf
-                    pkg_mgr_name = 'dnf'
+            try:
+                if int(collected_facts['ansible_distribution_major_version']) < 23:
+                    for yum in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'yum']:
+                        if os.path.exists(yum['path']):
+                            pkg_mgr_name = 'yum'
+                            break
+                else:
+                    for dnf in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'dnf']:
+                        if os.path.exists(dnf['path']):
+                            pkg_mgr_name = 'dnf'
+                            break
+            except ValueError:
+                # If there's some new magical Fedora version in the future,
+                # just default to dnf
+                pkg_mgr_name = 'dnf'
         return pkg_mgr_name
 
     def _check_apt_flavor(self, pkg_mgr_name):

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -73,21 +73,24 @@ class PkgMgrFactCollector(BaseFactCollector):
 
     def _check_rh_versions(self, pkg_mgr_name, collected_facts):
         if collected_facts['ansible_distribution'] == 'Fedora':
-            try:
-                if int(collected_facts['ansible_distribution_major_version']) < 23:
-                    for yum in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'yum']:
-                        if os.path.exists(yum['path']):
-                            pkg_mgr_name = 'yum'
-                            break
-                else:
-                    for dnf in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'dnf']:
-                        if os.path.exists(dnf['path']):
-                            pkg_mgr_name = 'dnf'
-                            break
-            except ValueError:
-                # If there's some new magical Fedora version in the future,
-                # just default to dnf
-                pkg_mgr_name = 'dnf'
+            if os.path.exists('/run/ostree-booted'):
+                return "atomic_container"
+            else:
+                try:
+                    if int(collected_facts['ansible_distribution_major_version']) < 23:
+                        for yum in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'yum']:
+                            if os.path.exists(yum['path']):
+                                pkg_mgr_name = 'yum'
+                                break
+                    else:
+                        for dnf in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'dnf']:
+                            if os.path.exists(dnf['path']):
+                                pkg_mgr_name = 'dnf'
+                                break
+                except ValueError:
+                    # If there's some new magical Fedora version in the future,
+                    # just default to dnf
+                    pkg_mgr_name = 'dnf'
         return pkg_mgr_name
 
     def _check_apt_flavor(self, pkg_mgr_name):


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Check the path /run/ostree-booted which I'm told by upstream that it
will always be present when a host system is Fedora/RHEL/CentOS
Atomic/CoreOS vs "traditional" distro instance to detect the
non-traditional instance and ensure pkg_mgr selection is correct

Fixes #49184

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
setup
