### PR TITLE
don't ignore SSH connection plugin options (move SSH connection plugin options away from PlayContext)

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -96,39 +96,6 @@ ANSIBLE_PIPELINING:
     key: pipelining
   type: boolean
   yaml: {key: plugins.connection.pipelining}
-ANSIBLE_SSH_ARGS:
-  # TODO: move to ssh plugin
-  default: -C -o ControlMaster=auto -o ControlPersist=60s
-  description:
-    - If set, this will override the Ansible default ssh arguments.
-    - In particular, users may wish to raise the ControlPersist time to encourage performance.  A value of 30 minutes may be appropriate.
-    - Be aware that if `-o ControlPath` is set in ssh_args, the control path setting is not used.
-  env: [{name: ANSIBLE_SSH_ARGS}]
-  ini:
-  - {key: ssh_args, section: ssh_connection}
-  yaml: {key: ssh_connection.ssh_args}
-ANSIBLE_SSH_CONTROL_PATH:
-  # TODO: move to ssh plugin
-  default: null
-  description:
-    - This is the location to save ssh's ControlPath sockets, it uses ssh's variable substitution.
-    - Since 2.3, if null, ansible will generate a unique hash. Use `%(directory)s` to indicate where to use the control dir path setting.
-    - Before 2.3 it defaulted to `control_path=%(directory)s/ansible-ssh-%%h-%%p-%%r`.
-    - Be aware that this setting is ignored if `-o ControlPath` is set in ssh args.
-  env: [{name: ANSIBLE_SSH_CONTROL_PATH}]
-  ini:
-  - {key: control_path, section: ssh_connection}
-  yaml: {key: ssh_connection.control_path}
-ANSIBLE_SSH_CONTROL_PATH_DIR:
-  # TODO: move to ssh plugin
-  default: ~/.ansible/cp
-  description:
-    - This sets the directory to use for ssh control path if the control path setting is null.
-    - Also, provides the `%(directory)s` variable for the control path setting.
-  env: [{name: ANSIBLE_SSH_CONTROL_PATH_DIR}]
-  ini:
-  - {key: control_path_dir, section: ssh_connection}
-  yaml: {key: ssh_connection.control_path_dir}
 ANSIBLE_SSH_EXECUTABLE:
   # TODO: move to ssh plugin
   default: ssh
@@ -141,15 +108,9 @@ ANSIBLE_SSH_EXECUTABLE:
   - {key: ssh_executable, section: ssh_connection}
   yaml: {key: ssh_connection.ssh_executable}
   version_added: "2.2"
-ANSIBLE_SSH_RETRIES:
-  # TODO: move to ssh plugin
-  default: 0
-  description: Number of attempts to establish a connection before we give up and report the host as 'UNREACHABLE'
-  env: [{name: ANSIBLE_SSH_RETRIES}]
-  ini:
-  - {key: retries, section: ssh_connection}
-  type: integer
-  yaml: {key: ssh_connection.retries}
+  vars:
+    - name: ansible_ssh_executable
+      version_added: '2.7'
 ANY_ERRORS_FATAL:
   name: Make Task failures fatal
   default: False
@@ -945,16 +906,6 @@ DEFAULT_ROLES_PATH:
   - {key: roles_path, section: defaults}
   type: pathspec
   yaml: {key: defaults.roles_path}
-DEFAULT_SCP_IF_SSH:
-  # TODO: move to ssh plugin
-  default: smart
-  description:
-    - "Preferred method to use when transferring files over ssh."
-    - When set to smart, Ansible will try them until one succeeds or they all fail.
-    - If set to True, it will force 'scp', if False it will use 'sftp'.
-  env: [{name: ANSIBLE_SCP_IF_SSH}]
-  ini:
-  - {key: scp_if_ssh, section: ssh_connection}
 DEFAULT_SELINUX_SPECIAL_FS:
   name: Problematic file systems
   default: fuse, nfs, vboxsf, ramfs, 9p
@@ -966,15 +917,6 @@ DEFAULT_SELINUX_SPECIAL_FS:
   ini:
   - {key: special_context_filesystems, section: selinux}
   type: list
