### PR TITLE
Fixes #49493. Updated cloudforms.py dynamic inventory to query the ho…

### DIFF
--- a/contrib/inventory/cloudforms.py
+++ b/contrib/inventory/cloudforms.py
@@ -271,7 +271,7 @@ class CloudFormsInventory(object):
 
         while not last_page:
             offset = page * limit
-            ret = self._get_json("%s/api/vms?offset=%s&limit=%s&expand=resources,tags,hosts,&attributes=ipaddresses" % (self.cloudforms_url, offset, limit))
+            ret = self._get_json("%s/api/vms?offset=%s&limit=%s&expand=resources,tags,hosts,&attributes=ipaddresses,hostnames" % (self.cloudforms_url, offset, limit))
             results += ret['resources']
             if ret['subcount'] < limit:
                 last_page = True
@@ -290,7 +290,9 @@ class CloudFormsInventory(object):
             print("Updating cache...")
 
         for host in self._get_hosts():
-            if self.cloudforms_suffix is not None and not host['name'].endswith(self.cloudforms_suffix):
+            if len(host['hostnames']) > 0 and host['hostnames'][0] is not None:
+                host['name'] = host['hostnames'][0]
+            elif self.cloudforms_suffix is not None and not host['name'].endswith(self.cloudforms_suffix):
                 host['name'] = host['name'] + self.cloudforms_suffix
 
             # Ignore VMs that are not powered on

--- a/contrib/inventory/cloudforms.py
+++ b/contrib/inventory/cloudforms.py
@@ -272,7 +272,7 @@ class CloudFormsInventory(object):
         while not last_page:
             offset = page * limit
             ret = self._get_json(
-                    "%s/api/vms?offset=%s&limit=%s&expand=resources,tags,hosts,&attributes=ipaddresses,hostnames" % (self.cloudforms_url, offset, limit))
+                "%s/api/vms?offset=%s&limit=%s&expand=resources,tags,hosts,&attributes=ipaddresses,hostnames" % (self.cloudforms_url, offset, limit))
             results += ret['resources']
             if ret['subcount'] < limit:
                 last_page = True

--- a/contrib/inventory/cloudforms.py
+++ b/contrib/inventory/cloudforms.py
@@ -271,7 +271,8 @@ class CloudFormsInventory(object):
 
         while not last_page:
             offset = page * limit
-            ret = self._get_json("%s/api/vms?offset=%s&limit=%s&expand=resources,tags,hosts,&attributes=ipaddresses,hostnames" % (self.cloudforms_url, offset, limit))
+            ret = self._get_json(
+                    "%s/api/vms?offset=%s&limit=%s&expand=resources,tags,hosts,&attributes=ipaddresses,hostnames" % (self.cloudforms_url, offset, limit))
             results += ret['resources']
             if ret['subcount'] < limit:
                 last_page = True


### PR DESCRIPTION
…stnames of the VM from CloudForms. If there is a hostname present, use it for the name of the host in the inventory. If not, fall back to using the name of the host in CloudForms.

##### SUMMARY
fixes #49493 

Default to using the hostname of the instance as the name of the host, if the hostname is present. Otherwise fall back to using the name of the instance in CloudForms.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
Dynamic inventories

##### ADDITIONAL INFORMATION
Verified using Tower 3.3 and CloudForms 4.6

* Tested adding a host that does not have a hostname in CloudForms via the inventory, verified that the name of the instance was the name of the VM in CloudForms
* Tested adding a host that does have a hostname in CloudForms via the inventory, verified that the name of the instance was set to be the hostname
