### PR TITLE
BOTMETA labels: docsite

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1084,6 +1084,8 @@ files:
   docs/:
     maintainers:
       - acozine
+  docs/docsite/:
+    labels: docsite
   docs/docsite/rst/network/:
     labels: networking
     maintainers:


### PR DESCRIPTION
##### SUMMARY
Labels for directories are only applied to modules, so need to explicitly add the docsite label.

`label:docsite -label:module -label:plugin` can be used to find PRs the only change `docs/docsite/`

##### ISSUE TYPE
- Docs Pull Request
