### PR TITLE
Fix AWS STS session detection

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -576,6 +576,8 @@ class Ec2Inventory(object):
         if self.boto_profile:
             connect_args['profile_name'] = self.boto_profile
             self.boto_fix_security_token_in_profile(connect_args)
+        elif os.environ.get('AWS_SESSION_TOKEN'):
+            connect_args['security_token'] = os.environ.get('AWS_SESSION_TOKEN')
 
         if self.iam_role:
             sts_conn = sts.connect_to_region(region, **connect_args)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If CLI has already assumed an IAM Role, then the cli environment has an additional variable: AWS_SESSION_TOKEN.
This needs to be forwarded to boto to successfully reuse the AWS session in boto.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #15215

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2 dynamic inventory script

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Ansible 2.7.2

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ERROR: "Authentication error retrieving ec2 inventory.
 - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment vars found but may not be correct
 - Boto configs found at '~/.aws/credentials', but the credentials contained may not be correct", while: getting EC2 instances

```
