### PR TITLE
[Backport 2.7] Fix win_nssm credentials quoting (#48761)

### DIFF
--- a/changelogs/fragments/48728-win_nssm-credential-quoting.yml
+++ b/changelogs/fragments/48728-win_nssm-credential-quoting.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "win_nssm - Switched to Argv-ToString for escaping NSSM credentials (https://github.com/ansible/ansible/issues/48728)"

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -403,7 +403,7 @@ Function Nssm-Update-Credentials
             }
 
             If ($nssm_result.stdout.split("`n`r")[0] -ne $fullUser) {
-                $cmd = "set ""$name"" ObjectName $fullUser '$password'"
+                $cmd = Argv-ToString @("set", $name, "ObjectName", $fullUser, $password)
                 $nssm_result = Nssm-Invoke $cmd
 
                 if ($nssm_result.rc -ne 0)


### PR DESCRIPTION
##### SUMMARY
* Fix win_nssm credentials quoting

Fix credential quoting for win_nssm after changes to the way nssm command is invoked in Ansible 2.7.1.

* Updating nssm command to update credentials to use Argv-ToString to properly escape password variable.

* Adding changelog fragment for fix of #48728.

(cherry picked from commit 15c5dbcc20702b3e7dba8982c846fc08dec51d56)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
win_nssm
