### PR TITLE
Clarify restrictions of excludes property in find module.

### DIFF
--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -45,7 +45,7 @@ options:
     excludes:
         description:
             - One or more (shell or regex) patterns, which type is controlled by C(use_regex) option.
-            - Items matching an C(excludes) pattern are culled from C(patterns) matches.
+            - Items whose basenames match an C(excludes) pattern are culled from C(patterns) matches.
               Multiple patterns can be specified using a list.
         type: list
         aliases: [ exclude ]


### PR DESCRIPTION
##### SUMMARY
Clarify documentation of the find module; the `excludes` property works on basenames only. 

As I was working with the find module, I was trying to match/exclude full paths, which does not work because the patterns and excludes work on basenames only and the module gives no warnings about this. This pull request is meant to help the next person who makes the same mistake as I did.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
find

##### ADDITIONAL INFORMATION
What do you think, should the find module be modified to support full path patterns and excludes?