### PR TITLE
Remove misleading statement passwords must be same

### DIFF
--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -38,9 +38,7 @@ To create a new encrypted data file, run the following command:
 
    ansible-vault create foo.yml
 
-First you will be prompted for a password.  The password used with vault currently must be the same for all files you wish to use together at the same time.
-
-After providing a password, the tool will launch whatever editor you have defined with $EDITOR, and defaults to vi (before 2.1 the default was vim).  Once you are done with the editor session, the file will be saved as encrypted data.
+First you will be prompted for a password. After providing a password, the tool will launch whatever editor you have defined with $EDITOR, and defaults to vi (before 2.1 the default was vim).  Once you are done with the editor session, the file will be saved as encrypted data.
 
 The default cipher is AES (which is shared-secret based).
 

--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -38,7 +38,7 @@ To create a new encrypted data file, run the following command:
 
    ansible-vault create foo.yml
 
-First you will be prompted for a password. After providing a password, the tool will launch whatever editor you have defined with $EDITOR, and defaults to vi (before 2.1 the default was vim).  Once you are done with the editor session, the file will be saved as encrypted data.
+First you will be prompted for a password. After providing a password, the tool will launch whatever editor you have defined with $EDITOR, and defaults to vi.  Once you are done with the editor session, the file will be saved as encrypted data.
 
 The default cipher is AES (which is shared-secret based).
 

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -42,8 +42,6 @@ class VaultCLI(CLI):
 
     Because Ansible tasks, handlers, and other objects are data, these can also be encrypted with vault.
     If you'd like to not expose what variables you are using, you can keep an individual task file entirely encrypted.
-
-    The password used with vault currently must be the same for all files you wish to use together at the same time.
     '''
 
     VALID_ACTIONS = ("create", "decrypt", "edit", "encrypt", "encrypt_string", "rekey", "view")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Since 2.4 Ansible has supported multiple vault passwords:
<https://docs.ansible.com/ansible/latest/user_guide/vault.html#multiple-vault-passwords>

Meaning lines like the following are misleading:

> The password used with vault currently must be the same for all files you wish
> to use together at the same time.

-- `docs/docsite/rst/user_guide/vault.rst`

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vault 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

To demonstrate this with Ansible 2.7, save the following as `example.yaml`:

```
- name: Display output from two vaults with different passwords
  hosts: localhost
  connection: local
  vars_files: [one.yaml, two.yaml]
  tasks:
    - name: View secret from one.yaml vault
      debug: { var: one }
    - name: View secret from two.yaml vault
      debug: { var: two }
```

Then run the three following commands choosing two different passwords:

```
$ echo 'one: 1' | ansible-vault encrypt --vault-id id1@prompt --output=one.yaml
$ echo 'two: 2' | ansible-vault encrypt --vault-id id2@prompt --output=two.yaml
$ ansible-playbook --vault-id id1@prompt --vault-id id2@prompt example.yaml
```

`ansible-vault` stores an ID in plain text in the vault file.

