### PR TITLE
Add seealso section to Windows and related modules

### DIFF
--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -74,6 +74,11 @@ notes:
        check for the existence of the file and report the correct changed status. If these are not supplied, the task will be skipped.
     -  The C(executable) parameter is removed since version 2.4. If you have a need for this parameter, use the M(shell) module instead.
     -  For Windows targets, use the M(win_command) module instead.
+seealso:
+- module: raw
+- module: script
+- module: shell
+- module: win_command
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/commands/expect.py
+++ b/lib/ansible/modules/commands/expect.py
@@ -69,6 +69,9 @@ notes:
   - The M(expect) module is designed for simple scenarios. For more complex
     needs, consider the use of expect code with the M(shell) or M(script)
     modules. (An example is part of the M(shell) module documentation)
+seealso:
+- module: script
+- module: shell
 author: "Matt Martz (@sivel)"
 '''
 

--- a/lib/ansible/modules/commands/psexec.py
+++ b/lib/ansible/modules/commands/psexec.py
@@ -203,6 +203,11 @@ notes:
   see U(https://support.microsoft.com/en-us/help/951016/description-of-user-account-control-and-remote-restrictions-in-windows).
 - For more information on this module and the various host requirements, see
   U(https://github.com/jborean93/pypsexec).
+seealso:
+- module: raw
+- module: win_command
+- module: win_psexec
+- module: win_shell
 author:
 - Jordan Borean (@jborean93)
 '''

--- a/lib/ansible/modules/commands/raw.py
+++ b/lib/ansible/modules/commands/raw.py
@@ -53,6 +53,11 @@ notes:
       which means it only works if C(executable) is set or using the module
       with privilege escalation (C(become)).
     - This module is also supported for Windows targets.
+seealso:
+- module: command
+- module: shell
+- module: win_command
+- module: win_shell
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/commands/script.py
+++ b/lib/ansible/modules/commands/script.py
@@ -47,6 +47,9 @@ notes:
     stderr is sent to stdout. If you depend on separated stdout and stderr result keys, please switch to a copy+command set of tasks instead of using script.
   - If the path to the local script contains spaces, it needs to be quoted.
   - This module is also supported for Windows targets.
+seealso:
+- module: shell
+- module: win_shell
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/commands/shell.py
+++ b/lib/ansible/modules/commands/shell.py
@@ -81,6 +81,11 @@ notes:
   - An alternative to using inline shell scripts with this module is to use
     the M(script) module possibly together with the M(template) module.
   - For Windows targets, use the M(win_shell) module instead.
+seealso:
+- module: command
+- module: raw
+- module: script
+- module: win_shell
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -76,6 +76,9 @@ options:
     - The path to the file to validate is passed in via '%s' which must be present as in the sshd example below.
     - The command is passed securely so shell features like expansion and pipes won't work.
     version_added: '2.0'
+seealso:
+- module: copy
+- module: win_copy
 author:
 - Stephen Fromm (@sfromm)
 extends_documentation_fragment:

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -104,13 +104,18 @@ extends_documentation_fragment:
     - files
     - validate
     - decrypt
-author:
-    - Ansible Core Team
-    - Michael DeHaan
 notes:
    - The M(copy) module recursively copy facility does not scale to lots (>hundreds) of files.
      For alternative, see M(synchronize) module, which is a wrapper around C(rsync).
    - For Windows targets, use the M(win_copy) module instead.
+seealso:
+- module: assemble
+- module: file
+- module: template
+- module: win_copy
+author:
+    - Ansible Core Team
+    - Michael DeHaan
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -23,12 +23,6 @@ description:
 - Alternatively, remove files, symlinks or directories.
 - Many other modules support the same options as the C(file) module - including M(copy), M(template), and M(assemble).
 - For Windows targets, use the M(win_file) module instead.
-notes:
-- For Windows targets, use the M(win_file) module instead.
-- See also M(copy), M(template) and M(assemble).
-author:
-- Ansible Core Team
-- Michael DeHaan
 options:
   path:
     description:
@@ -104,6 +98,17 @@ options:
     - Based on default Python format (see time.strftime doc).
     default: "%Y%m%d%H%M.%S"
     version_added: '2.7'
+notes:
+- For Windows targets, use the M(win_file) module instead.
+seealso:
+- module: assemble
+- module: copy
+- module: stat
+- module: template
+- module: win_file
+author:
+- Ansible Core Team
+- Michael DeHaan
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -17,12 +17,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 ---
 module: lineinfile
-author:
-    - Daniel Hokka Zakrissoni (@dhozac)
-    - Ahti Kitsik (@ahtik)
-extends_documentation_fragment:
-    - files
-    - validate
 short_description: Manage lines in text files
 description:
   - This module ensures a particular line is in a file, or replace an
@@ -122,8 +116,18 @@ options:
   others:
      description:
        - All arguments accepted by the M(file) module also work here.
+extends_documentation_fragment:
+    - files
+    - validate
 notes:
   - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
+seealso:
+- module: blockinfile
+- module: file
+- module: win_lineinfile
+author:
+    - Daniel Hokka Zakrissoni (@dhozac)
+    - Ahti Kitsik (@ahtik)
 """
 
 EXAMPLES = r"""

--- a/lib/ansible/modules/files/stat.py
+++ b/lib/ansible/modules/files/stat.py
@@ -73,6 +73,9 @@ options:
     aliases: [ attr, attributes ]
 notes:
      - For Windows targets, use the M(win_stat) module instead.
+seealso:
+- module: file
+- module: win_stat
 author: Bruce Pennypacker (@bpennypacker)
 '''
 

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -185,7 +185,9 @@ notes:
      encounters an error. Those synchronizing large numbers of files that are willing to trade safety for performance should call rsync directly.
    - link_destination is subject to the same limitations as the underlaying rsync daemon. Hard links are only preserved if the relative subtrees
      of the source and destination are the same. Attempts to hardlink into a directory that is a subdirectory of the source will be prevented.
-
+seealso:
+- module: copy
+- module: win_robocopy
 author:
 - Timothy Appnel (@tima)
 '''

