### PR TITLE
 Removed breaking type check from nagios module

### DIFF
--- a/changelogs/fragments/49568-type-checking.yaml
+++ b/changelogs/fragments/49568-type-checking.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "nagios - Removed redundant type check which caused crashes."

--- a/changelogs/fragments/49568-type-checking.yaml
+++ b/changelogs/fragments/49568-type-checking.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-- "nagios - Removed redundant type check which caused crashes."
+- "nagios - Removed redundant type check which caused crashes. Guardrails added elsewhere in earlier change."

--- a/changelogs/fragments/495680-type-checking.yaml
+++ b/changelogs/fragments/495680-type-checking.yaml
@@ -1,0 +1,2 @@
+---
+- Removed redundant type check in Nagios module which only existed to cause crashes

--- a/changelogs/fragments/495680-type-checking.yaml
+++ b/changelogs/fragments/495680-type-checking.yaml
@@ -1,2 +1,0 @@
----
-- Removed redundant type check in Nagios module which only existed to cause crashes

--- a/lib/ansible/modules/monitoring/nagios.py
+++ b/lib/ansible/modules/monitoring/nagios.py
@@ -65,6 +65,7 @@ options:
     description:
       - Minutes to schedule downtime for.
       - Only usable with the C(downtime) action.
+    type: int
     default: 30
   services:
     description:
@@ -270,7 +271,6 @@ def main():
     action = module.params['action']
     host = module.params['host']
     servicegroup = module.params['servicegroup']
-    minutes = module.params['minutes']
     services = module.params['services']
     cmdfile = module.params['cmdfile']
     command = module.params['command']
@@ -283,7 +283,7 @@ def main():
     # command = command
     #
     # AnsibleModule will verify most stuff, we need to verify
-    # 'minutes' and 'service' manually.
+    # 'service' manually.
 
     ##################################################################
     if action not in ['command', 'silence_nagios', 'unsilence_nagios']:
@@ -294,7 +294,6 @@ def main():
         # Make sure there's an actual service selected
         if not services:
             module.fail_json(msg='no service selected to set downtime for')
-        m = int(minutes)
 
     ######################################################################
     if action == 'delete_downtime':
@@ -308,8 +307,6 @@ def main():
         # Make sure there's an actual servicegroup selected
         if not servicegroup:
             module.fail_json(msg='no servicegroup selected to set downtime for')
-        # Make sure minutes is a number
-        m = int(minutes)
 
     ##################################################################
     if action in ['enable_alerts', 'disable_alerts']:
@@ -355,7 +352,7 @@ class Nagios(object):
         self.comment = kwargs['comment']
         self.host = kwargs['host']
         self.servicegroup = kwargs['servicegroup']
-        self.minutes = int(kwargs['minutes'])
+        self.minutes = kwargs['minutes']
         self.cmdfile = kwargs['cmdfile']
         self.command = kwargs['command']
 

--- a/lib/ansible/modules/monitoring/nagios.py
+++ b/lib/ansible/modules/monitoring/nagios.py
@@ -298,10 +298,8 @@ def main():
         # Make sure minutes is a number
         try:
             m = int(minutes)
-            if not isinstance(m, types.IntType):
-                module.fail_json(msg='minutes must be a number')
         except Exception:
-            module.fail_json(msg='invalid entry for minutes')
+            module.fail_json(msg='minutes is not a valid integer')
 
     ######################################################################
     if action == 'delete_downtime':
@@ -318,10 +316,8 @@ def main():
         # Make sure minutes is a number
         try:
             m = int(minutes)
-            if not isinstance(m, types.IntType):
-                module.fail_json(msg='minutes must be a number')
         except Exception:
-            module.fail_json(msg='invalid entry for minutes')
+            module.fail_json(msg='minutes is not a valid integer')
 
     ##################################################################
     if action in ['enable_alerts', 'disable_alerts']:

--- a/lib/ansible/modules/monitoring/nagios.py
+++ b/lib/ansible/modules/monitoring/nagios.py
@@ -193,7 +193,6 @@ EXAMPLES = '''
     command: DISABLE_FAILURE_PREDICTION
 '''
 
-import types
 import time
 import os.path
 import stat

--- a/lib/ansible/modules/monitoring/nagios.py
+++ b/lib/ansible/modules/monitoring/nagios.py
@@ -294,11 +294,7 @@ def main():
         # Make sure there's an actual service selected
         if not services:
             module.fail_json(msg='no service selected to set downtime for')
