### PR TITLE
Backport/2.7/ templar: ensure that exceptions are handled, fix 'AttributeError' (#48792)

### DIFF
--- a/changelogs/fragments/48792-templar-fix-AttributeError.yml
+++ b/changelogs/fragments/48792-templar-fix-AttributeError.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix AttributeError (Python 3 only) when an exception occurs while rendering a template

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -108,7 +108,7 @@ class AnsibleJ2Vars(Mapping):
             except AnsibleUndefinedVariable:
                 raise
             except Exception as e:
-                msg = getattr(e, 'message') or to_native(e)
+                msg = getattr(e, 'message', None) or to_native(e)
                 raise AnsibleError("An unhandled exception occurred while templating '%s'. "
                                    "Error was a %s, original message: %s" % (to_native(variable), type(e), msg))
 

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -50,6 +50,7 @@ class BaseTemplar(object):
             some_unsafe_var=wrap_var("unsafe_blip"),
             some_static_unsafe_var=wrap_var("static_unsafe_blip"),
             some_unsafe_keyword=wrap_var("{{ foo }}"),
+            str_with_error="{{ 'str' | from_json }}",
         )
         self.fake_loader = DictDataLoader({
             "/path/to/my_file.txt": "foo\n",
@@ -199,6 +200,10 @@ class TestTemplarTemplate(BaseTemplar, unittest.TestCase):
                                 'template error while templating string',
                                 self.templar.template,
                                 data)
+
+    def test_template_with_error(self):
+        """Check that AnsibleError is raised, fail if an unhandled exception is raised"""
+        self.assertRaises(AnsibleError, self.templar.template, "{{ str_with_error }}")
 
 
 class TestTemplarCleanData(BaseTemplar, unittest.TestCase):


### PR DESCRIPTION
##### SUMMARY
Backport of #48792.

Unit test included

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/template/vars.py

##### ADDITIONAL INFORMATION
Simple reproducer:
```
- hosts: localhost
  vars:
    not_json: "{{ 'test str' | from_json }}"
  tasks:
    - command: "echo {{ not_json }}"
````