### PR TITLE
ovirt add sync_networks

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -324,7 +324,7 @@ class HostNetworksModule(BaseModule):
                 self._service.service(entity.id).commit_net_config()
             self.changed = True
 
-def check_if_needs_sync(nics_service):
+def needs_sync(nics_service):
     nics = nics_service.list()
     for nic in nics:
         nic_service = nics_service.nic_service(nic.id)
@@ -377,7 +377,7 @@ def main():
         nic = search_by_name(nics_service, nic_name)
 
         if module.params["sync_networks"]:
-            if check_if_needs_sync(nics_service):
+            if needs_sync(nics_service):
                 host_service.sync_all_networks()
                 host_networks_module.changed = True
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -80,6 +80,7 @@ options:
         description:
             - "If I(true) networks will synchronize."
         type: bool
+        version_added: 2.8
 extends_documentation_fragment: ovirt
 '''
 
@@ -323,6 +324,14 @@ class HostNetworksModule(BaseModule):
                 self._service.service(entity.id).commit_net_config()
             self.changed = True
 
+def check_if_needs_sync(nics_service):
+    nics = nics_service.list()
+    for nic in nics:
+        nic_service = nics_service.nic_service(nic.id)
+        for network_attachment_service in nic_service.network_attachments_service().list():
+            if not network_attachment_service.in_sync:
+                return True
+    return False
 
 def main():
     argument_spec = ovirt_full_argument_spec(
@@ -368,7 +377,9 @@ def main():
         nic = search_by_name(nics_service, nic_name)
 
         if module.params["sync_networks"]:
-            host_service.sync_all_networks()
+            if check_if_needs_sync(nics_service):
+                host_service.sync_all_networks()
+                host_networks_module.changed = True
 
         network_names = [network['name'] for network in networks or []]
         state = module.params['state']

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -76,6 +76,10 @@ options:
         description:
             - "If I(true) network configuration will be persistent, by default they are temporarily."
         type: bool
+    sync_networks:
+        description:
+            - "If I(true) networks will synchronize."
+        type: bool
 extends_documentation_fragment: ovirt
 '''
 
@@ -333,6 +337,7 @@ def main():
         labels=dict(default=None, type='list'),
         check=dict(default=None, type='bool'),
         save=dict(default=None, type='bool'),
+        sync_networks=dict(default=False, type='bool'),
     )
     module = AnsibleModule(argument_spec=argument_spec)
 
@@ -362,8 +367,12 @@ def main():
         nics_service = host_service.nics_service()
         nic = search_by_name(nics_service, nic_name)
 
+        if module.params["sync_networks"]:
+            host_service.sync_all_networks()
+
         network_names = [network['name'] for network in networks or []]
         state = module.params['state']
+
         if (
             state == 'present' and
             (nic is None or host_networks_module.has_update(nics_service.service(nic.id)))

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -324,6 +324,7 @@ class HostNetworksModule(BaseModule):
                 self._service.service(entity.id).commit_net_config()
             self.changed = True
 
+
 def needs_sync(nics_service):
     nics = nics_service.list()
     for nic in nics:
@@ -332,6 +333,7 @@ def needs_sync(nics_service):
             if not network_attachment_service.in_sync:
                 return True
     return False
+
 
 def main():
     argument_spec = ovirt_full_argument_spec(

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -379,9 +379,10 @@ def main():
         nics_service = host_service.nics_service()
         nic = search_by_name(nics_service, nic_name)
 
-        if module.params["sync_networks"] and not module.check_mode:
+        if module.params["sync_networks"]:
             if needs_sync(nics_service):
-                host_service.sync_all_networks()
+                if not module.check_mode:
+                    host_service.sync_all_networks()
                 host_networks_module.changed = True
 
         network_names = [network['name'] for network in networks or []]

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -78,8 +78,9 @@ options:
         type: bool
     sync_networks:
         description:
-            - "If I(true) networks will synchronize."
+            - "If I(true) all networks will be synchronized before modification"
         type: bool
+        default: false
         version_added: 2.8
 extends_documentation_fragment: ovirt
 '''
@@ -378,7 +379,7 @@ def main():
         nics_service = host_service.nics_service()
         nic = search_by_name(nics_service, nic_name)
 
-        if module.params["sync_networks"]:
+        if module.params["sync_networks"] and not module.check_mode:
             if needs_sync(nics_service):
                 host_service.sync_all_networks()
                 host_networks_module.changed = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

add ovirt synch networks
when you have unsynchronized network and you need to sync them
you can got this issue from changing VLAN or MTU...
https://www.ovirt.org/documentation/how-to/networking/setupnetworks-syncnetworks/

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #39953

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
