### PR TITLE
Refine plugin docs

### DIFF
--- a/docs/docsite/rst/plugins/action.rst
+++ b/docs/docsite/rst/plugins/action.rst
@@ -14,19 +14,19 @@ The 'normal' action plugin is used for modules that do not already have an actio
 
 .. _enabling_action:
 
-Enabling Action Plugins
+Enabling action plugins
 -----------------------
 
 You can enable a custom action plugin by either dropping it into the ``action_plugins`` directory adjacent to your play, inside a role, or by putting it in one of the action plugin directory sources configured in :ref:`ansible.cfg <ansible_configuration_settings>`.
 
 .. _using_action:
 
-Using Action Plugins
+Using action plugins
 --------------------
 
 Action plugin are executed by default when an associated module is used; no action is required.
 
-Plugin List
+Plugin list
 -----------
 
 You cannot list action plugins directly, they show up as their counterpart modules:
@@ -36,19 +36,19 @@ Use ``ansible-doc <name>`` to see specific documentation and examples, this shou
 
 .. seealso::
 
-   :doc:`cache`
+   :ref:`cache_plugins`
        Ansible Cache plugins
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
-   :doc:`connection`
+   :ref:`connection_plugins`
        Ansible connection plugins
-   :doc:`inventory`
+   :ref:`inventory_plugins`
        Ansible inventory plugins
-   :doc:`shell`
+   :ref:`shell_plugins`
        Ansible Shell plugins
-   :doc:`strategy`
+   :ref:`strategy_plugins`
        Ansible Strategy plugins
-   :doc:`vars`
+   :ref:`vars_plugins`
        Ansible Vars plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/plugins/action.rst
+++ b/docs/docsite/rst/plugins/action.rst
@@ -1,3 +1,5 @@
+.. _action_plugins:
+
 Action Plugins
 ==============
 

--- a/docs/docsite/rst/plugins/cache.rst
+++ b/docs/docsite/rst/plugins/cache.rst
@@ -1,8 +1,10 @@
-.. contents:: Topics
-
 
 Cache Plugins
 =============
+
+.. contents::
+   :local:
+   :depth: 2
 
 Cache plugin implement a backend caching mechanism that allows Ansible to store gathered facts or inventory source data
 without the performance hit of retrieving them from source.

--- a/docs/docsite/rst/plugins/cache.rst
+++ b/docs/docsite/rst/plugins/cache.rst
@@ -1,3 +1,4 @@
+.. _cache_plugins:
 
 Cache Plugins
 =============

--- a/docs/docsite/rst/plugins/cache.rst
+++ b/docs/docsite/rst/plugins/cache.rst
@@ -10,7 +10,7 @@ Cache Plugins
 Cache plugin implement a backend caching mechanism that allows Ansible to store gathered facts or inventory source data
 without the performance hit of retrieving them from source.
 
-The default cache plugin is the :doc:`memory <cache/memory>` plugin, which only caches the data for the current execution of Ansible. Other plugins with persistent storage are available to allow caching the data across runs.
+The default cache plugin is the :ref:`memory <memory_cache>` plugin, which only caches the data for the current execution of Ansible. Other plugins with persistent storage are available to allow caching the data across runs.
 
 You can use a separate cache plugin for inventory and facts. If an inventory-specific cache plugin is not provided and inventory caching is enabled, the fact cache plugin is used for inventory.
 
@@ -113,19 +113,19 @@ Use ``ansible-doc -t cache <plugin name>`` to see specific documentation and exa
 
 .. seealso::
 
-   :doc:`action`
+   :ref:`action_plugins`
        Ansible Action plugins
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
-   :doc:`connection`
+   :ref:`connection_plugins`
        Ansible connection plugins
-   :doc:`inventory`
+   :ref:`inventory_plugins`
        Ansible inventory plugins
-   :doc:`shell`
+   :ref:`shell_plugins`
        Ansible Shell plugins
-   :doc:`strategy`
+   :ref:`strategy_plugins`
        Ansible Strategy plugins
