### PR TITLE
openssl_privatekey: add ECC support

### DIFF
--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -36,25 +36,35 @@ class OpenSSLObjectError(Exception):
     pass
 
 
-def get_fingerprint(path, passphrase=None):
-    """Generate the fingerprint of the public key. """
+def get_fingerprint_of_bytes(source):
+    """Generate the fingerprint of the given bytes."""
 
     fingerprint = {}
+
+    try:
+        for algo in hashlib.algorithms:
+            f = getattr(hashlib, algo)
+            pubkey_digest = f(source).hexdigest()
+            fingerprint[algo] = ':'.join(pubkey_digest[i:i + 2] for i in range(0, len(pubkey_digest), 2))
+    except AttributeError:
+        # Certain hashlib versions do not have algorithms attribute
+        return None
+
+    return fingerprint
+
+
+def get_fingerprint(path, passphrase=None):
+    """Generate the fingerprint of the public key. """
 
     privatekey = load_privatekey(path, passphrase)
     try:
         publickey = crypto.dump_publickey(crypto.FILETYPE_ASN1, privatekey)
-        for algo in hashlib.algorithms:
-            f = getattr(hashlib, algo)
-            pubkey_digest = f(publickey).hexdigest()
-            fingerprint[algo] = ':'.join(pubkey_digest[i:i + 2] for i in range(0, len(pubkey_digest), 2))
+        return get_fingerprint_of_bytes(publickey)
     except AttributeError:
         # If PyOpenSSL < 16.0 crypto.dump_publickey() will fail.
         # By doing this we prevent the code from raising an error
         # yet we return no value in the fingerprint hash.
-        pass
-
-    return fingerprint
+        return None
 
 
 def load_privatekey(path, passphrase=None):

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -42,13 +42,22 @@ def get_fingerprint_of_bytes(source):
     fingerprint = {}
 
     try:
-        for algo in hashlib.algorithms:
-            f = getattr(hashlib, algo)
-            pubkey_digest = f(source).hexdigest()
-            fingerprint[algo] = ':'.join(pubkey_digest[i:i + 2] for i in range(0, len(pubkey_digest), 2))
+        algorithms = hashlib.algorithms
     except AttributeError:
-        # Certain hashlib versions do not have algorithms attribute
-        return None
+        try:
+            algorithms = hashlib.algorithms_guaranteed
+        except AttributeError:
+            return None
+
+    for algo in algorithms:
+        f = getattr(hashlib, algo)
+        h = f(source)
+        try:
+            # Certain hash functions have a hexdigest() which expects a length parameter
+            pubkey_digest = h.hexdigest()
+        except TypeError:
+            pubkey_digest = h.hexdigest(32)
+        fingerprint[algo] = ':'.join(pubkey_digest[i:i + 2] for i in range(0, len(pubkey_digest), 2))
 
     return fingerprint
 

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -191,7 +191,7 @@ import os
 import traceback
 from distutils.version import LooseVersion
 
-MINIMAL_PYSOPENSSL_VERSION = '0.6'
+MINIMAL_PYOPENSSL_VERSION = '0.6'
 MINIMAL_CRYPTOGRAPHY_VERSION = '0.5'
 
 try:
@@ -594,7 +594,7 @@ def main():
     if backend == 'auto':
         # Detection what is possible
         can_use_cryptography = CRYPTOGRAPHY_FOUND and CRYPTOGRAPHY_VERSION >= LooseVersion(MINIMAL_CRYPTOGRAPHY_VERSION)
-        can_use_pyopenssl = PYOPENSSL_FOUND and PYOPENSSL_VERSION >= LooseVersion(MINIMAL_PYSOPENSSL_VERSION)
+        can_use_pyopenssl = PYOPENSSL_FOUND and PYOPENSSL_VERSION >= LooseVersion(MINIMAL_PYOPENSSL_VERSION)
 
         # Decision
         if module.params['cipher'] and module.params['passphrase'] and module.params['cipher'] != 'auto':
