### PR TITLE
set ansible_os_family from name variable in os-release for clearlinux…

### DIFF
--- a/changelogs/fragments/os-family_distro_variable_clearlinux.yaml
+++ b/changelogs/fragments/os-family_distro_variable_clearlinux.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- set ansible_os_family from name variable in os-release

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -386,6 +386,9 @@ class DistributionFiles:
         release = re.search('ID=(.*)', data)
         if release:
             clear_facts['distribution_release'] = release.groups()[0]
+        pname = re.search('NAME="(.*)"', data)
+        if pname:
+            clear_facts['distribution'] = pname.groups()[0]
         return True, clear_facts
 
 
@@ -450,7 +453,8 @@ class Distribution(object):
                      'AIX': ['AIX'],
                      'HP-UX': ['HPUX'],
                      'Darwin': ['MacOSX'],
-                     'FreeBSD': ['FreeBSD', 'TrueOS']}
+                     'FreeBSD': ['FreeBSD', 'TrueOS'],
+                     'ClearLinux': ['Clear Linux OS', 'Clear Linux Mix']}
 
     OS_FAMILY = {}
     for family, names in OS_FAMILY_MAP.items():

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -949,7 +949,7 @@ PRIVACY_POLICY_URL="http://www.intel.com/privacy"
     "name": "ClearLinux 26580",
     "result": {
         "distribution_release": "clear-linux-os",
-        "distribution": "ClearLinux",
+        "distribution": "Clear Linux OS",
         "distribution_major_version": "26580",
         "os_family": "ClearLinux",
         "distribution_version": "26580"


### PR DESCRIPTION
… OS (#49639)

* set ansible_os_family from name variable in os-release for clearlinux system

Signed-off-by: Josue David Hernandez Gutierrez <josue.d.hernandez.gutierrez@intel.com>

* Add os_family for clear linux and clear linux mixes

Signed-off-by: Josue David Hernandez Gutierrez <josue.d.hernandez.gutierrez@intel.com>
(cherry picked from commit 9202ef60b02053e5b5e6224cc4b5fc9c4c8786b0)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
