### PR TITLE
Add vars_prefix to prefix host_vars

### DIFF
--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -48,6 +48,9 @@ DOCUMENTATION = '''
             description:
                 - An optional service account email address if machineaccount is selected
                   and the user does not wish to use the default email.
+        vars_prefix:
+            description: prefix to apply to host variables, does not include facts nor params
+            default: 'gcp_'
 '''
 
 EXAMPLES = '''
@@ -101,7 +104,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         hostname = self._get_hostname(item)
         self.inventory.add_host(hostname)
         for key in item:
-            self.inventory.set_variable(hostname, key, item[key])
+            try:
+                self.inventory.set_variable(hostname, self.get_option('vars_prefix') + key, item[key])
+            except (ValueError, TypeError) as e:
+                self.display.warning("Could not set host info hostvar for %s, skipping %s: %s" % (hostname, key, to_native(e)))
         self.inventory.add_child('all', hostname)
 
     def verify_file(self, path):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently the gcp_compute dynamic inventory plugin adds host vars without a prefix, which might collide with variables defined elsewhere. This change adds a `vars_prefix` configuration option (similar as defined in foreman inventory plugin). The default for `vars_prefix` is set to `gcp_`, which you might want to change to '' to prevent breaking backward compatibility.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_compute.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Without this option, `gcp_compute` adds host vars like `disks`, `id`, `kind`, `labels`, `name`, `tags` etc without a prefix which might override variables you already have defined, for example in `group_vars`. To fix this, this module should support prefixing these variables.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
