### PR TITLE
New module lxca_switches for Lenovo XClarity Administrator

### DIFF
--- a/lib/ansible/modules/remote_management/lxca/lxca_switches.py
+++ b/lib/ansible/modules/remote_management/lxca/lxca_switches.py
@@ -112,7 +112,7 @@ EXAMPLES = '''
 RETURN = r'''
 result:
     description: switches detail from lxca
-    returned: always
+    returned: success
     type: dict
     sample:
       switchList:

--- a/lib/ansible/modules/remote_management/lxca/lxca_switches.py
+++ b/lib/ansible/modules/remote_management/lxca/lxca_switches.py
@@ -1,0 +1,246 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'supported_by': 'community',
+    'status': ['preview']
+}
+
+
+DOCUMENTATION = '''
+---
+version_added: "2.8"
+author:
+  - Naval Patel (@navalkp)
+  - Prashant Bhosale (@prabhosa)
+module: lxca_switches
+short_description: Custom module for lxca switches inventory utility
+description:
+  - This module returns/displays a inventory details of switches and enable/disable ports
+
+options:
+  uuid:
+    description:
+      uuid of device, this is string with length greater than 16.
+
+  command_options:
+    description:
+      options to filter switches information
+    default: switches
+    choices:
+      - switches
+      - switches_by_uuid
+      - switches_by_chassis_uuid
+      - switches_list_ports
+      - switches_change_status_of_ports
+
+  chassis:
+    description:
+      uuid of chassis, this is string with length greater than 16.
+
+  ports:
+    description:
+      ports of switch to operate on its comma separated string.
+
+  ports_action:
+    description:
+      enable or disable ports of switch.
+    choices:
+      - None
+      - enable
+      - disable
+
+extends_documentation_fragment:
+    - lxca_common
+'''
+
+EXAMPLES = '''
+# get all switches info
+- name: get switches data from LXCA
+  lxca_switches:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+
+# get specific switches info by uuid
+- name: get switches data from LXCA
+  lxca_switches:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+    uuid: "3C737AA5E31640CE949B10C129A8B01F"
+    command_options: switches_by_uuid
+
+# get specific switches info by chassis uuid
+- name: get switches data from LXCA
+  lxca_switches:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+    chassis: "3C737AA5E31640CE949B10C129A8B01F"
+    command_options: switches_by_chassis_uuid
+
+# get particular switch ports
+- name: get particular switch ports detailed data from LXCA
+  lxca_switches:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+    uuid: "3C737AA5E31640CE949B10C129A8B01F"
+    command_options: switches_list_ports
+
+# Update switch ports
+# ports = [1,3]
+- name: Update switch ports from LXCA
+  lxca_switches:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+    uuid: "3C737AA5E31640CE949B10C129A8B01F"
+    ports_action: enabled
+    ports: "{{ports}}"
+    command_options: switches_change_status_of_ports
+
+'''
+
+RETURN = r'''
+result:
+    description: switches detail from lxca
+    returned: always
+    type: dict
+    sample:
+      switchList:
+        - machineType: ''
+          model: ''
+          type: 'Switch'
+          uuid: '118D2C88C8FD11E4947B6EAE8B4BDCDF'
+          # bunch of properties
+        - machineType: ''
+          model: ''
+          type: 'Switch'
+          uuid: '223D2C88C8FD11E4947B6EAE8B4BDCDF'
+          # bunch of properties
+        # Multiple switches details
+'''
+
+import traceback
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.remote_management.lxca.common import LXCA_COMMON_ARGS, has_pylxca, connection_object
+try:
+    from pylxca import switches
+except ImportError:
+    pass
+
+
+UUID_REQUIRED = 'UUID of device is required for switches_by_uuid command.'
+UUID_REQUIRED_FOR_LIST_PORTS = 'UUID of device is required for switches_list_ports command.'
+UUID_REQUIRED_FOR_PORTS_ACTION = 'UUID of device is required for switches_change_status_of_ports command.'
+CHASSIS_UUID_REQUIRED = 'UUID of chassis is required for switches_by_chassis_uuid command.'
+PORTS_ACTION_REQUIRED = 'ports_action is required for switches_change_status_of_ports command.'
+PORTS_REQUIRED = 'ports is required for switches_change_status_of_ports command.'
+SUCCESS_MSG = "Success %s result"
+__changed__ = False
+
+
+def _switches(module, lxca_con):
+    return switches(lxca_con)
+
+
+def _switches_by_uuid(module, lxca_con):
+    if not module.params['uuid']:
+        module.fail_json(msg=UUID_REQUIRED)
+    return switches(lxca_con, uuid=module.params['uuid'])
+
+
+def _switches_by_chassis_uuid(module, lxca_con):
+    if not module.params['chassis']:
+        module.fail_json(msg=CHASSIS_UUID_REQUIRED)
+    return switches(lxca_con, chassis=module.params['chassis'])
+
+
+def switches_list_ports(module, lxca_con):
+    if not module.params['uuid']:
+        module.fail_json(msg=UUID_REQUIRED_FOR_LIST_PORTS)
+
+    return switches(lxca_con, uuid=module.params['uuid'], ports="")
+
+
+def switches_change_status_of_ports(module, lxca_con):
+    global __changed__
+    if not module.params['uuid']:
+        module.fail_json(msg=UUID_REQUIRED_FOR_PORTS_ACTION)
+    if not module.params['ports_action']:
+        module.fail_json(msg=PORTS_ACTION_REQUIRED)
+    if not module.params['ports']:
+        module.fail_json(msg=PORTS_REQUIRED)
+
+    __changed__ = True
+    return switches(lxca_con, uuid=module.params['uuid'],
+                    ports=module.params['ports'],
+                    action=module.params['ports_action'])
+
+
+def setup_module_object():
+    """
+    this function merge argument spec and create ansible module object
+    :return:
+    """
+    args_spec = dict(LXCA_COMMON_ARGS)
+    args_spec.update(INPUT_ARG_SPEC)
+    module = AnsibleModule(argument_spec=args_spec, supports_check_mode=False)
+
+    return module
+
+
+FUNC_DICT = {
+    'switches': _switches,
+    'switches_by_uuid': _switches_by_uuid,
+    'switches_by_chassis_uuid': _switches_by_chassis_uuid,
+    'switches_list_ports': switches_list_ports,
+    'switches_change_status_of_ports': switches_change_status_of_ports,
+}
+
+
+INPUT_ARG_SPEC = dict(
+    command_options=dict(default='switches', choices=['switches',
+                                                      'switches_by_uuid',
+                                                      'switches_by_chassis_uuid',
+                                                      'switches_list_ports',
+                                                      'switches_change_status_of_ports']),
+    uuid=dict(default=None),
+    chassis=dict(default=None),
+    ports=dict(default=None),
+    ports_action=dict(default=None, choices=[None, 'enable', 'disable'])
+)
+
+
+def execute_module(module):
+    """
+    This function invoke commands
+    :param module: Ansible module object
+    """
+    try:
+        with connection_object(module) as lxca_con:
+            result = FUNC_DICT[module.params['command_options']](module, lxca_con)
+            module.exit_json(changed=__changed__,
+                             msg=SUCCESS_MSG % module.params['command_options'],
+                             result=result)
+    except Exception as exception:
+        error_msg = '; '.join((e) for e in exception.args)
+        module.fail_json(msg=error_msg, exception=traceback.format_exc())
+
+
+def main():
+    module = setup_module_object()
+    has_pylxca(module)
+    execute_module(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/remote_management/lxca/test_lxca_switches.py
+++ b/test/units/modules/remote_management/lxca/test_lxca_switches.py
@@ -1,0 +1,98 @@
+import json
+
+import pytest
+from units.compat import mock
+from ansible.modules.remote_management.lxca import lxca_switches
+
+
+@pytest.fixture(scope='module')
+@mock.patch("ansible.module_utils.remote_management.lxca.common.close_conn", autospec=True)
+def setup_module(close_conn):
+    close_conn.return_value = True
+
+
+class TestMyModule():
+    @pytest.mark.parametrize('patch_ansible_module',
+                             [
+                                 {},
+                                 {
+                                     "auth_url": "https://10.240.14.195",
+                                     "login_user": "USERID",
+                                 },
+                                 {
+                                     "auth_url": "https://10.240.14.195",
+                                     "login_password": "Password",
+                                 },
+                                 {
+                                     "login_user": "USERID",
+                                     "login_password": "Password",
+                                 },
+                             ],
+                             indirect=['patch_ansible_module'])
+    @pytest.mark.usefixtures('patch_ansible_module')
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_switches.execute_module", autospec=True)
+    def test_without_required_parameters(self, _setup_conn, _execute_module,
+                                         mocker, capfd, setup_module):
+        """Failure must occurs when all parameters are missing"""
+        with pytest.raises(SystemExit):
+            _setup_conn.return_value = "Fake connection"
+            _execute_module.return_value = "Fake execution"
+            lxca_switches.main()
+        out, err = capfd.readouterr()
+        results = json.loads(out)
+        assert results['failed']
+        assert 'missing required arguments' in results['msg']
+
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_switches.execute_module", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_switches.AnsibleModule", autospec=True)
+    def test__argument_spec(self, ansible_mod_cls, _execute_module, _setup_conn, setup_module):
+        expected_arguments_spec = dict(
+            login_user=dict(required=True),
+            login_password=dict(required=True, no_log=True),
+            command_options=dict(default='switches', choices=['switches', 'switches_by_uuid',
+                                                              'switches_by_chassis_uuid',
+                                                              'switches_list_ports',
+                                                              'switches_change_status_of_ports']),
+            auth_url=dict(required=True),
+            uuid=dict(default=None),
+            chassis=dict(default=None),
+            ports=dict(default=None),
+            ports_action=dict(default=None, choices=[None, 'enable', 'disable'])
+        )
+        _setup_conn.return_value = "Fake connection"
+        _execute_module.return_value = []
+        mod_obj = ansible_mod_cls.return_value
+        args = {
+            "auth_url": "https://10.243.30.195",
+            "login_user": "USERID",
+            "login_password": "password",
+            "command_options": "switches",
+        }
+        mod_obj.params = args
+        lxca_switches.main()
+        assert(mock.call(argument_spec=expected_arguments_spec,
+                         supports_check_mode=False) == ansible_mod_cls.call_args)
+
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_switches._switches_by_uuid",
+                autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_switches.AnsibleModule",
+                autospec=True)
+    def test__switches_empty_list(self, ansible_mod_cls, _get_switches, _setup_conn, setup_module):
+        mod_obj = ansible_mod_cls.return_value
+        args = {
+            "auth_url": "https://10.243.30.195",
+            "login_user": "USERID",
+            "login_password": "password",
+            "uuid": "3C737AA5E31640CE949B10C129A8B01F",
+            "command_options": "switches_by_uuid",
+        }
+        mod_obj.params = args
+        _setup_conn.return_value = "Fake connection"
+        empty_switches_list = []
+        _get_switches.return_value = empty_switches_list
+        ret_switches = _get_switches(mod_obj, args)
+        assert mock.call(mod_obj, mod_obj.params) == _get_switches.call_args
+        assert _get_switches.return_value == ret_switches


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This module provide an interface to Lenovo XClarity Administrator. This module provides information about switches and allow to enable/disable switch ports
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lxca_switches
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Testing ansible module lxca_switches

