### PR TITLE
ACI: Add seealso fragments to module documentation

### DIFF
--- a/lib/ansible/modules/network/aci/aci_aaa_user.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user.py
@@ -22,13 +22,16 @@ notes:
   (even if that password was already set identically). This
   appears to be an inconsistency wrt. the idempotent nature
   of the APIC REST API. The vendor has been informed.
-- More information in :ref:`the ACI documentation <aci_guide_known_issues>`.
-- More information about the internal APIC class B(aaa:User) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+  More information in :ref:`the ACI documentation <aci_guide_known_issues>`.
+seealso:
+- module: aci_aaa_user_certificate
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(aaa:User).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 requirements:
-  - python-dateutil
+- python-dateutil
 version_added: '2.5'
 options:
   aaa_password:

--- a/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
@@ -20,8 +20,11 @@ description:
 notes:
 - The C(aaa_user) must exist before using this module in your playbook.
   The M(aci_aaa_user) module can be used for this.
-- More information about the internal APIC class B(aaa:UserCert) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_aaa_user
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(aaa:UserCert).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_access_port_block_to_access_port.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_block_to_access_port.py
@@ -17,9 +17,10 @@ module: aci_access_port_block_to_access_port
 short_description: Manage port blocks of Fabric interface policy leaf profile interface selectors (infra:HPortS, infra:PortBlk)
 description:
 - Manage port blocks of Fabric interface policy leaf profile interface selectors on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC classes B(infra:HPortS) and B(infra:PortBlk) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/)
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes B(infra:HPortS) and B(infra:PortBlk).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Simon Metzger (@smnmtzgr)
 version_added: '2.8'

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -17,9 +17,10 @@ module: aci_access_port_to_interface_policy_leaf_profile
 short_description: Manage Fabric interface policy leaf profile interface selectors (infra:HPortS, infra:RsAccBaseGrp, infra:PortBlk)
 description:
 - Manage Fabric interface policy leaf profile interface selectors on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC classes B(infra:HPortS), B(infra:RsAccBaseGrp) and B(infra:PortBlk) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/)
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes B(infra:HPortS), B(infra:RsAccBaseGrp) and B(infra:PortBlk).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Bruno Calogero (@brunocalogero)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_aep.py
+++ b/lib/ansible/modules/network/aci/aci_aep.py
@@ -17,9 +17,10 @@ short_description: Manage attachable Access Entity Profile (AEP) objects (infra:
 description:
 - Connect to external virtual and physical domains by using
   attachable Access Entity Profiles (AEP) on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC classes B(infra:AttEntityP) and B(infra:ProvAcc) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes B(infra:AttEntityP) and B(infra:ProvAcc).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Swetha Chunduri (@schunduri)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_aep_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_aep_to_domain.py
@@ -20,8 +20,12 @@ description:
 notes:
 - The C(aep) and C(domain) parameters should exist before using this module.
   The M(aci_aep) and M(aci_domain) can be used for these.
-- More information about the internal APIC class B(infra:RsDomP) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_aep
+- module: aci_domain
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(infra:RsDomP).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_ap.py
+++ b/lib/ansible/modules/network/aci/aci_ap.py
@@ -18,10 +18,13 @@ description:
 - Manage top level Application Profile (AP) objects on Cisco ACI fabrics
 notes:
 - This module does not manage EPGs, see M(aci_epg) to do this.
-- The C(tenant) used must exist before using this module in your playbook.
+- The used C(tenant) must exist before using this module in your playbook.
   The M(aci_tenant) module can be used for this.
-- More information about the internal APIC class B(fv:Ap) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fv:Ap).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Swetha Chunduri (@schunduri)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_bd.py
+++ b/lib/ansible/modules/network/aci/aci_bd.py
@@ -19,8 +19,11 @@ description:
 notes:
 - The C(tenant) used must exist before using this module in your playbook.
   The M(aci_tenant) module can be used for this.
