### PR TITLE
To resolve NIOS race condition when ip allocated via NIOS next available ip function

### DIFF
--- a/lib/ansible/modules/net_tools/nios/nios_a_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_a_record.py
@@ -119,7 +119,7 @@ EXAMPLES = '''
 - name: dynamically add a record to next available ip
   nios_a_record:
     name: a.ansible.com
-    ipv4: {nios_next_ip, 192.168.10.0/24}
+    ipv4: {nios_next_ip: 192.168.10.0/24}
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"

--- a/lib/ansible/modules/net_tools/nios/nios_a_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_a_record.py
@@ -39,7 +39,9 @@ options:
       - dns_view
   ipv4addr:
     description:
-      - Configures the IPv4 address for this A record.
+      - Configures the IPv4 address for this A record. Users can dynamically
+        allocate ipv4 address to A record by passing dictionary containing,
+        I(nios_next_ip) and I(CIDR network range). See example
     required: true
     aliases:
       - ipv4
@@ -107,6 +109,17 @@ EXAMPLES = '''
   nios_a_record:
     name: {new_name: a_new.ansible.com, old_name: a.ansible.com}
     ipv4: 192.168.10.1
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: dynamically add a record to next available ip
+  nios_a_record:
+    name: a.ansible.com
+    ipv4: {nios_next_ip, 192.168.10.0/24}
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"

--- a/lib/ansible/modules/net_tools/nios/nios_host_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_host_record.py
@@ -204,7 +204,7 @@ EXAMPLES = '''
   nios_host_record:
     name: host.ansible.com
     ipv4:
-      - address: {nios_next_ip, 192.168.10.0/24}
+      - address: {nios_next_ip: 192.168.10.0/24}
     comment: this is a test comment
     state: present
     provider:

--- a/lib/ansible/modules/net_tools/nios/nios_host_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_host_record.py
@@ -58,7 +58,9 @@ options:
     suboptions:
       ipv4addr:
         description:
-          - Configures the IPv4 address for the host record
+          - Configures the IPv4 address for the host record. Users can dynamically
+            allocate ipv4 address to host record by passing dictionary containing,
+            I(nios_next_ip) and I(CIDR network range). See example
         required: true
         aliases:
           - address
@@ -192,6 +194,18 @@ EXAMPLES = '''
       - address: 192.168.10.1
         dhcp: true
         mac: 00-80-C8-E3-4C-BD
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+- name: dynamically add host record to next available ip
+  nios_host_record:
+    name: host.ansible.com
+    ipv4:
+      - address: {nios_next_ip, 192.168.10.0/24}
+    comment: this is a test comment
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR raised to resolve bug #45218, where race condition was observed when multiple users try to provision an ip address, for both A/host records. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nios
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The race condition was observed coz two separate calls were being made, 1st for getting the next_available_ip and 2nd for actually registering the IP to records, now with changes next available address will be asked at the same time when the record is being created.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
