### PR TITLE
Fix for with_ini when used with YAML parameters.

### DIFF
--- a/lib/ansible/plugins/lookup/ini.py
+++ b/lib/ansible/plugins/lookup/ini.py
@@ -49,10 +49,7 @@ EXAMPLES = """
 - debug:
     msg: "{{ item }}"
   with_ini:
-    - value[1-2]
-    - section: section1
-    - file: "lookup.ini"
-    - re: true
+    - '.* section=section1 file=test.ini re=True'
 """
 
 RETURN = """
@@ -130,13 +127,15 @@ class LookupModule(LookupBase):
                 for param in params[1:]:
                     name, value = param.split('=')
                     if name not in paramvals:
-                        raise AnsibleAssertionError('%s not in paramvals' % name)
+                        raise AnsibleAssertionError('%s not in paramvals' %
+                                                    name)
                     paramvals[name] = value
             except (ValueError, AssertionError) as e:
                 raise AnsibleError(e)
 
             # Retrieve file path
-            path = self.find_file_in_search_path(variables, 'files', paramvals['file'])
+            path = self.find_file_in_search_path(variables, 'files',
+                                                 paramvals['file'])
 
             # Create StringIO later used to parse ini
             config = StringIO()
@@ -147,12 +146,14 @@ class LookupModule(LookupBase):
 
             # Open file using encoding
             contents, show_data = self._loader._get_file_contents(path)
-            contents = to_text(contents, errors='surrogate_or_strict', encoding=paramvals['encoding'])
+            contents = to_text(contents, errors='surrogate_or_strict',
+                               encoding=paramvals['encoding'])
             config.write(contents)
             config.seek(0, os.SEEK_SET)
 
             self.cp.readfp(config)
-            var = self.get_value(key, paramvals['section'], paramvals['default'], paramvals['re'])
+            var = self.get_value(key, paramvals['section'],
+                                 paramvals['default'], paramvals['re'])
             if var is not None:
                 if isinstance(var, MutableSequence):
                     for v in var:

--- a/test/units/plugins/lookup/test_ini.py
+++ b/test/units/plugins/lookup/test_ini.py
@@ -31,27 +31,27 @@ class TestINILookup(unittest.TestCase):
         # Simple case
         dict(
             term=u'keyA section=sectionA file=/path/to/file',
-            expected=[u'keyA', u'section=sectionA', u'file=/path/to/file'],
+            expected=[u'file=/path/to/file', u'keyA', u'section=sectionA'],
         ),
         dict(
             term=u'keyB section=sectionB with space file=/path/with/embedded spaces and/file',
-            expected=[u'keyB', u'section=sectionB with space', u'file=/path/with/embedded spaces and/file'],
+            expected=[u'file=/path/with/embedded spaces and/file', u'keyB', u'section=sectionB with space'],
         ),
         dict(
             term=u'keyC section=sectionC file=/path/with/equals/cn=com.ansible',
-            expected=[u'keyC', u'section=sectionC', u'file=/path/with/equals/cn=com.ansible'],
+            expected=[u'file=/path/with/equals/cn=com.ansible', u'keyC', u'section=sectionC'],
         ),
         dict(
             term=u'keyD section=sectionD file=/path/with space and/equals/cn=com.ansible',
-            expected=[u'keyD', u'section=sectionD', u'file=/path/with space and/equals/cn=com.ansible'],
+            expected=[u'file=/path/with space and/equals/cn=com.ansible', u'keyD', u'section=sectionD'],
         ),
         dict(
             term=u'keyE section=sectionE file=/path/with/unicode/くらとみ/file',
-            expected=[u'keyE', u'section=sectionE', u'file=/path/with/unicode/くらとみ/file'],
+            expected=[u'file=/path/with/unicode/くらとみ/file', u'keyE', u'section=sectionE'],
         ),
         dict(
             term=u'keyF section=sectionF file=/path/with/utf 8 and spaces/くらとみ/file',
-            expected=[u'keyF', u'section=sectionF', u'file=/path/with/utf 8 and spaces/くらとみ/file'],
+            expected=[u'file=/path/with/utf 8 and spaces/くらとみ/file', u'keyF', u'section=sectionF'],
         ),
     )
 
@@ -65,4 +65,5 @@ class TestINILookup(unittest.TestCase):
         for testcase in self.old_style_params_data:
             # print(testcase)
             params = _parse_params(testcase['term'])
+            params.sort()
             self.assertEqual(params, testcase['expected'])


### PR DESCRIPTION
### SUMMARY

Lookup ini is not working with current example in Ansible documentation.
Fix with_ini example and unittest

* Bugfix Pull Request

### COMPONENT NAME

`lib/ansible/plugins/lookup/ini.py`

### ANSIBLE VERSION

``` ansible 2.7.1
  config file = None
  configured module search path = ['/Users/sgolovat/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.7.1 (default, Nov  6 2018, 18:46:03) [Clang 10.0.0 (clang-1000.11.45.5)]
```

#### ADDITIONAL INFORMATION

Create a playbook test.yml with the following content:

```yaml
- name: "test"
  hosts: localhost
  gather_facts: no
  tasks:
    - name: "Test ini lookup"
      debug: var=item
      with_ini:
        - .*
        - section: section1
        - file: test.ini
        - re: true
```

You will need a file **test.ini** with the following content:

```ini
[section1]
a=1
b=2
[section2]
a=1
b=2
c=3
```
Launch this playbook (**ansible-playbook test.yml**).

What you get:
```
[WARNING]: Unable to find 'ansible.ini' in expected paths.

fatal: [localhost]: FAILED! => {"msg": "Invalid filename: 'None'"}
msg:
Invalid filename: 'None'
        to retry, use: --limit @/home/yannig/tmp/test.retry
```
Expected result:
```
ok: [localhost] => (item=1) => {
    "changed": false, 
    "item": "1"
}
ok: [localhost] => (item=2) => {
    "changed": false, 
    "item": "2"
}
```

Thus this example was removed.