### PR TITLE
[stable-2.7] Support version 3 of the redis python library (#49445)

### DIFF
--- a/changelogs/fragments/redis-3-compat.yaml
+++ b/changelogs/fragments/redis-3-compat.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- redis cache - Support version 3 of the redis python library (https://github.com/ansible/ansible/issues/49341)

--- a/lib/ansible/plugins/cache/redis.py
+++ b/lib/ansible/plugins/cache/redis.py
@@ -11,7 +11,7 @@ DOCUMENTATION = '''
         - This cache uses JSON formatted, per host records saved in Redis.
     version_added: "1.9"
     requirements:
-      - redis (python lib)
+      - redis>=2.4.5 (python lib)
     options:
       _uri:
         description:
@@ -48,9 +48,9 @@ from ansible.errors import AnsibleError
 from ansible.plugins.cache import BaseCacheModule
 
 try:
-    from redis import StrictRedis
+    from redis import StrictRedis, VERSION
 except ImportError:
-    raise AnsibleError("The 'redis' python module is required for the redis fact cache, 'pip install redis'")
+    raise AnsibleError("The 'redis' python module (version 2.4.5 or newer) is required for the redis fact cache, 'pip install redis'")
 
 
 class CacheModule(BaseCacheModule):
@@ -99,7 +99,10 @@ class CacheModule(BaseCacheModule):
         else:
             self._db.set(self._make_key(key), value2)
 
-        self._db.zadd(self._keys_set, time.time(), key)
+        if VERSION[0] == 2:
+            self._db.zadd(self._keys_set, time.time(), key)
+        else:
+            self._db.zadd(self._keys_set, {key: time.time()})
         self._cache[key] = value
 
     def _expire_keys(self):


### PR DESCRIPTION
* Support version 3 of the redis python library. Fixes #49341

* Document 2.4.5 minimum redis-py version
(cherry picked from commit 77de219)


Co-authored-by: Matt Martz <matt@sivel.net>