### PR TITLE
Add support for hex color in slack module

### DIFF
--- a/changelogs/fragments/11935-slack-add_hex_color_values.yaml
+++ b/changelogs/fragments/11935-slack-add_hex_color_values.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Add support for hex color values in Slack module.


### PR DESCRIPTION
##### SUMMARY
Fixes: #11935

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
changelogs/fragments/11935-slack-add_hex_color_values.yaml
lib/ansible/modules/notification/slack.py
test/units/modules/notification/test_slack.py