### PR TITLE
Fix typo in confirm new vault password message

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -236,7 +236,7 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         if create_new_password:
             prompt_formats['prompt'] = ['New vault password (%(vault_id)s): ',
-                                        'Confirm vew vault password (%(vault_id)s): ']
+                                        'Confirm new vault password (%(vault_id)s): ']
             # 2.3 format prompts for --ask-vault-pass
             prompt_formats['prompt_ask_vault_pass'] = ['New Vault password: ',
                                                        'Confirm New Vault password: ']


### PR DESCRIPTION
##### SUMMARY

The current message to confirm a new vault password reads:

`Confirm vew vault password (%(vault_id)s):`

I changed it to:
`Confirm new vault password (%(vault_id)s):`

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ansible-vault

##### ADDITIONAL INFORMATION

It is very easy to overlook this error and it took me today some minutes to spot the difference in a bash script that I use to create vaulted paswords more easily.

However, I would like this to be fixed so that I can expect the "correct" message in my script and don't have to worry about updating ansible.

As I assume there are other scripts out there for the same purpose, be aware that this might break those scripts but I'd still rather have this typo fixed one time soon than having to worry about when it hits me in the back at some random point in the future.

└─ $: ansible-vault encrypt_string test --vault-id test@prompt

To  test the issue type:
ansible-vault encrypt_string teststring --vault-id test-vault-id@prompt

you are then asked to enter the vault password twice. The message to confirm the vault password reads (old version):

```paste below
New vault password (test-vault-id):
Confirm vew vault password(test-vault-id):
```
