### PR TITLE
cloudstack: consider more keys optional

### DIFF
--- a/contrib/inventory/cloudstack.py
+++ b/contrib/inventory/cloudstack.py
@@ -232,25 +232,36 @@ class CloudStackInventory(object):
             data['_meta']['hostvars'][host_name]['affinity_group'] = host['affinitygroup']
             data['_meta']['hostvars'][host_name]['security_group'] = host['securitygroup']
             data['_meta']['hostvars'][host_name]['cpu_number'] = host['cpunumber']
-            data['_meta']['hostvars'][host_name]['cpu_speed'] = host['cpuspeed']
+            if 'cpuspeed' in host:
+                data['_meta']['hostvars'][host_name]['cpu_speed'] = host['cpuspeed']
             if 'cpuused' in host:
                 data['_meta']['hostvars'][host_name]['cpu_used'] = host['cpuused']
             data['_meta']['hostvars'][host_name]['created'] = host['created']
             data['_meta']['hostvars'][host_name]['memory'] = host['memory']
             data['_meta']['hostvars'][host_name]['tags'] = host['tags']
-            data['_meta']['hostvars'][host_name]['hypervisor'] = host['hypervisor']
+            if 'hypervisor' in host:
+                data['_meta']['hostvars'][host_name]['hypervisor'] = host['hypervisor']
             data['_meta']['hostvars'][host_name]['created'] = host['created']
             data['_meta']['hostvars'][host_name]['nic'] = []
             for nic in host['nic']:
-                data['_meta']['hostvars'][host_name]['nic'].append({
+                nicdata = {
                     'ip': nic['ipaddress'],
                     'mac': nic['macaddress'],
                     'netmask': nic['netmask'],
                     'gateway': nic['gateway'],
                     'type': nic['type'],
-                })
+                }
+                if 'ip6address' in nic:
+                    nicdata['ip6'] = nic['ip6address']
+                if 'gateway' in nic:
+                    nicdata['gateway'] = nic['gateway']
+                if 'netmask' in nic:
+                    nicdata['netmask'] = nic['netmask']
+                data['_meta']['hostvars'][host_name]['nic'].append(nicdata)
                 if nic['isdefault']:
                     data['_meta']['hostvars'][host_name]['default_ip'] = nic['ipaddress']
+                    if 'ip6address' in nic:
+                        data['_meta']['hostvars'][host_name]['default_ip6'] = nic['ip6address']
 
             group_name = ''
             if 'group' in host:

--- a/contrib/inventory/cloudstack.py
+++ b/contrib/inventory/cloudstack.py
@@ -157,24 +157,35 @@ class CloudStackInventory(object):
                 data['affinity_group'] = host['affinitygroup']
                 data['security_group'] = host['securitygroup']
                 data['cpu_number'] = host['cpunumber']
-                data['cpu_speed'] = host['cpuspeed']
+                if 'cpu_speed' in host:
+                    data['cpu_speed'] = host['cpuspeed']
                 if 'cpuused' in host:
                     data['cpu_used'] = host['cpuused']
                 data['memory'] = host['memory']
                 data['tags'] = host['tags']
-                data['hypervisor'] = host['hypervisor']
+                if 'hypervisor' in host:
+                    data['hypervisor'] = host['hypervisor']
                 data['created'] = host['created']
                 data['nic'] = []
                 for nic in host['nic']:
-                    data['nic'].append({
+                    nicdata = {
                         'ip': nic['ipaddress'],
                         'mac': nic['macaddress'],
                         'netmask': nic['netmask'],
                         'gateway': nic['gateway'],
                         'type': nic['type'],
-                    })
+                    }
+                    if 'ip6address' in nic:
+                        nicdata['ip6'] = nic['ip6address']
+                    if 'gateway' in nic:
+                        nicdata['gateway'] = nic['gateway']
+                    if 'netmask' in nic:
+                        nicdata['netmask'] = nic['netmask']
+                    data['nic'].append(nicdata)
                     if nic['isdefault']:
                         data['default_ip'] = nic['ipaddress']
+                        if 'ip6address' in nic:
+                            data['default_ip6'] = nic['ip6address']
                 break
         return data
 


### PR DESCRIPTION
##### SUMMARY

Apache Cloudstack response field are not exhibited by all providers. Non critical-ones
can be elided from the inventory data and thus make the cloudstack inventory more liberal
in what it accepts

##### ISSUE TYPE

- Enhancement Pull Request

##### COMPONENT NAME

Contrib's cloudstack inventory

