### PR TITLE
Allow win_uri to send json with just one item

### DIFF
--- a/changelogs/fragments/win_uri-oneitem-list.yaml
+++ b/changelogs/fragments/win_uri-oneitem-list.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_uri - allow to send a JSON array with just one item into - https://github.com/ansible/ansible/issues/49483

--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -179,7 +179,7 @@ if ($user -and $password) {
 }
 
 if ($null -ne $body) {
-    if ($body -is [Hashtable]) {
+    if ($body -is [System.Collections.IDictionary] -or $body -is [System.Collections.IList]) {
         $body_string = ConvertTo-Json -InputObject $body -Compress
     } elseif ($body -isnot [String]) {
         $body_string = $body.ToString()

--- a/test/integration/targets/win_uri/tasks/test.yml
+++ b/test/integration/targets/win_uri/tasks/test.yml
@@ -296,6 +296,29 @@
     - json_as_dict.json.json == json_as_dict_value
     - json_as_dict.status_code == 200
 
+- name: send JSON body with 1 item in list
+  win_uri:
+    url: https://{{httpbin_host}}/post
+    method: POST
+    body:
+      - foo: bar
+    headers:
+      'Content-Type': 'text/json'
+    return_content: yes
+  register: json_as_oneitemlist
+
+- name: set fact of expected json 1 item list
+  set_fact:
+    json_as_oneitemlist_value:
+      - foo: bar
+
+- name: assert send JSON body with 1 item in list
+  assert:
+    that:
+    - not json_as_oneitemlist.changed
+    - json_as_oneitemlist.json.json == json_as_oneitemlist_value
+    - json_as_oneitemlist.status_code == 200
+
 - name: get request with custom headers
   win_uri:
     url: https://{{httpbin_host}}/get


### PR DESCRIPTION
##### SUMMARY
Fixes #49483

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_uri

##### ADDITIONAL INFORMATION
As per subject, actually win_uri fails to send a JSON which contains just one item; instead it sends "System.Object[]".