### PR TITLE
Docker common consolidation

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -163,7 +163,8 @@ class AnsibleDockerClient(Client):
 
     def __init__(self, argument_spec=None, supports_check_mode=False, mutually_exclusive=None,
                  required_together=None, required_if=None, min_docker_version=MIN_DOCKER_VERSION,
-                 min_docker_api_version=None):
+                 min_docker_api_version=None, option_minimal_versions=None,
+                 option_minimal_versions_ignore_params=None):
 
         merged_arg_spec = dict()
         merged_arg_spec.update(DOCKER_COMMON_ARGS)
@@ -234,6 +235,9 @@ class AnsibleDockerClient(Client):
             self.docker_api_version = LooseVersion(self.docker_api_version_str)
             if self.docker_api_version < LooseVersion(min_docker_api_version):
                 self.fail('docker API version is %s. Minimum version required is %s.' % (self.docker_api_version_str, min_docker_api_version))
+
+        if option_minimal_versions is not None:
+            self._get_minimal_versions(option_minimal_versions, option_minimal_versions_ignore_params)
 
     def log(self, msg, pretty_print=False):
         pass
@@ -415,6 +419,58 @@ class AnsibleDockerClient(Client):
                       "You may also use TLS without verification by setting the tls parameter to true."
                       % (self.auth_params['tls_hostname'], match.group(1), match.group(1)))
         self.fail("SSL Exception: %s" % (error))
+
+    def _get_minimal_versions(self, option_minimal_versions, ignore_params=None):
+        self.option_minimal_versions = dict()
+        for option, data in self.module.argument_spec.items():
+            if ignore_params is not None:
+                if option in ignore_params:
+                    continue
+            self.option_minimal_versions[option] = dict()
+        self.option_minimal_versions.update(option_minimal_versions)
+
+        for option, data in self.option_minimal_versions.items():
+            # Test whether option is supported, and store result
+            support_docker_py = True
+            support_docker_api = True
+            if 'docker_py_version' in data:
+                support_docker_py = self.docker_py_version >= LooseVersion(data['docker_py_version'])
+            if 'docker_api_version' in data:
+                support_docker_api = self.docker_api_version >= LooseVersion(data['docker_api_version'])
+            data['supported'] = support_docker_py and support_docker_api
+            # Fail if option is not supported but used
+            if not data['supported']:
+                # Test whether option is specified
+                if 'detect_usage' in data:
+                    used = data['detect_usage']()
+                else:
+                    used = self.module.params.get(option) is not None
+                    if used and 'default' in self.module.argument_spec[option]:
+                        used = self.module.params[option] != self.module.argument_spec[option]['default']
+                if used:
+                    # If the option is used, compose error message.
+                    if 'usage_msg' in data:
+                        usg = data['usage_msg']
+                    else:
+                        usg = 'set %s option' % (option, )
+                    if not support_docker_api:
+                        msg = 'docker API version is %s. Minimum version required is %s to %s.'
+                        msg = msg % (self.docker_api_version_str, data['docker_api_version'], usg)
+                    elif not support_docker_py:
+                        if LooseVersion(data['docker_py_version']) < LooseVersion('2.0.0'):
+                            msg = ("docker-py version is %s. Minimum version required is %s to %s. "
+                                   "Consider switching to the 'docker' package if you do not require Python 2.6 support.")
+                        elif self.docker_py_version < LooseVersion('2.0.0'):
+                            msg = ("docker-py version is %s. Minimum version required is %s to %s. "
+                                   "You have to switch to the Python 'docker' package. First uninstall 'docker-py' before "
+                                   "installing 'docker' to avoid a broken installation.")
+                        else:
+                            msg = "docker version is %s. Minimum version required is %s to %s."
+                        msg = msg % (docker_version, data['docker_py_version'], usg)
+                    else:
+                        # should not happen
+                        msg = 'Cannot %s with your configuration.' % (usg, )
+                    self.fail(msg)
 
     def get_container(self, name=None):
         '''

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -741,3 +741,23 @@ class DifferenceTracker(object):
         '''
         result = [entry['name'] for entry in self._diff]
         return result
