### PR TITLE
ansible-test: change Fedora 24 to 28

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -51,8 +51,8 @@ matrix:
     - env: T=freebsd/11.1/1
     - env: T=linux/centos6/1
     - env: T=linux/centos7/1
-    - env: T=linux/fedora24/1
     - env: T=linux/fedora25/1
+    - env: T=linux/fedora28/1
     - env: T=linux/opensuse42.3/1
     - env: T=linux/ubuntu1404/1
     - env: T=linux/ubuntu1604/1
@@ -64,8 +64,8 @@ matrix:
     - env: T=freebsd/11.1/2
     - env: T=linux/centos6/2
     - env: T=linux/centos7/2
-    - env: T=linux/fedora24/2
     - env: T=linux/fedora25/2
+    - env: T=linux/fedora28/2
     - env: T=linux/opensuse42.3/2
     - env: T=linux/ubuntu1404/2
     - env: T=linux/ubuntu1604/2
@@ -77,8 +77,8 @@ matrix:
     - env: T=freebsd/11.1/3
     - env: T=linux/centos6/3
     - env: T=linux/centos7/3
-    - env: T=linux/fedora24/3
     - env: T=linux/fedora25/3
+    - env: T=linux/fedora28/3
     - env: T=linux/opensuse42.3/3
     - env: T=linux/ubuntu1404/3
     - env: T=linux/ubuntu1604/3

--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -1,10 +1,8 @@
 default name=quay.io/ansible/default-test-container:1.4.1 python=3
 centos6 name=quay.io/ansible/centos6-test-container:1.4.0 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.4.0 seccomp=unconfined
-fedora24 name=quay.io/ansible/fedora24-test-container:1.4.0 seccomp=unconfined
 fedora25 name=quay.io/ansible/fedora25-test-container:1.4.0 seccomp=unconfined
-fedora26py3 name=quay.io/ansible/fedora26py3-test-container:1.4.0 python=3
-fedora27py3 name=quay.io/ansible/fedora27py3-test-container:1.4.0 python=3
+fedora28 name=quay.io/ansible/fedora28-test-container:1.5.0
 opensuse42.3 name=quay.io/ansible/opensuse42.3-test-container:1.4.0 seccomp=unconfined
 ubuntu1404 name=quay.io/ansible/ubuntu1404-test-container:1.4.0 seccomp=unconfined
 ubuntu1604 name=quay.io/ansible/ubuntu1604-test-container:1.4.0 seccomp=unconfined


### PR DESCRIPTION
##### SUMMARY
Swap the Fedora 24 host to 28 in Shippable hosts.

Fixes https://github.com/ansible/ansible/issues/48762

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test
