### PR TITLE
aci_rest: Fix ignoring custom port

### DIFF
--- a/changelogs/fragments/49553-aci_rest-fix-ignoring-custom-port.yaml
+++ b/changelogs/fragments/49553-aci_rest-fix-ignoring-custom-port.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- aci_rest - Fix issue ignoring custom port

--- a/lib/ansible/modules/network/aci/aci_rest.py
+++ b/lib/ansible/modules/network/aci/aci_rest.py
@@ -387,8 +387,11 @@ def main():
             except Exception as e:
                 module.fail_json(msg='Failed to parse provided XML payload: %s' % to_text(e), payload=payload)
 
-    # Perform actual request using auth cookie (Same as aci_request, but also supports XML)
-    aci.url = '%(protocol)s://%(host)s/' % aci.params + path.lstrip('/')
+    # Perform actual request using auth cookie (Same as aci.request(), but also supports XML)
+    if 'port' in aci.params and aci.params['port'] is not None:
+        aci.url = '%(protocol)s://%(host)s:%(port)s/' % aci.params + path.lstrip('/')
+    else:
+        aci.url = '%(protocol)s://%(host)s/' % aci.params + path.lstrip('/')
     if aci.params['method'] != 'get':
         path += '?rsp-subtree=modified'
         aci.url = update_qsl(aci.url, {'rsp-subtree': 'modified'})


### PR DESCRIPTION
##### SUMMARY
This fixes #49553 

This should be backported to Ansible v2.7.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aci_rest