### PR TITLE
Fix in dict_merge to check for Mapping

### DIFF
--- a/lib/ansible/module_utils/network/common/utils.py
+++ b/lib/ansible/module_utils/network/common/utils.py
@@ -37,6 +37,7 @@ from itertools import chain
 from socket import inet_aton
 
 from ansible.module_utils._text import to_text
+from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils.basic import AnsibleFallbackNotFound
 
@@ -301,7 +302,7 @@ def dict_merge(base, other):
             if key in other:
                 item = other.get(key)
                 if item is not None:
-                    if isinstance(other[key], dict):
+                    if isinstance(other[key], Mapping):
                         combined[key] = dict_merge(value, other[key])
                     else:
                         combined[key] = other[key]


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Based on review comments for PR #49474 change the check
   for isinstance from `dict` to `Mapping`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/network/common/utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
