### PR TITLE
Use stderr, and allow use of environment for config

### DIFF
--- a/contrib/inventory/infoblox.py
+++ b/contrib/inventory/infoblox.py
@@ -30,6 +30,7 @@ from ansible.module_utils.net_tools.nios.api import normalize_extattrs, flatten_
 
 
 CONFIG_FILES = [
+    os.environ.get('INFOBLOX_CONFIG_FILE', None),
     '/etc/ansible/infoblox.yaml',
     '/etc/ansible/infoblox.yml'
 ]
@@ -54,7 +55,7 @@ def main():
         if os.path.exists(config_file):
             break
     else:
-        sys.stdout.write('unable to locate config file at /etc/ansible/infoblox.yaml\n')
+        sys.stderr.write('unable to locate config file at /etc/ansible/infoblox.yaml\n')
         sys.exit(-1)
 
     try:
@@ -63,7 +64,7 @@ def main():
         provider = config.get('provider') or {}
         wapi = WapiInventory(provider)
     except Exception as exc:
-        sys.stdout.write(to_text(exc))
+        sys.stderr.write(to_text(exc))
         sys.exit(-1)
 
     if args.host:


### PR DESCRIPTION


##### SUMMARY
Errors should send to stderr, and this allows the use of an environment var to point to where the YAML config lives.

This is particularly useful when using this script with AWX and custom credentials (injecting YAML config).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
infoblox.py