1. list all switches
2. list switch with uuid
3. list switch with chassis uuid
4. list ports of switch with uuid

(pylxca27) naval@osboxes:~/play/playbook/lxca_switches$ cat all_switches.yml 
---
- hosts: localhost
  connection: local
  tasks:
    - name: list switches
      lxca_switches:
        login_user: USERID
        login_password: CME44ibm
        auth_url: "https://10.243.9.238"
        command_options: switches
(pylxca27) naval@osboxes:~/play/playbook/lxca_switches$ ansible-playbook all_switches.yml
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] *****************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [list switches] *************************************************************************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0   

(pylxca27) naval@osboxes:~/play/playbook/lxca_switches$
(pylxca27) naval@osboxes:~/play/playbook/lxca_switches$ cat filter_by_uuid.yml 
---
- hosts: localhost
  connection: local
  tasks:
    - name: list nodes
      lxca_switches:
        login_user: USERID
        login_password: CME44ibm
        auth_url: "https://10.243.9.238"
        uuid: "4E28668DD4DCADD56CDB00C0DD1F1E51"
        command_options: switches_by_uuid
(pylxca27) naval@osboxes:~/play/playbook/lxca_switches$ 
(pylxca27) naval@osboxes:~/play/playbook/lxca_switches$ ansible-playbook filter_by_uuid.yml 
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] *****************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [list nodes] ****************************************************************************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0   

