### PR TITLE
Mercurial tests on Ubuntu 14.04 issue (TLSv1/TLSv1.1 support dropped on bitbucket)

### DIFF
--- a/lib/ansible/modules/source_control/hg.py
+++ b/lib/ansible/modules/source_control/hg.py
@@ -70,6 +70,9 @@ notes:
       SSH will prompt user to authorize the first contact with a remote host.  To avoid this prompt,
       one solution is to add the remote host public key in C(/etc/ssh/ssh_known_hosts) before calling
       the hg module, with the following command: ssh-keyscan remote_host.com >> /etc/ssh/ssh_known_hosts."
+    - As per 01 Dec 2018, Bitbucket has dropped support for TLSv1 and TLSv1.1 connections. As such,
+      if the underlying system still uses a Python version below 2.7.9, you will have issues checking out
+      bitbucket repositories. See U(https://bitbucket.org/blog/deprecating-tlsv1-tlsv1-1-2018-12-01).
 '''
 
 EXAMPLES = '''

--- a/test/integration/targets/hg/tasks/main.yml
+++ b/test/integration/targets/hg/tasks/main.yml
@@ -21,79 +21,32 @@
   register: has_hg
   ignore_errors: yes
 
-- name: install mercurial
-  include_tasks: install.yml
-  when: has_hg is failed
+- name: warn if the underlying system is not capable of running these tests
+  debug:
+    msg: >-
+      The mercurial client is not able to check out Bitbucket repositories as per the changes mentioned here:
+      https://bitbucket.org/blog/deprecating-tlsv1-tlsv1-1-2018-12-01 . Therefore these tests are skipped.
+  when: (ansible_distribution == "Ubuntu" and ansible_distribution_version == "14.04") or ansible_python_version is version("2.7.9", "<")
 
-- name: set where to extract the repo
-  set_fact: checkout_dir={{ output_dir }}/epdb
+- block:
+  - name: install mercurial
+    include_tasks: install.yml
+    when: has_hg is failed
 
-- name: set what repo to use
-  set_fact: repo=https://bitbucket.org/rpathsync/epdb
+  - name: test mercurial
+    include_tasks: run-tests.yml
 
-- name: clean out the output_dir
-  shell: rm -rf {{ output_dir }}/*
+  - name: uninstall mercurial
+    include_tasks: uninstall.yml
+    when: has_hg is failed
 
-- name: verify that mercurial is installed so this test can continue
-  shell: which hg
-
-- name: initial checkout
-  hg: repo={{ repo }} dest={{ checkout_dir }}
-  register: hg_result
-
-- debug: var=hg_result
-
-#- shell: ls ~/ansible_testing/epdb
-- shell: ls {{ checkout_dir }}
-
-- name: verify information about the initial clone
-  assert:
-    that:
-      - "'before' in hg_result"
-      - "'after' in hg_result"
-      - "not hg_result.before"
-      - "hg_result.changed"
-
-- name: repeated checkout
-  hg: repo={{ repo }} dest={{ checkout_dir }}
-  register: hg_result2
-
-- debug: var=hg_result2
-
-- name: check for tags
-  stat: path={{ checkout_dir }}/.hgtags
-  register: tags
-
-- name: check for remotes
-  stat: path={{ checkout_dir }}/.hg/branch
-  register: branches
-
-- debug: var=tags
-- debug: var=branches
-
-- name: assert presence of tags/trunk/branches
-  assert:
-    that:
-      - "tags.stat.isreg"
-      - "branches.stat.isreg"
-
-- name: verify on a reclone things are marked unchanged
-  assert:
-    that:
-      - "not hg_result2.changed"
-
-- name: Checkout non-existent repo clone
-  hg: repo=https://bitbucket.org/pyro46/pythonscript_1 clone=no update=no
-  register: hg_result3
-  ignore_errors: true
-
-- name: Verify result of non-existent repo clone
-  assert:
-    that:
-      - hg_result3.msg
-      - "'abort: HTTP Error 404: Not Found' in hg_result3.msg"
-      - "not hg_result3.changed"
-
-- name: uninstall mercurial
-  include_tasks: uninstall.yml
-  when: has_hg is failed
+  # As per the bitbucket changes in https://bitbucket.org/blog/deprecating-tlsv1-tlsv1-1-2018-12-01 , this
+  #  test will fail under certain circumstances, to avoid false positives, we skip these tests under the following
+  #  circumstances:
+  #
+  # - The ubuntu 14.04 image used on shippable runs python 2.7.6, so we skip explicitly for this image.
+  # - When ansible_python_version is not 2.7.9 or higher, mercurial is likely to also run using this same (old)
+  #   python version, which causes issues as per the link above.
+  when:
+  - not (ansible_distribution == "Ubuntu" and ansible_distribution_version == "14.04")
+  - ansible_python_version is version("2.7.9", ">=")

--- a/test/integration/targets/hg/tasks/run-tests.yml
+++ b/test/integration/targets/hg/tasks/run-tests.yml
@@ -1,0 +1,86 @@
+# test code for the hg module
+# (c) 2018, Ansible Project
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+- name: set where to extract the repo
+  set_fact: checkout_dir={{ output_dir }}/epdb
+
+- name: set what repo to use
+  set_fact: repo=https://bitbucket.org/rpathsync/epdb
+
+- name: clean out the output_dir
+  shell: rm -rf {{ output_dir }}/*
+
+- name: verify that mercurial is installed so this test can continue
+  shell: which hg
+
+- name: initial checkout
+  hg: repo={{ repo }} dest={{ checkout_dir }}
+  register: hg_result
+
+- debug: var=hg_result
+
+- shell: ls {{ checkout_dir }}
+
+- name: verify information about the initial clone
+  assert:
+    that:
+      - "'before' in hg_result"
+      - "'after' in hg_result"
+      - "not hg_result.before"
+      - "hg_result.changed"
+
+- name: repeated checkout
+  hg: repo={{ repo }} dest={{ checkout_dir }}
+  register: hg_result2
+
+- debug: var=hg_result2
+
+- name: check for tags
+  stat: path={{ checkout_dir }}/.hgtags
+  register: tags
+
+- name: check for remotes
+  stat: path={{ checkout_dir }}/.hg/branch
+  register: branches
+
+- debug: var=tags
+- debug: var=branches
+
+- name: assert presence of tags/trunk/branches
+  assert:
+    that:
+      - "tags.stat.isreg"
+      - "branches.stat.isreg"
+
+- name: verify on a reclone things are marked unchanged
+  assert:
+    that:
+      - "not hg_result2.changed"
+
+- name: Checkout non-existent repo clone
+  hg: repo=https://bitbucket.org/pyro46/pythonscript_1 clone=no update=no
+  register: hg_result3
+  ignore_errors: true
+
+- name: Verify result of non-existent repo clone
+  assert:
+    that:
+      - hg_result3.msg
+      - "'abort: HTTP Error 404: Not Found' in hg_result3.msg"
+      - "not hg_result3.changed"


### PR DESCRIPTION
##### SUMMARY
As per https://bitbucket.org/blog/deprecating-tlsv1-tlsv1-1-2018-12-01 , TLSv1 and TLSv1.1 is no longer supported on bitbucket. Since the shippable image for Ubuntu 14.04 uses Python 2.7.6, this causes issues running the mercurial tests on that image.

Modified the tests to ignore the 14.04 image, AND to ignore when python's version is <2.7.9 (as per the blog post). A debug message has been added to inform users when these tests are skipped.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hg, tests
