### PR TITLE
Reboot - Use IndexError in exception

### DIFF
--- a/changelogs/fragments/reboot-fix-exception-type.yaml
+++ b/changelogs/fragments/reboot-fix-exception-type.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - reboot - use IndexError instead of TypeError in exception

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -185,7 +185,7 @@ class ActionModule(ActionBase):
                 if action_desc:
                     try:
                         error = to_text(e).splitlines()[-1]
-                    except TypeError as e:
+                    except IndexError as e:
                         error = to_text(e)
                     display.debug("{0}: {1} fail '{2}', retrying in {3:.4} seconds...".format(self._task.action, action_desc,
                                                                                               error, fail_sleep))


### PR DESCRIPTION
##### SUMMARY

I used the incorrect exception type because, during testing, I left the `()` off of `splitlines`. This raised a `TypeError` exception. Instead, this should be `IndexError` if there is no last item in the lines of output from the error.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`reboot.py`