-- More information about the internal APIC class B(fv:BD) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fv:BD).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_bd_subnet.py
+++ b/lib/ansible/modules/network/aci/aci_bd_subnet.py
@@ -24,6 +24,9 @@ notes:
 seealso:
 - module: aci_bd
 - module: aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fv:Subnet).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
@@ -19,8 +19,12 @@ description:
 notes:
 - The C(bd) and C(l3out) parameters should exist before using this module.
   The M(aci_bd) and C(aci_l3out) can be used for these.
-- More information about the internal APIC class B(fv:RsBDToOut) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_bd
+- module: aci_l3out
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fv:RsBDToOut).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_config_rollback.py
+++ b/lib/ansible/modules/network/aci/aci_config_rollback.py
@@ -17,9 +17,11 @@ short_description: Provides rollback and rollback preview functionality (config:
 description:
 - Provides rollback and rollback preview functionality for Cisco ACI fabrics.
 - Config Rollbacks are done using snapshots C(aci_snapshot) with the configImportP class.
-notes:
-- More information about the internal APIC class B(config:ImportP) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_config_snapshot
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(config:ImportP).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_config_snapshot.py
+++ b/lib/ansible/modules/network/aci/aci_config_snapshot.py
@@ -22,8 +22,11 @@ notes:
 - The APIC does not provide a mechanism for naming the snapshots.
 - 'Snapshot files use the following naming structure: ce_<config export policy name>-<yyyy>-<mm>-<dd>T<hh>:<mm>:<ss>.<mss>+<hh>:<mm>.'
 - 'Snapshot objects use the following naming structure: run-<yyyy>-<mm>-<dd>T<hh>-<mm>-<ss>.'
-- More information about the internal APIC classes B(config:Snapshot) and B(config:ExportP) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_config_rollback
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes B(config:Snapshot) and B(config:ExportP).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_contract.py
+++ b/lib/ansible/modules/network/aci/aci_contract.py
@@ -21,8 +21,12 @@ notes:
   Contract Subjects can still be removed using this module.
 - The C(tenant) used must exist before using this module in your playbook.
   The M(aci_tenant) module can be used for this.
-- More information about the internal APIC class B(vz:BrCP) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_contract_subject
+- module: aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(vz:BrCP).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_contract_subject.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject.py
@@ -18,9 +18,13 @@ description:
 - Manage initial Contract Subjects on Cisco ACI fabrics.
 notes:
 - The C(tenant) and C(contract) used must exist before using this module in your playbook.
-- The M(aci_tenant) and M(aci_contract) modules can be used for this.
-- More information about the internal APIC class B(vz:Subj) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+  The M(aci_tenant) and M(aci_contract) modules can be used for this.
+seealso:
+- module: aci_contract
+- module: aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(vz:Subj).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Swetha Chunduri (@schunduri)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
@@ -18,9 +18,15 @@ description:
 - Bind Contract Subjects to Filters on Cisco ACI fabrics.
 notes:
 - The C(tenant), C(contract), C(subject), and C(filter_name) must exist before using this module in your playbook.
-- The M(aci_tenant), M(aci_contract), M(aci_contract_subject), and M(aci_filter) modules can be used for these.
-- More information about the internal APIC class B(vz:RsSubjFiltAtt) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+  The M(aci_tenant), M(aci_contract), M(aci_contract_subject), and M(aci_filter) modules can be used for these.
+seealso:
+- module: aci_tenant
+- module: aci_contract
+- module: aci_contract_subject
+- module: aci_filter
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(vz:RsSubjFiltAtt).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_domain.py
+++ b/lib/ansible/modules/network/aci/aci_domain.py
@@ -16,10 +16,11 @@ module: aci_domain
 short_description: Manage physical, virtual, bridged, routed or FC domain profiles (phys:DomP, vmm:DomP, l2ext:DomP, l3ext:DomP, fc:DomP)
 description:
 - Manage physical, virtual, bridged, routed or FC domain profiles on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC classes B(phys:DomP),
-  B(vmm:DomP), B(l2ext:DomP), B(l3ext:DomP) and B(fc:DomP) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes B(phys:DomP),
+               B(vmm:DomP), B(l2ext:DomP), B(l3ext:DomP) and B(fc:DomP)
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
@@ -20,8 +20,12 @@ description:
 notes:
 - The C(domain) and C(encap_pool) parameters should exist before using this module.
   The M(aci_domain) and M(aci_encap_pool) can be used for these.
-- More information about the internal APIC class B(infra:RsVlanNs) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_domain
+- module: aci_encap_pool
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(infra:RsVlanNs).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
@@ -20,8 +20,12 @@ description:
 notes:
 - The C(domain) and C(vlan_pool) parameters should exist before using this module.
   The M(aci_domain) and M(aci_vlan_pool) can be used for these.
-- More information about the internal APIC class B(infra:RsVlanNs) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_domain
+- module: aci_vlan_pool
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(infra:RsVlanNs).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool.py
@@ -16,9 +16,12 @@ module: aci_encap_pool
 short_description: Manage encap pools (fvns:VlanInstP, fvns:VxlanInstP, fvns:VsanInstP)
 description:
 - Manage vlan, vxlan, and vsan pools on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC classes B(fvns:VlanInstP), B(fvns:VxlanInstP) and B(fvns:VsanInstP) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_encap_pool_range
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes B(fvns:VlanInstP),
+               B(fvns:VxlanInstP) and B(fvns:VsanInstP)
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_encap_pool_range.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool_range.py
@@ -18,8 +18,11 @@ description:
 - Manage vlan, vxlan, and vsan ranges that are assigned to pools on Cisco ACI fabrics.
 notes:
 - The C(pool) must exist in order to add or delete a range.
-- More information about the internal APIC classes B(fvns:EncapBlk) and B(fvns:VsanEncapBlk) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_encap_pool
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes B(fvns:EncapBlk) and B(fvns:VsanEncapBlk).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_epg.py
+++ b/lib/ansible/modules/network/aci/aci_epg.py
@@ -19,8 +19,12 @@ description:
 notes:
 - The C(tenant) and C(app_profile) used must exist before using this module in your playbook.
   The M(aci_tenant) and M(aci_ap) modules can be used for this.
-- More information about the internal APIC class B(fv:AEPg) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- module: aci_ap
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fv:AEPg).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Swetha Chunduri (@schunduri)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
+++ b/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
@@ -19,8 +19,11 @@ description:
 notes:
 - The C(tenant) used must exist before using this module in your playbook.
   The M(aci_tenant) module can be used for this.
