### PR TITLE
Added Ansible UTM Module for managing reverse proxy form template entries

### DIFF
--- a/lib/ansible/modules/web_infrastructure/sophos_utm/utm_proxy_form_template.py
+++ b/lib/ansible/modules/web_infrastructure/sophos_utm/utm_proxy_form_template.py
@@ -1,0 +1,133 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Johannes Brunswicker <johannes.brunswicker@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = """
+---
+module: utm_proxy_form_template
+
+author: 
+    - Johannes Brunswicker (@MatrixCrawler)
+
+short_description: create, update or destroy reverse_proxy form_template entry in Sophos UTM
+
+description:
+    - Create, update or destroy a reverse_proxy location entry in SOPHOS UTM.
+    - This module needs to have the REST Ability of the UTM to be activated.
+
+version_added: "2.7" 
+
+options:
+    name:
+        description:
+          - The name of the object. Will be used to identify the entry
+        required: true
+    assets:
+        description:
+          - A list of hashes of assets. In the form "filename":"fileContentAsBase64" 
+        default: []
+        type: list
+    comment:
+        description:
+          - The optional comment string
+    filename:
+        description:
+          - A name for the file
+        type: string
+    template: 
+        description:
+          - The html template as base64 string that will be the content of C(filename)
+        type: string
+
+extends_documentation_fragment:
+    - utm
+"""
+
+EXAMPLES = """
+- name: Create UTM proxy_form_template
+  utm_proxy_form_template:
+    utm_host: sophos.host.name
+    utm_token: abcdefghijklmno1234
+    name: TestFormTemplateEntry
+    assets:
+      - "style.css":"abcdef12345691=="
+      - "logo.png":"1234567890abcdef=="
+    filename: "login.html"
+    template: "123456790=="
+    state: present
+
+- name: Remove UTM proxy_form_template
+  utm_proxy_form_template:
+    utm_host: sophos.host.name
+    utm_token: abcdefghijklmno1234
+    name: TestFormTemplateEntry
+    state: absent
+"""
+
+RETURN = """
+result:
+    description: The utm object that was created
+    returned: success
+    type: complex
+    contains:
+        _ref:
+            description: The reference name of the object
+            type: string
+        _locked:
+            description: Whether or not the object is currently locked
+            type: boolean
+        _type:
+            description: The type of the object
+            type: string
+        name:
+            description: The name of the object
+            type: string
+        assets:
+            description: A list of asset hashes
+            type: list
+        comment:
+            description: The comment string
+            type: string
+        filename:
+            description: The name of the template file
+            type: string
+        template:
+            description: The content of the template file in base64
+            type: string
+"""
+
+from ansible.module_utils.utm_utils import UTM, UTMModule
+from ansible.module_utils._text import to_native
+
+
+def main():
+    endpoint = "reverse_proxy/form_template"
+    key_to_check_for_changes = ["assets", "comment", "filename", "template"]
+    module = UTMModule(
+        argument_spec=dict(
+            name=dict(type='str', required=True),
+            assets=dict(type='list', elements='str', required=False),
+            comment=dict(type='str', required=False, default=""),
+            filename=dict(type='str', required=False),
+            template=dict(type='str', required=False)
+        )
+    )
+    try:
+        UTM(module, endpoint, key_to_check_for_changes).execute()
+    except Exception as e:
+        module.fail_json(msg=to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/web_infrastructure/sophos_utm/utm_proxy_form_template.py
+++ b/lib/ansible/modules/web_infrastructure/sophos_utm/utm_proxy_form_template.py
@@ -17,7 +17,7 @@ DOCUMENTATION = """
 ---
 module: utm_proxy_form_template
 
-author: 
+author:
     - Johannes Brunswicker (@MatrixCrawler)
 
 short_description: create, update or destroy reverse_proxy form_template entry in Sophos UTM
@@ -26,7 +26,7 @@ description:
     - Create, update or destroy a reverse_proxy location entry in SOPHOS UTM.
     - This module needs to have the REST Ability of the UTM to be activated.
 
-version_added: "2.7" 
+version_added: "2.8"
 
 options:
     name:
@@ -35,7 +35,7 @@ options:
         required: true
     assets:
         description:
-          - A list of hashes of assets. In the form "filename":"fileContentAsBase64" 
+          - A list of hashes of assets. In the form "filename":"fileContentAsBase64"
         default: []
         type: list
     comment:
@@ -44,11 +44,11 @@ options:
     filename:
         description:
           - A name for the file
-        type: string
-    template: 
+        type: str
+    template:
         description:
           - The html template as base64 string that will be the content of C(filename)
-        type: string
+        type: str
 
 extends_documentation_fragment:
     - utm
@@ -61,8 +61,10 @@ EXAMPLES = """
     utm_token: abcdefghijklmno1234
     name: TestFormTemplateEntry
     assets:
-      - "style.css":"abcdef12345691=="
-      - "logo.png":"1234567890abcdef=="
+      "style.css":
+        "abcdef12345691=="
+      "logo.png":
+        "1234567890abcdef=="
     filename: "login.html"
     template: "123456790=="
     state: present

--- a/lib/ansible/modules/web_infrastructure/sophos_utm/utm_proxy_form_template_info.py
+++ b/lib/ansible/modules/web_infrastructure/sophos_utm/utm_proxy_form_template_info.py
@@ -15,24 +15,40 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = """
 ---
-module: utm_proxy_form_template
+module: utm_proxy_form_template_info
 
-author: 
+author:
     - Johannes Brunswicker (@MatrixCrawler)
 
 short_description: query info for reverse_proxy form_template entry in Sophos UTM
 
 description:
-    - Gathers info for reverse_proxy form_template entry in SOPHOS UTM.
+    - Gathers info for reverse_proxy form_template entry in Sophos UTM.
     - This module needs to have the REST Ability of the UTM to be activated.
 
-version_added: "2.7" 
+version_added: "2.8"
 
 options:
     name:
         description:
           - The name of the object. Will be used to identify the entry
         required: true
+    assets:
+        description:
+          - A list of hashes of assets. In the form "filename":"fileContentAsBase64"
+        default: []
+        type: list
+    comment:
+        description:
+          - The optional comment string
+    filename:
+        description:
+          - A name for the file
+        type: str
+    template:
+        description:
+          - The html template as base64 string that will be the content of C(filename)
+        type: str
 
 extends_documentation_fragment:
     - utm

--- a/lib/ansible/modules/web_infrastructure/sophos_utm/utm_proxy_form_template_info.py
+++ b/lib/ansible/modules/web_infrastructure/sophos_utm/utm_proxy_form_template_info.py
@@ -1,0 +1,103 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Johannes Brunswicker <johannes.brunswicker@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = """
+---
+module: utm_proxy_form_template
+
+author: 
+    - Johannes Brunswicker (@MatrixCrawler)
+
+short_description: query info for reverse_proxy form_template entry in Sophos UTM
+
+description:
+    - Gathers info for reverse_proxy form_template entry in SOPHOS UTM.
+    - This module needs to have the REST Ability of the UTM to be activated.
+
+version_added: "2.7" 
+
+options:
+    name:
+        description:
+          - The name of the object. Will be used to identify the entry
+        required: true
+
+extends_documentation_fragment:
+    - utm
+"""
+
+EXAMPLES = """
+- name: Create UTM proxy_form_template
+  utm_proxy_form_template_info:
+    utm_host: sophos.host.name
+    utm_token: abcdefghijklmno1234
+    name: TestFormTemplateEntry
+"""
+
+RETURN = """
+result:
+    description: The utm object that was created
+    returned: success
+    type: complex
+    contains:
+        _ref:
+            description: The reference name of the object
+            type: string
+        _locked:
+            description: Whether or not the object is currently locked
+            type: boolean
+        _type:
+            description: The type of the object
+            type: string
+        name:
+            description: The name of the object
+            type: string
+        assets:
+            description: A list of asset hashes
+            type: list
+        comment:
+            description: The comment string
+            type: string
+        filename:
+            description: The name of the template file
+            type: string
+        template:
+            description: The content of the template file in base64
+            type: string
+"""
+
+from ansible.module_utils.utm_utils import UTM, UTMModule
+from ansible.module_utils._text import to_native
+
+
+def main():
+    endpoint = "reverse_proxy/form_template"
+    module = UTMModule(
+        argument_spec=dict(
+            name=dict(type='str', required=True),
+            assets=dict(type='list', elements='str', required=False),
+            comment=dict(type='str', required=False, default=""),
+            filename=dict(type='str', required=False),
+            template=dict(type='str', required=False)
+        )
+    )
+    try:
+        UTM(module, endpoint, info_only=True).execute()
+    except Exception as e:
+        module.fail_json(msg=to_native(e))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
This PR will add a new utm module which allows the management of reverse proxy form template entries of the Sophos UTM. This module integrates with the existing utm_utils .

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
- module/web_infrastructure/sophos_utm/utm_proxy_form_template.py
- module/web_infrastructure/sophos_utm/utm_proxy_form_template_info.py