--- a/lib/ansible/modules/files/tempfile.py
+++ b/lib/ansible/modules/files/tempfile.py
@@ -16,8 +16,6 @@ DOCUMENTATION = '''
 ---
 module: tempfile
 version_added: "2.3"
-author:
-  - Krzysztof Magosa (@krzysztof-magosa)
 short_description: Creates temporary files and directories.
 description:
   - The C(tempfile) module creates temporary files and directories. C(mktemp) command takes different parameters on various systems, this module helps
@@ -43,6 +41,10 @@ options:
     default: ""
 notes:
   - For Windows targets, use the M(win_tempfile) module instead.
+seealso:
+- module: win_tempfile
+author:
+  - Krzysztof Magosa (@krzysztof-magosa)
 '''
 
 EXAMPLES = """

--- a/lib/ansible/modules/files/template.py
+++ b/lib/ansible/modules/files/template.py
@@ -124,6 +124,10 @@ notes:
 - You can use the M(copy) module with the C(content:) option if you prefer the template inline,
   as part of the playbook.
 - For Windows you can use M(win_template) which uses '\\r\\n' as C(newline_sequence) by default.
+seealso:
+- module: copy
+- module: win_copy
+- module: win_template
 author:
 - Ansible Core Team
 - Michael DeHaan

--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -20,7 +20,6 @@ DOCUMENTATION = r'''
 module: unarchive
 version_added: '1.4'
 short_description: Unpacks an archive after (optionally) copying it from the local machine.
-extends_documentation_fragment: [ decrypt, files ]
 description:
      - The C(unarchive) module unpacks an archive.
      - By default, it will copy the source file from the local system to the target before unpacking.
@@ -86,7 +85,9 @@ options:
     type: 'bool'
     default: 'yes'
     version_added: "2.2"
-author: Michael DeHaan
+extends_documentation_fragment:
+- decrypt
+- files
 todo:
     - Re-implement tar support using native tarfile module.
     - Re-implement zip support using native zipfile module.
@@ -100,6 +101,9 @@ notes:
     - Existing files/directories in the destination which are not in the archive
       are ignored for purposes of deciding if the archive should be unpacked or not.
     - For Windows targets, use the M(win_unzip) module instead.
+seealso:
+- module: win_unzip
+author: Michael DeHaan
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -159,6 +159,9 @@ extends_documentation_fragment:
     - files
 notes:
      - For Windows targets, use the M(win_get_url) module instead.
+seealso:
+- module: uri
+- module: win_get_url
 author:
 - Jan-Piet Mens (@jpmens)
 '''

--- a/lib/ansible/modules/net_tools/basics/slurp.py
+++ b/lib/ansible/modules/net_tools/basics/slurp.py
@@ -31,7 +31,8 @@ notes:
    - This module returns an 'in memory' base64 encoded version of the file, take into account that this will require at least twice the RAM as the
      original file size.
    - This module is also supported for Windows targets.
-   - "See also: M(fetch)"
+seealso:
+- module: fetch
 author:
     - Ansible Core Team
     - Michael DeHaan (@mpdehaan)

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -148,6 +148,9 @@ notes:
   - The dependency on httplib2 was removed in Ansible 2.1.
   - The module returns all the HTTP headers in lower-case.
   - For Windows targets, use the M(win_uri) module instead.
+seealso:
+- module: get_url
+- module: win_uri
 author:
 - Romeo Theriault (@romeotheriault)
 '''

--- a/lib/ansible/modules/remote_management/wakeonlan.py
+++ b/lib/ansible/modules/remote_management/wakeonlan.py
@@ -32,8 +32,6 @@ options:
     description:
     - UDP port to use for magic Wake-on-LAN packet.
     default: 7
-author:
-- Dag Wieers (@dagwieers)
 todo:
   - Add arping support to check whether the system is up (before and after)
   - Enable check-mode support (when we have arping support)
@@ -42,6 +40,10 @@ notes:
   - This module sends a magic packet, without knowing whether it worked
   - Only works if the target system was properly configured for Wake-on-LAN (in the BIOS and/or the OS)
   - Some BIOSes have a different (configurable) Wake-on-LAN boot order (i.e. PXE first).
+seealso:
+- module: win_wakeonlan
+author:
+- Dag Wieers (@dagwieers)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/system/ping.py
+++ b/lib/ansible/modules/system/ping.py
@@ -34,6 +34,9 @@ options:
       - Data to return for the C(ping) return value.
       - If this parameter is set to C(crash), the module will cause an exception.
     default: pong
+seealso:
+- module: net_ping
+- module: win_ping
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/system/reboot.py
+++ b/lib/ansible/modules/system/reboot.py
@@ -55,6 +55,8 @@ options:
     type: str
 notes:
     - For Windows targets, use the M(win_reboot) module instead.
+seealso:
+- module: win_reboot
 author:
     - Matt Davis (@nitzmahone)
     - Sam Doran (@samdoran)

--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -14,9 +14,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: service
-author:
-    - Ansible Core Team
-    - Michael DeHaan
 version_added: "0.1"
 short_description:  Manage services
 description:
@@ -72,6 +69,11 @@ options:
         version_added: 2.2
 notes:
     - For Windows targets, use the M(win_service) module instead.
+seealso:
+- module: win_service
+author:
+    - Ansible Core Team
+    - Michael DeHaan
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -95,8 +95,10 @@ notes:
     can't be modified or created by the remote user either.
   - When waiting for a path, symbolic links will be followed.  Many other modules that manipulate files do not follow symbolic links,
     so operations on the path using other modules may not work exactly as expected.
-  - This module is also supported for Windows targets.
-  - See also M(wait_for_connection)
+seealso:
+- module: wait_for_connection
+- module: win_wait_for
+- module: win_wait_for_process
 author:
     - Jeroen Hoekx (@jhoekx)
     - John Jarvis (@jarv)

--- a/lib/ansible/modules/utilities/logic/wait_for_connection.py
+++ b/lib/ansible/modules/utilities/logic/wait_for_connection.py
@@ -43,7 +43,12 @@ options:
     default: 600
 notes:
 - This module is also supported for Windows targets.
-author: "Dag Wieers (@dagwieers)"
+seealso:
+- module: wait_for
+- module: win_wait_for
+- module: win_wait_for_process
+author:
+- Dag Wieers (@dagwieers)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_acl.py
+++ b/lib/ansible/modules/windows/win_acl.py
@@ -18,8 +18,6 @@ short_description: Set file/directory/registry permissions for a system user or 
 description:
 - Add or remove rights/permissions for a given user or group for the specified
   file, folder, registry key or AppPool identifies.
-- If adding ACL's for AppPool identities (available since 2.3), the Windows
-  Feature "Web-Scripting-Tools" must be enabled.
 options:
   path:
     description:
@@ -65,6 +63,11 @@ options:
       at U(https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.propagationflags.aspx).
     choices: [ InheritOnly, None, NoPropagateInherit ]
     default: "None"
+notes:
+- If adding ACL's for AppPool identities (available since 2.3), the Windows
+  Feature "Web-Scripting-Tools" must be enabled.
+seealso:
+- module: win_acl_inheritance
 author:
 - Phil Schwartz (@schwartzmx)
 - Trond Hindenes (@trondhindenes)

--- a/lib/ansible/modules/windows/win_acl_inheritance.py
+++ b/lib/ansible/modules/windows/win_acl_inheritance.py
@@ -37,6 +37,8 @@ options:
         of the ACL structure.
     type: bool
     default: 'no'
+seealso:
+- module: win_acl
 author:
 - Hans-Joachim Kliemeck (@h0nIg)
 '''

--- a/lib/ansible/modules/windows/win_audit_policy_system.py
+++ b/lib/ansible/modules/windows/win_audit_policy_system.py
@@ -15,11 +15,7 @@ module: win_audit_policy_system
 short_description: Used to make changes to the system wide Audit Policy
 description:
   - Used to make changes to the system wide Audit Policy.
-  - It is recommended to take a backup of the policies before adjusting them for the first time.
-  - See this page for in depth information U(https://technet.microsoft.com/en-us/library/cc766468.aspx).
 version_added: "2.5"
-author:
-  - Noah Sparks (@nwsparks)
 options:
   category:
     description:
@@ -37,6 +33,13 @@ options:
     required: yes
     type: list
     choices: [ failure, none, success ]
+notes:
+  - It is recommended to take a backup of the policies before adjusting them for the first time.
+  - See this page for in depth information U(https://technet.microsoft.com/en-us/library/cc766468.aspx).
+seealso:
+- module: win_audit_rule
+author:
+  - Noah Sparks (@nwsparks)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_audit_rule.py
+++ b/lib/ansible/modules/windows/win_audit_rule.py
@@ -19,8 +19,6 @@ description:
   - The behavior is designed to ignore inherited rules since those cannot be adjusted without first disabling
     the inheritance behavior. It will still print inherited rules in the output though for debugging purposes.
 version_added: "2.5"
-author:
-  - Noah Sparks (@nwsparks)
 options:
   path:
     description:
@@ -74,6 +72,10 @@ options:
       - Specifying C(absent) will remove all rules matching the defined I(user).
     choices: [ absent, present ]
     default: present
+seealso:
+- module: win_audit_policy_system
+author:
+  - Noah Sparks (@nwsparks)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -222,6 +222,14 @@ notes:
 - If (C(become)) is unavailable, use (M(win_hotfix) to install hotfixes instead
   of (M(win_chocolatey)) as (M(win_hotfix)) avoids using wusa.exe which cannot
   be run without (C(become)).
+seealso:
+- module: win_chocolatey_config
+- module: win_chocolatey_facts
+- module: win_chocolatey_feature
+- module: win_chocolatey_source
+- module: win_feature
+- module: win_package
+- module: win_updates
 author:
 - Trond Hindenes (@trondhindenes)
 - Peter Mounce (@petemounce)

--- a/lib/ansible/modules/windows/win_chocolatey_config.py
+++ b/lib/ansible/modules/windows/win_chocolatey_config.py
@@ -39,6 +39,11 @@ options:
       setting.
     - Cannot be null or an empty string, use C(state=absent) to unset a config
       value instead.
+seealso:
+- module: win_chocolatey
+- module: win_chocolatey_facts
+- module: win_chocolatey_feature
+- module: win_chocolatey_source
 author:
 - Jordan Borean (@jborean93)
 '''

--- a/lib/ansible/modules/windows/win_chocolatey_facts.py
+++ b/lib/ansible/modules/windows/win_chocolatey_facts.py
@@ -17,11 +17,16 @@ version_added: '2.8'
 short_description: Create a facts collection for Chocolatey
 description:
 - This module shows information from Chocolatey, such as installed packages, configuration, feature and sources.
+notes:
+- Chocolatey must be installed beforehand, use M(win_chocolatey) to do this.
+seealso:
+- module: win_chocolatey
+- module: win_chocolatey_config
+- module: win_chocolatey_feature
+- module: win_chocolatey_source
 author:
 - Simon Bärlocher (@sbaerlocher)
 - ITIGO AG (@itigoag)
-notes:
-- Chocolatey must be installed beforehand, use M(win_chocolatey) to do this.
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_chocolatey_feature.py
+++ b/lib/ansible/modules/windows/win_chocolatey_feature.py
@@ -30,6 +30,11 @@ options:
     - disabled
     - enabled
     default: enabled
+seealso:
+- module: win_chocolatey
+- module: win_chocolatey_config
+- module: win_chocolatey_facts
+- module: win_chocolatey_source
 author:
 - Jordan Borean (@jborean93)
 '''

--- a/lib/ansible/modules/windows/win_chocolatey_source.py
+++ b/lib/ansible/modules/windows/win_chocolatey_source.py
@@ -87,6 +87,11 @@ options:
     - always
     - on_create
     default: always
+seealso:
+- module: win_chocolatey
+- module: win_chocolatey_config
+- module: win_chocolatey_facts
+- module: win_chocolatey_feature
 author:
 - Jordan Borean (@jborean93)
 '''

--- a/lib/ansible/modules/windows/win_command.py
+++ b/lib/ansible/modules/windows/win_command.py
@@ -50,6 +50,12 @@ notes:
     - C(creates), C(removes), and C(chdir) can be specified after the command. For instance, if you only want to run a command if a certain file does not
       exist, use this.
     - For non-Windows targets, use the M(command) module instead.
+seealso:
+- module: command
+- module: psexec
+- module: raw
+- module: win_psexec
+- module: win_shell
 author:
     - Matt Davis (@nitzmahone)
 '''

--- a/lib/ansible/modules/windows/win_copy.py
+++ b/lib/ansible/modules/windows/win_copy.py
@@ -90,6 +90,11 @@ notes:
 - Because win_copy runs over WinRM, it is not a very efficient transfer
   mechanism. If sending large files consider hosting them on a web service and
   using M(win_get_url) instead.
+seealso:
+- module: assemble
+- module: copy
+- module: win_get_url
+- module: win_robocopy
 author:
 - Jon Hawkesworth (@jhawkesworth)
 - Jordan Borean (@jborean93)

--- a/lib/ansible/modules/windows/win_credential.py
+++ b/lib/ansible/modules/windows/win_credential.py
@@ -156,6 +156,9 @@ notes:
 - There can only be one credential per host and type. if a second credential is
   defined that uses the same host and type, then the original credential is
   overwritten.
+seealso:
+- module: win_user_right
+- module: win_whoami
 author:
 - Jordan Borean (@jborean93)
 '''

--- a/lib/ansible/modules/windows/win_defrag.py
+++ b/lib/ansible/modules/windows/win_defrag.py
@@ -16,6 +16,8 @@ short_description: Consolidate fragmented files on local volumes
 description:
 - Locates and consolidates fragmented files on local volumes to improve system performance.
 - 'More information regarding C(win_defrag) is available from: U(https://technet.microsoft.com/en-us/library/cc731650(v=ws.11).aspx)'
+requirements:
+- defrag.exe
 options:
   include_volumes:
     description:
@@ -39,8 +41,6 @@ options:
     - Run the operation on each volume in parallel in the background.
     type: bool
     default: 'no'
-requirements:
-- defrag.exe
 author:
 - Dag Wieers (@dagwieers)
 '''

--- a/lib/ansible/modules/windows/win_disk_facts.py
+++ b/lib/ansible/modules/windows/win_disk_facts.py
@@ -18,11 +18,11 @@ description:
      its volumes and partitions if existent.
 requirements:
     - Windows 8.1 / Windows 2012 (NT 6.2)
-author:
-    - Marc Tschapek (@marqelme)
 notes:
   - In order to understand all the returned properties and values please visit the following site and open the respective MSFT class
     U(https://msdn.microsoft.com/en-us/library/windows/desktop/hh830612.aspx)
+author:
+    - Marc Tschapek (@marqelme)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_domain.py
+++ b/lib/ansible/modules/windows/win_domain.py
@@ -71,6 +71,12 @@ options:
     type: str
     choices: [ Win2003, Win2008, Win2008R2, Win2012, Win2012R2, WinThreshold ]
     version_added: '2.8'
+seealso:
+- module: win_domain_controller
+- module: win_domain_computer
+- module: win_domain_group
+- module: win_domain_membership
+- module: win_domain_user
 author:
 - Matt Davis (@nitzmahone)
 '''

--- a/lib/ansible/modules/windows/win_domain_computer.py
+++ b/lib/ansible/modules/windows/win_domain_computer.py
@@ -18,6 +18,7 @@ description:
   - Create, read, update and delete computers in Active Directory using a
     windows bridge computer to launch New-ADComputer, Get-ADComputer,
     Set-ADComputer, Remove-ADComputer and Move-ADObject powershell commands.
+version_added: '2.6'
 options:
   name:
     description:
@@ -65,8 +66,12 @@ options:
       - present
       - absent
     default: present
-notes:
-version_added: 2.6
+seealso:
+- module: win_domain
+- module: win_domain_controller
+- module: win_domain_group
+- module: win_domain_membership
+- module: win_domain_user
 author: Daniel Sánchez Fábregas (@Daniel-Sanchez-Fabregas)
 '''
 

--- a/lib/ansible/modules/windows/win_domain_controller.py
+++ b/lib/ansible/modules/windows/win_domain_controller.py
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 module: win_domain_controller
 short_description: Manage domain controller/member server state for a Windows host
-version_added: 2.3
+version_added: '2.3'
 description:
      - Ensure that a Windows Server 2012+ host is configured as a domain controller or demoted to member server. This module may require
        subsequent use of the M(win_reboot) action if changes are made.
@@ -67,6 +67,12 @@ options:
     - If not set then the default path is C(%SYSTEMROOT%\SYSVOL).
     type: path
     version_added: '2.5'
+seealso:
+- module: win_domain
+- module: win_domain_computer
+- module: win_domain_group
+- module: win_domain_membership
+- module: win_domain_user
 author:
     - Matt Davis (@nitzmahone)
 '''

--- a/lib/ansible/modules/windows/win_domain_group.py
+++ b/lib/ansible/modules/windows/win_domain_group.py
@@ -97,6 +97,14 @@ options:
 notes:
 - This must be run on a host that has the ActiveDirectory powershell module
   installed.
+seealso:
+- module: win_domain
+- module: win_domain_controller
+- module: win_domain_computer
+- module: win_domain_membership
+- module: win_domain_user
+- module: win_group
+- module: win_group_membership
 author:
 - Jordan Borean (@jborean93)
 '''

--- a/lib/ansible/modules/windows/win_domain_membership.py
+++ b/lib/ansible/modules/windows/win_domain_membership.py
@@ -41,6 +41,15 @@ options:
   workgroup_name:
     description:
       - When C(state) is C(workgroup), the name of the workgroup that the Windows host should be in.
+seealso:
+- module: win_domain
+- module: win_domain_controller
+- module: win_domain_computer
+- module: win_domain_group
+- module: win_domain_user
+- module: win_group
+- module: win_group_membership
+- module: win_user
 author:
     - Matt Davis (@nitzmahone)
 '''

--- a/lib/ansible/modules/windows/win_domain_user.py
+++ b/lib/ansible/modules/windows/win_domain_user.py
@@ -169,6 +169,13 @@ notes:
   - Note that some individuals have confirmed successful operation on Windows
     2008R2 servers with AD and AD Web Services enabled, but this has not
     received the same degree of testing as Windows 2012R2.
+seealso:
+- module: win_domain
+- module: win_domain_controller
+- module: win_domain_computer
+- module: win_domain_group
+- module: win_domain_membership
+- module: win_user
 author:
     - Nick Chandler (@nwchandler)
 '''

--- a/lib/ansible/modules/windows/win_dotnet_ngen.py
+++ b/lib/ansible/modules/windows/win_dotnet_ngen.py
@@ -25,9 +25,9 @@ notes:
     - There are in fact two scheduled tasks for ngen but they have no triggers so aren't a problem.
     - There's no way to test if they've been completed.
     - The stdout is quite likely to be several megabytes.
+options: {}
 author:
 - Peter Mounce (@petemounce)
-options: {}
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_dotnet_ngen.py
+++ b/lib/ansible/modules/windows/win_dotnet_ngen.py
@@ -25,9 +25,9 @@ notes:
     - There are in fact two scheduled tasks for ngen but they have no triggers so aren't a problem.
     - There's no way to test if they've been completed.
     - The stdout is quite likely to be several megabytes.
-options: {}
 author:
 - Peter Mounce (@petemounce)
+options: {}
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_environment.py
+++ b/lib/ansible/modules/windows/win_environment.py
@@ -40,8 +40,6 @@ options:
     - Use C(process) to set for the current process.  Probably not that useful.
     choices: [ machine, user, process ]
     required: yes
-author:
-- Jon Hawkesworth (@jhawkesworth)
 notes:
 - This module is best-suited for setting the entire value of an
   environment variable. For safe element-based management of
@@ -52,6 +50,10 @@ notes:
   therefore will need restarting to pick up new environment settings.
   User level environment variables will require the user to log out
   and in again before they become available.
+seealso:
+- module: win_path
+author:
+- Jon Hawkesworth (@jhawkesworth)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_eventlog.py
+++ b/lib/ansible/modules/windows/win_eventlog.py
@@ -71,6 +71,8 @@ options:
       - The minimum number of days event entries must remain in the log.
       - This option is only used when C(overflow_action) is C(OverwriteOlder).
     type: int
+seealso:
+- module: win_eventlog_entry
 author:
     - Andrew Saraceni (@andrewsaraceni)
 '''

--- a/lib/ansible/modules/windows/win_eventlog_entry.py
+++ b/lib/ansible/modules/windows/win_eventlog_entry.py
@@ -53,6 +53,8 @@ options:
       - Value must be a comma-separated array of 8-bit unsigned integers (0 to 255).
 notes:
     - This module will always report a change when writing an event entry.
+seealso:
+- module: win_eventlog
 author:
     - Andrew Saraceni (@andrewsaraceni)
 '''

--- a/lib/ansible/modules/windows/win_feature.py
+++ b/lib/ansible/modules/windows/win_feature.py
@@ -50,6 +50,9 @@ options:
       - Not supported in Windows 2008 R2 and will be ignored.
       - Can either be C({driveletter}:\sources\sxs) or C(\\{IP}\share\sources\sxs).
     version_added: "2.1"
+seealso:
+- module: win_chocolatey
+- module: win_package
 author:
     - Paul Durivage (@angstwad)
     - Trond Hindenes (@trondhindenes)

--- a/lib/ansible/modules/windows/win_file.py
+++ b/lib/ansible/modules/windows/win_file.py
@@ -18,11 +18,6 @@ description:
        and can create or remove directories.
      - Unlike M(file), does not modify ownership, permissions or manipulate links.
      - For non-Windows targets, use the M(file) module instead.
-notes:
-    - For non-Windows targets, use the M(file) module instead.
-    - See also M(win_copy), M(win_template), M(copy), M(template), M(assemble)
-author:
-- Jon Hawkesworth (@jhawkesworth)
 options:
   path:
     description:
@@ -41,6 +36,18 @@ options:
         exist, while an existing file or directory will receive updated file access and
         modification times (similar to the way C(touch) works from the command line).
     choices: [ absent, directory, file, touch ]
+notes:
+    - For non-Windows targets, use the M(file) module instead.
+seealso:
+- module: assemble
+- module: copy
+- module: file
+- module: template
+- module: win_copy
+- module: win_stat
+- module: win_template
+author:
+- Jon Hawkesworth (@jhawkesworth)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_file_version.py
+++ b/lib/ansible/modules/windows/win_file_version.py
@@ -24,6 +24,8 @@ options:
       - Always provide absolute path.
     required: yes
     type: path
+seealso:
+- module: win_file
 author:
 - Sam Liu (@SamLiu79)
 '''

--- a/lib/ansible/modules/windows/win_firewall.py
+++ b/lib/ansible/modules/windows/win_firewall.py
@@ -18,6 +18,8 @@ version_added: '2.4'
 short_description: Enable or disable the Windows Firewall
 description:
 - Enable or Disable Windows Firewall profiles.
+requirements:
+  - This module requires Windows Management Framework 5 or later.
 options:
   profiles:
     description:
@@ -34,8 +36,8 @@ options:
     choices:
     - enabled
     - disabled
-requirements:
-  - This module requires Windows Management Framework 5 or later.
+seealso:
+- module: win_firewall_rule
 author:
 - Michael Eaton (@if-meaton)
 '''

--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -13,9 +13,6 @@ DOCUMENTATION = r'''
 ---
 module: win_firewall_rule
 version_added: "2.0"
-author:
-  - Artem Zinenko (@ar7z1)
-  - Timothy Vandenbrande (@TimothyVandenbrande)
 short_description: Windows firewall automation
 description:
   - Allows you to create/remove/update firewall rules.
@@ -85,6 +82,11 @@ options:
     - DEPRECATED in 2.4 and will be removed in 2.9.
     type: bool
     default: 'no'
+seealso:
+- module: win_firewall
+author:
+  - Artem Zinenko (@ar7z1)
+  - Timothy Vandenbrande (@TimothyVandenbrande)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_get_url.py
+++ b/lib/ansible/modules/windows/win_get_url.py
@@ -20,9 +20,6 @@ description:
 - Downloads files from HTTP, HTTPS, or FTP to the remote server. The remote
   server I(must) have direct access to the remote resource.
 - For non-Windows targets, use the M(get_url) module instead.
-author:
-- Paul Durivage (@angstwad)
-- Takeshi Kuramochi (@tksarah)
 options:
   url:
     description:
@@ -108,6 +105,13 @@ notes:
 - If your URL includes an escaped slash character (%2F) this module will convert it to a real slash.
   This is a result of the behaviour of the System.Uri class as described in
   L(the documentation,https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/network/schemesettings-element-uri-settings#remarks).
+seealso:
+- module: get_url
+- module: uri
+- module: win_uri
+author:
+- Paul Durivage (@angstwad)
+- Takeshi Kuramochi (@tksarah)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_group.py
+++ b/lib/ansible/modules/windows/win_group.py
@@ -34,6 +34,10 @@ options:
     default: present
 notes:
     - For non-Windows targets, please use the M(group) module instead.
+seealso:
+- module: group
+- module: win_domain_group
+- module: win_group_membership
 author:
 - Chris Hoffman (@chrishoffman)
 '''

--- a/lib/ansible/modules/windows/win_group_membership.py
+++ b/lib/ansible/modules/windows/win_group_membership.py
@@ -36,6 +36,10 @@ options:
       - Desired state of the members in the group.
     choices: [ absent, present ]
     default: present
+seealso:
+- module: win_domain_group
+- module: win_domain_membership
+- module: win_group
 author:
     - Andrew Saraceni (@andrewsaraceni)
 '''

--- a/lib/ansible/modules/windows/win_hostname.py
+++ b/lib/ansible/modules/windows/win_hostname.py
@@ -23,6 +23,8 @@ options:
     description:
     - The hostname to set for the computer.
     required: true
+seealso:
+- module: win_dns_client
 author:
 - Ripon Banik (@riponbanik)
 '''

--- a/lib/ansible/modules/windows/win_hotfix.py
+++ b/lib/ansible/modules/windows/win_hotfix.py
@@ -56,6 +56,9 @@ notes:
   U(https://developer.microsoft.com/en-us/windows/hardware/windows-assessment-deployment-kit),
   see examples to see how to do it with chocolatey.
 - You can download hotfixes from U(https://www.catalog.update.microsoft.com/Home.aspx).
+seealso:
+- module: win_package
+- module: win_updates
 author:
 - Jordan Borean (@jborean93)
 '''

--- a/lib/ansible/modules/windows/win_iis_virtualdirectory.py
+++ b/lib/ansible/modules/windows/win_iis_virtualdirectory.py
@@ -36,6 +36,11 @@ options:
     description:
       - The physical path to the folder in which the new virtual directory is created.
       - The specified folder must already exist.
+seealso:
+- module: win_iis_webapplication
+- module: win_iis_webapppool
+- module: win_iis_webbinding
+- module: win_iis_website
 author:
 - Henrik Wallström (@henrikwallstrom)
 '''

--- a/lib/ansible/modules/windows/win_iis_webapplication.py
+++ b/lib/ansible/modules/windows/win_iis_webapplication.py
@@ -36,6 +36,11 @@ options:
   application_pool:
     description:
     - The application pool in which the new site executes.
+seealso:
+- module: win_iis_virtualdirectory
+- module: win_iis_webapppool
+- module: win_iis_webbinding
+- module: win_iis_website
 author:
 - Henrik Wallström (@henrikwallstrom)
 '''

--- a/lib/ansible/modules/windows/win_iis_webapppool.py
+++ b/lib/ansible/modules/windows/win_iis_webapppool.py
@@ -51,6 +51,11 @@ options:
         is never idempotent.
       - If C(started) will ensure the app pool exists and is started.
       - If C(stopped) will ensure the app pool exists and is stopped.
+seealso:
+- module: win_iis_virtualdirectory
+- module: win_iis_webapplication
+- module: win_iis_webbinding
+- module: win_iis_website
 author:
 - Henrik Wallström (@henrikwallstrom)
 - Jordan Borean (@jborean93)

--- a/lib/ansible/modules/windows/win_iis_webbinding.py
+++ b/lib/ansible/modules/windows/win_iis_webbinding.py
@@ -57,6 +57,11 @@ options:
       - Set to c(0) to disable SNI.
       - Set to c(1) to enable SNI.
     version_added: "2.5"
+seealso:
+- module: win_iis_virtualdirectory
+- module: win_iis_webapplication
+- module: win_iis_webapppool
+- module: win_iis_website
 author:
   - Noah Sparks (@nwsparks)
   - Henrik Wallström (@henrikwallstrom)

--- a/lib/ansible/modules/windows/win_iis_website.py
+++ b/lib/ansible/modules/windows/win_iis_website.py
@@ -51,6 +51,11 @@ options:
   parameters:
     description:
       - Custom site Parameters from string where properties are separated by a pipe and property name/values by colon Ex. "foo:1|bar:2"
+seealso:
+- module: win_iis_virtualdirectory
+- module: win_iis_webapplication
+- module: win_iis_webapppool
+- module: win_iis_webbinding
 author:
 - Henrik Wallström (@henrikwallstrom)
 '''

--- a/lib/ansible/modules/windows/win_lineinfile.py
+++ b/lib/ansible/modules/windows/win_lineinfile.py
@@ -10,8 +10,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: win_lineinfile
-author:
-- Brian Lloyd (@brianlloyd)
 short_description: Ensure a particular line is in a file, or replace an existing line using a back-referenced regular expression
 description:
   - This module will search a file for a line, and ensure that it is present or absent.
@@ -94,6 +92,11 @@ options:
     default: windows
 notes:
   - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
+seealso:
+- module: assemble
+- module: lineinfile
+author:
+- Brian Lloyd (@brianlloyd)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_mapped_drive.py
+++ b/lib/ansible/modules/windows/win_mapped_drive.py
@@ -19,17 +19,6 @@ version_added: '2.4'
 short_description: Map network drives for users
 description:
 - Allows you to modify mapped network drives for individual users.
-notes:
-- You cannot use this module to access a mapped drive in another Ansible task,
-  drives mapped with this module are only accessible when logging in
-  interactively with the user through the console or RDP.
-- It is recommend to run this module with become or CredSSP when the remote
-  path requires authentication.
-- When using become or CredSSP, the task will have access to any local
-  credentials stored in the user's vault.
-- If become or CredSSP is not available, the I(username) and I(password)
-  options can be used for the initial authentication but these are not
-  persisted.
 options:
   letter:
     description:
@@ -66,6 +55,19 @@ options:
       custom credentials and become, or CredSSP cannot be used.
     - If become or CredSSP is used, any credentials saved with
       M(win_credential) will automatically be used instead.
+notes:
+- You cannot use this module to access a mapped drive in another Ansible task,
+  drives mapped with this module are only accessible when logging in
+  interactively with the user through the console or RDP.
+- It is recommend to run this module with become or CredSSP when the remote
+  path requires authentication.
+- When using become or CredSSP, the task will have access to any local
+  credentials stored in the user's vault.
+- If become or CredSSP is not available, the I(username) and I(password)
+  options can be used for the initial authentication but these are not
+  persisted.
+seealso:
+- module: win_credential
 author:
 - Jordan Borean (@jborean93)
 '''

--- a/lib/ansible/modules/windows/win_msg.py
+++ b/lib/ansible/modules/windows/win_msg.py
@@ -40,14 +40,17 @@ options:
       - The text of the message to be displayed.
       - The message must be less than 256 characters.
     default: Hello world!
-author:
-- Jon Hawkesworth (@jhawkesworth)
 notes:
    - This module must run on a windows host, so ensure your play targets windows
      hosts, or delegates to a windows host.
    - Messages are only sent to the local host where the module is run.
    - The module does not support sending to users listed in a file.
    - Setting wait to C(yes) can result in long run times on systems with many logged in users.
+seealso:
+- module: win_say
+- module: win_toast
+author:
+- Jon Hawkesworth (@jhawkesworth)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -73,6 +73,8 @@ options:
       - C(disabled) means that the service will stay off, regardless if it is needed or not.
     choices: [ auto, delayed, disabled, manual ]
     default: auto
+seealso:
+- module: win_service
 author:
   - Adam Keech (@smadam813)
   - George Frank (@georgefrank)

--- a/lib/ansible/modules/windows/win_owner.py
+++ b/lib/ansible/modules/windows/win_owner.py
@@ -30,6 +30,8 @@ options:
       - Indicates if the owner should be changed recursively
     type: bool
     default: 'no'
+seealso:
+- module: win_file
 author:
 - Hans-Joachim Kliemeck (@h0nIg)
 '''

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -139,6 +139,10 @@ notes:
   and the file is not an MSI.
 - All the installation checks under C(product_id) and C(creates_*) add
   together, if one fails then the program is considered to be absent.
+seealso:
+- module: win_chocolatey
+- module: win_hotfix
+- module: win_updates
 author:
 - Trond Hindenes (@trondhindenes)
 - Jordan Borean (@jborean93)

--- a/lib/ansible/modules/windows/win_path.py
+++ b/lib/ansible/modules/windows/win_path.py
@@ -43,8 +43,6 @@ options:
       - The level at which the environment variable specified by C(name) should be managed (either for the current user or global machine scope).
     choices: [ machine, user ]
     default: machine
-author:
-- Matt Davis (@nitzmahone)
 notes:
    - This module is for modifying indidvidual elements of path-like
      environment variables. For general-purpose management of other
@@ -55,6 +53,10 @@ notes:
      therefore will need restarting to pick up new environment settings.
      User level environment variables will require an interactive user to
      log out and in again before they become available.
+seealso:
+- module: win_environment
+author:
+- Matt Davis (@nitzmahone)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_ping.py
+++ b/lib/ansible/modules/windows/win_ping.py
@@ -30,6 +30,8 @@ options:
 notes:
   - For non-Windows targets, use the M(ping) module instead.
   - For Network targets, use the M(net_ping) module instead.
+seealso:
+- module: ping
 author:
 - Chris Church (@cchurch)
 '''

--- a/lib/ansible/modules/windows/win_power_plan.py
+++ b/lib/ansible/modules/windows/win_power_plan.py
@@ -17,16 +17,16 @@ description:
   - Windows defaults to C(balanced) which will cause CPU throttling. In some cases it can be preferable
     to change the mode to C(high performance) to increase CPU performance.
 version_added: "2.4"
-author:
-  - Noah Sparks (@nwsparks)
+requirements:
+  - Windows Server 2008R2 (6.1)/Windows 7 or higher
 options:
   name:
     description:
       - String value that indicates the desired power plan. The power plan must already be
         present on the system. Commonly there will be options for C(balanced) and C(high performance).
     required: yes
-requirements:
-  - Windows Server 2008R2 (6.1)/Windows 7 or higher
+author:
+  - Noah Sparks (@nwsparks)
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/windows/win_product_facts.py
+++ b/lib/ansible/modules/windows/win_product_facts.py
@@ -15,9 +15,9 @@ short_description: Provides Windows product information (product id, product key
 description:
 - Provides Windows product information.
 version_added: '2.5'
+options: {}
 author:
 - Dag Wieers (@dagwieers)
-options: {}
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_psexec.py
+++ b/lib/ansible/modules/windows/win_psexec.py
@@ -16,6 +16,8 @@ short_description: Runs commands (remotely) as another (privileged) user
 description:
 - Run commands (remotely) through the PsExec service
 - Run commands as another (domain) user (with elevated privileges)
+requirements:
+- Microsoft PsExec
 options:
   command:
     description:
@@ -105,8 +107,11 @@ options:
 notes:
 - More information related to Microsoft PsExec is available from
   U(https://technet.microsoft.com/en-us/sysinternals/bb897553.aspx)
-requirements:
-- Microsoft PsExec
+seealso:
+- module: psexec
+- module: raw
+- module: win_command
+- module: win_shell
 author:
 - Dag Wieers (@dagwieers)
 '''

--- a/lib/ansible/modules/windows/win_psmodule.py
+++ b/lib/ansible/modules/windows/win_psmodule.py
@@ -42,7 +42,8 @@ options:
     default: present
 notes:
    -  Powershell 5.0 or higher is needed.
-
+seealso:
+- module: win_psrepository
 author:
 - Daniele Lazzari (@dlazz)
 '''

--- a/lib/ansible/modules/windows/win_psrepository.py
+++ b/lib/ansible/modules/windows/win_psrepository.py
@@ -42,7 +42,9 @@ options:
 notes:
   - The PowerShellGet module (version 1.6.0 or newer) and the NuGet package provider (version 2.8.5.201 or newer) are required.
   - See the examples on how to update the NuGet package provider.
-  - You can't use M(win_psrepository) to re-register (add) removed PSGallery, use the command C(Register-PSRepository -Default) instead.
+  - You can't use C(win_psrepository) to re-register (add) removed PSGallery, use the command C(Register-PSRepository -Default) instead.
+seealso:
+- module: win_psmodule
 author:
 - Wojciech Sciesinski (@it-praktyk)
 '''

--- a/lib/ansible/modules/windows/win_rabbitmq_plugin.py
+++ b/lib/ansible/modules/windows/win_rabbitmq_plugin.py
@@ -15,8 +15,6 @@ short_description: Manage RabbitMQ plugins
 description:
   - Manage RabbitMQ plugins.
 version_added: "2.4"
-author:
-  - Artem Zinenko (@ar7z1)
 options:
   names:
     description:
@@ -37,6 +35,8 @@ options:
   prefix:
     description:
       - Specify a custom install prefix to a Rabbit.
+author:
+  - Artem Zinenko (@ar7z1)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -65,6 +65,8 @@ notes:
 - Beware that when C(win_reboot) returns, the Windows system may not have settled yet and some base services could be in limbo.
   This can result in unexpected behavior. Check the examples for ways to mitigate this.
 - For non-Windows targets, use the M(reboot) module instead.
+seealso:
+- module: reboot
 author:
 - Matt Davis (@nitzmahone)
 '''

--- a/lib/ansible/modules/windows/win_reg_stat.py
+++ b/lib/ansible/modules/windows/win_reg_stat.py
@@ -29,6 +29,9 @@ options:
     description:
     - The registry property name to get information for, the return json will not include the sub_keys and properties entries for the I(key) specified.
     aliases: [ entry, value, property ]
+seealso:
+- module: win_regedit
+- module: win_regmerge
 author:
 - Jordan Borean (@jborean93)
 '''

--- a/lib/ansible/modules/windows/win_regedit.py
+++ b/lib/ansible/modules/windows/win_regedit.py
@@ -87,6 +87,9 @@ notes:
   applying changes.
 - Beware that some registry hives (C(HKEY_USERS) in particular) do not allow to create new registry paths in the root folder.
 - Since ansible 2.4, when checking if a string registry value has changed, a case-sensitive test is used. Previously the test was case-insensitive.
+seealso:
+- module: win_reg_stat
+- module: win_regmerge
 author:
 - Adam Keech (@smadam813)
 - Josh Ludwig (@joshludwig)

--- a/lib/ansible/modules/windows/win_region.py
+++ b/lib/ansible/modules/windows/win_region.py
@@ -47,6 +47,8 @@ options:
               change.
         type: bool
         default: 'no'
+seealso:
+- module: win_timezone
 author:
 - Jordan Borean (@jborean93)
 '''

--- a/lib/ansible/modules/windows/win_regmerge.py
+++ b/lib/ansible/modules/windows/win_regmerge.py
@@ -35,8 +35,6 @@ options:
       - The parent key to use when comparing the contents of the registry to the contents of the file.  Needs to be in HKLM or HKCU part of registry.
         Use a PS-Drive style path for example HKLM:\SOFTWARE not HKEY_LOCAL_MACHINE\SOFTWARE
         If not supplied, or the registry key is not found, no comparison will be made, and the module will report changed.
-author:
-- Jon Hawkesworth (@jhawkesworth)
 notes:
    - Organise your registry files so that they contain a single root registry
      key if you want to use the compare_to functionality.
@@ -46,6 +44,11 @@ notes:
      differences on subsequent runs.
      To force registry change, use M(win_regedit) with state=absent before
      using M(win_regmerge).
+seeals:
+- module: win_reg_stat
+- module: win_regedit
+author:
+- Jon Hawkesworth (@jhawkesworth)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_regmerge.py
+++ b/lib/ansible/modules/windows/win_regmerge.py
@@ -44,7 +44,7 @@ notes:
      differences on subsequent runs.
      To force registry change, use M(win_regedit) with state=absent before
      using M(win_regmerge).
-seeals:
+seealso:
 - module: win_reg_stat
 - module: win_regedit
 author:

--- a/lib/ansible/modules/windows/win_robocopy.py
+++ b/lib/ansible/modules/windows/win_robocopy.py
@@ -46,12 +46,15 @@ options:
   flags:
     description:
       - Directly supply Robocopy flags. If set, C(purge) and C(recurse) will be ignored.
-author:
-- Corwin Brown (@blakfeld)
 notes:
 - This is not a complete port of the M(synchronize) module. Unlike the M(synchronize) module this only performs the sync/copy on the remote machine,
   not from the master to the remote machine.
 - This module does not currently support all Robocopy flags.
+seealso:
+- module: synchronize
+- module: win_copy
+author:
+- Corwin Brown (@blakfeld)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_say.py
+++ b/lib/ansible/modules/windows/win_say.py
@@ -54,8 +54,6 @@ options:
       - Full path to a C(.wav) file containing a sound to play after the text has been spoken.
       - Useful on conference calls to alert other speakers that ansible has finished speaking.
     type: path
-author:
-- Jon Hawkesworth (@jhawkesworth)
 notes:
    - Needs speakers or headphones to do anything useful.
    - |
@@ -67,6 +65,11 @@ notes:
                  $speech.Dispose()
 
    - Speech can be surprisingly slow, so it's best to keep message text short.
+seealso:
+- module: win_msg
+- module: win_toast
+author:
+- Jon Hawkesworth (@jhawkesworth)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_scheduled_task.py
+++ b/lib/ansible/modules/windows/win_scheduled_task.py
@@ -15,12 +15,6 @@ version_added: "2.0"
 short_description: Manage scheduled tasks
 description:
 - Creates/modified or removes Windows scheduled tasks.
-notes:
-- In Ansible 2.4 and earlier, this could only be run on Server 2012/Windows 8
-  or newer. Since 2.5 this restriction has been lifted.
-- The option names and structure for actions and triggers of a service follow
-  the C(RegisteredTask) naming standard and requirements, it would be useful to
-  read up on this guide if coming across any issues U(https://msdn.microsoft.com/en-us/library/windows/desktop/aa382542.aspx).
 options:
   # module definition options
   name:
@@ -397,6 +391,14 @@ options:
     - Whether the task will wake the computer when it is time to run the task.
     type: bool
     version_added: '2.5'
+notes:
+- In Ansible 2.4 and earlier, this could only be run on Server 2012/Windows 8
+  or newer. Since 2.5 this restriction has been lifted.
+- The option names and structure for actions and triggers of a service follow
+  the C(RegisteredTask) naming standard and requirements, it would be useful to
+  read up on this guide if coming across any issues U(https://msdn.microsoft.com/en-us/library/windows/desktop/aa382542.aspx).
+seealso:
+- module: win_scheduled_task_stat
 author:
 - Peter Mounce (@petemounce)
 - Jordan Borean (@jborean93)

--- a/lib/ansible/modules/windows/win_scheduled_task_stat.py
+++ b/lib/ansible/modules/windows/win_scheduled_task_stat.py
@@ -19,14 +19,17 @@ short_description: Get information about Windows Scheduled Tasks
 description:
 - Will return whether the folder and task exists.
 - Returns the names of tasks in the folder specified.
-- If C(name) is set and exists, will return information on the task itself.
 - Use M(win_scheduled_task) to configure a scheduled task.
 options:
   path:
     description: The folder path where the task lives.
     default: \
   name:
-    description: The name of the scheduled task to get information for.
+    description:
+    - The name of the scheduled task to get information for.
+    - If C(name) is set and exists, will return information on the task itself.
+seealso:
+- module: win_scheduled_task
 author:
 - Jordan Borean (@jborean93)
 '''

--- a/lib/ansible/modules/windows/win_security_policy.py
+++ b/lib/ansible/modules/windows/win_security_policy.py
@@ -18,16 +18,6 @@ short_description: Change local security policy settings
 description:
 - Allows you to set the local security policies that are configured by
   SecEdit.exe.
-notes:
-- This module uses the SecEdit.exe tool to configure the values, more details
-  of the areas and keys that can be configured can be found here
-  U(https://msdn.microsoft.com/en-us/library/bb742512.aspx).
-- If you are in a domain environment these policies may be set by a GPO policy,
-  this module can temporarily change these values but the GPO will override
-  it if the value differs.
-- You can also run C(SecEdit.exe /export /cfg C:\temp\output.ini) to view the
-  current policies set on your system.
-- When assigning user rights, use the M(win_user_right) module instead.
 options:
   section:
     description:
@@ -49,6 +39,18 @@ options:
     - The value for the ini key or policy name.
     - If the key takes in a boolean value then 0 = False and 1 = True.
     required: yes
+notes:
+- This module uses the SecEdit.exe tool to configure the values, more details
+  of the areas and keys that can be configured can be found here
+  U(https://msdn.microsoft.com/en-us/library/bb742512.aspx).
+- If you are in a domain environment these policies may be set by a GPO policy,
+  this module can temporarily change these values but the GPO will override
+  it if the value differs.
+- You can also run C(SecEdit.exe /export /cfg C:\temp\output.ini) to view the
+  current policies set on your system.
+- When assigning user rights, use the M(win_user_right) module instead.
+seealso:
+- module: win_user_right
 author:
 - Jordan Borean (@jborean93)
 '''

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -110,6 +110,9 @@ options:
     version_added: '2.3'
 notes:
 - For non-Windows targets, use the M(service) module instead.
+seealso:
+- module: service
+- module: win_nssm
 author:
 - Chris Hoffman (@chrishoffman)
 '''

--- a/lib/ansible/modules/windows/win_shell.py
+++ b/lib/ansible/modules/windows/win_shell.py
@@ -54,7 +54,13 @@ notes:
       Thus, it is not possible to use C(win_shell) to spawn long-running child or background processes.
       Consider creating a Windows service for managing background processes.
    - For non-Windows targets, use the M(shell) module instead.
-   - See also M(win_command), M(raw)
+seealso:
+- module: psexec
+- module: raw
+- module: script
+- module: shell
+- module: win_command
+- module: win_psexec
 author:
     - Matt Davis (@nitzmahone)
 '''

--- a/lib/ansible/modules/windows/win_shortcut.py
+++ b/lib/ansible/modules/windows/win_shortcut.py
@@ -68,11 +68,13 @@ options:
     type: bool
     default: no
     version_added: '2.8'
-author:
-- Dag Wieers (@dagwieers)
 notes:
 - 'The following options can include Windows environment variables: C(dest), C(args), C(description), C(dest), C(directory), C(icon) C(src)'
 - 'Windows has two types of shortcuts: Application and URL shortcuts. URL shortcuts only consists of C(dest) and C(src)'
+seealso:
+- module: win_file
+author:
+- Dag Wieers (@dagwieers)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_snmp.py
+++ b/lib/ansible/modules/windows/win_snmp.py
@@ -15,8 +15,6 @@ DOCUMENTATION = '''
 module: win_snmp
 version_added: '2.8'
 short_description: Configures the Windows SNMP service
-author:
-    - Michael Cassaniti (@mcassaniti)
 description:
     - This module configures the Windows SNMP service.
 options:
@@ -37,6 +35,8 @@ options:
         - C(remove) will remove SNMP community strings and/or SNMP managers
         default: set
         choices: [ add, set, remove ]
+author:
+    - Michael Cassaniti (@mcassaniti)
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/windows/win_stat.py
+++ b/lib/ansible/modules/windows/win_stat.py
@@ -53,6 +53,9 @@ options:
         version_added: "2.3"
 notes:
      - For non-Windows targets, use the M(stat) module instead.
+seealso:
+- module: stat
+- module: win_file
 author:
 - Chris Church (@cchurch)
 '''

--- a/lib/ansible/modules/windows/win_tempfile.py
+++ b/lib/ansible/modules/windows/win_tempfile.py
@@ -12,8 +12,6 @@ DOCUMENTATION = r'''
 ---
 module: win_tempfile
 version_added: "2.3"
-author:
-- Dag Wieers (@dagwieers)
 short_description: Creates temporary files and directories
 description:
   - Creates temporary files and directories.
@@ -40,6 +38,10 @@ options:
     default: ''
 notes:
   - For non-Windows targets, please use the M(tempfile) module instead.
+seealso:
+- module: tempfile
+author:
+- Dag Wieers (@dagwieers)
 '''
 
 EXAMPLES = r"""

