### PR TITLE
Local test docs: correct tox shell command usage

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -57,7 +57,7 @@ Interactive Shell
 Use the ``ansible-test shell`` command to get an interactive shell in the same environment used to run tests. Examples:
 
 * ``ansible-test shell --docker`` - Open a shell in the default docker container.
-* ``ansible-test shell --tox --python 3.6`` - Open a shell in the Python 3.6 ``tox`` environment.
+* ``ansible-test shell --tox 3.6`` - Open a shell in the Python 3.6 ``tox`` environment.
 
 
 Code Coverage


### PR DESCRIPTION
##### SUMMARY

The ansible-test shell command doesn't have a --python option; you
have to specify the tox environment directly to the --tox command

Partially fixes: #49349


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
ansible-test