### PR TITLE
Do not allow addressing an import from handlers via notify

### DIFF
--- a/changelogs/fragments/48936-import-handlers.yaml
+++ b/changelogs/fragments/48936-import-handlers.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- imports - Prevent the name of an import from being addressable as a handler, only the tasks within should
+  be addressable. Use an include instead of an import if you need to execute many tasks from a single handler
+  (https://github.com/ansible/ansible/issues/48936)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -402,7 +402,7 @@ class StrategyBase:
 
         def parent_handler_match(target_handler, handler_name):
             if target_handler:
-                if isinstance(target_handler, (TaskInclude, IncludeRole)):
+                if isinstance(target_handler, (TaskInclude, IncludeRole)) and not getattr(target_handler, 'statically_loaded', True):
                     try:
                         handler_vars = self._variable_manager.get_vars(play=iterator._play, task=target_handler)
                         templar = Templar(loader=self._loader, variables=handler_vars)

--- a/test/integration/targets/include_import/handler_addressing/playbook.yml
+++ b/test/integration/targets/include_import/handler_addressing/playbook.yml
@@ -1,0 +1,11 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: include_handler_test
+
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: import_handler_test

--- a/test/integration/targets/include_import/handler_addressing/roles/import_handler_test/handlers/main.yml
+++ b/test/integration/targets/include_import/handler_addressing/roles/import_handler_test/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: do_import
+  import_tasks: tasks/handlers.yml

--- a/test/integration/targets/include_import/handler_addressing/roles/import_handler_test/tasks/handlers.yml
+++ b/test/integration/targets/include_import/handler_addressing/roles/import_handler_test/tasks/handlers.yml
@@ -1,0 +1,2 @@
+- debug:
+    msg: import handler task

--- a/test/integration/targets/include_import/handler_addressing/roles/import_handler_test/tasks/main.yml
+++ b/test/integration/targets/include_import/handler_addressing/roles/import_handler_test/tasks/main.yml
@@ -1,0 +1,3 @@
+- command: "true"
+  notify:
+    - do_import

--- a/test/integration/targets/include_import/handler_addressing/roles/include_handler_test/handlers/main.yml
+++ b/test/integration/targets/include_import/handler_addressing/roles/include_handler_test/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: do_include
+  include_tasks: tasks/handlers.yml

--- a/test/integration/targets/include_import/handler_addressing/roles/include_handler_test/tasks/handlers.yml
+++ b/test/integration/targets/include_import/handler_addressing/roles/include_handler_test/tasks/handlers.yml
@@ -1,0 +1,2 @@
+- debug:
+    msg: include handler task

--- a/test/integration/targets/include_import/handler_addressing/roles/include_handler_test/tasks/main.yml
+++ b/test/integration/targets/include_import/handler_addressing/roles/include_handler_test/tasks/main.yml
@@ -1,0 +1,3 @@
+- command: "true"
+  notify:
+    - do_include

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -86,3 +86,7 @@ ansible-playbook public_exposure/no_overwrite_roles.yml -i ../../inventory "$@"
 
 # https://github.com/ansible/ansible/pull/48068
 ansible-playbook run_once/playbook.yml "$@"
+
+# https://github.com/ansible/ansible/issues/48936
+ansible-playbook -v handler_addressing/playbook.yml 2>&1 | tee test_handler_addressing.out
+test "$(egrep -c 'include handler task|ERROR! The requested handler '"'"'do_import'"'"' was not found' test_handler_addressing.out)" = 2


### PR DESCRIPTION
##### SUMMARY
Prevent the name of an import from being addressable as a handler, only the tasks within should be addressable. Use an include instead of an import if you need to execute many tasks from a single handler

Fixes #48936

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/strategy/__init__.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```