### PR TITLE
certificate_complete_chain: fix stacktrace on parsing error

### DIFF
--- a/lib/ansible/modules/crypto/certificate_complete_chain.py
+++ b/lib/ansible/modules/crypto/certificate_complete_chain.py
@@ -230,6 +230,7 @@ def load_PEM_list(module, path, fail_on_error=True):
             module.fail_json(msg=msg)
         else:
             module.warn(msg)
+            return []
 
 
 class CertificateSet(object):


### PR DESCRIPTION
##### SUMMARY
Fixes stacktrace in `CertificateSet._load_file()` when `load_PEM_list()` fails.

Fixes #49986.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
certificate_complete_chain