(pylxca27) naval@osboxes:~/play/playbook/lxca_switches$ cat filter_by_chassis_uuid.yml 
---
- hosts: localhost
  connection: local
  tasks:
    - name: list switches
      lxca_switches:
        login_user: USERID
        login_password: CME44ibm
        auth_url: "https://10.243.9.238"
        chassis: "9FFE022D2E2E11E1BD0EA8A7A12531B6"
        command_options: switches_by_chassis_uuid
(pylxca27) naval@osboxes:~/play/playbook/lxca_switches$ ansible-playbook filter_by_chassis_uuid.yml 
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] *****************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [list switches] *************************************************************************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0   

(pylxca27) naval@osboxes:~/play/playbook/lxca_switches$ cat list_switch_ports.yml 
---
- hosts: localhost
  connection: local
  tasks:
    - name: list switches ports
      lxca_switches:
        login_user: USERID
        login_password: CME44ibm
        auth_url: "https://10.243.9.238"
        uuid: "4E28668DD4DCADD56CDB00C0DD1F1E51"
        command_options: switches_list_ports
(pylxca27) naval@osboxes:~/play/playbook/lxca_switches$ ansible-playbook list_switch_ports.yml 
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] *****************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [list switches ports] *******************************************************************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0   

(pylxca27) naval@osboxes:~/play/playbook/lxca_switches$
```
