### PR TITLE
New module lxca_discover for Lenovo XClarity Administrator

### DIFF
--- a/lib/ansible/modules/remote_management/lxca/lxca_discover.py
+++ b/lib/ansible/modules/remote_management/lxca/lxca_discover.py
@@ -1,0 +1,168 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'supported_by': 'community',
+    'status': ['preview']
+}
+
+
+DOCUMENTATION = '''
+---
+version_added: "2.8"
+author:
+  - Naval Patel (@navalkp)
+  - Prashant Bhosale (@prabhosa)
+module: lxca_discover
+short_description: Custom module for lxca discover inventory utility
+description:
+  - This module returns/displays a inventory details of discover
+
+options:
+  discover_ip:
+    description:
+      discover for this ip,
+
+  jobid:
+    description:
+      discover status for jobid,
+
+  command_options:
+    description:
+      options to filter discover information
+    default: discover
+    choices:
+        - discover
+
+extends_documentation_fragment:
+    - lxca_common
+'''
+
+EXAMPLES = '''
+# get all discover info
+- name: get discover data from LXCA
+  lxca_discover:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+
+# get specific discover info by ip
+- name: get discover data from LXCA
+  lxca_discover:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+    ip: "10.243.12.244"
+    command_options: discover
+
+# get status of discover job by jobid
+- name: get discover data from LXCA
+  lxca_discover:
+    login_user: USERID
+    login_password: Password
+    auth_url: "https://10.243.15.168"
+    jobid: "23"
+    command_options: discover
+
+'''
+
+RETURN = r'''
+# discover all device
+result:
+  description: discover all detail from lxca
+  returned: success
+  type: dict
+  sample:
+    chassisList: {}
+    storageList: {}
+    nodeList: {}
+    rackswitchList: {}
+    contains:
+      jobid:
+        description: discover ip from  lxca
+        returned: success
+        type: string
+        sample: "293"
+
+'''
+
+
+import traceback
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.remote_management.lxca.common import LXCA_COMMON_ARGS, has_pylxca, connection_object
+try:
+    from pylxca import discover
+except ImportError:
+    pass
+
+
+SUCCESS_MSG = "Success %s result"
+
+
+def _discover(module, lxca_con):
+    result = None
+    if module.params.get('discover_ip', None):
+        result = {'jobid': discover(lxca_con, ip=module.params['discover_ip'])}
+    elif module.params.get('jobid', None):
+        result = discover(lxca_con, job=module.params['jobid'])
+    else:
+        result = discover(lxca_con)
+    return result
+
+
+def setup_module_object():
+    """
+    this function merge argument spec and create ansible module object
+    :return:
+    """
+    args_spec = dict(LXCA_COMMON_ARGS)
+    args_spec.update(INPUT_ARG_SPEC)
+    module = AnsibleModule(argument_spec=args_spec,
+                           mutually_exclusive=[['discover_ip', 'jobid']],
+                           supports_check_mode=False)
+
+    return module
+
+
+FUNC_DICT = {
+    'discover': _discover,
+}
+
+
+INPUT_ARG_SPEC = dict(
+    command_options=dict(default='discover', choices=list(FUNC_DICT)),
+    discover_ip=dict(default=None),
+    jobid=dict(default=None),
+)
+
+
+def execute_module(module):
+    """
+    This function invoke commands
+    :param module: Ansible module object
+    """
+    try:
+        with connection_object(module) as lxca_con:
+            result = FUNC_DICT[module.params['command_options']](module, lxca_con)
+            module.exit_json(changed=False,
+                             msg=SUCCESS_MSG % module.params['command_options'],
+                             result=result)
+    except Exception as exception:
+        error_msg = '; '.join((e) for e in exception.args)
+        module.fail_json(msg=error_msg, exception=traceback.format_exc())
+
+
+def main():
+    module = setup_module_object()
+    has_pylxca(module)
+    execute_module(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/remote_management/lxca/test_lxca_discover.py
+++ b/test/units/modules/remote_management/lxca/test_lxca_discover.py
@@ -1,0 +1,94 @@
+import json
+
+import pytest
+from units.compat import mock
+from ansible.modules.remote_management.lxca import lxca_discover
+
+
+@pytest.fixture(scope='module')
+@mock.patch("ansible.module_utils.remote_management.lxca.common.close_conn", autospec=True)
+def setup_module(close_conn):
+    close_conn.return_value = True
+
+
+class TestMyModule():
+    @pytest.mark.parametrize('patch_ansible_module',
+                             [
+                                 {},
+                                 {
+                                     "auth_url": "https://10.240.14.195",
+                                     "login_user": "USERID",
+                                 },
+                                 {
+                                     "auth_url": "https://10.240.14.195",
+                                     "login_password": "Password",
+                                 },
+                                 {
+                                     "login_user": "USERID",
+                                     "login_password": "Password",
+                                 },
+                             ],
+                             indirect=['patch_ansible_module'])
+    @pytest.mark.usefixtures('patch_ansible_module')
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_discover.execute_module", autospec=True)
+    def test_without_required_parameters(self, _setup_conn, _execute_module,
+                                         mocker, capfd, setup_module):
+        """Failure must occurs when all parameters are missing"""
+        with pytest.raises(SystemExit):
+            _setup_conn.return_value = "Fake connection"
+            _execute_module.return_value = "Fake execution"
+            lxca_discover.main()
+        out, err = capfd.readouterr()
+        results = json.loads(out)
+        assert results['failed']
+        assert 'missing required arguments' in results['msg']
+
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_discover.execute_module", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_discover.AnsibleModule", autospec=True)
+    def test__argument_spec(self, ansible_mod_cls, _execute_module, _setup_conn, setup_module):
+        expected_arguments_spec = dict(
+            login_user=dict(required=True),
+            login_password=dict(required=True, no_log=True),
+            command_options=dict(default='discover', choices=['discover']),
+            auth_url=dict(required=True),
+            discover_ip=dict(default=None),
+            jobid=dict(default=None),
+        )
+        _setup_conn.return_value = "Fake connection"
+        _execute_module.return_value = []
+        mod_obj = ansible_mod_cls.return_value
+        args = {
+            "auth_url": "https://10.243.30.195",
+            "login_user": "USERID",
+            "login_password": "password",
+            "command_options": "discover",
+        }
+        mod_obj.params = args
+        lxca_discover.main()
+        assert(mock.call(argument_spec=expected_arguments_spec,
+                         mutually_exclusive=[['discover_ip', 'jobid']],
+                         supports_check_mode=False) == ansible_mod_cls.call_args)
+
+    @mock.patch("ansible.module_utils.remote_management.lxca.common.setup_conn", autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_discover._discover",
+                autospec=True)
+    @mock.patch("ansible.modules.remote_management.lxca.lxca_discover.AnsibleModule",
+                autospec=True)
+    def test__discover_empty_list(self, ansible_mod_cls, _get_discover, _setup_conn, setup_module):
+        mod_obj = ansible_mod_cls.return_value
+        args = {
+            "auth_url": "https://10.243.30.195",
+            "login_user": "USERID",
+            "login_password": "password",
+            "uuid": "3C737AA5E31640CE949B10C129A8B01F",
+            "command_options": "discover",
+        }
+        mod_obj.params = args
+        _setup_conn.return_value = "Fake connection"
+        empty_discover_list = []
+        _get_discover.return_value = empty_discover_list
+        ret_discover = _get_discover(mod_obj, args)
+        assert mock.call(mod_obj, mod_obj.params) == _get_discover.call_args
+        assert _get_discover.return_value == ret_discover


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This module provide an interface to Lenovo XClarity Administrator. This module provides information about discovered device.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lxca_discover
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Testing ansible module lxca_discover

