### PR TITLE
Support for cache_from parameter in docker_image module

### DIFF
--- a/changelogs/fragments/49787-docker_image-cache_from.yaml
+++ b/changelogs/fragments/49787-docker_image-cache_from.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_image - Add ``cache_from`` option."

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -624,10 +624,16 @@ def main():
         buildargs=dict(type='dict', default=None),
     )
 
+    option_minimal_versions = dict(
+        cache_from=dict(docker_py_version='2.1.0', docker_api_version='1.25'),
+    )
+
     client = AnsibleDockerClient(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        min_docker_version='1.8.0',
         min_docker_api_version='1.20',
+        option_minimal_versions=option_minimal_versions,
     )
 
     results = dict(

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -538,7 +538,6 @@ class ImageManager(DockerBaseClass):
             forcerm=self.rm,
             dockerfile=self.dockerfile,
             decode=True,
-            cache_from=self.cache_from
         )
         if not HAS_DOCKER_PY_3:
             params['stream'] = True
@@ -551,6 +550,8 @@ class ImageManager(DockerBaseClass):
             for key, value in self.buildargs.items():
                 self.buildargs[key] = to_native(value)
             params['buildargs'] = self.buildargs
+        if self.cache_from:
+            params['cache_from'] = self.cache_from
 
         for line in self.client.build(**params):
             # line = json.loads(line)


### PR DESCRIPTION
##### SUMMARY
Add support for `cache_from` parameter in docker_image module

Fixes #21704

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_image

##### ADDITIONAL INFORMATION
Use cache_from option while building image:

```paste below
- name: Build image using cache
  docker_image:
    name: myimage:latest
    path: /path/to/build/dir
    cache_from:
      - nginx:latest
      - alpine:3.8
```
