### PR TITLE
[stable-2.7] openstack: fix parameter handling when cloud provided as dict (#42899)

### DIFF
--- a/changelogs/fragments/openstack-fixes-for-2.7.5.yaml
+++ b/changelogs/fragments/openstack-fixes-for-2.7.5.yaml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - openstack - fix parameter handling when cloud provided as dict
+    https://github.com/ansible/ansible/issues/42858
+  - os_user - Include domain parameter in user lookup
+    https://github.com/ansible/ansible/issues/42901
+  - os_user - Include domain parameter in user deletion
+    https://github.com/ansible/ansible/issues/42901

--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -134,11 +134,12 @@ def openstack_cloud_from_module(module, min_version='0.12.0'):
                 " excluded.")
             for param in (
                     'auth', 'region_name', 'verify',
-                    'cacert', 'key', 'api_timeout', 'interface'):
+                    'cacert', 'key', 'api_timeout', 'auth_type'):
                 if module.params[param] is not None:
                     module.fail_json(msg=fail_message.format(param=param))
-            if module.params['auth_type'] != 'password':
-                module.fail_json(msg=fail_message.format(param='auth_type'))
+            # For 'interface' parameter, fail if we receive a non-default value
+            if module.params['interface'] != 'public':
+                module.fail_json(msg=fail_message.format(param='interface'))
             return sdk, sdk.connect(**cloud_config)
         else:
             return sdk, sdk.connect(

--- a/lib/ansible/modules/cloud/openstack/os_user.py
+++ b/lib/ansible/modules/cloud/openstack/os_user.py
@@ -201,11 +201,12 @@ def main():
 
     sdk, cloud = openstack_cloud_from_module(module)
     try:
-        user = cloud.get_user(name)
-
         domain_id = None
         if domain:
             domain_id = _get_domain_id(cloud, domain)
+            user = cloud.get_user(name, domain_id=domain_id)
+        else:
+            user = cloud.get_user(name)
 
         if state == 'present':
             if update_password in ('always', 'on_create'):
@@ -271,7 +272,10 @@ def main():
             if user is None:
                 changed = False
             else:
-                cloud.delete_user(user['id'])
+                if domain:
+                    cloud.delete_user(user['id'], domain_id=domain_id)
+                else:
+                    cloud.delete_user(user['id'])
                 changed = True
             module.exit_json(changed=changed)
 


### PR DESCRIPTION

* openstack: fix parameter handling when cloud provided as dict

If a cloud is provided as dictionary:

 * Do not assert that 'interface' parameter is None. Instead,
   assert that it is 'public'.
 * Assert that 'auth_type' parameter is not set.

Fixes #42858

* os_user: Include domain parameter in user lookup

If a "domain" parameter is provided, use it in looking up
whether the user already exists.

Fixes #42901

* os_user: Include domain parameter in user deletion

If a "domain" parameter is provided, use it in deleting
the user also.

Fixes #42901
(cherry picked from commit e25dac9)

Co-authored-by: Carsten Koester <carsten@ckoester.net>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openstack
