### PR TITLE
Support version 3 of the redis python library

### DIFF
--- a/changelogs/fragments/redis-3-compat.yaml
+++ b/changelogs/fragments/redis-3-compat.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- redis cache - Support version 3 of the redis python library (https://github.com/ansible/ansible/issues/49341)

--- a/lib/ansible/plugins/cache/redis.py
+++ b/lib/ansible/plugins/cache/redis.py
@@ -48,7 +48,7 @@ from ansible.errors import AnsibleError
 from ansible.plugins.cache import BaseCacheModule
 
 try:
-    from redis import StrictRedis
+    from redis import StrictRedis, VERSION
 except ImportError:
     raise AnsibleError("The 'redis' python module is required for the redis fact cache, 'pip install redis'")
 
@@ -99,7 +99,10 @@ class CacheModule(BaseCacheModule):
         else:
             self._db.set(self._make_key(key), value2)
 
-        self._db.zadd(self._keys_set, time.time(), key)
+        if VERSION[0] == 2:
+            self._db.zadd(self._keys_set, time.time(), key)
+        else:
+            self._db.zadd(self._keys_set, {key: time.time()})
         self._cache[key] = value
 
     def _expire_keys(self):

--- a/lib/ansible/plugins/cache/redis.py
+++ b/lib/ansible/plugins/cache/redis.py
@@ -11,7 +11,7 @@ DOCUMENTATION = '''
         - This cache uses JSON formatted, per host records saved in Redis.
     version_added: "1.9"
     requirements:
-      - redis (python lib)
+      - redis>=2.4.5 (python lib)
     options:
       _uri:
         description:
@@ -50,7 +50,7 @@ from ansible.plugins.cache import BaseCacheModule
 try:
     from redis import StrictRedis, VERSION
 except ImportError:
-    raise AnsibleError("The 'redis' python module is required for the redis fact cache, 'pip install redis'")
+    raise AnsibleError("The 'redis' python module (version 2.4.5 or newer) is required for the redis fact cache, 'pip install redis'")
 
 
 class CacheModule(BaseCacheModule):


### PR DESCRIPTION
##### SUMMARY
Support version 3 of the redis python library. Fixes #49341

Version 3 added the following backwards incompatible change:

```
* 3.0.0
  BACKWARDS INCOMPATIBLE CHANGES
    * ZADD now requires all element names/scores be specified in a single
      dictionary argument named mapping. This was required to allow the NX,
      XX, CH and INCR options to be specified.
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/cache/redis.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```