### PR TITLE
Change net_* default behaviour on missing module

### DIFF
--- a/lib/ansible/plugins/action/net_base.py
+++ b/lib/ansible/plugins/action/net_base.py
@@ -107,18 +107,12 @@ class ActionModule(ActionBase):
                 display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
                 conn.send_command('exit')
 
-        if 'fail_on_missing_module' not in self._task.args:
-            self._task.args['fail_on_missing_module'] = False
-
         result = super(ActionModule, self).run(task_vars=task_vars)
 
         module = self._get_implementation_module(play_context.network_os, self._task.action)
 
         if not module:
-            if self._task.args['fail_on_missing_module']:
-                result['failed'] = True
-            else:
-                result['failed'] = False
+            result['failed'] = True
 
             result['msg'] = ('Could not find implementation module %s for %s' %
                              (self._task.action, play_context.network_os))
@@ -129,8 +123,6 @@ class ActionModule(ActionBase):
             # already started
             if 'network_os' in new_module_args:
                 del new_module_args['network_os']
-
-            del new_module_args['fail_on_missing_module']
 
             display.vvvv('Running implementation module %s' % module)
             result.update(self._execute_module(module_name=module,


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #35869 
- This changes the behaviour of net_* modules.
- Instead of depending on `fail_on_missing_module`, this fix will cause the task to fail by default if the respective implementation module is not present. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
net_base.py

##### ANSIBLE VERSION
```
devel
```