--- a/lib/ansible/modules/windows/win_template.py
+++ b/lib/ansible/modules/windows/win_template.py
@@ -90,6 +90,9 @@ notes:
     which changes the variable interpolation markers to  [% var %] instead of  {{ var }}.
     This is the best way to prevent evaluation of things that look like, but should not be Jinja2.
     raw/endraw in Jinja2 will not work as you expect because templates in Ansible are recursively evaluated."
+seealso:
+- module: template
+- module: win_copy
 author:
 - Jon Hawkesworth (@jhawkesworth)
 '''

--- a/lib/ansible/modules/windows/win_timezone.py
+++ b/lib/ansible/modules/windows/win_timezone.py
@@ -28,6 +28,8 @@ notes:
 - If running on Server 2008 the hotfix
   U(https://support.microsoft.com/en-us/help/2556308/tzutil-command-line-tool-is-added-to-windows-vista-and-to-windows-server-2008)
   needs to be installed to be able to run this module.
+seealso:
+- module: win_region
 author:
 - Phil Schwartz (@schwartzmx)
 '''

--- a/lib/ansible/modules/windows/win_toast.py
+++ b/lib/ansible/modules/windows/win_toast.py
@@ -47,13 +47,16 @@ options:
     description:
       - The notification title, which appears in the pop up..
     default: Notification HH:mm
