### PR TITLE
Support for pids_limit parameter in docker_container module

### DIFF
--- a/changelogs/fragments/49319-docker_container-pids_limit.yaml
+++ b/changelogs/fragments/49319-docker_container-pids_limit.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_container - Added support for ``pids_limit`` parameter in docker_container."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -408,6 +408,12 @@ options:
     description:
       - Set the PID namespace mode for the container.
       - Note that docker-py < 2.0 only supports 'host'. Newer versions allow all values supported by the docker daemon.
+  pids_limit:
+    description:
+      - Set PID limit for the container. It accepts an integer value.
+      - Set -1 for unlimited PID.
+    type: int
+    version_added: "2.8"
   privileged:
     description:
       - Give extended privileges to the container.
@@ -1012,6 +1018,7 @@ class TaskParameters(DockerBaseClass):
         self.oom_score_adj = None
         self.paused = None
         self.pid_mode = None
+        self.pids_limit = None
         self.privileged = None
         self.purge_networks = None
         self.pull = None
@@ -1276,6 +1283,7 @@ class TaskParameters(DockerBaseClass):
             device_write_bps='device_write_bps',
             device_read_iops='device_read_iops',
             device_write_iops='device_write_iops',
+            pids_limit='pids_limit',
         )
 
         if self.client.docker_py_version >= LooseVersion('1.9') and self.client.docker_api_version >= LooseVersion('1.22'):
@@ -1690,6 +1698,7 @@ class Container(DockerBaseClass):
         self.parameters_map['device_write_bps'] = 'device_write_bps'
         self.parameters_map['device_read_iops'] = 'device_read_iops'
         self.parameters_map['device_write_iops'] = 'device_write_iops'
+        self.parameters_map['pids_limit'] = 'pids_limit'
 
     def fail(self, msg):
         self.parameters.client.module.fail_json(msg=msg)
@@ -1814,6 +1823,7 @@ class Container(DockerBaseClass):
             device_write_bps=host_config.get('BlkioDeviceWriteBps'),
             device_read_iops=host_config.get('BlkioDeviceReadIOps'),
             device_write_iops=host_config.get('BlkioDeviceWriteIOps'),
+            pids_limit=host_config.get('PidsLimit'),
         )
         # Options which don't make sense without their accompanying option
         if self.parameters.restart_policy:
@@ -2782,6 +2792,7 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
             sysctls=dict(docker_py_version='1.10.0', docker_api_version='1.24'),
             userns_mode=dict(docker_py_version='1.10.0', docker_api_version='1.23'),
             uts=dict(docker_py_version='3.5.0', docker_api_version='1.25'),
+            pids_limit=dict(docker_py_version='1.10.0', docker_api_version='1.23'),
             # specials
             ipvX_address_supported=dict(docker_py_version='1.9.0', detect_usage=detect_ipvX_address_usage,
                                         usage_msg='ipv4_address or ipv6_address in networks'),
@@ -2937,6 +2948,7 @@ def main():
         output_logs=dict(type='bool', default=False),
         paused=dict(type='bool', default=False),
         pid_mode=dict(type='str'),
+        pids_limit=dict(type='int'),
         privileged=dict(type='bool', default=False),
         published_ports=dict(type='list', aliases=['ports'], elements='str'),
         pull=dict(type='bool', default=False),

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -410,8 +410,8 @@ options:
       - Note that docker-py < 2.0 only supports 'host'. Newer versions allow all values supported by the docker daemon.
   pids_limit:
     description:
-      - Set PID limit for the container. It accepts an integer value.
-      - Set -1 for unlimited PID.
+      - Set PIDs limit for the container. It accepts an integer value.
+      - Set -1 for unlimited PIDs.
     type: int
     version_added: "2.8"
   privileged:
@@ -1694,11 +1694,6 @@ class Container(DockerBaseClass):
         self.parameters_map['expected_cmd'] = 'command'
         self.parameters_map['expected_devices'] = 'devices'
         self.parameters_map['expected_healthcheck'] = 'healthcheck'
-        self.parameters_map['device_read_bps'] = 'device_read_bps'
-        self.parameters_map['device_write_bps'] = 'device_write_bps'
-        self.parameters_map['device_read_iops'] = 'device_read_iops'
-        self.parameters_map['device_write_iops'] = 'device_write_iops'
-        self.parameters_map['pids_limit'] = 'pids_limit'
 
     def fail(self, msg):
         self.parameters.client.module.fail_json(msg=msg)

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -2784,8 +2784,8 @@
     name: "{{ cname }}"
     state: started
     pids_limit: 10
-    force_kill: yes
   register: pids_limit_1
+  ignore_errors: yes
 
 - name: pids_limit (idempotency)
   docker_container:
@@ -2794,8 +2794,8 @@
     name: "{{ cname }}"
     state: started
     pids_limit: 10
-    force_kill: yes
   register: pids_limit_2
+  ignore_errors: yes
 
 - name: pids_limit (changed)
   docker_container:
@@ -2806,6 +2806,7 @@
     pids_limit: 20
     force_kill: yes
   register: pids_limit_3
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -2819,6 +2820,12 @@
     - pids_limit_1 is changed
     - pids_limit_2 is not changed
     - pids_limit_3 is changed
+  when: docker_py_version is version('1.10.0', '>=')
+- assert:
+    that:
+    - pids_limit_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.10.0') in pids_limit_1.msg"
+  when: docker_py_version is version('1.10.0', '<')
 
 ####################################################################
 ## privileged ######################################################

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -2774,6 +2774,53 @@
   when: docker_py_version is version('2.0.0', '<')
 
 ####################################################################
+## pids_limit ######################################################
+####################################################################
+
+- name: pids_limit
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    pids_limit: 10
+    force_kill: yes
+  register: pids_limit_1
+
+- name: pids_limit (idempotency)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    pids_limit: 10
+    force_kill: yes
+  register: pids_limit_2
+
+- name: pids_limit (changed)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    pids_limit: 20
+    force_kill: yes
+  register: pids_limit_3
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    force_kill: yes
+  diff: no
+
+- assert:
+    that:
+    - pids_limit_1 is changed
+    - pids_limit_2 is not changed
+    - pids_limit_3 is changed
+
+####################################################################
 ## privileged ######################################################
 ####################################################################
 


### PR DESCRIPTION
##### SUMMARY
This add pids_limit parameter support in docker_container module

Fixes #43337

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_container

##### ADDITIONAL INFORMATION
Set pids limit as,

```paste below
- name: Run container with limiting pids
  docker_container:
     name: example
     image: nginx:latest
     state: started
     pids_limit: 100
```
