### PR TITLE
Added Ansible UTM Module for managing reverse proxy auth profile entries

### DIFF
--- a/lib/ansible/modules/web_infrastructure/sophos_utm/utm_proxy_auth_profile.py
+++ b/lib/ansible/modules/web_infrastructure/sophos_utm/utm_proxy_auth_profile.py
@@ -1,0 +1,343 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Stephan Schwarz <stearz@gmx.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = """
+---
+module: utm_proxy_auth_profile
+
+author: 
+    - Stephan Schwarz (@stearz)
+
+short_description: create, update or destroy reverse_proxy auth_profile entry in Sophos UTM
+
+description:
+    - Create, update or destroy a reverse_proxy auth_profile entry in SOPHOS UTM.
+    - This module needs to have the REST Ability of the UTM to be activated.
+
+version_added: "2.7" 
+
+options:
+    name:
+        description:
+          - The name of the object. Will be used to identify the entry
+        required: true
+    aaa:
+        description:
+          - List of references to utm_aaa objects (allowed users or groups)
+        required: true
+    basic_prompt:
+        description:
+          - The message in the basic authentication prompt
+        required: true
+    backend_mode:
+        description:
+          - Specifies if the backend server needs authentication ([Basic|None])
+        default: None
+        choices:
+          - Basic
+          - None
+    backend_strip_basic_auth:
+        description:
+          - Should the login data be stripped when proxying the request to the backend host
+        default: True
+        choices:
+          - True
+          - False
+    backend_user_prefix:
+        description:
+          - Prefix string to prepend to the username for backend authentication
+        default: ""
+    backend_user_suffix:
+        description:
+          - Suffix string to append to the username for backend authentication
+        default: ""
+    comment:
+        description:
+          - Optional comment string
+        default: ""
+    frontend_cookie:
+        description:
+          - Frontend cookie name
+    frontend_cookie_secret:
+        description:
+          - Frontend cookie secret
+    frontend_form:
+        description:
+          - Frontend authentication form name
+    frontend_form_template:
+        description:
+          - Frontend authentication form template
+        default: ""
+    frontend_login:
+        description:
+          - Frontend login name
+    frontend_logout:
+        description:
+          - Frontend logout name
+    frontend_mode:
+        description:
+          - Frontend authentication mode (Form|Basic)
+        default: Basic
+        choices:
+          - Basic
+          - Form
+    frontend_realm:
+        description:
+          - Frontend authentication realm
+    frontend_session_allow_persistency:
+        description:
+          - Allow session persistency
+        default: False
+        choices:
+          - True
+          - False
+    frontend_session_lifetime:
+        description:
+          - session lifetime
+        required: true
+    frontend_session_lifetime_limited:
+        description:
+          - Specifies if limitation of session lifetime is active 
+        default: True
+        choices:
+          - True
+          - False
+    frontend_session_lifetime_scope:
+        description:
+          - scope for frontend_session_lifetime (days|hours|minutes)
+        default: hours
+        choices:
+          - days
+          - hours
+          - minutes
+    frontend_session_timeout:
+        description:
+          - session timeout
+        required: true
+    frontend_session_timeout_enabled:
+        description:
+          - Specifies if session timeout is active
+        default: True
+        choices:
+          - True
+          - False
+    frontend_session_timeout_scope:
+        description:
+          - scope for frontend_session_timeout (days|hours|minutes)
+        default: minutes
+        choices:
+          - days
+          - hours
+          - minutes
+    logout_delegation_urls:
+        description:
+          - List of logout URLs that logouts are delegated to
+        default: []
+    logout_mode:
+        description:
+          - Mode of logout (None|Delegation)
+        default: None
+        choices:
+          - None
+          - Delegation
+    redirect_to_requested_url:
+        description:
+          - Should a redirect to the requested URL be made
+        default: False
+        choices:
+          - True
+          - False
+
+extends_documentation_fragment:
+    - utm
+"""
+
+EXAMPLES = """
+- name: Create UTM proxy_auth_profile
+  utm_proxy_auth_profile:
+    utm_host: sophos.host.name
+    utm_token: abcdefghijklmno1234
+    name: TestAuthProfileEntry
+    aaa: [REF_OBJECT_STRING,REF_ANOTHEROBJECT_STRING]
+    basic_prompt: "Authentication required: Please login"
+    frontend_session_lifetime: 1
+    frontend_session_timeout: 1
+    state: present
+
+- name: Remove UTM proxy_auth_profile
+  utm_proxy_auth_profile:
+    utm_host: sophos.host.name
+    utm_token: abcdefghijklmno1234
+    name: TestAuthProfileEntry
+    state: absent
+
+- name: Read UTM proxy_auth_profile
+  utm_proxy_auth_profile:
+    utm_host: sophos.host.name
+    utm_token: abcdefghijklmno1234
+    name: TestAuthProfileEntry
+    state: info
+
+"""
+
+RETURN = """
+result:
+    description: The utm object that was created
+    returned: success
+    type: complex
+    contains:
+        _ref:
+            description: The reference name of the object
+            type: string
+        _locked:
+            description: Whether or not the object is currently locked
+            type: boolean
+        _type:
+            description: The type of the object
+            type: string
+        name:
+            description: The name of the object
+            type: string
+        aaa:
+            description: List of references to utm_aaa objects (allowed users or groups)
+            type: list
+        basic_prompt:
+            description: The message in the basic authentication prompt
+            type: string
+        backend_mode:
+            description: Specifies if the backend server needs authentication ([Basic|None])
+            type: string
+        backend_strip_basic_auth:
+            description: Should the login data be stripped when proxying the request to the backend host
+            type: boolean
+        backend_user_prefix:
+            description: Prefix string to prepend to the username for backend authentication
+            type: string
+        backend_user_suffix:
+            description: Suffix string to append to the username for backend authentication
+            type: string
+        comment:
+            description: Optional comment string
+            type: string
+        frontend_cookie:
+            description: Frontend cookie name
+            type: string
+        frontend_cookie_secret:
+            description: Frontend cookie secret
+            type: string
+        frontend_form:
+            description: Frontend authentication form name
+            type: string
+        frontend_form_template:
+            description: Frontend authentication form template
+            type: string
+        frontend_login:
+            description: Frontend login name
+            type: string
+        frontend_logout:
+            description: Frontend logout name
+            type: string
+        frontend_mode:
+            description: Frontend authentication mode (Form|Basic)
+            type: string
+        frontend_realm:
+            description: Frontend authentication realm
+            type: string
+        frontend_session_allow_persistency:
+            description: Allow session persistency
+            type: boolean
+        frontend_session_lifetime:
+            description: session lifetime
+            type: integer
+        frontend_session_lifetime_limited:
+            description: Specifies if limitation of session lifetime is active 
+            type: boolean
+        frontend_session_lifetime_scope:
+            description: scope for frontend_session_lifetime (days|hours|minutes)
+            type: string
+        frontend_session_timeout:
+            description: session timeout
+            type: integer
+        frontend_session_timeout_enabled:
+            description: Specifies if session timeout is active
+            type: boolean
+        frontend_session_timeout_scope:
+            description: scope for frontend_session_timeout (days|hours|minutes)
+            type: string
+        logout_delegation_urls:
+            description: List of logout URLs that logouts are delegated to
+            type: list
+        logout_mode:
+            description: Mode of logout (None|Delegation)
+            type: string
+        redirect_to_requested_url:
+            description: Should a redirect to the requested URL be made
+            type: boolean
+              
+"""
+
+from ansible.module_utils.utm_utils import UTM, UTMModule
+from ansible.module_utils._text import to_native
+
+
+def main():
+    endpoint = "reverse_proxy/auth_profile"
+    key_to_check_for_changes = ["aaa", "basic_prompt", "backend_mode", "backend_strip_basic_auth",
+                                "backend_user_prefix", "backend_user_suffix", "comment", "frontend_cookie",
+                                "frontend_cookie_secret", "frontend_form", "frontend_form_template",
+                                "frontend_login", "frontend_logout", "frontend_mode", "frontend_realm",
+                                "frontend_session_allow_persistency", "frontend_session_lifetime",
+                                "frontend_session_lifetime_limited", "frontend_session_lifetime_scope",
+                                "frontend_session_timeout", "frontend_session_timeout_enabled",
+                                "frontend_session_timeout_scope", "logout_delegation_urls", "logout_mode",
+                                "redirect_to_requested_url"]
+
+    module = UTMModule(
+        argument_spec=dict(
+            name=dict(type='str', required=True),
+            aaa=dict(type='list', elements='str', required=True),
+            basic_prompt=dict(type='str', required=True),
+            backend_mode=dict(type='str', required=False, default="None", choices=['Basic', 'None']),
+            backend_strip_basic_auth=dict(type='bool', required=False, default=True),
+            backend_user_prefix=dict(type='str', required=False, default=""),
+            backend_user_suffix=dict(type='str', required=False, default=""),
+            comment=dict(type='str', required=False, default=""),
+            frontend_cookie=dict(type='str', required=False),
+            frontend_cookie_secret=dict(type='str', required=False),
+            frontend_form=dict(type='str', required=False),
+            frontend_form_template=dict(type='str', required=False, default=""),
+            frontend_login=dict(type='str', required=False),
+            frontend_logout=dict(type='str', required=False),
+            frontend_mode=dict(type='str', required=False, default="Basic", choices=['Basic', 'Form']),
+            frontend_realm=dict(type='str', required=False),
+            frontend_session_allow_persistency=dict(type='bool', required=False, default=False),
+            frontend_session_lifetime=dict(type='int', required=True),
+            frontend_session_lifetime_limited=dict(type='bool', required=False, default=True),
+            frontend_session_lifetime_scope=dict(type='str', required=False, default="hours", choices=['days', 'hours', 'minutes']),
+            frontend_session_timeout=dict(type='int', required=True),
+            frontend_session_timeout_enabled=dict(type='bool', required=False, default=True),
+            frontend_session_timeout_scope=dict(type='str', required=False, default="minutes", choices=['days', 'hours', 'minutes']),
+            logout_delegation_urls=dict(type='list', elements='str', required=False, default=[]),
+            logout_mode=dict(type='str', required=False, default="None", choices=['None', 'Delegation']),
+            redirect_to_requested_url=dict(type='bool', required=False, default=False)
+        )
+    )
+    try:
+        UTM(module, endpoint, key_to_check_for_changes).execute()
+    except Exception as e:
+        module.fail_json(msg=to_native(e))
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/web_infrastructure/sophos_utm/utm_proxy_auth_profile.py
+++ b/lib/ansible/modules/web_infrastructure/sophos_utm/utm_proxy_auth_profile.py
@@ -17,7 +17,7 @@ DOCUMENTATION = """
 ---
 module: utm_proxy_auth_profile
 
-author: 
+author:
     - Stephan Schwarz (@stearz)
 
 short_description: create, update or destroy reverse_proxy auth_profile entry in Sophos UTM
@@ -26,7 +26,7 @@ description:
     - Create, update or destroy a reverse_proxy auth_profile entry in SOPHOS UTM.
     - This module needs to have the REST Ability of the UTM to be activated.
 
-version_added: "2.7" 
+version_added: "2.8"
 
 options:
     name:
@@ -51,6 +51,7 @@ options:
     backend_strip_basic_auth:
         description:
           - Should the login data be stripped when proxying the request to the backend host
+        type: bool
         default: True
         choices:
           - True
@@ -99,6 +100,7 @@ options:
     frontend_session_allow_persistency:
         description:
           - Allow session persistency
+        type: bool
         default: False
         choices:
           - True
@@ -109,7 +111,8 @@ options:
         required: true
     frontend_session_lifetime_limited:
         description:
-          - Specifies if limitation of session lifetime is active 
+          - Specifies if limitation of session lifetime is active
+        type: bool
         default: True
         choices:
           - True
@@ -129,6 +132,7 @@ options:
     frontend_session_timeout_enabled:
         description:
           - Specifies if session timeout is active
+        type: bool
         default: True
         choices:
           - True
@@ -155,6 +159,7 @@ options:
     redirect_to_requested_url:
         description:
           - Should a redirect to the requested URL be made
+        type: bool
         default: False
         choices:
           - True
@@ -262,7 +267,7 @@ result:
             description: session lifetime
             type: integer
         frontend_session_lifetime_limited:
-            description: Specifies if limitation of session lifetime is active 
+            description: Specifies if limitation of session lifetime is active
             type: boolean
         frontend_session_lifetime_scope:
             description: scope for frontend_session_lifetime (days|hours|minutes)
@@ -285,7 +290,6 @@ result:
         redirect_to_requested_url:
             description: Should a redirect to the requested URL be made
             type: boolean
-              
 """
 
 from ansible.module_utils.utm_utils import UTM, UTMModule
