### PR TITLE
Adds support for rate-based rules in AWS WAF

### DIFF
--- a/lib/ansible/module_utils/aws/waf.py
+++ b/lib/ansible/module_utils/aws/waf.py
@@ -159,7 +159,13 @@ def get_web_acl(client, module, web_acl_id):
 @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
 def list_rules_with_backoff(client):
     paginator = client.get_paginator('list_rules')
-    return paginator.paginate().build_full_result()['Rules']
+    regular_rules = paginator.paginate().build_full_result()['Rules']
+
+    # rate-base-rules cannot be paginated
+    rate_based_rules = client.list_rate_based_rules()['Rules']
+
+    rules = regular_rules + rate_based_rules
+    return rules
 
 
 @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)

--- a/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
@@ -140,7 +140,7 @@ import re
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.aws.waiters import get_waiter
 from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict
-from ansible.module_utils.aws.waf import list_rules_with_backoff, list_web_acls_with_backoff, run_func_with_change_token_backoff
+from ansible.module_utils.aws.waf import list_web_acls_with_backoff, run_func_with_change_token_backoff, list_rules_with_backoff
 
 
 def get_web_acl_by_name(client, module, name):
@@ -237,7 +237,8 @@ def format_for_update(rule, action):
             RuleId=rule['RuleId'],
             Action=dict(
                 Type=rule['Action']['Type']
-            )
+            ),
+            Type=rule['Type']
         )
     )
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Rate-based rules are available in the AWS API for the Web Application Firewall (WAF), but where not supported in ansible.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
aws_waf_web_acl
aws_waf_rule
