### PR TITLE
[stable-2.7] replace math round with ceiling for ansible_memtotal_mb + add new variables to display swapfile config

### DIFF
--- a/changelogs/fragments/windows-memtotal-facts.yml
+++ b/changelogs/fragments/windows-memtotal-facts.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - setup - fix the rounding of the ansible_memtotal_mb value on VMWare vm's (https://github.com/ansible/ansible/issues/49608)
+minor_changes:
+  - setup - add new facts to display the initial and maximum pagefile size

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -296,13 +296,16 @@ if ($gather_subset.Contains("local") -and $factpath -ne $null) {
 if($gather_subset.Contains('memory')) {
     $win32_cs = Get-LazyCimInstance Win32_ComputerSystem
     $win32_os = Get-LazyCimInstance Win32_OperatingSystem
+    $win32_pf = Get-LazyCimInstance Win32_PageFileSetting
     $ansible_facts += @{
         # Win32_PhysicalMemory is empty on some virtual platforms
-        ansible_memtotal_mb = ([math]::round($win32_cs.TotalPhysicalMemory / 1024 / 1024))
-        ansible_swaptotal_mb = ([math]::round($win32_os.TotalSwapSpaceSize / 1024 / 1024))
+        ansible_memtotal_mb = ([math]::ceiling($win32_cs.TotalPhysicalMemory / 1024 / 1024))
+        ansible_swaptotal_mb = ([math]::round($win32_os.TotalSwapSpaceSize / 1024))
+        ansible_memtotal = $win32_cs.TotalPhysicalMemory
+        ansible_swap_min = $win32_pf.InitialSize * 1024 * 1024
+        ansible_swap_max = $win32_pf.MaximumSize * 1024 * 1024
     }
 }
-
 
 if($gather_subset.Contains('platform')) {
     $win32_cs = Get-LazyCimInstance Win32_ComputerSystem


### PR DESCRIPTION
##### SUMMARY
[stable-2.7] replace math round with ceiling for ansible_memtotal_mb + add new variables to display swapfile config
Cherry picked from commit b3ac5b637a4ff6259c82b659517ab04f5c0b2f11
Original PR https://github.com/ansible/ansible/pull/49611
Issue https://github.com/ansible/ansible/issues/49608

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
/lib/ansible/modules/windows/setup.ps1
