### PR TITLE
Clarify that do until loops are unsupported on include tasks

### DIFF
--- a/lib/ansible/modules/utilities/logic/include_role.py
+++ b/lib/ansible/modules/utilities/logic/include_role.py
@@ -22,7 +22,8 @@ short_description: Load and execute a role
 description:
   - Loads and executes a role as a task dynamically. This frees roles from the `roles:` directive and allows them to be
     treated more as tasks.
-  - Unlike M(import_role), most keywords, including loops and conditionals, apply to this statement.
+  - Unlike M(import_role), most keywords, including loop, with_items, and conditionals, apply to this statement.
+  - The do until loop is not supported on M(include_role).
   - This module is also supported for Windows targets.
 version_added: "2.2"
 options:

--- a/lib/ansible/modules/utilities/logic/include_tasks.py
+++ b/lib/ansible/modules/utilities/logic/include_tasks.py
@@ -26,7 +26,8 @@ options:
   file:
     description:
       - The name of the imported file is specified directly without any other option.
-      - Unlike M(import_tasks), most keywords, including loops and conditionals, apply to this statement.
+      - Unlike M(import_tasks), most keywords, including loop, with_items, and conditionals, apply to this statement.
+      - The do until loop is not supported on M(include_tasks).
     version_added: '2.7'
   apply:
     description:


### PR DESCRIPTION
##### SUMMARY
Explicitly call out that do until loops are unsupported on include_tasks and include_role.

Fixes https://github.com/ansible/ansible/issues/49448.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
include_tasks
include_role