### PR TITLE
Fix iosxr netconf plugin response namespace (#49238)

### DIFF
--- a/changelogs/fragments/iosxr_netconf_plugin_fix.yaml
+++ b/changelogs/fragments/iosxr_netconf_plugin_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix iosxr netconf plugin response namespace (https://github.com/ansible/ansible/pull/49300)

--- a/lib/ansible/plugins/netconf/iosxr.py
+++ b/lib/ansible/plugins/netconf/iosxr.py
@@ -124,56 +124,80 @@ class Netconf(NetconfBase):
 
     # TODO: change .xml to .data_xml, when ncclient supports data_xml on all platforms
     @ensure_connected
-    def get(self, filter=None):
+    def get(self, filter=None, remove_ns=False):
         if isinstance(filter, list):
             filter = tuple(filter)
         try:
-            response = self.m.get(filter=filter)
-            return remove_namespaces(response)
+            resp = self.m.get(filter=filter)
+            if remove_ns:
+                response = remove_namespaces(resp)
+            else:
+                response = resp.data_xml if hasattr(resp, 'data_xml') else resp.xml
+            return response
         except RPCError as exc:
             raise Exception(to_xml(exc.xml))
 
     @ensure_connected
-    def get_config(self, source=None, filter=None):
+    def get_config(self, source=None, filter=None, remove_ns=False):
         if isinstance(filter, list):
             filter = tuple(filter)
         try:
-            response = self.m.get_config(source=source, filter=filter)
-            return remove_namespaces(response)
+            resp = self.m.get_config(source=source, filter=filter)
+            if remove_ns:
+                response = remove_namespaces(resp)
+            else:
+                response = resp.data_xml if hasattr(resp, 'data_xml') else resp.xml
+            return response
         except RPCError as exc:
             raise Exception(to_xml(exc.xml))
 
     @ensure_connected
-    def edit_config(self, config=None, format='xml', target='candidate', default_operation=None, test_option=None, error_option=None):
+    def edit_config(self, config=None, format='xml', target='candidate', default_operation=None, test_option=None, error_option=None, remove_ns=False):
         if config is None:
             raise ValueError('config value must be provided')
         try:
-            response = self.m.edit_config(config, format=format, target=target, default_operation=default_operation, test_option=test_option,
-                                          error_option=error_option)
-            return remove_namespaces(response)
+            resp = self.m.edit_config(config, format=format, target=target, default_operation=default_operation, test_option=test_option,
+                                      error_option=error_option)
+            if remove_ns:
+                response = remove_namespaces(resp)
+            else:
+                response = resp.data_xml if hasattr(resp, 'data_xml') else resp.xml
+            return response
         except RPCError as exc:
             raise Exception(to_xml(exc.xml))
 
     @ensure_connected
-    def commit(self, confirmed=False, timeout=None, persist=None):
+    def commit(self, confirmed=False, timeout=None, persist=None, remove_ns=False):
         try:
-            response = self.m.commit(confirmed=confirmed, timeout=timeout, persist=persist)
-            return remove_namespaces(response)
+            resp = self.m.commit(confirmed=confirmed, timeout=timeout, persist=persist)
+            if remove_ns:
+                response = remove_namespaces(resp)
+            else:
+                response = resp.data_xml if hasattr(resp, 'data_xml') else resp.xml
+            return response
         except RPCError as exc:
             raise Exception(to_xml(exc.xml))
 
     @ensure_connected
-    def validate(self, source="candidate"):
+    def validate(self, source="candidate", remove_ns=False):
         try:
-            response = self.m.validate(source=source)
-            return remove_namespaces(response)
+            resp = self.m.validate(source=source)
+            if remove_ns:
+                response = remove_namespaces(resp)
+            else:
+                response = resp.data_xml if hasattr(resp, 'data_xml') else resp.xml
+            return response
         except RPCError as exc:
             raise Exception(to_xml(exc.xml))
 
     @ensure_connected
-    def discard_changes(self):
+    def discard_changes(self, remove_ns=False):
         try:
-            response = self.m.discard_changes()
-            return remove_namespaces(response)
+            resp = self.m.discard_changes()
+            if remove_ns:
+                response = remove_namespaces(resp)
+            else:
+                response = resp.data_xml if hasattr(resp, 'data_xml') else resp.xml
+            return response
         except RPCError as exc:
             raise Exception(to_xml(exc.xml))


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Fix iosxr netconf plugin response namespace

*  iosxr netconf plugin removes namespace by default
   for all the responses as parsing of xml is easier without namespace in iosxr module. However, to validate the response received from device against yang model requires namespace to be present in the response.
*  Add a parameter in iosxr netconf plugin to control if the namespace
   should be removed from the response or not.

* Fix CI issues

* Fix review comment

Merged to devel https://github.com/ansible/ansible/pull/49238
(cherry picked from commit 829fc0fedad9fd544674049a8ba0a304a40c0f9b)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf/iosxr.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
