### PR TITLE
postgresql_user: Add role_grant, role_revoke parameters to set / change role membership of users; add comment parameter

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -399,7 +399,7 @@ def user_alter(db_connection, module, user, password, role_attr_flags, encrypted
 
         conn_limit_changing = (conn_limit is not None and conn_limit != current_role_attrs['rolconnlimit'])
 
-        if not pwchanging and not role_attr_flags_changing and not expires_changing and not conn_limit_changing:
+        if not pwchanging and (not role_attr_flags_changing and not role_grant and not role_revoke) and not expires_changing and not conn_limit_changing:
             return False
 
         alter = ['ALTER USER %(user)s' % {"user": pg_quote_identifier(user, 'role')}]
@@ -454,7 +454,7 @@ def user_alter(db_connection, module, user, password, role_attr_flags, encrypted
                 if current_role_attrs[PRIV_TO_AUTHID_COLUMN[role_attr_name]] != role_attr_value:
                     role_attr_flags_changing = True
 
-        if not role_attr_flags_changing:
+        if not role_attr_flags_changing and not role_grant and not role_revoke:
             return False
 
         alter = ['ALTER USER %(user)s' %

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -421,7 +421,7 @@ def user_alter(db_connection, module, user, password, role_attr_flags, encrypted
         conn_limit_changing = (conn_limit is not None and conn_limit != current_role_attrs['rolconnlimit'])
 
         if (not pwchanging and not role_attr_flags_changing and not membership_changing and
-            not expires_changing and not conn_limit_changing and not comment_changing):
+                not expires_changing and not conn_limit_changing and not comment_changing):
             return False
 
         alter = ['ALTER USER %(user)s' % {"user": pg_quote_identifier(user, 'role')}]

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -138,11 +138,11 @@ options:
   role_grant:
     description:
       - Grant membership in role to user.
-    version_added: '2.8'
+    version_added: '--'
   role_revoke:
     description:
       - Revoke membership in role from user.
-    version_added: '2.8'
+    version_added: '--'
 notes:
    - The default authentication assumes that you are either logging in as or
      sudo'ing to the postgres account on the host.
@@ -270,7 +270,7 @@ def user_exists(cursor, user):
     return cursor.rowcount > 0
 
 
-def user_add(cursor, user, password, role_attr_flags, encrypted, expires, conn_limit, role_grant):
+def user_add(cursor, user, password, module, role_attr_flags, encrypted, expires, conn_limit, role_grant):
     """Create a new database user (role)."""
     # Note: role_attr_flags escaped by parse_role_attrs and encrypted is a
     # literal
@@ -290,8 +290,7 @@ def user_add(cursor, user, password, role_attr_flags, encrypted, expires, conn_l
 
     if role_grant:
         if not user_exists(cursor, role_grant):
-            module.fail_json(msg='Role %s does not exist' % role_grant,
-                             exception=traceback.format_exc())
+            module.fail_json(msg='Role %s does not exist' % role_grant)
             return True
         query = 'GRANT %s TO %s' % (
             pg_quote_identifier(role_grant, 'role'), pg_quote_identifier(user, 'role'))
@@ -906,7 +905,7 @@ def main():
                 module.fail_json(msg=to_native(e), exception=traceback.format_exc())
         else:
             try:
-                changed = user_add(cursor, user, password,
+                changed = user_add(cursor, user, password, module,
                                    role_attr_flags, encrypted, expires, conn_limit, role_grant)
             except psycopg2.ProgrammingError as e:
                 module.fail_json(msg="Unable to add user with given requirement "

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -138,11 +138,11 @@ options:
   role_grant:
     description:
       - Grant membership in role to user.
-    version_added: '--'
+    version_added: '2.8'
   role_revoke:
     description:
       - Revoke membership in role from user.
-    version_added: '--'
+    version_added: '2.8'
 notes:
    - The default authentication assumes that you are either logging in as or
      sudo'ing to the postgres account on the host.


### PR DESCRIPTION
postgresql_user: Add role_grant, role_revoke parameters to set / change role membership of users.
Add comment parameter to set comment on user

The postgresql_user module allows to set privileges on tables or databases during user creation or altering but there is no possibility to define membership at the same time that would be quite convenient and useful.

To implement this, following parameters have been added:
* role_grant: _rolename_ Grant membership in role to user.
* role_revoke: _rolename_ Revoke membership in role from user.

This is an important possibility to add comment on role when create it, for this the following option has been added:
* comment: _Comment text here_