### PR TITLE
win_hotfix: use S3 bucket for update files in test

### DIFF
--- a/test/integration/targets/win_hotfix/defaults/main.yml
+++ b/test/integration/targets/win_hotfix/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 # these hotfixes, are for Hyper-V, there may be a chance the system already has them
 # but in most cases for our CI purposes they wouldn't be present
-test_win_hotfix_good_url: http://download.windowsupdate.com/c/msdownload/update/software/htfx/2015/01/windows8.1-kb3027108-v2-x64_66366c7be2d64d83b63cac42bc40c0a3c01bc70d.msu
-test_win_hotfix_reboot_url: http://download.windowsupdate.com/c/msdownload/update/software/htfx/2014/01/windows8.1-kb2913659-v2-x64_963a4d890c9ff9cc83a97cf54305de6451038ba4.msu
-test_win_hotfix_bad_url: http://download.windowsupdate.com/d/msdownload/update/software/secu/2016/07/windows8-rt-kb3172729-x64_69cab4c7785b1faa3fc450f32bed4873d53bb96f.msu
+test_win_hotfix_good_url: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/win_hotfix/windows8.1-kb3027108-v2-x64_66366c7be2d64d83b63cac42bc40c0a3c01bc70d.msu
+test_win_hotfix_reboot_url: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/win_hotfix/windows8.1-kb2913659-v2-x64_963a4d890c9ff9cc83a97cf54305de6451038ba4.msu
+test_win_hotfix_bad_url: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/win_hotfix/windows8-rt-kb3172729-x64_69cab4c7785b1faa3fc450f32bed4873d53bb96f.msu
 test_win_hotfix_path: C:\ansible\win_hotfix
 
 test_win_hotfix_kb: KB3027108


### PR DESCRIPTION
##### SUMMARY
Use our S3 bucket for sourcing our hotfix files to make the tests more stable.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
win_hotfix integration tests