### PR TITLE
Do not document buggy behavior.

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -101,9 +101,6 @@ options:
         restrictive umask by default (e.g., "0077") and you want to pip install
         packages which are to be used by all users. Note that this requires you
         to specify desired umask mode as an octal string, (e.g., "0022").
-        Specifying the mode as a decimal integer (e.g., 22) will also work, but
-        an octal integer (e.g., 0022) will be converted to decimal (18) before
-        evaluation, which is almost certainly not what was intended.
     version_added: "2.1"
 notes:
    - Please note that virtualenv (U(http://www.virtualenv.org/)) must be


### PR DESCRIPTION
Per @abadger remarks in #43256, we should avoid documenting buggy behavior.
 
+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Remove documentation that supplying an integer for the pip umask option "works, but was almost certainly not what was intended."

Fixes #43256 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pip
