### PR TITLE
os_image: correct doc for is_public option default

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -58,7 +58,7 @@ options:
      description:
         - Whether the image can be accessed publicly. Note that publicizing an image requires admin role by default.
      type: bool
-     default: 'yes'
+     default: 'no'
    filename:
      description:
         - The path to the file which has to be uploaded


### PR DESCRIPTION
On line 121, this option is set to False by default, but the
documentation was stating otherwise.

```
[...]
        is_public=dict(type='bool', default=False),
[...]

```
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
os_image