### PR TITLE
Fix _host_is_ipv6_address for encrypted strings

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -49,7 +49,7 @@ class ActionModule(ActionBase):
         return path
 
     def _host_is_ipv6_address(self, host):
-        return ':' in host
+        return ':' in to_text(host)
 
     def _format_rsync_rsh_target(self, host, path, user):
         ''' formats rsync rsh target, escaping ipv6 addresses if needed '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a check in `_host_is_ipv6_address` for encrypted strings.
Fixes #49363 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`synchronize.py`


