### PR TITLE
Fix fact cache

### DIFF
--- a/changelogs/fragments/vm_fix.yml
+++ b/changelogs/fragments/vm_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - fix issue with incorrect dict update in vars manager

--- a/changelogs/fragments/vm_fix.yml
+++ b/changelogs/fragments/vm_fix.yml
@@ -1,2 +1,6 @@
 bugfixes:
-    - fix issue with incorrect dict update in vars manager
+    - fix FactCache.update() to conform to the dict API.
+minor_changes:
+    - Moved the FactCache code from ansible.plugins.cache.FactCache to
+      ansible.vars.fact_cache.FactCache as it is not meant to be used to
+      implement cache plugins.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -63,7 +63,8 @@ Deprecated
   2. The ``FactCache.update()`` method has been converted to follow the dict API.  It now takes a
      dictionary as its sole argument and updates itself with the dictionary's items.  The previous
      API where ``update()`` took a key and a value will now issue a deprecation warning and will be
-     removed in 2.12.
+     removed in 2.12.  If you need the old behaviour switch to ``FactCache.first_order_merge()``
+     instead.
 
 Modules
 =======

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -52,6 +52,18 @@ Deprecated
         vars:
           ansible_aync_dir: /tmp/.ansible_async
 
+* Plugin writers who need a ``FactCache`` object should be aware of two deprecations:
+
+  1. The ``FactCache`` class has moved from ``ansible.plugins.cache.FactCache`` to
+     ``ansible.vars.fact_cache.FactCache``.  This is because the ``FactCache`` is not part of the
+     cache plugin API and cache plugin authors should not be subclassing it.  ``FactCache`` is still
+     available from its old location but will issue a deprecation warning when used from there.  The
+     old location will be removed in Ansible 2.12.
+
+  2. The ``FactCache.update()`` method has been converted to follow the dict API.  It now takes a
+     dictionary as its sole argument and updates itself with the dictionary's items.  The previous
+     API where ``update()`` took a key and a value will now issue a deprecation warning and will be
+     removed in 2.12.
 
 Modules
 =======

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -1,4 +1,5 @@
 # (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2018, Ansible Project
 #
 # This file is part of Ansible
 #
@@ -29,8 +30,25 @@ from ansible.module_utils._text import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.plugins.loader import cache_loader
 from ansible.utils.display import Display
+from ansible.vars.fact_cache import FactCache as RealFactCache
 
 display = Display()
+
+
+class FactCache(RealFactCache):
+    """
+    This is for backwards compatibility.  Will be removed after deprecation.  It was removed as it
+    wasn't actually part of the cache plugin API.  It's actually the code to make use of cache
+    plugins, not the cache plugin itself.  Subclassing it wouldn't yield a usable Cache Plugin and
+    there was no facility to use it as anything else.
+    """
+    def __init__(self, *args, **kwargs):
+        display.deprecated('ansible.plugins.cache.FactCache has been moved to'
+                           ' ansible.vars.fact_cache.FactCache.  If you are looking for the class'
+                           ' to subclass for a cache plugin, you want'
+                           ' ansible.plugins.cache.BaseCacheModule or one of its subclasses.',
+                           version='2.12')
+        super(FactCache, self).__init__(*args, **kwargs)
 
 
 class BaseCacheModule(with_metaclass(ABCMeta, object)):
