### PR TITLE
Deprecate the github_hooks module

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -83,6 +83,7 @@ The following modules will be removed in Ansible 2.12. Please update your playbo
 
 * ``foreman`` use <https://github.com/theforeman/foreman-ansible-modules> instead.
 * ``katello`` use <https://github.com/theforeman/foreman-ansible-modules> instead.
+* ``github_hooks`` use :ref:`github_webhook <github_webhook_module>` and :ref:`github_webhook_facts <github_webhook_facts_module>` instead.
 
 
 Noteworthy module changes

--- a/lib/ansible/modules/source_control/_github_hooks.py
+++ b/lib/ansible/modules/source_control/_github_hooks.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 
@@ -17,6 +17,10 @@ DOCUMENTATION = '''
 ---
 module: github_hooks
 short_description: Manages GitHub service hooks.
+deprecated:
+  removed_in: "2.12"
+  why: Replaced by more granular modules
+  alternative: Use M(github_webhook) and M(github_webhook_facts) instead.
 description:
      - Adds service hooks and removes service hooks that have an error status.
 version_added: "1.4"


### PR DESCRIPTION
##### SUMMARY

This is part of a two-part replacement for `github_hooks`, which lacks a number of important features and has a strange interface. The replacement modules are added here:

* `github_webhook`: https://github.com/ansible/ansible/pull/35813
* `github_webhook_facts`: https://github.com/ansible/ansible/pull/35814

`github_hooks` lacks a number of important features: The ability to specify the events on which a webhook should fire; the ability to add a shared secret to a hook; the ability to create hooks that do not verify SSL against their target; and more. I considered merely updating that module to add the features needed, but the existing interface is pretty odd and would be difficult to update in a backwards-compatible way. For instance, it has a built-in feature for deleting all hooks whose last request returned 504 (`action: clean504`), but no way to update an existing hook, or delete a specific hook. It requires you to provide the API URL to a repository, rather than just the name of the repo (and optionally a Github API base), which requires a fair degree of familiarity with the Github API.

It has other issues that are easier to fix, but still weighed in on my decision to replace rather than upgrade: it rolls its own API client layer rather than using an existing library; it appears to support both password and API token auth, but only accepts a single `oauthkey` argument, which is a misnomer in both cases.

Rather than try to update it and fix all of the issues, I replaced it with two modules whose usage patterns are, I hope, much more intuitive.

##### ISSUE TYPE

 - New Module Pull Request

(Except not really? Kind of the opposite TBH.)

##### COMPONENT NAME

github_hooks