### PR TITLE
removes space from example of L(link) syntax

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -258,7 +258,7 @@ Linking within module documentation
 
 You can link from your module documentation to other module docs, other resources on docs.ansible.com, and resources elsewhere on the internet. The correct formats for these links are:
 
-* ``L()`` for Links with a heading. For example: ``See L(IOS Platform Options guide, ../network/user_guide/platform_ios.html).``
+* ``L()`` for Links with a heading. For example: ``See L(IOS Platform Options guide,../network/user_guide/platform_ios.html).``
 * ``U()`` for URLs. For example: ``See U(https://www.ansible.com/products/tower) for an overview.``
 * ``I()`` for option names. For example: ``Required if I(state=present).``
 * ``C()`` for files and option values. For example: ``If not set the environment variable C(ACME_PASSWORD) will be used.``


### PR DESCRIPTION
##### SUMMARY
The example we gave on the page about documenting modules incorrectly showed a space between the text of the link and the destination of the link in the format, like this: `L(text, ../path/to/dest.html)`. If you follow this example, the entire entry shows as text, and the link goes back to the page you're already on.

This PR removes the space, correcting the example: `L(text,../path/to/dest.html)`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

