### PR TITLE
ACME: improve error handling

### DIFF
--- a/changelogs/fragments/49266-acme-error-messages.yml
+++ b/changelogs/fragments/49266-acme-error-messages.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ACME modules: improve error messages in some cases (include error returned by server)."

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -579,6 +579,8 @@ class ACMEAccount(object):
                             continue
                         if parse_json_result:
                             result = decoded_result
+                        else:
+                            result = content
                     except ValueError:
                         raise ModuleFailException("Failed to parse the ACME response: {0} {1}".format(url, content))
                 else:

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -564,7 +564,7 @@ class ACMEAccount(object):
             try:
                 content = resp.read()
             except AttributeError:
-                content = info.get('body')
+                content = info.pop('body')
 
             if content or not parse_json_result:
                 if (parse_json_result and info['content-type'].startswith('application/json')) or 400 <= info['status'] < 600:
@@ -610,7 +610,7 @@ class ACMEAccount(object):
             try:
                 content = resp.read()
             except AttributeError:
-                content = info.get('body')
+                content = info.pop('body')
 
         # Process result
         if parse_json_result:


### PR DESCRIPTION
##### SUMMARY
Two general ACME improvements extracted from #48444, which should be backported:
  1. In case `parse_json_result` is `False` and an error occurs, returns the return body instead of `{}`;
  2. Remove the return body from the `info` dict. (So if someone dumps the `info` dict, it will only contain headers etc.).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/acme.py
