### PR TITLE
Properly report install failures from dnf module

### DIFF
--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -1087,10 +1087,10 @@ class DnfModule(YumDnf):
                 self.module.exit_json(**response)
             else:
                 response['changed'] = True
+                if failure_response['failures']:
+                    failure_response['msg'] = 'Failed to install some of the specified packages',
+                    self.module.fail_json(**failure_response)
                 if self.module.check_mode:
-                    if failure_response['failures']:
-                        failure_response['msg'] = 'Failed to install some of the specified packages',
-                        self.module.fail_json(**failure_response)
                     response['msg'] = "Check mode: No changes made, but would have if not in check mode"
                     self.module.exit_json(**response)
 


### PR DESCRIPTION
##### SUMMARY
Fixes #49759 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
dnf

##### ADDITIONAL INFORMATION
Reporting of install failures was improperly guarded behind a list of packages to install when the first element changed in a list was found. This lead to the dnf module silently failing at times when it should not fail.

See issue report for description of failure conditions and example playbooks to trigger the behavior.