### PR TITLE
Don't just raise AnsibleError with the exception message

### DIFF
--- a/changelogs/fragments/vault-read-error.yml
+++ b/changelogs/fragments/vault-read-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vault - Improve error messages encountered when reading vault files (https://github.com/ansible/ansible/issues/49252)

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -1030,7 +1030,10 @@ class VaultEditor:
                 with open(filename, "rb") as fh:
                     data = fh.read()
         except Exception as e:
-            raise AnsibleError(to_native(e))
+            msg = to_native(e)
+            if not msg:
+                msg = repr(e)
+            raise AnsibleError('Unable to read source file (%s): %s' % (to_native(filename), msg))
 
         return data
 


### PR DESCRIPTION
##### SUMMARY
Don't just raise AnsibleError with the exception message. Fixes #49252

This PR aims to add additional context to errors encountered when reading in the src file when encrypting with vault.

In the case of some exceptions, they may not have message text, such as the case with `MemoryError`. To solve this we check if the message is empty, and if so, just repr the exception to give as much context as possible.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/parsing/vault/__init__.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```