### PR TITLE
[WIP] Fixed behavior when creating privatekey file in openssl_privatekey

### DIFF
--- a/changelogs/fragments/openssl_privatekey-generate.yaml
+++ b/changelogs/fragments/openssl_privatekey-generate.yaml
@@ -1,3 +1,2 @@
 bugfixes:
-  - openssl_privatekey can't create files which only have read permissions #48656(https://github.com/ansible/ansible/issues/48656)
-  - Overwrite the symbolic link with a file only when the force option is specified
+  - openssl_privatekey can't create files which only have read permissions (https://github.com/ansible/ansible/issues/48656)

--- a/changelogs/fragments/openssl_privatekey-generate.yaml
+++ b/changelogs/fragments/openssl_privatekey-generate.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - openssl_privatekey can't create files which only have read permissions #48656(https://github.com/ansible/ansible/issues/48656)
+  - Overwrite the symbolic link with a file only when the force option is specified

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -276,7 +276,7 @@ class PrivateKeyBase(crypto_utils.OpenSSLObject):
             try:
                 if not os.path.exists(self.path):
                     privatekey_file = os.open(
-                        self.path, os.O_WRONLY | os.O_CREAT, mode=0o600)
+                        self.path, os.O_WRONLY | os.O_CREAT, 0o600)
                     os.close(privatekey_file)
                 if isinstance(self.mode, string_types):
                     try:

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -288,12 +288,8 @@ class PrivateKeyBase(crypto_utils.OpenSSLObject):
                         except ValueError as e:
                             module.fail_json(msg="%s" % to_native(e), exception=traceback.format_exc())
                 privatekey_file = os.open(self.path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, self.mode)
+                os.write(privatekey_file, privatekey_data)
                 os.chmod(self.path, self.mode)
-                if self.cipher and self.passphrase:
-                    os.write(privatekey_file, crypto.dump_privatekey(crypto.FILETYPE_PEM, self.privatekey,
-                                                                     self.cipher, to_bytes(self.passphrase)))
-                else:
-                    os.write(privatekey_file, crypto.dump_privatekey(crypto.FILETYPE_PEM, self.privatekey))
                 os.close(privatekey_file)
                 self.changed = True
             except IOError as exc:

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -631,15 +631,6 @@ def main():
         private_key = PrivateKeyCryptography(module)
 
     if private_key.state == 'present':
-        # A value of 'path' should be a regular file.
-        # It should be failed if symblic link specified as a 'path' value.
-        if os.path.islink(module.params['path']) and not module.params['force']:
-            module.fail_json(
-                msg=(
-                    'The symbolic link is unable to specify'
-                    ' as a value of `path`: %s'
-                ) % module.params['path'])
-
         if module.check_mode:
             result = private_key.dump()
             result['changed'] = module.params['force'] or not private_key.check(module)

--- a/test/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -50,6 +50,11 @@
     cipher: "{{ 'aes256' if select_crypto_backend == 'pyopenssl' else 'auto' }}"
     select_crypto_backend: '{{ select_crypto_backend }}'
 
+- name: Generate privatekey7 - standard - with mode option
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey7.pem'
+    mode: 0400
+
 - set_fact:
     ecc_types: []
   when: select_crypto_backend == 'pyopenssl'

--- a/test/integration/targets/openssl_privatekey/tests/validate.yml
+++ b/test/integration/targets/openssl_privatekey/tests/validate.yml
@@ -70,6 +70,18 @@
       - privatekey6.stdout == '4096'
   when: openssl_version.stdout is version('0.9.8zh', '>=')
 
+
+- name: Validate privatekey7 (test - Privatekey file mode)
+  stat:
+    path: '{{ output_dir }}/privatekey7.pem'
+  register: privatekey7
+
+- name: Validate privatekey7 (assert - Privatekey file mode)
+  assert:
+    that:
+      - privatekey7.stat.mode == "0400"
+
+
 - name: Validate ECC generation (dump with OpenSSL)
   shell: "openssl ec -in {{ output_dir }}/privatekey-{{ item.item.curve }}.pem -noout -text | grep 'ASN1 OID: ' | sed 's/ASN1 OID: \\([^ ]*\\)/\\1/'"
   loop: "{{ privatekey_ecc_generate.results }}"


### PR DESCRIPTION
##### SUMMARY

This PR will fixes the following issues of the `openssl_privatekey` module:

- Fixed openssl_privatekey can't create files which only have read permissions #48656
- Fixed behavior when generating secret key file
- Fixed symbloic link handling without force option

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- openssl_privatekey module

##### ADDITIONAL INFORMATION

None
