### PR TITLE
Docs: Show parameter types (in purple)

### DIFF
--- a/docs/templates/list_of_CATEGORY_modules.rst.j2
+++ b/docs/templates/list_of_CATEGORY_modules.rst.j2
@@ -1,3 +1,6 @@
+{# avoids rST "isn't included in any toctree" errors for module docs #}
+:orphan:
+
 .. _@{ title.lower() + '_' + plugin_type + 's' }@:
 
 @{ title }@ @{ plugin_type + 's' }@

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -67,7 +67,7 @@ Aliases: @{ ','.join(aliases) }@
 {% if requirements -%}
 
 Requirements
-~~~~~~~~~~~~
+------------
 {%   if plugin_type == 'module' %}
 The below requirements are needed on the host that executes this @{ plugin_type }@.
 {%   else %}
@@ -116,11 +116,13 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 {% endfor %}
                 {# parameter name with required and/or introduced label #}
-                <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
-                    <b>@{ key }@</b>
-                    {% if value.get('type', None) %}<br/><div style="font-size: small; color: red">@{ value.type }@</div>{% endif %}
-                    {% if value.get('required', False) %}<br/><div style="font-size: small; color: red">required</div>{% endif %}
-                    {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
+                <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@" style="position: relative">
+                    <b>@{ key }@</b><br/>
+                    <div style="font-size: small">
+                        <div style="color: purple; display: inline">@{ value.type | documented_type }@</div>
+                        {% if value.get('required', False) %} / <div style="color: red; display: inline">required</div>{% endif %}
+                    </div>
+                    {% if value.version_added %}<div style="align: right; font-style: italic; font-size: small; color: darkgreen">added in v@{value.version_added}@</div>{% endif %}
                 </td>
                 {# default / choices #}
                 <td>
@@ -135,7 +137,7 @@ Parameters
                     {% endif %}
                     {# Show possible choices and highlight details #}
                     {% if value.choices %}
-                        <ul><b>Choices:</b>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
                             {% for choice in value.choices %}
                                 {# Turn boolean values in 'yes' and 'no' values #}
                                 {% if choice is sameas true %}
@@ -292,8 +294,8 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
                     <td class="elbow-placeholder"></td>
                 {% endfor %}
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@" colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
-                    <b>@{ key }@</b>
-                    <br/><div style="font-size: small; color: red">@{ value.type }@</div>
+                    <b>@{ key }@</b><br/>
+                    <div style="font-size: small; color: purple">@{ value.type | documented_type }@</div>
                     {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
@@ -364,8 +366,8 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <td class="elbow-placeholder">&nbsp;</td>
                 {% endfor %}
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
-                    <b>@{ key }@</b>
-                    <br/><div style="font-size: small; color: red">@{ value.type }@</div>
+                    <b>@{ key }@</b><br/>
+                    <div style="font-size: small; color: purple">@{ value.type | documented_type }@</div>
                     {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
@@ -432,7 +434,7 @@ For a list of other modules that are also maintained by @{ supported_by }@, see 
 {%       if metadata.supported_by in ('core', 'network') %}
 
 Support
-~~~~~~~
+-------
 
 For more information about Red Hat's support of this @{ plugin_type }@,
 please refer to this `Knowledge Base article <https://access.redhat.com/articles/rhel-top-support-policies/>`_
@@ -451,7 +453,7 @@ This @{ plugin_type }@ is flagged as **deprecated** and will be removed in versi
 {% if author is defined -%}
 
 Author
-~~~~~~
+------
 
 {%   for author_name in author %}
 - @{ author_name }@

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -11,7 +11,7 @@
 {% endfor %}
 
 {% if short_description %}
-{%   set title = module + ' - ' + short_description | rst_ify %}
+{%   set title = module + ' -- ' + short_description | rst_ify %}
 {% else %}
 {%   set title = module %}
 {% endif %}
@@ -405,40 +405,37 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
 {% endif %}
 
-Support
--------
+Status
+------
 
 {% if deprecated %}
 
-This @{ plugin_type }@ is flagged as **deprecated** and will be removed in version @{ deprecated['removed_in'] | default('') | string | rst_ify }@. For more information see `DEPRECATED`_.
+- This @{ plugin_type }@ will be removed in version @{ deprecated['removed_in'] | default('') | string | rst_ify }@. *[deprecated]*
+- For more information see `DEPRECATED`_.
 
 {% else %}
 
-Status
-~~~~~~
-
 {%   set support = { 'core': 'the Ansible Core Team', 'network': 'the Ansible Network Team', 'certified': 'an Ansible Partner', 'community': 'the Ansible Community', 'curated': 'a Third Party'} %}
-{%   set module_states = { 'preview': 'it is not guaranteed to have a backwards compatible interface', 'stableinterface': 'the maintainers for this module guarantee that no backward incompatible interface changes will be made'} %}
+{%   set module_states = { 'preview': 'not guaranteed to have a backwards compatible interface', 'stableinterface': 'guaranteed to have no backward incompatible interface changes going forward'} %}
 
 {%   if metadata %}
 {%     if metadata.status %}
 
 {%       for cur_state in metadata.status %}
-This @{ plugin_type }@ is flagged as **@{cur_state}@** which means that @{module_states[cur_state]}@.
+- This @{ plugin_type }@ is @{ module_states[cur_state] }@. *[@{ cur_state }@]*
 {%       endfor %}
 
 {%     endif %}
 
 {%     if metadata.supported_by %}
-
-Maintenance
-~~~~~~~~~~~
-
 {%       set supported_by = support[metadata.supported_by] %}
-This @{ plugin_type }@ is flagged as **@{metadata.supported_by}@** which means that it is :ref:`maintained by @{ supported_by }@ <modules_support>`.
+- This @{ plugin_type }@ is :ref:`maintained by @{ supported_by }@ <modules_support>`. *[@{ metadata.supported_by }@]*
 
 {%       if metadata.supported_by in ('core', 'network') %}
-More information about Red Hat's support of this @{ plugin_type }@ is available from this `Knowledge Base article <https://access.redhat.com/articles/3166901>`_.
+Red Hat Support
+~~~~~~~~~~~~~~~
+
+More information about Red Hat's support of this @{ plugin_type }@ is available from this `Red Hat Knowledge Base article <https://access.redhat.com/articles/3166901>`_.
 {%       endif %}
 
 {%     endif %}
@@ -448,9 +445,8 @@ More information about Red Hat's support of this @{ plugin_type }@ is available 
 {% endif %}
 
 {% if author is defined -%}
-
-Author
-~~~~~~
+Authors
+~~~~~~~
 
 {%   for author_name in author %}
 - @{ author_name }@

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -435,7 +435,7 @@ Maintenance
 ~~~~~~~~~~~
 
 {%       set supported_by = support[metadata.supported_by] %}
-This @{ plugin_type }@ is flagged as **@{metadata.supported_by}@** which means that it is :ref:`maintained by @{ supported_by }@ <modules_support>` as part of the :ref:`following set of supported modules <@{ metadata.supported_by }@_supported>`.
+This @{ plugin_type }@ is flagged as **@{metadata.supported_by}@** which means that it is :ref:`maintained by @{ supported_by }@ <modules_support>`.
 
 {%       if metadata.supported_by in ('core', 'network') %}
 More information about Red Hat's support of this @{ plugin_type }@ is available from this `Knowledge Base article <https://access.redhat.com/articles/3166901>`_.

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -438,7 +438,7 @@ Maintenance
 This @{ plugin_type }@ is flagged as **@{metadata.supported_by}@** which means that it is :ref:`maintained by @{ supported_by }@ <modules_support>` as part of the :ref:`following set of supported modules <@{ metadata.supported_by }@_supported>`.
 
 {%       if metadata.supported_by in ('core', 'network') %}
-More information about Red Hat's support of this @{ plugin_type }@ is available from this `Knowledge Base article <https://access.redhat.com/articles/rhel-top-support-policies/>`_.
+More information about Red Hat's support of this @{ plugin_type }@ is available from this `Knowledge Base article <https://access.redhat.com/articles/3166901>`_.
 {%       endif %}
 
 {%     endif %}

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -25,7 +25,7 @@
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 {# ------------------------------------------
  #
@@ -405,9 +405,17 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
 {% endif %}
 
+Support
+-------
+
+{% if deprecated %}
+
+This @{ plugin_type }@ is flagged as **deprecated** and will be removed in version @{ deprecated['removed_in'] | default('') | string | rst_ify }@. For more information see `DEPRECATED`_.
+
+{% else %}
+
 Status
-------
-{% if not deprecated %}
+~~~~~~
 
 {%   set support = { 'core': 'the Ansible Core Team', 'network': 'the Ansible Network Team', 'certified': 'an Ansible Partner', 'community': 'the Ansible Community', 'curated': 'a Third Party'} %}
 {%   set module_states = { 'preview': 'it is not guaranteed to have a backwards compatible interface', 'stableinterface': 'the maintainers for this module guarantee that no backward incompatible interface changes will be made'} %}
@@ -424,29 +432,18 @@ This @{ plugin_type }@ is flagged as **@{cur_state}@** which means that @{module
 {%     if metadata.supported_by %}
 
 Maintenance
------------
+~~~~~~~~~~~
 
 {%       set supported_by = support[metadata.supported_by] %}
-This @{ plugin_type }@ is flagged as **@{metadata.supported_by}@** which means that it is maintained by @{ supported_by }@. See :ref:`Module Maintenance & Support <modules_support>` for more info.
-
-For a list of other modules that are also maintained by @{ supported_by }@, see :ref:`here <@{ metadata.supported_by }@_supported>`.
+This @{ plugin_type }@ is flagged as **@{metadata.supported_by}@** which means that it is :ref:`maintained by @{ supported_by }@ <modules_support>` as part of the :ref:`following set of supported modules <@{ metadata.supported_by }@_supported>`.
 
 {%       if metadata.supported_by in ('core', 'network') %}
-
-Support
--------
-
-For more information about Red Hat's support of this @{ plugin_type }@,
-please refer to this `Knowledge Base article <https://access.redhat.com/articles/rhel-top-support-policies/>`_
+More information about Red Hat's support of this @{ plugin_type }@ is available from this `Knowledge Base article <https://access.redhat.com/articles/rhel-top-support-policies/>`_.
 {%       endif %}
 
 {%     endif %}
 
 {%   endif %}
-
-{% else %}
-
-This @{ plugin_type }@ is flagged as **deprecated** and will be removed in version @{ deprecated['removed_in'] | default('') | string | rst_ify }@. For more information see `DEPRECATED`_.
 
 {% endif %}
 

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -450,7 +450,7 @@ More information about Red Hat's support of this @{ plugin_type }@ is available 
 {% if author is defined -%}
 
 Author
-------
+~~~~~~
 
 {%   for author_name in author %}
 - @{ author_name }@

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -20,7 +20,7 @@
 @{ '+' * title|length }@
 
 {% if version_added is defined and version_added != '' -%}
-.. versionadded:: v@{ version_added | default('') }@
+.. versionadded:: @{ version_added | default('') }@
 {% endif %}
 
 .. contents::
@@ -122,7 +122,7 @@ Parameters
                         <span style="color: purple">@{ value.type | documented_type }@</span>
                         {% if value.get('required', False) %} / <span style="color: red">required</span>{% endif %}
                     </div>
-                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in v@{value.version_added}@</div>{% endif %}
+                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
                 </td>
                 {# default / choices #}
                 <td>
@@ -296,7 +296,7 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@" colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <b>@{ key }@</b>
                     <div style="font-size: small; color: purple">@{ value.type | documented_type }@</div>
-                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in v@{value.version_added}@</div>{% endif %}
+                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
                 <td>
@@ -368,7 +368,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <b>@{ key }@</b>
                     <div style="font-size: small; color: purple">@{ value.type | documented_type }@</div>
-                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in v@{value.version_added}@</div>{% endif %}
+                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
                 <td>

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -20,7 +20,7 @@
 @{ '+' * title|length }@
 
 {% if version_added is defined and version_added != '' -%}
-.. versionadded:: @{ version_added | default('') }@
+.. versionadded:: v@{ version_added | default('') }@
 {% endif %}
 
 .. contents::
@@ -116,7 +116,7 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 {% endfor %}
                 {# parameter name with required and/or introduced label #}
-                <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@" style="position: relative">
+                <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <b>@{ key }@</b>
                     <div style="font-size: small">
                         <span style="color: purple">@{ value.type | documented_type }@</span>

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -117,12 +117,12 @@ Parameters
                 {% endfor %}
                 {# parameter name with required and/or introduced label #}
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@" style="position: relative">
-                    <b>@{ key }@</b><br/>
+                    <b>@{ key }@</b>
                     <div style="font-size: small">
-                        <div style="color: purple; display: inline">@{ value.type | documented_type }@</div>
-                        {% if value.get('required', False) %} / <div style="color: red; display: inline">required</div>{% endif %}
+                        <span style="color: purple">@{ value.type | documented_type }@</span>
+                        {% if value.get('required', False) %} / <span style="color: red">required</span>{% endif %}
                     </div>
-                    {% if value.version_added %}<div style="align: right; font-style: italic; font-size: small; color: darkgreen">added in v@{value.version_added}@</div>{% endif %}
+                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in v@{value.version_added}@</div>{% endif %}
                 </td>
                 {# default / choices #}
                 <td>
@@ -294,9 +294,9 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
                     <td class="elbow-placeholder"></td>
                 {% endfor %}
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@" colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
-                    <b>@{ key }@</b><br/>
+                    <b>@{ key }@</b>
                     <div style="font-size: small; color: purple">@{ value.type | documented_type }@</div>
-                    {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
+                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
                 <td>
@@ -366,9 +366,9 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <td class="elbow-placeholder">&nbsp;</td>
                 {% endfor %}
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
-                    <b>@{ key }@</b><br/>
+                    <b>@{ key }@</b>
                     <div style="font-size: small; color: purple">@{ value.type | documented_type }@</div>
-                    {% if value.version_added %}<br/><div style="font-size: small; color: darkgreen">(added in @{value.version_added}@)</div>{% endif %}
+                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
                 <td>

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -296,7 +296,7 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@" colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <b>@{ key }@</b>
                     <div style="font-size: small; color: purple">@{ value.type | documented_type }@</div>
-                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
+                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in v@{value.version_added}@</div>{% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
                 <td>
@@ -368,7 +368,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <b>@{ key }@</b>
                     <div style="font-size: small; color: purple">@{ value.type | documented_type }@</div>
-                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
+                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in v@{value.version_added}@</div>{% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
                 <td>


### PR DESCRIPTION
##### SUMMARY
This is part of PR #45805 (of which there is no consensus if we want to do this).

The downside of not doing it fully, is that we won't have the parameter type in most documentation simply because it is missing from the documentation (and we don't use the arg_spec information).

But I am tired of waiting for improving at least this part for the modules I manage.

This PR includes:
- Visual changes to parameter type, required and version_added
- Translation of short type names (e.g. int) to descriptive names (e.g. integer)
- One-level TOC and reorganization/reduction of number of titles
- Improving cell margin/padding to optimize screen estate
- Reorganize support section

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
module docs