### PR TITLE
[docker_container] Fixes idempotency checks for network_mode

### DIFF
--- a/changelogs/fragments/49794-docker_container-network-mode.yml
+++ b/changelogs/fragments/49794-docker_container-network-mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- docker_container - fix ``network_mode`` idempotency if the ``container:<container-name>`` form is used (as opposed to ``container:<container-id>``) (https://github.com/ansible/ansible/issues/49794)

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1090,6 +1090,7 @@ class TaskParameters(DockerBaseClass):
         self.volume_binds = self._get_volume_binds(self.volumes)
         self.pid_mode = self._replace_container_names(self.pid_mode)
         self.ipc_mode = self._replace_container_names(self.ipc_mode)
+        self.network_mode = self._replace_container_names(self.network_mode)
 
         self.log("volumes:")
         self.log(self.volumes, pretty_print=True)

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -2440,11 +2440,42 @@
     force_kill: yes
   register: network_mode_3
 
+- name: network_mode (container mode setup)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname_h1 }}"
+    state: started
+
+- name: network_mode (container mode)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    network_mode: "container:{{ cname_h1 }}"
+    force_kill: yes
+  register: network_mode_4
+
+- name: network_mode (container mode idempotency)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    network_mode: "container:{{ cname_h1 }}"
+  register: network_mode_5
+
 - name: cleanup
   docker_container:
-    name: "{{ cname }}"
+    name: "{{ container_name }}"
     state: absent
     force_kill: yes
+  loop:
+  - "{{ cname }}"
+  - "{{ cname_h1 }}"
+  loop_control:
+    loop_var: container_name
   diff: no
 
 - assert:
@@ -2452,6 +2483,8 @@
     - network_mode_1 is changed
     - network_mode_2 is not changed
     - network_mode_3 is changed
+    - network_mode_4 is changed
+    - network_mode_5 is not changed
 
 ####################################################################
 ## networks, purge_networks ########################################


### PR DESCRIPTION
##### SUMMARY
Fixes #49794.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ADDITIONAL INFORMATION
Works with the following playbook:

```yaml
---
- hosts: localhost
  remote_user: root
  tasks:
  - name: network_mode (container mode setup)
    docker_container:
      image: alpine:3.8
      command: '/bin/sh -c "sleep 10m"'
      name: h1
      state: started
  
  - name: network_mode (container mode)
    docker_container:
      image: alpine:3.8
      command: '/bin/sh -c "sleep 10m"'
      name: test
      state: started
      network_mode: container:h1
  
  - name: network_mode (container mode idempotency)
    docker_container:
      image: alpine:3.8
      command: '/bin/sh -c "sleep 10m"'
      name: test
      state: started
      network_mode: container:h1
```
