### PR TITLE
backport/2.7/49597 doc: fix 'ansible-config' link

### DIFF
--- a/docs/templates/config.rst.j2
+++ b/docs/templates/config.rst.j2
@@ -11,7 +11,7 @@
 Ansible supports a few ways of providing configuration variables, mainly through environment variables, command line switches and an ini file named ``ansible.cfg``.
 
 Starting at Ansible 2.4 the ``ansible-config`` utility allows users to see all the configuration settings available, their defaults, how to set them and
-where their current value comes from. See :doc:ansible-config for more information.
+where their current value comes from. See :ref:`ansible-config` for more information.
 
 .. _ansible_configuration_settings_locations:
 


### PR DESCRIPTION
##### SUMMARY
Backport of #49597.

Fix `ansible-config` [link](https://docs.ansible.com/ansible/devel/cli/ansible-config.html)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
doc

##### ADDITIONAL INFORMATION
It seems ```:doc:`</cli/ansible-config>` ``` can be used too, I prefer ```:ref:`ansible-config` ``` which doesn't reference a path.

Screenshot of the updated page (documentation generated using `make alldocs`):
![screenshot_2018-12-06_12-11-25](https://user-images.githubusercontent.com/1356830/49580831-2fd52d80-f950-11e8-9fbb-a0f5d23a1c9f.png)