### PR TITLE
update openshift inventory plugin docs

### DIFF
--- a/lib/ansible/plugins/inventory/openshift.py
+++ b/lib/ansible/plugins/inventory/openshift.py
@@ -91,14 +91,14 @@ EXAMPLES = '''
 # Authenticate with token, and return all pods and services for all namespaces
 plugin: openshift
 connections:
-    host: https://192.168.64.4:8443
-    token: xxxxxxxxxxxxxxxx
-    ssl_verify: false
+  - host: https://192.168.64.4:8443
+    api_key: xxxxxxxxxxxxxxxx
+    verify_ssl: false
 
 # Use default config (~/.kube/config) file and active context, and return objects for a specific namespace
 plugin: openshift
 connections:
-    namespaces:
+  - namespaces:
     - testing
 
 # Use a custom config file, and a specific context.


### PR DESCRIPTION
##### SUMMARY
The old docs were not quite correct, this aims to fix that.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/openshift.py 

##### ADDITIONAL INFORMATION
The problem with these examples is that they conflict with the arg spec itself, from:

```
ansible-doc -t inventory openshift
```

I have been able to test _some_ of these variations, specifically providing host and/or namespace while having been logged into oc separately.
