### PR TITLE
powershell - add bootstrap wrapper to packaging manifest - 2.7

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include examples/hosts
 include examples/ansible.cfg
 include examples/scripts/ConfigureRemotingForAnsible.ps1
 include examples/scripts/upgrade_to_ps3.ps1
+recursive-include lib/ansible/executor/powershell *
 recursive-include lib/ansible/module_utils/powershell *
 recursive-include lib/ansible/modules *
 recursive-include lib/ansible/galaxy/data *

--- a/changelogs/fragments/powershell-bootstrap.yaml
+++ b/changelogs/fragments/powershell-bootstrap.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- powershell - add ``lib/ansible/executor/powershell`` to the packaging data

--- a/setup.py
+++ b/setup.py
@@ -245,6 +245,7 @@ static_setup_params = dict(
     packages=find_packages('lib'),
     package_data={
         '': [
+            'executor/powershell/*.ps1',
             'module_utils/powershell/*.psm1',
             'module_utils/powershell/*/*.psm1',
             'modules/windows/*.ps1',


### PR DESCRIPTION
##### SUMMARY
Include `lib/ansible/executor/powershell/bootstrap_wrapper.ps1` in the packaging manifest.

Fixes https://github.com/ansible/ansible/issues/49353

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
powershell