### PR TITLE
Fix eos terminal plugin regex

### DIFF
--- a/lib/ansible/plugins/terminal/eos.py
+++ b/lib/ansible/plugins/terminal/eos.py
@@ -45,7 +45,7 @@ class TerminalModule(TerminalBase):
         # Strings like this regarding VLANs are not errors
         re.compile(br"[^\r\n]+ not found(?! in current VLAN)", re.I),
         re.compile(br"'[^']' +returned error code: ?\d+"),
-        re.compile(br"[^\r\n]\/bin\/(?:ba)?sh"),
+        re.compile(br"[^\r\n](?<! shell )\/bin\/(?:ba)?sh"),
         re.compile(br"% More than \d+ OSPF instance", re.I),
         re.compile(br"% Subnet [0-9a-f.:/]+ overlaps", re.I),
         re.compile(br"Maximum number of pending sessions has been reached"),


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #48784 
- `eos_config` throws an error when we try to create a user with shell specified as `/bin/bash`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
eos.py

##### ANSIBLE VERSION
```
devel
```