-- More information about the internal APIC class B(mon:EPGPol) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(mon:EPGPol).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_epg_to_contract.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_contract.py
@@ -19,8 +19,14 @@ description:
 notes:
 - The C(tenant), C(app_profile), C(EPG), and C(Contract) used must exist before using this module in your playbook.
   The M(aci_tenant), M(aci_ap), M(aci_epg), and M(aci_contract) modules can be used for this.
-- More information about the internal APIC classes B(fv:RsCons) and B(fv:RsProv) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- module: aci_ap
+- module: aci_epg
+- module: aci_contract
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes B(fv:RsCons) and B(fv:RsProv).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_epg_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_domain.py
@@ -22,8 +22,14 @@ notes:
 - OpenStack VMM domains must not be created using this module. The OpenStack VMM domain is created directly
   by the Cisco APIC Neutron plugin as part of the installation and configuration.
   This module can be used to query status of an OpenStack VMM domain.
-- More information about the internal APIC class B(fv:RsDomAtt) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- module: aci_ap
+- module: aci_epg
+- module: aci_domain
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fv:RsDomAtt).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_fabric_node.py
+++ b/lib/ansible/modules/network/aci/aci_fabric_node.py
@@ -17,9 +17,10 @@ module: aci_fabric_node
 short_description: Manage Fabric Node Members (fabric:NodeIdentP)
 description:
 - Manage Fabric Node Members on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC class B(fabric:NodeIdentP) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fabric:NodeIdentP).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Bruno Calogero (@brunocalogero)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_filter.py
