### PR TITLE
fix: Make sure that the files excluded when extracting the archive are not checked (#45122)

### DIFF
--- a/changelogs/fragments/45122-fix-unarchive-excluded_files.yaml
+++ b/changelogs/fragments/45122-fix-unarchive-excluded_files.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Fixed: Make sure that the files excluded when extracting the archive are not checked. https://github.com/ansible/ansible/pull/45122"

--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -264,11 +264,13 @@ class ZipArchive(object):
         else:
             try:
                 for member in archive.namelist():
+                    exclude_flag = False
                     if self.excludes:
                         for exclude in self.excludes:
-                            if not fnmatch.fnmatch(member, exclude):
-                                self._files_in_archive.append(to_native(member))
-                    else:
+                            if fnmatch.fnmatch(member, exclude):
+                                exclude_flag = True
+                                break
+                    if not exclude_flag:
                         self._files_in_archive.append(to_native(member))
             except:
                 archive.close()
@@ -664,11 +666,14 @@ class TgzArchive(object):
             if filename.startswith('/'):
                 filename = filename[1:]
 
+            exclude_flag = False
             if self.excludes:
                 for exclude in self.excludes:
-                    if not fnmatch.fnmatch(filename, exclude):
-                        self._files_in_archive.append(to_native(filename))
-            else:
+                    if fnmatch.fnmatch(filename, exclude):
+                        exclude_flag = True
+                        break
+
+            if not exclude_flag:
                 self._files_in_archive.append(to_native(filename))
 
         return self._files_in_archive

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -225,11 +225,13 @@
     - zip
     - tar
 
-- name: Unpack archive file excluding glob files.
+- name: Unpack archive file excluding regular and glob files.
   unarchive:
     src: "{{ output_dir }}/unarchive-00.{{item}}"
     dest: "{{ output_dir }}/exclude-{{item}}"
-    exclude: "exclude/exclude-*.txt"
+    exclude: 
+      - "exclude/exclude-*.txt"
+      - "other/exclude-1.ext"
   with_items:
     - zip
     - tar
@@ -245,6 +247,7 @@
   assert:
     that:
       - "'exclude/exclude-1.txt' not in item.stdout"
+      - "'other/exclude-1.ext' not in item.stdout"
   with_items:
     - "{{ unarchive00.results }}"
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backporting unarchive bugfix : Make  sure than if we provide a list of excluded files for unarchive, those files aren't checked.
Fixes #45101
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
unarchive

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
