### PR TITLE
Fixed bug in netscaler_servicegroup module

### DIFF
--- a/lib/ansible/modules/network/netscaler/netscaler_servicegroup.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_servicegroup.py
@@ -459,6 +459,7 @@ def get_configured_service_members(client, module):
         # Make a copy to update
         config = copy.deepcopy(config)
         config['servicegroupname'] = module.params['servicegroupname']
+        config['state'] = config['state'].upper()
         member_proxy = ConfigProxy(
             actual=servicegroup_servicegroupmember_binding(),
             client=client,


### PR DESCRIPTION
##### SUMMARY
Fixed a bug in the netscaler_servicegroup module
Fixes #49888 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
netscaler_servicegroup

##### ADDITIONAL INFORMATION
Fixed the bug which caused the module to fail while comparing server objects
even when the config attributes were same the issue was with case sensitivity.

This commit fixes Issue #49888 (https://github.com/ansible/ansible/issues/49888)
