### PR TITLE
fixes an issue with dict_merge in network utils (#41107)

### DIFF
--- a/changelogs/fragments/49474-network_utils_dict_merge_fix.yaml
+++ b/changelogs/fragments/49474-network_utils_dict_merge_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- fixes an issue with dict_merge in network utils (https://github.com/ansible/ansible/pull/49474)

--- a/lib/ansible/module_utils/network/common/utils.py
+++ b/lib/ansible/module_utils/network/common/utils.py
@@ -34,6 +34,7 @@ from itertools import chain
 from struct import pack
 from socket import inet_aton, inet_ntoa
 
+from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils.six.moves import zip
 from ansible.module_utils.basic import AnsibleFallbackNotFound
@@ -275,7 +276,10 @@ def dict_merge(base, other):
             if key in other:
                 item = other.get(key)
                 if item is not None:
-                    combined[key] = dict_merge(value, other[key])
+                    if isinstance(other[key], Mapping):
+                        combined[key] = dict_merge(value, other[key])
+                    else:
+                        combined[key] = other[key]
                 else:
                     combined[key] = item
             else:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change address a problem where the dict_merge function would fail
due to the value being a nested dict.  This will now recursively pass
the value back through the dict_merge function.

(cherry picked from commit 2a4be2748fad885f88163a5b9b1b438fe3cb2ece)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/network/common/utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
