### PR TITLE
ufw: allow to insert rules relative to first/last IPv4/IPv6 rules

### DIFF
--- a/changelogs/fragments/49796-ufw-insert-relative-to.yml
+++ b/changelogs/fragments/49796-ufw-insert-relative-to.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- "ufw - type of option ``insert`` is now enforced to be ``int``."
+- "ufw - new ``insert_relative_to`` option allows to specify rule insertion position relative to first/last IPv4/IPv6 address."

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -52,7 +52,9 @@ options:
     choices: [ on, off, low, medium, high, full ]
   insert:
     description:
-      - Insert the corresponding rule as rule number NUM
+      - Insert the corresponding rule as rule number NUM.
+      - Note that ufw numbers rules starting with 1.
+    type: int
   rule:
     description:
       - Add firewall rule
@@ -247,7 +249,7 @@ def main():
             direction=dict(type='str', choices=['in', 'incoming', 'out', 'outgoing', 'routed']),
             delete=dict(type='bool', default=False),
             route=dict(type='bool', default=False),
-            insert=dict(type='str'),
+            insert=dict(type='int'),
             rule=dict(type='str', choices=['allow', 'deny', 'limit', 'reject']),
             interface=dict(type='str', aliases=['if']),
             log=dict(type='bool', default=False),

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -236,6 +236,10 @@ EXAMPLES = '''
 
 - name: Deny all IPv4 traffic to tcp port 20 on this host
   # This should be the third to last IPv4 rule
+  # (insert: -1 addresses the second to last IPv4 rule;
+  #  so the new rule will be inserted before the second
+  #  to last IPv4 rule, and will be come the third to last
+  #  IPv4 rule.)
   ufw:
     rule: deny
     proto: tcp

--- a/test/integration/targets/ufw/tasks/run-test.yml
+++ b/test/integration/targets/ufw/tasks/run-test.yml
@@ -16,3 +16,6 @@
     state: disabled
 - name: "Loading tasks from {{ item }}"
   include_tasks: "{{ item }}"
+- name: Reset to factory defaults
+  ufw:
+    state: reset

--- a/test/integration/targets/ufw/tasks/tests/insert_relative_to.yml
+++ b/test/integration/targets/ufw/tasks/tests/insert_relative_to.yml
@@ -1,0 +1,80 @@
+---
+- name: Enable
+  ufw:
+    state: enabled
+  register: enable
+
+# ## CREATE RULES ############################
+- name: ipv4
+  ufw:
+    rule: deny
+    port: 22
+    to_ip: 0.0.0.0
+- name: ipv4
+  ufw:
+    rule: deny
+    port: 23
+    to_ip: 0.0.0.0
+
+- name: ipv6
+  ufw:
+    rule: deny
+    port: 122
+    to_ip: "::"
+- name: ipv6
+  ufw:
+    rule: deny
+    port: 123
+    to_ip: "::"
+
+- name: first-ipv4
+  ufw:
+    rule: deny
+    port: 10
+    to_ip: 0.0.0.0
+    insert: 0
+    insert_relative_to: first-ipv4
+- name: last-ipv4
+  ufw:
+    rule: deny
+    port: 11
+    to_ip: 0.0.0.0
+    insert: 0
+    insert_relative_to: last-ipv4
+
+- name: first-ipv6
+  ufw:
+    rule: deny
+    port: 110
+    to_ip: "::"
+    insert: 0
+    insert_relative_to: first-ipv6
+- name: last-ipv6
+  ufw:
+    rule: deny
+    port: 111
+    to_ip: "::"
+    insert: 0
+    insert_relative_to: last-ipv6
+
+# ## CHECK RESULT ############################
+- name: Get rules
+  shell: |
+    ufw status | grep DENY | cut -f 1-2 -d ' ' | grep -E "^(0\.0\.0\.0|::) [123]+"
+  # Note that there was also a rule "ff02::fb mDNS" on at least one CI run;
+  # to ignore these, the extra filtering (grepping for DENY and the regex) makes
+  # sure to remove all rules not added here.
+  register: ufw_status
+- assert:
+    that:
+    - ufw_status.stdout_lines == expected_stdout
+  vars:
+    expected_stdout:
+    - "0.0.0.0 10"
+    - "0.0.0.0 22"
+    - "0.0.0.0 11"
+    - "0.0.0.0 23"
+    - ":: 110"
+    - ":: 122"
+    - ":: 111"
+    - ":: 123"


### PR DESCRIPTION
##### SUMMARY
Allows to insert rules relative to the first/last IPv4/IPv6 rules.

Especially useful is inserting relative to the first IPv6 rule, which is impossible without either parsing `ufw status numbered` manually or otherwise knowing exactly how many IPv4 rules are there. (This is a [known problem with ufw](https://bugs.launchpad.net/ufw/+bug/1368411).)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ufw
