### PR TITLE
Cast int for expire field to avoid call failure to sensu API (#33239)

### DIFF
--- a/changelogs/fragments/33239-sensu-expire-cast-int.yaml
+++ b/changelogs/fragments/33239-sensu-expire-cast-int.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- sensu_silence - Cast int for expire field to avoid call failure to sensu API.

--- a/lib/ansible/modules/monitoring/sensu_silence.py
+++ b/lib/ansible/modules/monitoring/sensu_silence.py
@@ -259,7 +259,7 @@ def main():
         argument_spec=dict(
             check=dict(required=False),
             creator=dict(required=False),
-            expire=dict(required=False),
+            expire=dict(type='int', required=False),
             expire_on_resolve=dict(type='bool', required=False),
             reason=dict(required=False),
             state=dict(default='present', choices=['present', 'absent']),


### PR DESCRIPTION
(cherry picked from commit bbab4c1b496f3b9fa07b7121adebbbe0cc8772b6)

* Cast int for expire field to avoid call failure to sensu API (#33239)

* Add changelog