-DEFAULT_SFTP_BATCH_MODE:
-  # TODO: move to ssh plugin
-  default: True
-  description: 'TODO: write it'
-  env: [{name: ANSIBLE_SFTP_BATCH_MODE}]
-  ini:
-  - {key: sftp_batch_mode, section: ssh_connection}
-  type: boolean
-  yaml: {key: ssh_connection.sftp_batch_mode}
 DEFAULT_SQUASH_ACTIONS:
   name: Squashable actions
   default: apk, apt, dnf, homebrew, openbsd_pkg, pacman, pip, pkgng, yum, zypper
@@ -992,16 +934,6 @@ DEFAULT_SQUASH_ACTIONS:
     why: Loop squashing is deprecated and this configuration will no longer be used
     version: "2.11"
     alternatives: a list directly with the module argument
-DEFAULT_SSH_TRANSFER_METHOD:
-  # TODO: move to ssh plugin
-  default:
-  description: 'unused?'
-  #  - "Preferred method to use when transferring files over ssh"
-  #  - Setting to smart will try them until one succeeds or they all fail
-  #choices: ['sftp', 'scp', 'dd', 'smart']
-  env: [{name: ANSIBLE_SSH_TRANSFER_METHOD}]
-  ini:
-  - {key: transfer_method, section: ssh_connection}
 DEFAULT_STDOUT_CALLBACK:
   name: Main display callback plugin
   default: default

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -848,9 +848,6 @@ class TaskExecutor:
         if not connection:
             raise AnsibleError("the connection plugin '%s' was not found" % conn_type)
 
-        # FIXME: remove once all plugins pull all data from self._options
-        self._play_context.set_options_from_plugin(connection)
-
         if any(((connection.supports_persistence and C.USE_PERSISTENT_CONNECTIONS), connection.force_persistence)):
             self._play_context.timeout = connection.get_option('persistent_command_timeout')
             display.vvvv('attempting to start connection', host=self._play_context.remote_addr)

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -144,14 +144,7 @@ class PlayContext(Base):
     # docker FIXME: remove these
     _docker_extra_args = FieldAttribute(isa='string')
 
-    # ssh # FIXME: remove these
     _ssh_executable = FieldAttribute(isa='string', default=C.ANSIBLE_SSH_EXECUTABLE)
-    _ssh_args = FieldAttribute(isa='string', default=C.ANSIBLE_SSH_ARGS)
-    _ssh_common_args = FieldAttribute(isa='string')
-    _sftp_extra_args = FieldAttribute(isa='string')
-    _scp_extra_args = FieldAttribute(isa='string')
-    _ssh_extra_args = FieldAttribute(isa='string')
-    _ssh_transfer_method = FieldAttribute(isa='string', default=C.DEFAULT_SSH_TRANSFER_METHOD)
 
     # ???
     _connection_lockfd = FieldAttribute(isa='int')
@@ -233,22 +226,6 @@ class PlayContext(Base):
 
         if play.force_handlers is not None:
             self.force_handlers = play.force_handlers
-
-    def set_options_from_plugin(self, plugin):
-        # generic derived from connection plugin, temporary for backwards compat, in the end we should not set play_context properties
-
-        # get options for plugins
-        options = C.config.get_configuration_definitions(get_plugin_class(plugin), plugin._load_name)
-        for option in options:
-            if option:
-                flag = options[option].get('name')
-                if flag:
-                    setattr(self, flag, self.connection.get_option(flag))
-
-        # TODO: made irrelavent by above
-        # get ssh options
-        # for flag in ('ssh_common_args', 'docker_extra_args', 'sftp_extra_args', 'scp_extra_args', 'ssh_extra_args'):
-        #     setattr(self, flag, getattr(options, flag, ''))
 
     def set_options(self, options):
         '''

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -277,6 +277,11 @@ class PlayContext(Base):
 
         # loop through a subset of attributes on the task object and set
         # connection fields based on their values
+        for attr in OPTION_FLAGS:
+            if hasattr(self, attr):
+                attr_val = getattr(self, attr)
+                setattr(new_info, attr, attr_val)
+
         for attr in TASK_ATTRIBUTE_OVERRIDES:
             if hasattr(task, attr):
                 attr_val = getattr(task, attr)

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -16,6 +16,7 @@ from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_bytes, to_text
+from ansible.playbook.play_context import OPTION_FLAGS
 from ansible.plugins import AnsiblePlugin
 from ansible.plugins.loader import shell_loader, connection_loader
 from ansible.utils.display import Display
@@ -104,6 +105,14 @@ class ConnectionBase(AnsiblePlugin):
         self._shell = shell_loader.get(shell_type)
         if not self._shell:
             raise AnsibleError("Invalid shell type specified (%s), or the plugin for that shell type is missing." % shell_type)
+
+    def get_option(self, option, hostvars=None):
+        value = super(ConnectionBase, self).get_option(option, hostvars)
+
+        if value is None and option in OPTION_FLAGS:
+            value = getattr(self._play_context, option, None)
+
+        return value
 
     @property
     def connected(self):

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -48,7 +48,11 @@ DOCUMENTATION = '''
               - name: ansible_password
               - name: ansible_ssh_pass
       ssh_args:
