### PR TITLE
ovirt: default save true in setup host networks

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -89,6 +89,8 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
+# In all examples the durability of the configuration created is dependent on the 'save' option value:
+
 # Create bond on eth0 and eth1 interface, and put 'myvlan' network on top of it and persist the new configuration:
 - name: Bonds
   ovirt_host_network:
@@ -108,7 +110,7 @@ EXAMPLES = '''
         gateway: 1.2.3.4
         version: v4
 
-# Create bond on eth1 and eth2 interface, specifiyng both mode and miimon temporarily:
+# Create bond on eth1 and eth2 interface, specifiyng both mode and miimon:
 - name: Bonds
   ovirt_host_network:
     name: myhost
@@ -121,14 +123,14 @@ EXAMPLES = '''
         - eth1
         - eth2
 
-# Remove bond0 bond from host interfaces temporarily:
+# Remove bond0 bond from host interfaces:
 - ovirt_host_network:
     state: absent
     name: myhost
     bond:
       name: bond0
 
-# Assign myvlan1 and myvlan2 vlans to host eth0 interface temporarily:
+# Assign myvlan1 and myvlan2 vlans to host eth0 interface:
 - ovirt_host_network:
     name: myhost
     interface: eth0
@@ -136,7 +138,7 @@ EXAMPLES = '''
       - name: myvlan1
       - name: myvlan2
 
-# Remove myvlan2 vlan from host eth0 interface temporarily:
+# Remove myvlan2 vlan from host eth0 interface:
 - ovirt_host_network:
     state: absent
     name: myhost
@@ -144,7 +146,7 @@ EXAMPLES = '''
     networks:
       - name: myvlan2
 
-# Remove all networks/vlans from host eth0 interface temporarily:
+# Remove all networks/vlans from host eth0 interface:
 - ovirt_host_network:
     state: absent
     name: myhost

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -74,7 +74,7 @@ options:
         type: bool
     save:
         description:
-            - "If I(true) network configuration will be persistent, by default they are temporarily."
+            - "If I(false) network configuration will be temporary, by default they are persistent."
         type: bool
     sync_networks:
         description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -74,7 +74,7 @@ options:
         type: bool
     save:
         description:
-            - "If I(false) network configuration will be temporary, by default they are persistent."
+            - "If I(false) network configuration will be temporary until next boot, by default they are persistent."
         type: bool
     sync_networks:
         description:
@@ -462,7 +462,6 @@ def main():
                         ],
                     ) for network in networks
                 ] if networks else None,
-                save=module.params['save'],
             )
         elif state == 'absent' and nic:
             attachments = []
@@ -503,7 +502,6 @@ def main():
                         otypes.NetworkLabel(id=str(name)) for name in labels
                     ] if labels else None,
                     removed_network_attachments=attachments if attachments else None,
-                    save=module.params['save'],
                 )
 
         nic = search_by_name(nics_service, nic_name)

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -348,7 +348,7 @@ def main():
         networks=dict(default=None, type='list'),
         labels=dict(default=None, type='list'),
         check=dict(default=None, type='bool'),
-        save=dict(default=None, type='bool'),
+        save=dict(default=True, type='bool'),
         sync_networks=dict(default=False, type='bool'),
     )
     module = AnsibleModule(argument_spec=argument_spec)
@@ -462,6 +462,7 @@ def main():
                         ],
                     ) for network in networks
                 ] if networks else None,
+                save=module.params['save'],
             )
         elif state == 'absent' and nic:
             attachments = []
@@ -502,6 +503,7 @@ def main():
                         otypes.NetworkLabel(id=str(name)) for name in labels
                     ] if labels else None,
                     removed_network_attachments=attachments if attachments else None,
+                    save=module.params['save'],
                 )
 
         nic = search_by_name(nics_service, nic_name)

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -74,8 +74,9 @@ options:
         type: bool
     save:
         description:
-            - "If I(true) network configuration will be persistent, otherwise it is temporary. Since Ansible 2.8 I(true) is the default."
+            - "If I(true) network configuration will be persistent, otherwise it is temporary. Default I(true) since Ansible 2.8."
         type: bool
+        default: True
     sync_networks:
         description:
             - "If I(true) all networks will be synchronized before modification"

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -74,7 +74,7 @@ options:
         type: bool
     save:
         description:
-            - "If I(false) network configuration will be temporary until next boot, by default they are persistent."
+            - "If I(true) network configuration will be persistent, otherwise it is temporary. Since Ansible 2.8 I(true) is the default."
         type: bool
     sync_networks:
         description:


### PR DESCRIPTION
Default value for save updated network configuration
during setup host networks is set to true.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_host_network

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
needs update of the api-model and regeneration of ovirt-sdk4
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
