### PR TITLE
[docker_container] Failing on non-string env values

### DIFF
--- a/changelogs/fragments/49843-docker_container-wrap-env.yaml
+++ b/changelogs/fragments/49843-docker_container-wrap-env.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - 'docker_container - fail when non-string env values are found, avoiding YAML parsing issues. (https://github.com/ansible/ansible/issues/49802)'

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -186,7 +186,7 @@ options:
   env:
     description:
       - Dictionary of key,value pairs.
-      - Values must be quoted in order to avoid YAML parsing losing data.
+      - Values which might be parsed as numbers, booleans or other types by the YAML parser must be quoted (e.g. C("true")) in order to avoid data loss.
     type: dict
   env_file:
     version_added: "2.2"
@@ -647,6 +647,8 @@ EXAMPLES = '''
      - "127.0.0.1:8081:9001/udp"
     env:
         SECRET_KEY: "ssssh"
+        # Values which might be parsed as numbers, booleans or other types by the YAML parser need to be quoted
+        BOOLEAN_KEY: "yes"
 
 - name: Container present
   docker_container:

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1609,7 +1609,7 @@ class TaskParameters(DockerBaseClass):
             for name, value in self.env.items():
                 if not isinstance(value, string_types):
                     self.fail("Non-string value found for env option. "
-                              "Env options must be wrapped in quotes to avoid YAML parsing. Key: %s Value: %s" % (name, str(value)))
+                              "Ambiguous env options must be wrapped in quotes to avoid YAML parsing. Key: %s" % (name, ))
                 final_env[name] = str(value)
         return final_env
 

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -186,6 +186,8 @@ options:
   env:
     description:
       - Dictionary of key,value pairs.
+      - Values must be quoted in order to avoid YAML parsing losing data.
+    type: dict
   env_file:
     version_added: "2.2"
     description:
@@ -644,7 +646,7 @@ EXAMPLES = '''
      - "8080:9000"
      - "127.0.0.1:8081:9001/udp"
     env:
-        SECRET_KEY: ssssh
+        SECRET_KEY: "ssssh"
 
 - name: Container present
   docker_container:
@@ -762,8 +764,8 @@ EXAMPLES = '''
     name: test
     image: ubuntu:18.04
     env:
-      - arg1: true
-      - arg2: whatever
+      - arg1: "true"
+      - arg2: "whatever"
     volumes:
       - /tmp:/tmp
     comparisons:
@@ -776,8 +778,8 @@ EXAMPLES = '''
     name: test
     image: ubuntu:18.04
     env:
-      - arg1: true
-      - arg2: whatever
+      - arg1: "true"
+      - arg2: "whatever"
     comparisons:
       '*': ignore  # by default, ignore *all* options (including image)
       env: strict   # except for environment variables; there, we want to be strict
@@ -1605,6 +1607,9 @@ class TaskParameters(DockerBaseClass):
                 final_env[name] = str(value)
         if self.env:
             for name, value in self.env.items():
+                if not isinstance(value, string_types):
+                    self.fail("Non-string value found for env option. "
+                              "Env options must be wrapped in quotes to avoid YAML parsing. Key: %s Value: %s" % (name, str(value)))
                 final_env[name] = str(value)
         return final_env
 

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -1177,10 +1177,11 @@
     name: "{{ cname }}"
     state: started
     env:
-      TEST1: "val1"
-      TEST2: "val2"
+      TEST1: val1
+      TEST2: val2
       TEST3: "False"
       TEST4: "true"
+      TEST5: "yes"
   register: env_1
 
 - name: env (idempotency)
@@ -1190,8 +1191,9 @@
     name: "{{ cname }}"
     state: started
     env:
-      TEST2: "val2"
-      TEST1: "val1"
+      TEST2: val2
+      TEST1: val1
+      TEST5: "yes"
       TEST3: "False"
       TEST4: "true"
   register: env_2
@@ -1203,7 +1205,7 @@
     name: "{{ cname }}"
     state: started
     env:
-      TEST1: "val1"
+      TEST1: val1
   register: env_3
 
 - name: env (more environment variables)
@@ -1213,8 +1215,8 @@
     name: "{{ cname }}"
     state: started
     env:
-      TEST1: "val1"
-      TEST3: "val3"
+      TEST1: val1
+      TEST3: val3
     force_kill: yes
   register: env_4
 

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -1177,8 +1177,10 @@
     name: "{{ cname }}"
     state: started
     env:
-      TEST1: val1
-      TEST2: val2
+      TEST1: "val1"
+      TEST2: "val2"
+      TEST3: "False"
+      TEST4: "true"
   register: env_1
 
 - name: env (idempotency)
@@ -1188,8 +1190,10 @@
     name: "{{ cname }}"
     state: started
     env:
-      TEST2: val2
-      TEST1: val1
+      TEST2: "val2"
+      TEST1: "val1"
+      TEST3: "False"
+      TEST4: "true"
   register: env_2
 
 - name: env (less environment variables)
@@ -1199,7 +1203,7 @@
     name: "{{ cname }}"
     state: started
     env:
-      TEST1: val1
+      TEST1: "val1"
   register: env_3
 
 - name: env (more environment variables)
@@ -1209,10 +1213,22 @@
     name: "{{ cname }}"
     state: started
     env:
-      TEST1: val1
-      TEST3: val3
+      TEST1: "val1"
+      TEST3: "val3"
     force_kill: yes
   register: env_4
+
+- name: env (fail unwrapped values)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    env:
+      TEST1: true
+    force_kill: yes
+  register: env_5
+  ignore_errors: yes
 
 - name: cleanup
   docker_container:
@@ -1227,6 +1243,8 @@
     - env_2 is not changed
     - env_3 is not changed
     - env_4 is changed
+    - env_5 is failed
+    - "('Non-string value found for env option.') in env_5.msg"
 
 ####################################################################
 ## env_file #########################################################


### PR DESCRIPTION
##### SUMMARY
Fixes #49802

Fail the module when non-string env values are used. Avoids issues (documented by @felixfontein below) around data loss due to YAML parsing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ADDITIONAL INFORMATION
N/A