@@ -242,65 +260,6 @@ class BaseFileCacheModule(BaseCacheModule):
         :arg filepath: The filepath to store it at
         """
         pass
-
-
-class FactCache(MutableMapping):
-
-    def __init__(self, *args, **kwargs):
-
-        self._plugin = cache_loader.get(C.CACHE_PLUGIN)
-        if not self._plugin:
-            raise AnsibleError('Unable to load the facts cache plugin (%s).' % (C.CACHE_PLUGIN))
-
-        # Backwards compat: self._display isn't really needed, just import the global display and use that.
-        self._display = display
-
-        # in memory cache so plugins don't expire keys mid run
-        self._cache = {}
-
-    def __getitem__(self, key):
-        if not self._plugin.contains(key):
-            raise KeyError
-        return self._plugin.get(key)
-
-    def __setitem__(self, key, value):
-        self._plugin.set(key, value)
-
-    def __delitem__(self, key):
-        self._plugin.delete(key)
-
-    def __contains__(self, key):
-        return self._plugin.contains(key)
-
-    def __iter__(self):
-        return iter(self._plugin.keys())
-
-    def __len__(self):
-        return len(self._plugin.keys())
-
-    def copy(self):
-        """ Return a primitive copy of the keys and values from the cache. """
-        return dict(self)
-
-    def keys(self):
-        return self._plugin.keys()
-
-    def flush(self):
-        """ Flush the fact cache of all keys. """
-        self._plugin.flush()
-
-    def update(self, host_facts):
-        """ We override the normal update to ensure we always use the 'setter' method """
-        for key in host_facts:
-            try:
-                host_cache = self._plugin.get(key)
-                if host_cache:
-                    host_cache.update(host_facts[key])
-                else:
-                    host_cache = host_facts[key]
-                self._plugin.set(key, host_cache)
-            except KeyError:
-                self._plugin.set(key, host_facts[key])
 
 
 class InventoryFileCacheModule(BaseFileCacheModule):

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -289,10 +289,18 @@ class FactCache(MutableMapping):
         """ Flush the fact cache of all keys. """
         self._plugin.flush()
 
-    def update(self, key, value):
-        host_cache = self._plugin.get(key)
-        host_cache.update(value)
-        self._plugin.set(key, host_cache)
+    def update(self, host_facts):
+        """ We override the normal update to ensure we always use the 'setter' method """
+        for key in host_facts:
+            try:
+                host_cache = self._plugin.get(key)
+                if host_cache:
+                    host_cache.update(host_facts[key])
+                else:
+                    host_cache = host_facts[key]
+                self._plugin.set(key, host_cache)
+            except KeyError:
+                self._plugin.set(key, host_facts[key])
 
 
 class InventoryFileCacheModule(BaseFileCacheModule):
@@ -311,7 +319,7 @@ class InventoryFileCacheModule(BaseFileCacheModule):
     def validate_cache_connection(self):
         try:
             super(InventoryFileCacheModule, self).validate_cache_connection()
-        except AnsibleError as e:
+        except AnsibleError:
             cache_connection_set = False
         else:
             cache_connection_set = True

--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -63,10 +63,10 @@ import os
 from ansible import constants as C
 from ansible.errors import AnsibleParserError
 from ansible.inventory.helpers import get_group_vars
-from ansible.plugins.cache import FactCache
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible.module_utils._text import to_native
 from ansible.utils.vars import combine_vars
+from ansible.vars.fact_cache import FactCache
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable):

--- a/lib/ansible/plugins/inventory/generator.py
+++ b/lib/ansible/plugins/inventory/generator.py
@@ -73,12 +73,11 @@ EXAMPLES = '''
 
 import os
 
+from itertools import product
+
 from ansible import constants as C
 from ansible.errors import AnsibleParserError
-from ansible.plugins.cache import FactCache
 from ansible.plugins.inventory import BaseInventoryPlugin
-
-from itertools import product
 
 
 class InventoryModule(BaseInventoryPlugin):
@@ -89,8 +88,6 @@ class InventoryModule(BaseInventoryPlugin):
     def __init__(self):
 
         super(InventoryModule, self).__init__()
-
-        self._cache = FactCache()
 
     def verify_file(self, path):
 

--- a/lib/ansible/vars/fact_cache.py
+++ b/lib/ansible/vars/fact_cache.py
@@ -1,0 +1,82 @@
+# Copyright: (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+from ansible import constants as C
+from ansible.errors import AnsibleError
+from ansible.module_utils.common._collections_compat import MutableMapping
+from ansible.plugins.loader import cache_loader
+from ansible.utils.display import Display
+
+
+display = Display()
+
+
+class FactCache(MutableMapping):
+
+    def __init__(self, *args, **kwargs):
+
+        self._plugin = cache_loader.get(C.CACHE_PLUGIN)
+        if not self._plugin:
+            raise AnsibleError('Unable to load the facts cache plugin (%s).' % (C.CACHE_PLUGIN))
+
+        super(FactCache, self).__init__(*args, **kwargs)
+
+    def __getitem__(self, key):
+        if not self._plugin.contains(key):
+            raise KeyError
+        return self._plugin.get(key)
+
+    def __setitem__(self, key, value):
+        self._plugin.set(key, value)
+
+    def __delitem__(self, key):
+        self._plugin.delete(key)
+
+    def __contains__(self, key):
+        return self._plugin.contains(key)
+
+    def __iter__(self):
+        return iter(self._plugin.keys())
+
+    def __len__(self):
+        return len(self._plugin.keys())
+
+    def copy(self):
+        """ Return a primitive copy of the keys and values from the cache. """
+        return dict(self)
+
+    def keys(self):
+        return self._plugin.keys()
+
+    def flush(self):
+        """ Flush the fact cache of all keys. """
+        self._plugin.flush()
+
+    def update(self, *args):
+        """ We override the normal update to ensure we always use the 'setter' method """
+        if len(args) == 2:
+            display.deprecated('Calling FactCache.update(key, value) is deprecated.  Use the'
+                               ' normal dict.update() signature of FactCache.update({key: value})'
+                               ' instead.', version='2.12')
+            host_facts = {args[0]: args[1]}
+        elif len(args) == 1:
+            host_facts = args[0]
+        else:
+            raise TypeError('update expected at most 1 argument, got {0}'.format(len(args)))
+
+        for key in host_facts:
+            try:
+                host_cache = self._plugin.get(key)
+                if host_cache:
+                    host_cache.update(host_facts[key])
+                else:
+                    host_cache = host_facts[key]
+                self._plugin.set(key, host_cache)
+            except KeyError:
+                self._plugin.set(key, host_facts[key])

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -622,8 +622,7 @@ class VariableManager:
         '''
         Clears the facts for a host
         '''
-        if hostname in self._fact_cache:
-            del self._fact_cache[hostname]
+        self._fact_cache.pop(hostname, None)
 
     def set_host_facts(self, host, facts):
         '''
@@ -633,13 +632,16 @@ class VariableManager:
         if not isinstance(facts, dict):
             raise AnsibleAssertionError("the type of 'facts' to set for host_facts should be a dict but is a %s" % type(facts))
 
-        if host.name not in self._fact_cache:
-            self._fact_cache[host.name] = facts
-        else:
+        try:
             try:
+                # this is a cache plugin, not a dictionary
+                self._fact_cache.update({host.name: facts})
+            except TypeError:
+                # this is here for backwards compatibilty for the time cache plugins were not 'dict compatible'
                 self._fact_cache.update(host.name, facts)
-            except KeyError:
-                self._fact_cache[host.name] = facts
+                display.deprecated("Your configured fact cache plugin is using a deprecated form of the 'update' method", version="2.12")
+        except KeyError:
+            self._fact_cache[host.name] = facts
 
     def set_nonpersistent_facts(self, host, facts):
         '''
@@ -649,13 +651,10 @@ class VariableManager:
         if not isinstance(facts, dict):
             raise AnsibleAssertionError("the type of 'facts' to set for nonpersistent_facts should be a dict but is a %s" % type(facts))
 
-        if host.name not in self._nonpersistent_fact_cache:
+        try:
+            self._nonpersistent_fact_cache[host.name].update(facts)
+        except KeyError:
             self._nonpersistent_fact_cache[host.name] = facts
-        else:
-            try:
-                self._nonpersistent_fact_cache[host.name].update(facts)
-            except KeyError:
-                self._nonpersistent_fact_cache[host.name] = facts
 
     def set_host_variable(self, host, varname, value):
         '''

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -36,10 +36,10 @@ from ansible.errors import AnsibleError, AnsibleParserError, AnsibleUndefinedVar
 from ansible.inventory.host import Host
 from ansible.inventory.helpers import sort_groups, get_group_vars
 from ansible.module_utils._text import to_native
-from ansible.module_utils.common._collections_compat import MutableMapping, Sequence
+from ansible.module_utils.common._collections_compat import Mapping, MutableMapping, Sequence
 from ansible.module_utils.six import iteritems, text_type, string_types
 from ansible.plugins.loader import lookup_loader, vars_loader
-from ansible.plugins.cache import FactCache
+from ansible.vars.fact_cache import FactCache
 from ansible.template import Templar
 from ansible.utils.display import Display
 from ansible.utils.listify import listify_lookup_plugin_terms
@@ -133,8 +133,8 @@ class VariableManager:
     @extra_vars.setter
     def extra_vars(self, value):
         ''' ensures a clean copy of the extra_vars are used to set the value '''
-        if not isinstance(value, MutableMapping):
-            raise AnsibleAssertionError("the type of 'value' for extra_vars should be a MutableMapping, but is a %s" % type(value))
+        if not isinstance(value, Mapping):
+            raise AnsibleAssertionError("the type of 'value' for extra_vars should be a Mapping, but is a %s" % type(value))
         self._extra_vars = value.copy()
 
     def set_inventory(self, inventory):
@@ -633,13 +633,7 @@ class VariableManager:
             raise AnsibleAssertionError("the type of 'facts' to set for host_facts should be a dict but is a %s" % type(facts))
 
         try:
-            try:
-                # this is a cache plugin, not a dictionary
-                self._fact_cache.update({host.name: facts})
-            except TypeError:
-                # this is here for backwards compatibilty for the time cache plugins were not 'dict compatible'
-                self._fact_cache.update(host.name, facts)
-                display.deprecated("Your configured fact cache plugin is using a deprecated form of the 'update' method", version="2.12")
+            self._fact_cache.update({host.name: facts})
         except KeyError:
             self._fact_cache[host.name] = facts
 
@@ -648,8 +642,8 @@ class VariableManager:
         Sets or updates the given facts for a host in the fact cache.
         '''
 
-        if not isinstance(facts, dict):
-            raise AnsibleAssertionError("the type of 'facts' to set for nonpersistent_facts should be a dict but is a %s" % type(facts))
+        if not isinstance(facts, Mapping):
+            raise AnsibleAssertionError("the type of 'facts' to set for nonpersistent_facts should be a Mapping but is a %s" % type(facts))
 
         try:
             self._nonpersistent_fact_cache[host.name].update(facts)


### PR DESCRIPTION
##### SUMMARY
    Fix FactCache.update() to conform to the dict API
    
    * Move ansible.plugins.cache.FactCache to
      ansible.vars.fact_cache.FactCache because this isn't part of the cache
      plugin API.
    * Add backwards compatibility when calling update on the new FactCache
    * Remove code for calling old FactCache. There's no way to call the old
      FactCache so there's no need for backwards compatible code for calling
      code.  Backwards compatibility is handling things which are calling
      the new FactCache.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/cache/__init__.py

##### ADDITIONAL INFORMATION
This is a rework of the fact cache as discussed with @nitzmahone @mattclay @sivel and @bcoca.  It addresses most of the problems raised with the previous PR except that it does not handle any potential performance regression (@nitzmahone's critique of how the new update() code interacts with the code in ```VariableManager.set_nonpersistent_facts()``` to call .dict.update() many more times than before.)

@nitzmahone's critique needs to be resolved before this can be considered ready to merge.

@sivel pointed out that the original bug report (that we end up calling dict.update(key, value) instead of FactCache.update(key, value) in some cases can be solved in a different way as well: 
``` python
# in VariableManager.__init__():
        try:
            self._fact_cache = FactCache()
        except AnsibleError as e:
            display.warning(to_native(e))
            # fallback to memory cache plugin
            C.CACHE_PLUGIN = 'memory'
            self._fact_cache = FactCache()
```

If we want to backport a fix for the issue, I think sivel;s method is how we should backport it as it avoids introducing any deprecations into the older releases.  However, sivel's method does not correct the problem of the FactCache advertising that it follows the dict API (by subclassing MutableMapping) while implementing an incompatible update() method.  So we probably should do something more like this in devel.