### PR TITLE
Preventing '/dev/tty not found' problems

### DIFF
--- a/changelogs/fragments/apt_repository-no-tty.yaml
+++ b/changelogs/fragments/apt_repository-no-tty.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt_repository - do not require a tty to prevent errors parsing GPG keys (https://github.com/ansible/ansible/issues/49949)

--- a/lib/ansible/modules/packaging/os/apt_repository.py
+++ b/lib/ansible/modules/packaging/os/apt_repository.py
@@ -430,7 +430,7 @@ class UbuntuSourcesList(SourcesList):
             if self.add_ppa_signing_keys_callback is not None:
                 info = self._get_ppa_info(ppa_owner, ppa_name)
                 if not self._key_already_exists(info['signing_key_fingerprint']):
-                    command = ['apt-key', 'adv', '--recv-keys', '--keyserver', 'hkp://keyserver.ubuntu.com:80', info['signing_key_fingerprint']]
+                    command = ['apt-key', 'adv', '--recv-keys', '--no-tty', '--keyserver', 'hkp://keyserver.ubuntu.com:80', info['signing_key_fingerprint']]
                     self.add_ppa_signing_keys_callback(command)
 
             file = file or self._suggest_filename('%s_%s' % (line, self.codename))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change fixes https://github.com/ansible/ansible/issues/49949

Follows the same rationale as https://github.com/ansible/ansible/pull/48580 did with `apt_key`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt_repository

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
I've followed the referred fix done to `apt_key` as the root cause is the same here, that is, a GPG error when invoked by both modules.
 
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I tested the problem with the installation of a PPA repository I have been using for a while: 'ppa:webupd8team/java'
It worked for some months, until this bug arose.
If you try to add a PPA repository which needs a GPG key to be imported, like the example below, you end up with an error by GPG:

```
- name: WebUpd8 repository
  apt_repository:
    repo:         'ppa:webupd8team/java'
    state:        present
    codename:    'trusty'
    update_cache: yes
  when: ( ansible_os_family == "Debian")
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before the change:
```paste below
fatal: [staging03]: FAILED! => {"changed": false, "cmd": "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 7B2C3B0889BF5709A105D03AC2518248EEA14886", "msg": "Warning: apt-key output should not be parsed (stdout is not a terminal)\ngpg: cannot open '/dev/tty': No such device or address", "rc": 2, "stderr": "Warning: apt-key output should not be parsed (stdout is not a terminal)\ngpg: cannot open '/dev/tty': No such device or address\n", "stderr_lines": ["Warning: apt-key output should not be parsed (stdout is not a terminal)", "gpg: cannot open '/dev/tty': No such device or address"], "stdout": "Executing: /tmp/apt-key-gpghome.y9zNAIZfBz/gpg.1.sh --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 7B2C3B0889BF5709A105D03AC2518248EEA14886\n", "stdout_lines": ["Executing: /tmp/apt-key-gpghome.y9zNAIZfBz/gpg.1.sh --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 7B2C3B0889BF5709A105D03AC2518248EEA14886"]}
```

After the change:

```
TASK [profile_oracle-java : WebUpd8 repository] *************************************************************************
changed: [staging03]
```