### PR TITLE
pip tests: skip distribute test case for py3 compat

### DIFF
--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -501,25 +501,28 @@
     state: absent
 
 # https://github.com/ansible/ansible/issues/47198
-- name: make sure the virtualenv does not exist
-  file:
-    state: absent
-    name: "{{ output_dir }}/pipenv"
+# distribute is a legacy package that will fail on newer Python 3 versions
+- block:
+  - name: make sure the virtualenv does not exist
+    file:
+      state: absent
+      name: "{{ output_dir }}/pipenv"
 
-- name: install distribute in the virtualenv
-  pip:
-    name: distribute
-    virtualenv: "{{ output_dir }}/pipenv"
-    state: present
+  - name: install distribute in the virtualenv
+    pip:
+      name: distribute
+      virtualenv: "{{ output_dir }}/pipenv"
+      state: present
 
-- name: try to remove distribute
-  pip:
-    state: "absent"
-    name: "distribute"
-    virtualenv: "{{ output_dir }}/pipenv"
-  ignore_errors: yes
-  register: remove_distribute
+  - name: try to remove distribute
+    pip:
+      state: "absent"
+      name: "distribute"
+      virtualenv: "{{ output_dir }}/pipenv"
+    ignore_errors: yes
+    register: remove_distribute
 
-- name: inspect the cmd
-  assert:
-    that: "'distribute' in remove_distribute.cmd"
+  - name: inspect the cmd
+    assert:
+      that: "'distribute' in remove_distribute.cmd"
+  when: ansible_python.version.major == 2


### PR DESCRIPTION
##### SUMMARY
Only run the distribute tests on older versions of Python. The distribute package is classified for Python 2, <= 3.3 so we just skip this on all Python 3 versions.

Relates to https://github.com/ansible/ansible/pull/47403

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pip