### PR TITLE
ansible-test: do not upgrade homebrew to speed up tests (#49914) - 2.6

### DIFF
--- a/test/integration/targets/archive/tasks/main.yml
+++ b/test/integration/targets/archive/tasks/main.yml
@@ -55,6 +55,10 @@
         update_homebrew: no
       become: yes
       become_user: "{{ brew_stat.stat.pw_name }}"
+      # Newer versions of brew want to compile a package which takes a long time. Do not upgrade homebrew until a
+      # proper solution can be found
+      environment:
+        HOMEBREW_NO_AUTO_UPDATE: True
   when:
     - ansible_python_version.split('.')[0] == '2'
     - ansible_os_family == 'Darwin'

--- a/test/integration/targets/iso_extract/tasks/7zip.yml
+++ b/test/integration/targets/iso_extract/tasks/7zip.yml
@@ -79,6 +79,10 @@
   become: yes
   become_user: "{{ brew_stat.stat.pw_name }}"
   when: ansible_distribution in ['MacOSX']
+  # Newer versions of brew want to compile a package which takes a long time. Do not upgrade homebrew until a
+  # proper solution can be found
+  environment:
+    HOMEBREW_NO_AUTO_UPDATE: True
 
 - name: Install 7zip package if we are on FreeBSD
   pkgng:

--- a/test/integration/targets/lookup_passwordstore/tasks/package.yml
+++ b/test/integration/targets/lookup_passwordstore/tasks/package.yml
@@ -48,3 +48,7 @@
   become: yes
   become_user: "{{ brew_stat.stat.pw_name }}"
   when: ansible_pkg_mgr == 'homebrew'
+  # Newer versions of brew want to compile a package which takes a long time. Do not upgrade homebrew until a
+  # proper solution can be found
+  environment:
+    HOMEBREW_NO_AUTO_UPDATE: True


### PR DESCRIPTION
(cherry picked from commit 695feea541fdc890c51350f1bef0f05b798fa035)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/49914

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test macos