-        # Make sure minutes is a number
-        try:
-            m = int(minutes)
-        except Exception:
-            module.fail_json(msg='minutes is not a valid integer')
+        m = int(minutes)
 
     ######################################################################
     if action == 'delete_downtime':
@@ -313,10 +309,7 @@ def main():
         if not servicegroup:
             module.fail_json(msg='no servicegroup selected to set downtime for')
         # Make sure minutes is a number
-        try:
-            m = int(minutes)
-        except Exception:
-            module.fail_json(msg='minutes is not a valid integer')
+        m = int(minutes)
 
     ##################################################################
     if action in ['enable_alerts', 'disable_alerts']:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -2322,7 +2322,6 @@ lib/ansible/modules/monitoring/monit.py validate-modules:E337
 lib/ansible/modules/monitoring/monit.py validate-modules:E338
 lib/ansible/modules/monitoring/nagios.py validate-modules:E317
 lib/ansible/modules/monitoring/nagios.py validate-modules:E324
-lib/ansible/modules/monitoring/nagios.py validate-modules:E337
 lib/ansible/modules/monitoring/nagios.py validate-modules:E338
 lib/ansible/modules/monitoring/newrelic_deployment.py validate-modules:E338
 lib/ansible/modules/monitoring/pagerduty.py validate-modules:E324


### PR DESCRIPTION
##### SUMMARY
Python 2.x (unknown point release when it started, I used Python 2.7.15rc1) returns `<type 'int'>` when casting minutes in the nagios module. Python 3.x (also unknown point release, I used Python 3.6.6) returns `<class 'int'>`. Changing from a numeric primitive to a class seems to have caused `types.IntTypes` to throw an exception when it attempted to compare the type, meaning that the two actions could never be used on a system defaulting to python 3.x.

This fix removes the `types.IntType` check, since the cast will throw an exception in any situation where the type check would fail. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Nagios

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This issue was caused by just running the nagios module with the action of "downtime".
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
(dev):~/devops/ansible ❯ ansible -i ec2.py tag_primary_role_nagios -u xxx -m nagios -a "action=downtime service=host host=localhost" -vvv
ansible 2.6.2
  config file = /root/devops/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.6 (default, Sep 12 2018, 18:26:19) [GCC 8.0.1 20180414 (experimental) [trunk revision 259383]]
Using /root/devops/ansible/ansible.cfg as config file
Parsed /root/devops/ansible/ec2.py inventory source with script plugin
META: ran handlers
Using module file /usr/local/lib/python3.6/dist-packages/ansible/modules/monitoring/nagios.py
<35.168.187.224> ESTABLISH SSH CONNECTION FOR USER: xxx
<35.168.187.224> SSH: EXEC ssh -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=xxx -o ConnectTimeout=40 -o ControlPath=/root/.ansible/cp/%h-%p-%r 35.168.187.224 '/bin/sh -c '"'"'/usr/bin/python && sleep 0'"'"''
<35.168.187.224> (1, b'\n{"msg": "invalid entry for minutes", "failed": true, "exception": "  File \\"/tmp/ansible_od56pxwn/ansible_module_nagios.py\\", line 300, in main\\n    if not isinstance(m, types.IntType):\\n", "invocation": {"module_args": {"action": "downtime", "service": "host", "host": "localhost", "services": "host", "author": "Ansible", "comment": "Scheduling downtime", "minutes": "30", "cmdfile": "/var/lib/nagios3/rw/nagios.cmd", "servicegroup": null, "command": null}}}\n', b'bash: warning: setlocale: LC_ALL: cannot change locale (en_CA.UTF-8)\n')
The full traceback is:
  File "/tmp/ansible_od56pxwn/ansible_module_nagios.py", line 300, in main
    if not isinstance(m, types.IntType):

nagios | FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "action": "downtime",
            "author": "Ansible",
            "cmdfile": "/var/lib/nagios3/rw/nagios.cmd",
            "command": null,
            "comment": "Scheduling downtime",
            "host": "localhost",
            "minutes": "30",
            "service": "host",
            "servicegroup": null,
            "services": "host"
        }
    },
    "msg": "invalid entry for minutes"
}
(dev):~/devops/ansible ❯ 

```
