### PR TITLE
preventing zero-length string value for option --limit

### DIFF
--- a/changelogs/fragments/49261_Limit_option_requires_non-zero_length_string_value.yaml
+++ b/changelogs/fragments/49261_Limit_option_requires_non-zero_length_string_value.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- ansible.cli.CLI.parse - Limit option requires non-zero length string value (https://github.com/ansible/ansible/pull/49261)

--- a/changelogs/fragments/49261_preventiong_zero_length_string_value_for_option_--limit.yaml
+++ b/changelogs/fragments/49261_preventiong_zero_length_string_value_for_option_--limit.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- ansible.cli.CLI.parse - raise exception if option --limit get zero length string value(https://github.com/ansible/ansible/pull/49261) 

--- a/changelogs/fragments/49261_preventiong_zero_length_string_value_for_option_--limit.yaml
+++ b/changelogs/fragments/49261_preventiong_zero_length_string_value_for_option_--limit.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-- ansible.cli.CLI.parse - raise exception if option --limit get zero length string value(https://github.com/ansible/ansible/pull/49261) 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -576,7 +576,10 @@ class CLI(with_metaclass(ABCMeta, object)):
         self.options, self.args = self.parser.parse_args(self.args[1:])
 
         # --limit must receive non-zero length string
-        if hasattr(self.options, 'subset') and  self.options.subset != C.DEFAULT_SUBSET and isinstance( self.options.subset, string_types) and len(self.options.subset) == 0:
+        if hasattr(self.options, 'subset') and  \
+           self.options.subset != C.DEFAULT_SUBSET and \
+           isinstance(self.options.subset, string_types) and \
+           len(self.options.subset) == 0:
             raise ValueError("ansible-playbook: error: --limit option requires non-zero length string")
 
         # process tags

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -577,10 +577,10 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         # --limit must receive non-zero length string
         if hasattr(self.options, 'subset') and  \
-           self.options.subset != C.DEFAULT_SUBSET and \
-           isinstance(self.options.subset, string_types) and \
-           len(self.options.subset) == 0:
-            raise ValueError("ansible-playbook: error: --limit option requires non-zero length string")
+                self.options.subset != C.DEFAULT_SUBSET and \
+                isinstance(self.options.subset, string_types) and \
+                len(self.options.subset) == 0:
+            raise AnsibleOptionsError("Limit option requires non-zero length string")
 
         # process tags
         if hasattr(self.options, 'tags') and not self.options.tags:

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -575,6 +575,10 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         self.options, self.args = self.parser.parse_args(self.args[1:])
 
+        # --limit must receive non-zero length string
+        if hasattr(self.options, 'subset') and  self.options.subset != C.DEFAULT_SUBSET and isinstance( self.options.subset, string_types) and len(self.options.subset) == 0:
+            raise ValueError("ansible-playbook: error: --limit option requires non-zero length string")
+
         # process tags
         if hasattr(self.options, 'tags') and not self.options.tags:
             # optparse defaults does not do what's expected

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -576,10 +576,8 @@ class CLI(with_metaclass(ABCMeta, object)):
         self.options, self.args = self.parser.parse_args(self.args[1:])
 
         # --limit must receive non-zero length string
-        if hasattr(self.options, 'subset') and  \
-                self.options.subset != C.DEFAULT_SUBSET and \
-                isinstance(self.options.subset, string_types) and \
-                len(self.options.subset) == 0:
+        limit = getattr(self.options, 'subset', C.DEFAULT_SUBSET)
+        if limit != C.DEFAULT_SUBSET and not limit:
             raise AnsibleOptionsError("Limit option requires non-zero length string")
 
         # process tags


### PR DESCRIPTION
##### SUMMARY

When running `ansible-playbook` with an zero length string value for the option `--limit `, the playbook will be applied on whole inventory or whole group specified by `- hosts`
It could result irreparable harm. It should be strictly forbidden.  

The empty argument could occur when running playbook inside a shell script where the shell variable is not valued.
 
  `ansible-playbook test.yaml --limit $testing_group ( $test_group is empty or not setted)`

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

function ansible.cli.CLI.parse(self)


##### ADDITIONAL INFORMATION

* The testing playbook:

```
---
- hosts: all
  gather_facts: no
  tasks:
  - ping:
```

* run playbook as:

```
$ ansible-playbook -i 'centos2,centos3,' test.yaml  --limit ""

PLAY [all] *******************************************************************************************

TASK [ping] ******************************************************************************************
ok: [centos3]
ok: [centos2]

PLAY RECAP *******************************************************************************************
centos2                    : ok=1    changed=0    unreachable=0    failed=0    skipped=0
centos3                    : ok=1    changed=0    unreachable=0    failed=0    skipped=0
```

* in order to prevent it,  non-zero length string check is done in ansible.cli.CLI.parse


* re-run playbook

```
$ ansible-playbook  -i 'centos2,centos3' test.yaml --limit ""
ERROR! Unexpected Exception, this is probably a bug: ansible-playbook: error: --limit option requires non-zero length string
to see the full traceback, use -vvv
```
   