### PR TITLE
Don't fail if a remote_addr with a '/' hits ansible_connection

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -229,6 +229,12 @@ def main():
         play_context.deserialize(pc_data)
         display.verbosity = play_context.verbosity
 
+        if '/' in play_context.remote_addr:
+            raise Exception(
+                "Remote host %s is invalid because it contains a '/'. You probably wanted to set "
+                "ansible_host to an IP address instead of a CIDR block" % play_context.remote_addr
+            )
+
     except Exception as e:
         rc = 1
         result.update({

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -179,6 +179,7 @@ class ConnectionProcess(object):
     def shutdown(self):
         """ Shuts down the local domain socket
         """
+        lock_path = unfrackpath("%s/.ansible_pc_lock_%s" % os.path.split(self.socket_path))
         if os.path.exists(self.socket_path):
             try:
                 if self.sock:
@@ -192,6 +193,10 @@ class ConnectionProcess(object):
                     os.remove(self.socket_path)
                     setattr(self.connection, '_socket_path', None)
                     setattr(self.connection, '_connected', False)
+
+        if os.path.exists(lock_path):
+            os.remove(lock_path)
+
         display.display('shutdown complete', log_only=True)
 
 
@@ -229,12 +234,6 @@ def main():
         play_context.deserialize(pc_data)
         display.verbosity = play_context.verbosity
 
-        if '/' in play_context.remote_addr:
-            raise Exception(
-                "Remote host %s is invalid because it contains a '/'. You probably wanted to set "
-                "ansible_host to an IP address instead of a CIDR block" % play_context.remote_addr
-            )
-
     except Exception as e:
         rc = 1
         result.update({
@@ -252,8 +251,8 @@ def main():
         tmp_path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
         makedirs_safe(tmp_path)
 
-        lock_path = unfrackpath("%s/.ansible_pc_lock_%s" % (tmp_path, play_context.remote_addr))
         socket_path = unfrackpath(cp % dict(directory=tmp_path))
+        lock_path = unfrackpath("%s/.ansible_pc_lock_%s" % os.path.split(socket_path))
 
         with file_lock(lock_path):
             if not os.path.exists(socket_path):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
~~This is _probably_ a CIDR block, but anything with a slash will fail,~~
~~so no need to try to parse to make sure~~

Fixes #49259

Remove the reliance of bare `remote_addr` on pc file locks. Locks are now per-connection, which should be fine, as the thing they lock is the socket.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible_connection