### PR TITLE
[2.7] docker_*: hint at DOCKER_CONFIG environment variable

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/docker.py
+++ b/lib/ansible/utils/module_docs_fragments/docker.py
@@ -107,4 +107,7 @@ notes:
       U(https://docker-py.readthedocs.io/en/stable/machine/) for more details.
     - When connecting to Docker daemon with TLS, you might need to install additional Python packages.
       For the Docker SDK for Python, version 2.4 or newer, this can be done by installing C(docker[tls]) with M(pip).
+    - Note that the Docker SDK for Python only allows to specify the path to the Docker configuration for very few functions.
+      In general, it will use C($HOME/docker/config.json) if the C(DOCKER_CONFIG) environment variable is not specified,
+      and use C($DOCKER_CONFIG/config.json) otherwise.
 '''


### PR DESCRIPTION
##### SUMMARY
Backport of #49689: provides hint for `DOCKER_CONFIG` environment variable directly supported by docker-py (see #48874).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_config
docker_container_facts
docker_container
docker_image_facts
docker_image
docker_login
docker_network
docker_prune
docker_secret
docker_service
docker_swarm
docker_swarm_service
docker_volume
