### PR TITLE
ansible-test: change Fedora 24, 25 to 28, 29 (#49586) - 2.6

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -50,8 +50,8 @@ matrix:
     - env: T=freebsd/11.1/1
     - env: T=linux/centos6/1
     - env: T=linux/centos7/1
-    - env: T=linux/fedora24/1
     - env: T=linux/fedora25/1
+    - env: T=linux/fedora28/1
     - env: T=linux/opensuse42.3/1
     - env: T=linux/ubuntu1404/1
     - env: T=linux/ubuntu1604/1
@@ -62,8 +62,8 @@ matrix:
     - env: T=freebsd/11.1/2
     - env: T=linux/centos6/2
     - env: T=linux/centos7/2
-    - env: T=linux/fedora24/2
     - env: T=linux/fedora25/2
+    - env: T=linux/fedora28/2
     - env: T=linux/opensuse42.3/2
     - env: T=linux/ubuntu1404/2
     - env: T=linux/ubuntu1604/2
@@ -74,8 +74,8 @@ matrix:
     - env: T=freebsd/11.1/3
     - env: T=linux/centos6/3
     - env: T=linux/centos7/3
-    - env: T=linux/fedora24/3
     - env: T=linux/fedora25/3
+    - env: T=linux/fedora28/3
     - env: T=linux/opensuse42.3/3
     - env: T=linux/ubuntu1404/3
     - env: T=linux/ubuntu1604/3

--- a/shippable.yml
+++ b/shippable.yml
@@ -50,8 +50,8 @@ matrix:
     - env: T=freebsd/11.1/1
     - env: T=linux/centos6/1
     - env: T=linux/centos7/1
-    - env: T=linux/fedora25/1
     - env: T=linux/fedora28/1
+    - env: T=linux/fedora29/1
     - env: T=linux/opensuse42.3/1
     - env: T=linux/ubuntu1404/1
     - env: T=linux/ubuntu1604/1
@@ -62,8 +62,8 @@ matrix:
     - env: T=freebsd/11.1/2
     - env: T=linux/centos6/2
     - env: T=linux/centos7/2
-    - env: T=linux/fedora25/2
     - env: T=linux/fedora28/2
+    - env: T=linux/fedora29/2
     - env: T=linux/opensuse42.3/2
     - env: T=linux/ubuntu1404/2
     - env: T=linux/ubuntu1604/2
@@ -74,8 +74,8 @@ matrix:
     - env: T=freebsd/11.1/3
     - env: T=linux/centos6/3
     - env: T=linux/centos7/3
-    - env: T=linux/fedora25/3
     - env: T=linux/fedora28/3
+    - env: T=linux/fedora29/3
     - env: T=linux/opensuse42.3/3
     - env: T=linux/ubuntu1404/3
     - env: T=linux/ubuntu1604/3

--- a/test/integration/targets/yum/tasks/main.yml
+++ b/test/integration/targets/yum/tasks/main.yml
@@ -47,6 +47,9 @@
   when:
     - ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux', 'Fedora']
     - ansible_python.version.major == 2
+    # yum in Fedora 28 is deprecated and does not support boolean (rich) dependencies used in the tests.
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1489315
+    - not (ansible_distribution == 'Fedora' and ansible_distribution_version == '28')
 
 - block:
     - include: 'repo.yml'
@@ -59,6 +62,9 @@
   when:
     - ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux', 'Fedora']
     - ansible_python.version.major == 2
+    # yum in Fedora 28 is deprecated and does not support boolean (rich) dependencies used in the tests.
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1489315
+    - not (ansible_distribution == 'Fedora' and ansible_distribution_version == '28')
 
 # We can't run yum --installroot tests on dnf systems.  Dnf systems revert to
 # yum-deprecated, and yum-deprecated refuses to run if yum.conf exists
@@ -76,3 +82,6 @@
   when:
     - (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version|int > 6) or ansible_distribution in ['Fedora']
     - ansible_python.version.major == 2
+    # yum in Fedora 28 is deprecated and does not support boolean (rich) dependencies used in the tests.
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1489315
+    - not (ansible_distribution == 'Fedora' and ansible_distribution_version == '28')

--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -1,10 +1,8 @@
 default name=quay.io/ansible/default-test-container:1.4.1 python=3
 centos6 name=quay.io/ansible/centos6-test-container:1.4.0 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.4.0 seccomp=unconfined
-fedora24 name=quay.io/ansible/fedora24-test-container:1.4.0 seccomp=unconfined
 fedora25 name=quay.io/ansible/fedora25-test-container:1.4.0 seccomp=unconfined
-fedora26py3 name=quay.io/ansible/fedora26py3-test-container:1.4.0 python=3
-fedora27py3 name=quay.io/ansible/fedora27py3-test-container:1.4.0 python=3
+fedora28 name=quay.io/ansible/fedora28-test-container:1.5.0
 opensuse42.3 name=quay.io/ansible/opensuse42.3-test-container:1.4.0 seccomp=unconfined
 ubuntu1404 name=quay.io/ansible/ubuntu1404-test-container:1.4.0 seccomp=unconfined
 ubuntu1604 name=quay.io/ansible/ubuntu1604-test-container:1.4.0 seccomp=unconfined

--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -1,8 +1,8 @@
 default name=quay.io/ansible/default-test-container:1.4.1 python=3
 centos6 name=quay.io/ansible/centos6-test-container:1.4.0 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.4.0 seccomp=unconfined
-fedora25 name=quay.io/ansible/fedora25-test-container:1.4.0 seccomp=unconfined
 fedora28 name=quay.io/ansible/fedora28-test-container:1.5.0
+fedora29 name=quay.io/ansible/fedora29-test-container:1.5.0 python=3
 opensuse42.3 name=quay.io/ansible/opensuse42.3-test-container:1.4.0 seccomp=unconfined
 ubuntu1404 name=quay.io/ansible/ubuntu1404-test-container:1.4.0 seccomp=unconfined
 ubuntu1604 name=quay.io/ansible/ubuntu1604-test-container:1.4.0 seccomp=unconfined

--- a/test/utils/shippable/linux.sh
+++ b/test/utils/shippable/linux.sh
@@ -15,4 +15,4 @@ fi
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
-    --docker "${image}"
+    --docker "${image}" --continue-on-error

--- a/test/utils/shippable/linux.sh
+++ b/test/utils/shippable/linux.sh
@@ -15,4 +15,4 @@ fi
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
-    --docker "${image}" --continue-on-error
+    --docker "${image}"


### PR DESCRIPTION
(cherry picked from commit 5392caee1445d9663c3f3416aa57b6bcb9fdc630)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/49586 and https://github.com/ansible/ansible/pull/49634

Things to do before merge

* ~Fix yum tests~ - skip tests due to yum being deprecated and not supporting rich dependencies which are used throughout the tests

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
ansible-test