### PR TITLE
Allow tags to be templated from a variable

### DIFF
--- a/changelogs/fragments/tags-var.yaml
+++ b/changelogs/fragments/tags-var.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- tags - allow tags to be specified by a variable (https://github.com/ansible/ansible/issues/49825)

--- a/test/integration/targets/tags/runme.sh
+++ b/test/integration/targets/tags/runme.sh
@@ -14,7 +14,7 @@ export LC_ALL=en_US.UTF-8
 
 # Run everything by default
 [ "$("${COMMAND[@]}" | grep -F Task_with | xargs)" = \
-"Task_with_tag TAGS: [tag] Task_with_always_tag TAGS: [always] Task_with_unicode_tag TAGS: [くらとみ] Task_with_list_of_tags TAGS: [café, press] Task_without_tag TAGS: []" ]
+"Task_with_tag TAGS: [tag] Task_with_always_tag TAGS: [always] Task_with_unicode_tag TAGS: [くらとみ] Task_with_list_of_tags TAGS: [café, press] Task_without_tag TAGS: [] Task_with_csv_tags TAGS: [tag1, tag2] Task_with_templated_tags TAGS: [tag3]" ]
 
 # Run the exact tags, and always
 [ "$("${COMMAND[@]}" --tags tag | grep -F Task_with | xargs)" = \
@@ -22,11 +22,11 @@ export LC_ALL=en_US.UTF-8
 
 # Skip one tag
 [ "$("${COMMAND[@]}" --skip-tags tag | grep -F Task_with | xargs)" = \
-"Task_with_always_tag TAGS: [always] Task_with_unicode_tag TAGS: [くらとみ] Task_with_list_of_tags TAGS: [café, press] Task_without_tag TAGS: []" ]
+"Task_with_always_tag TAGS: [always] Task_with_unicode_tag TAGS: [くらとみ] Task_with_list_of_tags TAGS: [café, press] Task_without_tag TAGS: [] Task_with_csv_tags TAGS: [tag1, tag2] Task_with_templated_tags TAGS: [tag3]" ]
 
 # Skip a unicode tag
 [ "$("${COMMAND[@]}" --skip-tags 'くらとみ' | grep -F Task_with | xargs)" = \
-"Task_with_tag TAGS: [tag] Task_with_always_tag TAGS: [always] Task_with_list_of_tags TAGS: [café, press] Task_without_tag TAGS: []" ]
+"Task_with_tag TAGS: [tag] Task_with_always_tag TAGS: [always] Task_with_list_of_tags TAGS: [café, press] Task_without_tag TAGS: [] Task_with_csv_tags TAGS: [tag1, tag2] Task_with_templated_tags TAGS: [tag3]" ]
 
 # Run just a unicode tag and always
 [ "$("${COMMAND[@]}" --tags 'くらとみ' | grep -F Task_with | xargs)" = \
@@ -39,3 +39,11 @@ export LC_ALL=en_US.UTF-8
 # Run tag with never
 [ "$("${COMMAND[@]}" --tags donever | grep -F Task_with | xargs)" = \
 "Task_with_always_tag TAGS: [always] Task_with_never_tag TAGS: [donever, never]" ]
+
+# Run csv tags
+[ "$("${COMMAND[@]}" --tags tag1 | grep -F Task_with | xargs)" = \
+"Task_with_always_tag TAGS: [always] Task_with_csv_tags TAGS: [tag1, tag2]" ]
+
+# Run templated tags
+[ "$("${COMMAND[@]}" --tags tag3 | grep -F Task_with | xargs)" = \
+"Task_with_always_tag TAGS: [always] Task_with_templated_tags TAGS: [tag3]" ]

--- a/test/integration/targets/tags/test_tags.yml
+++ b/test/integration/targets/tags/test_tags.yml
@@ -3,6 +3,9 @@
   hosts: localhost
   gather_facts: False
   connection: local
+  vars:
+    the_tags:
+      - tag3
   tasks:
     - name: Task_with_tag
       debug: msg=
@@ -23,3 +26,9 @@
     - name: Task_with_never_tag
       debug: msg=NEVER
       tags: ['never', 'donever']
+    - name: Task_with_csv_tags
+      debug: msg=csv
+      tags: tag1,tag2
+    - name: Task_with_templated_tags
+      debug: msg=templated
+      tags: "{{ the_tags }}"

--- a/test/units/playbook/test_taggable.py
+++ b/test/units/playbook/test_taggable.py
@@ -98,8 +98,5 @@ class TestTaggable(unittest.TestCase):
     def test_evaluate_tags_accepts_lists(self):
         self.assert_evaluate_equal(True, ['tag1', 'tag2'], ['tag2'], [])
 
-    def test_evaluate_tags_accepts_strings(self):
-        self.assert_evaluate_equal(True, 'tag1,tag2', ['tag2'], [])
-
     def test_evaluate_tags_with_repeated_tags(self):
         self.assert_evaluate_equal(False, ['tag', 'tag'], [], ['tag'])


### PR DESCRIPTION
##### SUMMARY
Allow tags to be templated from a variable. Fixes #49825

The problem that we run into here, is that when we call `_extend_value` from `Task._get_parent_attribute`, we turn `'{{ foo }}'` into `['{{ foo }}']`.

Later when `{{foo}}` is templated, that becomes `[['foo', 'bar']]`

Basically, I get around this problem in this PR, by flattening `tags`.

Additionally this PR removes 2 unneeded methods `Taggable.__init__` and `Taggable._load_tags`. `_load_tags` basically duplicated the code in `evaluate_tags`, but with less available functionality.

Additionally, the `itertools.groupby` was unneeded, as it was added when tags was meant to not be a list in that context (https://github.com/ansible/ansible/commit/0eb1c880ddac9547560040311739b5ca8291a642), the `set` does what is needed.



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```