1. Discover all device 
2. Discover device using ip address, this will return jobid
3. Get status of job using jobid

(pylxca27) naval@osboxes:~/play/playbook/lxca_discover$ cat all_discover.yml 
---
- hosts: localhost
  connection: local
  tasks:
    - name: list discover
      lxca_discover:
        login_user: USERID
        login_password: CME44ibm
        auth_url: "https://10.243.9.238"
        command_options: discover
(pylxca27) naval@osboxes:~/play/playbook/lxca_discover$ ansible-playbook all_discover.yml 
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] *****************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [list discover] *************************************************************************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0   

(pylxca27) naval@osboxes:~/play/playbook/lxca_discover$ cat discover_by_ip.yml 
---
- hosts: localhost
  connection: local
  tasks:
    - name: start discovery of device by ip, it returns job id
      lxca_discover:
        login_user: USERID
        login_password: CME44ibm
        auth_url: "https://10.243.9.238"
        discover_ip: "10.243.16.234"
        command_options: discover

		(pylxca27) naval@osboxes:~/play/playbook/lxca_discover$ ansible-playbook discover_by_ip.yml -v
No config file found; using defaults
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] *****************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [start discovery of device by ip, it returns job id] ************************************************************************************
ok: [localhost] => {"changed": false, "msg": "Success discover result", "result": {"jobid": "156"}}

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0 

(pylxca27) naval@osboxes:~/play/playbook/lxca_discover$ cat discover_job_status.yml 
---
- hosts: localhost
  connection: local
  tasks:
    - name: discover job status
      lxca_discover:
        login_user: USERID
        login_password: CME44ibm
        auth_url: "https://10.243.9.238"
        jobid: "156"
        command_options: discover

(pylxca27) naval@osboxes:~/play/playbook/lxca_discover$ ansible-playbook discover_job_status.yml  
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] *****************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [discover job status] *******************************************************************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0 
```
