### PR TITLE
Use blkid instead of udevadm when lsblk < 2.33 to gather fs uuids

### DIFF
--- a/test/units/module_utils/facts/hardware/linux_data.py
+++ b/test/units/module_utils/facts/hardware/linux_data.py
@@ -47,26 +47,10 @@ LSBLK_OUTPUT_2 = b"""
 
 LSBLK_UUIDS = {'/dev/sda1': '66Ojcd-ULtu-1cZa-Tywo-mx0d-RF4O-ysA9jK'}
 
-UDEVADM_UUID = 'N/A'
+BLKID_UUID = 'N/A'
 
-UDEVADM_OUTPUT = """
-UDEV_LOG=3
-DEVPATH=/devices/pci0000:00/0000:00:07.0/virtio2/block/vda/vda1
-MAJOR=252
-MINOR=1
-DEVNAME=/dev/vda1
-DEVTYPE=partition
-SUBSYSTEM=block
-MPATH_SBIN_PATH=/sbin
-ID_PATH=pci-0000:00:07.0-virtio-pci-virtio2
-ID_PART_TABLE_TYPE=dos
-ID_FS_UUID=57b1a3e7-9019-4747-9809-7ec52bba9179
-ID_FS_UUID_ENC=57b1a3e7-9019-4747-9809-7ec52bba9179
-ID_FS_VERSION=1.0
-ID_FS_TYPE=ext4
-ID_FS_USAGE=filesystem
-LVM_SBIN_PATH=/sbin
-DEVLINKS=/dev/block/252:1 /dev/disk/by-path/pci-0000:00:07.0-virtio-pci-virtio2-part1 /dev/disk/by-uuid/57b1a3e7-9019-4747-9809-7ec52bba9179
+BLKID_OUTPUT = """
+57b1a3e7-9019-4747-9809-7ec52bba9179
 """
 
 MTAB = """

--- a/test/units/module_utils/facts/hardware/test_linux.py
+++ b/test/units/module_utils/facts/hardware/test_linux.py
@@ -25,7 +25,7 @@ from ansible.module_utils.facts import timeout
 
 from ansible.module_utils.facts.hardware import linux
 
-from . linux_data import LSBLK_OUTPUT, LSBLK_OUTPUT_2, LSBLK_UUIDS, MTAB, MTAB_ENTRIES, BIND_MOUNTS, STATVFS_INFO, UDEVADM_UUID, UDEVADM_OUTPUT
+from . linux_data import LSBLK_OUTPUT, LSBLK_OUTPUT_2, LSBLK_UUIDS, MTAB, MTAB_ENTRIES, BIND_MOUNTS, STATVFS_INFO, BLKID_UUID, BLKID_OUTPUT
 
 with open(os.path.join(os.path.dirname(__file__), '../fixtures/findmount_output.txt')) as f:
     FINDMNT_OUTPUT = f.read()
@@ -50,13 +50,13 @@ class TestFactsLinuxHardwareGetMountFacts(unittest.TestCase):
     @patch('ansible.module_utils.facts.hardware.linux.LinuxHardware._find_bind_mounts', return_value=BIND_MOUNTS)
     @patch('ansible.module_utils.facts.hardware.linux.LinuxHardware._lsblk_uuid', return_value=LSBLK_UUIDS)
     @patch('ansible.module_utils.facts.hardware.linux.get_mount_size', side_effect=mock_get_mount_size)
-    @patch('ansible.module_utils.facts.hardware.linux.LinuxHardware._udevadm_uuid', return_value=UDEVADM_UUID)
+    @patch('ansible.module_utils.facts.hardware.linux.LinuxHardware._blkid_uuid', return_value=BLKID_UUID)
     def test_get_mount_facts(self,
                              mock_get_mount_size,
                              mock_lsblk_uuid,
                              mock_find_bind_mounts,
                              mock_mtab_entries,
-                             mock_udevadm_uuid):
+                             mock_blkid_uuid):
         module = Mock()
         # Returns a LinuxHardware-ish
         lh = linux.LinuxHardware(module=module, load_on_init=False)
@@ -165,10 +165,10 @@ class TestFactsLinuxHardwareGetMountFacts(unittest.TestCase):
         self.assertEqual(lsblk_uuids[b'/dev/mapper/an-example-mapper with a space in the name'], b'84639acb-013f-4d2f-9392-526a572b4373')
         self.assertEqual(lsblk_uuids[b'/dev/sda1'], b'32caaec3-ef40-4691-a3b6-438c3f9bc1c0')
 
-    def test_udevadm_uuid(self):
+    def test_blkid_uuid(self):
         module = Mock()
-        module.run_command = Mock(return_value=(0, UDEVADM_OUTPUT, ''))  # (rc, out, err)
+        module.run_command = Mock(return_value=(0, BLKID_OUTPUT, ''))  # (rc, out, err)
         lh = linux.LinuxHardware(module=module, load_on_init=False)
-        udevadm_uuid = lh._udevadm_uuid('mock_device')
+        blkid_uuid = lh._blkid_uuid('mock_device')
 
-        self.assertEqual(udevadm_uuid, '57b1a3e7-9019-4747-9809-7ec52bba9179')
+        self.assertEqual(blkid_uuid, '57b1a3e7-9019-4747-9809-7ec52bba9179')

--- a/test/units/module_utils/facts/test_facts.py
+++ b/test/units/module_utils/facts/test_facts.py
@@ -265,7 +265,7 @@ LSBLK_OUTPUT_2 = b"""
 
 LSBLK_UUIDS = {'/dev/sda1': '66Ojcd-ULtu-1cZa-Tywo-mx0d-RF4O-ysA9jK'}
 
-UDEVADM_UUID = 'N/A'
+BLKID_UUID = 'N/A'
 
 MTAB = """
 sysfs /sys sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0
@@ -538,12 +538,12 @@ class TestFactsLinuxHardwareGetMountFacts(unittest.TestCase):
     @patch('ansible.module_utils.facts.hardware.linux.LinuxHardware._mtab_entries', return_value=MTAB_ENTRIES)
     @patch('ansible.module_utils.facts.hardware.linux.LinuxHardware._find_bind_mounts', return_value=BIND_MOUNTS)
     @patch('ansible.module_utils.facts.hardware.linux.LinuxHardware._lsblk_uuid', return_value=LSBLK_UUIDS)
-    @patch('ansible.module_utils.facts.hardware.linux.LinuxHardware._udevadm_uuid', return_value=UDEVADM_UUID)
+    @patch('ansible.module_utils.facts.hardware.linux.LinuxHardware._blkid_uuid', return_value=BLKID_UUID)
     def test_get_mount_facts(self,
                              mock_lsblk_uuid,
                              mock_find_bind_mounts,
                              mock_mtab_entries,
-                             mock_udevadm_uuid):
+                             mock_blkid_uuid):
         module = Mock()
         # Returns a LinuxHardware-ish
         lh = hardware.linux.LinuxHardware(module=module, load_on_init=False)


### PR DESCRIPTION
##### SUMMARY
Sometimes udevadm takes more than 10 seconds to gather the device
informations, causing facts gathering to hit the default timeout.

This change tries to fix #43884 by replacing use of udevadm with
blkid, which collects a lot less informations but still provides
for a fs-independent way to gather a fs uuid.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils