### PR TITLE
openstack: report HttpException details to user

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_coe_cluster_template.py
+++ b/lib/ansible/modules/cloud/openstack/os_coe_cluster_template.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -365,6 +366,8 @@ def main():
             else:
                 cloud.delete_coe_cluster_template(name)
                 module.exit_json(changed=True)
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_flavor_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_flavor_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -217,6 +218,8 @@ def main():
         module.exit_json(changed=False,
                          ansible_facts=dict(openstack_flavors=flavors))
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_floating_ip.py
+++ b/lib/ansible/modules/cloud/openstack/os_floating_ip.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -246,6 +247,8 @@ def main():
                 module.exit_json(changed=True)
             module.exit_json(changed=changed, floating_ip=f_ip)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_group.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -159,6 +160,8 @@ def main():
                 changed = True
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -177,6 +178,8 @@ def main():
                 changed = True
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_image_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_image_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -158,6 +159,8 @@ def main():
             module.exit_json(changed=False, ansible_facts=dict(
                 openstack_image=images))
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_ironic.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -328,6 +329,8 @@ def main():
             else:
                 module.exit_json(changed=False, result="Server not found")
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_ironic_inspect.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic_inspect.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -136,6 +137,8 @@ def main():
         else:
             module.fail_json(msg="node not found.")
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_ironic_node.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic_node.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -338,6 +339,8 @@ def main():
             module.fail_json(msg="State must be present, absent, "
                                  "maintenance, off")
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_keypair.py
+++ b/lib/ansible/modules/cloud/openstack/os_keypair.py
@@ -6,6 +6,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -148,6 +149,8 @@ def main():
                 module.exit_json(changed=True)
             module.exit_json(changed=False)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_keystone_domain.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_domain.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -177,6 +178,8 @@ def main():
                 changed = True
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_keystone_domain_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_domain_facts.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -120,6 +121,8 @@ def main():
         module.exit_json(changed=False, ansible_facts=dict(
             openstack_domains=domains))
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -201,6 +202,8 @@ def main():
                 changed = True
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_keystone_role.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_role.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -119,6 +120,8 @@ def main():
                 changed = True
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_keystone_service.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_service.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -186,6 +187,8 @@ def main():
                 changed = True
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_listener.py
+++ b/lib/ansible/modules/cloud/openstack/os_listener.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 
 __metaclass__ = type
 
@@ -248,6 +249,8 @@ def main():
                     _lb_wait_for_status(module, cloud, lb, "ACTIVE", ["ERROR"])
 
             module.exit_json(changed=changed)
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_loadbalancer.py
+++ b/lib/ansible/modules/cloud/openstack/os_loadbalancer.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 
 __metaclass__ = type
 
@@ -597,6 +598,8 @@ def main():
                 changed = True
 
             module.exit_json(changed=changed)
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_member.py
+++ b/lib/ansible/modules/cloud/openstack/os_member.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 
 __metaclass__ = type
 
@@ -219,6 +220,8 @@ def main():
                 changed = True
 
             module.exit_json(changed=changed)
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_network.py
+++ b/lib/ansible/modules/cloud/openstack/os_network.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -212,6 +213,8 @@ def main():
                 cloud.delete_network(name)
                 module.exit_json(changed=True)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_networks_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_networks_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -136,6 +137,8 @@ def main():
         module.exit_json(changed=False, ansible_facts=dict(
             openstack_networks=networks))
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -263,6 +264,8 @@ def main():
                 module.exit_json(changed=True)
             module.exit_json(changed=False)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_nova_host_aggregate.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_host_aggregate.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -171,6 +172,8 @@ def main():
                 changed = True
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_object.py
+++ b/lib/ansible/modules/cloud/openstack/os_object.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -117,6 +118,8 @@ def main():
         changed = process_object(cloud, **module.params)
 
         module.exit_json(changed=changed)
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_pool.py
+++ b/lib/ansible/modules/cloud/openstack/os_pool.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 
 __metaclass__ = type
 
@@ -259,6 +260,8 @@ def main():
                 changed = True
 
             module.exit_json(changed=changed)
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -358,6 +359,8 @@ def main():
                 changed = True
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_port_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_port_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -205,6 +206,8 @@ def main():
         module.exit_json(changed=False, ansible_facts=dict(
             openstack_ports=ports))
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_project.py
+++ b/lib/ansible/modules/cloud/openstack/os_project.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -203,6 +204,8 @@ def main():
                 changed = True
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=e.message, extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_project_access.py
+++ b/lib/ansible/modules/cloud/openstack/os_project_access.py
@@ -14,6 +14,7 @@
 # along with this software.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -191,6 +192,8 @@ def main():
                          resource=resource,
                          id=resource_id)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), **module.params)
 

