### PR TITLE
Pluribus Networks admin session timeout module

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_admin_session_timeout.py
+++ b/lib/ansible/modules/network/netvisor/pn_admin_session_timeout.py
@@ -1,0 +1,121 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_admin_session_timeout
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.8"
+short_description: CLI command to modify admin-session-timeout
+description:
+  - This module is used to modify login session timeout.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: False
+    type: str
+  state:
+    description:
+      - State the action to perform. Use 'update' to
+        modify the admin-session-timeout.
+    required: True
+    choices: ['update']
+  pn_timeout:
+    description:
+      - Maximum time to wait for user activity before
+        terminating login session. Minimum should be 60s.
+    required: False
+    type: str
+"""
+
+EXAMPLES = """
+- name: admin session timeout functionality
+  pn_admin_session_timeout.py:
+    pn_cliswitch: "sw01"
+    state: "update"
+    pn_timeout: "61s"
+
+- name: admin session timeout functionality
+  pn_admin_session_timeout.py:
+    pn_cliswitch: "sw01"
+    state: "update"
+    pn_timeout: "1d"
+
+- name: admin session timeout functionality
+  pn_admin_session_timeout.py:
+    pn_cliswitch: "sw01"
+    state: "update"
+    pn_timeout: "10d20m3h15s"
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: string
+stdout:
+  description: set of responses from the admin-session-timeout command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the admin-session-timeout command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    global state_map
+    state_map = dict(
+        update='admin-session-timeout-modify'
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_timeout=dict(required=False, type='str'),
+        ),
+        required_together=[['state', 'pn_timeout']],
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    timeout = module.params['pn_timeout']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+    if command == 'admin-session-timeout-modify':
+        cli += ' %s ' % command
+        if timeout:
+            cli += ' timeout ' + timeout
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This module would configure admin session timeout value on PN netvisor.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
admin session timeout module

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```
