### PR TITLE
Fix nxos_vxlan_vtep test

### DIFF
--- a/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
@@ -27,6 +27,10 @@
 - set_fact: def_global_suppress_arp="false"
   when: platform is search('N9K') and (major_version is version('9.2', 'ge'))
 
+# This parameter requires a switch reload.
+# The line below can be commented out if needed to verify the functionality.
+- set_fact: global_suppress_arp="false"
+
 - block:
   - name: "Apply N7K specific setup config"
     include: targets/nxos_vxlan_vtep/tasks/platform/n7k/setup.yaml


### PR DESCRIPTION
##### SUMMARY
This PR disables testing of the `global_suppress_arp` parameter since it requires a reload of the switch device and causes a test failure under normal conditions.  The fact can be commented out on a case by case basis for testing.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_vxlan_vtep

##### ADDITIONAL INFORMATION

Attempting to configure global suppress arp on an n9k generates the following error

```bash
n9k-109(config)# interface nve1
n9k-109(config-if-nve)# terminal dont-ask
n9k-109(config-if-nve)# source-interface loopback0
n9k-109(config-if-nve)# host-reachability protocol bgp
n9k-109(config-if-nve)# global ingress-replication protocol bgp
n9k-109(config-if-nve)# global suppress-arp
ERROR: Please configure TCAM region for Ingress ARP-Ether ACL before configuring ARP supression.
```
To configure or re-configure TCAM regions, a reload of the switch is required.