-author:
-- Jon Hawkesworth (@jhawkesworth)
 notes:
    - This module must run on a windows 10 or Server 2016 host, so ensure your play targets windows hosts, or delegates to a windows host.
    - The module does not fail if there are no logged in users to notify.
    - Messages are only sent to the local host where the module is run.
    - You must run this module with async, otherwise it will hang until the expire period has passed.
+seealso:
+- module: win_msg
+- module: win_say
+author:
+- Jon Hawkesworth (@jhawkesworth)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_unzip.py
+++ b/lib/ansible/modules/windows/win_unzip.py
@@ -56,6 +56,8 @@ notes:
   has the ability to recursively unzip files within the src zip file provided and also functionality for many other compression types. If the destination
   directory does not exist, it will be created before unzipping the file.  Specifying rm parameter will force removal of the src file after extraction.
 - For non-Windows targets, use the M(unarchive) module instead.
+seealso:
+- module: unarchive
 author:
 - Phil Schwartz (@schwartzmx)
 '''

--- a/lib/ansible/modules/windows/win_updates.py
+++ b/lib/ansible/modules/windows/win_updates.py
@@ -93,8 +93,6 @@ options:
         type: bool
         default: 'no'
         version_added: '2.6'
-author:
-- Matt Davis (@nitzmahone)
 notes:
 - C(win_updates) must be run by a user with membership in the local Administrators group.
 - C(win_updates) will use the default update service configured for the machine (Windows Update, Microsoft Update, WSUS, etc).
@@ -105,6 +103,13 @@ notes:
   Performance depends on many factors, including OS version, number of updates, system load, and update server load.
 - More information about PowerShell and how it handles RegEx strings can be
   found at U(https://technet.microsoft.com/en-us/library/2007.11.powershell.aspx).
+seealso:
+- module: win_chocolatey
+- module: win_feature
+- module: win_hotfix
+- module: win_package
+author:
+- Matt Davis (@nitzmahone)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_uri.py
+++ b/lib/ansible/modules/windows/win_uri.py
@@ -142,6 +142,9 @@ options:
     version_added: '2.5'
 notes:
 - For non-Windows targets, use the M(uri) module instead.
+seealso:
+- module: uri
+- module: win_get_url
 author:
 - Corwin Brown (@blakfeld)
 - Dag Wieers (@dagwieers)

--- a/lib/ansible/modules/windows/win_user.py
+++ b/lib/ansible/modules/windows/win_user.py
@@ -98,6 +98,12 @@ options:
     default: present
 notes:
      - For non-Windows targets, use the M(user) module instead.
+seealso:
+- module: user
+- module: win_domain_membership
+- module: win_domain_user
+- module: win_group
+- module: win_group_membership
 author:
     - Paul Durivage (@angstwad)
     - Chris Church (@cchurch)

--- a/lib/ansible/modules/windows/win_user_right.py
+++ b/lib/ansible/modules/windows/win_user_right.py
@@ -19,9 +19,6 @@ short_description: Manage Windows User Rights
 description:
 - Add, remove or set User Rights for a group or users or groups.
 - You can set user rights for both local and domain accounts.
-notes:
-- If the server is domain joined this module can change a right but if a GPO
-  governs this right then the changes won't last.
 options:
   name:
     description:
@@ -46,6 +43,13 @@ options:
     - C(set) will replace the users/groups of the existing right.
     default: set
     choices: [ add, remove, set ]
+notes:
+- If the server is domain joined this module can change a right but if a GPO
+  governs this right then the changes won't last.
+seealso:
+- module: win_group
+- module: win_group_membership
+- module: win_user
 author:
 - Jordan Borean (@jborean93)
 '''

