### PR TITLE
Jenkins_plugin: Handle 'latest' version when installing plugin for first time

### DIFF
--- a/changelogs/fragments/49723-jenkins-plugin-install-latest.yaml
+++ b/changelogs/fragments/49723-jenkins-plugin-install-latest.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "jenkins_plugin - ``version: latest`` should install new plugins with their dependencies"

--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -387,7 +387,7 @@ class JenkinsPlugin(object):
                 self.params['jenkins_home'],
                 self.params['name']))
 
-        if not self.is_installed and self.params['version'] is None:
+        if not self.is_installed and self.params['version'] in [None, 'latest']:
             if not self.module.check_mode:
                 # Install the plugin (with dependencies)
                 install_script = (


### PR DESCRIPTION
##### SUMMARY
Otherwise, a fresh install of a plugin with 'version: latest' gets installed without its dependencies, rendering the plugin effectively useless.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`jenkins_plugin`

##### ADDITIONAL INFORMATION

