### PR TITLE
Update lambda documentation for runtimes

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -35,22 +35,23 @@ options:
     required: true
   state:
     description:
-      - Create or delete Lambda function
+      - Create or delete Lambda function.
     default: present
     choices: [ 'present', 'absent' ]
   runtime:
     description:
-      - The runtime environment for the Lambda function you are uploading. Required when creating a function. Use parameters as described in boto3 docs.
-        Current example runtime environments are nodejs, nodejs4.3, java8 or python2.7
-      - Required when C(state=present)
+      - The runtime environment for the Lambda function you are uploading.
+      - Required when creating a function. Uses parameters as described in boto3 docs.
+      - Required when C(state=present).
+      - For supported list of runtimes, see U(https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
   role:
     description:
       - The Amazon Resource Name (ARN) of the IAM role that Lambda assumes when it executes your function to access any other Amazon Web Services (AWS)
         resources. You may use the bare ARN if the role belongs to the same AWS account.
-      - Required when C(state=present)
+      - Required when C(state=present).
   handler:
     description:
-      - The function within your code that Lambda calls to begin execution
+      - The function within your code that Lambda calls to begin execution.
   zip_file:
     description:
       - A .zip file containing your deployment package
@@ -58,13 +59,13 @@ options:
     aliases: [ 'src' ]
   s3_bucket:
     description:
-      - Amazon S3 bucket name where the .zip file containing your deployment package is stored
+      - Amazon S3 bucket name where the .zip file containing your deployment package is stored.
       - If C(state=present) then either zip_file or s3_bucket must be present.
-      - s3_bucket and s3_key are required together
+      - C(s3_bucket) and C(s3_key) are required together.
   s3_key:
     description:
-      - The Amazon S3 object (the deployment package) key name you want to upload
-      - s3_bucket and s3_key are required together
+      - The Amazon S3 object (the deployment package) key name you want to upload.
+      - C(s3_bucket) and C(s3_key) are required together.
   s3_object_version:
     description:
       - The Amazon S3 object (the deployment package) version you want to upload.
@@ -77,7 +78,7 @@ options:
     default: 3
   memory_size:
     description:
-      - The amount of memory, in MB, your Lambda function is given
+      - The amount of memory, in MB, your Lambda function is given.
     default: 128
   vpc_subnet_ids:
     description:
@@ -97,7 +98,7 @@ options:
     version_added: "2.3"
   tags:
     description:
-      - tag dict to apply to the function (requires botocore 1.5.40 or above)
+      - tag dict to apply to the function (requires botocore 1.5.40 or above).
     version_added: "2.5"
 author:
     - 'Steyn Huizinga (@steynovich)'
@@ -217,7 +218,7 @@ def get_account_id(module, region=None, endpoint=None, **aws_connect_kwargs):
 
     get_account_id tries too find out the account that we are working
     on.  It's not guaranteed that this will be easy so we try in
-    several different ways.  Giving either IAM or STS privilages to
+    several different ways.  Giving either IAM or STS privileges to
     the account should be enough to permit this.
     """
     account_id = None


### PR DESCRIPTION
##### SUMMARY
There is no API or AWS command to list down latest available
runtimes. Updated documentation with AWS official lambda docs.

Fixes: #49552

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/lambda.py