### PR TITLE
[stable-2.6] Disable failing ec2_vpc_vpn_facts test.

### DIFF
--- a/test/integration/targets/ec2_vpc_vpn_facts/aliases
+++ b/test/integration/targets/ec2_vpc_vpn_facts/aliases
@@ -1,2 +1,3 @@
 cloud/aws
 shippable/aws/group2
+disabled


### PR DESCRIPTION
##### SUMMARY

[stable-2.6] Disable failing ec2_vpc_vpn_facts test.

(cherry picked from commit df1c9d0f254a755283f33591ccb0eea85ff4c83f)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ec2_vpc_vpn_facts integration test
