### PR TITLE
AWS Module Documentation Edits (Second Attempt)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -179,7 +179,7 @@ options:
     description:
       - a list of hash/dictionaries of volumes to add to the new instance; '[{"key":"value", "key":"value"}]'; keys allowed
         are - device_name (str; required), delete_on_termination (bool; False), device_type (deprecated), ephemeral (str),
-        encrypted (bool; False), snapshot (str), volume_type (str), volume_size (int, GB), iops (int) - device_type
+        encrypted (bool; False), snapshot (str), volume_type (str), volume_size (int, GiB), iops (int) - device_type
         is deprecated use volume_type, iops must be set when volume_type='io1', ephemeral and snapshot are mutually exclusive.
   ebs_optimized:
     version_added: "1.6"
@@ -1102,7 +1102,7 @@ def create_instances(module, ec2, vpc, override_count=None):
                 for volume in volumes:
                     if 'device_name' not in volume:
                         module.fail_json(msg='Device name must be set for volume')
-                    # Minimum volume size is 1GB. We'll use volume size explicitly set to 0
+                    # Minimum volume size is 1GiB. We'll use volume size explicitly set to 0
                     # to be a signal not to create this volume
                     if 'volume_size' not in volume or int(volume['volume_size']) > 0:
                         bdm[volume['device_name']] = create_block_device(module, ec2, volume)

--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -71,7 +71,7 @@ options:
     description:
       - List of device hashes/dictionaries with custom configurations (same block-device-mapping parameters).
       - >
-        Valid properties include: device_name, volume_type, size/volume_size (in GB), delete_on_termination (boolean), no_device (boolean),
+        Valid properties include: device_name, volume_type, size/volume_size (in GiB), delete_on_termination (boolean), no_device (boolean),
         snapshot_id, iops (for io1 volume_type), encrypted
   delete_snapshot:
     description:

--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -487,7 +487,7 @@ def create_launch_config(connection, module):
         for volume in volumes:
             if 'device_name' not in volume:
                 module.fail_json(msg='Device name must be set for volume')
-            # Minimum volume size is 1GB. We'll use volume size explicitly set to 0 to be a signal not to create this volume
+            # Minimum volume size is 1GiB. We'll use volume size explicitly set to 0 to be a signal not to create this volume
             if 'volume_size' not in volume or int(volume['volume_size']) > 0:
                 block_device_mapping.append(create_block_device_meta(module, volume))
 


### PR DESCRIPTION
##### SUMMARY
Changing instances of "GB" to "GiB" when referring to AWS instance volumes.


##### ISSUE TYPE
Module documentation update

##### COMPONENT NAME
```
ec2.py
ec2_ami.py
ec2_lc.py
```

##### ADDITIONAL INFORMATION
Changes related to the following PR:
https://github.com/ansible/ansible/pull/49242