### PR TITLE
VMware: Fix vmware guest customvalues

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -328,7 +328,7 @@ def gather_vm_facts(content, vm):
 
     cfm = content.customFieldsManager
     # Resolve custom values
-    for value_obj in vm.summary.customValue:
+    for value_obj in vm.config.extraConfig:
         kn = value_obj.key
         if cfm is not None and cfm.field:
             for f in cfm.field:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1497,8 +1497,7 @@ class PyVmomiHelper(PyVmomi):
                 self.module.exit_json(msg="customvalues items required both 'key' and 'value fields.")
 
             # If kv is not kv fetched from facts, change it
-            valuetype = type(kv['value'])
-            if valuetype is bool or valuetype is int:
+            if isinstance(kv['value'], (bool, int)):
                 specifiedvalue = str(kv['value']).upper()
                 comparisonvalue = facts['customvalues'].get(kv['key'], '').upper()
             else:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1497,10 +1497,18 @@ class PyVmomiHelper(PyVmomi):
                 self.module.exit_json(msg="customvalues items required both 'key' and 'value fields.")
 
             # If kv is not kv fetched from facts, change it
-            if kv['key'] not in facts['customvalues'] or facts['customvalues'][kv['key']] != kv['value']:
+            valuetype = type(kv['value'])
+            if valuetype is bool or valuetype is int:
+                specifiedvalue = str(kv['value']).upper()
+                comparisonvalue = facts['customvalues'].get(kv['key'], '').upper()
+            else:
+                specifiedvalue = kv['value']
+                comparisonvalue = facts['customvalues'].get(kv['key'], '')
+
+            if (kv['key'] not in facts['customvalues'] and kv['value'] != '') or comparisonvalue != specifiedvalue:
                 option = vim.option.OptionValue()
                 option.key = kv['key']
-                option.value = kv['value']
+                option.value = specifiedvalue
 
                 vm_custom_spec.extraConfig.append(option)
                 changed = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Presently, the vmware_guest module does not handle boolean data types for customvalues.  Additionally, it is not idempotent for any values as the fact gatherer is looking in the wrong place.  I also added some additional handing for boolean values, integer values, and empty values.

Fixes #49793
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest
vmware module_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
