### PR TITLE
new module lxca_cmms for Lenovo XClarity Administrator

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -305,6 +305,7 @@ files:
   $modules/remote_management/hpilo/: dagwieers haad
   $modules/remote_management/imc/: dagwieers
   $modules/remote_management/ipmi/: cloudnull
+  $modules/remote_management/lxca/: navalkp prabhosa
   $modules/remote_management/manageiq/: $team_manageiq
   $modules/remote_management/redfish/: $team_redfish
   $modules/remote_management/stacki/stacki_host.py: bbyhuy bsanders
@@ -619,6 +620,9 @@ files:
       - windows
   $module_utils/redfish_utils.py:
     maintainers: $team_redfish
+  $module_utils/remote_management/lxca:
+    maintainers: navalkp prabhosa
+    labels: lxca
   $module_utils/remote_management/ucs:
     maintainers: $team_ucs
     labels: ucs

--- a/lib/ansible/modules/remote_management/lxca/lxca_cmms.py
+++ b/lib/ansible/modules/remote_management/lxca/lxca_cmms.py
@@ -1,0 +1,177 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'supported_by': 'community',
+    'status': ['preview']
+}
+
+
+DOCUMENTATION = '''
+---
+version_added: "2.8"
+author:
+  - Naval Patel (@navalkp)
+  - Prashant Bhosale (@prabhosa)
+module: lxca_cmms
+short_description: Custom module for lxca cmms inventory utility
+description:
+  - This module returns/displays a inventory details of cmms
+
+options:
+  uuid:
+    description:
+      uuid of device, this is string with length greater than 16.
+
+  command_options:
+    description:
+      options to filter nodes information
+    default: cmms
+    choices:
+        - cmms
+        - cmms_by_uuid
+        - cmms_by_chassis_uuid
+
+  chassis:
+    description:
+      uuid of chassis, this is string with length greater than 16.
+
+extends_documentation_fragment:
+    - lxca_common
+'''
+
+EXAMPLES = '''
+# get all cmms info
+- name: get nodess data from LXCA
+  lxca_cmms:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+
+# get specific cmms info by uuid
+- name: get nodes data from LXCA
+  lxca_cmms:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+    uuid: "3C737AA5E31640CE949B10C129A8B01F"
+    command_options: cmms_by_uuid
+
+# get specific cmms info by chassis uuid
+- name: get nodes data from LXCA
+  lxca_cmms:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+    chassis: "3C737AA5E31640CE949B10C129A8B01F"
+    command_options: cmms_by_chassis_uuid
+
+'''
+
+RETURN = r'''
+result:
+    description: cmms detail from lxca
+    returned: always
+    type: dict
+    sample:
+      cmmList:
+        - machineType: ''
+          model: ''
+          type: 'CMM'
+          uuid: '118D2C88C8FD11E4947B6EAE8B4BDCDF'
+          # bunch of properties
+        - machineType: ''
+          model: ''
+          type: 'CMM'
+          uuid: '223D2C88C8FD11E4947B6EAE8B4BDCDF'
+          # bunch of properties
+        # Multiple cmms details
+'''
+
+import traceback
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.remote_management.lxca.common import LXCA_COMMON_ARGS, has_pylxca, connection_object
+try:
+    from pylxca import cmms
+except Exception:
+    pass
+
+
+UUID_REQUIRED = 'UUID of device is required for nodes_by_uuid command.'
+CHASSIS_UUID_REQUIRED = 'UUID of chassis is required for cmms_by_chassis_uuid command.'
+SUCCESS_MSG = "Success %s result"
+
+
+def _cmms(module, lxca_con):
+    return cmms(lxca_con)
+
+
+def _cmms_by_uuid(module, lxca_con):
+    if not module.params['uuid']:
+        module.fail_json(msg=UUID_REQUIRED)
+    return cmms(lxca_con, module.params['uuid'])
+
+
+def _cmms_by_chassis_uuid(module, lxca_con):
+    if not module.params['chassis']:
+        module.fail_json(msg=CHASSIS_UUID_REQUIRED)
+    return cmms(lxca_con, chassis=module.params['chassis'])
+
+
+def setup_module_object():
+    """
+    this function merge argument spec and create ansible module object
+    :return:
+    """
+    args_spec = dict(LXCA_COMMON_ARGS)
+    args_spec.update(INPUT_ARG_SPEC)
+    module = AnsibleModule(argument_spec=args_spec, supports_check_mode=False)
+
+    return module
+
+
+FUNC_DICT = {
+    'cmms': _cmms,
+    'cmms_by_uuid': _cmms_by_uuid,
+    'cmms_by_chassis_uuid': _cmms_by_chassis_uuid,
+}
+
+
+INPUT_ARG_SPEC = dict(
+    command_options=dict(default='cmms', choices=['cmms', 'cmms_by_uuid',
+                                                  'cmms_by_chassis_uuid']),
+    uuid=dict(default=None),
+    chassis=dict(default=None)
+)
+
+
+def execute_module(module):
+    """
+    This function invoke commands
+    :param module: Ansible module object
+    """
+    try:
+        with connection_object(module) as lxca_con:
+            result = FUNC_DICT[module.params['command_options']](module, lxca_con)
+            module.exit_json(changed=False,
+                             msg=SUCCESS_MSG % module.params['command_options'],
+                             result=result)
+    except Exception as exception:
+        error_msg = '; '.join((e) for e in exception.args)
+        module.fail_json(msg=error_msg, exception=traceback.format_exc())
+
+
+def main():
+    module = setup_module_object()
+    has_pylxca(module)
+    execute_module(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/lxca/lxca_cmms.py
+++ b/lib/ansible/modules/remote_management/lxca/lxca_cmms.py
@@ -99,11 +99,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.remote_management.lxca.common import LXCA_COMMON_ARGS, has_pylxca, connection_object
 try:
     from pylxca import cmms
-except Exception:
+except ImportError:
     pass
 
 
-UUID_REQUIRED = 'UUID of device is required for nodes_by_uuid command.'
+UUID_REQUIRED = 'UUID of device is required for cmms_by_uuid command.'
 CHASSIS_UUID_REQUIRED = 'UUID of chassis is required for cmms_by_chassis_uuid command.'
 SUCCESS_MSG = "Success %s result"
 

--- a/lib/ansible/modules/remote_management/lxca/lxca_cmms.py
+++ b/lib/ansible/modules/remote_management/lxca/lxca_cmms.py
@@ -77,7 +77,7 @@ EXAMPLES = '''
 RETURN = r'''
 result:
     description: cmms detail from lxca
-    returned: always
+    returned: success
     type: dict
     sample:
       cmmList:

--- a/test/units/modules/remote_management/lxca/test_lxca_cmms.py
+++ b/test/units/modules/remote_management/lxca/test_lxca_cmms.py
@@ -1,0 +1,98 @@
+import json
+
+import pytest
+from units.compat import mock
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible.modules.remote_management.lxca import lxca_cmms
+from ansible.module_utils.remote_management.lxca.common import setup_conn
+from ansible.module_utils.remote_management.lxca.common import close_conn
+
+
+@pytest.fixture(scope='module')
+@mock.patch("ansible.module_utils.remote_management.lxca.common.close_conn", autospec=True)
+def setup_module(close_conn):
+    close_conn.return_value = True
+
+
+class TestMyModule():
+    @pytest.mark.parametrize('patch_ansible_module',
+                             [
+                                 {},
+                                 {
+                                     "auth_url": "https://10.240.14.195",
+                                     "login_user": "USERID",
+                                 },
+                                 {
+                                     "auth_url": "https://10.240.14.195",
+                                     "login_password": "Password",
+                                 },
+                                 {
+                                     "login_user": "USERID",
+                                     "login_password": "Password",
+                                 },
+                             ],
+                             indirect=['patch_ansible_module'])
+    @pytest.mark.usefixtures('patch_ansible_module')
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_cmms.execute_module", autospec=True)
+    def test_without_required_parameters(self, _setup_conn, _execute_module,
+                                         mocker, capfd, setup_module):
+        """Failure must occurs when all parameters are missing"""
+        with pytest.raises(SystemExit):
+            _setup_conn.return_value = "Fake connection"
+            _execute_module.return_value = "Fake execution"
+            lxca_cmms.main()
+        out, err = capfd.readouterr()
+        results = json.loads(out)
+        assert results['failed']
+        assert 'missing required arguments' in results['msg']
+
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_cmms.execute_module", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_cmms.AnsibleModule", autospec=True)
+    def test__argument_spec(self, ansible_mod_cls, _execute_module, _setup_conn, setup_module):
+        expected_arguments_spec = dict(
+            login_user=dict(required=True),
+            login_password=dict(required=True, no_log=True),
+            command_options=dict(default='cmms', choices=['cmms', 'cmms_by_uuid',
+                                                          'cmms_by_chassis_uuid']),
+            auth_url=dict(required=True),
+            uuid=dict(default=None),
+            chassis=dict(default=None),
+        )
+        _setup_conn.return_value = "Fake connection"
+        _execute_module.return_value = []
+        mod_obj = ansible_mod_cls.return_value
+        args = {
+            "auth_url": "https://10.243.30.195",
+            "login_user": "USERID",
+            "login_password": "password",
+            "command_options": "cmms",
+        }
+        mod_obj.params = args
+        lxca_cmms.main()
+        assert(mock.call(argument_spec=expected_arguments_spec,
+                         supports_check_mode=False) == ansible_mod_cls.call_args)
+
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_cmms._cmms_by_uuid",
+                autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_cmms.AnsibleModule",
+                autospec=True)
+    def test__cmms_empty_list(self, ansible_mod_cls, _get_cmms, _setup_conn, setup_module):
+        mod_obj = ansible_mod_cls.return_value
+        args = {
+            "auth_url": "https://10.243.30.195",
+            "login_user": "USERID",
+            "login_password": "password",
+            "uuid": "3C737AA5E31640CE949B10C129A8B01F",
+            "command_options": "cmms_by_uuid",
+        }
+        mod_obj.params = args
+        _setup_conn.return_value = "Fake connection"
+        empty_nodes_list = []
+        _get_cmms.return_value = empty_nodes_list
+        ret_cmms = _get_cmms(mod_obj, args)
+        assert mock.call(mod_obj, mod_obj.params) == _get_cmms.call_args
+        assert _get_cmms.return_value == ret_cmms

--- a/test/units/modules/remote_management/lxca/test_lxca_cmms.py
+++ b/test/units/modules/remote_management/lxca/test_lxca_cmms.py
@@ -2,11 +2,7 @@ import json
 
 import pytest
 from units.compat import mock
-from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
 from ansible.modules.remote_management.lxca import lxca_cmms
-from ansible.module_utils.remote_management.lxca.common import setup_conn
-from ansible.module_utils.remote_management.lxca.common import close_conn
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
this module provide an interface to Lenovo XClarity Administrator. This module provides information about cmms
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lxca_cmms
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To get list of cmms by chassis uuid following playbook can be used
`---
- hosts: localhost
  connection: local
  tasks:
    - name: list cmms
      lxca_cmms:
        login_user: USERID
        login_password: CME44ibm
        auth_url: "https://10.243.9.238"
        chassis: "9FFE022D2E2E11E1BD0EA8A7A12531B6"
        command_options: cmms_by_chassis_uuid`
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

PLAY [localhost] *****************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [list cmms] *****************************************************************************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0   


```
