### PR TITLE
Provide more message text for many sub-errors

### DIFF
--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -67,6 +67,9 @@ class AnsibleError(Exception):
                 self.message = '%s\n\n%s' % (to_native(message), to_native(extended_error))
             else:
                 self.message = '%s' % to_native(message)
+        elif isinstance(message, Exception):
+            # Some exceptions (like KeyError) give unhelpful information from __str__
+            self.message = '%s' % to_native(message.__repr__())
         else:
             self.message = '%s' % to_native(message)
         if orig_exc:


### PR DESCRIPTION
##### SUMMARY
Many errors are getting truncated to the point of being incomprehensible.

This is due to some python nuances, but it's clear that `__repr__` contains the details that a human would actually be interested in.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory plugins

lib/ansible/errors/__init__.py

##### ADDITIONAL INFORMATION
This is what I would get before if I did not provide the `service_account_file` to the gcp_compute inventory plugin:

```paste below
 [WARNING]:  * Failed to parse /Users/alancoding/Documents/repos/ansible-inventory-file-examples/plugins/example_gce/gcp.yml with auto plugin: 'service_account_file'

  File "/Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.7.2.post0-py2.7.egg/ansible/inventory/manager.py", line 270, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.7.2.post0-py2.7.egg/ansible/plugins/inventory/auto.py", line 55, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.7.2.post0-py2.7.egg/ansible/plugins/inventory/gcp_compute.py", line 353, in parse
    zones = self._get_zones(config_data)
  File "/Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.7.2.post0-py2.7.egg/ansible/plugins/inventory/gcp_compute.py", line 145, in _get_zones
    zones_response = self.fetch_list(config_data, link, '')
  File "/Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.7.2.post0-py2.7.egg/ansible/plugins/inventory/gcp_compute.py", line 135, in fetch_list
    response = auth.get(link, params={'filter': query})
  File "/Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.7.2.post0-py2.7.egg/ansible/module_utils/gcp_utils.py", line 76, in get
    return self.session().get(url, **kwargs)
  File "/Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.7.2.post0-py2.7.egg/ansible/module_utils/gcp_utils.py", line 107, in session
    self._credentials().with_scopes(self.module.params['scopes']))
  File "/Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.7.2.post0-py2.7.egg/ansible/module_utils/gcp_utils.py", line 132, in _credentials
    path = os.path.realpath(os.path.expanduser(self.module.params['service_account_file']))
```

revised:

```
 [WARNING]:  * Failed to parse /Users/alancoding/Documents/repos/ansible-inventory-file-examples/plugins/example_gce/gcp.yml with auto plugin: KeyError('service_account_file',)

  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible/inventory/manager.py", line 267, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible/plugins/inventory/auto.py", line 55, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible/plugins/inventory/gcp_compute.py", line 363, in parse
    zones = self._get_zones(config_data)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible/plugins/inventory/gcp_compute.py", line 155, in _get_zones
    zones_response = self.fetch_list(config_data, link, '')
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible/plugins/inventory/gcp_compute.py", line 145, in fetch_list
    response = auth.get(link, params={'filter': query})
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible/module_utils/gcp_utils.py", line 76, in get
    return self.session().get(url, **kwargs)
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible/module_utils/gcp_utils.py", line 106, in session
    return AuthorizedSession(self._credentials())
  File "/Users/alancoding/.virtualenvs/tower-qa/lib/python2.7/site-packages/ansible-2.8.0.dev0-py2.7.egg/ansible/module_utils/gcp_utils.py", line 131, in _credentials
    path = os.path.realpath(os.path.expanduser(self.module.params['service_account_file']))

```

Inside of `lib/ansible/inventory/manager.py` an error from a plugin is saved as

```python
failures.append({'src': source, 'plugin': plugin_name, 'exc': AnsibleError(e)})
```

I can't disagree with your call pattern. It seems fine to me, but `e` is passed to the exception class `__init__` as `message` and then gets converted to a string, which the new error returns on _both_ `__str__` and `__repr__`, and that's not okay because of how many common exceptions work.

```python
>>> try:
...   {}['a']
... except Exception as e:
...   ke = e
... 
>>> '%s' % to_native(ke)
"'a'"
>>> print ke.__repr__()
KeyError('a',)
```

This avoids introducing a new code path for this unique case in `AnsibleError`'s `__repr__` (although I would say this would be the most correct solution), because there are a lot of other cases that I don't want to get into.