-   :doc:`vars`
+   :ref:`vars_plugins`
        Ansible Vars plugins
    `User Mailing List <https://groups.google.com/forum/#!forum/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/plugins/callback.rst
+++ b/docs/docsite/rst/plugins/callback.rst
@@ -1,3 +1,4 @@
+.. _callback_plugins:
 
 Callback Plugins
 ----------------

--- a/docs/docsite/rst/plugins/callback.rst
+++ b/docs/docsite/rst/plugins/callback.rst
@@ -1,8 +1,10 @@
-.. contents:: Topics
-
 
 Callback Plugins
 ----------------
+
+.. contents::
+   :local:
+   :depth: 2
 
 Callback plugins enable adding new behaviors to Ansible when responding to events.
 By default, callback plugins control most of the output you see when running the command line programs,

--- a/docs/docsite/rst/plugins/callback.rst
+++ b/docs/docsite/rst/plugins/callback.rst
@@ -1,7 +1,7 @@
 .. _callback_plugins:
 
 Callback Plugins
-----------------
+================
 
 .. contents::
    :local:
@@ -13,19 +13,18 @@ but can also be used to add additional output, integrate with other tools and ma
 
 .. _callback_examples:
 
-Example Callback Plugins
-++++++++++++++++++++++++
+Example callback plugins
+------------------------
 
-The :doc:`log_plays <callback/log_plays>` callback is an example of how to record playbook events to a log file,
-and the :doc:`mail <callback/mail>` callback sends email on playbook failures.
+The :ref:`log_plays <log_plays_callback>` callback is an example of how to record playbook events to a log file,
+and the :ref:`mail <mail_callback>` callback sends email on playbook failures.
 
-The :doc:`osx_say <callback/osx_say>` callback responds with computer synthesized speech on macOS in relation to playbook events.
-
+The :ref:`osx_say <osx_say_callback>` callback responds with computer synthesized speech on macOS in relation to playbook events.
 
 .. _enabling_callbacks:
 
-Enabling Callback Plugins
-++++++++++++++++++++++++++
+Enabling callback plugins
+-------------------------
 
 You can activate a custom callback by either dropping it into a ``callback_plugins`` directory adjacent to your play,  inside a role, or by putting it in one of the callback directory sources configured in :ref:`ansible.cfg <ansible_configuration_settings>`.
 
@@ -37,9 +36,8 @@ Most callbacks shipped with Ansible are disabled by default and need to be white
 
   #callback_whitelist = timer, mail, profile_roles
 
-
-Managing stdout
-```````````````
+Setting a callback plugin for ``ansible-playbook``
+--------------------------------------------------
 
 You can only have one plugin be the main manager of your console output. If you want to replace the default, you should define CALLBACK_TYPE = stdout in the subclass and then configure the stdout plugin in :ref:`ansible.cfg <ansible_configuration_settings>`. For example:
 
@@ -55,8 +53,8 @@ or for my custom callback:
 
 This only affects :ref:`ansible-playbook` by default.
 
-Managing AdHoc
-``````````````
+Setting a callback plugin for ad-hoc commands
+---------------------------------------------
 
 The :ref:`ansible` ad hoc command specifically uses a different callback plugin for stdout,
 so there is an extra setting in :ref:`ansible_configuration_settings` you need to add to use the stdout callback defined above:
@@ -75,12 +73,11 @@ You can also set this as an environment variable:
 
 .. _callback_plugin_list:
 
-Plugin List
-+++++++++++
+Plugin list
+-----------
 
 You can use ``ansible-doc -t callback -l`` to see the list of available plugins.
 Use ``ansible-doc -t callback <plugin name>`` to see specific documents and examples.
-
 
 .. toctree:: :maxdepth: 1
     :glob:
@@ -90,19 +87,19 @@ Use ``ansible-doc -t callback <plugin name>`` to see specific documents and exam
 
 .. seealso::
 
-   :doc:`action`
+   :ref:`action_plugins`
        Ansible Action plugins
-   :doc:`cache`
+   :ref:`cache_plugins`
        Ansible cache plugins
-   :doc:`connection`
+   :ref:`connection_plugins`
        Ansible connection plugins
-   :doc:`inventory`
+   :ref:`inventory_plugins`
        Ansible inventory plugins
-   :doc:`shell`
+   :ref:`shell_plugins`
        Ansible Shell plugins
-   :doc:`strategy`
+   :ref:`strategy_plugins`
        Ansible Strategy plugins
