### PR TITLE
VMware: Update example vmware_deploy_ovf

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
@@ -119,7 +119,7 @@ EXAMPLES = r'''
 
 # Deploys a new VM named 'NewVM' in specific datacenter/cluster, with network mapping taken from variable and using ova template from an absolute path
 - vmware_deploy_ovf:
-    hostname: 192.168.100.100
+    hostname: '{{ vcenter_hostname }}'
     username: vCenteruser
     password: vCenterpassword
     datacenter: Datacenter1

--- a/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
@@ -116,6 +116,21 @@ EXAMPLES = r'''
     ovf: /path/to/ubuntu-16.04-amd64.ovf
     wait_for_ip_address: true
   delegate_to: localhost
+
+# Deploys a new VM named 'NewVM' in specific datacenter/cluster, with network mapping taken from variable and using ova template from an absolute path
+- vmware_deploy_ovf:
+    hostname: 192.168.100.100
+    username: vCenteruser
+    password: vCenterpassword
+    datacenter: Datacenter1
+    cluster: Cluster1
+    datastore: vsandatastore
+    name: NewVM
+    networks: "{u'VM Network':u'{{ ProvisioningNetworkLabel }}'}"
+    validate_certs: no
+    power_on: no
+    ovf: /absolute/path/to/template/mytemplate.ova
+  delegate_to: localhost
 '''
 
 

--- a/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
@@ -121,7 +121,7 @@ EXAMPLES = r'''
 - vmware_deploy_ovf:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
-    password: vCenterpassword
+    password: '{{ vcenter_password }}'
     datacenter: Datacenter1
     cluster: Cluster1
     datastore: vsandatastore

--- a/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
@@ -120,7 +120,7 @@ EXAMPLES = r'''
 # Deploys a new VM named 'NewVM' in specific datacenter/cluster, with network mapping taken from variable and using ova template from an absolute path
 - vmware_deploy_ovf:
     hostname: '{{ vcenter_hostname }}'
-    username: vCenteruser
+    username: '{{ vcenter_username }}'
     password: vCenterpassword
     datacenter: Datacenter1
     cluster: Cluster1


### PR DESCRIPTION
Provided more detailed example using additional, often used parameters

+label: docsite_pr

##### SUMMARY
Provided more complex example of using the actual module, since I struggled a bit when I used it myself for the first time. I think the example may be useful for other folks since the networks parameter is tricky and also the ovf needs an absolute path to work, it wasn't clearly stated in the documentation.

##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME
vmware_deploy_ovf
##### ADDITIONAL INFORMATION
None, just documentation update
