### PR TITLE
azure_rm_managed_disk: properly handle os_type on creation

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk_facts.py
@@ -132,7 +132,7 @@ def managed_disk_to_dict(managed_disk):
         create_option=create_data.create_option.value.lower(),
         source_uri=create_data.source_uri or create_data.source_resource_id,
         disk_size_gb=managed_disk.disk_size_gb,
-        os_type=managed_disk.os_type.value if managed_disk.os_type else None,
+        os_type=managed_disk.os_type.value.lower() if managed_disk.os_type else None,
         storage_account_type=managed_disk.sku.name.value if managed_disk.sku else None,
         managed_by=managed_disk.managed_by
     )

--- a/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
+++ b/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
@@ -7,9 +7,10 @@
  - name: Clearing (if) previous disks were created
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{item }}"
+       name: "{{ item }}"
        state: absent
    with_items:
+     - "md{{ rpfx }}os"
      - "md{{ rpfx }}2"
      - "md{{ rpfx }}1"
 
@@ -17,6 +18,7 @@
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
        name: "md{{ rpfx }}1"
+       storage_account_type: "Standard_LRS"
        disk_size_gb: 1
        tags:
            testing: testing
@@ -59,6 +61,45 @@
      that:
        - output.changed
        - output.state.id is defined
+       - output.state.os_type == None
+
+ - name: Change the operating system type of the managed disk to linux
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}"
+       name: "md{{ rpfx }}1"
+       disk_size_gb: 1
+       os_type: linux
+       storage_account_type: "Standard_LRS"
+       tags:
+           testing: testing
+           delete: never
+   register: output
+
+ - assert:
+     that:
+       - output.changed
+       - output.state.os_type == 'linux'
+
+ - name: Create new managed disk with an os_type specified at creation
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}"
+       name: "md{{ rpfx }}os"
+       storage_account_type: "Standard_LRS"
+       disk_size_gb: 1
+       os_type: windows
+   register: win
+
+ - name: Assert status of os_type specified at creation
+   assert:
+     that:
+       - win.changed
+       - win.state.os_type == 'windows'
+
+ - name: Clean up managed disk created with os_type
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}"
+       name: "md{{ rpfx }}os"
+       state: absent
 
  - name: Copy disk to a new managed disk
    azure_rm_managed_disk:
@@ -181,6 +222,7 @@
            - "azure_managed_disk | length == 1"
            - azure_managed_disk[0].storage_account_type == "Premium_LRS"
            - azure_managed_disk[0].disk_size_gb == 2
+           - "azure_managed_disk[0].os_type == 'linux'"
 
  - name: Gather facts
    azure_rm_managed_disk_facts:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module `azure_rm_managed_disk` accepts `os_type` but did nothing with it.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_managed_disk

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
bash-4.4# ansible --version
ansible 2.8.0.dev0 (azure-managed-disk-type da9e5f6c7a) last updated 2018/11/30 18:12:54 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /ansible/lib/ansible
  executable location = /ansible/bin/ansible
  python version = 2.7.15 (default, Sep 12 2018, 02:38:23) [GCC 6.4.0]

```
