### PR TITLE
add "save_when" to ios_banner

### DIFF
--- a/lib/ansible/modules/network/ios/ios_banner.py
+++ b/lib/ansible/modules/network/ios/ios_banner.py
@@ -15,12 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'network'}
-
-
 DOCUMENTATION = """
 ---
 module: ios_banner
@@ -52,8 +49,24 @@ options:
         present in the current devices active running configuration.
     default: present
     choices: ['present', 'absent']
+  save_when:
+    description:
+      - When changes are made to the device running-configuration, the
+        changes are not copied to non-volatile storage by default.  Using
+        this argument will change that before.  If the argument is set to
+        I(always), then the running-config will always be copied to the
+        startup-config and the I(modified) flag will always be set to
+        True.  If the argument is set to I(modified), then the running-config
+        will only be copied to the startup-config if it has changed since
+        the last save to startup-config.  If the argument is set to
+        I(never), the running-config will never be copied to the
+        startup-config.  If the argument is set to I(changed), then the running-config
+        will only be copied to the startup-config if the task has made a change.
+        I(changed) was added in Ansible 2.8.
+    default: never
+    choices: ['always', 'never', 'modified', 'changed']
+    version_added: "2.8"
 """
-
 EXAMPLES = """
 - name: configure the login banner
   ios_banner:
@@ -63,20 +76,17 @@ EXAMPLES = """
       that contains a multiline
       string
     state: present
-
 - name: remove the motd banner
   ios_banner:
     banner: motd
     state: absent
-
+    save_when: modified
 - name: Configure banner from file
   ios_banner:
     banner:  motd
     text: "{{ lookup('file', './config_partial/raw_banner.cfg') }}"
     state: present
-
 """
-
 RETURN = """
 commands:
   description: The list of configuration mode commands to send to the device
@@ -94,16 +104,12 @@ from ansible.module_utils.network.ios.ios import load_config, run_commands
 from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
 from ansible.module_utils.network.common.config import NetworkConfig
 import re
-
-
 def map_obj_to_commands(updates, module):
     commands = list()
     want, have = updates
     state = module.params['state']
-
     if state == 'absent' and 'text' in have.keys() and have['text']:
         commands.append('no banner %s' % module.params['banner'])
-
     elif state == 'present':
         if want['text'] and (want['text'] != have.get('text')):
             banner_cmd = 'banner %s' % module.params['banner']
@@ -111,10 +117,7 @@ def map_obj_to_commands(updates, module):
             banner_cmd += want['text'].strip()
             banner_cmd += '\n@'
             commands.append(banner_cmd)
-
     return commands
-
-
 def map_config_to_obj(module):
     rc, out, err = exec_command(module, 'show banner %s' % module.params['banner'])
     if rc == 0:
@@ -132,19 +135,15 @@ def map_config_to_obj(module):
         obj['text'] = output
         obj['state'] = 'present'
     return obj
-
-
 def map_params_to_obj(module):
     text = module.params['text']
     if text:
         text = str(text).strip()
-
     return {
         'banner': module.params['banner'],
         'text': text,
         'state': module.params['state']
     }
-
 def save_config(module, result):
     result['changed'] = True
     if not module.check_mode:
@@ -153,7 +152,6 @@ def save_config(module, result):
         module.warn('Skipping command `copy running-config startup-config` '
                     'due to check_mode.  Configuration not copied to '
                     'non-volatile storage')
-
 def main():
     """ main entry point for module execution
     """
@@ -161,49 +159,39 @@ def main():
         banner=dict(required=True, choices=['login', 'motd', 'exec', 'incoming', 'slip-ppp']),
         text=dict(),
         state=dict(default='present', choices=['present', 'absent']),
-        save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never')
+        save_when=dict(default='never', choices=['always', 'never', 'modified', 'changed'])
     )
-
     argument_spec.update(ios_argument_spec)
-
     required_if = [('state', 'present', ('text',))]
-
     module = AnsibleModule(argument_spec=argument_spec,
                            required_if=required_if,
                            supports_check_mode=True)
-      
+
     warnings = list()
     check_args(module, warnings)
-
     result = {'changed': False}
     if warnings:
         result['warnings'] = warnings
     want = map_params_to_obj(module)
     have = map_config_to_obj(module)
-
     commands = map_obj_to_commands((want, have), module)
     result['commands'] = commands
