### PR TITLE
added dhcp standard options (#49729)

### DIFF
--- a/lib/ansible/modules/net_tools/nios/nios_network.py
+++ b/lib/ansible/modules/net_tools/nios/nios_network.py
@@ -48,7 +48,10 @@ options:
     suboptions:
       name:
         description:
-          - The name of the DHCP option to configure
+          - The name of the DHCP option to configure. The standard options are
+            C(router), C(router-templates), C(domain-name-servers), C(domain-name),
+            C(broadcast-address), C(broadcast-address-offset), C(dhcp-lease-time),
+            and C(dhcp6.name-servers).
       num:
         description:
           - The number of the DHCP option to configure


### PR DESCRIPTION
(cherry picked from commit 418c03a686856bb25c2249a0e2466d416a2dc188)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions ->
Add nios dhcp options list
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nios_network
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
