### PR TITLE
ADD Task verbosity option, contol when task is printed

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -82,6 +82,7 @@ class Task(Base, Conditional, Taggable, Become):
     _register = FieldAttribute(isa='string')
     _retries = FieldAttribute(isa='int', default=3)
     _until = FieldAttribute(isa='list', default=list)
+    _verbosity = FieldAttribute(isa='int', default=0)
 
     # deprecated, used to be loop and loop_args but loop has been repurposed
     _loop_with = FieldAttribute(isa='string', private=True, inherit=False)

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -97,6 +97,10 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_ok(self, result):
 
+        # task verbosity check
+        if result._task.verbosity > self._display.verbosity:
+            return
+
         delegated_vars = result._result.get('_ansible_delegated_vars', None)
 
         if isinstance(result._task, TaskInclude):
@@ -135,6 +139,10 @@ class CallbackModule(CallbackBase):
             self._display.display(msg, color=color)
 
     def v2_runner_on_skipped(self, result):
+
+        # task verbosity check
+        if result._task.verbosity > self._display.verbosity:
+            return
 
         if self.display_skipped_hosts:
 
@@ -189,7 +197,9 @@ class CallbackModule(CallbackBase):
             self._last_task_name = task.get_name().strip()
 
             # Display the task banner immediately if we're not doing any filtering based on task result
-            if self.display_skipped_hosts and self.display_ok_hosts:
+            # check task verbosity setting
+            # check of TaskInclude to fix stale included statements if banner is to be skipped
+            if isinstance(task, TaskInclude) or (self.display_skipped_hosts and self.display_ok_hosts and not task.verbosity > self._display.verbosity):
                 self._print_task_banner(task)
 
     def _print_task_banner(self, task):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This implements #50022.

There are many auxiliary tasks that only bloat the output of long plays. Adding the `verbosity` option allows one to control in which verbosity level minimum, the task will be printed. In other words if the minimum verbosity level of the task is greater than the runtime verbosity setting (as selected by -vv) it's output will not be printed. The behavior will be like the [debug module](https://docs.ansible.com/ansible/2.7/modules/debug_module.html?highlight=debug).

NOTE: This is different from the #24215 where we want to increase  a specific task's verbosity setting. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This also could deprecate the **selected** output callback.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
core
callback

##### ADDITIONAL INFORMATION
- Known **issue** is with **import_task** the verbosity is accepted as valid but has no op.
- In **include_tasks** the keyword is not accepted (an exception is thrown). A proposal is to propagate to the included tasks as a default, but respect the child tasks' verbosity setting if any.

### TODO
- [ ] FIX import_task semantics

##### EXAMPLE OUTPUT
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```yaml
## VARS:
#  descr
---
  - hosts: all
    gather_facts: no
    tasks:

    - name: Command
      command: pwd

    - name: Command(V1)
      command: pwd
      verbosity: 1
```

#### run normal
```
$ ansible-playbook testverb1.yml -i hosts 
PLAY [all] ****************************************************************************************************

TASK [Command] ************************************************************************************************
changed: [localhost]

PLAY RECAP ****************************************************************************************************
localhost                  : ok=2    changed=2    unreachable=0    failed=0    skipped=0   

```

#### run with verbosity 1
```
$ ansible-playbook testverb1.yml -i hosts  -v
Using /etc/ansible/ansible.cfg as config file

PLAY [all] ****************************************************************************************************

TASK [Command] ************************************************************************************************
changed: [localhost] => {"changed": true, "cmd": ["pwd"], "delta": "0:00:00.001414", "end": "2018-12-17 16:35:17.729410", "rc": 0, "start": "2018-12-17 16:35:17.727996", "stderr": "", "stderr_lines": [], "stdout": "/ansible/test", "stdout_lines": ["/ansible/test"]}

TASK [Command(V1)] ********************************************************************************************
changed: [localhost] => {"changed": true, "cmd": ["pwd"], "delta": "0:00:00.001333", "end": "2018-12-17 16:35:17.813542", "rc": 0, "start": "2018-12-17 16:35:17.812209", "stderr": "", "stderr_lines": [], "stdout": "/ansible/test", "stdout_lines": ["/ansible/test"]}

PLAY RECAP ****************************************************************************************************
localhost                  : ok=2    changed=2    unreachable=0    failed=0    skipped=0   


```
<!--- HINT: You can also paste gist.github.com links for larger files -->
