### PR TITLE
ACI: Add types to modules and  doc fragment

### DIFF
--- a/lib/ansible/modules/network/aci/aci_aaa_user.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user.py
@@ -37,6 +37,7 @@ options:
   aaa_password:
     description:
     - The password of the locally-authenticated user.
+    type: str
   aaa_password_lifetime:
     description:
     - The lifetime of the locally-authenticated user password.
@@ -48,6 +49,7 @@ options:
   aaa_user:
     description:
     - The name of the locally-authenticated user user to add.
+    type: str
     aliases: [ name, user ]
   clear_password_history:
     description:
@@ -56,10 +58,12 @@ options:
   description:
     description:
     - Description for the AAA user.
+    type: str
     aliases: [ descr ]
   email:
     description:
     - The email address of the locally-authenticated user.
+    type: str
   enabled:
     description:
     - The status of the locally-authenticated user account.
@@ -67,6 +71,7 @@ options:
   expiration:
     description:
     - The expiration date of the locally-authenticated user account.
+    type: str
   expires:
     description:
     - Whether to enable an expiration date for the locally-authenticated user account.
@@ -74,16 +79,20 @@ options:
   first_name:
     description:
     - The first name of the locally-authenticated user.
+    type: str
   last_name:
     description:
     - The last name of the locally-authenticated user.
+    type: str
   phone:
     description:
     - The phone number of the locally-authenticated user.
+    type: str
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
+++ b/lib/ansible/modules/network/aci/aci_aaa_user_certificate.py
@@ -32,24 +32,29 @@ options:
   aaa_user:
     description:
     - The name of the user to add a certificate to.
+    type: str
     required: yes
   aaa_user_type:
     description:
     - Whether this is a normal user or an appuser.
+    type: str
     choices: [ appuser, user ]
     default: user
   certificate:
     description:
     - The PEM format public key extracted from the X.509 certificate.
+    type: str
     aliases: [ cert_data, certificate_data ]
   certificate_name:
     description:
     - The name of the user certificate entry in ACI.