+++ b/lib/ansible/modules/network/aci/aci_filter.py
@@ -20,8 +20,11 @@ description:
 notes:
 - The C(tenant) used must exist before using this module in your playbook.
   The M(aci_tenant) module can be used for this.
-- More information about the internal APIC class B(vz:Filter) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(vz:Filter).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_filter_entry.py
+++ b/lib/ansible/modules/network/aci/aci_filter_entry.py
@@ -19,8 +19,12 @@ description:
 notes:
 - The C(tenant) and C(filter) used must exist before using this module in your playbook.
   The M(aci_tenant) and M(aci_filter) modules can be used for this.
-- More information about the internal APIC class B(vz:Entry) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- module: aci_filter
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(vz:Entry).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_firmware_source.py
+++ b/lib/ansible/modules/network/aci/aci_firmware_source.py
@@ -20,9 +20,10 @@ description:
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.5'
-notes:
-- More information about the internal APIC class B(firmware:OSource) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(firmware:OSource).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 options:
   source:
     description:

--- a/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
@@ -19,9 +19,10 @@ description:
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.4'
-notes:
-- More information about the internal APIC class B(fc:IfPol) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fc:IfPol).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 options:
   fc_policy:
     description:

--- a/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
@@ -19,9 +19,10 @@ description:
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.4'
-notes:
-- More information about the internal APIC class B(l2:IfPol) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(l2:IfPol).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 options:
   l2_policy:
     description:

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
@@ -20,8 +20,10 @@ description:
 notes:
 - When using the module please select the appropriate link_aggregation_type (lag_type).
   C(link) for Port Channel(PC), C(node) for Virtual Port Channel(VPC) and C(leaf) for Leaf Access Port Policy Group.
-- More information about the internal APIC classes B(infra:AccBndlGrp) and B(infra:AccPortGrp) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes B(infra:AccBndlGrp) and B(infra:AccPortGrp).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Bruno Calogero (@brunocalogero)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
@@ -17,9 +17,10 @@ module: aci_interface_policy_leaf_profile
 short_description: Manage fabric interface policy leaf profiles (infra:AccPortP)
 description:
 - Manage fabric interface policy leaf profiles on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC class B(infra:AccPortP) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(infra:AccPortP).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Bruno Calogero (@brunocalogero)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
@@ -16,9 +16,10 @@ module: aci_interface_policy_lldp
 short_description: Manage LLDP interface policies (lldp:IfPol)
 description:
 - Manage LLDP interface policies on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC class B(lldp:IfPol) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(lldp:IfPol).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
@@ -16,9 +16,10 @@ module: aci_interface_policy_mcp
 short_description: Manage MCP interface policies (mcp:IfPol)
 description:
 - Manage MCP interface policies on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC class B(mcp:IfPol) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(mcp:IfPol).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_interface_policy_ospf.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_ospf.py
@@ -17,9 +17,10 @@ module: aci_interface_policy_ospf
 short_description: Manage OSPF interface policies (ospf:IfPol)
 description:
 - Manage OSPF interface policies on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC class B(ospf:IfPol) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(ospf:IfPol).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.7'

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
@@ -16,9 +16,10 @@ module: aci_interface_policy_port_channel
 short_description: Manage port channel interface policies (lacp:LagPol)
 description:
 - Manage port channel interface policies on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC class B(lacp:LagPol) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(lacp:LagPol).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
@@ -16,9 +16,10 @@ module: aci_interface_policy_port_security
 short_description: Manage port security (l2:PortSecurityPol)
 description:
 - Manage port security on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC class B(l2:PortSecurityPol) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(l2:PortSecurityPol).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
@@ -19,8 +19,11 @@ description:
 - Bind interface selector profiles to switch policy leaf profiles on Cisco ACI fabrics.
 notes:
 - This module requires an existing leaf profile, the module M(aci_switch_policy_leaf_profile) can be used for this.
