### PR TITLE
New module lxca_scalablesystem for Lenovo XClarity Administrator

### DIFF
--- a/lib/ansible/modules/remote_management/lxca/lxca_scalablesystem.py
+++ b/lib/ansible/modules/remote_management/lxca/lxca_scalablesystem.py
@@ -1,0 +1,174 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'supported_by': 'community',
+    'status': ['preview']
+}
+
+
+DOCUMENTATION = '''
+---
+version_added: "2.8"
+author:
+  - Naval Patel (@navalkp)
+  - Prashant Bhosale (@prabhosa)
+module: lxca_scalablesystem
+short_description: Custom module for lxca scalablesystem inventory utility
+description:
+  - This module returns/displays a inventory details of scalablesystem
+
+options:
+  uuid:
+    description:
+      uuid of scalable complex, this is string with length greater than 16.
+
+  command_options:
+    description:
+      options to filter scalablesystem information
+    default: scalablesystem
+    choices:
+        - scalablesystem
+
+  device_type:
+    description:
+      scalable complex device type
+    default: null
+    choices:
+      - None
+      - flex
+      - rackserver
+
+extends_documentation_fragment:
+    - lxca_common
+'''
+
+EXAMPLES = '''
+# get all scalablesystem info
+- name: get scalablesystem data from LXCA
+  lxca_scalablesystem:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+
+# get specific scalablesystem info by uuid
+- name: get scalablesystem data from LXCA
+  lxca_scalablesystem:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+    uuid: "3C737AA5E31640CE949B10C129A8B01F"
+    command_options: scalablesystem
+
+# get specific scalablesystem info by device_type
+- name: get scalablesystem data from LXCA
+  lxca_scalablesystem:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+    device_type: "flex"
+    command_options: scalablesystem
+
+# get specific scalablesystem info by device_type and uuid
+- name: get scalablesystem data from LXCA
+  lxca_scalablesystem:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+    uuid: "3C737AA5E31640CE949B10C129A8B01F"
+    device_type: "flex"
+    command_options: scalablesystem
+
+'''
+
+RETURN = r'''
+result:
+    description: scalablesystem detail from lxca
+    returned: always
+    type: dict
+    sample:
+      ComplexList:
+        - complexID: "7E7FA27D"
+          nodeCount: 2
+          partitionCount: 1
+          uuid: '118D2C88C8FD11E4947B6EAE8B4BDCDF'
+          # bunch of properties
+        - complexID: "7E7FB277"
+          nodeCount: 3
+          partitionCount: 1
+          uuid: '328D2DD8C8FD11E4947B6EAE8B4BDCFF'
+          # bunch of properties
+        # Multiple scalablesystem details
+'''
+
+import traceback
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.remote_management.lxca.common import LXCA_COMMON_ARGS, has_pylxca, connection_object
+try:
+    from pylxca import scalablesystem
+except ImportError:
+    pass
+
+SUCCESS_MSG = "Success %s result"
+
+
+def _scalablesystem(module, lxca_con):
+    return scalablesystem(lxca_con,
+                          id=module.params['uuid'],
+                          type=module.params['device_type'])
+
+
+def setup_module_object():
+    """
+    this function merge argument spec and create ansible module object
+    :return:
+    """
+    args_spec = dict(LXCA_COMMON_ARGS)
+    args_spec.update(INPUT_ARG_SPEC)
+    module = AnsibleModule(argument_spec=args_spec, supports_check_mode=False)
+
+    return module
+
+
+FUNC_DICT = {
+    'scalablesystem': _scalablesystem,
+}
+
+
+INPUT_ARG_SPEC = dict(
+    command_options=dict(default='scalablesystem', choices=list(FUNC_DICT)),
+    uuid=dict(default=None),
+    device_type=dict(default=None, choices=[None, 'flex', 'rackserver'])
+)
+
+
+def execute_module(module):
+    """
+    This function invoke commands
+    :param module: Ansible module object
+    """
+    try:
+        with connection_object(module) as lxca_con:
+            result = FUNC_DICT[module.params['command_options']](module, lxca_con)
+            module.exit_json(changed=False,
+                             msg=SUCCESS_MSG % module.params['command_options'],
+                             result=result)
+    except Exception as exception:
+        error_msg = '; '.join((e) for e in exception.args)
+        module.fail_json(msg=error_msg, exception=traceback.format_exc())
+
+
+def main():
+    module = setup_module_object()
+    has_pylxca(module)
+    execute_module(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/lxca/lxca_scalablesystem.py
+++ b/lib/ansible/modules/remote_management/lxca/lxca_scalablesystem.py
@@ -90,7 +90,7 @@ EXAMPLES = '''
 RETURN = r'''
 result:
     description: scalablesystem detail from lxca
-    returned: always
+    returned: success
     type: dict
     sample:
       ComplexList:

--- a/test/units/modules/remote_management/lxca/test_lxca_scalablesystem.py
+++ b/test/units/modules/remote_management/lxca/test_lxca_scalablesystem.py
@@ -1,0 +1,93 @@
+import json
+
+import pytest
+from units.compat import mock
+from ansible.modules.remote_management.lxca import lxca_scalablesystem
+
+
+@pytest.fixture(scope='module')
+@mock.patch("ansible.module_utils.remote_management.lxca.common.close_conn", autospec=True)
+def setup_module(close_conn):
+    close_conn.return_value = True
+
+
+class TestMyModule():
+    @pytest.mark.parametrize('patch_ansible_module',
+                             [
+                                 {},
+                                 {
+                                     "auth_url": "https://10.240.14.195",
+                                     "login_user": "USERID",
+                                 },
+                                 {
+                                     "auth_url": "https://10.240.14.195",
+                                     "login_password": "Password",
+                                 },
+                                 {
+                                     "login_user": "USERID",
+                                     "login_password": "Password",
+                                 },
+                             ],
+                             indirect=['patch_ansible_module'])
+    @pytest.mark.usefixtures('patch_ansible_module')
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_scalablesystem.execute_module", autospec=True)
+    def test_without_required_parameters(self, _setup_conn, _execute_module,
+                                         mocker, capfd, setup_module):
+        """Failure must occurs when all parameters are missing"""
+        with pytest.raises(SystemExit):
+            _setup_conn.return_value = "Fake connection"
+            _execute_module.return_value = "Fake execution"
+            lxca_scalablesystem.main()
+        out, err = capfd.readouterr()
+        results = json.loads(out)
+        assert results['failed']
+        assert 'missing required arguments' in results['msg']
+
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_scalablesystem.execute_module", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_scalablesystem.AnsibleModule", autospec=True)
+    def test__argument_spec(self, ansible_mod_cls, _execute_module, _setup_conn, setup_module):
+        expected_arguments_spec = dict(
+            login_user=dict(required=True),
+            login_password=dict(required=True, no_log=True),
+            command_options=dict(default='scalablesystem', choices=['scalablesystem']),
+            auth_url=dict(required=True),
+            uuid=dict(default=None),
+            device_type=dict(default=None, choices=[None, 'flex', 'rackserver'])
+        )
+        _setup_conn.return_value = "Fake connection"
+        _execute_module.return_value = []
+        mod_obj = ansible_mod_cls.return_value
+        args = {
+            "auth_url": "https://10.243.30.195",
+            "login_user": "USERID",
+            "login_password": "password",
+            "command_options": "scalablesystem",
+        }
+        mod_obj.params = args
+        lxca_scalablesystem.main()
+        assert(mock.call(argument_spec=expected_arguments_spec,
+                         supports_check_mode=False) == ansible_mod_cls.call_args)
+
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_scalablesystem._scalablesystem",
+                autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_scalablesystem.AnsibleModule",
+                autospec=True)
+    def test__scalablesystem_empty_list(self, ansible_mod_cls, _get_scalablesystem, _setup_conn, setup_module):
+        mod_obj = ansible_mod_cls.return_value
+        args = {
+            "auth_url": "https://10.243.30.195",
+            "login_user": "USERID",
+            "login_password": "password",
+            "uuid": "3C737AA5E31640CE949B10C129A8B01F",
+            "command_options": "scalablesystem",
+        }
+        mod_obj.params = args
+        _setup_conn.return_value = "Fake connection"
+        empty_scalablesystem_list = []
+        _get_scalablesystem.return_value = empty_scalablesystem_list
+        ret_scalablesystem = _get_scalablesystem(mod_obj, args)
+        assert mock.call(mod_obj, mod_obj.params) == _get_scalablesystem.call_args
+        assert _get_scalablesystem.return_value == ret_scalablesystem


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This module provide an interface to Lenovo XClarity Administrator. This module provides information about Scalable Complex system.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lxca_scalablesystem
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Testing ansible module lxca_scalablesystem

