### PR TITLE
Add Direct Rule support for Firewall Module (rebase of #34027)

### DIFF
--- a/lib/ansible/module_utils/firewalld.py
+++ b/lib/ansible/module_utils/firewalld.py
@@ -16,6 +16,7 @@ try:
 
     from firewall.client import FirewallClient
     from firewall.client import FirewallClientZoneSettings
+    from firewall.client import FirewallClientDirect
     from firewall.errors import FirewallError
     fw_offline = False
     import_failure = False
@@ -132,6 +133,21 @@ class FirewallTransaction(object):
             self.fw.config.set_zone_config(fw_zone, fw_settings.settings)
         else:
             fw_zone.update(fw_settings)
+
+    def get_direct_settings(self):
+        if self.fw_offline:
+            fw_direct = self.fw.config.get_direct()
+            fw_settings = FirewallClientDirect(settings=fw_direct.export_config())
+        else:
+            fw_direct = self.fw.config().direct()
+            fw_settings = fw_direct.getSettings()
+        return (fw_direct, fw_settings)
+
+    def update_direct_settings(self, fw, fw_settings):
+        if self.fw_offline:
+            fw.import_config(fw_settings.settings)
+        else:
+            fw.update(fw_settings)
 
     def get_enabled_immediate(self):
         raise NotImplementedError

--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -225,7 +225,7 @@ EXAMPLES = r'''
     chain: sshg
     fw_family: ipv4
     table: filter
-    direct_rule: '-m tcp -p tcp --dport 332 -j ACCEPT'
+    direct_rule: -m tcp -p tcp --dport 332 -j ACCEPT
     permanent: true
     state: disabled
 

--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -793,7 +793,7 @@ def main():
             table=dict(required=False, default=None),
             direct_rule=dict(type='str'),
             fw_family=dict(required=False, default=None),
-            rule_priority=dict(type='int', required=False, default=0)
+            rule_priority=dict(type='int', default=0),
         ),
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -788,7 +788,7 @@ def main():
             interface=dict(type='str'),
             masquerade=dict(type='str'),
             offline=dict(type='bool'),
-            chain=dict(required=False, default=None),
+            chain=dict(type='str'),
             table=dict(required=False, default=None),
             direct_rule=dict(required=False, default=None),
             fw_family=dict(required=False, default=None),

--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -218,7 +218,7 @@ EXAMPLES = r'''
     chain: sshg
     fw_family: ipv4
     table: filter
-    direct_rule: '-m tcp -p tcp --dport 332 -j ACCEPT'
+    direct_rule: -m tcp -p tcp --dport 332 -j ACCEPT
     permanent: true
     state: enabled
 

--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -790,7 +790,7 @@ def main():
             masquerade=dict(type='str'),
             offline=dict(type='bool'),
             chain=dict(type='str'),
-            table=dict(required=False, default=None),
+            table=dict(type='str'),
             direct_rule=dict(type='str'),
             fw_family=dict(type='str'),
             rule_priority=dict(type='int', default=0),

--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -100,7 +100,8 @@ options:
     version_added: "2.3"
   direct_rule:
     description:
-      - 'The firewalld iptables direct rule you would like to enable/disable.'
+      - The firewalld iptables direct rule you would like to enable/disable.
+    type: str
     version_added: "2.8"
   chain:
     description:

--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -803,7 +803,7 @@ def main():
     timeout = module.params['timeout']
     interface = module.params['interface']
     masquerade = module.params['masquerade']
-    chain = None if not module.params['chain'] else module.params['chain']
+    chain = module.params['chain'] if module.params['chain'] else None
     direct_rule = None if not module.params['direct_rule'] else module.params['direct_rule']
     fw_family = None if not module.params['fw_family'] else module.params['fw_family']
     rule_priority = None if not module.params['rule_priority'] else module.params['rule_priority']

--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -104,7 +104,8 @@ options:
     version_added: "2.8"
   chain:
     description:
-      - 'The iptables chain in which to insert the direct_rule, used with the C(direct_rule) option.'
+      - The iptables chain in which to insert the direct_rule, used with the C(direct_rule) option.
+    type: str
     version_added: "2.8"
   table:
     description:

--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -794,7 +794,7 @@ def main():
             fw_family=dict(required=False, default=None),
             rule_priority=dict(type='int', required=False, default=0)
         ),
-        supports_check_mode=True
+        supports_check_mode=True,
     )
 
     permanent = module.params['permanent']

--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -791,7 +791,7 @@ def main():
             offline=dict(type='bool'),
             chain=dict(type='str'),
             table=dict(required=False, default=None),
-            direct_rule=dict(required=False, default=None),
+            direct_rule=dict(type='str'),
             fw_family=dict(required=False, default=None),
             rule_priority=dict(type='int', required=False, default=0)
         ),

--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -792,7 +792,7 @@ def main():
             chain=dict(type='str'),
             table=dict(required=False, default=None),
             direct_rule=dict(type='str'),
-            fw_family=dict(required=False, default=None),
+            fw_family=dict(type='str'),
             rule_priority=dict(type='int', default=0),
         ),
         supports_check_mode=True,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
rebase/port of https://github.com/ansible/ansible/pull/34027 post `firewalld` module refactor

Add support Direct rule operations add/remove
Operation syntax
 Add Chain
```yaml
    -  firewalld:
          chain: sshg
          fw_family: ipv4
          table: filter
          permanent: true
          state: enabled
```
Add rule to chain
```yaml
    -  firewalld:
          chain: sshg
          fw_family: ipv4
          table: filter
          direct_rule: '-m tcp -p tcp --dport 332 -j ACCEPT'
          permanent: true
          state: enabled
```
Remove rule from chain
```yaml
    - firewalld:
          chain: sshg
          fw_family: ipv4
          table: filter
          direct_rule: '-m tcp -p tcp --dport 332 -j ACCEPT'
          permanent: true 
          state: disabled
```
Remove chain
```yaml
    -  firewalld:
          chain: sshg
          fw_family: ipv4
          table: filter
          permanent: true
```

Add passthrough
```yaml
    - firewalld:
          fw_family: ipv4
          direct_rule: '-I FORWARD -o bridge3 -j ACCEPT'
          permanent: true
          state: enabled
```
Remove passthrough
```yaml
    - firewalld:
          fw_family: ipv4
          direct_rule: '-I FORWARD -o bridge3 -j ACCEPT'
          permanent: true
          state: disabled
```

Contact: pershin87@yandex.ru

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
firewalld module
