### PR TITLE
new module Lxca chassis for Lenovo XClarity Administrator

### DIFF
--- a/lib/ansible/modules/remote_management/lxca/lxca_chassis.py
+++ b/lib/ansible/modules/remote_management/lxca/lxca_chassis.py
@@ -85,14 +85,14 @@ result:
     type: dict
     sample:
       chassisList:
-        - machineType: ''
-          model: ''
-          type: 'Rack-TowerServer'
+        - machineType: '8721'
+          model: 'HC1'
+          type: 'chassis'
           uuid: '118D2C88C8FD11E4947B6EAE8B4BDCDF'
           # bunch of properties
-        - machineType: ''
-          model: ''
-          type: 'Rack-TowerServer'
+        - machineType: '8721'
+          model: 'HC1'
+          type: 'chassis'
           uuid: '223D2C88C8FD11E4947B6EAE8B4BDCDF'
           # bunch of properties
         # Multiple chassis details

--- a/lib/ansible/modules/remote_management/lxca/lxca_chassis.py
+++ b/lib/ansible/modules/remote_management/lxca/lxca_chassis.py
@@ -1,0 +1,184 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'supported_by': 'community',
+    'status': ['preview']
+}
+
+
+DOCUMENTATION = '''
+---
+version_added: "2.8"
+author:
+  - Naval Patel (@navalkp)
+  - Prashant Bhosale (@prabhosa)
+module: lxca_chassis
+short_description: Custom module for lxca chassis inventory utility
+description:
+  - This module returns/displays a inventory details of chassis
+
+options:
+  uuid:
+    description:
+      uuid of device, this is string with length greater than 16.
+
+  command_options:
+    description:
+      options to filter chassis information
+    default: chassis
+    choices:
+        - chassis
+        - chassis_by_uuid
+        - chassis_status_managed
+        - chassis_status_unmanaged
+
+extends_documentation_fragment:
+    - lxca_common
+'''
+
+EXAMPLES = '''
+# get all chassis info
+- name: get chassis data from LXCA
+  lxca_chassis:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+
+# get specific chassis info by uuid
+- name: get chassis data from LXCA
+  lxca_chassis:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+    uuid: "3C737AA5E31640CE949B10C129A8B01F"
+    command_options: chassis_by_uuid
+
+# get managed chassis
+- name: get chassis data from LXCA
+  lxca_chassis:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+    command_options: chassis_status_managed
+
+# get unmanaged chassis
+- name: get chassis data from LXCA
+  lxca_chassis:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+    command_options: chassis_status_managed
+
+'''
+
+RETURN = r'''
+result:
+    description: chassis detail from lxca
+    returned: always
+    type: dict
+    sample:
+      chassisList:
+        - machineType: ''
+          model: ''
+          type: 'Rack-TowerServer'
+          uuid: '118D2C88C8FD11E4947B6EAE8B4BDCDF'
+          # bunch of properties
+        - machineType: ''
+          model: ''
+          type: 'Rack-TowerServer'
+          uuid: '223D2C88C8FD11E4947B6EAE8B4BDCDF'
+          # bunch of properties
+        # Multiple chassis details
+'''
+
+import traceback
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.remote_management.lxca.common import LXCA_COMMON_ARGS, has_pylxca, connection_object
+try:
+    from pylxca import chassis
+except ImportError:
+    pass
+
+
+UUID_REQUIRED = 'UUID of device is required for chassis_by_uuid command.'
+SUCCESS_MSG = "Success %s result"
+
+
+def _chassis(module, lxca_con):
+    return chassis(lxca_con)
+
+
+def _chassis_by_uuid(module, lxca_con):
+    if not module.params['uuid']:
+        module.fail_json(msg=UUID_REQUIRED)
+    return chassis(lxca_con, module.params['uuid'])
+
+
+def _chassis_status_managed(module, lxca_con):
+    return chassis(lxca_con, status='managed')
+
+
+def _chassis_status_unmanaged(module, lxca_con):
+    return chassis(lxca_con, status='unmanaged')
+
+
+def setup_module_object():
+    """
+    this function merge argument spec and create ansible module object
+    :return:
+    """
+    args_spec = dict(LXCA_COMMON_ARGS)
+    args_spec.update(INPUT_ARG_SPEC)
+    module = AnsibleModule(argument_spec=args_spec, supports_check_mode=False)
+
+    return module
+
+
+FUNC_DICT = {
+    'chassis': _chassis,
+    'chassis_by_uuid': _chassis_by_uuid,
+    'chassis_status_managed': _chassis_status_managed,
+    'chassis_status_unmanaged': _chassis_status_unmanaged
+}
+
+
+INPUT_ARG_SPEC = dict(
+    command_options=dict(default='chassis', choices=['chassis',
+                                                     'chassis_by_uuid',
+                                                     'chassis_status_managed',
+                                                     'chassis_status_unmanaged']),
+    uuid=dict(default=None)
+)
+
+
+def execute_module(module):
+    """
+    This function invoke commands
+    :param module: Ansible module object
+    """
+    try:
+        with connection_object(module) as lxca_con:
+            result = FUNC_DICT[module.params['command_options']](module, lxca_con)
+            module.exit_json(changed=False,
+                             msg=SUCCESS_MSG % module.params['command_options'],
+                             result=result)
+    except Exception as exception:
+        error_msg = '; '.join((e) for e in exception.args)
+        module.fail_json(msg=error_msg, exception=traceback.format_exc())
+
+
+def main():
+    module = setup_module_object()
+    has_pylxca(module)
+    execute_module(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/lxca/lxca_chassis.py
+++ b/lib/ansible/modules/remote_management/lxca/lxca_chassis.py
@@ -81,7 +81,7 @@ EXAMPLES = '''
 RETURN = r'''
 result:
     description: chassis detail from lxca
-    returned: always
+    returned: success
     type: dict
     sample:
       chassisList:

--- a/test/units/modules/remote_management/lxca/test_lxca_chassis.py
+++ b/test/units/modules/remote_management/lxca/test_lxca_chassis.py
@@ -1,0 +1,99 @@
+import json
+
+import pytest
+from units.compat import mock
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible.modules.remote_management.lxca import lxca_chassis
+from ansible.module_utils.remote_management.lxca.common import setup_conn
+from ansible.module_utils.remote_management.lxca.common import close_conn
+
+
+@pytest.fixture(scope='module')
+@mock.patch("ansible.module_utils.remote_management.lxca.common.close_conn", autospec=True)
+def setup_module(close_conn):
+    close_conn.return_value = True
+
+
+class TestMyModule():
+    @pytest.mark.parametrize('patch_ansible_module',
+                             [
+                                 {},
+                                 {
+                                     "auth_url": "https://10.240.14.195",
+                                     "login_user": "USERID",
+                                 },
+                                 {
+                                     "auth_url": "https://10.240.14.195",
+                                     "login_password": "Password",
+                                 },
+                                 {
+                                     "login_user": "USERID",
+                                     "login_password": "Password",
+                                 },
+                             ],
+                             indirect=['patch_ansible_module'])
+    @pytest.mark.usefixtures('patch_ansible_module')
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_chassis.execute_module", autospec=True)
+    def test_without_required_parameters(self, _setup_conn, _execute_module,
+                                         mocker, capfd, setup_module):
+        """Failure must occurs when all parameters are missing"""
+        with pytest.raises(SystemExit):
+            _setup_conn.return_value = "Fake connection"
+            _execute_module.return_value = "Fake execution"
+            lxca_chassis.main()
+        out, err = capfd.readouterr()
+        results = json.loads(out)
+        assert results['failed']
+        assert 'missing required arguments' in results['msg']
+
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_chassis.execute_module", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_chassis.AnsibleModule", autospec=True)
+    def test__argument_spec(self, ansible_mod_cls, _execute_module, _setup_conn, setup_module):
+        expected_arguments_spec = dict(
+            login_user=dict(required=True),
+            login_password=dict(required=True, no_log=True),
+            command_options=dict(default='chassis', choices=['chassis',
+                                                             'chassis_by_uuid',
+                                                             'chassis_status_managed',
+                                                             'chassis_status_unmanaged']),
+            auth_url=dict(required=True),
+            uuid=dict(default=None),
+        )
+        _setup_conn.return_value = "Fake connection"
+        _execute_module.return_value = []
+        mod_obj = ansible_mod_cls.return_value
+        args = {
+            "auth_url": "https://10.243.30.195",
+            "login_user": "USERID",
+            "login_password": "password",
+            "command_options": "chassis",
+        }
+        mod_obj.params = args
+        lxca_chassis.main()
+        assert(mock.call(argument_spec=expected_arguments_spec,
+                         supports_check_mode=False) == ansible_mod_cls.call_args)
+
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_chassis._chassis_by_uuid",
+                autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_chassis.AnsibleModule",
+                autospec=True)
+    def test__chassis_empty_list(self, ansible_mod_cls, _get_chassis, _setup_conn, setup_module):
+        mod_obj = ansible_mod_cls.return_value
+        args = {
+            "auth_url": "https://10.243.30.195",
+            "login_user": "USERID",
+            "login_password": "password",
+            "uuid": "3C737AA5E31640CE949B10C129A8B01F",
+            "command_options": "chassis_by_uuid",
+        }
+        mod_obj.params = args
+        _setup_conn.return_value = "Fake connection"
+        empty_chassis_list = []
+        _get_chassis.return_value = empty_chassis_list
+        ret_chassis = _get_chassis(mod_obj, args)
+        assert mock.call(mod_obj, mod_obj.params) == _get_chassis.call_args
+        assert _get_chassis.return_value == ret_chassis

--- a/test/units/modules/remote_management/lxca/test_lxca_chassis.py
+++ b/test/units/modules/remote_management/lxca/test_lxca_chassis.py
@@ -2,11 +2,7 @@ import json
 
 import pytest
 from units.compat import mock
-from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
 from ansible.modules.remote_management.lxca import lxca_chassis
-from ansible.module_utils.remote_management.lxca.common import setup_conn
-from ansible.module_utils.remote_management.lxca.common import close_conn
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This module provide an interface to Lenovo XClarity Administrator. This module provides information about chassis
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lxca_chassis
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
(pylxca27) naval@osboxes:~/play/playbook/lxca_chassis$ cat all_chassis.yml 
---
- hosts: localhost
  connection: local
  tasks:
    - name: list chassis
      lxca_chassis:
        login_user: USERID
        login_password: CME44ibm
        auth_url: "https://10.243.9.238"
        command_options: chassis
(pylxca27) naval@osboxes:~/play/playbook/lxca_chassis$ ansible-playbook all_chassis.yml 
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] *****************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [list chassis] **************************************************************************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0  
```
