### PR TITLE
Small documentation update: Clarify daemon-reload always executing.

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -44,13 +44,14 @@ options:
         type: bool
     daemon_reload:
         description:
-            - run daemon-reload before doing any other operations, to make sure systemd has read any changes. Reloading will also occur if the module does not start or stop anything.
+            - Run daemon-reload before doing any other operations, to make sure systemd has read any changes.
+            - When set to C(yes), runs daemon-reload even if the module does not start or stop anything.
         type: bool
         default: 'no'
         aliases: [ daemon-reload ]
     daemon_reexec:
         description:
-            - run daemon_reexec command before doing any other operations, the systemd manager will serialize the manager state.
+            - Run daemon_reexec command before doing any other operations, the systemd manager will serialize the manager state.
         type: bool
         default: 'no'
         aliases: [ daemon-reexec ]

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -44,7 +44,7 @@ options:
         type: bool
     daemon_reload:
         description:
-            - run daemon-reload before doing any other operations, to make sure systemd has read any changes.
+            - run daemon-reload before doing any other operations, to make sure systemd has read any changes. Reloading will also occur if the module does not start or stop anything.
         type: bool
         default: 'no'
         aliases: [ daemon-reload ]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I could not find in the documentation whether or not daemon-reload is executed when 'state: stopped' is requested from a service that is already stopped. I looked it up in the code and updated the docs.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
systemd