### PR TITLE
Only one strategy_plugins page

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -17,8 +17,6 @@ the play as fast as it can.::
       ...
 
 
-.. _strategy_plugins:
-
 Strategy Plugins
 `````````````````
 


### PR DESCRIPTION
##### SUMMARY

Previously we had two strategy_plugins anchors, lets link to the new one defined in https://github.com/ansible/ansible/commit/e70030961858566592c922435cb6ed5fa3ed7baf

##### ISSUE TYPE
- Docs Pull Request