+
+
+def clean_booleans_for_docker_api(data):
+    '''
+    Go doesn't like Python booleans 'True' or 'False', while Ansible is just
+    fine with them in YAML. As such, they need to be converted in cases where
+    we pass dictionaries to the Docker API (e.g. docker_network's
+    driver_options and docker_prune's filters).
+    '''
+    result = dict()
+    if data is not None:
+        for k, v in data.items():
+            if v is True:
+                v = 'true'
+            elif v is False:
+                v = 'false'
+            else:
+                v = str(v)
+            result[str(k)] = v
+    return result

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -799,7 +799,7 @@ class DifferenceTracker(object):
         return result
 
 
-def clean_booleans_for_docker_api(data):
+def clean_dict_booleans_for_docker_api(data):
     '''
     Go doesn't like Python booleans 'True' or 'False', while Ansible is just
     fine with them in YAML. As such, they need to be converted in cases where

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -422,7 +422,7 @@ class AnsibleDockerClient(Client):
 
     def _get_minimal_versions(self, option_minimal_versions, ignore_params=None):
         self.option_minimal_versions = dict()
-        for option, data in self.module.argument_spec.items():
+        for option in self.module.argument_spec:
             if ignore_params is not None:
                 if option in ignore_params:
                     continue

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -952,16 +952,6 @@ def split_colon_ipv6(input, module):
     return result
 
 
-def detect_ipvX_address_usage():
-    '''
-    Helper function to detect whether any specified network uses ipv4_address or ipv6_address
-    '''
-    for network in self.module.params.get("networks") or []:
-        if network.get('ipv4_address') is not None or network.get('ipv6_address') is not None:
-            return True
-    return False
-
-
 class TaskParameters(DockerBaseClass):
     '''
     Access and parse module parameters
@@ -2774,6 +2764,18 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
         self.option_minimal_versions['stop_timeout']['supported'] = stop_timeout_supported
 
     def __init__(self, **kwargs):
+        def detect_ipvX_address_usage():
+            '''
+            Helper function to detect whether any specified network uses ipv4_address or ipv6_address
+            '''
+            for network in self.module.params.get("networks") or []:
+                if network.get('ipv4_address') is not None or network.get('ipv6_address') is not None:
+                    return True
+            return False
+        if 'option_minimal_versions' in kwargs:
+            if 'ipvX_address_supported' in kwargs['option_minimal_versions']:
+                if 'detect_usage' not in kwargs['option_minimal_versions']['ipvX_address_supported']:
+                    kwargs['option_minimal_versions']['ipvX_address_supported']['detect_usage'] = detect_ipvX_address_usage
         super(AnsibleDockerClientContainer, self).__init__(option_minimal_versions_ignore_params=self.__NON_CONTAINER_PROPERTY_OPTIONS, **kwargs)
         self._get_additional_minimal_versions()
         self._parse_comparisons()
@@ -2926,8 +2928,7 @@ def main():
         uts=dict(docker_py_version='3.5.0', docker_api_version='1.25'),
         pids_limit=dict(docker_py_version='1.10.0', docker_api_version='1.23'),
         # specials
-        ipvX_address_supported=dict(docker_py_version='1.9.0', detect_usage=detect_ipvX_address_usage,
-                                    usage_msg='ipv4_address or ipv6_address in networks'),
+        ipvX_address_supported=dict(docker_py_version='1.9.0', usage_msg='ipv4_address or ipv6_address in networks'),  # detect_usage set above
         stop_timeout=dict(),  # see above!
     )
 

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -952,6 +952,16 @@ def split_colon_ipv6(input, module):
     return result
 
 
