### PR TITLE
require git when trying to use it in ansible-galaxy cli (#49212)

### DIFF
--- a/changelogs/fragments/49212-require-git-ansible-galaxy.yaml
+++ b/changelogs/fragments/49212-require-git-ansible-galaxy.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - "ansible-galaxy: properly warn when git isn't found in an installed bin path instead of traceback"

--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -159,7 +159,7 @@ class RoleRequirement(RoleDefinition):
             raise AnsibleError("- scm %s is not currently supported" % scm)
 
         try:
-            scm_path = get_bin_path(scm)
+            scm_path = get_bin_path(scm, required=True)
         except (ValueError, OSError, IOError):
             raise AnsibleError("could not find/use %s, it is required to continue with installing %s" % (scm, src))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* require git when trying to use it in ansible-galaxy cli

Previously we weren't setting `required=True` when calling
`get_bin_path` and the path would return `None`, this would cause
a traceback when attempting to ' '.join() to create a string
representation of the failed command for error output

Fixes #49200

Signed-off-by: Adam Miller <admiller@redhat.com>

* add changelog

Signed-off-by: Adam Miller <admiller@redhat.com>
(cherry picked from commit 81540bd754e8f96857057e3391f0d299273ebec2)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-galaxy

