### PR TITLE
Allow overwrite of SSH key

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -116,27 +116,27 @@ options:
         aliases: ['createhome']
     move_home:
         description:
-            - If set to C(yes) when used with C(home=), attempt to move the user's old home
-              directory to the specified directory if it isn't there already and the old home exists.
+            - "If set to C(yes) when used with C(home: ), attempt to move the user's old home
+              directory to the specified directory if it isn't there already and the old home exists."
         type: bool
         default: "no"
     system:
         description:
-            - When creating an account C(state=present), setting this to C(yes) makes the user a system account.
-              This setting cannot be changed on existing users.
+            - "When creating an account C(state: present), setting this to C(yes) makes the user a system account.
+              This setting cannot be changed on existing users."
         type: bool
         default: "no"
     force:
         description:
-            - This only affects C(state=absent), it forces removal of the user and associated directories on supported platforms.
-              The behavior is the same as C(userdel --force), check the man page for C(userdel) on your system for details and support.
-            - When used with C(generate_ssh_key=yes) this forces an existing key to be overwritten.
+            - "This only affects C(state: absent), it forces removal of the user and associated directories on supported platforms.
+              The behavior is the same as C(userdel --force), check the man page for C(userdel) on your system for details and support."
+            - "When used with C(generate_ssh_key: yes) this forces an existing key to be overwritten."
         type: bool
         default: "no"
     remove:
         description:
-            - This only affects C(state=absent), it attempts to remove directories associated with the user.
-              The behavior is the same as C(userdel --remove), check the man page for details and support.
+            - "This only affects C(state: absent), it attempts to remove directories associated with the user.
+              The behavior is the same as C(userdel --remove), check the man page for details and support."
         type: bool
         default: "no"
     login_class:
@@ -144,8 +144,8 @@ options:
             - Optionally sets the user's login class, a feature of most BSD OSs.
     generate_ssh_key:
         description:
-            - Whether to generate a SSH key for the user in question.
-              This will not overwrite an existing SSH key unless used with C(force=yes).
+            - "Whether to generate a SSH key for the user in question.
+              This will not overwrite an existing SSH key unless used with C(force: yes)."
         type: bool
         default: "no"
         version_added: "0.9"
@@ -212,7 +212,7 @@ options:
             - Sets the profile of the user.
             - Does nothing when used with other platforms.
             - Can set multiple profiles using comma separation.
-            - To delete all the profiles, use profile=''
+            - "To delete all the profiles, use C(profile: '')"
             - Currently supported on Illumos/Solaris.
         version_added: "2.8"
     authorization:
@@ -220,7 +220,7 @@ options:
             - Sets the authorization of the user.
             - Does nothing when used with other platforms.
             - Can set multiple authorizations using comma separation.
-            - To delete all authorizations, use authorization=''
+            - "To delete all authorizations, use C(authorization: '')"
             - Currently supported on Illumos/Solaris.
         version_added: "2.8"
     role:
@@ -228,7 +228,7 @@ options:
             - Sets the role of the user.
             - Does nothing when used with other platforms.
             - Can set multiple roles using comma separation.
-            - To delete all roles, use role=''
+            - "To delete all roles, use C(role: '')"
             - Currently supported on Illumos/Solaris.
         version_added: "2.8"
 '''
@@ -892,7 +892,7 @@ class User(object):
                 # ssh-keygen doesn't support overwriting the key interactively, so send 'y' to confirm
                 overwrite = 'y'
             else:
-                return (None, 'Key already exists, use force=yes to overwrite', '')
+                return (None, 'Key already exists, use "force: yes" to overwrite', '')
         cmd = [self.module.get_bin_path('ssh-keygen', True)]
         cmd.append('-t')
         cmd.append(self.ssh_type)


### PR DESCRIPTION
##### SUMMARY
Add support to user.py for overwriting an existing SSH key. Fixes #23439 and replaces previous PR #42146.

The user module is able to generate an SSH key for a new user, but is not able to overwrite an existing key. In some scenarios it is useful to regenerate SSH keys, such as when they have been compromised or a templated filesystem is used. This PR introduces this capability, by using the existing `force` parameter (it seemed a simpler approach). There should be no clash, since the parameter is currently used when removing a user, and this PR will make use of it when adding/modifying a user.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
user.py

##### ANSIBLE VERSION
Tested with Ubuntu 16.04.5, Ansible 2.7.4 and Python 2.7.12

##### ADDITIONAL INFORMATION
The ssh-keygen command only supports overwriting an existing key interactively, by answering 'y' when prompted. This PR uses the data parameter of run_command to send 'y' to stdin.