### PR TITLE
Fix issues related to track feature

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_static_route.py
+++ b/lib/ansible/modules/network/nxos/nxos_static_route.py
@@ -153,7 +153,7 @@ def get_configured_track(module, ctrack):
     track_exists = False
     command = 'show track'
     try:
-        body = run_commands(module, [command])
+        body = run_commands(module, {'command': command, 'output': 'text'})
         match = re.findall(r'Track\s+(\d+)', body[0])
     except IndexError:
         return None

--- a/test/integration/targets/nxos_static_route/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_static_route/tests/common/sanity.yaml
@@ -3,13 +3,26 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
-- block:
-  - name: configure track
-    nxos_config:
-      lines:
-        - track 1 ip sla 1
-      provider: "{{ connection }}"
+# Flag used to test the track feature.  Some platforms
+# don't support it so this flag will be toggled accordingly.
+- set_fact: test_track_feature="true"
 
+- name: configure track
+  nxos_config:
+    lines:
+      - track 1 ip sla 1
+    provider: "{{ connection }}"
+  register: cmd_result
+  ignore_errors: yes
+
+- debug: msg="cmd result {{ cmd_result }}"
+
+- set_fact: test_track_feature="false"
+  when: cmd_result.failed
+
+- debug: msg="Test Track Feature {{ test_track_feature }}"
+
+- block:
   - name: create static route
     nxos_static_route: &configure_static
       prefix: "192.168.20.64/24"
@@ -68,18 +81,22 @@
       provider: "{{ connection }}"
     with_items: "{{ vrfs }}"
     register: result
+    when: test_track_feature
 
   - assert: *true
+    when: test_track_feature
 
   - name: "Config track Idempotence"
     nxos_static_route: *config_static_track
     with_items: "{{ vrfs }}"
     register: result
+    when: test_track_feature
 
   - assert: *false
+    when: test_track_feature
 
   - name: configure static route with not configured track
-    nxos_static_route: &config_static_track
+    nxos_static_route:
       prefix: "192.168.20.64/24"
       next_hop: "192.0.2.3"
       route_name: default
@@ -91,10 +108,12 @@
     with_items: "{{ vrfs }}"
     register: result
     ignore_errors: yes
+    when: test_track_feature
 
   - assert:
       that:
         - "result.failed == True"
+    when: test_track_feature
 
   - name: remove static route
     nxos_static_route: &remove_static
@@ -157,6 +176,7 @@
         - no track 1
       provider: "{{ connection }}"
     ignore_errors: yes
+    when: test_track_feature
 
   - name: remove static route
     nxos_static_route:


### PR DESCRIPTION
##### SUMMARY
This PR fixes a few issues that were introduced by (https://github.com/ansible/ansible/pull/48710)

* The module would error out when run using transport `nxapi`.
* Removed duplicate yaml anhor `&config_static_track` that caused the test playbook to terminate early.
* Add playbook logic to skip the `track` feature tests on platforms that don't support it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_static_route

##### ADDITIONAL INFORMATION
When transport was set to `nxapi` the following error was generated.

```bash
TASK [nxos_static_route : configure static route with track] ******************************************************************************************************************************************************************
task path: /nxos_ansible/fix_ansible/test/integration/targets/nxos_static_route/tests/common/sanity.yaml:59
<n9k.example.com> connection transport is nxapi
<n9k.example.com> ESTABLISH LOCAL CONNECTION FOR USER: mwiebe
<n9k.example.com> EXEC /bin/sh -c 'echo ~mwiebe && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1543863273.91-88753093837121 `" && echo ansible-tmp-1543863273.91-88753093837121="` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1543863273.91-88753093837121 `" ) && sleep 0'
Using module file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/modules/network/nxos/nxos_static_route.py
<n9k.example.com> PUT /Users/mwiebe/.ansible/tmp/ansible-local-11025MsPY1T/tmpN5acVq TO /Users/mwiebe/.ansible/tmp/ansible-tmp-1543863273.91-88753093837121/AnsiballZ_nxos_static_route.py
<n9k.example.com> EXEC /bin/sh -c 'chmod u+x /Users/mwiebe/.ansible/tmp/ansible-tmp-1543863273.91-88753093837121/ /Users/mwiebe/.ansible/tmp/ansible-tmp-1543863273.91-88753093837121/AnsiballZ_nxos_static_route.py && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '/Users/mwiebe/Virtualenvs/py2-ansible/bin/python /Users/mwiebe/.ansible/tmp/ansible-tmp-1543863273.91-88753093837121/AnsiballZ_nxos_static_route.py && sleep 0'
<n9k.example.com> EXEC /bin/sh -c 'rm -f -r /Users/mwiebe/.ansible/tmp/ansible-tmp-1543863273.91-88753093837121/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/Users/mwiebe/.ansible/tmp/ansible-tmp-1543863273.91-88753093837121/AnsiballZ_nxos_static_route.py", line 113, in <module>
    _ansiballz_main()
  File "/Users/mwiebe/.ansible/tmp/ansible-tmp-1543863273.91-88753093837121/AnsiballZ_nxos_static_route.py", line 105, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/Users/mwiebe/.ansible/tmp/ansible-tmp-1543863273.91-88753093837121/AnsiballZ_nxos_static_route.py", line 48, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_nxos_static_route_payload_VPeWop/__main__.py", line 321, in <module>
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_nxos_static_route_payload_VPeWop/__main__.py", line 309, in main
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_nxos_static_route_payload_VPeWop/__main__.py", line 107, in reconcile_candidate
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_nxos_static_route_payload_VPeWop/__main__.py", line 170, in set_route_command
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_nxos_static_route_payload_VPeWop/__main__.py", line 157, in get_configured_track
  File "/Users/mwiebe/Virtualenvs/py2-ansible/lib/python2.7/re.py", line 181, in findall
    return _compile(pattern, flags).findall(string)
TypeError: expected string or buffer

failed: [n9k.example.com] (item=default) => {
    "changed": false, 
    "item": "default", 
    "module_stderr": "Traceback (most recent call last):\n  File \"/Users/mwiebe/.ansible/tmp/ansible-tmp-1543863273.91-88753093837121/AnsiballZ_nxos_static_route.py\", line 113, in <module>\n    _ansiballz_main()\n  File \"/Users/mwiebe/.ansible/tmp/ansible-tmp-1543863273.91-88753093837121/AnsiballZ_nxos_static_route.py\", line 105, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/Users/mwiebe/.ansible/tmp/ansible-tmp-1543863273.91-88753093837121/AnsiballZ_nxos_static_route.py\", line 48, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_nxos_static_route_payload_VPeWop/__main__.py\", line 321, in <module>\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_nxos_static_route_payload_VPeWop/__main__.py\", line 309, in main\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_nxos_static_route_payload_VPeWop/__main__.py\", line 107, in reconcile_candidate\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_nxos_static_route_payload_VPeWop/__main__.py\", line 170, in set_route_command\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_nxos_static_route_payload_VPeWop/__main__.py\", line 157, in get_configured_track\n  File \"/Users/mwiebe/Virtualenvs/py2-ansible/lib/python2.7/re.py\", line 181, in findall\n    return _compile(pattern, flags).findall(string)\nTypeError: expected string or buffer\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", 
    "rc": 1
}
```