### PR TITLE
Fix yum/dnf handling of URIs that don't end in .rpm

### DIFF
--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -743,9 +743,10 @@ class DnfModule(YumDnf):
         already_loaded_comps = False  # Only load this if necessary, it's slow
 
         for name in self.names:
-            if name.endswith(".rpm"):
-                if '://' in name:
-                    name = self.fetch_rpm_from_url(name)
+            if '://' in name:
+                name = self.fetch_rpm_from_url(name)
+                filenames.append(name)
+            elif name.endswith(".rpm"):
                 filenames.append(name)
             elif name.startswith("@") or ('/' in name):
                 if not already_loaded_comps:

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -853,7 +853,7 @@ class YumModule(YumDnf):
             downgrade_candidate = False
 
             # check if pkgspec is installed (if possible for idempotence)
-            if spec.endswith('.rpm'):
+            if spec.endswith('.rpm') or '://' in spec:
                 if '://' not in spec and not os.path.exists(spec):
                     res['msg'] += "No RPM file matching '%s' found on system" % spec
                     res['results'].append("No RPM file matching '%s' found on system" % spec)
@@ -863,6 +863,12 @@ class YumModule(YumDnf):
                 if '://' in spec:
                     with self.set_env_proxy():
                         package = fetch_file(self.module, spec)
+                        if not package.endswith('.rpm'):
+                            # yum requires a local file to have the extension of .rpm and we
+                            # can not guarantee that from an URL (redirects, proxies, etc)
+                            new_package_path = '%s.rpm' % package
+                            os.rename(package, new_package_path)
+                            package = new_package_path
                 else:
                     package = spec
 


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix yum/dnf handling of URIs that don't end in .rpm

Fixes #49727

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum
dnf

##### ADDITIONAL INFORMATION
For the Ansible `devel` branch (2.8.0preAlpha), this PR depends on https://github.com/ansible/ansible/pull/49824 because until that's fixed we get `NameError: global name 'TimeoutError' is not defined` on RHEL.
