### PR TITLE
Add explicit ansible_httpapi_port setting

### DIFF
--- a/test/integration/targets/nxos_nxapi_transports/tests/nxapi/assert_transports.yaml
+++ b/test/integration/targets/nxos_nxapi_transports/tests/nxapi/assert_transports.yaml
@@ -7,6 +7,7 @@
   vars:
     ansible_httpapi_use_ssl: yes
     ansible_httpapi_validate_certs: no
+    ansible_httpapi_port: 443
   register: result
 
 - name: Assert command over connection httpapi was successful


### PR DESCRIPTION
##### SUMMARY
This fix sets the `ansible_httpapi_port` to `443` for the  `nxos_nxapi_transports/tests/nxapi/assert_transports.yaml` test.

Without this the test may not use the correct port for the test and fail to connect to the device.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_nxapi_transports

##### ADDITIONAL INFORMATION
We are seeing the following problem on our Ubuntu ansible controller when the default setting in `group_vars` for `ansible_httpapi_port` is `80`.  With the same settings on MacOS we don't see the same problem.

```bash
334157: %LIB-6-INFO: task path: /root/agents-ci/ansible/test/integration/targets/nxos_nxapi_transports/tests/nxapi/assert_transports.yaml:3
334158: %LIB-6-INFO: loaded API plugin for network_os nxos
334159: %LIB-6-INFO: loaded cliconf plugin for network_os nxos
334160: %LIB-6-INFO: <n9k.example.com> attempting to start connection
334161: %LIB-6-INFO: <n9k.example.com> using connection plugin httpapi
334162: %LIB-6-INFO: <n9k.example.com> local domain socket does not exist, starting it
334163: %LIB-6-INFO: <n9k.example.com> control socket path is /root/.ansible/pc/ce29c02853
334164: %LIB-6-INFO: <n9k.example.com> loaded API plugin for network_os nxos
334165: %LIB-6-INFO: <n9k.example.com> loaded cliconf plugin for network_os nxos
334166: %LIB-6-INFO: <n9k.example.com> connection to remote device started successfully
334167: %LIB-6-INFO: <n9k.example.com> local domain socket listeners started successfully
334168: %LIB-6-INFO: <n9k.example.com> 
334169: %LIB-6-INFO: <n9k.example.com> local domain socket path is /root/.ansible/pc/ce29c02853
334170: %LIB-6-INFO: <n9k.example.com> ESTABLISH LOCAL CONNECTION FOR USER: root
334171: %LIB-6-INFO: <n9k.example.com> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-local-27938lvtihq/ansible-tmp-1543096515.81-117785014710593 `" && echo ansible-tmp-1543096515.81-117785014710593="` echo /root/.ansible/tmp/ansible-local-27938lvtihq/ansible-tmp-1543096515.81-117785014710593 `" ) && sleep 0'
334172: %LIB-6-INFO: Using module file /root/agents-ci/ansible/lib/ansible/modules/network/nxos/nxos_command.py
334173: %LIB-6-INFO: <n9k.example.com> PUT /root/.ansible/tmp/ansible-local-27938lvtihq/tmpf4JXno TO /root/.ansible/tmp/ansible-local-27938lvtihq/ansible-tmp-1543096515.81-117785014710593/AnsiballZ_nxos_command.py
334174: %LIB-6-INFO: <n9k.example.com> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-local-27938lvtihq/ansible-tmp-1543096515.81-117785014710593/ /root/.ansible/tmp/ansible-local-27938lvtihq/ansible-tmp-1543096515.81-117785014710593/AnsiballZ_nxos_command.py && sleep 0'
334175: %LIB-6-INFO: <n9k.example.com> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-local-27938lvtihq/ansible-tmp-1543096515.81-117785014710593/AnsiballZ_nxos_command.py && sleep 0'
334176: %LIB-6-INFO: <n9k.example.com> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-local-27938lvtihq/ansible-tmp-1543096515.81-117785014710593/ > /dev/null 2>&1 && sleep 0'
334177: %LIB-6-INFO: The full traceback is:
334178: %LIB-6-INFO: WARNING: The below traceback may *not* be related to the actual failure.
334179: %LIB-6-INFO:   File "/tmp/ansible_nxos_command_payload_TlfPNh/ansible_nxos_command_payload.zip/ansible/module_utils/network/nxos/nxos.py", line 158, in run_commands
334180: %LIB-6-INFO:     out = connection.run_commands(commands, check_rc)
334181: %LIB-6-INFO:   File "/tmp/ansible_nxos_command_payload_TlfPNh/ansible_nxos_command_payload.zip/ansible/module_utils/connection.py", line 201, in __rpc__
334182: %LIB-6-INFO:     raise ConnectionError(to_text(msg, errors='surrogate_then_replace'), code=code)
334183: %LIB-6-INFO: fatal: [n9k.example.com]: FAILED! => {
334184: %LIB-6-INFO:     "changed": false, 
334185: %LIB-6-INFO:     "invocation": {
334186: %LIB-6-INFO:         "module_args": {
334187: %LIB-6-INFO:             "auth_pass": null, 
334188: %LIB-6-INFO:             "authorize": null, 
334189: %LIB-6-INFO:             "commands": [
334190: %LIB-6-INFO:                 "show hostname"
334191: %LIB-6-INFO:             ], 
334192: %LIB-6-INFO:             "host": null, 
334193: %LIB-6-INFO:             "interval": 1, 
334194: %LIB-6-INFO:             "match": "all", 
334195: %LIB-6-INFO:             "password": null, 
334196: %LIB-6-INFO:             "port": null, 
334197: %LIB-6-INFO:             "provider": null, 
334198: %LIB-6-INFO:             "retries": 10, 
334199: %LIB-6-INFO:             "ssh_keyfile": null, 
334200: %LIB-6-INFO:             "timeout": null, 
334201: %LIB-6-INFO:             "transport": null, 
334202: %LIB-6-INFO:             "use_ssl": null, 
334203: %LIB-6-INFO:             "username": null, 
334204: %LIB-6-INFO:             "validate_certs": null, 
334205: %LIB-6-INFO:             "wait_for": null
334206: %LIB-6-INFO:         }
334207: %LIB-6-INFO:     }, 
334208: %LIB-6-INFO:     "msg": "Could not connect to https://n9k.example.com:80/ins: [Errno 111] Connection refused"
```