### PR TITLE
ec2_vpc_nacl fails when the VPC is configured with IPv6

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
@@ -169,8 +169,8 @@ DEFAULT_RULE_FIELDS_IPV6 = {
     'Protocol': '-1'
 }
 
-DEFAULT_INGRESS = [ dict(list(DEFAULT_RULE_FIELDS.items()) + [('Egress', False)]), dict(list(DEFAULT_RULE_FIELDS_IPV6.items()) + [('Egress', False)]) ]
-DEFAULT_EGRESS = [ dict(list(DEFAULT_RULE_FIELDS.items()) + [('Egress', True)]), dict(list(DEFAULT_RULE_FIELDS_IPV6.items()) + [('Egress', True)]) ]
+DEFAULT_INGRESS = [dict(list(DEFAULT_RULE_FIELDS.items()) + [('Egress', False)]), dict(list(DEFAULT_RULE_FIELDS_IPV6.items()) + [('Egress', False)])]
+DEFAULT_EGRESS = [dict(list(DEFAULT_RULE_FIELDS.items()) + [('Egress', True)]), dict(list(DEFAULT_RULE_FIELDS_IPV6.items()) + [('Egress', True)])]
 
 def match_default_rules(rule, egress):
     default_rules = DEFAULT_EGRESS if egress else DEFAULT_INGRESS

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
@@ -225,7 +225,7 @@ def nacls_changed(nacl, client, module):
     nacl_id = nacl['NetworkAcls'][0]['NetworkAclId']
     nacl = describe_network_acl(client, module)
     entries = nacl['NetworkAcls'][0]['Entries']
-    tmp_egress = [entry for entry in entries if entry['Egress'] is True and rule['RuleNumber'] < 32767]
+    tmp_egress = [entry for entry in entries if entry['Egress'] is True and entry['RuleNumber'] < 32767]
     tmp_ingress = [entry for entry in entries if entry['Egress'] is False]
     egress = [rule for rule in tmp_egress if rule['RuleNumber'] < 32767]
     ingress = [rule for rule in tmp_ingress if rule['RuleNumber'] < 32767]

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
@@ -225,10 +225,8 @@ def nacls_changed(nacl, client, module):
     nacl_id = nacl['NetworkAcls'][0]['NetworkAclId']
     nacl = describe_network_acl(client, module)
     entries = nacl['NetworkAcls'][0]['Entries']
-    tmp_egress = [entry for entry in entries if entry['Egress'] is True and entry['RuleNumber'] < 32767]
-    tmp_ingress = [entry for entry in entries if entry['Egress'] is False]
-    egress = [rule for rule in tmp_egress if rule['RuleNumber'] < 32767]
-    ingress = [rule for rule in tmp_ingress if rule['RuleNumber'] < 32767]
+    egress = [rule for rule in entries if rule['Egress'] is True and rule['RuleNumber'] < 32767]
+    ingress = [rule for rule in entries if rule['Egress'] is False and rule['RuleNumber'] < 32767]
     if rules_changed(egress, params['egress'], True, nacl_id, client, module):
         changed = True
     if rules_changed(ingress, params['ingress'], False, nacl_id, client, module):

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
@@ -162,8 +162,21 @@ DEFAULT_RULE_FIELDS = {
     'Protocol': '-1'
 }
 
-DEFAULT_INGRESS = dict(list(DEFAULT_RULE_FIELDS.items()) + [('Egress', False)])
-DEFAULT_EGRESS = dict(list(DEFAULT_RULE_FIELDS.items()) + [('Egress', True)])
+DEFAULT_RULE_FIELDS_IPV6 = {
+    'RuleNumber': 32768,
+    'RuleAction': 'deny',
+    'CidrBlock': '::/0',
+    'Protocol': '-1'
+}
+
+DEFAULT_INGRESS = [ dict(list(DEFAULT_RULE_FIELDS.items()) + [('Egress', False)]), dict(list(DEFAULT_RULE_FIELDS_IPV6.items()) + [('Egress', False)]) ]
+DEFAULT_EGRESS = [ dict(list(DEFAULT_RULE_FIELDS.items()) + [('Egress', True)]), dict(list(DEFAULT_RULE_FIELDS_IPV6.items()) + [('Egress', True)]) ]
+
+def match_default_rules(rule, egress):
+    default_rules = DEFAULT_EGRESS if egress else DEFAULT_INGRESS
+    for r in default_rules:
+        if r['RuleNumber'] == rule['RuleNumber']:
+            return True
 
 # VPC-supported IANA protocol numbers
 # http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
