### PR TITLE
Revert "fix cache 'update' method to be 'mapping' compatible"

### DIFF
--- a/changelogs/fragments/vm_fix.yml
+++ b/changelogs/fragments/vm_fix.yml
@@ -1,2 +1,0 @@
-bugfixes:
-    - fix issue with incorrect dict update in vars manager

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -289,18 +289,10 @@ class FactCache(MutableMapping):
         """ Flush the fact cache of all keys. """
         self._plugin.flush()
 
-    def update(self, host_facts):
-        """ We override the normal update to ensure we always use the 'setter' method """
-        for key in host_facts:
-            try:
-                host_cache = self._plugin.get(key)
-                if host_cache:
-                    host_cache.update(host_facts[key])
-                else:
-                    host_cache = host_facts[key]
-                self._plugin.set(key, host_cache)
-            except KeyError:
-                self._plugin.set(key, host_facts[key])
+    def update(self, key, value):
+        host_cache = self._plugin.get(key)
+        host_cache.update(value)
+        self._plugin.set(key, host_cache)
 
 
 class InventoryFileCacheModule(BaseFileCacheModule):
@@ -319,7 +311,7 @@ class InventoryFileCacheModule(BaseFileCacheModule):
     def validate_cache_connection(self):
         try:
             super(InventoryFileCacheModule, self).validate_cache_connection()
-        except AnsibleError:
+        except AnsibleError as e:
             cache_connection_set = False
         else:
             cache_connection_set = True


### PR DESCRIPTION
This reverts commit 68301f890addfe4ca8d3b57063e2f70fd21474c9.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
plugins/cache/__init__.py
