### PR TITLE
replace math round with ceiling for ansible_memtotal_mb + add new variables to display swapfile config

### DIFF
--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -298,7 +298,7 @@ if($gather_subset.Contains('memory')) {
     $win32_os = Get-LazyCimInstance Win32_OperatingSystem
     $ansible_facts += @{
         # Win32_PhysicalMemory is empty on some virtual platforms
-        ansible_memtotal_mb = ([math]::round($win32_cs.TotalPhysicalMemory / 1024 / 1024))
+        ansible_memtotal_mb = ([math]::ceiling($win32_cs.TotalPhysicalMemory / 1024 / 1024))
         ansible_swaptotal_mb = ([math]::round($win32_os.TotalSwapSpaceSize / 1024 / 1024))
     }
 }

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -300,7 +300,7 @@ if($gather_subset.Contains('memory')) {
     $ansible_facts += @{
         # Win32_PhysicalMemory is empty on some virtual platforms
         ansible_memtotal_mb = ([math]::ceiling($win32_cs.TotalPhysicalMemory / 1024 / 1024))
-	ansible_swaptotal_mb = ([math]::round($win32_os.TotalSwapSpaceSize / 1024))
+        ansible_swaptotal_mb = ([math]::round($win32_os.TotalSwapSpaceSize / 1024))
         ansible_memtotal = $win32_cs.TotalPhysicalMemory
         ansible_swap_min = $win32_pf.InitialSize * 1024 * 1024
         ansible_swap_max = $win32_pf.MaximumSize * 1024 * 1024

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -295,10 +295,12 @@ if ($gather_subset.Contains("local") -and $factpath -ne $null) {
 
 if($gather_subset.Contains('memory')) {
     $win32_cs = Get-LazyCimInstance Win32_ComputerSystem
+    $win32_os = Get-LazyCimInstance Win32_OperatingSystem
     $win32_pf = Get-LazyCimInstance Win32_PageFileSetting
     $ansible_facts += @{
         # Win32_PhysicalMemory is empty on some virtual platforms
         ansible_memtotal_mb = ([math]::ceiling($win32_cs.TotalPhysicalMemory / 1024 / 1024))
+	ansible_swaptotal_mb = ([math]::round($win32_os.TotalSwapSpaceSize / 1024))
         ansible_memtotal = $win32_cs.TotalPhysicalMemory
         ansible_swap_min = $win32_pf.InitialSize * 1024 * 1024
         ansible_swap_max = $win32_pf.MaximumSize * 1024 * 1024

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -295,14 +295,15 @@ if ($gather_subset.Contains("local") -and $factpath -ne $null) {
 
 if($gather_subset.Contains('memory')) {
     $win32_cs = Get-LazyCimInstance Win32_ComputerSystem
-    $win32_os = Get-LazyCimInstance Win32_OperatingSystem
+    $win32_pf = Get-LazyCimInstance Win32_PageFileSetting
     $ansible_facts += @{
         # Win32_PhysicalMemory is empty on some virtual platforms
         ansible_memtotal_mb = ([math]::ceiling($win32_cs.TotalPhysicalMemory / 1024 / 1024))
-        ansible_swaptotal_mb = ([math]::round($win32_os.TotalSwapSpaceSize / 1024 / 1024))
+        ansible_memtotal = $win32_cs.TotalPhysicalMemory
+        ansible_swap_min = $win32_pf.InitialSize
+        ansible_swap_max = $win32_pf.MaximumSize
     }
 }
-
 
 if($gather_subset.Contains('platform')) {
     $win32_cs = Get-LazyCimInstance Win32_ComputerSystem

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -300,8 +300,8 @@ if($gather_subset.Contains('memory')) {
         # Win32_PhysicalMemory is empty on some virtual platforms
         ansible_memtotal_mb = ([math]::ceiling($win32_cs.TotalPhysicalMemory / 1024 / 1024))
         ansible_memtotal = $win32_cs.TotalPhysicalMemory
-        ansible_swap_min = $win32_pf.InitialSize
-        ansible_swap_max = $win32_pf.MaximumSize
+        ansible_swap_min = $win32_pf.InitialSize * 1024 * 1024
+        ansible_swap_max = $win32_pf.MaximumSize * 1024 * 1024
     }
 }
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The Powershell command behind the ansible_memtotal_mb uses a math round of the TotalPhysicalMemory, but it's always rounding the value down.
Because of this, a server with 2GB for example reports 2047MB memotal_mb.
This PR replaces the `round` method with `ceiling` so the actual value is reported by ansible_memtotal_mb.

Fixes #49608 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
./lib/ansible/modules/windows/setup.ps1

