### PR TITLE
Fix ReST formatting for Galaxy docs link

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -399,7 +399,7 @@ Ansible Galaxy
 
 The client ``ansible-galaxy`` is included in Ansible. The Galaxy client allows you to download roles from Ansible Galaxy, and also provides an excellent default framework for creating your own roles. 
 
-Read the Ansible Galaxy documentation <https://galaxy.ansible.com/docs/>_ page for more information
+Read the `Ansible Galaxy documentation <https://galaxy.ansible.com/docs/>`_ page for more information
 
 .. seealso::
 


### PR DESCRIPTION
##### SUMMARY
Previously, the ReStructured Text formatting for the link to the Ansible Galaxy docs was missing the backticks, causing the link to display like

> Read the Ansible Galaxy documentation \<https://galaxy.ansible.com/docs/>_ page for more information

Now, I've put in the backticks to make it look more like

> Read the [Ansible Galaxy documentation](https://galaxy.ansible.com/docs/) page for more information

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Docs

##### ADDITIONAL INFORMATION
See https://docs.ansible.com/ansible/2.7/user_guide/playbooks_reuse_roles.html#ansible-galaxy