### PR TITLE
Set lower timout for win_reboot test

### DIFF
--- a/test/integration/targets/win_reboot/tasks/main.yml
+++ b/test/integration/targets/win_reboot/tasks/main.yml
@@ -31,9 +31,9 @@
 - name: reboot with test command that fails
   win_reboot:
     test_command: 'FAIL'
-    reboot_timeout: 120
+    reboot_timeout: 60
   register: reboot_fail_test
-  failed_when: "reboot_fail_test.msg != 'Timed out waiting for post-reboot test command (timeout=120)'"
+  failed_when: "reboot_fail_test.msg != 'Timed out waiting for post-reboot test command (timeout=60)'"
 
 # try and reboot the host with a non admin user, we expect an error here
 # this requires a bit of setup to create the user and allow it to connect


### PR DESCRIPTION
##### SUMMARY
The current timeout of 120 is pretty high and can probably be lower.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`win_reboot.py`

##### ADDITIONAL INFORMATION

This tests is running a post reboot test command that fails, making the plugin think the node has not successfully rebooted. This is to test the function that runs the test command to make sure it's doing the right thing.

If this timeout is set too low, the plugin will fail while the system is rebooting, not because the post reboot test command fails.