### PR TITLE
PSRP: Move default loglevel of pypsrp to WARNING

### DIFF
--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -207,7 +207,7 @@ class Connection(ConnectionBase):
         super(Connection, self).__init__(*args, **kwargs)
 
         if not C.DEFAULT_DEBUG:
-            logging.getLogger('pypsrp').setLevel(logging.INFO)
+            logging.getLogger('pypsrp').setLevel(logging.WARNING)
             logging.getLogger('requests_credssp').setLevel(logging.INFO)
             logging.getLogger('urllib3').setLevel(logging.INFO)
 


### PR DESCRIPTION
##### SUMMARY
We don't need the INFO messages from the pypsrp library.

This fixes jborean93/pypsrp#18

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
psrp