### PR TITLE
Print hostname when fails to generate keyed groups

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -343,7 +343,7 @@ class Constructable(object):
                         key = self._compose(keyed.get('key'), variables)
                     except Exception as e:
                         if strict:
-                            raise AnsibleParserError("Could not generate group from %s entry: %s" % (keyed.get('key'), to_native(e)))
+                            raise AnsibleParserError("Could not generate group for host %s from %s entry: %s" % (host, keyed.get('key'), to_native(e)))
                         continue
 
                     if key:


### PR DESCRIPTION
##### SUMMARY

This is a trivial update in a logging message to print the *hostname* when there is an error generating a group using *keyed_groups*.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/inventory/__init__.py
