### PR TITLE
WIP try to find out where Shippable perf issues are for Windows tests

### DIFF
--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -296,16 +296,13 @@ if ($gather_subset.Contains("local") -and $factpath -ne $null) {
 if($gather_subset.Contains('memory')) {
     $win32_cs = Get-LazyCimInstance Win32_ComputerSystem
     $win32_os = Get-LazyCimInstance Win32_OperatingSystem
-    $win32_pf = Get-LazyCimInstance Win32_PageFileSetting
     $ansible_facts += @{
         # Win32_PhysicalMemory is empty on some virtual platforms
-        ansible_memtotal_mb = ([math]::ceiling($win32_cs.TotalPhysicalMemory / 1024 / 1024))
-        ansible_swaptotal_mb = ([math]::round($win32_os.TotalSwapSpaceSize / 1024))
-        ansible_memtotal = $win32_cs.TotalPhysicalMemory
-        ansible_swap_min = $win32_pf.InitialSize * 1024 * 1024
-        ansible_swap_max = $win32_pf.MaximumSize * 1024 * 1024
+        ansible_memtotal_mb = ([math]::round($win32_cs.TotalPhysicalMemory / 1024 / 1024))
+        ansible_swaptotal_mb = ([math]::round($win32_os.TotalSwapSpaceSize / 1024 / 1024))
     }
 }
+
 
 if($gather_subset.Contains('platform')) {
     $win32_cs = Get-LazyCimInstance Win32_ComputerSystem


### PR DESCRIPTION
##### SUMMARY
Windows tests are running slow in Shippable 2008 - 2012 R2. This is reverting the last 24 commits to see if it's something we have changed or something wrong with Shippable.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
windows