### PR TITLE
Fix for changes in clearlinux (#49344)

### DIFF
--- a/changelogs/fragments/clear_system_variablse.yml
+++ b/changelogs/fragments/clear_system_variablse.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Change the position to search os-release since clearlinux new versions are providing /etc/os-release too

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -74,9 +74,9 @@ class DistributionFiles:
         {'path': '/etc/lsb-release', 'name': 'Debian'},
         {'path': '/etc/lsb-release', 'name': 'Mandriva'},
         {'path': '/etc/sourcemage-release', 'name': 'SMGL'},
+        {'path': '/usr/lib/os-release', 'name': 'ClearLinux'},
         {'path': '/etc/os-release', 'name': 'NA'},
         {'path': '/etc/coreos/update.conf', 'name': 'Coreos'},
-        {'path': '/usr/lib/os-release', 'name': 'ClearLinux'},
     )
 
     SEARCH_STRING = {
@@ -405,9 +405,9 @@ class Distribution(object):
         {'path': '/etc/lsb-release', 'name': 'Mandriva'},
         {'path': '/etc/altlinux-release', 'name': 'Altlinux'},
         {'path': '/etc/sourcemage-release', 'name': 'SMGL'},
+        {'path': '/usr/lib/os-release', 'name': 'ClearLinux'},
         {'path': '/etc/os-release', 'name': 'NA'},
         {'path': '/etc/coreos/update.conf', 'name': 'Coreos'},
-        {'path': '/usr/lib/os-release', 'name': 'ClearLinux'},
     )
 
     SEARCH_STRING = {

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -912,36 +912,49 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     },
 
     # ClearLinux https://github.com/ansible/ansible/issues/31501#issuecomment-340861535
-    {
-        "platform.dist": [
-            "Clear Linux OS for Intel Architecture",
-            "18450",
-            "clear-linux-os"
-        ],
-        "input": {
-            "/usr/lib/os-release": '''
-NAME="Clear Linux OS for Intel Architecture"
+{
+    "platform.dist": [
+        "Clear Linux OS",
+        "26580",
+        "clear-linux-os"
+    ],
+    "input": {
+        "/etc/os-release": '''
+NAME="Clear Linux OS"
 VERSION=1
 ID=clear-linux-os
-VERSION_ID=18450
-PRETTY_NAME="Clear Linux OS for Intel Architecture"
+ID_LIKE=clear-linux-os
+VERSION_ID=26580
+PRETTY_NAME="Clear Linux OS"
+ANSI_COLOR="1;35"
+HOME_URL="https://clearlinux.org"
+SUPPORT_URL="https://clearlinux.org"
+BUG_REPORT_URL="mailto:dev@lists.clearlinux.org"
+PRIVACY_POLICY_URL="http://www.intel.com/privacy"
+''',
+        "/usr/lib/os-release": '''
+NAME="Clear Linux OS"
+VERSION=1
+ID=clear-linux-os
+ID_LIKE=clear-linux-os
+VERSION_ID=26580
+PRETTY_NAME="Clear Linux OS"
 ANSI_COLOR="1;35"
 HOME_URL="https://clearlinux.org"
 SUPPORT_URL="https://clearlinux.org"
 BUG_REPORT_URL="mailto:dev@lists.clearlinux.org"
 PRIVACY_POLICY_URL="http://www.intel.com/privacy"
 '''
-        },
-        "name": "Clear Linux OS for Intel Architecture 1",
-        "result": {
-            "distribution_release": "clear-linux-os",
-            "distribution": "ClearLinux",
-            "distribution_major_version": "18450",
-            "os_family": "ClearLinux",
-            "distribution_version": "18450"
-        }
     },
-
+    "name": "ClearLinux 26580",
+    "result": {
+        "distribution_release": "clear-linux-os",
+        "distribution": "ClearLinux",
+        "distribution_major_version": "26580",
+        "os_family": "ClearLinux",
+        "distribution_version": "26580"
+    }
+},
     # ArchLinux with no /etc/arch-release but with a /etc/os-release with NAME=Arch Linux
     # The fact needs to map 'Arch Linux' to 'Archlinux' for compat with 2.3 and earlier facts
     {


### PR DESCRIPTION
* Fix for changes in clearlinux

clearlinux is now providing /etc/os-release file and ansible is identifying as NA
then this change allow ansible to find it

Signed-off-by: Josue David Hernandez Gutierrez <josue.d.hernandez.gutierrez@intel.com>

* Add changelog fragment for clearlinux changes

Signed-off-by: Josue David Hernandez Gutierrez <josue.d.hernandez.gutierrez@intel.com>
(cherry picked from commit 6d42c5020a9f77ac2a865dda45b649f5d2602d9d)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
