### PR TITLE
Clean up some roadmap dates

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_1.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_1.rst
@@ -1,7 +1,7 @@
 ===========
 Ansible 2.1
 ===========
-**Target: April**
+**Target: April 2016**
 
 .. contents:: Topics
 

--- a/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_6.rst
@@ -20,10 +20,6 @@ Actual
 - 2018-06-18 Release Candidate 3
 - 2018-06-25 Release Candidate 4
 - 2018-06-26 Release Candidate 5
-
-Expected
-========
-
 - 2018-06-28 Final Release
 
 


### PR DESCRIPTION
##### SUMMARY
- Add year to the 2.1 roadmap target.
- Move 2.6 final release from expected to actual timeline. As expected, [v2.6.0](https://github.com/ansible/ansible/releases/tag/v2.6.0) was tagged Jun 28.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Docs, roadmap