+    type: str
     aliases: [ cert_name ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_access_port_block_to_access_port.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_block_to_access_port.py
@@ -28,16 +28,19 @@ options:
   leaf_interface_profile:
     description:
     - The name of the Fabric access policy leaf interface profile.
+    type: str
     required: yes
     aliases: [ leaf_interface_profile_name ]
   access_port_selector:
     description:
     -  The name of the Fabric access policy leaf interface profile access port selector.
+    type: str
     required: yes
     aliases: [ name, access_port_selector_name ]
   leaf_port_blk:
     description:
     - The name of the Fabric access policy leaf interface profile access port block.
+    type: str
     required: yes
     aliases: [ leaf_port_blk_name ]
   leaf_port_blk_description:
@@ -46,25 +49,30 @@ options:
   from_port:
     description:
     - The beginning (from-range) of the port range block for the leaf access port block.
-    aliases: [ from, fromPort, from_port_range ]
+    type: str
     required: yes
+    aliases: [ from, fromPort, from_port_range ]
   to_port:
     description:
     - The end (to-range) of the port range block for the leaf access port block.
-    aliases: [ to, toPort, to_port_range ]
+    type: str
     required: yes
+    aliases: [ to, toPort, to_port_range ]
   from_card:
     description:
     - The beginning (from-range) of the card range block for the leaf access port block.
+    type: str
     aliases: [ from_card_range ]
   to_card:
     description:
     - The end (to-range) of the card range block for the leaf access port block.
+    type: str
     aliases: [ to_card_range ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -28,16 +28,19 @@ options:
   leaf_interface_profile:
     description:
     - The name of the Fabric access policy leaf interface profile.
+    type: str
     required: yes
     aliases: [ leaf_interface_profile_name ]
   access_port_selector:
     description:
     -  The name of the Fabric access policy leaf interface profile access port selector.
+    type: str
     required: yes
     aliases: [ name, access_port_selector_name ]
   description:
     description:
     - The description to assign to the C(access_port_selector)
+    type: str
   leaf_port_blk:
     description:
     - B(Deprecated)
@@ -45,6 +48,7 @@ options:
     - The parameter will be removed in Ansible 2.12.
     - HORIZONTALLINE
     - The name of the Fabric access policy leaf interface profile access port block.
+    type: str
     required: yes
     aliases: [ leaf_port_blk_name ]
   leaf_port_blk_description:
@@ -54,6 +58,7 @@ options:
     - The parameter will be removed in Ansible 2.12.
     - HORIZONTALLINE
     - The description to assign to the C(leaf_port_blk)
+    type: str
   from_port:
     description:
     - B(Deprecated)
@@ -61,8 +66,9 @@ options:
     - The parameter will be removed in Ansible 2.12.
     - HORIZONTALLINE
     - The beginning (from-range) of the port range block for the leaf access port block.
-    aliases: [ from, fromPort, from_port_range ]
+    type: str
     required: yes
+    aliases: [ from, fromPort, from_port_range ]
   to_port:
     description:
     - B(Deprecated)
@@ -70,8 +76,9 @@ options:
     - The parameter will be removed in Ansible 2.12.
     - HORIZONTALLINE
     - The end (to-range) of the port range block for the leaf access port block.
-    aliases: [ to, toPort, to_port_range ]
+    type: str
     required: yes
+    aliases: [ to, toPort, to_port_range ]
   from_card:
     description:
     - B(Deprecated)
@@ -79,6 +86,7 @@ options:
     - The parameter will be removed in Ansible 2.12.
     - HORIZONTALLINE
     - The beginning (from-range) of the card range block for the leaf access port block.
+    type: str
     aliases: [ from_card_range ]
     version_added: '2.6'
   to_card:
@@ -88,15 +96,18 @@ options:
     - The parameter will be removed in Ansible 2.12.
     - HORIZONTALLINE
     - The end (to-range) of the card range block for the leaf access port block.
+    type: str
     aliases: [ to_card_range ]
     version_added: '2.6'
   policy_group:
     description:
     - The name of the fabric access policy group to be associated with the leaf interface profile interface selector.
+    type: str
     aliases: [ policy_group_name ]
   interface_type:
     description:
     - The type of interface for the static EPG deployement.
+    type: str
     choices: [ fex, port_channel, switch_port, vpc ]
     default: switch_port
     version_added: '2.6'
@@ -104,6 +115,7 @@ options:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_aep.py
+++ b/lib/ansible/modules/network/aci/aci_aep.py
@@ -28,11 +28,13 @@ options:
   aep:
     description:
     - The name of the Attachable Access Entity Profile.
+    type: str
     required: yes
     aliases: [ aep_name, name ]
   description:
     description:
     - Description for the AEP.
+    type: str
     aliases: [ descr ]
   infra_vlan:
     description:
@@ -47,6 +49,7 @@ options:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     default: present
     choices: [ absent, present, query ]
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_aep_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_aep_to_domain.py
@@ -33,20 +33,24 @@ options:
   aep:
     description:
     - The name of the Attachable Access Entity Profile.
+    type: str
     aliases: [ aep_name ]
   domain:
     description:
     - Name of the physical or virtual domain being associated with the AEP.
+    type: str
     aliases: [ domain_name, domain_profile ]
   domain_type:
     description:
     - Determines if the Domain is physical (phys) or virtual (vmm).
+    type: str
     choices: [ fc, l2dom, l3dom, phys, vmm ]
     aliases: [ type ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
   vm_provider:
@@ -54,6 +58,7 @@ options:
     - The VM platform for VMM Domains.
     - Support for Kubernetes was added in ACI v3.0.
     - Support for CloudFoundry, OpenShift and Red Hat was added in ACI v3.1.
+    type: str
     choices: [ cloudfoundry, kubernetes, microsoft, openshift, openstack, redhat, vmware ]
 extends_documentation_fragment: aci
 '''

--- a/lib/ansible/modules/network/aci/aci_ap.py
+++ b/lib/ansible/modules/network/aci/aci_ap.py
@@ -29,26 +29,30 @@ author:
 - Swetha Chunduri (@schunduri)
 version_added: '2.4'
 options:
-   tenant:
-     description:
-     - The name of an existing tenant.
-     required: yes
-     aliases: [ tenant_name ]
-   ap:
-     description:
-     - The name of the application network profile.
-     required: yes
-     aliases: [ app_profile, app_profile_name, name ]
-   description:
-     description:
-     - Description for the AP.
-     aliases: [ descr ]
-   state:
-     description:
-     - Use C(present) or C(absent) for adding or removing.
-     - Use C(query) for listing an object or multiple objects.
-     choices: [ absent, present, query ]
-     default: present
+  tenant:
+    description:
+    - The name of an existing tenant.
+    type: str
+    required: yes
+    aliases: [ tenant_name ]
+  ap:
+    description:
+    - The name of the application network profile.
+    type: str
+    required: yes
+    aliases: [ app_profile, app_profile_name, name ]
+  description:
+    description:
+    - Description for the AP.
+    type: str
+    aliases: [ descr ]
+  state:
+    description:
+    - Use C(present) or C(absent) for adding or removing.
+    - Use C(query) for listing an object or multiple objects.
+    type: str
+    choices: [ absent, present, query ]
+    default: present
 extends_documentation_fragment: aci
 '''
 

--- a/lib/ansible/modules/network/aci/aci_bd.py
+++ b/lib/ansible/modules/network/aci/aci_bd.py
@@ -36,15 +36,18 @@ options:
   bd:
     description:
     - The name of the Bridge Domain.
+    type: str
     aliases: [ bd_name, name ]
   bd_type:
     description:
     - The type of traffic on the Bridge Domain.
     - The APIC defaults to C(ethernet) when unset during creation.
+    type: str
     choices: [ ethernet, fc ]
   description:
     description:
     - Description for the Bridge Domain.
+    type: str
   enable_multicast:
     description:
     - Determines if PIM is enabled.
@@ -65,20 +68,24 @@ options:
     description:
     - Determines if GARP should be enabled to detect when End Points move.
     - The APIC defaults to C(garp) when unset during creation.
+    type: str
     choices: [ default, garp ]
   endpoint_retention_action:
     description:
     - Determines if the Bridge Domain should inherit or resolve the End Point Retention Policy.
     - The APIC defaults to C(resolve) when unset during creation.
+    type: str
     choices: [ inherit, resolve ]
   endpoint_retention_policy:
     description:
     - The name of the End Point Retention Policy the Bridge Domain should use when
       overriding the default End Point Retention Policy.
+    type: str
   igmp_snoop_policy:
     description:
     - The name of the IGMP Snooping Policy the Bridge Domain should use when
       overriding the default IGMP Snooping Policy.
+    type: str
   ip_learning:
     description:
     - Determines if the Bridge Domain should learn End Point IPs.
@@ -88,15 +95,18 @@ options:
     description:
     - The name of the IPv6 Neighbor Discovery Policy the Bridge Domain should use when
       overridding the default IPV6 ND Policy.
+    type: str
   l2_unknown_unicast:
     description:
     - Determines what forwarding method to use for unknown l2 destinations.
     - The APIC defaults to C(proxy) when unset during creation.
+    type: str
     choices: [ proxy, flood ]
   l3_unknown_multicast:
     description:
     - Determines the forwarding method to use for unknown multicast destinations.
     - The APIC defaults to C(flood) when unset during creation.
+    type: str
     choices: [ flood, opt-flood ]
   limit_ip_learn:
     description:
@@ -107,26 +117,31 @@ options:
     description:
     - The MAC Address to assign to the C(bd) instead of using the default.
     - The APIC defaults to C(00:22:BD:F8:19:FF) when unset during creation.
+    type: str
     aliases: [ mac ]
     version_added: '2.5'
   multi_dest:
     description:
     - Determines the forwarding method for L2 multicast, broadcast, and link layer traffic.
     - The APIC defaults to C(bd-flood) when unset during creation.
+    type: str
     choices: [ bd-flood, drop, encap-flood ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
   tenant:
     description:
     - The name of the Tenant.
+    type: str
     aliases: [ tenant_name ]
   vrf:
     description:
     - The name of the VRF.
+    type: str
     aliases: [ vrf_name ]
 extends_documentation_fragment: aci
 '''

--- a/lib/ansible/modules/network/aci/aci_bd_subnet.py
+++ b/lib/ansible/modules/network/aci/aci_bd_subnet.py
@@ -34,10 +34,12 @@ options:
   bd:
     description:
     - The name of the Bridge Domain.
+    type: str
     aliases: [ bd_name ]
   description:
     description:
     - The description for the Subnet.
+    type: str
     aliases: [ descr ]
   enable_vip:
     description:
@@ -47,6 +49,7 @@ options:
   gateway:
     description:
     - The IPv4 or IPv6 gateway address for the Subnet.
+    type: str
     aliases: [ gateway_ip ]
   mask:
     description:
@@ -59,6 +62,7 @@ options:
   nd_prefix_policy:
     description:
     - The IPv6 Neighbor Discovery Prefix Policy to associate with the Subnet.
+    type: str
   preferred:
     description:
     - Determines if the Subnet is preferred over all available Subnets. Only one Subnet per Address Family (IPv4/IPv6).
@@ -68,9 +72,11 @@ options:
   route_profile:
     description:
     - The Route Profile to the associate with the Subnet.
+    type: str
   route_profile_l3_out:
     description:
     - The L3 Out that contains the assocated Route Profile.
+    type: str
   scope:
     description:
     - Determines the scope of the Subnet.
@@ -92,19 +98,23 @@ options:
     - The C(nd_ra) option is used to treate the gateway_ip address as a Neighbor Discovery Router Advertisement Prefix.
     - The C(no_gw) option is used to remove default gateway functionality from the gateway address.
     - The APIC defaults to C(nd_ra) when unset during creation.
+    type: str
     choices: [ nd_ra, no_gw, querier_ip, unspecified ]
   subnet_name:
     description:
     - The name of the Subnet.
+    type: str
     aliases: [ name ]
   tenant:
     description:
     - The name of the Tenant.
+    type: str
     aliases: [ tenant_name ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
@@ -32,18 +32,22 @@ options:
   bd:
     description:
     - The name of the Bridge Domain.
+    type: str
     aliases: [ bd_name, bridge_domain ]
   l3out:
     description:
     - The name of the l3out to associate with th Bridge Domain.
+    type: str
   tenant:
     description:
     - The name of the Tenant.
+    type: str
     aliases: [ tenant_name ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_config_rollback.py
+++ b/lib/ansible/modules/network/aci/aci_config_rollback.py
@@ -29,16 +29,20 @@ options:
   compare_export_policy:
     description:
     - The export policy that the C(compare_snapshot) is associated to.
+    type: str
   compare_snapshot:
     description:
     - The name of the snapshot to compare with C(snapshot).
+    type: str
   description:
     description:
     - The description for the Import Policy.
+    type: str
     aliases: [ descr ]
   export_policy:
     description:
     - The export policy that the C(snapshot) is associated to.
+    type: str
     required: yes
   fail_on_decrypt:
     description:
@@ -49,24 +53,29 @@ options:
     description:
     - Determines how the import should be handled by the APIC.
     - The APIC defaults to C(atomic) when unset.
+    type: str
     choices: [ atomic, best-effort ]
   import_policy:
     description:
     - The name of the Import Policy to use for config rollback.
+    type: str
   import_type:
     description:
     - Determines how the current and snapshot configuration should be compared for replacement.
     - The APIC defaults to C(replace) when unset.
+    type: str
     choices: [ merge, replace ]
   snapshot:
     description:
     - The name of the snapshot to rollback to, or the base snapshot to use for comparison.
     - The C(aci_snapshot) module can be used to query the list of available snapshots.
+    type: str
     required: yes
   state:
     description:
     - Use C(preview) for previewing the diff between two snapshots.
     - Use C(rollback) for reverting the configuration to a previous snapshot.
+    type: str
     choices: [ preview, rollback ]
     default: rollback
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_config_snapshot.py
+++ b/lib/ansible/modules/network/aci/aci_config_snapshot.py
@@ -34,15 +34,18 @@ options:
   description:
     description:
     - The description for the Config Export Policy.
+    type: str
     aliases: [ descr ]
   export_policy:
     description:
     - The name of the Export Policy to use for Config Snapshots.
+    type: str
     aliases: [ name ]
   format:
     description:
     - Sets the config backup to be formatted in JSON or XML.
     - The APIC defaults to C(json) when unset.
+    type: str
     choices: [ json, xml ]
   include_secure:
     description:
@@ -58,10 +61,12 @@ options:
   snapshot:
     description:
     - The name of the snapshot to delete.
+    type: str
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_contract.py
+++ b/lib/ansible/modules/network/aci/aci_contract.py
@@ -34,37 +34,44 @@ options:
   contract:
     description:
     - The name of the contract.
+    type: str
     required: yes
     aliases: [ contract_name, name ]
   description:
     description:
     - Description for the contract.
+    type: str
     aliases: [ descr ]
   tenant:
     description:
     - The name of the tenant.
+    type: str
     required: yes
     aliases: [ tenant_name ]
   scope:
     description:
     - The scope of a service contract.
     - The APIC defaults to C(context) when unset during creation.
+    type: str
     choices: [ application-profile, context, global, tenant ]
   priority:
     description:
     - The desired QoS class to be used.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
     choices: [ level1, level2, level3, unspecified ]
   dscp:
     description:
     - The target Differentiated Service (DSCP) value.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
     choices: [ AF11, AF12, AF13, AF21, AF22, AF23, AF31, AF32, AF33, AF41, AF42, AF43, CS0, CS1, CS2, CS3, CS4, CS5, CS6, CS7, EF, VA, unspecified ]
     aliases: [ target ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_contract_subject.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject.py
@@ -32,14 +32,17 @@ options:
   tenant:
     description:
     - The name of the tenant.
+    type: str
     aliases: [ tenant_name ]
   subject:
     description:
     - The contract subject name.
+    type: str
     aliases: [ contract_subject, name, subject_name ]
   contract:
     description:
     - The name of the Contract.
+    type: str
     aliases: [ contract_name ]
   reverse_filter:
     description:
@@ -51,32 +54,38 @@ options:
     description:
     - The QoS class.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
     choices: [ level1, level2, level3, unspecified ]
   dscp:
     description:
     - The target DSCP.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
     choices: [ AF11, AF12, AF13, AF21, AF22, AF23, AF31, AF32, AF33, AF41, AF42, AF43,
                CS0, CS1, CS2, CS3, CS4, CS5, CS6, CS7, EF, VA, unspecified ]
     aliases: [ target ]
   description:
     description:
     - Description for the contract subject.
+    type: str
     aliases: [ descr ]
   consumer_match:
     description:
     - The match criteria across consumers.
     - The APIC defaults to C(at_least_one) when unset during creation.
+    type: str
     choices: [ all, at_least_one, at_most_one, none ]
   provider_match:
     description:
     - The match criteria across providers.
     - The APIC defaults to C(at_least_one) when unset during creation.
+    type: str
     choices: [ all, at_least_one, at_most_one, none ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
@@ -34,30 +34,36 @@ options:
   contract:
     description:
     - The name of the contract.
+    type: str
     aliases: [ contract_name ]
   filter:
     description:
     - The name of the Filter to bind to the Subject.
+    type: str
     aliases: [ filter_name ]
   log:
     description:
     - Determines if the binding should be set to log.
     - The APIC defaults to C(none) when unset during creation.
+    type: str
     choices: [ log, none ]
     aliases: [ directive ]
   subject:
     description:
     - The name of the Contract Subject.
+    type: str
     aliases: [ contract_subject, subject_name ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
   tenant:
     description:
     - The name of the tenant.
+    type: str
     required: yes
     aliases: [ tenant_name ]
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_domain.py
+++ b/lib/ansible/modules/network/aci/aci_domain.py
@@ -28,6 +28,7 @@ options:
   domain:
     description:
     - Name of the physical, virtual, bridged routed or FC domain profile.
+    type: str
     aliases: [ domain_name, domain_profile, name ]
   domain_type:
     description:
@@ -37,25 +38,30 @@ options:
     - 'C(l3dom): The external routed domain profile is a policy for managing L3 routed infrastructure outside the fabric.'
     - 'C(phys): The physical domain profile stores the physical resources and encap resources that should be used for EPGs associated with this domain.'
     - 'C(vmm): The VMM domain profile is a policy for grouping VM controllers with similar networking policy requirements.'
+    type: str
     choices: [ fc, l2dom, l3dom, phys, vmm ]
     aliases: [ type ]
   dscp:
     description:
     - The target Differentiated Service (DSCP) value.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
     choices: [ AF11, AF12, AF13, AF21, AF22, AF23, AF31, AF32, AF33, AF41, AF42, AF43, CS0, CS1, CS2, CS3, CS4, CS5, CS6, CS7, EF, VA, unspecified ]
     aliases: [ target ]
   encap_mode:
     description:
     - The layer 2 encapsulation protocol to use with the virtual switch.
+    type: str
     choices: [ unknown, vlan, vxlan ]
   multicast_address:
     description:
     - The muticast IP address to use for the virtual switch.
+    type: str
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
   vm_provider:
@@ -63,11 +69,13 @@ options:
     - The VM platform for VMM Domains.
     - Support for Kubernetes was added in ACI v3.0.
     - Support for CloudFoundry, OpenShift and Red Hat was added in ACI v3.1.
+    type: str
     choices: [ cloudfoundry, kubernetes, microsoft, openshift, openstack, redhat, vmware ]
   vswitch:
     description:
     - The virtual switch to use for vmm domains.
     - The APIC defaults to C(default) when unset during creation.
+    type: str
     choices: [ avs, default, dvs, unknown ]
 extends_documentation_fragment: aci
 '''

--- a/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_encap_pool.py
@@ -33,30 +33,36 @@ options:
   domain:
     description:
     - Name of the domain being associated with the Encap Pool.
+    type: str
     aliases: [ domain_name, domain_profile ]
   domain_type:
     description:
     - Determines if the Domain is physical (phys) or virtual (vmm).
+    type: str
     choices: [ fc, l2dom, l3dom, phys, vmm ]
   pool:
     description:
     - The name of the pool.
+    type: str
     aliases: [ pool_name ]
   pool_allocation_mode:
     description:
     - The method used for allocating encaps to resources.
     - Only vlan and vsan support allocation modes.
+    type: str
     choices: [ dynamic, static]
     aliases: [ allocation_mode, mode ]
   pool_type:
     description:
     - The encap type of C(pool).
+    type: str
     required: yes
     choices: [ vlan, vsan, vxlan ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
   vm_provider:
@@ -64,6 +70,7 @@ options:
     - The VM platform for VMM Domains.
     - Support for Kubernetes was added in ACI v3.0.
     - Support for CloudFoundry, OpenShift and Red Hat was added in ACI v3.1.
+    type: str
     choices: [ cloudfoundry, kubernetes, microsoft, openshift, openstack, redhat, vmware ]
 extends_documentation_fragment: aci
 '''

--- a/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_domain_to_vlan_pool.py
@@ -33,25 +33,30 @@ options:
   domain:
     description:
     - Name of the domain being associated with the VLAN Pool.
+    type: str
     aliases: [ domain_name, domain_profile ]
   domain_type:
     description:
     - Determines if the Domain is physical (phys) or virtual (vmm).
+    type: str
     choices: [ fc, l2dom, l3dom, phys, vmm ]
   pool:
     description:
     - The name of the pool.
+    type: str
     aliases: [ pool_name, vlan_pool ]
   pool_allocation_mode:
     description:
     - The method used for allocating VLANs to resources.
-    choices: [ dynamic, static]
+    type: str
     required: yes
+    choices: [ dynamic, static]
     aliases: [ allocation_mode, mode ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
   vm_provider:
@@ -59,6 +64,7 @@ options:
     - The VM platform for VMM Domains.
     - Support for Kubernetes was added in ACI v3.0.
     - Support for CloudFoundry, OpenShift and Red Hat was added in ACI v3.1.
+    type: str
     choices: [ cloudfoundry, kubernetes, microsoft, openshift, openstack, redhat, vmware ]
 extends_documentation_fragment: aci
 '''

--- a/lib/ansible/modules/network/aci/aci_encap_pool.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool.py
@@ -29,20 +29,24 @@ options:
   description:
     description:
     - Description for the C(pool).
+    type: str
     aliases: [ descr ]
   pool:
     description:
     - The name of the pool.
+    type: str
     aliases: [ name, pool_name ]
   pool_allocation_mode:
     description:
     - The method used for allocating encaps to resources.
     - Only vlan and vsan support allocation modes.
+    type: str
     choices: [ dynamic, static ]
     aliases: [ allocation_mode, mode ]
   pool_type:
     description:
     - The encap type of C(pool).
+    type: str
     required: yes
     aliases: [ type ]
     choices: [ vlan, vxlan, vsan]
@@ -50,6 +54,7 @@ options:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_encap_pool_range.py
+++ b/lib/ansible/modules/network/aci/aci_encap_pool_range.py
@@ -31,25 +31,30 @@ options:
     description:
     - The method used for allocating encaps to resources.
     - Only vlan and vsan support allocation modes.
+    type: str
     choices: [ dynamic, inherit, static]
     aliases: [ mode ]
   description:
     description:
     - Description for the pool range.
+    type: str
     aliases: [ descr ]
   pool:
     description:
     - The name of the pool that the range should be assigned to.
+    type: str
     aliases: [ pool_name ]
   pool_allocation_mode:
     description:
     - The method used for allocating encaps to resources.
     - Only vlan and vsan support allocation modes.
+    type: str
     choices: [ dynamic, static]
     aliases: [ pool_mode ]
   pool_type:
     description:
     - The encap type of C(pool).
+    type: str
     required: yes
     aliases: [ type ]
     choices: [ vlan, vxlan, vsan]
@@ -61,6 +66,7 @@ options:
   range_name:
     description:
     - The name to give to the encap range.
+    type: str
     aliases: [ name, range ]
   range_start:
     description:
@@ -71,6 +77,7 @@ options:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_epg.py
+++ b/lib/ansible/modules/network/aci/aci_epg.py
@@ -32,39 +32,47 @@ options:
   tenant:
     description:
     - Name of an existing tenant.
+    type: str
     aliases: [ tenant_name ]
   ap:
     description:
     - Name of an existing application network profile, that will contain the EPGs.
+    type: str
     required: yes
     aliases: [ app_profile, app_profile_name ]
   epg:
     description:
     - Name of the end point group.
+    type: str
     required: yes
     aliases: [ epg_name, name ]
   bd:
     description:
     - Name of the bridge domain being associated with the EPG.
+    type: str
     aliases: [ bd_name, bridge_domain ]
   priority:
     description:
     - The QoS class.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
     choices: [ level1, level2, level3, unspecified ]
   intra_epg_isolation:
     description:
     - The Intra EPG Isolation.
     - The APIC defaults to C(unenforced) when unset during creation.
+    type: str
     choices: [ enforced, unenforced ]
   description:
     description:
     - Description for the EPG.
+    type: str
     aliases: [ descr ]
   fwd_control:
     description:
     - The forwarding control used by the EPG.
     - The APIC defaults to C(none) when unset during creation.
+    type: str
     choices: [ none, proxy-arp ]
   preferred_group:
     description:
@@ -77,6 +85,7 @@ options:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
+++ b/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
@@ -31,21 +31,25 @@ options:
   monitoring_policy:
     description:
     - The name of the monitoring policy.
+    type: str
     required: yes
     aliases: [ name ]
   description:
     description:
     - Description for the monitoring policy.
+    type: str
     aliases: [ descr ]
   tenant:
     description:
     - The name of the tenant.
+    type: str
     required: yes
     aliases: [ tenant_name ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_epg_to_contract.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_contract.py
@@ -34,39 +34,47 @@ options:
   ap:
     description:
     - Name of an existing application network profile, that will contain the EPGs.
+    type: str
     aliases: [ app_profile, app_profile_name ]
   contract:
     description:
     - The name of the contract.
+    type: str
     aliases: [ contract_name ]
   contract_type:
     description:
     - Determines if the EPG should Provide or Consume the Contract.
+    type: str
     required: yes
     choices: [ consumer, provider ]
   epg:
     description:
     - The name of the end point group.
+    type: str
     aliases: [ epg_name ]
   priority:
     description:
     - QoS class.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
     choices: [ level1, level2, level3, unspecified ]
   provider_match:
     description:
     - The matching algorithm for Provided Contracts.
     - The APIC defaults to C(at_least_one) when unset during creation.
+    type: str
     choices: [ all, at_least_one, at_most_one, none ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
   tenant:
     description:
     - Name of an existing tenant.
+    type: str
     aliases: [ tenant_name ]
 extends_documentation_fragment: aci
 '''

--- a/lib/ansible/modules/network/aci/aci_epg_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_domain.py
@@ -38,23 +38,28 @@ options:
     description:
     - Allows micro-segmentation.
     - The APIC defaults to C(encap) when unset during creation.
+    type: str
     choices: [ encap, useg ]
   ap:
     description:
     - Name of an existing application network profile, that will contain the EPGs.
+    type: str
     aliases: [ app_profile, app_profile_name ]
   deploy_immediacy:
     description:
     - Determines when the policy is pushed to hardware Policy CAM.
     - The APIC defaults to C(lazy) when unset during creation.
+    type: str
     choices: [ immediate, lazy ]
   domain:
     description:
     - Name of the physical or virtual domain being associated with the EPG.
+    type: str
     aliases: [ domain_name, domain_profile ]
   domain_type:
     description:
     - Specify whether the Domain is a physical (phys), a virtual (vmm) or an L2 external domain association (l2dom).
+    type: str
     choices: [ l2dom, phys, vmm ]
     aliases: [ type ]
   encap:
@@ -67,10 +72,12 @@ options:
     description:
     - The ecapsulataion method to be used.
     - The APIC defaults to C(auto) when unset during creation.
+    type: str
     choices: [ auto, vlan, vxlan ]
   epg:
     description:
     - Name of the end point group.
+    type: str
     aliases: [ epg_name, name ]
   netflow:
     description:
@@ -86,22 +93,26 @@ options:
     description:
     - Determines when the policies should be resolved and available.
     - The APIC defaults to C(lazy) when unset during creation.
+    type: str
     choices: [ immediate, lazy, pre-provision ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
   tenant:
     description:
     - Name of an existing tenant.
+    type: str
     aliases: [ tenant_name ]
   vm_provider:
     description:
     - The VM platform for VMM Domains.
     - Support for Kubernetes was added in ACI v3.0.
     - Support for CloudFoundry, OpenShift and Red Hat was added in ACI v3.1.
+    type: str
     choices: [ cloudfoundry, kubernetes, microsoft, openshift, openstack, redhat, vmware ]
 extends_documentation_fragment: aci
 '''

--- a/lib/ansible/modules/network/aci/aci_fabric_node.py
+++ b/lib/ansible/modules/network/aci/aci_fabric_node.py
@@ -32,6 +32,7 @@ options:
   serial:
     description:
     - Serial Number for the new Fabric Node Member.
+    type: str
     aliases: [ serial_number ]
   node_id:
     description:
@@ -40,20 +41,24 @@ options:
   switch:
     description:
     - Switch Name for the new Fabric Node Member.
+    type: str
     aliases: [ name, switch_name ]
   description:
     description:
     - Description for the new Fabric Node Member.
+    type: str
     aliases: [ descr ]
   role:
     description:
     - Role for the new Fabric Node Member.
+    type: str
     aliases: [ role_name ]
     choices: [ leaf, spine, unspecified ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_filter.py
+++ b/lib/ansible/modules/network/aci/aci_filter.py
@@ -32,21 +32,25 @@ options:
   filter:
     description:
     - The name of the filter.
+    type: str
     required: yes
     aliases: [ filter_name, name ]
   description:
     description:
     - Description for the filter.
+    type: str
     aliases: [ descr ]
   tenant:
     description:
     - The name of the tenant.
+    type: str
     required: yes
     aliases: [ tenant_name ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_filter_entry.py
+++ b/lib/ansible/modules/network/aci/aci_filter_entry.py
@@ -33,57 +33,69 @@ options:
     description:
     - The arp flag to use when the ether_type is arp.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
     choices: [ arp_reply, arp_request, unspecified ]
   description:
     description:
     - Description for the Filter Entry.
+    type: str
     aliases: [ descr ]
   dst_port:
     description:
     - Used to set both destination start and end ports to the same value when ip_protocol is tcp or udp.
     - Accepted values are any valid TCP/UDP port range.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
   dst_port_end:
     description:
     - Used to set the destination end port when ip_protocol is tcp or udp.
     - Accepted values are any valid TCP/UDP port range.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
   dst_port_start:
     description:
     - Used to set the destination start port when ip_protocol is tcp or udp.
     - Accepted values are any valid TCP/UDP port range.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
   entry:
     description:
     - Then name of the Filter Entry.
+    type: str
     aliases: [ entry_name, filter_entry, name ]
   ether_type:
     description:
     - The Ethernet type.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
     choices: [ arp, fcoe, ip, mac_security, mpls_ucast, trill, unspecified ]
   filter:
     description:
-      The name of Filter that the entry should belong to.
+    - The name of Filter that the entry should belong to.
+    type: str
     aliases: [ filter_name ]
   icmp_msg_type:
     description:
     - ICMPv4 message type; used when ip_protocol is icmp.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
     choices: [ dst_unreachable, echo, echo_reply, src_quench, time_exceeded, unspecified ]
   icmp6_msg_type:
     description:
     - ICMPv6 message type; used when ip_protocol is icmpv6.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
     choices: [ dst_unreachable, echo_request, echo_reply, neighbor_advertisement, neighbor_solicitation, redirect, time_exceeded, unspecified ]
   ip_protocol:
     description:
     - The IP Protocol type when ether_type is ip.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
     choices: [ eigrp, egp, icmp, icmpv6, igmp, igp, l2tp, ospfigp, pim, tcp, udp, unspecified ]
   state:
     description:
     - present, absent, query
+    type: str
     default: present
     choices: [ absent, present, query ]
   stateful:
@@ -93,6 +105,7 @@ options:
   tenant:
     description:
     - The name of the tenant.
+    type: str
     aliases: [ tenant_name ]
 extends_documentation_fragment: aci
 '''

--- a/lib/ansible/modules/network/aci/aci_firmware_source.py
+++ b/lib/ansible/modules/network/aci/aci_firmware_source.py
@@ -28,6 +28,7 @@ options:
   source:
     description:
     - The identifying name for the outside source of images, such as an HTTP or SCP server.
+    type: str
     required: yes
     aliases: [ name, source_name ]
   polling_interval:
@@ -37,22 +38,27 @@ options:
   url_protocol:
     description:
     - The Firmware download protocol.
+    type: str
     choices: [ http, local, scp, usbkey ]
     default: scp
     aliases: [ url_proto ]
   url:
     description:
       The firmware URL for the image(s) on the source.
+    type: str
   url_password:
     description:
       The Firmware password or key string.
+    type: str
   url_username:
     description:
       The username for the source.
+    type: str
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_fc.py
@@ -27,21 +27,25 @@ options:
   fc_policy:
     description:
     - The name of the Fiber Channel interface policy.
+    type: str
     required: yes
     aliases: [ name ]
   description:
     description:
     - The description of the Fiber Channel interface policy.
+    type: str
     aliases: [ descr ]
   port_mode:
     description:
     - The Port Mode to use.
     - The APIC defaults to C(f) when unset during creation.
+    type: str
     choices: [ f, np ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_l2.py
@@ -27,16 +27,19 @@ options:
   l2_policy:
     description:
     - The name of the Layer 2 interface policy.
+    type: str
     required: yes
     aliases: [ name ]
   description:
     description:
     - The description of the Layer 2 interface policy.
+    type: str
     aliases: [ descr ]
   qinq:
     description:
     - Determines if QinQ is disabled or if the port should be considered a core or edge port.
     - The APIC defaults to C(disabled) when unset during creation.
+    type: str
     choices: [ core, disabled, edge ]
   vepa:
     description:
@@ -47,11 +50,13 @@ options:
     description:
     - The scope of the VLAN.
     - The APIC defaults to C(global) when unset during creation.
+    type: str
     choices: [ global, portlocal ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_policy_group.py
@@ -31,10 +31,12 @@ options:
   policy_group:
     description:
     - Name of the leaf policy group to be added/deleted.
+    type: str
     aliases: [ name, policy_group_name ]
   description:
     description:
     - Description for the leaf policy group to be created.
+    type: str
     aliases: [ descr ]
   lag_type:
     description:
@@ -42,77 +44,95 @@ options:
     - C(leaf) for Leaf Access Port Policy Group
     - C(link) for Port Channel (PC)
     - C(node) for Virtual Port Channel (VPC)
-    aliases: [ lag_type_name ]
-    choices: [ leaf, link, node ]
+    type: str
     required: yes
+    choices: [ leaf, link, node ]
+    aliases: [ lag_type_name ]
   link_level_policy:
     description:
     - Choice of link_level_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ link_level_policy_name ]
   cdp_policy:
     description:
     - Choice of cdp_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ cdp_policy_name ]
   mcp_policy:
     description:
     - Choice of mcp_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ mcp_policy_name ]
   lldp_policy:
     description:
     - Choice of lldp_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ lldp_policy_name ]
   stp_interface_policy:
     description:
     - Choice of stp_interface_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ stp_interface_policy_name ]
   egress_data_plane_policing_policy:
     description:
     - Choice of egress_data_plane_policing_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ egress_data_plane_policing_policy_name ]
   ingress_data_plane_policing_policy:
     description:
     - Choice of ingress_data_plane_policing_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ ingress_data_plane_policing_policy_name ]
   priority_flow_control_policy:
     description:
     - Choice of priority_flow_control_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ priority_flow_control_policy_name ]
   fibre_channel_interface_policy:
     description:
     - Choice of fibre_channel_interface_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ fibre_channel_interface_policy_name ]
   slow_drain_policy:
     description:
     - Choice of slow_drain_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ slow_drain_policy_name ]
   port_channel_policy:
     description:
     - Choice of port_channel_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ port_channel_policy_name ]
   monitoring_policy:
     description:
     - Choice of monitoring_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ monitoring_policy_name ]
   storm_control_interface_policy:
     description:
     - Choice of storm_control_interface_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ storm_control_interface_policy_name ]
   l2_interface_policy:
     description:
     - Choice of l2_interface_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ l2_interface_policy_name ]
   port_security_policy:
     description:
     - Choice of port_security_policy to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ port_security_policy_name ]
   aep:
     description:
     - Choice of attached_entity_profile (AEP) to be used as part of the leaf policy group to be created.
+    type: str
     aliases: [ aep_name ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_leaf_profile.py
@@ -28,16 +28,19 @@ options:
   leaf_interface_profile:
     description:
     - The name of the Fabric access policy leaf interface profile.
+    type: str
     required: yes
     aliases: [ name, leaf_interface_profile_name ]
   description:
     description:
     - Description for the Fabric access policy leaf interface profile.
+    type: str
     aliases: [ descr ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_lldp.py
@@ -27,11 +27,13 @@ options:
   lldp_policy:
     description:
     - The LLDP interface policy name.
+    type: str
     required: yes
     aliases: [ name ]
   description:
     description:
     - The description for the LLDP interface policy name.
+    type: str
     aliases: [ descr ]
   receive_state:
     description:
@@ -47,6 +49,7 @@ options:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_mcp.py
@@ -27,11 +27,13 @@ options:
   mcp:
     description:
     - The name of the MCP interface.
+    type: str
     required: yes
     aliases: [ mcp_interface, name ]
   description:
     description:
     - The description for the MCP interface.
+    type: str
     aliases: [ descr ]
   admin_state:
     description:
@@ -42,6 +44,7 @@ options:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_interface_policy_ospf.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_ospf.py
@@ -28,6 +28,7 @@ options:
   tenant:
     description:
     - The name of the Tenant the OSPF interface policy should belong to.
+    type: str
     required: yes
     aliases: [ tenant_name ]
   ospf:
@@ -35,17 +36,20 @@ options:
     - The OSPF interface policy name.
     - This name can be between 1 and 64 alphanumeric characters.
     - Note that you cannot change this name after the object has been saved.
+    type: str
     required: yes
     aliases: [ ospf_interface, name ]
   description:
     description:
     - The description for the OSPF interface.
+    type: str
     aliases: [ descr ]
   network_type:
     description:
     - The OSPF interface policy network type.
     - OSPF supports broadcast and point-to-point.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
     choices: [ bcast, p2p ]
   cost:
     description:
@@ -64,6 +68,7 @@ options:
       interface subconfiguration mode command.
     - Accepted values range between C(1) and C(450).
     - The APIC defaults to C(0) when unset during creation.
+    type: str
   controls:
     description:
     - The interface policy controls.
@@ -126,6 +131,7 @@ options:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_channel.py
@@ -27,11 +27,13 @@ options:
   port_channel:
     description:
     - Name of the port channel.
+    type: str
     required: yes
     aliases: [ name ]
   description:
     description:
     - The description for the port channel.
+    type: str
     aliases: [ descr ]
   max_links:
     description:
@@ -50,6 +52,7 @@ options:
     - Port channel interface policy mode.
     - Determines the LACP method to use for forming port-channels.
     - The APIC defaults to C(off) when unset during creation.
+    type: str
     choices: [ active, mac-pin, mac-pin-nicload, 'off', passive ]
   fast_select:
     description:
@@ -90,6 +93,7 @@ options:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_port_security.py
@@ -27,11 +27,13 @@ options:
   port_security:
     description:
     - The name of the port security.
+    type: str
     required: yes
     aliases: [ name ]
   description:
     description:
     - The description for the contract.
+    type: str
     aliases: [ descr ]
   max_end_points:
     description:
@@ -43,6 +45,7 @@ options:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_interface_selector_to_switch_policy_leaf_profile.py
@@ -31,15 +31,18 @@ options:
   leaf_profile:
     description:
     - Name of the Leaf Profile to which we add a Selector.
+    type: str
     aliases: [ leaf_profile_name ]
   interface_selector:
     description:
     - Name of Interface Profile Selector to be added and associated with the Leaf Profile.
+    type: str
     aliases: [ name, interface_selector_name, interface_profile_name ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_l3out.py
@@ -33,27 +33,32 @@ options:
   tenant:
     description:
     - Name of an existing tenant.
+    type: str
     required: yes
     aliases: [ tenant_name ]
   l3out:
     description:
     - Name of L3Out being created.
+    type: str
     required: yes
     aliases: [ l3out_name, name ]
   vrf:
     description:
     - Name of the VRF being associated with the L3Out.
+    type: str
     required: yes
     aliases: [ vrf_name ]
   domain:
     description:
     - Name of the external L3 domain being associated with the L3Out.
+    type: str
     required: yes
     aliases: [ ext_routed_domain_name, routed_domain ]
   dscp:
     description:
     - The target Differentiated Service (DSCP) value.
     - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
     choices: [ AF11, AF12, AF13, AF21, AF22, AF23, AF31, AF32, AF33, AF41, AF42, AF43, CS0, CS1, CS2, CS3, CS4, CS5, CS6, CS7, EF, VA, unspecified ]
     aliases: [ target ]
   route_control:
@@ -70,16 +75,19 @@ options:
   asn:
     description:
     - The AS number for the L3Out. Only applicable when using 'eigrp' as the l3protocol
+    type: str
     aliases: [ as_number ]
     version_added: '2.8'
   description:
     description:
     - Description for the L3Out.
+    type: str
     aliases: [ descr ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
+++ b/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
@@ -31,15 +31,18 @@ options:
   rtp:
     description:
     - The name of the route tag policy.
+    type: str
     required: yes
     aliases: [ name, rtp_name ]
   description:
     description:
     - The description for the route tag policy.
+    type: str
     aliases: [ descr ]
   tenant:
     description:
     - The name of the tenant.
+    type: str
     required: yes
     aliases: [ tenant_name ]
   tag:
@@ -52,6 +55,7 @@ options:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_rest.py
+++ b/lib/ansible/modules/network/aci/aci_rest.py
@@ -45,13 +45,15 @@ options:
     - Using C(delete) is typically used for deleting objects.
     - Using C(get) is typically used for querying objects.
     - Using C(post) is typically used for modifying objects.
-    default: get
+    type: str
     choices: [ delete, get, post ]
+    default: get
     aliases: [ action ]
   path:
     description:
     - URI being used to execute API calls.
     - Must end in C(.xml) or C(.json).
+    type: str
     required: yes
     aliases: [ uri ]
   content:
@@ -60,6 +62,7 @@ options:
     - This may be convenient to template simple requests.
     - For anything complex use the C(template) lookup plugin (see examples)
       or the M(template) module with parameter C(src).
+    type: str
   src:
     description:
     - Name of the absolute path of the filname that includes the body

--- a/lib/ansible/modules/network/aci/aci_static_binding_to_epg.py
+++ b/lib/ansible/modules/network/aci/aci_static_binding_to_epg.py
@@ -34,18 +34,22 @@ options:
   tenant:
     description:
     - Name of an existing tenant.
+    type: str
     aliases: [ tenant_name ]
   ap:
     description:
     - Name of an existing application network profile, that will contain the EPGs.
+    type: str
     aliases: [ app_profile, app_profile_name ]
   epg:
     description:
     - The name of the end point group.
+    type: str
     aliases: [ epg_name ]
   description:
     description:
     - Description for the static path to EPG binding.
+    type: str
     aliases: [ descr ]
     version_added: '2.7'
   encap_id:
@@ -66,6 +70,7 @@ options:
     description:
     - The Deployement Immediacy of Static EPG on PC, VPC or Interface.
     - The APIC defaults to C(lazy) when unset during creation.
+    type: str
     choices: [ immediate, lazy ]
   interface_mode:
     description:
@@ -74,11 +79,13 @@ options:
     - Values C(access) and C(untagged) are identical.
     - Values C(regular), C(tagged) and C(trunk) are identical.
     - The APIC defaults to C(trunk) when unset during creation.
+    type: str
     choices: [ 802.1p, access, native, regular, tagged, trunk, untagged ]
     aliases: [ interface_mode_name, mode ]
   interface_type:
     description:
     - The type of interface for the static EPG deployement.
+    type: str
     choices: [ fex, port_channel, switch_port, vpc ]
     default: switch_port
   pod_id:
@@ -93,11 +100,13 @@ options:
     - When C(interface_type) is C(switch_port), C(port_channel), or C(fex), then C(leafs) is a string of the leaf ID.
     - When C(interface_type) is C(vpc), then C(leafs) is a list with both leaf IDs.
     - The C(leafs) value is usually something like '101' or '101-102' depending on C(connection_type).
+    type: str
     aliases: [ leaves, nodes, paths, switches ]
   interface:
     description:
     - The C(interface) string value part of the tDn.
     - Usually a policy group like C(test-IntPolGrp) or an interface of the following format C(1/7) depending on C(interface_type).
+    type: str
   extpaths:
     description:
     - The C(extpaths) integer value part of the tDn.
@@ -108,6 +117,7 @@ options:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
+++ b/lib/ansible/modules/network/aci/aci_switch_leaf_selector.py
@@ -33,21 +33,26 @@ options:
   description:
     description:
     - The description to assign to the C(leaf).
+    type: str
   leaf_profile:
     description:
     - Name of the Leaf Profile to which we add a Selector.
+    type: str
     aliases: [ leaf_profile_name ]
   leaf:
     description:
     - Name of Leaf Selector.
+    type: str
     aliases: [ name, leaf_name, leaf_profile_leaf_name, leaf_selector_name ]
   leaf_node_blk:
     description:
     - Name of Node Block range to be added to Leaf Selector of given Leaf Profile.
+    type: str
     aliases: [ leaf_node_blk_name, node_blk_name ]
   leaf_node_blk_description:
     description:
     - The description to assign to the C(leaf_node_blk)
+    type: str
   from:
     description:
     - Start of Node Block range.
@@ -61,11 +66,13 @@ options:
   policy_group:
     description:
     - Name of the Policy Group to be added to Leaf Selector of given Leaf Profile.
+    type: str
     aliases: [ name, policy_group_name ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_switch_policy_leaf_profile.py
@@ -29,15 +29,18 @@ options:
   leaf_profile:
     description:
     - The name of the Leaf Profile.
+    type: str
     aliases: [ leaf_profile_name, name ]
   description:
     description:
     - Description for the Leaf Profile.
+    type: str
     aliases: [ descr ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_switch_policy_vpc_protection_group.py
+++ b/lib/ansible/modules/network/aci/aci_switch_policy_vpc_protection_group.py
@@ -29,32 +29,35 @@ options:
   protection_group:
     description:
     - The name of the Explicit vPC Protection Group.
-    aliases: [ name, protection_group_name ]
+    type: str
     required: yes
+    aliases: [ name, protection_group_name ]
   protection_group_id:
     description:
     - The Explicit vPC Protection Group ID.
-    required: yes
     type: int
+    required: yes
     aliases: [ id ]
   vpc_domain_policy:
     description:
     - The vPC domain policy to be associated with the Explicit vPC Protection Group.
+    type: str
     aliases: [ vpc_domain_policy_name ]
   switch_1_id:
     description:
     - The ID of the first Leaf Switch for the Explicit vPC Protection Group.
-    required: yes
     type: int
+    required: yes
   switch_2_id:
     description:
     - The ID of the Second Leaf Switch for the Explicit vPC Protection Group.
-    required: yes
     type: int
+    required: yes
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_taboo_contract.py
+++ b/lib/ansible/modules/network/aci/aci_taboo_contract.py
@@ -32,26 +32,31 @@ options:
   taboo_contract:
     description:
     - The name of the Taboo Contract.
+    type: str
     required: yes
     aliases: [ name ]
   description:
     description:
     - The description for the Taboo Contract.
+    type: str
     aliases: [ descr ]
   tenant:
     description:
     - The name of the tenant.
+    type: str
     required: yes
     aliases: [ tenant_name ]
   scope:
     description:
     - The scope of a service contract.
     - The APIC defaults to C(context) when unset during creation.
+    type: str
     choices: [ application-profile, context, global, tenant ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_tenant.py
+++ b/lib/ansible/modules/network/aci/aci_tenant.py
@@ -27,16 +27,19 @@ options:
   tenant:
     description:
     - The name of the tenant.
+    type: str
     required: yes
     aliases: [ name, tenant_name ]
   description:
     description:
     - Description for the tenant.
+    type: str
     aliases: [ descr ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
@@ -31,19 +31,23 @@ options:
   action_rule:
     description:
     - The name of the action rule profile.
+    type: str
     aliases: [ action_rule_name, name ]
   description:
     description:
     - The description for the action rule profile.
+    type: str
     aliases: [ descr ]
   tenant:
     description:
     - The name of the tenant.
+    type: str
     aliases: [ tenant_name ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
@@ -31,10 +31,12 @@ options:
   tenant:
     description:
     - The name of an existing tenant.
+    type: str
     aliases: [ tenant_name ]
   epr_policy:
     description:
     - The name of the end point retention policy.
+    type: str
     aliases: [ epr_name, name ]
   bounce_age:
     description:
@@ -46,6 +48,7 @@ options:
     description:
     - Determines if the bounce entries are installed by RARP Flood or COOP Protocol.
     - The APIC defaults to C(coop) when unset during creation.
+    type: str
     choices: [ coop, flood ]
   hold_interval:
     description:
@@ -74,11 +77,13 @@ options:
   description:
     description:
     - Description for the End point rentention policy.
+    type: str
     aliases: [ descr ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_dst_group.py
@@ -31,21 +31,25 @@ options:
   dst_group:
     description:
     - The name of the SPAN destination group.
+    type: str
     required: yes
     aliases: [ name ]
   description:
     description:
     - The description of the SPAN destination group.
+    type: str
     aliases: [ descr ]
   tenant:
     description:
     - The name of the tenant.
+    type: str
     required: yes
     aliases: [ tenant_name ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group.py
@@ -36,23 +36,28 @@ options:
   description:
     description:
     - The description for Span source group.
+    type: str
     aliases: [ descr ]
   dst_group:
     description:
     - The Span destination group to associate with the source group.
+    type: str
   src_group:
     description:
     - The name of the Span source group.
+    type: str
     aliases: [ name ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
   tenant:
     description:
     - The name of the Tenant.
+    type: str
     aliases: [ tenant_name ]
 extends_documentation_fragment: aci
 '''

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
@@ -33,22 +33,27 @@ options:
   description:
     description:
     - The description for Span source group to destination group binding.
+    type: str
     aliases: [ descr ]
   dst_group:
     description:
     - The Span destination group to associate with the source group.
+    type: str
   src_group:
     description:
     - The name of the Span source group.
+    type: str
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
   tenant:
     description:
     - The name of the Tenant.
+    type: str
     aliases: [ tenant_name ]
 extends_documentation_fragment: aci
 '''

--- a/lib/ansible/modules/network/aci/aci_vlan_pool.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool.py
@@ -30,20 +30,24 @@ options:
   pool_allocation_mode:
     description:
     - The method used for allocating VLANs to resources.
-    aliases: [ allocation_mode, mode ]
+    type: str
     choices: [ dynamic, static]
+    aliases: [ allocation_mode, mode ]
   description:
     description:
     - Description for the C(pool).
+    type: str
     aliases: [ descr ]
   pool:
     description:
     - The name of the pool.
+    type: str
     aliases: [ name, pool_name ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
+++ b/lib/ansible/modules/network/aci/aci_vlan_pool_encap_block.py
@@ -33,19 +33,23 @@ options:
   allocation_mode:
     description:
     - The method used for allocating encaps to resources.
-    aliases: [ mode ]
+    type: str
     choices: [ dynamic, inherit, static]
+    aliases: [ mode ]
   description:
     description:
     - Description for the pool encap block.
+    type: str
     aliases: [ descr ]
   pool:
     description:
     - The name of the pool that the encap block should be assigned to.
+    type: str
     aliases: [ pool_name ]
   pool_allocation_mode:
     description:
     - The method used for allocating encaps to resources.
+    type: str
     choices: [ dynamic, static]
     aliases: [ pool_mode ]
   block_end:
@@ -56,6 +60,7 @@ options:
   block_name:
     description:
     - The name to give to the encap block.
+    type: str
     aliases: [ name ]
   block_start:
     description:
@@ -66,6 +71,7 @@ options:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/modules/network/aci/aci_vrf.py
+++ b/lib/ansible/modules/network/aci/aci_vrf.py
@@ -32,27 +32,33 @@ options:
   tenant:
     description:
     - The name of the Tenant the VRF should belong to.
+    type: str
     aliases: [ tenant_name ]
   vrf:
     description:
     - The name of the VRF.
+    type: str
     aliases: [ context, name, vrf_name ]
   policy_control_direction:
     description:
     - Determines if the policy should be enforced by the fabric on ingress or egress.
+    type: str
     choices: [ egress, ingress ]
   policy_control_preference:
     description:
     - Determines if the fabric should enforce contract policies to allow routing and packet forwarding.
+    type: str
     choices: [ enforced, unenforced ]
   description:
     description:
     - The description for the VRF.
+    type: str
     aliases: [ descr ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
     - Use C(query) for listing an object or multiple objects.
+    type: str
     choices: [ absent, present, query ]
     default: present
 extends_documentation_fragment: aci

--- a/lib/ansible/utils/module_docs_fragments/aci.py
+++ b/lib/ansible/utils/module_docs_fragments/aci.py
@@ -7,38 +7,44 @@
 
 class ModuleDocFragment(object):
     # Standard files documentation fragment
-    DOCUMENTATION = '''
+    DOCUMENTATION = r'''
 options:
   host:
     description:
     - IP Address or hostname of APIC resolvable by Ansible control host.
+    type: str
     required: yes
     aliases: [ hostname ]
   port:
     description:
     - Port number to be used for REST connection.
     - The default value depends on parameter `use_ssl`.
+    type: int
   username:
     description:
     - The username to use for authentication.
+    type: str
     default: admin
     aliases: [ user ]
   password:
     description:
     - The password to use for authentication.
     - This option is mutual exclusive with C(private_key). If C(private_key) is provided too, it will be used instead.
+    type: str
     required: yes
   private_key:
     description:
     - PEM formatted file that contains your private key to be used for signature-based authentication.
     - The name of the key (without extension) is used as the certificate name in ACI, unless C(certificate_name) is specified.
     - This option is mutual exclusive with C(password). If C(password) is provided too, it will be ignored.
+    type: str
     required: yes
     aliases: [ cert_key ]
   certificate_name:
     description:
     - The X.509 certificate name attached to the APIC AAA user used for signature-based authentication.
     - It defaults to the C(private_key) basename, without extension.
+    type: str
     aliases: [ cert_name ]
   output_level:
     description:
@@ -46,6 +52,7 @@ options:
     - C(normal) means the standard output, incl. C(current) dict
     - C(info) adds informational output, incl. C(previous), C(proposed) and C(sent) dicts
     - C(debug) adds debugging output, incl. C(filter_string), C(method), C(response), C(status) and C(url) information
+    type: str
     choices: [ debug, info, normal ]
     default: normal
   timeout:


### PR DESCRIPTION
##### SUMMARY
We were still missing types for the ACI module parameters (as we expected #45805 to be merged).
This PR adds those types now.

This relates to #49966

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ACI module docs