### PR TITLE
Reboot - Fix VMware ESXi not working by adding appropriate commands

### DIFF
--- a/changelogs/fragments/reboot-vmware-esxi.yaml
+++ b/changelogs/fragments/reboot-vmware-esxi.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - reboot - add appropriate commands to make the plugin work with VMware ESXi (https://github.com/ansible/ansible/issues/48425)

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -45,10 +45,12 @@ class ActionModule(ActionBase):
         'macosx': 'who -b',
         'solaris': 'who -b',
         'sunos': 'who -b',
+        'vmkernel': 'grep booted /var/log/vmksummary.log | tail -n 1',
     }
 
     SHUTDOWN_COMMANDS = {
         'alpine': 'reboot',
+        'vmkernel': 'reboot',
     }
 
     SHUTDOWN_COMMAND_ARGS = {
@@ -59,10 +61,12 @@ class ActionModule(ActionBase):
         'openbsd': '-r +{delay_min} "{message}"',
         'solaris': '-y -g {delay_sec} -i 6 "{message}"',
         'sunos': '-y -g {delay_sec} -i 6 "{message}"',
+        'vmkernel': '-d {delay_sec}',
     }
 
     TEST_COMMANDS = {
-        'solaris': 'who'
+        'solaris': 'who',
+        'vmkernel': 'who',
     }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
##### SUMMARY
VMware ESXi uses different commands for checking last boot time, uptime, and validation after reboot. This PR adds the appropriate commands and arguments.

Fixes #48425
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`reboot.py`

##### ADDITIONAL INFORMATION

This is based off of #49272 and will need to be rebased after that PR is merged.

Tested with ESXi 6.7.0