### PR TITLE
Dry run (--check mode) prints discrete banner at the beginning and the end of the playbook, play and task execution. 

### DIFF
--- a/changelogs/fragments/check_mode_markers.yml
+++ b/changelogs/fragments/check_mode_markers.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add new option to default standard out callback plugin, ``ANSIBLE_CHECK_MODE_MARKERS``, which adds check mode markers (``DRY RUN``, ``CHECK_MODE``) to the output when running in check mode. It is off by default.

--- a/test/integration/targets/callback_default/callback_default.out.check_markers_dry.stderr
+++ b/test/integration/targets/callback_default/callback_default.out.check_markers_dry.stderr
@@ -1,0 +1,2 @@
++ ansible-playbook -i inventory --check test_dryrun.yml
+++ set +x

--- a/test/integration/targets/callback_default/callback_default.out.check_markers_dry.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.check_markers_dry.stdout
@@ -1,0 +1,78 @@
+
+DRY RUN ************************************************************************
+
+PLAY [A common play] [CHECK MODE] **********************************************
+
+TASK [debug] [CHECK MODE] ******************************************************
+ok: [testhost] => {
+    "msg": "ansible_check_mode: True"
+}
+
+TASK [Command] [CHECK MODE] ****************************************************
+skipping: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] [CHECK MODE] ******************************
+skipping: [testhost]
+
+PLAY [Play with check_mode: true (runs always in check_mode)] [CHECK MODE] *****
+
+TASK [debug] [CHECK MODE] ******************************************************
+ok: [testhost] => {
+    "msg": "ansible_check_mode: True"
+}
+
+TASK [Command] [CHECK MODE] ****************************************************
+skipping: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] [CHECK MODE] ******************************
+skipping: [testhost]
+
+PLAY [Play with check_mode: false (runs always in wet mode)] *******************
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "msg": "ansible_check_mode: True"
+}
+
+TASK [Command] *****************************************************************
+changed: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] [CHECK MODE] ******************************
+skipping: [testhost]
+
+PLAY [Play with a block with check_mode: true] [CHECK MODE] ********************
+
+TASK [Command] [CHECK MODE] ****************************************************
+skipping: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] [CHECK MODE] ******************************
+skipping: [testhost]
+
+PLAY [Play with a block with check_mode: false] [CHECK MODE] *******************
+
+TASK [Command] *****************************************************************
+changed: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] [CHECK MODE] ******************************
+skipping: [testhost]
+
+PLAY RECAP *********************************************************************
+testhost                   : ok=10   changed=7    unreachable=0    failed=0    skipped=8    rescued=0    ignored=0   
+
+
+DRY RUN ************************************************************************

--- a/test/integration/targets/callback_default/callback_default.out.check_markers_wet.stderr
+++ b/test/integration/targets/callback_default/callback_default.out.check_markers_wet.stderr
@@ -1,0 +1,2 @@
++ ansible-playbook -i inventory test_dryrun.yml
+++ set +x

--- a/test/integration/targets/callback_default/callback_default.out.check_markers_wet.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.check_markers_wet.stdout
@@ -1,0 +1,74 @@
+
+PLAY [A common play] ***********************************************************
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "msg": "ansible_check_mode: False"
+}
+
+TASK [Command] *****************************************************************
+changed: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] [CHECK MODE] ******************************
+skipping: [testhost]
+
+PLAY [Play with check_mode: true (runs always in check_mode)] [CHECK MODE] *****
+
+TASK [debug] [CHECK MODE] ******************************************************
+ok: [testhost] => {
+    "msg": "ansible_check_mode: False"
+}
+
+TASK [Command] [CHECK MODE] ****************************************************
+skipping: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] [CHECK MODE] ******************************
+skipping: [testhost]
+
+PLAY [Play with check_mode: false (runs always in wet mode)] *******************
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "msg": "ansible_check_mode: False"
+}
+
+TASK [Command] *****************************************************************
+changed: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] [CHECK MODE] ******************************
+skipping: [testhost]
+
+PLAY [Play with a block with check_mode: true] *********************************
+
+TASK [Command] [CHECK MODE] ****************************************************
+skipping: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] [CHECK MODE] ******************************
+skipping: [testhost]
+
+PLAY [Play with a block with check_mode: false] ********************************
+
+TASK [Command] *****************************************************************
+changed: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] [CHECK MODE] ******************************
+skipping: [testhost]
+
+PLAY RECAP *********************************************************************
+testhost                   : ok=11   changed=8    unreachable=0    failed=0    skipped=7    rescued=0    ignored=0   
+

