### PR TITLE
Backport/2.7/49912 yumdnf uri handling

### DIFF
--- a/changelogs/fragments/yumdnf-better-uri-handling.yaml
+++ b/changelogs/fragments/yumdnf-better-uri-handling.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "yum and dnf can now handle installing packages from URIs that are proxy redirects and don't end in the .rpm file extension"

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -726,9 +726,10 @@ class DnfModule(YumDnf):
         already_loaded_comps = False  # Only load this if necessary, it's slow
 
         for name in self.names:
-            if name.endswith(".rpm"):
-                if '://' in name:
-                    name = self.fetch_rpm_from_url(name)
+            if '://' in name:
+                name = self.fetch_rpm_from_url(name)
+                filenames.append(name)
+            elif name.endswith(".rpm"):
                 filenames.append(name)
             elif name.startswith("@") or ('/' in name):
                 if not already_loaded_comps:

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -872,7 +872,7 @@ class YumModule(YumDnf):
             downgrade_candidate = False
 
             # check if pkgspec is installed (if possible for idempotence)
-            if spec.endswith('.rpm'):
+            if spec.endswith('.rpm') or '://' in spec:
                 if '://' not in spec and not os.path.exists(spec):
                     res['msg'] += "No RPM file matching '%s' found on system" % spec
                     res['results'].append("No RPM file matching '%s' found on system" % spec)
@@ -882,6 +882,12 @@ class YumModule(YumDnf):
                 if '://' in spec:
                     with self.set_env_proxy():
                         package = self.fetch_rpm_from_url(spec)
+                        if not package.endswith('.rpm'):
+                            # yum requires a local file to have the extension of .rpm and we
+                            # can not guarantee that from an URL (redirects, proxies, etc)
+                            new_package_path = '%s.rpm' % package
+                            os.rename(package, new_package_path)
+                            package = new_package_path
                 else:
                     package = spec
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of PRs #49912 and #49962 to fix yum and dnf handling of URIs that don't end in .rpm 

Fixes #49727 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum
dnf
