### PR TITLE
[WIP] Cache templated handler names

### DIFF
--- a/changelogs/fragments/49022-cache-handler-names.yaml
+++ b/changelogs/fragments/49022-cache-handler-names.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- handlers - Cache templated handler names to improve performance, eliminating duplicate calls to ``get_vars`` and ``templar``
+  (https://github.com/ansible/ansible/issues/49022)


### PR DESCRIPTION
##### SUMMARY
Cache templated handler names to improve performance, eliminating duplicate calls to `get_vars` and `templar`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/strategy/__init__.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```