### PR TITLE
[s3_bucket] Handle error when bucket doesn't exist

### DIFF
--- a/changelogs/fragments/s3_bucket_delete_nonexistent_bucket.yml
+++ b/changelogs/fragments/s3_bucket_delete_nonexistent_bucket.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Handle error paginating object versions when bucket does not exist (https://github.com/ansible/ansible/issues/49393)

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -120,7 +120,7 @@ import time
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.module_utils.six import string_types
 from ansible.module_utils.basic import to_text
-from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code
 from ansible.module_utils.ec2 import compare_policies, ec2_argument_spec, boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_tag_list
 from ansible.module_utils.ec2 import get_aws_connection_info, boto3_conn, AWSRetry
 
@@ -447,10 +447,13 @@ def paginated_list(s3_client, **pagination_params):
 
 
 def paginated_versions_list(s3_client, **pagination_params):
-    pg = s3_client.get_paginator('list_object_versions')
-    for page in pg.paginate(**pagination_params):
-        # We have to merge the Versions and DeleteMarker lists here, as DeleteMarkers can still prevent a bucket deletion
-        yield [(data['Key'], data['VersionId']) for data in (page.get('Versions', []) + page.get('DeleteMarkers', []))]
+    try:
+        pg = s3_client.get_paginator('list_object_versions')
+        for page in pg.paginate(**pagination_params):
+            # We have to merge the Versions and DeleteMarker lists here, as DeleteMarkers can still prevent a bucket deletion
+            yield [(data['Key'], data['VersionId']) for data in (page.get('Versions', []) + page.get('DeleteMarkers', []))]
+    except is_boto3_error_code('NoSuchBucket'):
+        yield []
 
 
 def destroy_bucket(s3_client, module):


### PR DESCRIPTION
Handle paginating object versions when bucket does not exist
changelog

##### SUMMARY
Fixes #49393
This is odd. I'm not really sure why this occurs (I haven't been able to reproduce it in my account). This should fix the traceback though.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
