### PR TITLE
Pluribus Networks dhcp filter module with unit tests

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_dhcp_filter.py
+++ b/lib/ansible/modules/network/netvisor/pn_dhcp_filter.py
@@ -27,9 +27,10 @@ options:
     type: str
   state:
     description:
-      - State the action to perform. Use 'present' to create dhcp-filter and
-        'absent' to delete dhcp-filter 'update' to modify the dhcp-filter.
+      - State the action to perform. Use C(present) to create dhcp-filter and
+        C(absent) to delete dhcp-filter C(update) to modify the dhcp-filter.
     required: True
+    type: str
     choices: ['present', 'absent', 'update']
   pn_trusted_ports:
     description:

--- a/lib/ansible/modules/network/netvisor/pn_dhcp_filter.py
+++ b/lib/ansible/modules/network/netvisor/pn_dhcp_filter.py
@@ -110,7 +110,6 @@ def check_cli(module, cli):
 def main():
     """ This section is for arguments parsing """
 
-    global state_map
     state_map = dict(
         present='dhcp-filter-create',
         absent='dhcp-filter-delete',

--- a/lib/ansible/modules/network/netvisor/pn_dhcp_filter.py
+++ b/lib/ansible/modules/network/netvisor/pn_dhcp_filter.py
@@ -1,0 +1,174 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_dhcp_filter
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.8"
+short_description: CLI command to create/modify/delete dhcp-filter
+description:
+  - This module can be used to create, delete and modify a DHCP filter config.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: False
+    type: str
+  state:
+    description:
+      - State the action to perform. Use 'present' to create dhcp-filter and
+        'absent' to delete dhcp-filter 'update' to modify the dhcp-filter.
+    required: True
+    choices: ['present', 'absent', 'update']
+  pn_trusted_ports:
+    description:
+      - trusted ports of dhcp config.
+    required: False
+    type: str
+  pn_name:
+    description:
+      - name of the DHCP filter.
+    required: false
+    type: str
+"""
+
+EXAMPLES = """
+- name: dhcp filter create
+  pn_dhcp_filter:
+    pn_cliswitch: "sw01"
+    pn_name: "foo"
+    state: "present"
+    pn_trusted_ports: "1"
+
+- name: dhcp filter delete
+  pn_dhcp_filter:
+    pn_cliswitch: "sw01"
+    pn_name: "foo"
+    state: "absent"
+    pn_trusted_ports: "1"
+
+- name: dhcp filter modify
+  pn_dhcp_filter:
+    pn_cliswitch: "sw01"
+    pn_name: "foo"
+    state: "update"
+    pn_trusted_ports: "1,2"
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: string
+stdout:
+  description: set of responses from the dhcp-filter command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the dhcp-filter command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+
+
+def check_cli(module, cli):
+    """
+    This method checks for idempotency using the dhcp-filter-show command.
+    If a user with given name exists, return True else False.
+    :param module: The Ansible module to fetch input parameters
+    :param cli: The CLI string
+    """
+    user_name = module.params['pn_name']
+
+    cli += ' dhcp-filter-show format name no-show-headers'
+    out = module.run_command(cli.split(), use_unsafe_shell=True)[1]
+
+    out = out.split()
+
+    return True if user_name in out else False
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    global state_map
+    state_map = dict(
+        present='dhcp-filter-create',
+        absent='dhcp-filter-delete',
+        update='dhcp-filter-modify'
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_trusted_ports=dict(required=False, type='str'),
+            pn_name=dict(required=False, type='str'),
+        ),
+        required_if=[
+            ["state", "present", ["pn_name", "pn_trusted_ports"]],
+            ["state", "absent", ["pn_name"]],
+            ["state", "update", ["pn_name", "pn_trusted_ports"]]
+        ]
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    trusted_ports = module.params['pn_trusted_ports']
+    name = module.params['pn_name']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    USER_EXISTS = check_cli(module, cli)
+    cli += ' %s name %s ' % (command, name)
+
+    if command == 'dhcp-filter-modify':
+        if USER_EXISTS is False:
+            module.fail_json(
+                failed=True,
+                msg='dhcp-filter with name %s does not exist' % name
+            )
+    if command == 'dhcp-filter-delete':
+        if USER_EXISTS is False:
+            module.exit_json(
+                skipped=True,
+                msg='dhcp-filter with name %s does not exist' % name
+            )
+    if command == 'dhcp-filter-create':
+        if USER_EXISTS is True:
+            module.exit_json(
+                skipped=True,
+                msg='dhcp-filter with name %s already exists' % name
+            )
+    if command != 'dhcp-filter-delete':
+        if trusted_ports:
+            cli += ' trusted-ports ' + trusted_ports
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/netvisor/pn_dhcp_filter.py
+++ b/lib/ansible/modules/network/netvisor/pn_dhcp_filter.py
@@ -71,7 +71,7 @@ RETURN = """
 command:
   description: the CLI command run on the target node.
   returned: always
-  type: string
+  type: str
 stdout:
   description: set of responses from the dhcp-filter command.
   returned: always

--- a/test/units/modules/network/netvisor/test_pn_dhcp_filter.py
+++ b/test/units/modules/network/netvisor/test_pn_dhcp_filter.py
@@ -1,0 +1,75 @@
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from units.compat.mock import patch
+from ansible.modules.network.netvisor import pn_dhcp_filter
+from units.modules.utils import set_module_args
+from .nvos_module import TestNvosModule, load_fixture
+
+
+class TestDhcpFilterModule(TestNvosModule):
+
+    module = pn_dhcp_filter
+
+    def setUp(self):
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_dhcp_filter.run_cli')
+        self.run_nvos_commands = self.mock_run_nvos_commands.start()
+
+        self.mock_run_check_cli = patch('ansible.modules.network.netvisor.pn_dhcp_filter.check_cli')
+        self.run_check_cli = self.mock_run_check_cli.start()
+
+    def tearDown(self):
+        self.mock_run_nvos_commands.stop()
+
+    def run_cli_patch(self, module, cli, state_map):
+        if state_map['present'] == 'dhcp-filter-create':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        elif state_map['absent'] == 'dhcp-filter-delete':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        elif state_map['update'] == 'dhcp-filter-modify':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        module.exit_json(**results)
+
+    def load_fixtures(self, commands=None, state=None, transport='cli'):
+        self.run_nvos_commands.side_effect = self.run_cli_patch
+        if state == 'present':
+            self.run_check_cli.return_value = False
+        if state == 'absent':
+            self.run_check_cli.return_value = True
+        if state == 'update':
+            self.run_check_cli.return_value = True
+
+    def test_dhcp_filter_create(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
+                         'pn_trusted_ports': '1', 'state': 'present'})
+        result = self.execute_module(changed=True, state='present')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dhcp-filter-create name foo  trusted-ports 1'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_dhcp_filter_delete(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
+                         'state': 'absent'})
+        result = self.execute_module(changed=True, state='absent')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dhcp-filter-delete name foo '
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_dhcp_filter_update(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
+                         'pn_trusted_ports': '2', 'state': 'update'})
+        result = self.execute_module(changed=True, state='absent')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dhcp-filter-modify name foo  trusted-ports 2'
+        self.assertEqual(result['cli_cmd'], expected_cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Point feature of DHCP filter for Pluribus Networks Netvisor switches  -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
pn_dhcp_filter.py module with unit tests.

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```
