### PR TITLE
svc: Support service_src relative to service_dir

### DIFF
--- a/lib/ansible/modules/system/svc.py
+++ b/lib/ansible/modules/system/svc.py
@@ -149,10 +149,14 @@ class Svc(object):
             self.downed = os.path.lexists('%s/down' % self.svc_full)
             self.get_status()
         else:
+            if not os.path.isabs(self.src_full):
+                os.chdir(self.service_dir)
             self.downed = os.path.lexists('%s/down' % self.src_full)
             self.state = 'stopped'
 
     def enable(self):
+        if not os.path.isabs(self.src_full):
+            os.chdir(self.service_dir)
         if os.path.exists(self.src_full):
             try:
                 os.symlink(self.src_full, self.svc_full)
@@ -162,6 +166,8 @@ class Svc(object):
             self.module.fail_json(msg="Could not find source for service to enable (%s)." % self.src_full)
 
     def disable(self):
+        if not os.path.isabs(self.src_full):
+            os.chdir(self.service_dir)
         try:
             os.unlink(self.svc_full)
         except OSError as e:


### PR DESCRIPTION
##### SUMMARY
This allows

```
service_src: "../../usr/local/myservices"
service_dir: "/var/service"
```

so that a daemontools service's symlink is relative. Example: FreeBSD host with jails. Each jail is a child filesystem. Using relative symlinks will make them correct no matter whether logged in on the host or a jail, since we don't use absolute paths.

```
# ls -l /var/service
lrwxr-xr-x  1 root  wheel  47 Dec 10 13:39 autorestart-openvpn -> ../../usr/local/myservices/autorestart-openvpn
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
svc module