+def detect_ipvX_address_usage():
+    '''
+    Helper function to detect whether any specified network uses ipv4_address or ipv6_address
+    '''
+    for network in self.module.params.get("networks") or []:
+        if network.get('ipv4_address') is not None or network.get('ipv6_address') is not None:
+            return True
+    return False
+
+
 class TaskParameters(DockerBaseClass):
     '''
     Access and parse module parameters
@@ -2744,99 +2754,7 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
             self.module.warn('The ignore_image option has been overridden by the comparisons option!')
         self.comparisons = comparisons
 
-    def _get_minimal_versions(self):
-        # Helper function to detect whether any specified network uses ipv4_address or ipv6_address
-        def detect_ipvX_address_usage():
-            for network in self.module.params.get("networks") or []:
-                if network.get('ipv4_address') is not None or network.get('ipv6_address') is not None:
-                    return True
-            return False
-
-        self.option_minimal_versions = dict(
-            # internal options
-            log_config=dict(),
-            publish_all_ports=dict(),
-            ports=dict(),
-            volume_binds=dict(),
-            name=dict(),
-        )
-        for option, data in self.module.argument_spec.items():
-            if option in self.__NON_CONTAINER_PROPERTY_OPTIONS:
-                continue
-            self.option_minimal_versions[option] = dict()
-        self.option_minimal_versions.update(dict(
-            device_read_bps=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
-            device_read_iops=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
-            device_write_bps=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
-            device_write_iops=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
-            dns_opts=dict(docker_api_version='1.21', docker_py_version='1.10.0'),
-            ipc_mode=dict(docker_api_version='1.25'),
-            mac_address=dict(docker_api_version='1.25'),
-            oom_killer=dict(docker_py_version='2.0.0'),
-            oom_score_adj=dict(docker_api_version='1.22', docker_py_version='2.0.0'),
-            shm_size=dict(docker_api_version='1.22'),
-            stop_signal=dict(docker_api_version='1.21'),
-            tmpfs=dict(docker_api_version='1.22'),
-            volume_driver=dict(docker_api_version='1.21'),
-            memory_reservation=dict(docker_api_version='1.21'),
-            kernel_memory=dict(docker_api_version='1.21'),
-            auto_remove=dict(docker_py_version='2.1.0', docker_api_version='1.25'),
-            healthcheck=dict(docker_py_version='2.0.0', docker_api_version='1.24'),
-            init=dict(docker_py_version='2.2.0', docker_api_version='1.25'),
-            runtime=dict(docker_py_version='2.4.0', docker_api_version='1.25'),
-            sysctls=dict(docker_py_version='1.10.0', docker_api_version='1.24'),
-            userns_mode=dict(docker_py_version='1.10.0', docker_api_version='1.23'),
-            uts=dict(docker_py_version='3.5.0', docker_api_version='1.25'),
-            pids_limit=dict(docker_py_version='1.10.0', docker_api_version='1.23'),
-            # specials
-            ipvX_address_supported=dict(docker_py_version='1.9.0', detect_usage=detect_ipvX_address_usage,
-                                        usage_msg='ipv4_address or ipv6_address in networks'),
-            stop_timeout=dict(),  # see below!
-        ))
-
-        for option, data in self.option_minimal_versions.items():
-            # Test whether option is supported, and store result
-            support_docker_py = True
-            support_docker_api = True
-            if 'docker_py_version' in data:
-                support_docker_py = self.docker_py_version >= LooseVersion(data['docker_py_version'])
-            if 'docker_api_version' in data:
-                support_docker_api = self.docker_api_version >= LooseVersion(data['docker_api_version'])
-            data['supported'] = support_docker_py and support_docker_api
-            # Fail if option is not supported but used
-            if not data['supported']:
-                # Test whether option is specified
-                if 'detect_usage' in data:
-                    used = data['detect_usage']()
-                else:
-                    used = self.module.params.get(option) is not None
-                    if used and 'default' in self.module.argument_spec[option]:
-                        used = self.module.params[option] != self.module.argument_spec[option]['default']
-                if used:
-                    # If the option is used, compose error message.
-                    if 'usage_msg' in data:
-                        usg = data['usage_msg']
-                    else:
-                        usg = 'set %s option' % (option, )
-                    if not support_docker_api:
-                        msg = 'docker API version is %s. Minimum version required is %s to %s.'
-                        msg = msg % (self.docker_api_version_str, data['docker_api_version'], usg)
-                    elif not support_docker_py:
-                        if LooseVersion(data['docker_py_version']) < LooseVersion('2.0.0'):
-                            msg = ("docker-py version is %s. Minimum version required is %s to %s. "
-                                   "Consider switching to the 'docker' package if you do not require Python 2.6 support.")
-                        elif self.docker_py_version < LooseVersion('2.0.0'):
-                            msg = ("docker-py version is %s. Minimum version required is %s to %s. "
-                                   "You have to switch to the Python 'docker' package. First uninstall 'docker-py' before "
-                                   "installing 'docker' to avoid a broken installation.")
-                        else:
-                            msg = "docker version is %s. Minimum version required is %s to %s."
-                        msg = msg % (docker_version, data['docker_py_version'], usg)
-                    else:
-                        # should not happen
-                        msg = 'Cannot %s with your configuration.' % (usg, )
-                    self.fail(msg)
-
+    def _get_additional_minimal_versions(self):
         stop_timeout_supported = self.docker_api_version >= LooseVersion('1.25')
         stop_timeout_needed_for_update = self.module.params.get("stop_timeout") is not None and self.module.params.get('state') != 'absent'
         if stop_timeout_supported:
@@ -2856,8 +2774,8 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
         self.option_minimal_versions['stop_timeout']['supported'] = stop_timeout_supported
 
     def __init__(self, **kwargs):
-        super(AnsibleDockerClientContainer, self).__init__(**kwargs)
-        self._get_minimal_versions()
+        super(AnsibleDockerClientContainer, self).__init__(option_minimal_versions_ignore_params=self.__NON_CONTAINER_PROPERTY_OPTIONS, **kwargs)
+        self._get_additional_minimal_versions()
         self._parse_comparisons()
 
 
@@ -2977,11 +2895,48 @@ def main():
         ('state', 'present', ['image'])
     ]
 
+    option_minimal_versions = dict(
+        # internal options
+        log_config=dict(),
+        publish_all_ports=dict(),
+        ports=dict(),
+        volume_binds=dict(),
+        name=dict(),
+        device_read_bps=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
+        device_read_iops=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
+        device_write_bps=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
+        device_write_iops=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
+        dns_opts=dict(docker_api_version='1.21', docker_py_version='1.10.0'),
+        ipc_mode=dict(docker_api_version='1.25'),
+        mac_address=dict(docker_api_version='1.25'),
+        oom_killer=dict(docker_py_version='2.0.0'),
+        oom_score_adj=dict(docker_api_version='1.22', docker_py_version='2.0.0'),
+        shm_size=dict(docker_api_version='1.22'),
+        stop_signal=dict(docker_api_version='1.21'),
+        tmpfs=dict(docker_api_version='1.22'),
+        volume_driver=dict(docker_api_version='1.21'),
+        memory_reservation=dict(docker_api_version='1.21'),
+        kernel_memory=dict(docker_api_version='1.21'),
+        auto_remove=dict(docker_py_version='2.1.0', docker_api_version='1.25'),
+        healthcheck=dict(docker_py_version='2.0.0', docker_api_version='1.24'),
+        init=dict(docker_py_version='2.2.0', docker_api_version='1.25'),
+        runtime=dict(docker_py_version='2.4.0', docker_api_version='1.25'),
+        sysctls=dict(docker_py_version='1.10.0', docker_api_version='1.24'),
+        userns_mode=dict(docker_py_version='1.10.0', docker_api_version='1.23'),
+        uts=dict(docker_py_version='3.5.0', docker_api_version='1.25'),
+        pids_limit=dict(docker_py_version='1.10.0', docker_api_version='1.23'),
+        # specials
+        ipvX_address_supported=dict(docker_py_version='1.9.0', detect_usage=detect_ipvX_address_usage,
+                                    usage_msg='ipv4_address or ipv6_address in networks'),
+        stop_timeout=dict(),  # see above!
+    )
+
     client = AnsibleDockerClientContainer(
         argument_spec=argument_spec,
         required_if=required_if,
         supports_check_mode=True,
         min_docker_api_version='1.20',
+        option_minimal_versions=option_minimal_versions,
     )
 
     cm = ContainerManager(client)

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2772,11 +2772,49 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
                 if network.get('ipv4_address') is not None or network.get('ipv6_address') is not None:
                     return True
             return False
-        if 'option_minimal_versions' in kwargs:
-            if 'ipvX_address_supported' in kwargs['option_minimal_versions']:
-                if 'detect_usage' not in kwargs['option_minimal_versions']['ipvX_address_supported']:
-                    kwargs['option_minimal_versions']['ipvX_address_supported']['detect_usage'] = detect_ipvX_address_usage
-        super(AnsibleDockerClientContainer, self).__init__(option_minimal_versions_ignore_params=self.__NON_CONTAINER_PROPERTY_OPTIONS, **kwargs)
+
+        option_minimal_versions = dict(
+            # internal options
+            log_config=dict(),
+            publish_all_ports=dict(),
+            ports=dict(),
+            volume_binds=dict(),
+            name=dict(),
+            # normal options
+            device_read_bps=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
+            device_read_iops=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
+            device_write_bps=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
+            device_write_iops=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
+            dns_opts=dict(docker_api_version='1.21', docker_py_version='1.10.0'),
+            ipc_mode=dict(docker_api_version='1.25'),
+            mac_address=dict(docker_api_version='1.25'),
+            oom_killer=dict(docker_py_version='2.0.0'),
+            oom_score_adj=dict(docker_api_version='1.22', docker_py_version='2.0.0'),
+            shm_size=dict(docker_api_version='1.22'),
+            stop_signal=dict(docker_api_version='1.21'),
+            tmpfs=dict(docker_api_version='1.22'),
+            volume_driver=dict(docker_api_version='1.21'),
+            memory_reservation=dict(docker_api_version='1.21'),
+            kernel_memory=dict(docker_api_version='1.21'),
+            auto_remove=dict(docker_py_version='2.1.0', docker_api_version='1.25'),
+            healthcheck=dict(docker_py_version='2.0.0', docker_api_version='1.24'),
+            init=dict(docker_py_version='2.2.0', docker_api_version='1.25'),
+            runtime=dict(docker_py_version='2.4.0', docker_api_version='1.25'),
+            sysctls=dict(docker_py_version='1.10.0', docker_api_version='1.24'),
+            userns_mode=dict(docker_py_version='1.10.0', docker_api_version='1.23'),
+            uts=dict(docker_py_version='3.5.0', docker_api_version='1.25'),
+            pids_limit=dict(docker_py_version='1.10.0', docker_api_version='1.23'),
+            # specials
+            ipvX_address_supported=dict(docker_py_version='1.9.0', detect_usage=detect_ipvX_address_usage,
+                                        usage_msg='ipv4_address or ipv6_address in networks'),  # see above
+            stop_timeout=dict(),  # see _get_additional_minimal_versions()
+        )
+
+        super(AnsibleDockerClientContainer, self).__init__(
+            option_minimal_versions=option_minimal_versions,
+            option_minimal_versions_ignore_params=self.__NON_CONTAINER_PROPERTY_OPTIONS,
+            **kwargs
+        )
         self._get_additional_minimal_versions()
         self._parse_comparisons()
 
@@ -2897,47 +2935,11 @@ def main():
         ('state', 'present', ['image'])
     ]
 
-    option_minimal_versions = dict(
-        # internal options
-        log_config=dict(),
-        publish_all_ports=dict(),
-        ports=dict(),
-        volume_binds=dict(),
-        name=dict(),
-        device_read_bps=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
-        device_read_iops=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
-        device_write_bps=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
-        device_write_iops=dict(docker_py_version='1.9.0', docker_api_version='1.22'),
-        dns_opts=dict(docker_api_version='1.21', docker_py_version='1.10.0'),
-        ipc_mode=dict(docker_api_version='1.25'),
-        mac_address=dict(docker_api_version='1.25'),
-        oom_killer=dict(docker_py_version='2.0.0'),
-        oom_score_adj=dict(docker_api_version='1.22', docker_py_version='2.0.0'),
-        shm_size=dict(docker_api_version='1.22'),
-        stop_signal=dict(docker_api_version='1.21'),
-        tmpfs=dict(docker_api_version='1.22'),
-        volume_driver=dict(docker_api_version='1.21'),
-        memory_reservation=dict(docker_api_version='1.21'),
-        kernel_memory=dict(docker_api_version='1.21'),
-        auto_remove=dict(docker_py_version='2.1.0', docker_api_version='1.25'),
-        healthcheck=dict(docker_py_version='2.0.0', docker_api_version='1.24'),
-        init=dict(docker_py_version='2.2.0', docker_api_version='1.25'),
-        runtime=dict(docker_py_version='2.4.0', docker_api_version='1.25'),
-        sysctls=dict(docker_py_version='1.10.0', docker_api_version='1.24'),
-        userns_mode=dict(docker_py_version='1.10.0', docker_api_version='1.23'),
-        uts=dict(docker_py_version='3.5.0', docker_api_version='1.25'),
-        pids_limit=dict(docker_py_version='1.10.0', docker_api_version='1.23'),
-        # specials
-        ipvX_address_supported=dict(docker_py_version='1.9.0', usage_msg='ipv4_address or ipv6_address in networks'),  # detect_usage set above
-        stop_timeout=dict(),  # see above!
-    )
-
     client = AnsibleDockerClientContainer(
         argument_spec=argument_spec,
         required_if=required_if,
         supports_check_mode=True,
         min_docker_api_version='1.20',
-        option_minimal_versions=option_minimal_versions,
     )
 
     cm = ContainerManager(client)

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -318,59 +318,6 @@ def get_ip_version(cidr):
 
 class DockerNetworkManager(object):
 
-    def _get_minimal_versions(self):
-        # TODO: Move this and the same from docker_container.py to docker_common.py
-        self.option_minimal_versions = dict()
-        for option, data in self.client.module.argument_spec.items():
-            self.option_minimal_versions[option] = dict()
-        self.option_minimal_versions.update(dict(
-            scope=dict(docker_py_version='2.6.0', docker_api_version='1.30'),
-            attachable=dict(docker_py_version='2.0.0', docker_api_version='1.26'),
-        ))
-
-        for option, data in self.option_minimal_versions.items():
-            # Test whether option is supported, and store result
-            support_docker_py = True
-            support_docker_api = True
-            if 'docker_py_version' in data:
-                support_docker_py = self.client.docker_py_version >= LooseVersion(data['docker_py_version'])
-            if 'docker_api_version' in data:
-                support_docker_api = self.client.docker_api_version >= LooseVersion(data['docker_api_version'])
-            data['supported'] = support_docker_py and support_docker_api
-            # Fail if option is not supported but used
-            if not data['supported']:
-                # Test whether option is specified
-                if 'detect_usage' in data:
-                    used = data['detect_usage']()
-                else:
-                    used = self.client.module.params.get(option) is not None
-                    if used and 'default' in self.client.module.argument_spec[option]:
-                        used = self.client.module.params[option] != self.client.module.argument_spec[option]['default']
-                if used:
-                    # If the option is used, compose error message.
-                    if 'usage_msg' in data:
-                        usg = data['usage_msg']
-                    else:
-                        usg = 'set %s option' % (option, )
-                    if not support_docker_api:
-                        msg = 'docker API version is %s. Minimum version required is %s to %s.'
-                        msg = msg % (self.client.docker_api_version_str, data['docker_api_version'], usg)
-                    elif not support_docker_py:
-                        if LooseVersion(data['docker_py_version']) < LooseVersion('2.0.0'):
-                            msg = ("docker-py version is %s. Minimum version required is %s to %s. "
-                                   "Consider switching to the 'docker' package if you do not require Python 2.6 support.")
-                        elif self.client.docker_py_version < LooseVersion('2.0.0'):
-                            msg = ("docker-py version is %s. Minimum version required is %s to %s. "
-                                   "You have to switch to the Python 'docker' package. First uninstall 'docker-py' before "
-                                   "installing 'docker' to avoid a broken installation.")
-                        else:
-                            msg = "docker version is %s. Minimum version required is %s to %s."
-                        msg = msg % (docker_version, data['docker_py_version'], usg)
-                    else:
-                        # should not happen
-                        msg = 'Cannot %s with your configuration.' % (usg, )
-                    self.client.fail(msg)
-
     def __init__(self, client):
         self.client = client
         self.parameters = TaskParameters(client)
@@ -382,8 +329,6 @@ class DockerNetworkManager(object):
         self.diff = self.client.module._diff
         self.diff_tracker = DifferenceTracker()
         self.diff_result = dict()
-
-        self._get_minimal_versions()
 
         self.existing_network = self.get_existing_network()
 
@@ -650,13 +595,19 @@ def main():
         ('ipam_config', 'ipam_options')
     ]
 
+    option_minimal_versions = dict(
+        scope=dict(docker_py_version='2.6.0', docker_api_version='1.30'),
+        attachable=dict(docker_py_version='2.0.0', docker_api_version='1.26'),
+    )
+
     client = AnsibleDockerClient(
         argument_spec=argument_spec,
         mutually_exclusive=mutually_exclusive,
         supports_check_mode=True,
         min_docker_version='1.10.0',
-        min_docker_api_version='1.22'
+        min_docker_api_version='1.22',
         # "The docker server >= 1.10.0"
+        option_minimal_versions=option_minimal_versions
     )
 
     cm = DockerNetworkManager(client)

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -255,6 +255,7 @@ from ansible.module_utils.docker_common import (
     DockerBaseClass,
     docker_version,
     DifferenceTracker,
+    clean_booleans_for_docker_api,
 )
 
 try:
@@ -313,22 +314,6 @@ def get_ip_version(cidr):
     elif CIDR_IPV6.match(cidr):
         return 'ipv6'
     raise ValueError('"{0}" is not a valid CIDR'.format(cidr))
-
-
-def get_driver_options(driver_options):
-    # TODO: Move this and the same from docker_prune.py to docker_common.py
-    result = dict()
-    if driver_options is not None:
-        for k, v in driver_options.items():
-            # Go doesn't like 'True' or 'False'
-            if v is True:
-                v = 'true'
-            elif v is False:
-                v = 'false'
-            else:
-                v = str(v)
-            result[str(k)] = v
-    return result
 
 
 class DockerNetworkManager(object):
@@ -410,7 +395,7 @@ class DockerNetworkManager(object):
             self.parameters.ipam_config = [self.parameters.ipam_options]
 
         if self.parameters.driver_options:
-            self.parameters.driver_options = get_driver_options(self.parameters.driver_options)
+            self.parameters.driver_options = clean_booleans_for_docker_api(self.parameters.driver_options)
 
         state = self.parameters.state
         if state == 'present':

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -255,7 +255,7 @@ from ansible.module_utils.docker_common import (
     DockerBaseClass,
     docker_version,
     DifferenceTracker,
-    clean_booleans_for_docker_api,
+    clean_dict_booleans_for_docker_api,
 )
 
 try:
@@ -340,7 +340,7 @@ class DockerNetworkManager(object):
             self.parameters.ipam_config = [self.parameters.ipam_options]
 
         if self.parameters.driver_options:
-            self.parameters.driver_options = clean_booleans_for_docker_api(self.parameters.driver_options)
+            self.parameters.driver_options = clean_dict_booleans_for_docker_api(self.parameters.driver_options)
 
         state = self.parameters.state
         if state == 'present':
@@ -607,7 +607,7 @@ def main():
         min_docker_version='1.10.0',
         min_docker_api_version='1.22',
         # "The docker server >= 1.10.0"
-        option_minimal_versions=option_minimal_versions
+        option_minimal_versions=option_minimal_versions,
     )
 
     cm = DockerNetworkManager(client)

--- a/lib/ansible/modules/cloud/docker/docker_prune.py
+++ b/lib/ansible/modules/cloud/docker/docker_prune.py
@@ -176,26 +176,10 @@ from distutils.version import LooseVersion
 from ansible.module_utils.docker_common import AnsibleDockerClient
 
 try:
-    from ansible.module_utils.docker_common import docker_version
+    from ansible.module_utils.docker_common import docker_version, clean_booleans_for_docker_api
 except Exception as dummy:
     # missing docker-py handled in ansible.module_utils.docker
     pass
-
-
-def get_filters(module, name):
-    result = dict()
-    filters = module.params.get(name)
-    if filters is not None:
-        for k, v in filters.items():
-            # Go doesn't like 'True' or 'False'
-            if v is True:
-                v = 'true'
-            elif v is False:
-                v = 'false'
-            else:
-                v = str(v)
-            result[str(k)] = v
-    return result
 
 
 def main():
@@ -227,24 +211,24 @@ def main():
     result = dict()
 
     if client.module.params['containers']:
-        filters = get_filters(client.module, 'containers_filters')
+        filters = clean_booleans_for_docker_api(client.module.params.get('containers_filters'))
         res = client.prune_containers(filters=filters)
         result['containers'] = res.get('ContainersDeleted') or []
         result['containers_space_reclaimed'] = res['SpaceReclaimed']
 
     if client.module.params['images']:
-        filters = get_filters(client.module, 'images_filters')
+        filters = clean_booleans_for_docker_api(client.module.params.get('images_filters'))
         res = client.prune_images(filters=filters)
         result['images'] = res.get('ImagesDeleted') or []
         result['images_space_reclaimed'] = res['SpaceReclaimed']
 
     if client.module.params['networks']:
-        filters = get_filters(client.module, 'networks_filters')
+        filters = clean_booleans_for_docker_api(client.module.params.get('networks_filters'))
         res = client.prune_networks(filters=filters)
         result['networks'] = res.get('NetworksDeleted') or []
 
     if client.module.params['volumes']:
-        filters = get_filters(client.module, 'volumes_filters')
+        filters = clean_booleans_for_docker_api(client.module.params.get('volumes_filters'))
         res = client.prune_volumes(filters=filters)
         result['volumes'] = res.get('VolumesDeleted') or []
         result['volumes_space_reclaimed'] = res['SpaceReclaimed']

--- a/lib/ansible/modules/cloud/docker/docker_prune.py
+++ b/lib/ansible/modules/cloud/docker/docker_prune.py
@@ -176,7 +176,7 @@ from distutils.version import LooseVersion
 from ansible.module_utils.docker_common import AnsibleDockerClient
 
 try:
-    from ansible.module_utils.docker_common import docker_version, clean_booleans_for_docker_api
+    from ansible.module_utils.docker_common import docker_version, clean_dict_booleans_for_docker_api
 except Exception as dummy:
     # missing docker-py handled in ansible.module_utils.docker
     pass
@@ -211,24 +211,24 @@ def main():
     result = dict()
 
     if client.module.params['containers']:
-        filters = clean_booleans_for_docker_api(client.module.params.get('containers_filters'))
+        filters = clean_dict_booleans_for_docker_api(client.module.params.get('containers_filters'))
         res = client.prune_containers(filters=filters)
         result['containers'] = res.get('ContainersDeleted') or []
         result['containers_space_reclaimed'] = res['SpaceReclaimed']
 
     if client.module.params['images']:
-        filters = clean_booleans_for_docker_api(client.module.params.get('images_filters'))
+        filters = clean_dict_booleans_for_docker_api(client.module.params.get('images_filters'))
         res = client.prune_images(filters=filters)
         result['images'] = res.get('ImagesDeleted') or []
         result['images_space_reclaimed'] = res['SpaceReclaimed']
 
     if client.module.params['networks']:
-        filters = clean_booleans_for_docker_api(client.module.params.get('networks_filters'))
+        filters = clean_dict_booleans_for_docker_api(client.module.params.get('networks_filters'))
         res = client.prune_networks(filters=filters)
         result['networks'] = res.get('NetworksDeleted') or []
 
     if client.module.params['volumes']:
-        filters = clean_booleans_for_docker_api(client.module.params.get('volumes_filters'))
+        filters = clean_dict_booleans_for_docker_api(client.module.params.get('volumes_filters'))
         res = client.prune_volumes(filters=filters)
         result['volumes'] = res.get('VolumesDeleted') or []
         result['volumes_space_reclaimed'] = res['SpaceReclaimed']


### PR DESCRIPTION
##### SUMMARY
Fixes #49563 and #49564

Consolidates Go Boolean cleaning and minimum version checks into docker_common.py.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_common
docker_network
docker_prune
docker_container
docker_swarm

##### ADDITIONAL INFORMATION
I can't get the docker_container integ tests passing locally (auto-remove fails for some reason), but docker_network's are running fine on my machine. Additionally, testing with old versions of docker-py resulted in seeing the expected errors coming out of the validation for both docker_network and docker_container.

Edit: docker_network and docker_swarm tests are passing. Manual testing for outdated versions is working as expected. I explicitly tested docker_container with an old docker-py and an `ipv4_address` network and it responded correctly, so the latest change to pass in the function for `detect_usage` is working as expected.