### PR TITLE
Fix reverse_inventory order to work on python3

### DIFF
--- a/changelogs/fragments/playbook-order-py3.yaml
+++ b/changelogs/fragments/playbook-order-py3.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- host execution order - Fix ``reverse_inventory`` to work on python3

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -24,6 +24,9 @@ import os
 import re
 import itertools
 
+from operator import attrgetter
+from random import shuffle
+
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.inventory.data import InventoryData
@@ -367,14 +370,12 @@ class InventoryManager(object):
 
             # sort hosts list if needed (should only happen when called from strategy)
             if order in ['sorted', 'reverse_sorted']:
-                from operator import attrgetter
                 hosts = sorted(self._hosts_patterns_cache[pattern_hash][:], key=attrgetter('name'), reverse=(order == 'reverse_sorted'))
             elif order == 'reverse_inventory':
-                hosts = sorted(self._hosts_patterns_cache[pattern_hash][:], reverse=True)
+                hosts = self._hosts_patterns_cache[pattern_hash][::-1]
             else:
                 hosts = self._hosts_patterns_cache[pattern_hash][:]
                 if order == 'shuffle':
-                    from random import shuffle
                     shuffle(hosts)
                 elif order not in [None, 'inventory']:
                     raise AnsibleOptionsError("Invalid 'order' specified for inventory hosts: %s" % order)


### PR DESCRIPTION
##### SUMMARY
This PR addresses the following exception on Python3:

```
  File "/Users/matt/projects/ansibledev/ansible/lib/ansible/inventory/manager.py", line 374, in get_hosts
    hosts = sorted(self._hosts_patterns_cache[pattern_hash][:], reverse=True)
TypeError: '<' not supported between instances of 'Host' and 'Host'
```

Additionally, this PR moves some conditional imports the the top level.  There is no technical reason to make them conditional.  This import change can actually result in improved performance if calling `get_hosts` multiple times.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/inventory/manager.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```