### PR TITLE
[stable-2.7] Make squash deprecation messages less misleading (#49551)

### DIFF
--- a/changelogs/fragments/squash-deprecation-message.yml
+++ b/changelogs/fragments/squash-deprecation-message.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Improve the deprecation message for squashing, to not give misleading advice

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import re
 import pty
 import time
 import json
@@ -417,10 +418,18 @@ class TaskExecutor:
                         # name/pkg or the name/pkg field doesn't have any variables
                         # and thus the items can't be squashed
                         if template_no_item != template_with_item:
+                            if self._task.loop_with and self._task.loop_with not in ('items', 'list'):
+                                value_text = "\"{{ query('%s', %r) }}\"" % (self._task.loop_with, self._task.loop)
+                            else:
+                                value_text = '%r' % self._task.loop
+                            # Without knowing the data structure well, it's easiest to strip python2 unicode
+                            # literals after stringifying
+                            value_text = re.sub(r"\bu'", "'", value_text)
+
                             display.deprecated(
                                 'Invoking "%s" only once while using a loop via squash_actions is deprecated. '
-                                'Instead of using a loop to supply multiple items and specifying `%s: %s`, '
-                                'please use `%s: %r` and remove the loop' % (self._task.action, found, name, found, self._task.loop),
+                                'Instead of using a loop to supply multiple items and specifying `%s: "%s"`, '
+                                'please use `%s: %s` and remove the loop' % (self._task.action, found, name, found, value_text),
                                 version='2.11'
                             )
                             for item in items:


### PR DESCRIPTION
(cherry picked from commit 69d230f)


Co-authored-by: Matt Martz <matt@sivel.net>