-          description: Arguments to pass to all ssh cli tools
+          description:
+            - Arguments to pass to all ssh cli tools.
+            - If set, this will override the Ansible default ssh arguments.
+            - In particular, users may wish to raise the ControlPersist time to encourage performance.  A value of 30 minutes may be appropriate.
+            - Be aware that if `-o ControlPath` is set in ssh_args, the control path setting is not used.
           default: '-C -o ControlMaster=auto -o ControlPersist=60s'
           ini:
               - section: 'ssh_connection'
@@ -69,20 +73,6 @@ DOCUMENTATION = '''
                 version_added: '2.7'
           vars:
               - name: ansible_ssh_common_args
-      ssh_executable:
-          default: ssh
-          description:
-            - This defines the location of the ssh binary. It defaults to ``ssh`` which will use the first ssh binary available in $PATH.
-            - This option is usually not required, it might be useful when access to system ssh is restricted,
-              or when using ssh wrappers to connect to remote hosts.
-          env: [{name: ANSIBLE_SSH_EXECUTABLE}]
-          ini:
-          - {key: ssh_executable, section: ssh_connection}
-          #const: ANSIBLE_SSH_EXECUTABLE
-          version_added: "2.2"
-          vars:
-              - name: ansible_ssh_executable
-                version_added: '2.7'
       sftp_executable:
           default: sftp
           description:
@@ -140,8 +130,8 @@ DOCUMENTATION = '''
               version_added: '2.7'
       retries:
           # constant: ANSIBLE_SSH_RETRIES
-          description: Number of attempts to connect.
-          default: 3
+          description: Number of attempts to establish a connection before we give up and report the host as 'UNREACHABLE'
+          default: 0
           type: integer
           env:
             - name: ANSIBLE_SSH_RETRIES
@@ -155,8 +145,8 @@ DOCUMENTATION = '''
                 version_added: '2.7'
       port:
           description: Remote port to connect to.
-          type: int
           default: 22
+          type: int
           ini:
             - section: defaults
               key: remote_port
@@ -214,6 +204,8 @@ DOCUMENTATION = '''
         description:
           - This is the location to save ssh's ControlPath sockets, it uses ssh's variable substitution.
           - Since 2.3, if null, ansible will generate a unique hash. Use `%(directory)s` to indicate where to use the control dir path setting.
+          - Before 2.3 it defaulted to `control_path=%(directory)s/ansible-ssh-%%h-%%p-%%r`.
+          - Be aware that this setting is ignored if `-o ControlPath` is set in ssh args.
         env:
           - name: ANSIBLE_SSH_CONTROL_PATH
         ini:
@@ -248,15 +240,23 @@ DOCUMENTATION = '''
       scp_if_ssh:
         default: smart
         description:
-          - "Prefered method to use when transfering files over ssh"
-          - When set to smart, Ansible will try them until one succeeds or they all fail
-          - If set to True, it will force 'scp', if False it will use 'sftp'
+          - "Prefered method to use when transfering files over ssh."
+          - When set to smart, Ansible will try them until one succeeds or they all fail.
+          - If set to True, it will force 'scp', if False it will use 'sftp'.
         env: [{name: ANSIBLE_SCP_IF_SSH}]
         ini:
         - {key: scp_if_ssh, section: ssh_connection}
         vars:
           - name: ansible_scp_if_ssh
             version_added: '2.7'
+      transfer_method:
+        description: 'unused?'
+        #  - "Preferred method to use when transferring files over ssh"
+        #  - Setting to smart will try them until one succeeds or they all fail
+        #choices: ['sftp', 'scp', 'dd', 'smart']
+        env: [{name: ANSIBLE_SSH_TRANSFER_METHOD}]
+        ini:
+        - {key: transfer_method, section: ssh_connection}
       use_tty:
         version_added: '2.5'
         default: 'yes'

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -145,7 +145,6 @@ DOCUMENTATION = '''
                 version_added: '2.7'
       port:
           description: Remote port to connect to.
