### PR TITLE
add path info to role list

### DIFF
--- a/changelogs/fragments/nicer_role_list.yml
+++ b/changelogs/fragments/nicer_role_list.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - now galaxy shows each path where it finds roles when listing them

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -474,7 +474,7 @@ class GalaxyCLI(CLI):
             name = self.args.pop()
             gr = GalaxyRole(self.galaxy, name)
             if gr.metadata:
-                display.display('# %s' % gr.path)
+                display.display('# %s' % os.path.dirname(gr.path))
                 _display_role(gr)
             else:
                 display.display("- the role %s was not found" % name)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -466,7 +466,7 @@ class GalaxyCLI(CLI):
             if install_info:
                 version = install_info.get("version", None)
             if not version:
-                version = "(unkown version)"
+                version = "(unknown version)"
             display.display("- %s, %s" % (gr.name, version))
 
         if len(self.args) == 1:

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -460,45 +460,46 @@ class GalaxyCLI(CLI):
         if len(self.args) > 1:
             raise AnsibleOptionsError("- please specify only one role to list, or specify no roles to see a full list")
 
+        def _display_role(gr):
+            install_info = gr.install_info
+            version = None
+            if install_info:
+                version = install_info.get("version", None)
+            if not version:
+                version = "(unkown version)"
+            display.display("- %s, %s" % (gr.name, version))
+
         if len(self.args) == 1:
-            # show only the request role, if it exists
+            # show the requested role, if it exists
             name = self.args.pop()
             gr = GalaxyRole(self.galaxy, name)
             if gr.metadata:
-                install_info = gr.install_info
-                version = None
-                if install_info:
-                    version = install_info.get("version", None)
-                if not version:
-                    version = "(unknown version)"
-                # show some more info about single roles here
-                display.display("- %s, %s" % (name, version))
+                display.display('# %s' % gr.path)
+                _display_role(gr)
             else:
                 display.display("- the role %s was not found" % name)
         else:
             # show all valid roles in the roles_path directory
             roles_path = self.options.roles_path
             path_found = False
+            warnings = []
             for path in roles_path:
                 role_path = os.path.expanduser(path)
                 if not os.path.exists(role_path):
-                    display.warning("- the configured path %s does not exist." % role_path)
+                    warnings.append("- the configured path %s does not exist." % role_path)
                     continue
                 elif not os.path.isdir(role_path):
-                    display.warning("- the configured path %s, exists, but it is not a directory." % role_path)
+                    warnings.append("- the configured path %s, exists, but it is not a directory." % role_path)
                     continue
+                display.display('# %s' % role_path)
                 path_files = os.listdir(role_path)
                 path_found = True
                 for path_file in path_files:
                     gr = GalaxyRole(self.galaxy, path_file, path=path)
                     if gr.metadata:
-                        install_info = gr.install_info
-                        version = None
-                        if install_info:
-                            version = install_info.get("version", None)
-                        if not version:
-                            version = "(unknown version)"
-                        display.display("- %s, %s" % (path_file, version))
+                        _display_role(gr)
+            for w in warnings:
+                display.warning(w)
             if not path_found:
                 raise AnsibleOptionsError("- None of the provided paths was usable. Please specify a valid path with --roles-path")
         return 0


### PR DESCRIPTION
 - use same display format for both listing all and specific roles
 - show warnings at end to allow selecting the output w/o interruption

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-galaxy

##### ADDITIONAL INFORMATION

Before:
```
- test1, (unknown version)
 [WARNING]: - the configured path /usr/share/ansible/roles does not exist.

- geerlingguy.apache, 2.0.0
- test-1, (unknown version)
- test2, (unknown version)
- test1, (unknown version)

```

After:
```
# /home/bcoca/.ansible/roles
- test1, (unknown version)
# /etc/ansible/roles
- geerlingguy.apache, 2.0.0
- test-1, (unknown version)
- test2, (unknown version)
- test1, (unknown version)
 [WARNING]: - the configured path /usr/share/ansible/roles does not exist.
```