@@ -236,10 +249,10 @@ def nacls_changed(nacl, client, module):
     nacl_id = nacl['NetworkAcls'][0]['NetworkAclId']
     nacl = describe_network_acl(client, module)
     entries = nacl['NetworkAcls'][0]['Entries']
-    tmp_egress = [entry for entry in entries if entry['Egress'] is True and DEFAULT_EGRESS != entry]
+    tmp_egress = [entry for entry in entries if entry['Egress'] is True and not match_default_rules(entry, True)]
     tmp_ingress = [entry for entry in entries if entry['Egress'] is False]
-    egress = [rule for rule in tmp_egress if DEFAULT_EGRESS != rule]
-    ingress = [rule for rule in tmp_ingress if DEFAULT_INGRESS != rule]
+    egress = [rule for rule in tmp_egress if not match_default_rules(rule, True)]
+    ingress = [rule for rule in tmp_ingress if not match_default_rules(rule, False)]
     if rules_changed(egress, params['egress'], True, nacl_id, client, module):
         changed = True
     if rules_changed(ingress, params['ingress'], False, nacl_id, client, module):

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
@@ -172,12 +172,6 @@ DEFAULT_RULE_FIELDS_IPV6 = {
 DEFAULT_INGRESS = [dict(list(DEFAULT_RULE_FIELDS.items()) + [('Egress', False)]), dict(list(DEFAULT_RULE_FIELDS_IPV6.items()) + [('Egress', False)])]
 DEFAULT_EGRESS = [dict(list(DEFAULT_RULE_FIELDS.items()) + [('Egress', True)]), dict(list(DEFAULT_RULE_FIELDS_IPV6.items()) + [('Egress', True)])]
 
-def match_default_rules(rule, egress):
-    default_rules = DEFAULT_EGRESS if egress else DEFAULT_INGRESS
-    for r in default_rules:
-        if r['RuleNumber'] == rule['RuleNumber']:
-            return True
-
 # VPC-supported IANA protocol numbers
 # http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
 PROTOCOL_NUMBERS = {'all': -1, 'icmp': 1, 'tcp': 6, 'udp': 17, }
@@ -187,6 +181,13 @@ PROTOCOL_NUMBERS = {'all': -1, 'icmp': 1, 'tcp': 6, 'udp': 17, }
 def icmp_present(entry):
     if len(entry) == 6 and entry[1] == 'icmp' or entry[1] == 1:
         return True
+
+
+def match_default_rules(rule, egress):
+    default_rules = DEFAULT_EGRESS if egress else DEFAULT_INGRESS
+    for r in default_rules:
+        if r['RuleNumber'] == rule['RuleNumber']:
+            return True
 
 
 def load_tags(module):


### PR DESCRIPTION
##### SUMMARY
The ec2_vpc_nacl module always fails when an AWS VPC is configured with an IPv6 subnet. When a user executes an ec2_vpc_nacl task, an error message occurs and the following error message is displayed: 

"msg": "An error occurred (InvalidParameterValue) when calling the DeleteNetworkAclEntry operation: Value (32768) for parameter ruleNumber is invalid. Rulenumber must be in range 1..32766"

Fixes #41079 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_nacl

##### ADDITIONAL INFORMATION
During execution, the ec2_vpc_nacl the module builds a list of NACL rules that need to be deleted, then attempts to delete the rules. Rules which exist in the AWS VPC but not in the Ansible YAML are candidates for deletion. However, the module should not attempt to delete the "default" DENY rules because these rules must always be present and cannot be deleted.

The default rule for IPv4 has Rule Number 32767. The ec2_vpc_nacl module has built-in knowledge of this rule. The default rule for IPv6 has Rule Number 32768. The ec2_vpc_nacl module does NOT have built-in knowledge of this rule.  The module calls delete_network_acl_entry() with the default rule for IPv6. The module has a test to skip the default IPv4 rule ( number 32767), but it does not skip the IPv6 default rule, which has rule number 32768.

```
* | ALL Traffic | ALL | ALL | 0.0.0.0/0 | DENY |  
* | ALL Traffic | ALL | ALL | ::/0          | DENY |   <== Rule with Number 32768.
```

DEFAULT_RULE_FIELDS = {
    'RuleNumber': 32767,
    'RuleAction': 'deny',
    'CidrBlock': '0.0.0.0/0',
    'Protocol': '-1'
}

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
"msg": "An error occurred (InvalidParameterValue) when calling the DeleteNetworkAclEntry operation: Value (32768) for parameter ruleNumber is invalid. Rulenumber must be in range 1..32766"
```

