### PR TITLE
Put in documented default for gcp_compute filters

### DIFF
--- a/changelogs/fragments/50025-gcp_compute_filters_default.yml
+++ b/changelogs/fragments/50025-gcp_compute_filters_default.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gcp_compute inventory plugin - apply documented default when one is not provided.

--- a/docs/docsite/rst/scenario_guides/guide_gce.rst
+++ b/docs/docsite/rst/scenario_guides/guide_gce.rst
@@ -145,7 +145,6 @@ Here's an example of a valid inventory file:
     plugin: gcp_compute
     projects:
       - graphite-playground
-    filters:
     auth_kind: serviceaccount
     service_account_file: /home/alexstephen/my_account.json
 

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -331,6 +331,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not isinstance(config_data['projects'], list):
             raise AnsibleParserError("Projects must be a list in GCP inventory YAML files")
 
+        # add in documented defaults
+        if 'filters' not in config_data:
+            config_data['filters'] = None
+
         projects = config_data['projects']
         zones = config_data.get('zones')
         config_data['scopes'] = ['https://www.googleapis.com/auth/compute']


### PR DESCRIPTION
##### SUMMARY
The plugin documentation claims that this field has a default, but it will not work without adding a field in the inventory file.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/gcp_compute.py

##### ADDITIONAL INFORMATION
Previously, inventory files of this type would fail with a KeyError (surfaced confusingly)

```yaml
plugin: gcp_compute
zones:
  - us-east1-d
projects:
  - foo-bar-foo
service_account_file: example_gce/creds.json
auth_kind: serviceaccount
```

the docs from `ansible-doc -t inventory gcp_compute` give the following:

```
- filters
        A list of filter value pairs. Available filters are listed here
        https://cloud.google.com/compute/docs/reference/rest/v1/instances/list. Each additional filter in the list will act be added
        as an AND condition (filter1 and filter2)
        [Default: (null)]
```

If the default is null, then I expect that the user does not need to provide it to avoid errors. That's the point of having defaults.