@@ -615,7 +615,7 @@ def main():
             module.fail_json(msg=('Can detect none of the Python libraries '
                                   'cryptography (>= {0}) and pyOpenSSL (>= {1})').format(
                                       MINIMAL_CRYPTOGRAPHY_VERSION,
-                                      MINIMAL_PYSOPENSSL_VERSION))
+                                      MINIMAL_PYOPENSSL_VERSION))
     if backend == 'pyopenssl':
         if not PYOPENSSL_FOUND:
             module.fail_json(msg='The Python pyOpenSSL library is required')

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -23,7 +23,10 @@ version_added: "2.3"
 short_description: Generate OpenSSL private keys.
 description:
     - "This module allows one to (re)generate OpenSSL private keys. One can
-       generate either RSA or DSA private keys. Keys are generated in PEM format."
+       generate L(RSA,https://en.wikipedia.org/wiki/RSA_(cryptosystem)),
+       L(DSA,https://en.wikipedia.org/wiki/Digital_Signature_Algorithm) or
+       L(ECC,https://en.wikipedia.org/wiki/Elliptic-curve_cryptography)
+       private keys. Keys are generated in PEM format."
     - "The module can use the cryptography Python library, or the pyOpenSSL Python
        library. By default, it tries to detect which one is available. This can be
        overridden with the I(select_crypto_backend) option."
@@ -616,7 +619,7 @@ def main():
         if not PYOPENSSL_FOUND:
             module.fail_json(msg='The Python pyOpenSSL library is required')
         private_key = PrivateKeyPyOpenSSL(module)
-    if backend == 'cryptography':
+    elif backend == 'cryptography':
         if not CRYPTOGRAPHY_FOUND:
             module.fail_json(msg='The Python cryptography library is required')
         private_key = PrivateKeyCryptography(module)

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -29,7 +29,7 @@ description:
        overridden with the I(select_crypto_backend) option."
 requirements:
     - "One of the following Python libraries:"
-    - "cryptography >= 0.5"
+    - "cryptography >= 1.2.3 (older versions might work as well)"
     - "pyOpenSSL"
 options:
     state:
@@ -193,7 +193,7 @@ import traceback
 from distutils.version import LooseVersion
 
 MINIMAL_PYOPENSSL_VERSION = '0.6'
-MINIMAL_CRYPTOGRAPHY_VERSION = '0.5'
+MINIMAL_CRYPTOGRAPHY_VERSION = '1.2.3'
 
 try:
     import OpenSSL

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -60,40 +60,28 @@ options:
         required: false
         choices:
             - secp384r1
-            - NIST-P-384
             - secp521r1
-            - NIST-P-521
             - secp224r1
-            - NIST-P-224
             - secp192r1
-            - NIST-P-192
             - secp256k1
-            - brainpool-p256r1
-            - brainpool-p384r1
-            - brainpool-p512r1
+            - brainpoolP256r1
+            - brainpoolP384r1
+            - brainpoolP512r1
             - sect571k1
-            - NIST-K-571
             - sect409k1
-            - NIST-K-409
             - sect283k1
-            - NIST-K-283
             - sect233k1
-            - NIST-K-233
             - sect163k1
-            - NIST-K-163
             - sect571r1
-            - NIST-B-571
             - sect409r1
-            - NIST-B-409
             - sect283r1
-            - NIST-B-283
             - sect233r1
-            - NIST-B-233
             - sect163r2
-            - NIST-B-163
         description:
             - Note that not all curves are supported by all versions of C(cryptography).
-            - For maximal interoperability, C(secp256k1) or C(secp384r1) should be used.
+            - For maximal interoperability, C(secp384r1) or C(secp256k1) should be used.
+            - We use the curve names as defined in the
+              L(IANA registry for TLS,https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8).
         version_added: "2.8"
     force:
         required: false
@@ -429,37 +417,23 @@ class PrivateKeyCryptography(PrivateKeyBase):
 
         self.curves = dict()
         self._add_curve('secp384r1', 'SECP384R1')
-        self._add_curve('NIST-P-384', 'SECP384R1')  # alias
         self._add_curve('secp521r1', 'SECP521R1')
-        self._add_curve('NIST-P-521', 'SECP521R1')  # alias
         self._add_curve('secp224r1', 'SECP224R1')
-        self._add_curve('NIST-P-224', 'SECP224R1')  # alias
         self._add_curve('secp192r1', 'SECP192R1')
-        self._add_curve('NIST-P-192', 'SECP192R1')  # alias
         self._add_curve('secp256k1', 'SECP256K1')
-        self._add_curve('brainpool-p256r1', 'BrainpoolP256R1', deprecated=True)
-        self._add_curve('brainpool-p384r1', 'BrainpoolP384R1', deprecated=True)
-        self._add_curve('brainpool-p512r1', 'BrainpoolP512R1', deprecated=True)
+        self._add_curve('brainpoolP256r1', 'BrainpoolP256R1', deprecated=True)
+        self._add_curve('brainpoolP384r1', 'BrainpoolP384R1', deprecated=True)
+        self._add_curve('brainpoolP512r1', 'BrainpoolP512R1', deprecated=True)
         self._add_curve('sect571k1', 'SECT571K1', deprecated=True)
-        self._add_curve('NIST-K-571', 'SECT571K1', deprecated=True)  # alias
         self._add_curve('sect409k1', 'SECT409K1', deprecated=True)
-        self._add_curve('NIST-K-409', 'SECT409K1', deprecated=True)  # alias
         self._add_curve('sect283k1', 'SECT283K1', deprecated=True)
-        self._add_curve('NIST-K-283', 'SECT283K1', deprecated=True)  # alias
         self._add_curve('sect233k1', 'SECT233K1', deprecated=True)
-        self._add_curve('NIST-K-233', 'SECT233K1', deprecated=True)  # alias
         self._add_curve('sect163k1', 'SECT163K1', deprecated=True)
-        self._add_curve('NIST-K-163', 'SECT163K1', deprecated=True)  # alias
         self._add_curve('sect571r1', 'SECT571R1', deprecated=True)
-        self._add_curve('NIST-B-571', 'SECT571R1', deprecated=True)  # alias
         self._add_curve('sect409r1', 'SECT409R1', deprecated=True)
-        self._add_curve('NIST-B-409', 'SECT409R1', deprecated=True)  # alias
         self._add_curve('sect283r1', 'SECT283R1', deprecated=True)
-        self._add_curve('NIST-B-283', 'SECT283R1', deprecated=True)  # alias
         self._add_curve('sect233r1', 'SECT233R1', deprecated=True)
-        self._add_curve('NIST-B-233', 'SECT233R1', deprecated=True)  # alias
         self._add_curve('sect163r2', 'SECT163R2', deprecated=True)
-        self._add_curve('NIST-B-163', 'SECT163R2', deprecated=True)  # alias
 
         self.module = module
         self.cryptography_backend = cryptography.hazmat.backends.default_backend()
@@ -584,13 +558,10 @@ def main():
                 # 'X448', 'X25519',
             ], type='str'),
             curve=dict(choices=[
-                'secp384r1', 'NIST-P-384', 'secp521r1', 'NIST-P-521', 'secp224r1', 'NIST-P-224',
-                'secp192r1', 'NIST-P-192', 'secp256k1',
-                'brainpool-p256r1', 'brainpool-p384r1', 'brainpool-p512r1',
-                'sect571k1', 'NIST-K-571', 'sect409k1', 'NIST-K-409', 'sect283k1', 'NIST-K-283',
-                'sect233k1', 'NIST-K-233', 'sect163k1', 'NIST-K-163', 'sect571r1', 'NIST-B-571',
-                'sect409r1', 'NIST-B-409', 'sect283r1', 'NIST-B-283', 'sect233r1', 'NIST-B-233',
-                'sect163r2', 'NIST-B-163',
+                'secp384r1', 'secp521r1', 'secp224r1', 'secp192r1', 'secp256k1',
+                'brainpoolP256r1', 'brainpoolP384r1', 'brainpoolP512r1',
+                'sect571k1', 'sect409k1', 'sect283k1', 'sect233k1', 'sect163k1',
+                'sect571r1', 'sect409r1', 'sect283r1', 'sect233r1', 'sect163r2',
             ], type='str'),
             force=dict(default=False, type='bool'),
             path=dict(required=True, type='path'),

--- a/test/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -49,3 +49,136 @@
     passphrase: ànsïblé
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
     select_crypto_backend: '{{ select_crypto_backend }}'
+
+- set_fact:
+    ecc_types: []
+  when: select_crypto_backend == 'pyopenssl'
+- set_fact:
+    ecc_types:
+    # - curve: X448
+    #   min_cryptography_version: "2.5"
+    # - curve: X25519
+    #   min_cryptography_version: "2.0"
+    - curve: secp384r1
+      openssl_name: secp384r1
+      min_cryptography_version: "0.5"
+    - curve: NIST-P-384
+      openssl_name: secp384r1
+      min_cryptography_version: "0.5"
+    - curve: secp521r1
+      openssl_name: secp521r1
+      min_cryptography_version: "0.5"
+    - curve: NIST-P-521
+      openssl_name: secp521r1
+      min_cryptography_version: "0.5"
+    - curve: secp224r1
+      openssl_name: secp224r1
+      min_cryptography_version: "0.5"
+    - curve: NIST-P-224
+      openssl_name: secp224r1
+      min_cryptography_version: "0.5"
+    - curve: secp192r1
+      openssl_name: prime192v1
+      min_cryptography_version: "0.5"
+    - curve: NIST-P-192
+      openssl_name: prime192v1
+      min_cryptography_version: "0.5"
+    - curve: secp256k1
+      openssl_name: secp256k1
+      min_cryptography_version: "0.9"
+    - curve: brainpool-p256r1
+      openssl_name: brainpoolP256r1
+      min_cryptography_version: "2.2"
+    - curve: brainpool-p384r1
+      openssl_name: brainpoolP384r1
+      min_cryptography_version: "2.2"
+    - curve: brainpool-p512r1
+      openssl_name: brainpoolP512r1
+      min_cryptography_version: "2.2"
+    - curve: sect571k1
+      openssl_name: sect571k1
+      min_cryptography_version: "0.5"
+    - curve: NIST-K-571
+      openssl_name: sect571k1
+      min_cryptography_version: "0.5"
+    - curve: sect409k1
+      openssl_name: sect409k1
+      min_cryptography_version: "0.5"
+    - curve: NIST-K-409
+      openssl_name: sect409k1
+      min_cryptography_version: "0.5"
+    - curve: sect283k1
+      openssl_name: sect283k1
+      min_cryptography_version: "0.5"
+    - curve: NIST-K-283
+      openssl_name: sect283k1
+      min_cryptography_version: "0.5"
+    - curve: sect233k1
+      openssl_name: sect233k1
+      min_cryptography_version: "0.5"
+    - curve: NIST-K-233
+      openssl_name: sect233k1
+      min_cryptography_version: "0.5"
+    - curve: sect163k1
+      openssl_name: sect163k1
+      min_cryptography_version: "0.5"
+    - curve: NIST-K-163
+      openssl_name: sect163k1
+      min_cryptography_version: "0.5"
+    - curve: sect571r1
+      openssl_name: sect571r1
+      min_cryptography_version: "0.5"
+    - curve: NIST-B-571
+      openssl_name: sect571r1
+      min_cryptography_version: "0.5"
+    - curve: sect409r1
+      openssl_name: sect409r1
+      min_cryptography_version: "0.5"
+    - curve: NIST-B-409
+      openssl_name: sect409r1
+      min_cryptography_version: "0.5"
+    - curve: sect283r1
+      openssl_name: sect283r1
+      min_cryptography_version: "0.5"
+    - curve: NIST-B-283
+      openssl_name: sect283r1
+      min_cryptography_version: "0.5"
+    - curve: sect233r1
+      openssl_name: sect233r1
+      min_cryptography_version: "0.5"
+    - curve: NIST-B-233
+      openssl_name: sect233r1
+      min_cryptography_version: "0.5"
+    - curve: sect163r2
+      openssl_name: sect163r2
+      min_cryptography_version: "0.5"
+    - curve: NIST-B-163
+      openssl_name: sect163r2
+      min_cryptography_version: "0.5"
+  when: select_crypto_backend == 'cryptography'
+
+- name: Test ECC key generation
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey-{{ item.curve }}.pem'
+    type: "{{ item.curve }}"
+    select_crypto_backend: '{{ select_crypto_backend }}'
+  when: |
+    cryptography_version.stdout is version(item.min_cryptography_version, '>=') and
+    item.openssl_name in openssl_ecc_list
+  loop: "{{ ecc_types }}"
+  loop_control:
+    label: "{{ item.curve }}"
+  register: privatekey_ecc_generate
+
+- name: Test ECC key generation (idempotency)
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey-{{ item.curve }}.pem'
+    type: "{{ item.curve }}"
+    select_crypto_backend: '{{ select_crypto_backend }}'
+  when: |
+    cryptography_version.stdout is version(item.min_cryptography_version, '>=') and
+    item.openssl_name in openssl_ecc_list
+  loop: "{{ ecc_types }}"
+  loop_control:
+    label: "{{ item.curve }}"
+  register: privatekey_ecc_idempotency

--- a/test/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -1,0 +1,51 @@
+---
+- name: Generate privatekey1 - standard
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey1.pem'
+    select_crypto_backend: '{{ select_crypto_backend }}'
+
+- name: Generate privatekey2 - size 2048
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey2.pem'
+    size: 2048
+    select_crypto_backend: '{{ select_crypto_backend }}'
+
+- name: Generate privatekey3 - type DSA
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey3.pem'
+    type: DSA
+    size: 3072
+    select_crypto_backend: '{{ select_crypto_backend }}'
+
+- name: Generate privatekey4 - standard
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey4.pem'
+    select_crypto_backend: '{{ select_crypto_backend }}'
+
+- name: Delete privatekey4 - standard
+  openssl_privatekey:
+    state: absent
+    path: '{{ output_dir }}/privatekey4.pem'
+    select_crypto_backend: '{{ select_crypto_backend }}'
+
+- name: Generate privatekey5 - standard - with passphrase
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey5.pem'
+    passphrase: ansible
+    cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
+    select_crypto_backend: '{{ select_crypto_backend }}'
+
+- name: Generate privatekey5 - standard - idempotence
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey5.pem'
+    passphrase: ansible
+    cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
+    select_crypto_backend: '{{ select_crypto_backend }}'
+  register: privatekey5_idempotence
+
+- name: Generate privatekey6 - standard - with non-ASCII passphrase
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey6.pem'
+    passphrase: ànsïblé
+    cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
+    select_crypto_backend: '{{ select_crypto_backend }}'

--- a/test/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -62,97 +62,55 @@
     - curve: secp384r1
       openssl_name: secp384r1
       min_cryptography_version: "0.5"
-    - curve: NIST-P-384
-      openssl_name: secp384r1
-      min_cryptography_version: "0.5"
     - curve: secp521r1
-      openssl_name: secp521r1
-      min_cryptography_version: "0.5"
-    - curve: NIST-P-521
       openssl_name: secp521r1
       min_cryptography_version: "0.5"
     - curve: secp224r1
       openssl_name: secp224r1
       min_cryptography_version: "0.5"
-    - curve: NIST-P-224
-      openssl_name: secp224r1
-      min_cryptography_version: "0.5"
     - curve: secp192r1
-      openssl_name: prime192v1
-      min_cryptography_version: "0.5"
-    - curve: NIST-P-192
       openssl_name: prime192v1
       min_cryptography_version: "0.5"
     - curve: secp256k1
       openssl_name: secp256k1
       min_cryptography_version: "0.9"
-    - curve: brainpool-p256r1
+    - curve: brainpoolP256r1
       openssl_name: brainpoolP256r1
       min_cryptography_version: "2.2"
-    - curve: brainpool-p384r1
+    - curve: brainpoolP384r1
       openssl_name: brainpoolP384r1
       min_cryptography_version: "2.2"
-    - curve: brainpool-p512r1
+    - curve: brainpoolP512r1
       openssl_name: brainpoolP512r1
       min_cryptography_version: "2.2"
     - curve: sect571k1
       openssl_name: sect571k1
       min_cryptography_version: "0.5"
-    - curve: NIST-K-571
-      openssl_name: sect571k1
-      min_cryptography_version: "0.5"
     - curve: sect409k1
-      openssl_name: sect409k1
-      min_cryptography_version: "0.5"
-    - curve: NIST-K-409
       openssl_name: sect409k1
       min_cryptography_version: "0.5"
     - curve: sect283k1
       openssl_name: sect283k1
       min_cryptography_version: "0.5"
-    - curve: NIST-K-283
-      openssl_name: sect283k1
-      min_cryptography_version: "0.5"
     - curve: sect233k1
-      openssl_name: sect233k1
-      min_cryptography_version: "0.5"
-    - curve: NIST-K-233
       openssl_name: sect233k1
       min_cryptography_version: "0.5"
     - curve: sect163k1
       openssl_name: sect163k1
       min_cryptography_version: "0.5"
-    - curve: NIST-K-163
-      openssl_name: sect163k1
-      min_cryptography_version: "0.5"
     - curve: sect571r1
-      openssl_name: sect571r1
-      min_cryptography_version: "0.5"
-    - curve: NIST-B-571
       openssl_name: sect571r1
       min_cryptography_version: "0.5"
     - curve: sect409r1
       openssl_name: sect409r1
       min_cryptography_version: "0.5"
-    - curve: NIST-B-409
-      openssl_name: sect409r1
-      min_cryptography_version: "0.5"
     - curve: sect283r1
-      openssl_name: sect283r1
-      min_cryptography_version: "0.5"
-    - curve: NIST-B-283
       openssl_name: sect283r1
       min_cryptography_version: "0.5"
     - curve: sect233r1
       openssl_name: sect233r1
       min_cryptography_version: "0.5"
-    - curve: NIST-B-233
-      openssl_name: sect233r1
-      min_cryptography_version: "0.5"
     - curve: sect163r2
-      openssl_name: sect163r2
-      min_cryptography_version: "0.5"
-    - curve: NIST-B-163
       openssl_name: sect163r2
       min_cryptography_version: "0.5"
   when: select_crypto_backend == 'cryptography'

--- a/test/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -160,7 +160,8 @@
 - name: Test ECC key generation
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey-{{ item.curve }}.pem'
-    type: "{{ item.curve }}"
+    type: ECC
+    curve: "{{ item.curve }}"
     select_crypto_backend: '{{ select_crypto_backend }}'
   when: |
     cryptography_version.stdout is version(item.min_cryptography_version, '>=') and
@@ -173,7 +174,8 @@
 - name: Test ECC key generation (idempotency)
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey-{{ item.curve }}.pem'
-    type: "{{ item.curve }}"
+    type: ECC
+    curve: "{{ item.curve }}"
     select_crypto_backend: '{{ select_crypto_backend }}'
   when: |
     cryptography_version.stdout is version(item.min_cryptography_version, '>=') and

--- a/test/integration/targets/openssl_privatekey/tasks/main.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/main.yml
@@ -1,4 +1,31 @@
 ---
+- name: Find out which elliptic curves are supported by installed OpenSSL
+  command: openssl ecparam -list_curves
+  register: openssl_ecc
+
+- name: Compile list of elliptic curves supported by OpenSSL
+  set_fact:
+    openssl_ecc_list: |
+      {{
+        openssl_ecc.stdout_lines
+        | map('regex_search', '^ *([a-zA-Z0-9_-]+) *: .*$')
+        | select()
+        | map('regex_replace', '^ *([a-zA-Z0-9_-]+) *: .*$', '\1')
+        | list
+      }}
+  when: ansible_distribution != 'CentOS' or ansible_distribution_major_version != '6'
+  # CentOS comes with a very old jinja2 which does not include the map() filter...
+- name: Compile list of elliptic curves supported by OpenSSL (CentOS 6)
+  set_fact:
+    openssl_ecc_list:
+    - secp384r1
+    - secp521r1
+    - prime256v1
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '6'
+
+- name: List of elliptic curves supported by OpenSSL
+  debug: var=openssl_ecc_list
+
 - block:
   - name: Running tests with pyOpenSSL backend
     include_tasks: impl.yml
@@ -28,4 +55,4 @@
 
   - import_tasks: ../tests/validate.yml
 
-  when: cryptography_version.stdout is version('1.5', '>=')
+  when: cryptography_version.stdout is version('0.5', '>=')

--- a/test/integration/targets/openssl_privatekey/tasks/main.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/main.yml
@@ -1,43 +1,31 @@
-- name: Generate privatekey1 - standard
-  openssl_privatekey:
-    path: '{{ output_dir }}/privatekey1.pem'
+---
+- block:
+  - name: Running tests with pyOpenSSL backend
+    include_tasks: impl.yml
+    vars:
+      select_crypto_backend: pyopenssl
 
-- name: Generate privatekey2 - size 2048
-  openssl_privatekey:
-    path: '{{ output_dir }}/privatekey2.pem'
-    size: 2048
+  - import_tasks: ../tests/validate.yml
 
-- name: Generate privatekey3 - type DSA
-  openssl_privatekey:
-    path: '{{ output_dir }}/privatekey3.pem'
-    type: DSA
+  # FIXME: minimal pyOpenSSL version?!
+  when: pyopenssl_version.stdout is version('0.6', '>=')
 
-- name: Generate privatekey4 - standard
-  openssl_privatekey:
-    path: '{{ output_dir }}/privatekey4.pem'
-
-- name: Delete privatekey4 - standard
-  openssl_privatekey:
+- name: Remove output directory
+  file:
+    path: "{{ output_dir }}"
     state: absent
-    path: '{{ output_dir }}/privatekey4.pem'
 
-- name: Generate privatekey5 - standard - with passphrase
-  openssl_privatekey:
-    path: '{{ output_dir }}/privatekey5.pem'
-    passphrase: ansible
-    cipher: aes256
+- name: Re-create output directory
+  file:
+    path: "{{ output_dir }}"
+    state: directory
 
-- name: Generate privatekey5 - standard - idempotence
-  openssl_privatekey:
-    path: '{{ output_dir }}/privatekey5.pem'
-    passphrase: ansible
-    cipher: aes256
-  register: privatekey5_idempotence
+- block:
+  - name: Running tests with cryptography backend
+    include_tasks: impl.yml
+    vars:
+      select_crypto_backend: cryptography
 
-- name: Generate privatekey6 - standard - with non-ASCII passphrase
-  openssl_privatekey:
-    path: '{{ output_dir }}/privatekey6.pem'
-    passphrase: ànsïblé
-    cipher: aes256
+  - import_tasks: ../tests/validate.yml
 
-- import_tasks: ../tests/validate.yml
+  when: cryptography_version.stdout is version('1.5', '>=')

--- a/test/integration/targets/openssl_privatekey/tasks/main.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/main.yml
@@ -56,3 +56,40 @@
   - import_tasks: ../tests/validate.yml
 
   when: cryptography_version.stdout is version('0.5', '>=')
+
+- name: Check that fingerprints do not depend on the backend
+  block:
+  - name: "Fingerprint comparison: pyOpenSSL"
+    openssl_privatekey:
+      path: '{{ output_dir }}/fingerprint-{{ item }}.pem'
+      type: "{{ item }}"
+      size: 1024
+      select_crypto_backend: pyopenssl
+    loop:
+    - RSA
+    - DSA
+    register: fingerprint_pyopenssl
+
+  - name: "Fingerprint comparison: cryptography"
+    openssl_privatekey:
+      path: '{{ output_dir }}/fingerprint-{{ item }}.pem'
+      type: "{{ item }}"
+      size: 1024
+      select_crypto_backend: cryptography
+    loop:
+    - RSA
+    - DSA
+    register: fingerprint_cryptography
+
+  - name: Verify that fingerprints match
+    assert:
+      that: item.0.fingerprint[item.2] == item.1.fingerprint[item.2]
+    when: item.0 is not skipped and item.1 is not skipped
+    loop: |
+      {{ query('nested',
+            fingerprint_pyopenssl.results | zip(fingerprint_cryptography.results),
+            fingerprint_pyopenssl.results[0].fingerprint.keys()
+      ) if fingerprint_pyopenssl.results[0].fingerprint else [] }}
+    loop_control:
+      label: "{{ [item.0.item, item.2] }}"
+  when: pyopenssl_version.stdout is version('0.6', '>=') and cryptography_version.stdout is version('0.5', '>=')

--- a/test/integration/targets/openssl_privatekey/tests/validate.yml
+++ b/test/integration/targets/openssl_privatekey/tests/validate.yml
@@ -1,3 +1,4 @@
+---
 - name: Validate privatekey1 (test - RSA key with size 4096 bits)
   shell: "openssl rsa -noout -text -in {{ output_dir }}/privatekey1.pem  | grep Private | sed 's/\\(RSA\\s\\)*Private-Key: (\\(.*\\) bit.*)/\\2/'"
   register: privatekey1
@@ -18,14 +19,14 @@
       - privatekey2.stdout == '2048'
 
 
-- name: Validate privatekey3 (test - DSA key with size 4096 bits)
+- name: Validate privatekey3 (test - DSA key with size 3072 bits)
   shell: "openssl dsa -noout -text -in {{ output_dir }}/privatekey3.pem  | grep Private | sed 's/\\(RSA\\s\\)*Private-Key: (\\(.*\\) bit.*)/\\2/'"
   register: privatekey3
 
-- name: Validate privatekey3 (assert - DSA key with size 4096 bits)
+- name: Validate privatekey3 (assert - DSA key with size 3072 bits)
   assert:
     that:
-      - privatekey3.stdout == '4096'
+      - privatekey3.stdout == '3072'
 
 
 - name: Validate privatekey4 (test - Ensure key has been removed)

--- a/test/integration/targets/openssl_privatekey/tests/validate.yml
+++ b/test/integration/targets/openssl_privatekey/tests/validate.yml
@@ -69,3 +69,38 @@
     that:
       - privatekey6.stdout == '4096'
   when: openssl_version.stdout is version('0.9.8zh', '>=')
+
+- name: Validate ECC generation (dump with OpenSSL)
+  shell: "openssl ec -in {{ output_dir }}/privatekey-{{ item.item.curve }}.pem -noout -text | grep 'ASN1 OID: ' | sed 's/ASN1 OID: \\([^ ]*\\)/\\1/'"
+  loop: "{{ privatekey_ecc_generate.results }}"
+  register: privatekey_ecc_dump
+  when: openssl_version.stdout is version('0.9.8zh', '>=') and 'skip_reason' not in item
+  loop_control:
+    label: "{{ item.item.curve }}"
+
+- name: Validate ECC generation
+  assert:
+    that:
+    - item is changed
+  loop: "{{ privatekey_ecc_generate.results }}"
+  when: "'skip_reason' not in item"
+  loop_control:
+    label: "{{ item.item.curve }}"
+
+- name: Validate ECC generation (curve type)
+  assert:
+    that:
+    - "'skip_reason' in item or item.item.item.openssl_name == item.stdout"
+  loop: "{{ privatekey_ecc_dump.results }}"
+  when: "'skip_reason' not in item"
+  loop_control:
+    label: "{{ item.item.item }} - {{ item.stdout if 'stdout' in item else '<unsupported>' }}"
+
+- name: Validate ECC generation idempotency
+  assert:
+    that:
+    - item is not changed
+  loop: "{{ privatekey_ecc_idempotency.results }}"
+  when: "'skip_reason' not in item"
+  loop_control:
+    label: "{{ item.item.curve }}"

--- a/test/integration/targets/setup_openssl/tasks/main.yml
+++ b/test/integration/targets/setup_openssl/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Incluse OS-specific variables
   include_vars: '{{ ansible_os_family }}.yml'
   when: not ansible_os_family == "Darwin"


### PR DESCRIPTION
##### SUMMARY
This adds elliptic curve cryptography support to `openssl_privatekey`. The first step is to allow two backends (pyOpenSSL, cryptography). The second step is to add ECC support when using the cryptography backend.

First step for #32626.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openssl_privatekey
