### PR TITLE
link from API stub page to module_utils page

### DIFF
--- a/docs/docsite/rst/api/index.rst
+++ b/docs/docsite/rst/api/index.rst
@@ -4,9 +4,8 @@
 Ansible API Documentation
 *************************
 
-The Ansible API is under construction. These stub references will be documented in future.  For now, there is a legacy :ref:`documentation page <ansible.module_utils>` for the ``AnsibleModule``.
-
-
+The Ansible API is under construction. These stub references for attributes, classes, functions, methods, and modules will be documented in future.
+The :ref:`module utilities <ansible.module_utils>` included in ``ansible.module_utils.basic`` and ``AnsibleModule`` are documented under Reference & Appendices.
 
 .. contents::
    :local:


### PR DESCRIPTION
##### SUMMARY
The old wording described a "legacy" page, but thanks to #48416 that page is up to date. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
