### PR TITLE
azure_rm_image: fix creation of image with data disks

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_image.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_image.py
@@ -251,7 +251,7 @@ class AzureRMImage(AzureRMModuleBase):
         if blob_uri or disk or snapshot:
             snapshot_resource = self.compute_models.SubResource(id=snapshot) if snapshot else None
             managed_disk = self.compute_models.SubResource(id=disk) if disk else None
-            return self.compute_models.ImageDataDisk(lun,
+            return self.compute_models.ImageDataDisk(lun=lun,
                                                      blob_uri=blob_uri,
                                                      snapshot=snapshot_resource,
                                                      managed_disk=managed_disk)

--- a/test/integration/targets/azure_rm_image/tasks/main.yml
+++ b/test/integration/targets/azure_rm_image/tasks/main.yml
@@ -6,6 +6,7 @@
       public_ip_name: "pip{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
       security_group_name: "sg{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
       blob_name: "blob{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+      empty_disk_name: "emptydisk{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
 
 - name: Create storage account
   azure_rm_storageaccount:
@@ -78,12 +79,22 @@
       name: "{{ vm_name }}"
       vm_size: Standard_A0
 
+- name: Create new empty managed disk
+  azure_rm_managed_disk:
+      resource_group: "{{ resource_group }}"
+      name: "{{ empty_disk_name }}"
+      storage_account_type: "Standard_LRS"
+      disk_size_gb: 1
+  register: emptydisk
+
 - name: Create an image from VM (check mode)
   azure_rm_image:
       resource_group: "{{ resource_group }}"
       source: "https://{{ storage_name }}.blob.core.windows.net/{{ storage_container_name }}/{{ blob_name }}.vhd"
       name: testimage001
       os_type: Linux
+      data_disk_sources:
+          - "{{ empty_disk_name }}"
   check_mode: yes
   register: output
 
@@ -159,6 +170,12 @@
 - assert:
     that:
       - not output.changed
+
+- name: Delete empty disk
+  azure_rm_managed_disk:
+      resource_group: "{{ resource_group }}"
+      name: "{{ empty_disk_name }}"
+      state: absent
 
 - name: Delete VM
   azure_rm_virtualmachine:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Creation of images with data disks would always fail, as the lun parameter to ImageDataDisk must be named.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_image

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
bash-4.4# ansible --version
ansible 2.8.0.dev0 (azure-image-lun-fix dbf5887937) last updated 2018/11/30 22:13:33 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /ansible/lib/ansible
  executable location = /ansible/bin/ansible
  python version = 2.7.15 (default, Sep 12 2018, 02:38:23) [GCC 6.4.0]
```
