### PR TITLE
Fix idempotency issues 2

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -629,7 +629,7 @@ class RedfishUtils(object):
         response = self.post_request(self.root_uri + reset_bios_settings_uri, {}, HEADERS)
         if response['ret'] is False:
             return response
-        return {'ret': True}
+        return {'ret': True, 'changed': True, 'msg': "Set BIOS to default settings"}
 
     def set_one_time_boot_device(self, bootdevice):
         result = {}

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -664,7 +664,25 @@ class RedfishUtils(object):
         return {'ret': True}
 
     def set_manager_attributes(self, attr):
-        attributes = "Attributes"
+        result = {}
+        # Here I'm making the assumption that the key 'Attributes' is part of the URI.
+        # It may not, but in the hardware I tested with, getting to the final URI where
+        # the Manager Attributes are, appear to be part of a specific OEM extension.
+        key = "Attributes"
+
+        # Search for key entry and extract URI from it
+        response = self.get_request(self.root_uri + self.manager_uri + "/" + key)
+        if response['ret'] is False:
+            return response
+        result['ret'] = True
+        data = response['data']
+
+        if key not in data:
+            return {'ret': False, 'msg': "Key %s not found" % key}
+
+        # Check if attribute exists
+        if attr['mgr_attr_name'] not in data[key]:
+            return {'ret': False, 'msg': "Manager attribute %s not found" % attr['mgr_attr_name']}
 
         # Example: manager_attr = {\"name\":\"value\"}
         # Check if value is a number. If so, convert to int.
@@ -673,11 +691,15 @@ class RedfishUtils(object):
         else:
             manager_attr = "{\"%s\": \"%s\"}" % (attr['mgr_attr_name'], attr['mgr_attr_value'])
 
+        # Find out if value is already set to what we want. If yes, return
+        if data[key][attr['mgr_attr_name']] == attr['mgr_attr_value']:
+            return {'ret': True, 'changed': False, 'msg': "Manager attribute already set"}
+
         payload = {"Attributes": json.loads(manager_attr)}
-        response = self.patch_request(self.root_uri + self.manager_uri + "/" + attributes, payload, HEADERS)
+        response = self.patch_request(self.root_uri + self.manager_uri + "/" + key, payload, HEADERS)
         if response['ret'] is False:
             return response
-        return {'ret': True}
+        return {'ret': True, 'changed': True, 'msg': "Modified Manager attribute %s" % attr['mgr_attr_name']}
 
     def set_bios_attributes(self, attr):
         result = {}


### PR DESCRIPTION
##### SUMMARY
Fixes idempotency issues in `set_manager_attributes` and `set_bios_default_settings`. In `set_manager_attributes`, checks first if the desired manager attribute is already set to the desired value.

Fixes https://github.com/ansible/ansible/issues/49209

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
redfish_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Before this patch, a manager attribute setting would always update regardless whether it was already set or not.

With this patch, it only updates if the attribute is not already set to what is specified.