-   :doc:`vars`
+   :ref:`vars_plugins`
        Ansible Vars plugins
    `User Mailing List <https://groups.google.com/forum/#!forum/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/plugins/connection.rst
+++ b/docs/docsite/rst/plugins/connection.rst
@@ -1,3 +1,4 @@
+.. _connection_plugins:
 
 Connection Plugins
 ------------------

--- a/docs/docsite/rst/plugins/connection.rst
+++ b/docs/docsite/rst/plugins/connection.rst
@@ -1,7 +1,7 @@
 .. _connection_plugins:
 
 Connection Plugins
-------------------
+==================
 
 .. contents::
    :local:
@@ -15,28 +15,28 @@ The basics of these connection types are covered in the :ref:`getting started<in
 
 .. _ssh_plugins:
 
-ssh Plugins
-+++++++++++
+``ssh`` plugins
+---------------
 
 Because ssh is the default protocol used in system administration and the protocol most used in Ansible, ssh options are included in the command line tools. See :ref:`ansible-playbook` for more details.
 
 .. _enabling_connection:
 
-Enabling Connection Plugins
-+++++++++++++++++++++++++++
+Adding connection plugins
+-------------------------
 
 You can extend Ansible to support other transports (such as SNMP or message bus) by dropping a custom plugin
 into the ``connection_plugins`` directory.
 
 .. _using_connection:
 
-Using Connection Plugins
-++++++++++++++++++++++++
+Using connection plugins
+------------------------
 
-The transport can be changed via :ref:`configuration<ansible_configuration_settings>`, at the command line (``-c``, ``--connection``), as a :ref:`keyword <playbook_keywords>` in your play, or by setting a :ref:`variable<behavioral_parameters>`, most often in your inventory.
-For example, for Windows machines you might want to use the :doc:`winrm<connection/winrm>` plugin.
+You can set the connection plugin globally via :ref:`configuration<ansible_configuration_settings>`, at the command line (``-c``, ``--connection``), as a :ref:`keyword <playbook_keywords>` in your play, or by setting a :ref:`variable<behavioral_parameters>`, most often in your inventory.
+For example, for Windows machines you might want to set the :ref:`winrm <winrm_connection>` plugin as an inventory variable.
 
-Most connection plugins can operate with a minimum configuration. By default they use the :ref:`inventory hostname<inventory_hostnames_lookup>` and defaults to find the target host.
+Most connection plugins can operate with minimal configuration. By default they use the :ref:`inventory hostname<inventory_hostnames_lookup>` and defaults to find the target host.
 
 Plugins are self-documenting. Each plugin should document its configuration options. The following are connection variables common to most connection plugins:
 
@@ -52,7 +52,7 @@ Each plugin might also have a specific version of a variable that overrides the 
 .. _connection_plugin_list:
 
 Plugin List
-+++++++++++
+-----------
 
 You can use ``ansible-doc -t connection -l`` to see the list of available plugins.
 Use ``ansible-doc -t connection <plugin name>`` to see detailed documentation and examples.
@@ -68,7 +68,7 @@ Use ``ansible-doc -t connection <plugin name>`` to see detailed documentation an
 
    :ref:`Working with Playbooks<working_with_playbooks>`
        An introduction to playbooks
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
    :ref:`Filters<playbooks_filters>`
        Jinja2 filter plugins
@@ -76,7 +76,7 @@ Use ``ansible-doc -t connection <plugin name>`` to see detailed documentation an
        Jinja2 test plugins
    :ref:`Lookups<playbooks_lookups>`
        Jinja2 lookup plugins
-   :doc:`vars`
+   :ref:`vars_plugins`
        Ansible vars plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/plugins/connection.rst
+++ b/docs/docsite/rst/plugins/connection.rst
@@ -1,7 +1,10 @@
-.. contents:: Topics
 
 Connection Plugins
 ------------------
+
+.. contents::
+   :local:
+   :depth: 2
 
 Connection plugins allow Ansible to connect to the target hosts so it can execute tasks on them. Ansible ships with many connection plugins, but only one can be used per host at a time.
 

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -12,7 +12,7 @@ Inventory plugins allow users to point at data sources to compile the inventory 
 
 .. _enabling_inventory:
 
