### PR TITLE
Remove erroneous extra-vars example

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -962,30 +962,10 @@ key=value format::
 .. note:: Values passed in using the ``key=value`` syntax are interpreted as strings.
           Use the JSON format if you need to pass in anything that shouldn't be a string (Booleans, integers, floats, lists etc).
 
-.. versionadded:: 1.2
-
 JSON string format::
 
     ansible-playbook release.yml --extra-vars '{"version":"1.23.45","other_variable":"foo"}'
     ansible-playbook arcade.yml --extra-vars '{"pacman":"mrs","ghosts":["inky","pinky","clyde","sue"]}'
-
-.. versionadded:: 1.3
-
-YAML string format::
-
-    ansible-playbook release.yml --extra-vars '
-    version: "1.23.45"
-    other_variable: foo'
-
-    ansible-playbook arcade.yml --extra-vars '
-    pacman: mrs
-    ghosts:
-    - inky
-    - pinky
-    - clyde
-    - sue'
-
-.. versionadded:: 1.3
 
 vars from a JSON or YAML file::
 
@@ -995,16 +975,12 @@ This is useful for, among other things, setting the hosts group or the user for 
 
 Escaping quotes and other special characters:
 
-.. versionadded:: 1.2
-
 Ensure you're escaping quotes appropriately for both your markup (e.g. JSON), and for
 the shell you're operating in.::
 
     ansible-playbook arcade.yml --extra-vars "{\"name\":\"Conan O\'Brien\"}"
     ansible-playbook arcade.yml --extra-vars '{"name":"Conan O'\\\''Brien"}'
     ansible-playbook script.yml --extra-vars "{\"dialog\":\"He said \\\"I just can\'t get enough of those single and double-quotes"\!"\\\"\"}"
-
-.. versionadded:: 1.3
 
 In these cases, it's probably best to use a JSON or YAML file containing the variable
 definitions.


### PR DESCRIPTION
##### SUMMARY
Remove erroneous extra-vars example, and a few really old versionadded indicators. Fixes #38415

This example has never worked, and should not have been included.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/user_guide/playbooks_variables.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```