-
     if commands:
         if not module.check_mode:
             response = load_config(module, commands)
-
         result['changed'] = True
-      
-    if module.params['save_when'] == 'always' or module.params['save']:
+
+    if module.params['save_when'] == 'always':
         save_config(module, result)
     elif module.params['save_when'] == 'modified':
         output = run_commands(module, ['show running-config', 'show startup-config'])
-
         running_config = NetworkConfig(indent=1, contents=output[0])
         startup_config = NetworkConfig(indent=1, contents=output[1])
-
         if running_config.sha1 != startup_config.sha1:
             save_config(module, result)
     elif module.params['save_when'] == 'changed' and result['changed']:
         save_config(module, result)
-      
-    module.exit_json(**result)
 
+    module.exit_json(**result)
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/ios/ios_banner.py
+++ b/lib/ansible/modules/network/ios/ios_banner.py
@@ -104,6 +104,8 @@ from ansible.module_utils.network.ios.ios import load_config, run_commands
 from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
 from ansible.module_utils.network.common.config import NetworkConfig
 import re
+
+
 def map_obj_to_commands(updates, module):
     commands = list()
     want, have = updates
@@ -118,6 +120,8 @@ def map_obj_to_commands(updates, module):
             banner_cmd += '\n@'
             commands.append(banner_cmd)
     return commands
+
+  
 def map_config_to_obj(module):
     rc, out, err = exec_command(module, 'show banner %s' % module.params['banner'])
     if rc == 0:
@@ -135,6 +139,8 @@ def map_config_to_obj(module):
         obj['text'] = output
         obj['state'] = 'present'
     return obj
+  
+  
 def map_params_to_obj(module):
     text = module.params['text']
     if text:
@@ -144,6 +150,8 @@ def map_params_to_obj(module):
         'text': text,
         'state': module.params['state']
     }
+  
+  
 def save_config(module, result):
     result['changed'] = True
     if not module.check_mode:
@@ -152,6 +160,8 @@ def save_config(module, result):
         module.warn('Skipping command `copy running-config startup-config` '
                     'due to check_mode.  Configuration not copied to '
                     'non-volatile storage')
+        
+        
 def main():
     """ main entry point for module execution
     """
@@ -193,5 +203,7 @@ def main():
         save_config(module, result)
 
     module.exit_json(**result)
+    
+    
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/ios/ios_banner.py
+++ b/lib/ansible/modules/network/ios/ios_banner.py
@@ -160,7 +160,7 @@ def main():
     argument_spec = dict(
         banner=dict(required=True, choices=['login', 'motd', 'exec', 'incoming', 'slip-ppp']),
         text=dict(),
-        state=dict(default='present', choices=['present', 'absent'],
+        state=dict(default='present', choices=['present', 'absent']),
         save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never')
     )
 

--- a/lib/ansible/modules/network/ios/ios_banner.py
+++ b/lib/ansible/modules/network/ios/ios_banner.py
@@ -121,7 +121,7 @@ def map_obj_to_commands(updates, module):
             commands.append(banner_cmd)
     return commands
 
-  
+
 def map_config_to_obj(module):
     rc, out, err = exec_command(module, 'show banner %s' % module.params['banner'])
     if rc == 0:
@@ -139,8 +139,8 @@ def map_config_to_obj(module):
         obj['text'] = output
         obj['state'] = 'present'
     return obj
-  
-  
+
+
 def map_params_to_obj(module):
     text = module.params['text']
     if text:
@@ -150,8 +150,8 @@ def map_params_to_obj(module):
         'text': text,
         'state': module.params['state']
     }
-  
-  
+
+
 def save_config(module, result):
     result['changed'] = True
     if not module.check_mode:
@@ -160,8 +160,8 @@ def save_config(module, result):
         module.warn('Skipping command `copy running-config startup-config` '
                     'due to check_mode.  Configuration not copied to '
                     'non-volatile storage')
-        
-        
+
+
 def main():
     """ main entry point for module execution
     """
@@ -203,7 +203,7 @@ def main():
         save_config(module, result)
 
     module.exit_json(**result)
-    
-    
+
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY

I have add "save_when" functionality, taken from ios_config. However ios_banner arguments need to be updated. I have tried to reverse engineering the code to understand where the argument list has to be updated but I could not find the bottom of it
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_banner