### PR TITLE
Override help string version

### DIFF
--- a/changelogs/fragments/49545-ansible-doc_version_help.yaml
+++ b/changelogs/fragments/49545-ansible-doc_version_help.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Updated Ansible version help message in help section.

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -417,6 +417,10 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         # base opts
         parser = SortedOptParser(usage, version=CLI.version("%prog"), description=desc, epilog=epilog)
+        parser.remove_option('--version')
+        version_help = "show program's version number, config file location, configured module search path," \
+                       " module location, executable location and exit"
+        parser.add_option('--version', action="version", help=version_help)
         parser.add_option('-v', '--verbose', dest='verbosity', default=C.DEFAULT_VERBOSITY, action="count",
                           help="verbose mode (-vvv for more, -vvvv to enable connection debugging)")
 


### PR DESCRIPTION
##### SUMMARY
This fix adds additional help message to version command options

Fixes: #20488

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/cli/__init__.py

##### ADDITIONAL INFORMATION
After fix version help looks like this - 
```paste below
...
  --version             show program's version number, config file location,
                        configured module search path, module location,
                        executable location and exit
...
```
