### PR TITLE
Disable failing ec2_vpc_vpn_facts test.

### DIFF
--- a/test/integration/targets/ec2_vpc_vpn_facts/aliases
+++ b/test/integration/targets/ec2_vpc_vpn_facts/aliases
@@ -1,2 +1,3 @@
 cloud/aws
 shippable/aws/group2
+disabled


### PR DESCRIPTION
##### SUMMARY

Disable failing ec2_vpc_vpn_facts test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ec2_vpc_vpn_facts integration test

##### ADDITIONAL INFORMATION

See https://github.com/ansible/ansible/issues/49751 for details on the failures.