### PR TITLE
[2.7] certificate_complete_chain: fix stacktrace on parsing error

### DIFF
--- a/changelogs/fragments/49987-certificate_complete_chain-error.yml
+++ b/changelogs/fragments/49987-certificate_complete_chain-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "certificate_complete_chain - fix behavior when invalid file is parsed while reading intermediate or root certificates."

--- a/lib/ansible/modules/crypto/certificate_complete_chain.py
+++ b/lib/ansible/modules/crypto/certificate_complete_chain.py
@@ -230,6 +230,7 @@ def load_PEM_list(module, path, fail_on_error=True):
             module.fail_json(msg=msg)
         else:
             module.warn(msg)
+            return []
 
 
 class CertificateSet(object):


### PR DESCRIPTION
##### SUMMARY
Backport of #49987 to stable-2.7: fix stacktrace when error happens while parsing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
certificate_complete_chain