-          default: 22
           type: int
           ini:
             - section: defaults
@@ -168,7 +167,6 @@ DOCUMENTATION = '''
             - name: ansible_user
             - name: ansible_ssh_user
       pipelining:
-          default: ANSIBLE_PIPELINING
           description:
             - Pipelining reduces the number of SSH operations required to execute a module on the remote server,
               by executing many Ansible modules without actual file transfer.

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1102,7 +1102,6 @@ class StrategyBase:
                 del self._active_connections[target_host]
             else:
                 connection = connection_loader.get(play_context.connection, play_context, os.devnull)
-                play_context.set_options_from_plugin(connection)
 
             if connection:
                 try:

--- a/test/integration/targets/connection_ssh/clean_ssh_common_args.yml
+++ b/test/integration/targets/connection_ssh/clean_ssh_common_args.yml
@@ -1,0 +1,18 @@
+- hosts: ssh
+  serial: 1  # ssh group contains 2 inventory hosts: localhost
+  tasks:
+    - name: Delete local test-ansible.cfg
+      file:
+        path: "{{ playbook_dir }}/test-ansible.cfg"
+        state: absent
+      connection: local
+
+    - name: Remove remote unprivileged remote user
+      user:
+        name: '{{ remote_unprivileged_user }}'
+        state: absent
+
+    - name: Restore pam_nologin configuration
+      command: mv /var/run/nologin.backup /var/run/nologin
+      args:
+        removes: /var/run/nologin.backup

--- a/test/integration/targets/connection_ssh/playbook_dir/group_vars/all.yml
+++ b/test/integration/targets/connection_ssh/playbook_dir/group_vars/all.yml
@@ -1,0 +1,2 @@
+---
+ansible_ssh_common_args: "-o User={{ lookup('env', 'remote_user') }}"

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -2,6 +2,8 @@
 
 set -eux
 
+./ssh_common_args.sh "$@"
+
 # sftp
 ./posix.sh "$@"
 # scp

--- a/test/integration/targets/connection_ssh/setup_ssh_common_args.yml
+++ b/test/integration/targets/connection_ssh/setup_ssh_common_args.yml
@@ -1,0 +1,42 @@
+- name: Create a remote unprivileged remote user and test-ansible.cfg
+  hosts: ssh
+  serial: 1  # ssh group contains 2 inventory hosts: localhost
+  tasks:
+    - name: Create remote unprivileged remote group
+      group:
+        name: '{{ remote_unprivileged_user }}'
+
+    - name: Create remote unprivileged remote user
+      user:
+        name: '{{ remote_unprivileged_user }}'
+        group: '{{ remote_unprivileged_user }}'
+      register: user
+
+    - file:
+        path: "{{ user.home }}/.ssh"
+        owner: '{{ remote_unprivileged_user }}'
+        group: '{{ remote_unprivileged_user }}'
+        state: directory
+        mode: 0700
+
+    - name: Duplicate authorized_keys
+      copy:
+        src: $HOME/.ssh/authorized_keys
+        dest: '{{ user.home }}/.ssh/authorized_keys'
+        owner: '{{ remote_unprivileged_user }}'
+        group: '{{ remote_unprivileged_user }}'
+        mode: 0600
+        remote_src: yes
+
+    - name: Create local test-ansible.cfg
+      copy:
+        content: |
+          [ssh_connection]
+          ssh_common_args = "-o User={{ remote_unprivileged_user }}"
+        dest: "{{ playbook_dir }}/test-ansible.cfg"
+      connection: local
+
+    - name: Enable login for other users
+      command: mv /var/run/nologin /var/run/nologin.backup
+      args:
+        removes: /var/run/nologin

--- a/test/integration/targets/connection_ssh/ssh_common_args.sh
+++ b/test/integration/targets/connection_ssh/ssh_common_args.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eux
+
+rm -f test-ansible.cfg  # just in case
+
+trap 'cleanup' EXIT
+
+remote_user=tmp_ansible_test_user
+remote_user_var="-e remote_unprivileged_user=${remote_user}"
+
+# Set ANSIBLE_SSH_ARGS to empty string in order to disable ControlPersist (otherwise second playbook will use same remote user than first playbook)
+export ANSIBLE_SSH_ARGS=""
+
+# Create remote user and test-ansible.cfg
+ansible-playbook -i test_connection.inventory -v "${remote_user_var}" setup_ssh_common_args.yml "$@"
+
+# Ensure --ssh-common-args is taken in account (test-ansible.cfg not used)
+ansible-playbook -i test_connection.inventory -v "${remote_user_var}" test_ssh_common_args.yml --ssh-common-args="-o \"User=${remote_user}\"" "$@"
+
+# Check that ssh_common_args in test-ansible.cfg is taken in account
+ANSIBLE_CONFIG=./test-ansible.cfg ansible-playbook -i test_connection.inventory -v "${remote_user_var}" test_ssh_common_args.yml "$@"
+
+function cleanup {
+    ansible-playbook -i test_connection.inventory -v "${remote_user_var}" clean_ssh_common_args.yml "$@"
+}

--- a/test/integration/targets/connection_ssh/test_ssh_common_args.yml
+++ b/test/integration/targets/connection_ssh/test_ssh_common_args.yml
@@ -1,0 +1,8 @@
+- hosts: ssh
+  serial: 1  # ssh group contains 2 inventory hosts: localhost
+  tasks:
+    - name: Ensure remote user is remote_unprivileged_user
+      assert:
+        fail_msg: "'{{ remote_unprivileged_user }}' expected instead of '{{ ansible_user_id}}'"
+        that:
+          - ansible_user_id == remote_unprivileged_user

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -81,8 +81,6 @@ class TestConnectionBaseClass(unittest.TestCase):
         conn._build_command.return_value = 'ssh something something'
         conn._run = MagicMock()
         conn._run.return_value = (0, 'stdout', 'stderr')
-        conn.get_option = MagicMock()
-        conn.get_option.return_value = True
 
         res, stdout, stderr = conn.exec_command('ssh')
         res, stdout, stderr = conn.exec_command('ssh', 'this is some data')
@@ -208,11 +206,11 @@ class TestConnectionBaseClass(unittest.TestCase):
         conn._bare_run.return_value = (0, '', '')
         conn.host = "some_host"
 
-        C.ANSIBLE_SSH_RETRIES = 9
+        conn.set_options(var_options={'ansible_ssh_retries': 9})
 
-        # Test with C.DEFAULT_SCP_IF_SSH set to smart
+        # Test with 'scp_if_ssh' set to 'smart'
         # Test when SFTP works
-        C.DEFAULT_SCP_IF_SSH = 'smart'
+        conn.set_options(var_options={'ansible_scp_if_ssh': 'smart'})
         expected_in_data = b' '.join((b'put', to_bytes(shlex_quote('/path/to/in/file')), to_bytes(shlex_quote('/path/to/dest/file')))) + b'\n'
         conn.put_file('/path/to/in/file', '/path/to/dest/file')
         conn._bare_run.assert_called_with('some command to run', expected_in_data, checkrc=False)
@@ -223,16 +221,16 @@ class TestConnectionBaseClass(unittest.TestCase):
         conn._bare_run.assert_called_with('some command to run', None, checkrc=False)
         conn._bare_run.side_effect = None
 
-        # test with C.DEFAULT_SCP_IF_SSH enabled
-        C.DEFAULT_SCP_IF_SSH = True
+        # test with 'scp_if_ssh' enabled
+        conn.set_options(var_options={'ansible_scp_if_ssh': True})
         conn.put_file('/path/to/in/file', '/path/to/dest/file')
         conn._bare_run.assert_called_with('some command to run', None, checkrc=False)
 
         conn.put_file(u'/path/to/in/file/with/unicode-fö〩', u'/path/to/dest/file/with/unicode-fö〩')
         conn._bare_run.assert_called_with('some command to run', None, checkrc=False)
 
-        # test with C.DEFAULT_SCP_IF_SSH disabled
-        C.DEFAULT_SCP_IF_SSH = False
+        # test with 'scp_if_ssh' disabled
+        conn.set_options(var_options={'ansible_scp_if_ssh': False})
         expected_in_data = b' '.join((b'put', to_bytes(shlex_quote('/path/to/in/file')), to_bytes(shlex_quote('/path/to/dest/file')))) + b'\n'
         conn.put_file('/path/to/in/file', '/path/to/dest/file')
         conn._bare_run.assert_called_with('some command to run', expected_in_data, checkrc=False)
@@ -265,13 +263,12 @@ class TestConnectionBaseClass(unittest.TestCase):
         conn._bare_run.return_value = (0, '', '')
         conn.host = "some_host"
 
-        C.ANSIBLE_SSH_RETRIES = 9
+        conn.set_options(var_options={'ansible_ssh_retries': 9})
 
-        # Test with C.DEFAULT_SCP_IF_SSH set to smart
+        # Test with 'scp_if_ssh' set to 'smart'
         # Test when SFTP works
-        C.DEFAULT_SCP_IF_SSH = 'smart'
         expected_in_data = b' '.join((b'get', to_bytes(shlex_quote('/path/to/in/file')), to_bytes(shlex_quote('/path/to/dest/file')))) + b'\n'
-        conn.set_options({})
+        conn.set_options(var_options={'ansible_scp_if_ssh': 'smart'})
         conn.fetch_file('/path/to/in/file', '/path/to/dest/file')
         conn._bare_run.assert_called_with('some command to run', expected_in_data, checkrc=False)
 
@@ -281,16 +278,16 @@ class TestConnectionBaseClass(unittest.TestCase):
         conn._bare_run.assert_called_with('some command to run', None, checkrc=False)
         conn._bare_run.side_effect = None
 
-        # test with C.DEFAULT_SCP_IF_SSH enabled
-        C.DEFAULT_SCP_IF_SSH = True
+        # test with 'scp_if_ssh' enabled
+        conn.set_options(var_options={'ansible_scp_if_ssh': True})
         conn.fetch_file('/path/to/in/file', '/path/to/dest/file')
         conn._bare_run.assert_called_with('some command to run', None, checkrc=False)
 
         conn.fetch_file(u'/path/to/in/file/with/unicode-fö〩', u'/path/to/dest/file/with/unicode-fö〩')
         conn._bare_run.assert_called_with('some command to run', None, checkrc=False)
 
-        # test with C.DEFAULT_SCP_IF_SSH disabled
-        C.DEFAULT_SCP_IF_SSH = False
+        # test with 'scp_if_ssh' disabled
+        conn.set_options(var_options={'ansible_scp_if_ssh': False})
         expected_in_data = b' '.join((b'get', to_bytes(shlex_quote('/path/to/in/file')), to_bytes(shlex_quote('/path/to/dest/file')))) + b'\n'
         conn.fetch_file('/path/to/in/file', '/path/to/dest/file')
         conn._bare_run.assert_called_with('some command to run', expected_in_data, checkrc=False)
@@ -502,8 +499,6 @@ class TestSSHConnectionRun(object):
 @pytest.mark.usefixtures('mock_run_env')
 class TestSSHConnectionRetries(object):
     def test_retry_then_success(self, monkeypatch):
-        monkeypatch.setattr(C, 'HOST_KEY_CHECKING', False)
-        monkeypatch.setattr(C, 'ANSIBLE_SSH_RETRIES', 3)
 
         monkeypatch.setattr('time.sleep', lambda x: None)
 
@@ -524,8 +519,9 @@ class TestSSHConnectionRetries(object):
 
         self.conn._build_command = MagicMock()
         self.conn._build_command.return_value = 'ssh'
-        self.conn.get_option = MagicMock()
-        self.conn.get_option.return_value = True
+
+        self.conn.set_options(var_options={'ansible_ssh_host_key_checking': False})
+        self.conn.set_options(var_options={'ansible_ssh_retries': 3})
 
         return_code, b_stdout, b_stderr = self.conn.exec_command('ssh', 'some data')
         assert return_code == 0
@@ -533,8 +529,6 @@ class TestSSHConnectionRetries(object):
         assert b_stderr == b'my_stderr'
 
     def test_multiple_failures(self, monkeypatch):
-        monkeypatch.setattr(C, 'HOST_KEY_CHECKING', False)
-        monkeypatch.setattr(C, 'ANSIBLE_SSH_RETRIES', 9)
 
         monkeypatch.setattr('time.sleep', lambda x: None)
 
@@ -551,31 +545,28 @@ class TestSSHConnectionRetries(object):
 
         self.conn._build_command = MagicMock()
         self.conn._build_command.return_value = 'ssh'
-        self.conn.get_option = MagicMock()
-        self.conn.get_option.return_value = True
+
+        self.conn.set_options(var_options={'ansible_ssh_host_key_checking': False})
+        self.conn.set_options(var_options={'ansible_ssh_retries': 9})
 
         pytest.raises(AnsibleConnectionFailure, self.conn.exec_command, 'ssh', 'some data')
         assert self.mock_popen.call_count == 10
 
     def test_abitrary_exceptions(self, monkeypatch):
-        monkeypatch.setattr(C, 'HOST_KEY_CHECKING', False)
-        monkeypatch.setattr(C, 'ANSIBLE_SSH_RETRIES', 9)
-
         monkeypatch.setattr('time.sleep', lambda x: None)
 
         self.conn._build_command = MagicMock()
         self.conn._build_command.return_value = 'ssh'
-        self.conn.get_option = MagicMock()
-        self.conn.get_option.return_value = True
 
         self.mock_popen.side_effect = [Exception('bad')] * 10
+
+        self.conn.set_options(var_options={'ansible_ssh_host_key_checking': False})
+        self.conn.set_options(var_options={'ansible_ssh_retries': 9})
+
         pytest.raises(Exception, self.conn.exec_command, 'ssh', 'some data')
         assert self.mock_popen.call_count == 10
 
     def test_put_file_retries(self, monkeypatch):
-        monkeypatch.setattr(C, 'HOST_KEY_CHECKING', False)
-        monkeypatch.setattr(C, 'ANSIBLE_SSH_RETRIES', 3)
-
         monkeypatch.setattr('time.sleep', lambda x: None)
         monkeypatch.setattr('ansible.plugins.connection.ssh.os.path.exists', lambda x: True)
 
@@ -596,6 +587,9 @@ class TestSSHConnectionRetries(object):
 
         self.conn._build_command = MagicMock()
         self.conn._build_command.return_value = 'sftp'
+
+        self.conn.set_options(var_options={'ansible_ssh_host_key_checking': False})
+        self.conn.set_options(var_options={'ansible_ssh_retries': 3})
 
         return_code, b_stdout, b_stderr = self.conn.put_file('/path/to/in/file', '/path/to/dest/file')
         assert return_code == 0
@@ -604,9 +598,6 @@ class TestSSHConnectionRetries(object):
         assert self.mock_popen.call_count == 2
 
     def test_fetch_file_retries(self, monkeypatch):
-        monkeypatch.setattr(C, 'HOST_KEY_CHECKING', False)
-        monkeypatch.setattr(C, 'ANSIBLE_SSH_RETRIES', 3)
-
         monkeypatch.setattr('time.sleep', lambda x: None)
         monkeypatch.setattr('ansible.plugins.connection.ssh.os.path.exists', lambda x: True)
 
@@ -627,6 +618,9 @@ class TestSSHConnectionRetries(object):
 
         self.conn._build_command = MagicMock()
         self.conn._build_command.return_value = 'sftp'
+
+        self.conn.set_options(var_options={'ansible_ssh_host_key_checking': False})
+        self.conn.set_options(var_options={'ansible_ssh_retries': 3})
 
         return_code, b_stdout, b_stderr = self.conn.fetch_file('/path/to/in/file', '/path/to/dest/file')
         assert return_code == 0


### PR DESCRIPTION
##### SUMMARY
* Take in account SSH connection plugin options mentioned in 1a70681630417b959becf7449ce838b4dcd1ecd7. For example Ansible 2.7, `ANSIBLE_SSH_COMMON_ARGS` environment variable is [documented](https://docs.ansible.com/ansible/2.7/plugins/connection/ssh.html) but ignored: output of `ANSIBLE_SSH_COMMON_ARGS="-o \"Port=2222\"" ansible all -i test, -m ping  -vvvv |grep "SSH: EXEC"` command doesn't mention `Port=2222`.
* remove SSH connection plugin options from main configuration
* doc: mention config file and environment variables in _variable precedence_ section

Integration tests provided.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
config

##### ADDITIONAL INFORMATION
Note that `ANSIBLE_SSH_ARGS` (and other SSH related environment variables) will be removed from docs/docsite/rst/reference_appendices/config.rst.

Could be added to https://github.com/ansible/ansible/projects/8.

Thanks to @adriensaladin for pointing out this issue.