@@ -310,7 +314,7 @@ def main():
             aaa=dict(type='list', elements='str', required=True),
             basic_prompt=dict(type='str', required=True),
             backend_mode=dict(type='str', required=False, default="None", choices=['Basic', 'None']),
-            backend_strip_basic_auth=dict(type='bool', required=False, default=True),
+            backend_strip_basic_auth=dict(type='bool', required=False, default=True, choices=[True, False]),
             backend_user_prefix=dict(type='str', required=False, default=""),
             backend_user_suffix=dict(type='str', required=False, default=""),
             comment=dict(type='str', required=False, default=""),
@@ -322,22 +326,23 @@ def main():
             frontend_logout=dict(type='str', required=False),
             frontend_mode=dict(type='str', required=False, default="Basic", choices=['Basic', 'Form']),
             frontend_realm=dict(type='str', required=False),
-            frontend_session_allow_persistency=dict(type='bool', required=False, default=False),
+            frontend_session_allow_persistency=dict(type='bool', required=False, default=False, choices=[True, False]),
             frontend_session_lifetime=dict(type='int', required=True),
-            frontend_session_lifetime_limited=dict(type='bool', required=False, default=True),
+            frontend_session_lifetime_limited=dict(type='bool', required=False, default=True, choices=[True, False]),
             frontend_session_lifetime_scope=dict(type='str', required=False, default="hours", choices=['days', 'hours', 'minutes']),
             frontend_session_timeout=dict(type='int', required=True),
-            frontend_session_timeout_enabled=dict(type='bool', required=False, default=True),
+            frontend_session_timeout_enabled=dict(type='bool', required=False, default=True, choices=[True, False]),
             frontend_session_timeout_scope=dict(type='str', required=False, default="minutes", choices=['days', 'hours', 'minutes']),
             logout_delegation_urls=dict(type='list', elements='str', required=False, default=[]),
             logout_mode=dict(type='str', required=False, default="None", choices=['None', 'Delegation']),
-            redirect_to_requested_url=dict(type='bool', required=False, default=False)
+            redirect_to_requested_url=dict(type='bool', required=False, default=False, choices=[True, False])
         )
     )
     try:
         UTM(module, endpoint, key_to_check_for_changes).execute()
     except Exception as e:
         module.fail_json(msg=to_native(e))
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY
This PR will add a new utm module which allows the management of reverse proxy auth profile entries of the Sophos UTM. This module integrates with the existing utm_utils .

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
- module/web_infrastructure/sophos_utm/utm_proxy_auth_profile.py