--- a/lib/ansible/modules/windows/win_wait_for.py
+++ b/lib/ansible/modules/windows/win_wait_for.py
@@ -87,6 +87,9 @@ options:
     - The maximum number of seconds to wait for.
     type: int
     default: 300
+seealso:
+- module: wait_for
+- module: win_wait_for_process
 author:
 - Jordan Borean (@jborean93)
 '''

--- a/lib/ansible/modules/windows/win_wait_for_process.py
+++ b/lib/ansible/modules/windows/win_wait_for_process.py
@@ -82,6 +82,9 @@ options:
       before erroring out.
     type: int
     default: 300
+seealso:
+- module: wait_for
+- module: win_wait_for
 author:
 - Charles Crossan (@crossan007)
 '''

--- a/lib/ansible/modules/windows/win_wakeonlan.py
+++ b/lib/ansible/modules/windows/win_wakeonlan.py
@@ -29,14 +29,16 @@ options:
     - UDP port to use for magic Wake-on-LAN packet.
     type: int
     default: 7
-author:
-- Dag Wieers (@dagwieers)
 todo:
 - Does not have SecureOn password support
 notes:
 - This module sends a magic packet, without knowing whether it worked. It always report a change.
 - Only works if the target system was properly configured for Wake-on-LAN (in the BIOS and/or the OS).
 - Some BIOSes have a different (configurable) Wake-on-LAN boot order (i.e. PXE first).
+seealso:
+- module: wakeonlan
+author:
+- Dag Wieers (@dagwieers)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_webpicmd.py
+++ b/lib/ansible/modules/windows/win_webpicmd.py
@@ -28,6 +28,8 @@ options:
     description:
       - Name of the package to be installed.
     required: yes
+seealso:
+- module: win_package
 author:
 - Peter Mounce (@petemounce)
 '''

--- a/lib/ansible/modules/windows/win_whoami.py
+++ b/lib/ansible/modules/windows/win_whoami.py
@@ -24,6 +24,10 @@ notes:
 - If running this module with a non admin user, the logon rights will be an
   empty list as Administrator rights are required to query LSA for the
   information.
+seealso:
+- module: win_credential
+- module: win_group_membership
+- module: win_user_right
 author:
 - Jordan Borean (@jborean93)
 '''


### PR DESCRIPTION
##### SUMMARY
This implements a `seealso:` section in the module documentation of Windows modules and related modules.

This relates to: #45949

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Various modules