### PR TITLE
facts: detect FreeBSD KVM guests

### DIFF
--- a/changelogs/fragments/49158-detect-kvm-on-freebsd.yaml
+++ b/changelogs/fragments/49158-detect-kvm-on-freebsd.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Detect FreeBSD KVM guests in facts (https://github.com/ansible/ansible/issues/49158)

--- a/lib/ansible/module_utils/facts/virtual/freebsd.py
+++ b/lib/ansible/module_utils/facts/virtual/freebsd.py
@@ -19,9 +19,10 @@ __metaclass__ = type
 import os
 
 from ansible.module_utils.facts.virtual.base import Virtual, VirtualCollector
+from ansible.module_utils.facts.virtual.sysctl import VirtualSysctlDetectionMixin
 
 
-class FreeBSDVirtual(Virtual):
+class FreeBSDVirtual(Virtual, VirtualSysctlDetectionMixin):
     """
     This is a FreeBSD-specific subclass of Virtual.  It defines
     - virtualization_type
@@ -38,6 +39,14 @@ class FreeBSDVirtual(Virtual):
         if os.path.exists('/dev/xen/xenstore'):
             virtual_facts['virtualization_type'] = 'xen'
             virtual_facts['virtualization_role'] = 'guest'
+
+        if virtual_facts['virtualization_type'] == '':
+            virtual_product_facts = self.detect_virt_product('kern.vm_guest') or self.detect_virt_product('hw.hv_vendor')
+            virtual_facts.update(virtual_product_facts)
+
+        if virtual_facts['virtualization_type'] == '':
+            virtual_vendor_facts = self.detect_virt_vendor('hw.model')
+            virtual_facts.update(virtual_vendor_facts)
 
         return virtual_facts
 

--- a/lib/ansible/module_utils/facts/virtual/sysctl.py
+++ b/lib/ansible/module_utils/facts/virtual/sysctl.py
@@ -30,7 +30,7 @@ class VirtualSysctlDetectionMixin(object):
         if self.sysctl_path:
             rc, out, err = self.module.run_command("%s -n %s" % (self.sysctl_path, key))
             if rc == 0:
-                if re.match('(KVM|Bochs|SmartDC).*', out):
+                if re.match('(KVM|kvm|Bochs|SmartDC).*', out):
                     virtual_product_facts['virtualization_type'] = 'kvm'
                     virtual_product_facts['virtualization_role'] = 'guest'
                 elif re.match('.*VMware.*', out):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes: #49158
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/module_utils/facts/virtual/freebsd.py
lib/ansible/module_utils/facts/virtual/sysctl.py

##### ADDITIONAL INFORMATION
Before:
```
$ ansible -m setup -a 'filter=ansible_virtualization_*' freebsd
192.168.122.133 | SUCCESS => {
    "ansible_facts": {
        "ansible_virtualization_role": "", 
        "ansible_virtualization_type": ""
    }, 
    "changed": false
}
```
After:
```
 $ ansible -m setup -a 'filter=ansible_virtualization_*' freebsd
192.168.122.133 | SUCCESS => {
    "ansible_facts": {
        "ansible_virtualization_role": "guest", 
        "ansible_virtualization_type": "kvm"
    }, 
    "changed": false
}
```