### PR TITLE
Added organization in the scm_credential get

### DIFF
--- a/changelogs/fragments/49884-tower-project-scm-cred-org-fallback.yaml
+++ b/changelogs/fragments/49884-tower-project-scm-cred-org-fallback.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "tower_project - getting project credential falls back to project organization if there's more than one cred with the same name"

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
@@ -149,7 +149,7 @@ def main():
                         try:
                             cred = cred_res.get(name=scm_credential)
                         except (tower_cli.exceptions.MultipleResults) as multi_res_excinfo:
-                            module.warn('Multiple credentials found for {}, falling back looking in project organization'.format(scm_credential))
+                            module.warn('Multiple credentials found for {0}, falling back looking in project organization'.format(scm_credential))
                             cred = cred_res.get(name=scm_credential, organization=org['id'])
                         scm_credential = cred['id']
                     except (exc.NotFound) as excinfo:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
@@ -146,7 +146,11 @@ def main():
                 if scm_credential:
                     try:
                         cred_res = tower_cli.get_resource('credential')
-                        cred = cred_res.get(name=scm_credential, organization=org['id'])
+                        try:
+                            cred = cred_res.get(name=scm_credential)
+                        except (tower_cli.exceptions.MultipleResults) as multi_res_excinfo:
+                            module.warn('Multiple credentials found for {}, falling back looking in project organization'.format(scm_credential))
+                            cred = cred_res.get(name=scm_credential, organization=org['id'])
                         scm_credential = cred['id']
                     except (exc.NotFound) as excinfo:
                         module.fail_json(msg='Failed to update project, credential not found: {0}'.format(scm_credential), changed=False)

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
@@ -146,7 +146,7 @@ def main():
                 if scm_credential:
                     try:
                         cred_res = tower_cli.get_resource('credential')
-                        cred = cred_res.get(name=scm_credential)
+                        cred = cred_res.get(name=scm_credential, organization=org['id'])
                         scm_credential = cred['id']
                     except (exc.NotFound) as excinfo:
                         module.fail_json(msg='Failed to update project, credential not found: {0}'.format(scm_credential), changed=False)

--- a/test/integration/targets/tower_project/tasks/main.yml
+++ b/test/integration/targets/tower_project/tasks/main.yml
@@ -47,3 +47,32 @@
     organization: Default
     scm_type: git
     scm_url: https://github.com/ansible/ansible
+
+- name: "Create {{ item }}"
+  tower_organization:
+    name: "{{ item }}"
+  loop:
+    - TestOrg1
+    - TestOrg2
+
+- name: "Create credential"
+  tower_credential:
+    kind: scm
+    name: TestCred1
+    organization: "{{ item }}"
+  loop:
+    - TestOrg2
+    - TestOrg1
+
+- name: Create project TestProject
+  tower_project:
+    name: TestProject
+    organization: TestOrg1
+    scm_type: git
+    scm_url: "https://github.com/ansible/ansible"
+    scm_credential: TestCred1
+  register: multi_org_cred_project
+
+- assert:
+    that:
+      - "multi_org_cred_project is changed"


### PR DESCRIPTION
##### SUMMARY
Added organization parameter to the `cred_res.get()` call to avoid having issues when a credential with the same name is defined in more than one Tower Organization. 
See #49883 for example.
This should also, ofc fix #49883

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tower_project

##### ADDITIONAL INFORMATION
See #49883
```paste below

```
