### PR TITLE
Added npm ci command

### DIFF
--- a/changelogs/fragments/49664-npm-added-ci-param.yaml
+++ b/changelogs/fragments/49664-npm-added-ci-param.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "npm ci feature added which allows to install a project with a clean slate: https://docs.npmjs.com/cli/ci.html"

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -281,7 +281,7 @@ def main():
 
     changed = False
     if ci is True:
-        npm.ci_install()	
+        npm.ci_install()
         changed = True
     elif state == 'present':
         installed, missing = npm.list()

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -280,7 +280,7 @@ def main():
               unsafe_perm=unsafe_perm, state=state)
 
     changed = False
-    if ci is True:	
+    if ci is True:
         npm.ci_install()	
         changed = True
     elif state == 'present':

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -280,7 +280,7 @@ def main():
               unsafe_perm=unsafe_perm, state=state)
 
     changed = False
-    if ci is True:
+    if ci:
         npm.ci_install()
         changed = True
     elif state == 'present':

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -280,7 +280,7 @@ def main():
               unsafe_perm=unsafe_perm, state=state)
 
     changed = False
-    if ci == True:
+    if ci is True:
         npm.ci_install()
         changed = True
     if state == 'present':

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -59,6 +59,12 @@ options:
     type: bool
     default: no
     version_added: "2.8"
+  ci:
+    description:
+      - Install packages based on package-lock file, same as running npm ci
+    type: bool
+    default: no
+    version_added: "2.8"
   production:
     description:
       - Install dependencies in production mode, excluding devDependencies
@@ -211,6 +217,9 @@ class Npm(object):
     def install(self):
         return self._exec(['install'])
 
+    def ci_install(self):
+        return self._exec(['ci'])
+
     def update(self):
         return self._exec(['update'])
 
@@ -241,6 +250,7 @@ def main():
         state=dict(default='present', choices=['present', 'absent', 'latest']),
         ignore_scripts=dict(default=False, type='bool'),
         unsafe_perm=dict(default=False, type='bool'),
+        ci=dict(default=False, type='bool'),
     )
     arg_spec['global'] = dict(default='no', type='bool')
     module = AnsibleModule(
@@ -258,6 +268,7 @@ def main():
     state = module.params['state']
     ignore_scripts = module.params['ignore_scripts']
     unsafe_perm = module.params['unsafe_perm']
+    ci = module.params['ci']
 
     if not path and not glbl:
         module.fail_json(msg='path must be specified when not using global')
@@ -269,6 +280,9 @@ def main():
               unsafe_perm=unsafe_perm, state=state)
 
     changed = False
+    if ci == True:
+        npm.ci_install()
+        changed = True
     if state == 'present':
         installed, missing = npm.list()
         if missing:

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -280,17 +280,20 @@ def main():
               unsafe_perm=unsafe_perm, state=state)
 
     changed = False
-    if state == 'present':
+    if ci is True:	
+        npm.ci_install()	
+        changed = True
+    elif state == 'present':
         installed, missing = npm.list()
         if missing:
             changed = True
-            npm.install() if not ci else npm.ci_install()
+            npm.install()
     elif state == 'latest':
         installed, missing = npm.list()
         outdated = npm.list_outdated()
         if missing:
             changed = True
-            npm.install() if not ci else npm.ci_install()
+            npm.install()
         if outdated:
             changed = True
             npm.update()

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -280,20 +280,17 @@ def main():
               unsafe_perm=unsafe_perm, state=state)
 
     changed = False
-    if ci is True:
-        npm.ci_install()
-        changed = True
     if state == 'present':
         installed, missing = npm.list()
         if missing:
             changed = True
-            npm.install()
+            npm.install() if not ci else npm.ci_install()
     elif state == 'latest':
         installed, missing = npm.list()
         outdated = npm.list_outdated()
         if missing:
             changed = True
-            npm.install()
+            npm.install() if not ci else npm.ci_install()
         if outdated:
             changed = True
             npm.update()


### PR DESCRIPTION
##### SUMMARY
npm ci is a new command that allows to install packages based on the package-lock which is a lot faster and prevents the installation of newer versions of packages and dependancies.
More info: https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable
Solved issue #49664 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
npm

##### ADDITIONAL INFORMATION

