### PR TITLE
Update intro_inventory.rst to show YAML ranges

### DIFF
--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -103,10 +103,21 @@ Generally speaking, this is not the best way to define variables that describe y
 
 If you are adding a lot of hosts following similar patterns, you can do this rather than listing each hostname:
 
+In INI:
+
 .. code-block:: guess
 
     [webservers]
     www[01:50].example.com
+    
+In YAML:
+
+.. code-block:: yaml
+
+    ...
+      webservers:
+        hosts:
+          www[01:50].example.com:
 
 For numeric patterns, leading zeros can be included or removed, as desired. Ranges are inclusive.  You can also define alphabetic ranges:
 


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
The current version of this page only shows an INI example for listing a range of hosts using [00:50] or similar formatting. This works in YAML inventories, too, but the documentation does not make this clear.

I added a YAML example, similar to what is done elsewhere in the document, to make this more clear.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
intro_inventory.rst