### PR TITLE
ovirt_storage_connection: Fix issue in detaching the connection

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_connection.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_connection.py
@@ -147,25 +147,40 @@ class StorageConnectionModule(BaseModule):
             vfs_type=self.param('vfs_type'),
         )
 
+    def _get_storage_domain_service(self):
+        sds_service = self._connection.system_service().storage_domains_service()
+        sd = search_by_name(sds_service, self.param('storage'))
+        if sd is None:
+            raise Exception(
+                "Storage '%s' was not found." % self.param('storage')
+            )
+        return sd, sds_service.storage_domain_service(sd.id)
+
     def post_present(self, entity_id):
         if self.param('storage'):
-            sds_service = self._connection.system_service().storage_domains_service()
-            sd = search_by_name(sds_service, self.param('storage'))
-            if sd is None:
-                raise Exception(
-                    "Storage '%s' was not found." % self.param('storage')
-                )
-
+            sd, sd_service = self._get_storage_domain_service()
             if entity_id not in [
                 sd_conn.id for sd_conn in self._connection.follow_link(sd.storage_connections)
             ]:
-                scs_service = sds_service.storage_domain_service(sd.id).storage_connections_service()
+                scs_service = sd_service.storage_connections_service()
                 if not self._module.check_mode:
                     scs_service.add(
                         connection=otypes.StorageConnection(
                             id=entity_id,
                         ),
                     )
+                self.changed = True
+
+    def pre_remove(self, entity_id):
+        if self.param('storage'):
+            sd, sd_service = self._get_storage_domain_service()
+            if entity_id in [
+                sd_conn.id for sd_conn in self._connection.follow_link(sd.storage_connections)
+            ]:
+                scs_service = sd_service.storage_connections_service()
+                sc_service = scs_service.connection_service(entity_id)
+                if not self._module.check_mode:
+                    sc_service.remove()
                 self.changed = True
 
     def update_check(self, entity):
@@ -254,6 +269,7 @@ def main():
             )
             storage_connection_module.post_present(ret['id'])
         elif state == 'absent':
+            storage_connection_module.pre_remove(module.params['id'])
             ret = storage_connection_module.remove(entity=entity)
 
         module.exit_json(**ret)


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently deleting the storage connection just tries to delete the
connection but it doesn't detach the connection from storage domain.
The patch first tries to detach the connection from storage domain
before attempting to delete the same if the storage domain parameter
is provided.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ovirt_storage_connection
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
