### PR TITLE
[Backport 2.7] sets admin_password to no_log in na_ontap_cifs_server

### DIFF
--- a/changelogs/fragments/46604-ontap-cifs-server-no-log-password.yaml
+++ b/changelogs/fragments/46604-ontap-cifs-server-no-log-password.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixes issue where a password parameter was not set to no_log

--- a/lib/ansible/modules/storage/netapp/na_ontap_cifs_server.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_cifs_server.py
@@ -127,7 +127,7 @@ class NetAppOntapcifsServer(object):
             workgroup=dict(required=False, type='str', default=None),
             domain=dict(required=False, type='str'),
             admin_user_name=dict(required=False, type='str'),
-            admin_password=dict(required=False, type='str'),
+            admin_password=dict(required=False, type='str', no_log=True),
             ou=dict(required=False, type='str'),
             force=dict(required=False, type='bool'),
             vserver=dict(required=True, type='str'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
admin_password is not currently set to no_log. Updated the dict definition to do so.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Reference https://github.com/ansible/ansible/pull/46604
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