-- More information about the internal APIC class B(infra:RsAccPortP) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_switch_policy_leaf_profile
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(infra:RsAccPortP).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Bruno Calogero (@brunocalogero)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_l3out.py
@@ -19,8 +19,13 @@ description:
 notes:
 - The C(tenant) and C(domain) and C(vrf) used must exist before using this module in your playbook.
   The M(aci_tenant) and M(aci_domain) and M(aci_vrf) modules can be used for this.
-- More information about the internal APIC class B(l3ext:Out) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- module: aci_domain
+- module: aci_vrf
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(l3ext:Out).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Rostyslav Davydenko (@rost-d)
 version_added: '2.6'

--- a/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
+++ b/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
@@ -19,8 +19,11 @@ description:
 notes:
 - The C(tenant) used must exist before using this module in your playbook.
   The M(aci_tenant) module can be used for this.
-- More information about the internal APIC class B(l3ext:RouteTagPol) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(l3ext:RouteTagPol).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_rest.py
+++ b/lib/ansible/modules/network/aci/aci_rest.py
@@ -26,8 +26,11 @@ notes:
   This is a known APIC problem and has been reported to the vendor. A workaround for this issue exists.
   More information in :ref:`the ACI documentation <aci_guide_known_issues>`.
 - XML payloads require the C(lxml) and C(xmljson) python libraries. For JSON payloads nothing special is needed.
-- More information regarding the APIC REST API is available from
-  L(the Cisco APIC REST API Configuration Guide,http://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/sw/2-x/rest_cfg/2_1_x/b_Cisco_APIC_REST_API_Configuration_Guide.html).  # NOQA
+seealso:
+- module: aci_tenant
+- name: Cisco APIC REST API Configuration Guide
+  description: More information about the APIC REST API.
+  link: http://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/sw/2-x/rest_cfg/2_1_x/b_Cisco_APIC_REST_API_Configuration_Guide.html
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_static_binding_to_epg.py
+++ b/lib/ansible/modules/network/aci/aci_static_binding_to_epg.py
@@ -20,8 +20,13 @@ description:
 notes:
 - The C(tenant), C(ap), C(epg) used must exist before using this module in your playbook.
   The M(aci_tenant), M(aci_ap), M(aci_epg) modules can be used for this.
-- More information about the internal APIC classes B(fv:RsPathAtt) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- module: aci_ap
+- module: aci_epg
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fv:RsPathAtt).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Bruno Calogero (@brunocalogero)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
+++ b/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
@@ -18,10 +18,14 @@ short_description: Bind leaf selectors to switch policy leaf profiles (infra:Lea
 description:
 - Bind leaf selectors (with node block range and policy group) to switch policy leaf profiles on Cisco ACI fabrics.
 notes:
-- This module is to be used with M(aci_switch_policy_leaf_profile)
+- This module is to be used with M(aci_switch_policy_leaf_profile).
   One first creates a leaf profile (infra:NodeP) and then creates an associated selector (infra:LeafS),
-- More information about the internal APIC classes B(infra:LeafS), B(infra:NodeBlk) and B(infra:RsAccNodePGrp) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_switch_policy_leaf_profile
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes B(infra:LeafS),
+               B(infra:NodeBlk) and B(infra:RsAccNodePGrp).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Bruno Calogero (@brunocalogero)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
@@ -17,9 +17,11 @@ module: aci_switch_policy_leaf_profile
 short_description: Manage switch policy leaf profiles (infra:NodeP)
 description:
 - Manage switch policy leaf profiles on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC class B(infra:NodeP) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_switch_policy_leaf_profile
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(infra:NodeP).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Bruno Calogero (@brunocalogero)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_switch_policy_vpc_protection_group.py
+++ b/lib/ansible/modules/network/aci/aci_switch_policy_vpc_protection_group.py
@@ -17,9 +17,11 @@ module: aci_switch_policy_vpc_protection_group
 short_description: Manage switch policy explicit vPC protection groups (fabric:ExplicitGEp, fabric:NodePEp).
 description:
 - Manage switch policy explicit vPC protection groups on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC classes B(fabric:ExplicitGEp) and B(fabric:NodePEp) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_switch_policy_leaf_profile
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes B(fabric:ExplicitGEp) and B(fabric:NodePEp).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Bruno Calogero (@brunocalogero)
 version_added: '2.5'

--- a/lib/ansible/modules/network/aci/aci_taboo_contract.py
+++ b/lib/ansible/modules/network/aci/aci_taboo_contract.py
@@ -20,8 +20,11 @@ description:
 notes:
 - The C(tenant) used must exist before using this module in your playbook.
   The M(aci_tenant) module can be used for this.
-- More information about the internal APIC class B(vz:BrCP) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(vz:BrCP).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_tenant.py
+++ b/lib/ansible/modules/network/aci/aci_tenant.py
@@ -16,9 +16,10 @@ module: aci_tenant
 short_description: Manage tenants (fv:Tenant)
 description:
 - Manage tenants on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC class B(fv:Tenant) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fv:Tenant).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
