### PR TITLE
shell & multiline YAML free form: add integration test

### DIFF
--- a/test/integration/targets/parsing/roles/test_good_parsing/tasks/main.yml
+++ b/test/integration/targets/parsing/roles/test_good_parsing/tasks/main.yml
@@ -108,7 +108,23 @@
 
 - assert:
     that:
-       result.stdout_lines == [ 'old', 'mcdonald', 'had', 'a', 'farm' ]
+      - result.cmd == 'echo old\necho mcdonald\necho had\necho a\necho farm\n'
+      - result.stdout_lines == [ 'old', 'mcdonald', 'had', 'a', 'farm' ]
+
+- name: 'multi-line inline shell commands (without variable, see: #45853)'
+  # literal block styles with strip block chomping indicator and 3 spaces indentation
+  shell: |-3
+     cat - <<'EOF'
+     line1
+      line2
+     line3
+     EOF
+  register: result
+
+- assert:
+    that:
+      - result.cmd == "cat - <<'EOF'\nline1\n line2\nline3\nEOF"
+      - result.stdout_lines == [ 'line1', ' line2', 'line3' ]
 
 - name: passing same arg to shell command is legit
   shell: echo foo --arg=a --arg=b


### PR DESCRIPTION
##### SUMMARY

Ensure whitespace isn't added after a newline (see #45853 and #46380). This bug didn't occur when free form is a Jinja variable, hence this new test.

Using:
- either `devel` without b72e989e1837ccad8dcdc926c43ccbc4d8cdfe44
- or `stable-2.7` (bugfix hasn't been backported to stable-2.7)

this new test fails:
```
TASK [test_good_parsing : multi-line inline shell commands (without variable, see: #45853)] ***
changed: [testhost] => {"changed": true, "cmd": "cat - <<'EOF'\n line1\n line2\n line3\n EOF", "delta": "0:00:00.014396", "end": "2018-12-17 01:12:37.611955", "rc": 0, "start": "2018-12-17 01:12:37.597559", "stderr": "/bin/sh: line 4: warning: here-document at line 0 delimited by end-of-file (wanted `EOF')", "stderr_lines": ["/bin/sh: line 4: warning: here-document at line 0 delimited by end-of-file (wanted `EOF')"], "stdout": " line1\n line2\n line3\n EOF", "stdout_lines": [" line1", " line2", " line3", " EOF"]}

TASK [test_good_parsing : assert] ***
fatal: [testhost]: FAILED! => {
    "assertion": "result.cmd == \"cat - <<'EOF'\\nline1\\n line2\\nline3\\nEOF\"", 
    "changed": false, 
    "evaluated_to": false, 
    "msg": "Assertion failed"
}

```

This new test also fails on `devel` (with or without #46380 applied):
```
TASK [test_good_parsing : multi-line inline shell commands (without variable, see: #45853)] ***
changed: [testhost] => {"changed": true, "cmd": "cat - <<'EOF'\nline1\nline2\nline3\nEOF", "delta": "0:00:00.014264", "end": "2018-12-17 01:05:40.730822", "rc": 0, "start": "2018-12-17 01:05:40.716558", "stderr": "", "stderr_lines": [], "stdout": "line1\nline2\nline3", "stdout_lines": ["line1", "line2", "line3"]}

TASK [test_good_parsing : assert] ***
fatal: [testhost]: FAILED! => {
    "assertion": "result.cmd == \"cat - <<'EOF'\\nline1\\n line2\\nline3\\nEOF\"", 
    "changed": false, 
    "evaluated_to": false, 
    "msg": "Assertion failed"
}
```

@dagwieers should not this test pass on `devel` with #46380 applied ?

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/parsing/roles/test_good_parsing/tasks/main.yml

##### ADDITIONAL INFORMATION
