### PR TITLE
Pluribus Networks pn access list ip module

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_access_list_ip.py
+++ b/lib/ansible/modules/network/netvisor/pn_access_list_ip.py
@@ -18,8 +18,7 @@ author: "Pluribus Networks (rpachi@pluribusnetworks.com)"
 version_added: "2.8"
 short_description: CLI command to add/remove access-list-ip
 description:
-  - This modules is used to dd IPs associated with access list
-    and remove IPs associated with access list.
+  - This modules can be used to add and remove IPs associated with access list.
 options:
   pn_cliswitch:
     description:
@@ -29,19 +28,19 @@ options:
   state:
     description:
       - State the action to perform. Use 'present' to add access-list-ip and
-      'absent' to remove access-list-ip.
+        'absent' to remove access-list-ip.
     required: True
-    choices: [ "present", "absent"]
+    choices: ["present", "absent"]
   pn_ip:
     description:
-      - IP associated with the access list
-    required: false
-    type: str
+      - IP associated with the access list.
+    required: False
     default: '::'
+    type: str
   pn_name:
     description:
-      - Access List Name
-    required: false
+      - Access List Name.
+    required: False
     type: str
 """
 
@@ -99,7 +98,7 @@ def check_cli(module, cli):
     show = cli + \
         ' access-list-ip-show name %s format ip no-show-headers' % name
     show = shlex.split(show)
-    out = module.run_command(show)[1]
+    out = module.run_command(show, use_unsafe_shell=True)[1]
 
     out = out.split()
     # Global flags
@@ -114,7 +113,7 @@ def main():
     global state_map
     state_map = dict(
         present='access-list-ip-add',
-        absent='access-list-ip-remove'
+        absent='access-list-ip-remove',
     )
 
     module = AnsibleModule(
@@ -128,7 +127,7 @@ def main():
         required_if=(
             ["state", "present", ["pn_name"]],
             ["state", "absent", ["pn_name", "pn_ip"]],
-            ),
+        ),
     )
 
     # Accessing the arguments
@@ -157,8 +156,8 @@ def main():
         if command == 'access-list-ip-add':
             if IP_EXISTS is True:
                 module.exit_json(
-                     skipped=True,
-                     msg='access list with ip %s already exists' % ip
+                    skipped=True,
+                    msg='access list with ip %s already exists' % ip
                 )
         if ip:
             cli += ' ip ' + ip

--- a/lib/ansible/modules/network/netvisor/pn_access_list_ip.py
+++ b/lib/ansible/modules/network/netvisor/pn_access_list_ip.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 ---
 module: pn_access_list_ip
-author: "Pluribus Networks (rpachi@pluribusnetworks.com)"
+author: "Pluribus Networks (@rajaspachipulusu17)"
 version_added: "2.8"
 short_description: CLI command to add/remove access-list-ip
 description:
@@ -79,7 +79,6 @@ changed:
   type: bool
 """
 
-import shlex
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
 
@@ -94,11 +93,9 @@ def check_cli(module, cli):
     """
     name = module.params['pn_name']
     ip = module.params['pn_ip']
+    cli += ' access-list-ip-show name %s format ip no-show-headers' % name
 
-    show = cli + \
-        ' access-list-ip-show name %s format ip no-show-headers' % name
-    show = shlex.split(show)
-    out = module.run_command(show, use_unsafe_shell=True)[1]
+    out = module.run_command(cli.split(), use_unsafe_shell=True)[1]
 
     out = out.split()
     # Global flags

--- a/lib/ansible/modules/network/netvisor/pn_access_list_ip.py
+++ b/lib/ansible/modules/network/netvisor/pn_access_list_ip.py
@@ -1,0 +1,170 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_access_list_ip
+author: "Pluribus Networks (rpachi@pluribusnetworks.com)"
+version_added: "2.8"
+short_description: CLI command to add/remove access-list-ip
+description:
+  - This modules is used to dd IPs associated with access list
+    and remove IPs associated with access list.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: False
+    type: str
+  state:
+    description:
+      - State the action to perform. Use 'present' to add access-list-ip and
+      'absent' to remove access-list-ip.
+    required: True
+    choices: [ "present", "absent"]
+  pn_ip:
+    description:
+      - IP associated with the access list
+    required: false
+    type: str
+    default: '::'
+  pn_name:
+    description:
+      - Access List Name
+    required: false
+    type: str
+"""
+
+EXAMPLES = """
+- name: access list ip functionality
+  pn_access_list_ip:
+    pn_cliswitch: "sw01"
+    pn_name: "foo"
+    pn_ip: "172.16.3.1"
+    state: "present"
+
+- name: access list ip functionality
+  pn_access_list_ip:
+    pn_cliswitch: "sw01"
+    pn_name: "foo"
+    pn_ip: "172.16.3.1"
+    state: "absent"
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: string
+stdout:
+  description: set of responses from the access-list-ip command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the access-list-ip command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+import shlex
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+
+
+def check_cli(module, cli):
+    """
+    This method checks for idempotency using the access-list-ip-show command.
+    If ip  exists, return IP_EXISTS as True else False.
+    :param module: The Ansible module to fetch input parameters
+    :param cli: The CLI string
+    :return Global Booleans: IP_EXISTS
+    """
+    name = module.params['pn_name']
+    ip = module.params['pn_ip']
+
+    show = cli + \
+        ' access-list-ip-show name %s format ip no-show-headers' % name
+    show = shlex.split(show)
+    out = module.run_command(show)[1]
+
+    out = out.split()
+    # Global flags
+    global IP_EXISTS
+
+    IP_EXISTS = True if ip in out else False
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    global state_map
+    state_map = dict(
+        present='access-list-ip-add',
+        absent='access-list-ip-remove'
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_ip=dict(required=False, type='str', default='::'),
+            pn_name=dict(required=False, type='str'),
+        ),
+        required_if=(
+            ["state", "present", ["pn_name"]],
+            ["state", "absent", ["pn_name", "pn_ip"]],
+            ),
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    ip = module.params['pn_ip']
+    name = module.params['pn_name']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    check_cli(module, cli)
+    cli += ' %s name %s ' % (command, name)
+
+    if command == 'access-list-ip-remove':
+        if IP_EXISTS is False:
+            module.exit_json(
+                skipped=True,
+                msg='access-list with ip %s does not exist' % ip
+            )
+        if ip:
+            cli += ' ip ' + ip
+    else:
+        if command == 'access-list-ip-add':
+            if IP_EXISTS is True:
+                module.exit_json(
+                     skipped=True,
+                     msg='access list with ip %s already exists' % ip
+                )
+        if ip:
+            cli += ' ip ' + ip
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
<!--- Point feature for Pluribus Networks Netvisor switches  -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
pn_access_list_ip module  which would add associate ip address to access list.

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```