1. list all scalablesystem
2. list scalablesystem with uuid
3. list scalablesystem with device_type
4. list scalablesystem with uuid and device_type

(pylxca27) naval@osboxes:~/play/playbook/lxca_scalablesystem$ cat all_scalablesystem.yml 
---
- hosts: localhost
  connection: local
  tasks:
    - name: list scalablesystem
      lxca_scalablesystem:
        login_user: USERID
        login_password: CME44ibm
        auth_url: "https://10.243.9.238"
        command_options: scalablesystem
(pylxca27) naval@osboxes:~/play/playbook/lxca_scalablesystem$ ansible-playbook all_scalablesystem.yml 
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] *****************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [list scalablesystem] *******************************************************************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0   

(pylxca27) naval@osboxes:~/play/playbook/lxca_scalablesystem$ cat filter_by_uuid.yml 
---
- hosts: localhost
  connection: local
  tasks:
    - name: list scalablesystem
      lxca_scalablesystem:
        login_user: USERID
        login_password: CME44ibm
        auth_url: "https://10.243.9.238"
        uuid: "443C88946E2D11E38C1C6CAE8B702DC0"
        command_options: scalablesystem
(pylxca27) naval@osboxes:~/play/playbook/lxca_scalablesystem$ ansible-playbook filter_by_uuid.yml 
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] *****************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [list scalablesystem] *******************************************************************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0 

(pylxca27) naval@osboxes:~/play/playbook/lxca_scalablesystem$ cat filter_by_devicetype.yml 
---
- hosts: localhost
  connection: local
  tasks:
    - name: list scalablesystem
      lxca_scalablesystem:
        login_user: USERID
        login_password: CME44ibm
        auth_url: "https://10.243.9.238"
        device_type: "flex"
        command_options: scalablesystem
(pylxca27) naval@osboxes:~/play/playbook/lxca_scalablesystem$ ansible-playbook filter_by_devicetype.yml 
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] *****************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [list scalablesystem] *******************************************************************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0   

(pylxca27) naval@osboxes:~/play/playbook/lxca_scalablesystem$ cat filter_by_uuid_and_devicetype.yml 
---
- hosts: localhost
  connection: local
  tasks:
    - name: list scalablesystem
      lxca_scalablesystem:
        login_user: USERID
        login_password: CME44ibm
        auth_url: "https://10.243.9.238"
        uuid: "443C88946E2D11E38C1C6CAE8B702DC0"
        device_type: "flex"
        command_options: scalablesystem
(pylxca27) naval@osboxes:~/play/playbook/lxca_scalablesystem$ ansible-playbook filter_by_uuid_and_devicetype.yml 
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] *****************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [list scalablesystem] *******************************************************************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0
```
