### PR TITLE
Backport/2.7/48933

### DIFF
--- a/changelogs/fragments/ovirt_storage_connection_password-comparison.yaml
+++ b/changelogs/fragments/ovirt_storage_connection_password-comparison.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ovirt_storage_connection - comparing passwords breaks idempotency in update_check (https://github.com/ansible/ansible/issues/48933)

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_connection.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_connection.py
@@ -176,7 +176,6 @@ class StorageConnectionModule(BaseModule):
             equal(self.param('nfs_timeout'), entity.nfs_timeo) and
             equal(self.param('nfs_retrans'), entity.nfs_retrans) and
             equal(self.param('mount_options'), entity.mount_options) and
-            equal(self.param('password'), entity.password) and
             equal(self.param('username'), entity.username) and
             equal(self.param('port'), entity.port) and
             equal(self.param('target'), entity.target) and


### PR DESCRIPTION
##### SUMMARY
Comparing provided password parameter against returned entity password breaks idempotency as storage_connections_service() returns passwords as NoneType.

https://github.com/ansible/ansible/pull/48933

cherry-picked from: https://github.com/ansible/ansible/commit/5cd31578cc9f5bbc5b3ce751fcd32ff68598be44
##### ISSUE TYPE
- Bugfix Pull Request
