### PR TITLE
Do not load user kube config if path specified

### DIFF
--- a/changelogs/fragments/49952-avoid-loading-kube-config-when-auth-given.yml
+++ b/changelogs/fragments/49952-avoid-loading-kube-config-when-auth-given.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openshift inventory plugin - do not default create client if auth parameters were given.

--- a/lib/ansible/plugins/inventory/k8s.py
+++ b/lib/ansible/plugins/inventory/k8s.py
@@ -165,7 +165,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable, K8sAnsibleM
             self.fetch_objects(connections)
 
     def fetch_objects(self, connections):
-        client = self.get_api_client()
 
         if connections:
             if not isinstance(connections, list):
@@ -184,6 +183,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable, K8sAnsibleM
                     self.get_pods_for_namespace(client, name, namespace)
                     self.get_services_for_namespace(client, name, namespace)
         else:
+            client = self.get_api_client()
             name = self.get_default_host_name(client.configuration.host)
             namespaces = self.get_available_namespaces(client)
             for namespace in namespaces:

--- a/lib/ansible/plugins/inventory/openshift.py
+++ b/lib/ansible/plugins/inventory/openshift.py
@@ -123,9 +123,11 @@ class InventoryModule(K8sInventoryModule):
 
     def fetch_objects(self, connections):
         super(InventoryModule, self).fetch_objects(connections)
-        client = self.get_api_client()
 
         if connections:
+            if not isinstance(connections, list):
+                raise K8sInventoryException("Expecting connections to be a list.")
+
             for connection in connections:
                 client = self.get_api_client(**connection)
                 name = connection.get('name', self.get_default_host_name(client.configuration.host))
@@ -136,6 +138,7 @@ class InventoryModule(K8sInventoryModule):
                 for namespace in namespaces:
                     self.get_routes_for_namespace(client, name, namespace)
         else:
+            client = self.get_api_client()
             name = self.get_default_host_name(client.configuration.host)
             namespaces = self.get_available_namespaces(client)
             for namespace in namespaces:


### PR DESCRIPTION
##### SUMMARY
The existing inventory plugins for k8s will create a `client` object with default parameters before using the parameters specified in the inventory file.

That is a major problem if anyone using this ever intends to save their kube config somewhere other than the default location - because this caused it to fail on trying to read from the default location.

Doing this is unnecessary, so the duplication creation of the `client` object is removed here.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/openshift.py
lib/ansible/plugins/inventory/k8s.py

##### ADDITIONAL INFORMATION
Walking through reproduction of issue:

 - do `oc login <host>`
 - `cp ~/.kube/config ./mai_config`
 - `rm -rf ~/.kube/`
 - `ansible-inventory -i openshift.yml --list` with the following inventory:

```yaml
plugin: openshift
connections:
    - host: https://<my host>:8443
      kubeconfig: mai_config
      verify_ssl: false
      namespaces:
        - <my namespace>
```

Running that before this fix produces:

```paste below
 [WARNING]:  * Failed to parse /Users/alancoding/Documents/repos/tower-qa/openshift.yml with auto plugin: [Errno 2] No such file or directory: '/Users/alancoding/.kube/config'

  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/inventory/manager.py", line 267, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/plugins/inventory/auto.py", line 55, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/plugins/inventory/k8s.py", line 147, in parse
    self.setup(config_data, cache, cache_key)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/plugins/inventory/k8s.py", line 165, in setup
    self.fetch_objects(connections)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/plugins/inventory/openshift.py", line 126, in fetch_objects
    client = self.get_api_client()
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible/module_utils/k8s/common.py", line 164, in get_api_client
    kubernetes.config.load_kube_config(auth.get('kubeconfig'), auth.get('context'))
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/kubernetes/config/kube_config.py", line 521, in load_kube_config
    config_persister=config_persister)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/kubernetes/config/kube_config.py", line 478, in _get_kube_config_loader_for_yaml_file
    with open(filename) as f:
```

(some line numbers might be a little off)

With this fix, the inventory content will get returned.

Note: this seems to _not_ fix username/password or token authentication, but I believe it gets us closer. See https://github.com/openshift/openshift-restclient-python/issues/249 for more on that.

Also see related docs PR: https://github.com/ansible/ansible/pull/49901