### PR TITLE
Fix two regressions in flatpak and flatpak_remote modules

### DIFF
--- a/lib/ansible/modules/packaging/os/flatpak.py
+++ b/lib/ansible/modules/packaging/os/flatpak.py
@@ -6,6 +6,27 @@
 # Copyright: (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+
+# ATTENTION CONTRIBUTORS!
+#
+# TL;DR: Run this module's integration tests manually before opening a pull request
+#
+# Long explanation:
+# The integration tests for this module are currently NOT run on the Ansible project's continuous
+# delivery pipeline. So please: When you make changes to this module, make sure that you run the
+# included integration tests manually for both Python 2 and Python 3:
+#
+#   Python 2:
+#       ansible-test integration -v --docker fedora28 --docker-privileged --allow-unsupported --python 2.7 flatpak
+#   Python 3:
+#       ansible-test integration -v --docker fedora28 --docker-privileged --allow-unsupported --python 3.6 flatpak
+#
+# Because of external dependencies, the current integration tests are somewhat too slow and brittle
+# to be included right now. I have plans to rewrite the integration tests based on a local flatpak
+# repository so that they can be included into the normal CI pipeline.
+# //oolongbrothers
+
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/lib/ansible/modules/packaging/os/flatpak.py
+++ b/lib/ansible/modules/packaging/os/flatpak.py
@@ -145,7 +145,7 @@ def uninstall_flat(module, binary, name, method):
     """Remove an existing flatpak."""
     global result
     installed_flat_name = _match_installed_flat_name(module, binary, name, method)
-    command = "{0} uninstall --{1} {2}".format(binary, method, installed_flat_name)
+    command = "{0} uninstall -y --{1} {2}".format(binary, method, installed_flat_name)
     _flatpak_command(module, module.check_mode, command)
     result['changed'] = True
 

--- a/lib/ansible/modules/packaging/os/flatpak_remote.py
+++ b/lib/ansible/modules/packaging/os/flatpak_remote.py
@@ -6,6 +6,27 @@
 # Copyright: (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+
+# ATTENTION CONTRIBUTORS!
+#
+# TL;DR: Run this module's integration tests manually before opening a pull request
+#
+# Long explanation:
+# The integration tests for this module are currently NOT run on the Ansible project's continuous
+# delivery pipeline. So please: When you make changes to this module, make sure that you run the
+# included integration tests manually for both Python 2 and Python 3:
+#
+#   Python 2:
+#       ansible-test integration -v --docker fedora28 --docker-privileged --allow-unsupported --python 2.7 flatpak_remote
+#   Python 3:
+#       ansible-test integration -v --docker fedora28 --docker-privileged --allow-unsupported --python 3.6 flatpak_remote
+#
+# Because of external dependencies, the current integration tests are somewhat too slow and brittle
+# to be included right now. I have plans to rewrite the integration tests based on a local flatpak
+# repository so that they can be included into the normal CI pipeline.
+# //oolongbrothers
+
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/lib/ansible/modules/packaging/os/flatpak_remote.py
+++ b/lib/ansible/modules/packaging/os/flatpak_remote.py
@@ -148,7 +148,7 @@ def remote_exists(module, binary, name, method):
     output = _flatpak_command(module, False, command)
     for line in output.splitlines():
         listed_remote = line.split()
-        if listed_remote[0] == name:
+        if listed_remote[0] == to_native(name):
             return True
     return False
 


### PR DESCRIPTION
##### SUMMARY
This fixes two bugs currently present in the `flatpak` and `flatpak_remote` modules respectively.

I also added a notice for contributors to run (the currently disabled) integration tests manually, that way more regressions could be avoided until I am ready with rewriting the integration tests so that they can be included into the normal CI runs.

This PR supersedes PR #45361, which I have closed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
flatpak
flatpak_remote

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```
ansible 2.8.0.dev0 (flatpak_python_23_compatility_fixes2 fa4ba58e87) last updated 2018/12/07 13:51:19 (GMT +200)
  config file = None
  configured module search path = [u'/home/.../.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/...ansible/lib/ansible
  executable location = /home/.../ansible/bin/ansible
  python version = 2.7.15 (default, Oct 15 2018, 18:36:25) [GCC 7.3.1 20180712 (Red Hat 7.3.1-6)]
```

##### ADDITIONAL INFORMATION

The Python 2 and 3 compatibility of this PR has been verified running integration tests using docker:

`flatpak`:

Python 3
```
ansible-test integration -v --docker fedora28 --docker-privileged --allow-unsupported --python 3.6 flatpak
```

Python 2
```
ansible-test integration -v --docker fedora28 --docker-privileged --allow-unsupported --python 2.7 flatpak
```

`flatpak_remote`:

Python 3
```
ansible-test integration -v --docker fedora28 --docker-privileged --allow-unsupported --python 3.6 flatpak_remote
```

Python 2
```
ansible-test integration -v --docker fedora28 --docker-privileged --allow-unsupported --python 2.7 flatpak_remote
```
