### PR TITLE
[docker_network] Adding `scope` and `attachable` flags

### DIFF
--- a/changelogs/fragments/docker_network-adding-scope-and-attachable-flags.yaml
+++ b/changelogs/fragments/docker_network-adding-scope-and-attachable-flags.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "docker_network - ``scope`` is now used to set the ``Scope`` property of the docker network during creation."
+  - "docker_network - ``attachable`` is now used to set the ``Attachable`` property of the docker network during creation."

--- a/changelogs/fragments/docker_network-requirements.yaml
+++ b/changelogs/fragments/docker_network-requirements.yaml
@@ -2,3 +2,4 @@
 minor_changes:
   - "docker_network - Minimum docker-py version increased from ``1.8.0`` to ``1.10.0``."
   - "docker_network - Minimum docker server version increased from ``1.9.0`` to ``1.10.0``."
+  - "docker_network - Minimum docker API version explcitly set to ``1.22``."

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -429,7 +429,7 @@ class SwarmManager(DockerBaseClass):
             self.client.leave_swarm(force=self.parameters.force)
         except APIError as exc:
             self.client.fail(msg="This node can not leave the Swarm Cluster: %s" % to_native(exc))
-        self.results['actions'].append("Node has leaved the swarm cluster")
+        self.results['actions'].append("Node has left the swarm cluster")
         self.results['changed'] = True
 
     def __get_node_info(self):

--- a/test/integration/targets/docker_network/tasks/tests/options.yml
+++ b/test/integration/targets/docker_network/tasks/tests/options.yml
@@ -92,3 +92,100 @@
     - driver_options_3 is not changed
     - driver_options_4 is changed
     - driver_options_5 is not changed
+
+####################################################################
+## scope ###########################################################
+####################################################################
+
+- block:
+  - name: scope
+    docker_network:
+      name: "{{ nname_1 }}"
+      driver: bridge
+      scope: local
+    register: scope_1
+
+  - name: scope (idempotency)
+    docker_network:
+      name: "{{ nname_1 }}"
+      driver: bridge
+      scope: local
+    register: scope_2
+
+  - name: swarm
+    docker_swarm:
+      state: present
+      advertise_addr: "{{ansible_default_ipv4.address}}"
+
+  # Driver change alongside scope is intentional - bridge doesn't appear to support anything but local, and overlay can't downgrade to local. Additionally, overlay reports as swarm for swarm OR global, so no change is reported in that case.
+  # Test output indicates that the scope is altered, at least, so manual inspection will be required to verify this going forward, unless we come up with a test driver that supports multiple scopes.
+  - name: scope (change)
+    docker_network:
+      name: "{{ nname_1 }}"
+      driver: overlay
+      scope: swarm
+    register: scope_3
+
+  - name: cleanup network
+    docker_network:
+      name: "{{ nname_1 }}"
+      state: absent
+      force: yes
+
+  - assert:
+      that:
+      - scope_1 is changed
+      - scope_2 is not changed
+      - scope_3 is changed
+
+  always:
+  - name: cleanup swarm
+    docker_swarm:
+      state: absent
+      force: yes
+
+  # Requirements for docker_swarm
+  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')
+
+####################################################################
+## attachable ######################################################
+####################################################################
+
+- name: attachable
+  docker_network:
+    name: "{{ nname_1 }}"
+    attachable: true
+  register: attachable_1
+  ignore_errors: yes
+  
+- name: attachable (idempotency)
+  docker_network:
+    name: "{{ nname_1 }}"
+    attachable: true
+  register: attachable_2
+  ignore_errors: yes
+  
+- name: attachable (change)
+  docker_network:
+    name: "{{ nname_1 }}"
+    attachable: false
+  register: attachable_3
+  ignore_errors: yes
+  
+- name: cleanup
+  docker_network:
+    name: "{{ nname_1 }}"
+    state: absent
+    force: yes
+
+- assert:
+    that:
+    - attachable_1 is changed
+    - attachable_2 is not changed
+    - attachable_3 is changed
+  when: docker_py_version is version('2.0.0', '>=')
+- assert:
+    that:
+    - attachable_1 is failed
+    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.0.0') in attachable_1.msg"
+  when: docker_py_version is version('2.0.0', '<')

--- a/test/integration/targets/docker_swarm/tasks/test_swarm.yml
+++ b/test/integration/targets/docker_swarm/tasks/test_swarm.yml
@@ -52,7 +52,7 @@
     assert:
       that:
          - 'output.changed'
-         - 'output.actions[0] == "Node has leaved the swarm cluster"'
+         - 'output.actions[0] == "Node has left the swarm cluster"'
 
   always:
   - name: Cleanup


### PR DESCRIPTION
##### SUMMARY
Incorporating the abandoned work from PRs #35288 and #45552. Also adding in
the version checking from `docker_container.py`, which should be abstracted
out to `docker_common.py`.

Part of the work for https://github.com/ansible/community/issues/408

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_network

##### ADDITIONAL INFORMATION
Integration tests passing with `ansible-test integration -v docker_network --docker ubuntu1604`