### PR TITLE
Become for chroot connection plugin

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -159,6 +159,9 @@ MAGIC_VARIABLE_MAPPING = dict(
     # docker TODO: remove
     docker_extra_args=('ansible_docker_extra_args', ),
 
+    # chroot
+    chroot_become=('ansible_chroot_become', ),
+
     # become
     become=('ansible_become', ),
     become_method=('ansible_become_method', ),


### PR DESCRIPTION
##### SUMMARY
Add chroot_become variable to chroot plugin.
Execute chroot command via sudo if chroot_become is true.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins.connection.chroot

##### ADDITIONAL INFORMATION
This feature useful when user have root permissions only for `chroot path` command.
As example:
```paste below
# sudoers has something like:
ansibleuser    ALL=NOPASSWD: /usr/sbin/chroot /mnt/chroot *

# inventory file:
_chroot ansible_connection=chroot ansible_host=/mnt/chroot ansible_chroot_become=yes
```
