### PR TITLE
Pluribus networks admin session timeout module with unit tests

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_admin_session_timeout.py
+++ b/lib/ansible/modules/network/netvisor/pn_admin_session_timeout.py
@@ -32,7 +32,6 @@ options:
     required: True
     type: str
     choices: ['update']
-    type: str
   pn_timeout:
     description:
       - Maximum time to wait for user activity before

--- a/lib/ansible/modules/network/netvisor/pn_admin_session_timeout.py
+++ b/lib/ansible/modules/network/netvisor/pn_admin_session_timeout.py
@@ -42,19 +42,19 @@ options:
 
 EXAMPLES = """
 - name: admin session timeout functionality
-  pn_admin_session_timeout.py:
+  pn_admin_session_timeout:
     pn_cliswitch: "sw01"
     state: "update"
     pn_timeout: "61s"
 
 - name: admin session timeout functionality
-  pn_admin_session_timeout.py:
+  pn_admin_session_timeout:
     pn_cliswitch: "sw01"
     state: "update"
     pn_timeout: "1d"
 
 - name: admin session timeout functionality
-  pn_admin_session_timeout.py:
+  pn_admin_session_timeout:
     pn_cliswitch: "sw01"
     state: "update"
     pn_timeout: "10d20m3h15s"
@@ -86,7 +86,6 @@ from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
 def main():
     """ This section is for arguments parsing """
 
-    global state_map
     state_map = dict(
         update='admin-session-timeout-modify'
     )

--- a/lib/ansible/modules/network/netvisor/pn_admin_session_timeout.py
+++ b/lib/ansible/modules/network/netvisor/pn_admin_session_timeout.py
@@ -1,0 +1,124 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_admin_session_timeout
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.8"
+short_description: CLI command to modify admin-session-timeout
+description:
+  - This module can be used to modify admin session timeout.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: False
+    type: str
+  state:
+    description:
+      - State the action to perform.
+        C(update) to modify the admin-session-timeout.
+    required: True
+    type: str
+    choices: ['update']
+    type: str
+  pn_timeout:
+    description:
+      - Maximum time to wait for user activity before
+        terminating login session. Minimum should be 60s.
+    required: False
+    type: str
+"""
+
+EXAMPLES = """
+- name: admin session timeout functionality
+  pn_admin_session_timeout.py:
+    pn_cliswitch: "sw01"
+    state: "update"
+    pn_timeout: "61s"
+
+- name: admin session timeout functionality
+  pn_admin_session_timeout.py:
+    pn_cliswitch: "sw01"
+    state: "update"
+    pn_timeout: "1d"
+
+- name: admin session timeout functionality
+  pn_admin_session_timeout.py:
+    pn_cliswitch: "sw01"
+    state: "update"
+    pn_timeout: "10d20m3h15s"
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: string
+stdout:
+  description: set of responses from the admin-session-timeout command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the admin-session-timeout command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+import shlex
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    global state_map
+    state_map = dict(
+        update='admin-session-timeout-modify'
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_timeout=dict(required=False, type='str'),
+        ),
+        required_together=[['state', 'pn_timeout']],
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    timeout = module.params['pn_timeout']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+    if command == 'admin-session-timeout-modify':
+        cli += ' %s ' % command
+        if timeout:
+            cli += ' timeout ' + timeout
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/netvisor/pn_admin_session_timeout.py
+++ b/lib/ansible/modules/network/netvisor/pn_admin_session_timeout.py
@@ -79,7 +79,6 @@ changed:
   type: bool
 """
 
-import shlex
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
 

--- a/test/units/modules/network/netvisor/test_pn_admin_session_timeout.py
+++ b/test/units/modules/network/netvisor/test_pn_admin_session_timeout.py
@@ -1,0 +1,56 @@
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from units.compat.mock import patch
+from ansible.modules.network.netvisor import pn_admin_session_timeout
+from units.modules.utils import set_module_args
+from .nvos_module import TestNvosModule, load_fixture
+
+
+class TestAdminServiceModule(TestNvosModule):
+
+    module = pn_admin_session_timeout
+
+    def setUp(self):
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_admin_session_timeout.run_cli')
+        self.run_nvos_commands = self.mock_run_nvos_commands.start()
+
+    def tearDown(self):
+        self.mock_run_nvos_commands.stop()
+
+    def run_cli_patch(self, module, cli, state_map):
+        if state_map['update'] == 'admin-session-timeout-modify':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        module.exit_json(**results)
+
+    def load_fixtures(self, commands=None, state=None, transport='cli'):
+        self.run_nvos_commands.side_effect = self.run_cli_patch
+
+    def test_admin_session_timeout_modify_t1(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_timeout': '61s',
+                         'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-session-timeout-modify  timeout 61s'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_admin_session_timeout_modify_t2(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_timeout': '1d',
+                         'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-session-timeout-modify  timeout 1d'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_admin_session_timeout_modify_t3(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_timeout': '10d20m3h15s',
+                         'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 admin-session-timeout-modify  timeout 10d20m3h15s'
+        self.assertEqual(result['cli_cmd'], expected_cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Point feature of admin session timeout for Pluribus Networks Netvisor switches  -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
pn_session_timeout.py module with unit tests.

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```
