### PR TITLE
Add force_archive option to archive module to allow archiving and compression of single files

### DIFF
--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -45,9 +45,16 @@ options:
     type: path
   exclude_path:
     description:
-      - Remote absolute path, glob, or list of paths or globs for the file or files to exclude from the archive.
+      - Remote absolute path, glob, or list of paths or globs for the file or files to exclude from the archive
     type: str
     version_added: '2.4'
+  force_archive:
+    version_added: '2.8'
+    description:
+      - Allow you to force the module to treat this as an archive even if only a single file is specified.
+      - By default behaviour is maintained. i.e A when a single file is specified it is compressed only (not archived).
+    type: bool
+    default: false
   remove:
     description:
       - Remove any added source files and trees after adding to archive.
@@ -105,6 +112,19 @@ EXAMPLES = r'''
     exclude_path:
     - /path/to/foo/ba*
     format: bz2
+
+- name: Use gzip to compress a single archive (i.e don't archive it first with tar)
+  archive:
+    path: /path/to/foo/single.file
+    dest: /path/file.gz
+    format: gz
+
+- name: Create a tar.gz archive of a single file.
+  archive:
+    path: /path/to/foo/single.file
+    dest: /path/file.tar.gz
+    format: gz
+    force_archive: true
 '''
 
 RETURN = r'''
@@ -176,6 +196,7 @@ def main():
             format=dict(type='str', default='gz', choices=['bz2', 'gz', 'tar', 'xz', 'zip']),
             dest=dict(type='path'),
             exclude_path=dict(type='list'),
+            force_archive=dict(type='bool', default=False),
             remove=dict(type='bool', default=False),
         ),
         add_file_common_args=True,
@@ -192,6 +213,7 @@ def main():
     expanded_paths = []
     expanded_exclude_paths = []
     format = params['format']
+    force_archive = params['force_archive']
     globby = False
     changed = False
     state = 'absent'
@@ -236,9 +258,13 @@ def main():
     if not expanded_paths:
         return module.fail_json(path=', '.join(paths), expanded_paths=', '.join(expanded_paths), msg='Error, no source paths were found')
 
-    # If we actually matched multiple files or TRIED to, then
-    # treat this as a multi-file archive
-    archive = globby or os.path.isdir(expanded_paths[0]) or len(expanded_paths) > 1
+    # Only try to determine if we are working with an archive or not if we haven't set archive to true
+    if not force_archive:
+        # If we actually matched multiple files or TRIED to, then
+        # treat this as a multi-file archive
+        archive = globby or os.path.isdir(expanded_paths[0]) or len(expanded_paths) > 1
+    else:
+        archive = True
 
     # Default created file name (for single-file archives) to
     # <file>.<format>

--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -45,7 +45,7 @@ options:
     type: path
   exclude_path:
     description:
-      - Remote absolute path, glob, or list of paths or globs for the file or files to exclude from the archive
+      - Remote absolute path, glob, or list of paths or globs for the file or files to exclude from the archive.
     type: str
     version_added: '2.4'
   force_archive:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR enables a user to force the archive module to create an archive when working with a single file. (Rather than just compressing the file)

NOTE: This is not applicable to zip files as the default behaviour for zipping a single file is to archive already.

NOTE: This PR does not change the default behaviour of the module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/files/archive.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
#### Before PR
1. Create a file to be archived
```bash
echo asdf > test.file
```
2. Archive the file
```bash
ansible localhost -m archive -a "dest=test.tar.gz path=test.file"
```
3. List the files in the archive
```bash
tar --list -f test.tar.gz
```
No files are listed as the tar archive was not created the file was only compressed using gzip.

4. Decompress file using gunzip
```bash
cat test.tar.gz | gunzip
```
Output:
```
asdf
```
Contents of file is shown after being decompressed as the tar archive was not created the file was only compressed using gzip.
#### After PR:
1. Create a file to be archived
```bash
echo asdf > test.file
```
2. Archive the file
```bash
ansible localhost -m archive -a "dest=test.tar.gz path=test.file force_archive=true"
```
3. List the files in the archive
```bash
tar --list -f test.tar.gz
```
Output:
```
test.file
```
`test.file` is correctly listed