### PR TITLE
Filter DNSimple request by record name.

### DIFF
--- a/changelogs/fragments/49981-filter-dnsimple-request-by-record-name.yaml
+++ b/changelogs/fragments/49981-filter-dnsimple-request-by-record-name.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - fix DNSimple to ensure check works even when the number of records is larger than 100

--- a/lib/ansible/modules/net_tools/dnsimple.py
+++ b/lib/ansible/modules/net_tools/dnsimple.py
@@ -236,7 +236,7 @@ def main():
 
         # need the not none check since record could be an empty string
         if domain and record is not None:
-            records = [r['record'] for r in client.records(str(domain))]
+            records = [r['record'] for r in client.records(str(domain), params={'name': record})]
 
             if not record_type:
                 module.fail_json(msg="Missing the record type")


### PR DESCRIPTION
The request was not filtered and DNSimple returns only the first 100
records so if the number of records is larger the check could fail.

This patch fixes the issue and also makes the check to perform better.

##### SUMMARY

Fixes #49980

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

dnsimple
