### PR TITLE
WIP: Explain the suggestion how to get rid of the command module's recommendation.

### DIFF
--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -145,8 +145,8 @@ from ansible.module_utils.common.collections import is_iterable
 
 def check_command(module, commandline):
     arguments = {'chown': 'owner', 'chmod': 'mode', 'chgrp': 'group',
-                 'ln': 'state=link', 'mkdir': 'state=directory',
-                 'rmdir': 'state=absent', 'rm': 'state=absent', 'touch': 'state=touch'}
+                 'ln': 'state: link', 'mkdir': 'state: directory',
+                 'rmdir': 'state: absent', 'rm': 'state: absent', 'touch': 'state: touch'}
     commands = {'curl': 'get_url or uri', 'wget': 'get_url or uri',
                 'svn': 'subversion', 'service': 'service',
                 'mount': 'mount', 'rpm': 'yum, dnf or zypper', 'yum': 'yum', 'apt-get': 'apt',
@@ -160,8 +160,8 @@ def check_command(module, commandline):
     command = os.path.basename(command)
 
     disable_suffix = "If you need to use command because {mod} is insufficient you can add" \
-                     " warn=False to this command task or set command_warnings=False in" \
-                     " ansible.cfg to get rid of this message."
+                     " warn: no to this command task or set command_warnings=False in" \
+                     " the [defaults] section of ansible.cfg to get rid of this message."
     substitutions = {'mod': None, 'cmd': command}
 
     if command in arguments:


### PR DESCRIPTION
##### SUMMARY

In many cases when the `command` module is used for something for which a more specific module
exists, a warning is generated. That warning contains instructs to

> ... add warn=False to this command task ... to get rid of this message.

This is a useful hint, only it doesn't work. What one should add is `warn: no`. (It's probably from the days before ansible adopted YAML?)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

command

##### ADDITIONAL INFORMATION

Even though `warn: false` might also work, I prefer `warn: no` for consistency with the `warn` parameter's [documentation](https://docs.ansible.com/ansible/latest/modules/command_module.html#parameters).

To demonstrate the bug, save this as file `bug_produce.yaml` and run with `ansible-playbook bug_produce.yaml`.

```
# This playbook demonstrates the warning and how to get rid of it properly.

- hosts: localhost

  tasks:

  - name: This shows the warning.
    command:
      argv:
        - touch
        - /tmp/some_stupid_file

  - name: This does not show the warning, the proper way.
    command:
      warn: no
      argv:
        - touch
        - /tmp/some_other_file

#   - name: This does as the present buggy instructions say. Does not work.
#     command:
#       warn=False
#       argv:
#         - touch
#         - /tmp/yet_another_file
```

The message you see is:

> TASK [This shows the warning.] *************************************************    
>  [WARNING]: Consider using the file module with state=touch rather than running touch.  If you need to use command because file is insufficient you can add warn=False to this command task or set command_warnings=False in ansible.cfg to get rid of this message.