### PR TITLE
postgresql_schema: permit to drop cascade schema

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -57,7 +57,7 @@ options:
   cascade_drop:
     description:
       - Drop schema with CASCADE to remove child objects
-    type: bool  
+    type: bool
     default: false
     version_added: '2.8'
   ssl_mode:

--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -57,6 +57,7 @@ options:
   cascade_drop:
     description:
       - Drop schema with CASCADE to remove child objects
+    type: bool  
     default: false
     version_added: '2.8'
   ssl_mode:

--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -54,6 +54,11 @@ options:
       - The schema state.
     default: present
     choices: [ "present", "absent" ]
+  cascade_drop:
+    description:
+      - Drop schema with CASCADE to remove child objects
+    default: false
+    version_added: '2.8'
   ssl_mode:
     description:
       - Determines whether or with what priority a secure SSL TCP/IP connection
@@ -91,6 +96,11 @@ EXAMPLES = '''
     name: acme
     owner: bob
 
+# Drop schema "acme" with cascade
+- postgresql_schema:
+    name: acme
+    ensure: absent
+    cascade_drop: yes
 '''
 
 RETURN = '''
@@ -149,9 +159,11 @@ def schema_exists(cursor, schema):
     return cursor.rowcount == 1
 
 
-def schema_delete(cursor, schema):
+def schema_delete(cursor, schema, cascade):
     if schema_exists(cursor, schema):
         query = "DROP SCHEMA %s" % pg_quote_identifier(schema, 'schema')
+        if cascade:
+            query += " CASCADE"
         cursor.execute(query)
         return True
     else:
@@ -200,6 +212,7 @@ def main():
             schema=dict(required=True, aliases=['name']),
             owner=dict(default=""),
             database=dict(default="postgres"),
+            cascade_drop=dict(type="bool", default=False),
             state=dict(default="present", choices=["absent", "present"]),
             ssl_mode=dict(default='prefer', choices=[
                           'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
@@ -215,6 +228,7 @@ def main():
     owner = module.params["owner"]
     state = module.params["state"]
     sslrootcert = module.params["ssl_rootcert"]
+    cascade_drop = module.params["cascade_drop"]
     changed = False
 
     # To use defaults values, keyword arguments must be absent, so
@@ -272,7 +286,7 @@ def main():
 
         if state == "absent":
             try:
-                changed = schema_delete(cursor, schema)
+                changed = schema_delete(cursor, schema, cascade_drop)
             except SQLParseError as e:
                 module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add CASCADE keyword support to remove a schema with child objects

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_schema

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.7.3.0
```