@@ -19,8 +19,11 @@ description:
 notes:
 - The C(tenant) used must exist before using this module in your playbook.
   The M(aci_tenant) module can be used for this.
-- More information about the internal APIC class B(rtctrl:AttrP) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(rtctrl:AttrP).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
@@ -19,8 +19,11 @@ description:
 notes:
 - The C(tenant) used must exist before using this module in your playbook.
   The M(aci_tenant) module can be used for this.
-- More information about the internal APIC class B(fv:EpRetPol) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fv:EpRetPol).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Swetha Chunduri (@schunduri)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
@@ -19,8 +19,11 @@ description:
 notes:
 - The C(tenant) used must exist before using this module in your playbook.
   The M(aci_tenant) module can be used for this.
-- More information about the internal APIC class B(span:DestGrp) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(span:DestGrp).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Dag Wieers (@dagwieers)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
@@ -19,8 +19,11 @@ description:
 notes:
 - The C(tenant) used must exist before using this module in your playbook.
   The M(aci_tenant) module can be used for this.
-- More information about the internal APIC class B(span:SrcGrp) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(span:SrcGrp).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
@@ -19,8 +19,13 @@ description:
 notes:
 - The C(tenant), C(src_group), and C(dst_group) must exist before using this module in your playbook.
   The M(aci_tenant), M(aci_tenant_span_src_group), and M(aci_tenant_span_dst_group) modules can be used for this.
-- More information about the internal APIC class B(span:SrcGrp) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- module: aci_tenant_span_src_group
+- module: aci_tenant_span_dst_group
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(span:SrcGrp).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'

--- a/lib/ansible/modules/network/aci/aci_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool.py
@@ -18,9 +18,10 @@ module: aci_vlan_pool
 short_description: Manage VLAN pools (fvns:VlanInstP)
 description:
 - Manage VLAN pools on Cisco ACI fabrics.
-notes:
-- More information about the internal APIC class B(fvns:VlanInstP) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fvns:VlanInstP).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 - Dag Wieers (@dagwieers)

--- a/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
@@ -20,8 +20,11 @@ description:
 - Manage VLAN encap blocks that are assigned to VLAN pools on Cisco ACI fabrics.
 notes:
 - The C(pool) must exist in order to add or delete a encap block.
-- More information about the internal APIC class B(fvns:EncapBlk) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_vlan_pool
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fvns:EncapBlk).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 - Dag Wieers (@dagwieers)

--- a/lib/ansible/modules/network/aci/aci_vrf.py
+++ b/lib/ansible/modules/network/aci/aci_vrf.py
@@ -20,8 +20,11 @@ description:
 notes:
 - The C(tenant) used must exist before using this module in your playbook.
   The M(aci_tenant) module can be used for this.
-- More information about the internal APIC class B(fv:Ctx) from
-  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+seealso:
+- module: aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fv:Ctx).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jacob McGill (@jmcgill298)
 version_added: '2.4'


### PR DESCRIPTION
##### SUMMARY
This PR adds `seealso:` sections to ACI modules.

This relates to #45949

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ACI modules