--- a/test/integration/targets/callback_default/callback_default.out.check_nomarkers_dry.stderr
+++ b/test/integration/targets/callback_default/callback_default.out.check_nomarkers_dry.stderr
@@ -1,0 +1,2 @@
++ ansible-playbook -i inventory --check test_dryrun.yml
+++ set +x

--- a/test/integration/targets/callback_default/callback_default.out.check_nomarkers_dry.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.check_nomarkers_dry.stdout
@@ -1,0 +1,74 @@
+
+PLAY [A common play] ***********************************************************
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "msg": "ansible_check_mode: True"
+}
+
+TASK [Command] *****************************************************************
+skipping: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] *******************************************
+skipping: [testhost]
+
+PLAY [Play with check_mode: true (runs always in check_mode)] ******************
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "msg": "ansible_check_mode: True"
+}
+
+TASK [Command] *****************************************************************
+skipping: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] *******************************************
+skipping: [testhost]
+
+PLAY [Play with check_mode: false (runs always in wet mode)] *******************
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "msg": "ansible_check_mode: True"
+}
+
+TASK [Command] *****************************************************************
+changed: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] *******************************************
+skipping: [testhost]
+
+PLAY [Play with a block with check_mode: true] *********************************
+
+TASK [Command] *****************************************************************
+skipping: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] *******************************************
+skipping: [testhost]
+
+PLAY [Play with a block with check_mode: false] ********************************
+
+TASK [Command] *****************************************************************
+changed: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] *******************************************
+skipping: [testhost]
+
+PLAY RECAP *********************************************************************
+testhost                   : ok=10   changed=7    unreachable=0    failed=0    skipped=8    rescued=0    ignored=0   
+

--- a/test/integration/targets/callback_default/callback_default.out.check_nomarkers_wet.stderr
+++ b/test/integration/targets/callback_default/callback_default.out.check_nomarkers_wet.stderr
@@ -1,0 +1,2 @@
++ ansible-playbook -i inventory test_dryrun.yml
+++ set +x

--- a/test/integration/targets/callback_default/callback_default.out.check_nomarkers_wet.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.check_nomarkers_wet.stdout
@@ -1,0 +1,74 @@
+
+PLAY [A common play] ***********************************************************
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "msg": "ansible_check_mode: False"
+}
+
+TASK [Command] *****************************************************************
+changed: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] *******************************************
+skipping: [testhost]
+
+PLAY [Play with check_mode: true (runs always in check_mode)] ******************
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "msg": "ansible_check_mode: False"
+}
+
+TASK [Command] *****************************************************************
+skipping: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] *******************************************
+skipping: [testhost]
+
+PLAY [Play with check_mode: false (runs always in wet mode)] *******************
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "msg": "ansible_check_mode: False"
+}
+
+TASK [Command] *****************************************************************
+changed: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] *******************************************
+skipping: [testhost]
+
+PLAY [Play with a block with check_mode: true] *********************************
+
+TASK [Command] *****************************************************************
+skipping: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] *******************************************
+skipping: [testhost]
+
+PLAY [Play with a block with check_mode: false] ********************************
+
+TASK [Command] *****************************************************************
+changed: [testhost]
+
+TASK [Command with check_mode: false] ******************************************
+changed: [testhost]
+
+TASK [Command with check_mode: true] *******************************************
+skipping: [testhost]
+
+PLAY RECAP *********************************************************************
+testhost                   : ok=11   changed=8    unreachable=0    failed=0    skipped=7    rescued=0    ignored=0   
+

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -28,6 +28,26 @@ run_test() {
 	diff -u "${ORIGFILE}.${testname}.stderr" "${OUTFILE}.${testname}.stderr" || diff_failure
 }
 
