### PR TITLE
adding example for route53_facts using start_record_name

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53_facts.py
+++ b/lib/ansible/modules/cloud/amazon/route53_facts.py
@@ -178,11 +178,11 @@ EXAMPLES = '''
         zone: "test.io"
       register: AWSINFO
 
-    - name: GRAB ROUTE53 INFORMATION
+    - name: grab Route53 record information
       route53_facts:
         type: A
         query: record_sets
-        hosted_zone_id: "{{AWSINFO.zone_id}}"
+        hosted_zone_id: "{{ AWSINFO.zone_id }}"
         start_record_name: "host1.workshop.test.io"
       register: RECORDS
 '''

--- a/lib/ansible/modules/cloud/amazon/route53_facts.py
+++ b/lib/ansible/modules/cloud/amazon/route53_facts.py
@@ -170,6 +170,21 @@ EXAMPLES = '''
     next_marker: "{{ first_facts.NextMarker }}"
     max_items: 1
   when: "{{ 'NextMarker' in first_facts }}"
+
+- name: retrieve host entries starting with host1.workshop.test.io
+  block:
+    - name: grab zone id
+      route53_zone:
+        zone: "test.io"
+      register: AWSINFO
+
+    - name: GRAB ROUTE53 INFORMATION
+      route53_facts:
+        type: A
+        query: record_sets
+        hosted_zone_id: "{{AWSINFO.zone_id}}"
+        start_record_name: "host1.workshop.test.io"
+      register: RECORDS
 '''
 try:
     import boto


### PR DESCRIPTION
##### SUMMARY
this example shows two things not shown here already->
- dynamically looking up hosted zone id using the route53_zone module (vs knowing the ID we can use the name)
- showing an example of start_record_name which takes an entire record, not just a partial name

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
route53_facts

##### ADDITIONAL INFORMATION
DOC change only, no change of features/functions
