### PR TITLE
[2.7] docker_swarm_service: ensure idempotency when the user parameter is None

### DIFF
--- a/changelogs/fragments/49235-docker_swarm_service-user-default.yaml
+++ b/changelogs/fragments/49235-docker_swarm_service-user-default.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - 'docker_swarm_service: fails because of default "user: root" (https://github.com/ansible/ansible/issues/49199)'
+minor_changes:
+  - 'docker_swarm_service: use docker defaults for the ``user`` parameter if it is set to ``null``'

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -273,7 +273,10 @@ options:
   user:
     required: false
     default: root
-    description: username or UID
+    description:
+    - username or UID.
+    - "If set to C(null) the image provided value (or the one already
+       set for the service) will be used"
 extends_documentation_fragment:
 - docker
 requirements:
@@ -718,7 +721,7 @@ class DockerService(DockerBaseClass):
             differences.append('update_order')
         if self.image != os.image.split('@')[0]:
             differences.append('image')
-        if self.user != os.user:
+        if self.user and self.user != os.user:
             differences.append('user')
         if self.dns != os.dns:
             differences.append('dns')


### PR DESCRIPTION
##### SUMMARY
Backport of #49235 to `stable-2.7`.

CC @dariko

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm_service
