### PR TITLE
IBM_Storage: fix host_add_ports

### DIFF
--- a/lib/ansible/module_utils/ibm_sa_utils.py
+++ b/lib/ansible/module_utils/ibm_sa_utils.py
@@ -76,7 +76,7 @@ def build_pyxcli_command(fields):
     """ Builds the args for pyxcli using the exact args from ansible"""
     pyxcli_args = {}
     for field in fields:
-        if field in AVAILABLE_PYXCLI_FIELDS and fields[field]:
+        if field in AVAILABLE_PYXCLI_FIELDS and fields[field] != '':
             pyxcli_args[field] = fields[field]
     return pyxcli_args
 

--- a/lib/ansible/modules/storage/ibm/ibm_sa_host_ports.py
+++ b/lib/ansible/modules/storage/ibm/ibm_sa_host_ports.py
@@ -99,7 +99,7 @@ def main():
 
     xcli_client = connect_ssl(module)
     # required args
-    ports = None
+    ports = []
     try:
         ports = xcli_client.cmd.host_list_ports(
             host=module.params.get('host')).as_list
@@ -109,9 +109,14 @@ def main():
     port_exists = False
     ports = [port.get('port_name') for port in ports]
 
+    fc_ports = (module.params.get('fcaddress')
+                if module.params.get('fcaddress') else [])
+    iscsi_ports = (module.params.get('iscsi_name')
+                   if module.params.get('iscsi_name') else [])
     for port in ports:
-        if port in module.params.get('iscsi_name', "") or port in module.params.get('fcaddress', ""):
+        if port in iscsi_ports or port in fc_ports:
             port_exists = True
+            break
     state_changed = False
     if state == 'present' and not port_exists:
         state_changed = execute_pyxcli_command(


### PR DESCRIPTION


##### SUMMARY
iscsi_name and fcaddress fields are not required by default.
This commit make sure that no exception is thrown if only
on field supplied

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ibm_sa_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ansible 2.8.0.dev0 (fix_ibm_storage_host_add_ports b5d12e307a) last updated 2018/11/27 15:24:02 (GMT +300)
```
