### PR TITLE
Add support for variable_{start,end}_string

### DIFF
--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -1,19 +1,7 @@
-# (c) 2015, Michael DeHaan <michael.dehaan@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2015, Michael DeHaan <michael.dehaan@gmail.com>
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
@@ -65,7 +53,7 @@ class ActionModule(ActionBase):
             try:
                 import jinja2.defaults
             except ImportError:
-                raise AnsibleError('Unable to import Jinja2 defaults for determing Jinja2 features.')
+                raise AnsibleError('Unable to import Jinja2 defaults for determining Jinja2 features.')
 
             try:
                 jinja2.defaults.LSTRIP_BLOCKS

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -1,9 +1,7 @@
-# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
-# (c) 2012-17 Ansible Project
+# Copyright: (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# Copyright: (c) 2012-17, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
@@ -13,18 +11,33 @@ DOCUMENTATION = """
     version_added: "0.9"
     short_description: retrieve contents of file after templating with Jinja2
     description:
-      - this is mostly a noop, to be used as a with_list loop when you dont want the content transformed in any way.
+      - this is mostly a noop, to be used as a with_list loop when you do not want the content transformed in any way.
     options:
       _terms:
         description: list of files to template
       convert_data:
         type: bool
         description: whether to convert YAML into data. If False, strings that are YAML will be left untouched.
+      variable_start_string:
+        description: The string marking the beginning of a print statement.
+        default: '{{'
+        version_added: '2.8'
+        type: str
+      variable_end_string:
+        description: The string marking the end of a print statement.
+        default: '}}'
+        version_added: '2.8'
+        type: str
 """
 
 EXAMPLES = """
 - name: show templating results
-  debug: msg="{{ lookup('template', './some_template.j2') }}
+  debug:
+    msg: "{{ lookup('template', './some_template.j2') }}"
+
+- name: show templating results with different variable start and end string
+  debug:
+    msg: "{{ lookup('template', './some_template.j2', variable_start_string='[%', variable_end_string='%]') }}"
 """
 
 RETURN = """
@@ -51,6 +64,9 @@ class LookupModule(LookupBase):
         lookup_template_vars = kwargs.get('template_vars', {})
         ret = []
 
+        variable_start_string = kwargs.get('variable_start_string', None)
+        variable_end_string = kwargs.get('variable_end_string', None)
+
         for term in terms:
             display.debug("File lookup term: %s" % term)
 
@@ -74,6 +90,10 @@ class LookupModule(LookupBase):
                     else:
                         searchpath = [self._loader._basedir, os.path.dirname(lookupfile)]
                     self._templar.environment.loader.searchpath = searchpath
+                    if variable_start_string is not None:
+                        self._templar.environment.variable_start_string = variable_start_string
+                    if variable_end_string is not None:
+                        self._templar.environment.variable_end_string = variable_end_string
 
                     # The template will have access to all existing variables,
                     # plus some added by ansible (e.g., template_{path,mtime}),

--- a/test/integration/targets/lookups/tasks/main.yml
+++ b/test/integration/targets/lookups/tasks/main.yml
@@ -1,20 +1,6 @@
 # test code for lookup plugins
-# (c) 2014, James Tanner <tanner.jc@gmail.com>
-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2014, James Tanner <tanner.jc@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # FILE LOOKUP
 
@@ -286,6 +272,17 @@
 - assert:
     that:
       - "hello_world|trim == 'Hello world!'"
+
+
+- name: Test that we have a proper jinja search path in template lookup with different variable start and end string
+  vars:
+    my_var: world
+  set_fact:
+    hello_world_string: "{{ lookup('template', 'hello_string.txt', variable_start_string='[%', variable_end_string='%]') }}"
+
+- assert:
+    that:
+      - "hello_world_string|trim == 'Hello world!'"
 
 # Vars lookups
 

--- a/test/integration/targets/lookups/templates/hello_string.txt
+++ b/test/integration/targets/lookups/templates/hello_string.txt
@@ -1,0 +1,1 @@
+Hello [% my_var %]!


### PR DESCRIPTION
##### SUMMARY
Template lookup plugin now support variable_start_string and
variable_end_string, just like template module.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/template.py
lib/ansible/plugins/lookup/template.py
test/integration/targets/lookups/tasks/main.yml
test/integration/targets/lookups/templates/hello_string.txt