--- a/lib/ansible/modules/cloud/openstack/os_project_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_project_facts.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -145,6 +146,8 @@ def main():
         module.exit_json(changed=False, ansible_facts=dict(
             openstack_projects=projects))
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_quota.py
+++ b/lib/ansible/modules/cloud/openstack/os_quota.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -441,6 +442,8 @@ def main():
                          openstack_quotas=project_quota_output
                          )
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_recordset.py
+++ b/lib/ansible/modules/cloud/openstack/os_recordset.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -228,6 +229,8 @@ def main():
                 changed = True
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_router.py
+++ b/lib/ansible/modules/cloud/openstack/os_router.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -479,6 +480,8 @@ def main():
                 cloud.delete_router(router_id)
                 module.exit_json(changed=True)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_security_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -155,6 +156,8 @@ def main():
                 changed = True
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -361,6 +362,8 @@ def main():
 
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -7,6 +7,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -731,6 +732,8 @@ def main():
         elif state == 'absent':
             _get_server_state(module, cloud)
             _delete_server(module, cloud)
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -239,6 +240,8 @@ def main():
                 _wait(timeout, cloud, server, action, module, sdk)
             module.exit_json(changed=True)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_server_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -98,6 +99,8 @@ def main():
         module.exit_json(changed=False, ansible_facts=dict(
             openstack_servers=openstack_servers))
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_server_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_group.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -164,6 +165,8 @@ def main():
                 cloud.delete_server_group(server_group['id'])
                 changed = True
             module.exit_json(changed=changed)
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_server_metadata.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_metadata.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -163,6 +164,8 @@ def main():
         module.exit_json(
             changed=changed, server_id=server.id, metadata=server.metadata)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=e.message, extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_server_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_volume.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -139,6 +140,8 @@ def main():
                 result='Detached volume from server'
             )
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except (sdk.exceptions.OpenStackCloudException, sdk.exceptions.ResourceTimeout) as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_stack.py
+++ b/lib/ansible/modules/cloud/openstack/os_stack.py
@@ -261,6 +261,8 @@ def main():
                 if not cloud.delete_stack(name, wait=module.params['wait']):
                     module.fail_json(msg='delete stack failed for stack: %s' % name)
             module.exit_json(changed=changed)
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=to_native(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -350,6 +351,8 @@ def main():
                 cloud.delete_subnet(subnet_name)
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_subnets_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnets_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -151,6 +152,8 @@ def main():
         module.exit_json(changed=False, ansible_facts=dict(
             openstack_subnets=subnets))
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_user.py
+++ b/lib/ansible/modules/cloud/openstack/os_user.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -284,6 +285,8 @@ def main():
                 changed = True
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_user_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_user_facts.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -153,6 +154,8 @@ def main():
         module.exit_json(changed=False, ansible_facts=dict(
             openstack_users=users))
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_user_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_user_group.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -99,6 +100,8 @@ def main():
 
         module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), extra_data=e.extra_data)
 

--- a/lib/ansible/modules/cloud/openstack/os_user_role.py
+++ b/lib/ansible/modules/cloud/openstack/os_user_role.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -191,6 +192,8 @@ def main():
 
         module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -160,6 +161,8 @@ def main():
             _present_volume(module, cloud)
         if state == 'absent':
             _absent_volume(module, cloud, sdk)
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/openstack/os_volume_snapshot.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume_snapshot.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -170,6 +171,8 @@ def main():
             module.fail_json(
                 msg="No volume with name or id '{0}' was found.".format(
                     module.params['volume']))
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except (sdk.exceptions.OpenStackCloudException, sdk.exceptions.ResourceTimeout) as e:
         module.fail_json(msg=e.message)
 

--- a/lib/ansible/modules/cloud/openstack/os_zone.py
+++ b/lib/ansible/modules/cloud/openstack/os_zone.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
 __metaclass__ = type
 
 
@@ -206,6 +207,8 @@ def main():
                 changed = True
             module.exit_json(changed=changed)
 
+    except sdk.exceptions.HttpException as e:
+        module.fail_json(msg=to_native(e), extra_data=e.details)
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))
 


### PR DESCRIPTION
##### SUMMARY

openstacksdk will raise `HttpException` if the server encounters a problem with the client request.

For example, this can happen if we request an `os_volume` and we are already at quota ("VolumeLimitExceeded"), or if we request an `os_server` with a non-existent key name ("Invalid key_name provided.").

Prior to this change, we simply displayed vague error messages like "Error in creating volume" or "Unknown error", which is the simple `str` representation of the exception.

When openstacksdk raises `HttpException`, pass the details of that exception into `fail_json()`. This provides the Ansible user with a clearer explanation about what is failing and why.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openstack

##### ADDITIONAL INFORMATION
I would appreciate a review by someone who knows openstacksdk, because it seems odd that the current code that `catch`es `sdk.exceptions.OpenStackCloudException` and passes `e.extra_data` into `fail_json()` is not helping here.