-Enabling Inventory Plugins
+Enabling inventory plugins
 --------------------------
 
 Most inventory plugins shipped with Ansible are disabled by default and need to be whitelisted in your
@@ -34,7 +34,7 @@ This list also establishes the order in which each plugin tries to parse an inve
 
 .. _using_inventory:
 
-Using Inventory Plugins
+Using inventory plugins
 -----------------------
 
 The only requirement for using an inventory plugin after it is enabled is to provide an inventory source to parse.
@@ -123,9 +123,9 @@ Use ``ansible-doc -t inventory <plugin name>`` to see plugin-specific documentat
 
    :ref:`about_playbooks`
        An introduction to playbooks
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
-   :doc:`connection`
+   :ref:`connection_plugins`
        Ansible connection plugins
    :ref:`playbooks_filters`
        Jinja2 filter plugins
@@ -133,7 +133,7 @@ Use ``ansible-doc -t inventory <plugin name>`` to see plugin-specific documentat
        Jinja2 test plugins
    :ref:`playbooks_lookups`
        Jinja2 lookup plugins
-   :doc:`vars`
+   :ref:`vars_plugins`
        Ansible vars plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -1,9 +1,11 @@
-.. contents:: Topics
-
 .. _inventory_plugins:
 
 Inventory Plugins
 =================
+
+.. contents::
+   :local:
+   :depth: 2
 
 Inventory plugins allow users to point at data sources to compile the inventory of hosts that Ansible uses to target tasks, either via the ``-i /path/to/file`` and/or ``-i 'host1, host2'`` command line parameters or from other configuration sources.
 
