### PR TITLE
Make squash deprecation messages less misleading

### DIFF
--- a/changelogs/fragments/squash-deprecation-message.yml
+++ b/changelogs/fragments/squash-deprecation-message.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Improve the deprecation message for squashing, to not give misleading advice


### PR DESCRIPTION
##### SUMMARY
This PR aims to make the package module squashing deprecation message less misleading when using lookups other than `items` or `list`.

As of now, you would get a message like the following, using `with_lines`:

```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items and
 specifying `name: {{ item }}`, please use `name: u'cat squash.txt'` and remove
the loop. This feature will be removed in version 2.11. Deprecation warnings can
be disabled by setting deprecation_warnings=False in ansible.cfg.
```

With this PR:

```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items and
 specifying `name: "{{ item }}"`, please use `name: "{{ query('lines', 'cat
squash.txt') }}"` and remove the loop. This feature will be removed in version
2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False
in ansible.cfg
```

There are likely edge cases where this wont work, but this gets us closer.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_executor.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```