### PR TITLE
removes references to hardcoding, regularizes whitelist note

### DIFF
--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -17,7 +17,7 @@ DOCUMENTATION = '''
       - In 2.4 and above you can just put it in the main Ansible configuration file.
     version_added: "2.2"
     requirements:
-      - whitelisting in configuration
+      - whitelist in configuration
       - requests (python library)
     options:
       url:

--- a/lib/ansible/plugins/callback/grafana_annotations.py
+++ b/lib/ansible/plugins/callback/grafana_annotations.py
@@ -38,7 +38,7 @@ DOCUMENTATION = """
       - This callback will report start, failed and stats events to Grafana as annotations (https://grafana.com)
     version_added: "2.6"
     requirements:
-      - whitelisting in configuration
+      - whitelist in configuration
     options:
       grafana_url:
         description: Grafana annotations api URL

--- a/lib/ansible/plugins/callback/hipchat.py
+++ b/lib/ansible/plugins/callback/hipchat.py
@@ -9,7 +9,7 @@ DOCUMENTATION = '''
     callback: hipchat
     callback_type: notification
     requirements:
-      - whitelist in configuration.
+      - whitelist in configuration
       - prettytable (python lib)
     short_description: post task events to hipchat
     description:

--- a/lib/ansible/plugins/callback/jabber.py
+++ b/lib/ansible/plugins/callback/jabber.py
@@ -14,6 +14,7 @@ DOCUMENTATION = '''
       - This callback plugin sends status updates to a HipChat channel during playbook execution.
     version_added: "2.2"
     requirements:
+      - whitelist in configuration
       - xmpp (python lib https://github.com/ArchipelProject/xmpppy)
     options:
       server:

--- a/lib/ansible/plugins/callback/logdna.py
+++ b/lib/ansible/plugins/callback/logdna.py
@@ -13,7 +13,7 @@ DOCUMENTATION = '''
     version_added: "2.7"
     requirements:
       - LogDNA Python Library (https://github.com/logdna/python)
-      - whitelisting in configuration
+      - whitelist in configuration
     options:
       conf_key:
         required: True

--- a/lib/ansible/plugins/callback/logentries.py
+++ b/lib/ansible/plugins/callback/logentries.py
@@ -14,7 +14,7 @@ DOCUMENTATION = '''
       - In 2.4 and above you can just put it in the main Ansible configuration file.
     version_added: "2.0"
     requirements:
-      - whitelisting in configuration
+      - whitelist in configuration
       - certifi (python library)
       - flatdict (python library), if you want to use the 'flatten' option
     options:

--- a/lib/ansible/plugins/callback/logstash.py
+++ b/lib/ansible/plugins/callback/logstash.py
@@ -13,7 +13,7 @@ DOCUMENTATION = '''
       - This callback will report facts and task events to Logstash https://www.elastic.co/products/logstash
     version_added: "2.3"
     requirements:
-      - whitelisting in configuration
+      - whitelist in configuration
       - logstash (python library)
     options:
       server:

--- a/lib/ansible/plugins/callback/mail.py
+++ b/lib/ansible/plugins/callback/mail.py
@@ -16,7 +16,7 @@ version_added: '2.0'
 author:
 - Dag Wieers (@dagwieers)
 requirements:
-- whitelisting in configuration
+- whitelist in configuration
 options:
   mta:
     description: Mail Transfer Agent, server that accepts SMTP

--- a/lib/ansible/plugins/callback/profile_roles.py
+++ b/lib/ansible/plugins/callback/profile_roles.py
@@ -14,7 +14,7 @@ DOCUMENTATION = '''
     description:
         - This callback module provides profiling for ansible roles.
     requirements:
-      - whitelisting in configuration
+      - whitelist in configuration
 '''
 
 import collections

--- a/lib/ansible/plugins/callback/profile_tasks.py
+++ b/lib/ansible/plugins/callback/profile_tasks.py
@@ -22,7 +22,7 @@ DOCUMENTATION = '''
       - It also lists the top/bottom time consuming tasks in the summary (configurable)
       - Before 2.4 only the environment variables were available for configuration.
     requirements:
-      - whitelisting in configuration - see examples section below for details.
+      - whitelist in configuration - see examples section below for details.
     options:
       output_limit:
         description: Number of tasks to display in the summary

--- a/lib/ansible/plugins/callback/splunk.py
+++ b/lib/ansible/plugins/callback/splunk.py
@@ -28,7 +28,7 @@ DOCUMENTATION = '''
       - Credit to "Ryan Currah (@ryancurrah)" for original source upon which this is based.
     version_added: "2.7"
     requirements:
-      - Whitelisting this callback plugin
+      - Whitelist in configuration
       - 'Create a HTTP Event Collector in Splunk'
       - 'Define the url and token in ansible.cfg'
     options:

--- a/lib/ansible/plugins/callback/sumologic.py
+++ b/lib/ansible/plugins/callback/sumologic.py
@@ -26,7 +26,7 @@ description:
   - This callback plugin will send task results as JSON formatted events to a Sumologic HTTP collector source
 version_added: "2.6"
 requirements:
-  - Whitelisting this callback plugin
+  - Whitelist in configuration
   - 'Create a HTTP collector source in Sumologic and specify a custom timestamp format of C(yyyy-MM-dd HH:mm:ss ZZZZ) and a custom timestamp locator
     of C("timestamp": "(.*)")'
 options:

--- a/lib/ansible/plugins/callback/tree.py
+++ b/lib/ansible/plugins/callback/tree.py
@@ -9,6 +9,7 @@ DOCUMENTATION = '''
     callback: tree
     callback_type: notification
     requirements:
+      - whitelist in configuration
       - invoked in the command line
     short_description: Save host events to files
     version_added: "2.0"

--- a/lib/ansible/plugins/inventory/ini.py
+++ b/lib/ansible/plugins/inventory/ini.py
@@ -23,9 +23,9 @@ DOCUMENTATION = '''
           Unlike host lines, C(:vars) sections accept only a single entry per line, so everything after the C(=) must be the value for the entry.
         - Do not rely on types set during definition, always make sure you specify type with a filter when needed when consuming the variable.
         - See the Examples for proper quoting to prevent changes to variable type.
+    requirements:
+        - whitelist in configuration
     notes:
-        - Replaces the previously hardcoded INI inventory.
-        - Must be whitelisted in configuration to function.
         - Consider switching to YAML format for inventory sources to avoid confusion on the actual type of a variable.
           The YAML inventory plugin processes variable values consistently and correctly.
 '''

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -35,8 +35,7 @@ DOCUMENTATION = '''
           C(--host) will only be used if no C(_meta) key is present.
           This is a performance optimization as the script would be called per host otherwise.
     notes:
-        - It takes the place of the previously hardcoded script inventory.
-        - In order to function, it requires being whitelisted in configuration, which is true by default.
+        - Whitelisted in configuration by default.
 '''
 
 import os

--- a/lib/ansible/plugins/vars/host_group_vars.py
+++ b/lib/ansible/plugins/vars/host_group_vars.py
@@ -27,8 +27,6 @@ DOCUMENTATION = '''
         - Files are restricted by extension to one of .yaml, .json, .yml or no extension.
         - Hidden (starting with '.') and backup (ending with '~') files and directories are ignored.
         - Only applies to inventory sources that are existing paths.
-    notes:
-        - It takes the place of the previously hardcoded group_vars/host_vars loading.
     options:
       _valid_extensions:
         default: [".yml", ".yaml", ".json"]


### PR DESCRIPTION
##### SUMMARY
Following up on a discussion with @bcoca, this PR removes the last references in the plugin docs to things that used to be hardcoded. 

In the interests of tidiness, it also makes all the references in the plugin docs to "whitelisting" the same.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
