### PR TITLE
Fix google auth scoping for unscoped credentials (#46740)

### DIFF
--- a/changelogs/fragments/46740-gcp-utils-credentials-scoping.yaml
+++ b/changelogs/fragments/46740-gcp-utils-credentials-scoping.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "gcp_utils - fix google auth scoping issue with application default credentials or google cloud engine credentials. Only scope credentials that can be scoped."

--- a/lib/ansible/module_utils/gcp_utils.py
+++ b/lib/ansible/module_utils/gcp_utils.py
@@ -103,8 +103,7 @@ class GcpSession(object):
             self.module.fail_json(msg=inst.message)
 
     def session(self):
-        return AuthorizedSession(
-            self._credentials().with_scopes(self.module.params['scopes']))
+        return AuthorizedSession(self._credentials())
 
     def _validate(self):
         if not HAS_REQUESTS:
@@ -126,11 +125,11 @@ class GcpSession(object):
     def _credentials(self):
         cred_type = self.module.params['auth_kind']
         if cred_type == 'application':
-            credentials, project_id = google.auth.default()
+            credentials, project_id = google.auth.default(scopes=self.module.params['scopes'])
             return credentials
         elif cred_type == 'serviceaccount':
             path = os.path.realpath(os.path.expanduser(self.module.params['service_account_file']))
-            return service_account.Credentials.from_service_account_file(path)
+            return service_account.Credentials.from_service_account_file(path).with_scopes(self.module.params['scopes'])
         elif cred_type == 'machineaccount':
             return google.auth.compute_engine.Credentials(
                 self.module.params['service_account_email'])


### PR DESCRIPTION
* Fix google auth scoping for unscoped credentials

* Add changelog fragment

(cherry picked from commit c8ecac8dc21de19769be030eaf3222cd0f6f420e)

##### SUMMARY
see https://github.com/ansible/ansible/pull/46740

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
gcp_compute inventory (module_utils)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
