### PR TITLE
network_cli - ansible_command_timeout not working as expected

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -453,7 +453,7 @@ class Connection(NetworkConnectionBase):
         except (socket.timeout, AttributeError):
             display.vvvv(traceback.format_exc(), host=self._play_context.remote_addr)
             raise AnsibleConnectionFailure("timeout: value is %s seconds trying to send command: %s"
-                                           % (self._ssh_shell.gettimeout(), command.strip())
+                                           % (self._ssh_shell.gettimeout(), command.strip()))
 
     def _handle_buffer_read_timeout(self, signum, frame):
         display.vvvv("Response received, triggered 'persistent_buffer_read_timeout' timer of %s seconds"

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -452,7 +452,7 @@ class Connection(NetworkConnectionBase):
             return to_text(response, errors='surrogate_or_strict')
         except (socket.timeout, AttributeError):
             display.vvvv(traceback.format_exc(), host=self._play_context.remote_addr)
-            raise AnsibleConnectionFailure("timeout: value is %s seconds trying to send command: %s"
+            raise AnsibleConnectionFailure("timeout value %s seconds reached while trying to send command: %s"
                                            % (self._ssh_shell.gettimeout(), command.strip()))
 
     def _handle_buffer_read_timeout(self, signum, frame):

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -370,8 +370,11 @@ class Connection(NetworkConnectionBase):
         command_prompt_matched = False
         matched_prompt_window = window_count = 0
 
+        cache_socket_timeout = self._ssh_shell.gettimeout()
         command_timeout = self.get_option('persistent_command_timeout')
         self._validate_timeout_value(command_timeout, "persistent_command_timeout")
+        if cache_socket_timeout != command_timeout:
+            self._ssh_shell.settimeout(command_timeout)
 
         buffer_read_timeout = self.get_option('persistent_buffer_read_timeout')
         self._validate_timeout_value(buffer_read_timeout, "persistent_buffer_read_timeout")
@@ -393,6 +396,8 @@ class Connection(NetworkConnectionBase):
                     signal.alarm(command_timeout)
 
                 except AnsibleCmdRespRecv:
+                    # reset socket timeout to global timeout
+                    self._ssh_shell.settimeout(cache_socket_timeout)
                     return self._command_response
             else:
                 data = self._ssh_shell.recv(256)
@@ -423,6 +428,8 @@ class Connection(NetworkConnectionBase):
                 resp = self._strip(self._last_response)
                 self._command_response = self._sanitize(resp, command)
                 if buffer_read_timeout == 0.0:
+                    # reset socket timeout to global timeout
+                    self._ssh_shell.settimeout(cache_socket_timeout)
                     return self._command_response
                 else:
                     command_prompt_matched = True
@@ -445,7 +452,8 @@ class Connection(NetworkConnectionBase):
             return to_text(response, errors='surrogate_or_strict')
         except (socket.timeout, AttributeError):
             display.vvvv(traceback.format_exc(), host=self._play_context.remote_addr)
-            raise AnsibleConnectionFailure("timeout trying to send command: %s" % command.strip())
+            raise AnsibleConnectionFailure("timeout: value is %s seconds trying to send command: %s"
+                                           % (self._ssh_shell.gettimeout(), command.strip())
 
     def _handle_buffer_read_timeout(self, signum, frame):
         display.vvvv("Response received, triggered 'persistent_buffer_read_timeout' timer of %s seconds"


### PR DESCRIPTION
Signed-off-by: Deepak Agrawal <deepacks@gmail.com>

##### SUMMARY
Fixes #49466 
This issue will be hit only for specific set of ios_command that does not output anything for long time. So even if command_timeout has been set to longer duration, no activity on paramiko channel will cause socket.timeout. 

Fix is to wait for socket timeout as per task var timeout set for that particular task. It will then roll back to socket timeout set at playbook/connection level.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```