+run_test_dryrun() {
+	local testname=$1
+	# optional, pass --check to run a dry run
+	local chk=${2:-}
+
+	# This needed to satisfy shellcheck that can not accept unquoted variable
+	cmd="ansible-playbook -i inventory ${chk} test_dryrun.yml"
+
+	# The shenanigans with redirection and 'tee' are to capture STDOUT and
+	# STDERR separately while still displaying both to the console
+	{ $cmd \
+		> >(set +x; tee "${OUTFILE}.${testname}.stdout"); } \
+		2> >(set +x; tee "${OUTFILE}.${testname}.stderr" >&2)
+	# Scrub deprication warning that shows up in Python 2.6 on CentOS 6
+	sed -i -e '/RandomPool_DeprecationWarning/d' "${OUTFILE}.${testname}.stderr"
+
+	diff -u "${ORIGFILE}.${testname}.stdout" "${OUTFILE}.${testname}.stdout" || diff_failure
+	diff -u "${ORIGFILE}.${testname}.stderr" "${OUTFILE}.${testname}.stderr" || diff_failure
+}
+
 diff_failure() {
 	if [[ $INIT = 0 ]]; then
 		echo "FAILURE...diff mismatch!"
@@ -41,11 +61,11 @@ cleanup() {
 	fi
 
 	if [[ -f "${BASEFILE}.unreachable.stdout" ]]; then
-	    rm -rf "${BASEFILE}.unreachable.stdout"
+		rm -rf "${BASEFILE}.unreachable.stdout"
 	fi
 
 	if [[ -f "${BASEFILE}.unreachable.stderr" ]]; then
-	    rm -rf "${BASEFILE}.unreachable.stderr"
+		rm -rf "${BASEFILE}.unreachable.stderr"
 	fi
 
 	# Restore TTY cols
@@ -91,6 +111,7 @@ export ANSIBLE_NOCOLOR=1
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=1
 export ANSIBLE_DISPLAY_OK_HOSTS=1
 export ANSIBLE_DISPLAY_FAILED_STDERR=0
+export ANSIBLE_CHECK_MODE_MARKERS=0
 
 run_test default
 
@@ -128,6 +149,30 @@ set +e
 ansible-playbook -i inventory test_2.yml > >(set +x; tee "${BASEFILE}.unreachable.stdout";) 2> >(set +x; tee "${BASEFILE}.unreachable.stderr" >&2) || true
 set -e
 if test "$(grep -c 'UNREACHABLE' "${BASEFILE}.unreachable.stderr")" -ne 1; then
-    echo "Test failed"
-    exit 1
+	echo "Test failed"
+	exit 1
 fi
+
+## DRY RUN tests
+#
+# Default settings with dry run tasks
+export ANSIBLE_DISPLAY_SKIPPED_HOSTS=1
+export ANSIBLE_DISPLAY_OK_HOSTS=1
+export ANSIBLE_DISPLAY_FAILED_STDERR=1
+# Enable Check mode markers
+export ANSIBLE_CHECK_MODE_MARKERS=1
+
+# Test the wet run with check markers
+run_test_dryrun check_markers_wet
+
+# Test the dry run with check markers
+run_test_dryrun check_markers_dry --check
+
+# Disable Check mode markers
+export ANSIBLE_CHECK_MODE_MARKERS=0
+
+# Test the wet run without check markers
+run_test_dryrun check_nomarkers_wet
+
+# Test the dry run without check markers
+run_test_dryrun check_nomarkers_dry --check

--- a/test/integration/targets/callback_default/test_dryrun.yml
+++ b/test/integration/targets/callback_default/test_dryrun.yml
@@ -1,0 +1,93 @@
+---
+- name: A common play
+  hosts: testhost
+  gather_facts: no
+  tasks:
+  - debug: 
+      msg: 'ansible_check_mode: {{ansible_check_mode}}'
+
+  - name: Command
+    command: ls -l
+
+  - name: "Command with check_mode: false"
+    command: ls -l
+    check_mode: false
+
+  - name: "Command with check_mode: true"
+    command: ls -l
+    check_mode: true
+
+
+- name: "Play with check_mode: true (runs always in check_mode)"
+  hosts: testhost
+  gather_facts: no
+  check_mode: true
+  tasks:
+  - debug: 
+      msg: 'ansible_check_mode: {{ansible_check_mode}}'
+
+  - name: Command
+    command: ls -l
+ 
+  - name: "Command with check_mode: false"
+    command: ls -l
+    check_mode: false
+
+  - name: "Command with check_mode: true"
+    command: ls -l
+    check_mode: true
+
+
+- name: "Play with check_mode: false (runs always in wet mode)"
+  hosts: testhost
+  gather_facts: no
+  check_mode: false
+  tasks:
+  - debug: 
+      msg: 'ansible_check_mode: {{ansible_check_mode}}'
+
+  - name: Command
+    command: ls -l
+
+  - name: "Command with check_mode: false"
+    command: ls -l
+    check_mode: false
+
+  - name: "Command with check_mode: true"
+    command: ls -l
+    check_mode: true
+
+
+- name: "Play with a block with check_mode: true"
+  hosts: testhost
+  gather_facts: no
+  tasks:
+  - block:
+    - name: Command
+      command: ls -l
+
+    - name: "Command with check_mode: false"
+      command: ls -l
+      check_mode: false
+
+    - name: "Command with check_mode: true"
+      command: ls -l
+      check_mode: true
+    check_mode: true
+
+- name: "Play with a block with check_mode: false"
+  hosts: testhost
+  gather_facts: no
+  tasks:
+  - block:
+    - name: Command
+      command: ls -l
+
+    - name: "Command with check_mode: false"
+      command: ls -l
+      check_mode: false
+
+    - name: "Command with check_mode: true"
+      command: ls -l
+      check_mode: true
+    check_mode: false


### PR DESCRIPTION
##### SUMMARY
fixes #48787
<!--- Describe the change below, including rationale and design decisions -->
Dry run (--check mode) should print discrete banner at the beginning and more importantly at the end of the playbook execution, in order to clarify understanding of what was actually done.

When running long playbooks it might be good practice to first execute a dry run in order to have an idea of the actual changes that will be made. Also one could accompany this mode with --diff in order to see file changes and such, for modules that support this.

In the current implementation the output of a normal (wet) and dry run is the same. Thus, it can become very confusing what was the the actual mode of a playbook when scrolling back at the playbook output, or even worse when reading a log file, if the output is logged (via ansible configuration option log_path). In this case it is impossible to understand if the run was a dry or a wet one.

Thus it is proposed to prepend and append a banner (this one being more important since it is viewed next to the playbook summary) when a playbook is run in check mode (dry run). This should also be printed to the log file.

Also after discussions in #48873, this adds discrete banners to the PLAY and TASK indicating the play's or task's check mode either from option configuration (`check_mode: yes` option) or from runtime (`--dry-run` argument). 

The difference in TASK semantics is that check_mode can be enabled from task config, meaning that a module is configured to execute in check mode in order to achieve the normal playbook outcome (wet run without --check-mode) (possilby having the purpose to collect/display information).

On the other hand PLAYBOOK runtime argument, means that the operator/administrator of the playbook needs to invoke a dry run. It is up to the playbook to implement this correctly. Usually in this mode, most (if not all) of the tasks, will be executed in CHECK MODE in order to implement the PLAYBOOK's dry run.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ ansible-playbook -C -i hosts test/testinc.yml 

DRY RUN ****************************************************************************************************************************

PLAY [all] [CHECK MODE] ************************************************************************************************************

TASK [Something in the way] [CHECK MODE] *******************************************************************************************
ok: [localhost] => {
    "msg": "Inside include playbook"
}

PLAY RECAP *************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0   


DRY RUN ****************************************************************************************************************************
```
