### PR TITLE
plugin_formatter.py: accept multiple template dirs

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -334,7 +334,7 @@ def generate_parser():
     p.add_option("-A", "--ansible-version", action="store", dest="ansible_version", default="unknown", help="Ansible version number")
     p.add_option("-M", "--module-dir", action="store", dest="module_dir", default=MODULEDIR, help="Ansible library path")
     p.add_option("-P", "--plugin-type", action="store", dest="plugin_type", default='module', help="The type of plugin (module, lookup, etc)")
-    p.add_option("-T", "--template-dir", action="store", dest="template_dir", default="hacking/templates", help="directory containing Jinja2 templates")
+    p.add_option("-T", "--template-dir", action="append", dest="template_dir", help="directory containing Jinja2 templates")
     p.add_option("-t", "--type", action='store', dest='type', choices=['rst'], default='rst', help="Document type")
     p.add_option("-o", "--output-dir", action="store", dest="output_dir", default=None, help="Output directory for module files")
     p.add_option("-I", "--includes-file", action="store", dest="includes_file", default=None, help="Create a file containing list of processed modules")
@@ -651,6 +651,8 @@ def main():
     # INIT
     p = generate_parser()
     (options, args) = p.parse_args()
+    if not options.template_dir:
+        options.template_dir = ["hacking/templates"]
     validate_options(options)
     display.verbosity = options.verbosity
     plugin_type = options.plugin_type


### PR DESCRIPTION
this allows to override certain templates without copying the whole
template directory

##### SUMMARY
When using the plugin formatter to build documentation of custom modules/plugins *and* wanting to override certain parts of the default ansible docs templates, you currently have to copy *all* templates to a separate folder and edit the one you want changed.

[Jinja's FileSystemLoader](http://jinja.pocoo.org/docs/2.10/api/#jinja2.FileSystemLoader) accepts both, a string and a list as the `searchpath`, so let's pass a list instead :)

This can be used like this:

```shell
python docs/bin/plugin_formatter.py --module-dir <path_to_custom>/modules \
  --template-dir <path_to_custom>/docs/_templates --template-dir docs/templates \
  --type rst --output-dir <path_to_custom>/docs/modules/ 
```

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

Can't decide, as it's a docs feature? :)

##### COMPONENT NAME
plugin_formatter.py