@@ -109,7 +111,7 @@ If a host does not have the variables in the configuration above (i.e. ``tags.Na
 Plugin List
 -----------
 
-You can use ``ansible-doc -t inventory -l`` to see the list of available plugins. 
+You can use ``ansible-doc -t inventory -l`` to see the list of available plugins.
 Use ``ansible-doc -t inventory <plugin name>`` to see plugin-specific documentation and examples.
 
 .. toctree:: :maxdepth: 1

--- a/docs/docsite/rst/plugins/lookup.rst
+++ b/docs/docsite/rst/plugins/lookup.rst
@@ -1,7 +1,7 @@
 .. _lookup_plugins:
 
 Lookup Plugins
---------------
+==============
 
 .. contents::
    :local:
@@ -28,16 +28,16 @@ Lookups are an Ansible-specific extension to the Jinja2 templating language.
 
 .. _enabling_lookup:
 
-Enabling Lookup Plugins
-+++++++++++++++++++++++
+Enabling lookup plugins
+-----------------------
 
 You can activate a custom lookup by either dropping it into a ``lookup_plugins`` directory adjacent to your play, inside a role, or by putting it in one of the lookup directory sources configured in :ref:`ansible.cfg <ansible_configuration_settings>`.
 
 
 .. _using_lookup:
 
-Using Lookup Plugins
-++++++++++++++++++++
+Using lookup plugins
+--------------------
 
 Lookup plugins can be used anywhere you can use templating in Ansible: in a play, in variables file, or in a Jinja2 template for the :ref:`template <template_module>` module.
 
@@ -47,7 +47,7 @@ Lookup plugins can be used anywhere you can use templating in Ansible: in a play
     file_contents: "{{lookup('file', 'path/to/file.txt')}}"
 
 Lookups are an integral part of loops. Wherever you see ``with_``, the part after the underscore is the name of a lookup.
-This is also the reason most lookups output lists and take lists as input; for example, ``with_items`` uses the :doc:`items <lookup/items>` lookup:
+This is also the reason most lookups output lists and take lists as input; for example, ``with_items`` uses the :ref:`items <items_lookup>` lookup:
 
 .. code-block:: yaml
 
@@ -110,15 +110,15 @@ Fatal error (the default)::
 
 .. _query:
 
-query
-+++++
+Invoking lookup plugins with ``query``
+--------------------------------------
 
 .. versionadded:: 2.5
 
 In Ansible 2.5, a new jinja2 function called ``query`` was added for invoking lookup plugins. The difference between ``lookup`` and ``query`` is largely that ``query`` will always return a list.
 The default behavior of ``lookup`` is to return a string of comma separated values. ``lookup`` can be explicitly configured to return a list using ``wantlist=True``.
 
-This was done primarily to provide an easier and more consistent interface for interacting with the new ``loop`` keyword, while maintaining backwards compatibiltiy with other uses of ``lookup``.
+This was done primarily to provide an easier and more consistent interface for interacting with the new ``loop`` keyword, while maintaining backwards compatibility with other uses of ``lookup``.
 
 The following examples are equivalent::
 
@@ -135,8 +135,8 @@ Additionally, ``q`` was introduced as a shortform of ``query``::
 
 .. _lookup_plugins_list:
 
-Plugin List
-+++++++++++
+Plugin list
+-----------
 
 You can use ``ansible-doc -t lookup -l`` to see the list of available plugins. Use ``ansible-doc -t lookup <plugin name>`` to see specific documents and examples.
 
@@ -150,9 +150,9 @@ You can use ``ansible-doc -t lookup -l`` to see the list of available plugins. U
 
    :ref:`about_playbooks`
        An introduction to playbooks
-   :doc:`inventory`
+   :ref:`inventory_plugins`
        Ansible inventory plugins
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
    :ref:`playbooks_filters`
        Jinja2 filter plugins

--- a/docs/docsite/rst/plugins/lookup.rst
+++ b/docs/docsite/rst/plugins/lookup.rst
@@ -1,9 +1,11 @@
-.. contents:: Topics
-
 .. _lookup_plugins:
 
 Lookup Plugins
 --------------
+
+.. contents::
+   :local:
+   :depth: 2
 
 Lookup plugins allow Ansible to access data from outside sources.
 This can include reading the filesystem in addition to contacting external datastores and services.

--- a/docs/docsite/rst/plugins/plugins.rst
+++ b/docs/docsite/rst/plugins/plugins.rst
@@ -10,7 +10,7 @@ Ansible ships with a number of handy plugins, and you can easily write your own.
 
 This section covers the various types of plugins that are included with Ansible:
 
-.. toctree:: 
+.. toctree::
    :maxdepth: 1
 
    action
@@ -32,7 +32,7 @@ This section covers the various types of plugins that are included with Ansible:
        An introduction to playbooks
    :ref:`ansible_configuration_settings`
        Ansible configuration documentation and settings
-   :doc:`../user_guide/command_line_tools`
+   :ref:`command_line_tools`
        Ansible tools, description and options
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/plugins/shell.rst
+++ b/docs/docsite/rst/plugins/shell.rst
@@ -1,3 +1,4 @@
+.. _shell_plugins:
 
 Shell Plugins
 -------------

--- a/docs/docsite/rst/plugins/shell.rst
+++ b/docs/docsite/rst/plugins/shell.rst
@@ -1,7 +1,7 @@
 .. _shell_plugins:
 
 Shell Plugins
--------------
+=============
 
 .. contents::
    :local:
@@ -12,8 +12,8 @@ the target machine and allow the user to configure certain behaviors related to 
 
 .. _enabling_shell:
 
-Enabling Shell Plugins
-++++++++++++++++++++++
+Enabling shell plugins
+----------------------
 
 You can add a custom shell plugin by dropping it into a ``shell_plugins`` directory adjacent to your play, inside a role,
 or by putting it in one of the shell plugin directory sources configured in :ref:`ansible.cfg <ansible_configuration_settings>`.
@@ -23,8 +23,8 @@ or by putting it in one of the shell plugin directory sources configured in :ref
 
 .. _using_shell:
 
-Using Shell Plugins
-+++++++++++++++++++
+Using shell plugins
+-------------------
 
 In addition to the default configuration settings in :ref:`ansible_configuration_settings`, you can use
 the connection variable :ref:`ansible_shell_type <ansible_shell_type>` to select the plugin to use.
@@ -40,17 +40,17 @@ detailed in the plugin themselves (linked below).
 
 .. seealso::
 
-   :doc:`../user_guide/playbooks`
+   :ref:`about_playbooks`
        An introduction to playbooks
-   :doc:`inventory`
+   :ref:`inventory_plugins`
        Ansible inventory plugins
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
-   :doc:`../user_guide/playbooks_filters`
+   :ref:`playbooks_filters`
        Jinja2 filter plugins
-   :doc:`../user_guide/playbooks_tests`
+   :ref:`playbooks_tests`
        Jinja2 test plugins
-   :doc:`../user_guide/playbooks_lookups`
+   :ref:`playbooks_lookups`
        Jinja2 lookup plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/plugins/shell.rst
+++ b/docs/docsite/rst/plugins/shell.rst
@@ -1,7 +1,10 @@
-.. contents:: Topics
 
 Shell Plugins
 -------------
+
+.. contents::
+   :local:
+   :depth: 2
 
 Shell plugins work to ensure that the basic commands Ansible runs are properly formatted to work with
 the target machine and allow the user to configure certain behaviors related to how Ansible executes tasks.

--- a/docs/docsite/rst/plugins/strategy.rst
+++ b/docs/docsite/rst/plugins/strategy.rst
@@ -1,7 +1,7 @@
 .. _strategy_plugins:
 
 Strategy Plugins
-----------------
+================
 
 .. contents::
    :local:
@@ -11,20 +11,19 @@ Strategy plugins control the flow of play execution by handling task and host sc
 
 .. _enable_strategy:
 
-Enabling Strategy Plugins
-+++++++++++++++++++++++++
+Enabling strategy plugins
+-------------------------
 
-Strategy plugins shipped with Ansible are enabled by default. You can enable a custom strategy plugin by
+All strategy plugins shipped with Ansible are enabled by default. You can enable a custom strategy plugin by
 putting it in one of the lookup directory sources configured in :ref:`ansible.cfg <ansible_configuration_settings>`.
-
 
 .. _using_strategy:
 
-Using Strategy Plugins
-++++++++++++++++++++++
+Using strategy plugins
+----------------------
 
 Only one strategy plugin can be used in a play, but you can use different ones for each play in a playbook or ansible run.
-The default is the :doc:`linear <strategy/linear>` plugin. You can change this default in Ansible :ref:`configuration <ansible_configuration_settings>` using an environment variable:
+The default is the :ref:`linear <linear_strategy>` plugin. You can change this default in Ansible :ref:`configuration <ansible_configuration_settings>` using an environment variable:
 
 .. code-block:: shell
 
@@ -53,8 +52,8 @@ You can also specify the strategy plugin in the play via the :ref:`strategy keyw
 
 .. _strategy_plugin_list:
 
-Plugin List
-+++++++++++
+Plugin list
+-----------
 
 You can use ``ansible-doc -t strategy -l`` to see the list of available plugins.
 Use ``ansible-doc -t strategy <plugin name>`` to see plugin-specific specific documentation and examples.
@@ -69,9 +68,9 @@ Use ``ansible-doc -t strategy <plugin name>`` to see plugin-specific specific do
 
    :ref:`about_playbooks`
        An introduction to playbooks
-   :doc:`inventory`
+   :ref:`inventory_plugins`
        Ansible inventory plugins
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
    :ref:`playbooks_filters`
        Jinja2 filter plugins

--- a/docs/docsite/rst/plugins/strategy.rst
+++ b/docs/docsite/rst/plugins/strategy.rst
@@ -1,8 +1,10 @@
-.. contents:: Topics
-
 
 Strategy Plugins
 ----------------
+
+.. contents::
+   :local:
+   :depth: 2
 
 Strategy plugins control the flow of play execution by handling task and host scheduling.
 
@@ -53,7 +55,7 @@ You can also specify the strategy plugin in the play via the :ref:`strategy keyw
 Plugin List
 +++++++++++
 
-You can use ``ansible-doc -t strategy -l`` to see the list of available plugins. 
+You can use ``ansible-doc -t strategy -l`` to see the list of available plugins.
 Use ``ansible-doc -t strategy <plugin name>`` to see plugin-specific specific documentation and examples.
 
 

--- a/docs/docsite/rst/plugins/strategy.rst
+++ b/docs/docsite/rst/plugins/strategy.rst
@@ -1,3 +1,4 @@
+.. _strategy_plugins:
 
 Strategy Plugins
 ----------------

--- a/docs/docsite/rst/plugins/vars.rst
+++ b/docs/docsite/rst/plugins/vars.rst
@@ -1,3 +1,4 @@
+.. _vars_plugins:
 
 Vars Plugins
 ------------

--- a/docs/docsite/rst/plugins/vars.rst
+++ b/docs/docsite/rst/plugins/vars.rst
@@ -1,8 +1,10 @@
-.. contents:: Topics
-
 
 Vars Plugins
 ------------
+
+.. contents::
+   :local:
+   :depth: 2
 
 Vars plugins inject additional variable data into Ansible runs that did not come from an inventory source, playbook, or command line. Playbook constructs like 'host_vars' and 'group_vars' work using vars plugins.
 
@@ -32,7 +34,7 @@ Vars plugins are used automatically after they are enabled.
 Plugin Lists
 ++++++++++++
 
-You can use ``ansible-doc -t vars -l`` to see the list of available plugins. 
+You can use ``ansible-doc -t vars -l`` to see the list of available plugins.
 Use ``ansible-doc -t vars <plugin name>`` to see specific plugin-specific documentation and examples.
 
 

--- a/docs/docsite/rst/plugins/vars.rst
+++ b/docs/docsite/rst/plugins/vars.rst
@@ -1,7 +1,7 @@
 .. _vars_plugins:
 
 Vars Plugins
-------------
+============
 
 .. contents::
    :local:
@@ -16,16 +16,16 @@ The :ref:`host_group_vars <host_group_vars_vars>` plugin shipped with Ansible en
 
 .. _enable_vars:
 
-Enabling Vars Plugins
-+++++++++++++++++++++
+Enabling vars plugins
+---------------------
 
 You can activate a custom vars plugin by either dropping it into a ``vars_plugins`` directory adjacent to your play,  inside a role, or by putting it in one of the directory sources configured in :ref:`ansible.cfg <ansible_configuration_settings>`.
 
 
 .. _using_vars:
 
-Using Vars Plugins
-++++++++++++++++++
+Using vars plugins
+------------------
 
 Vars plugins are used automatically after they are enabled.
 
@@ -33,7 +33,7 @@ Vars plugins are used automatically after they are enabled.
 .. _vars_plugin_list:
 
 Plugin Lists
-++++++++++++
+------------
 
 You can use ``ansible-doc -t vars -l`` to see the list of available plugins.
 Use ``ansible-doc -t vars <plugin name>`` to see specific plugin-specific documentation and examples.
@@ -46,19 +46,19 @@ Use ``ansible-doc -t vars <plugin name>`` to see specific plugin-specific docume
 
 .. seealso::
 
-   :doc:`action`
+   :ref:`action_plugins`
        Ansible Action plugins
-   :doc:`cache`
+   :ref:`cache_plugins`
        Ansible Cache plugins
-   :doc:`callback`
+   :ref:`callback_plugins`
        Ansible callback plugins
-   :doc:`connection`
+   :ref:`connection_plugins`
        Ansible connection plugins
-   :doc:`inventory`
+   :ref:`inventory_plugins`
        Ansible inventory plugins
-   :doc:`shell`
+   :ref:`shell_plugins`
        Ansible Shell plugins
-   :doc:`strategy`
+   :ref:`strategy_plugins`
        Ansible Strategy plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/user_guide/command_line_tools.rst
+++ b/docs/docsite/rst/user_guide/command_line_tools.rst
@@ -1,10 +1,12 @@
+.. _command_line_tools:
+
 Working with Command Line Tools
 ===============================
 
 Most users are familiar with `ansible` and `ansible-playbook`, but those are not the only utilities Ansible provides.
-Below is a complete list of Ansible utilities. Each page contains a description of the utility and a listing of supported parameters.	
+Below is a complete list of Ansible utilities. Each page contains a description of the utility and a listing of supported parameters.
 
-.. toctree:: 
+.. toctree::
    :maxdepth: 1
 
    ../cli/ansible.rst
@@ -16,4 +18,3 @@ Below is a complete list of Ansible utilities. Each page contains a description 
    ../cli/ansible-playbook.rst
    ../cli/ansible-pull.rst
    ../cli/ansible-vault.rst
-   


### PR DESCRIPTION
##### SUMMARY
Brings the plugin pages up to current docs standards by:
- adding an anchor to every page
- converting all `:doc:` links to `:ref:` links
- making the header markings consistent, per #35520
- making the header text "Sentence case"

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

