### PR TITLE
docker_swarm: fix minimal API version

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -141,7 +141,7 @@ requirements:
        module has been superseded by L(docker,https://pypi.org/project/docker/)
        (see L(here,https://github.com/docker/docker-py/issues/1310) for details).
        Version 2.1.0 or newer is only available with the C(docker) module."
-    - Docker API >= 1.35
+    - Docker API >= 1.25
 author:
   - Thierry Bouvet (@tbouvet)
 '''
@@ -283,6 +283,60 @@ class TaskParameters(DockerBaseClass):
 
 class SwarmManager(DockerBaseClass):
 
+    def _get_minimal_versions(self):
+        # TODO: Move this and the same from docker_container.py to docker_common.py
+        self.option_minimal_versions = dict()
+        for option, data in self.client.module.argument_spec.items():
+            self.option_minimal_versions[option] = dict()
+        self.option_minimal_versions.update(dict(
+            signing_ca_cert=dict(docker_api_version='1.30'),
+            signing_ca_key=dict(docker_api_version='1.30'),
+            ca_force_rotate=dict(docker_api_version='1.30'),
+        ))
+
+        for option, data in self.option_minimal_versions.items():
+            # Test whether option is supported, and store result
+            support_docker_py = True
+            support_docker_api = True
+            if 'docker_py_version' in data:
+                support_docker_py = self.client.docker_py_version >= LooseVersion(data['docker_py_version'])
+            if 'docker_api_version' in data:
+                support_docker_api = self.client.docker_api_version >= LooseVersion(data['docker_api_version'])
+            data['supported'] = support_docker_py and support_docker_api
+            # Fail if option is not supported but used
+            if not data['supported']:
+                # Test whether option is specified
+                if 'detect_usage' in data:
+                    used = data['detect_usage']()
+                else:
+                    used = self.client.module.params.get(option) is not None
+                    if used and 'default' in self.client.module.argument_spec[option]:
+                        used = self.client.module.params[option] != self.client.module.argument_spec[option]['default']
+                if used:
+                    # If the option is used, compose error message.
+                    if 'usage_msg' in data:
+                        usg = data['usage_msg']
+                    else:
+                        usg = 'set %s option' % (option, )
+                    if not support_docker_api:
+                        msg = 'docker API version is %s. Minimum version required is %s to %s.'
+                        msg = msg % (self.client.docker_api_version_str, data['docker_api_version'], usg)
+                    elif not support_docker_py:
+                        if LooseVersion(data['docker_py_version']) < LooseVersion('2.0.0'):
+                            msg = ("docker-py version is %s. Minimum version required is %s to %s. "
+                                   "Consider switching to the 'docker' package if you do not require Python 2.6 support.")
+                        elif self.client.docker_py_version < LooseVersion('2.0.0'):
+                            msg = ("docker-py version is %s. Minimum version required is %s to %s. "
+                                   "You have to switch to the Python 'docker' package. First uninstall 'docker-py' before "
+                                   "installing 'docker' to avoid a broken installation.")
+                        else:
+                            msg = "docker version is %s. Minimum version required is %s to %s."
+                        msg = msg % (docker_version, data['docker_py_version'], usg)
+                    else:
+                        # should not happen
+                        msg = 'Cannot %s with your configuration.' % (usg, )
+                    self.client.fail(msg)
+
     def __init__(self, client, results):
 
         super(SwarmManager, self).__init__()
@@ -290,6 +344,8 @@ class SwarmManager(DockerBaseClass):
         self.client = client
         self.results = results
         self.check_mode = self.client.check_mode
+
+        self._get_minimal_versions()
 
         self.parameters = TaskParameters(client)
 
@@ -506,7 +562,7 @@ def main():
         supports_check_mode=True,
         required_if=required_if,
         min_docker_version='2.6.0',
-        min_docker_api_version='1.35',
+        min_docker_api_version='1.25',
     )
 
     results = dict(

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -214,6 +214,7 @@ actions:
 '''
 
 import json
+from distutils.version import LooseVersion
 from time import sleep
 try:
     from docker.errors import APIError
@@ -221,7 +222,11 @@ except ImportError:
     # missing docker-py handled in ansible.module_utils.docker_common
     pass
 
-from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseClass
+from ansible.module_utils.docker_common import (
+    AnsibleDockerClient,
+    DockerBaseClass,
+    docker_version,
+)
 from ansible.module_utils._text import to_native
 
 

--- a/test/integration/targets/docker_config/tasks/main.yml
+++ b/test/integration/targets/docker_config/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - include_tasks: test_docker_config.yml
-  # Maximum of 1.30 (docker API version for docker_config) and 1.35 (docker API version for docker_swarm) is 1.35
-  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')
+  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.30', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_config tests!"
-  when: not(docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.30', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_network/tasks/tests/options.yml
+++ b/test/integration/targets/docker_network/tasks/tests/options.yml
@@ -145,7 +145,7 @@
       force: yes
 
   # Requirements for docker_swarm
-  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')
+  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.25', '>=')
 
 ####################################################################
 ## attachable ######################################################

--- a/test/integration/targets/docker_network/tasks/tests/overlay.yml
+++ b/test/integration/targets/docker_network/tasks/tests/overlay.yml
@@ -58,4 +58,4 @@
       force: yes
 
   # Requirements for docker_swarm
-  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')
+  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.25', '>=')

--- a/test/integration/targets/docker_secret/tasks/main.yml
+++ b/test/integration/targets/docker_secret/tasks/main.yml
@@ -1,7 +1,6 @@
 - include_tasks: test_secrets.yml
   # Maximum of 2.1.0 (docker-py version for docker_secrets) and 2.6.0 (docker-py version for docker_swarm) is 2.6.0
-  # Maximum of 1.25 (docker API version for docker_secrets) and 1.35 (docker API version for docker_swarm) is 1.35
-  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')
+  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.25', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_secrets tests!"
-  when: not(docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_swarm/tasks/main.yml
+++ b/test/integration/targets/docker_swarm/tasks/main.yml
@@ -1,5 +1,5 @@
 - include_tasks: test_swarm.yml
-  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')
+  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.25', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_swarm tests!"
-  when: not(docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)

--- a/test/integration/targets/docker_swarm_service/tasks/main.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/main.yml
@@ -1,6 +1,5 @@
 - include_tasks: test_swarm_service.yml
-  # Maximum of 2.0.0 (docker-py version for docker_swarm_service) and 2.6.0 (docker-py version for docker_swarm) is 2.6.0
-  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')
+  when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.25', '>=')
 
 - fail: msg="Too old docker / docker-py version to run docker_swarm_service tests!"
-  when: not(docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.35', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)
+  when: not(docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.25', '>=')) and (ansible_distribution != 'CentOS' or ansible_distribution_major_version|int > 6)


### PR DESCRIPTION
##### SUMMARY
Adds correct minimal API version for `docker_swarm` (v1.25; needed for everything except three options, which require v1.30).

Fixes #48657.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm
