### PR TITLE
Add new type 'mode' for Unix permissions/umask

### DIFF
--- a/lib/ansible/modules/cloud/opennebula/one_service.py
+++ b/lib/ansible/modules/cloud/opennebula/one_service.py
@@ -73,7 +73,8 @@ options:
     default: present
   mode:
     description:
-      - Set permission mode of a service instance in octet format, e.g. C(600) to give owner C(use) and C(manage) and nothing to group and others.
+      - Set permission mode of a service instance in octet format, e.g. C('0600') to give owner C(use) and C(manage) and nothing to group and others
+    type: mode
   owner_id:
     description:
       - ID of the user which will be set as the owner of the service
@@ -123,7 +124,7 @@ EXAMPLES = '''
     template_name: 'app1_template'
     service_name: 'app1'
     group_id: 1
-    mode: '660'
+    mode: '0660'
 
 # Instantiate a new service with template_id and pass custom_attrs dict
 - one_service:
@@ -153,7 +154,7 @@ EXAMPLES = '''
     service_name: 'app2'
     owner_id: 34
     group_id: 113
-    mode: '600'
+    mode: '0600'
 
 # Instantiate service and wait for it to become RUNNING
 -  one_service:
@@ -673,7 +674,7 @@ def main():
             "choices": ['present', 'absent'],
             "type": "str"
         },
-        "mode": {"required": False, "type": "str"},
+        "mode": {"required": False, "type": "mode_str"},  # TODO: Replace this with type 'mode' in Ansible 2.12
         "owner_id": {"required": False, "type": "int"},
         "group_id": {"required": False, "type": "int"},
         "unique": {"default": False, "type": "bool"},

--- a/lib/ansible/modules/cloud/opennebula/one_vm.py
+++ b/lib/ansible/modules/cloud/opennebula/one_vm.py
@@ -133,7 +133,8 @@ options:
       - NOTE':' Instances with the least IDs will be terminated first.
   mode:
     description:
-      - Set permission mode of the instance in octet format, e.g. C(600) to give owner C(use) and C(manage) and nothing to group and others.
+      - Set permission mode of the instance in octet format, e.g. C('0600') to give owner C(use) and C(manage) and nothing to group and others.
+    type: str
   owner_id:
     description:
       - ID of the user which will be set as the owner of the instance
@@ -192,12 +193,12 @@ EXAMPLES = '''
 - one_vm:
     template_id: 90
     group_id: 16
-    mode: 660
+    mode: '0660'
 
 # Change VM's permissions to 640
 - one_vm:
     instance_ids: 5
-    mode: 640
+    mode: '0640'
 
 # Deploy 2 new instances and set memory, vcpu, disk_size and 3 networks
 - one_vm:
@@ -1245,7 +1246,7 @@ def main():
             "choices": ['present', 'absent', 'rebooted', 'poweredoff', 'running'],
             "type": "str"
         },
-        "mode": {"required": False, "type": "str"},
+        "mode": {"required": False, "type": "mode_str"},
         "owner_id": {"required": False, "type": "int"},
         "group_id": {"required": False, "type": "int"},
         "wait": {"default": True, "type": "bool"},

--- a/lib/ansible/modules/cloud/univention/udm_share.py
+++ b/lib/ansible/modules/cloud/univention/udm_share.py
@@ -361,7 +361,7 @@ def main():
             sambaCustomSettings=dict(type='list',
                                      aliases=['samba_custom_settings'],
                                      default=[]),
-            sambaDirectoryMode=dict(type='str',
+            sambaDirectoryMode=dict(type='mode_str',  # TODO: Replace this with type 'mode' in Ansible 2.12
                                     aliases=['samba_directory_mode'],
                                     default='0755'),
             sambaDirectorySecurityMode=dict(type='str',

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -74,13 +74,13 @@ options:
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
     - As of Ansible 2.3, the mode may also be the special string C(preserve).
     - C(preserve) means that the file will be given the same permissions as the source file.
-    type: path
+    type: mode
   directory_mode:
     description:
     - When doing a recursive copy set the mode for the directories.
     - If this is not set we will use the system defaults.
     - The mode is only set on directories which are newly created, and will not affect those that already existed.
-    type: raw
+    type: mode
     version_added: '1.5'
   remote_src:
     description:
@@ -477,7 +477,7 @@ def main():
             backup=dict(type='bool', default=False),
             force=dict(type='bool', default=True, aliases=['thirsty']),
             validate=dict(type='str'),
-            directory_mode=dict(type='raw'),
+            directory_mode=dict(type='mode'),
             remote_src=dict(type='bool'),
             local_follow=dict(type='bool'),
             checksum=dict(type='str'),

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -130,7 +130,7 @@ EXAMPLES = r'''
     path: /work
     owner: root
     group: root
-    mode: '1777'
+    mode: '01777'
 
 - name: Create a symbolic link
   file:

--- a/lib/ansible/modules/files/stat.py
+++ b/lib/ansible/modules/files/stat.py
@@ -155,8 +155,8 @@ stat:
         mode:
             description: Unix permissions of the file in octal
             returned: success, path exists and user can read stats
-            type: octal
-            sample: 1755
+            type: mode
+            sample: '01755'
         isdir:
             description: Tells you if the path is a directory
             returned: success, path exists and user can read stats

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -101,6 +101,7 @@ options:
         restrictive umask by default (e.g., "0077") and you want to pip install
         packages which are to be used by all users. Note that this requires you
         to specify desired umask mode as an octal string, (e.g., "0022").
+    type: mode
     version_added: "2.1"
 notes:
    - Please note that virtualenv (U(http://www.virtualenv.org/)) must be
@@ -576,7 +577,7 @@ def main():
             editable=dict(type='bool', default=False),
             chdir=dict(type='path'),
             executable=dict(type='path'),
-            umask=dict(type='str'),
+            umask=dict(type='mode_str'),  # TODO: Replace this with type 'mode' in Ansible 2.12
         ),
         required_one_of=[['name', 'requirements']],
         mutually_exclusive=[['name', 'requirements'], ['executable', 'virtualenv']],

--- a/lib/ansible/modules/packaging/os/apt_repository.py
+++ b/lib/ansible/modules/packaging/os/apt_repository.py
@@ -36,6 +36,7 @@ options:
     mode:
         description:
             - The octal mode for newly created files in sources.list.d
+        type: mode
         default: '0644'
         version_added: "1.6"
     update_cache:
@@ -482,7 +483,7 @@ def main():
         argument_spec=dict(
             repo=dict(type='str', required=True),
             state=dict(type='str', default='present', choices=['absent', 'present']),
-            mode=dict(type='raw'),
+            mode=dict(type='mode'),
             update_cache=dict(type='bool', default=True, aliases=['update-cache']),
             filename=dict(type='str'),
             # This should not be needed, but exists as a failsafe

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -122,6 +122,7 @@ options:
         description:
             - The umask to set before doing any checkouts, or any other
               repository maintenance.
+        type: mode
         version_added: "2.2"
 
     recursive:
@@ -1025,7 +1026,7 @@ def main():
             bare=dict(default='no', type='bool'),
             recursive=dict(default='yes', type='bool'),
             track_submodules=dict(default='no', type='bool'),
-            umask=dict(default=None, type='raw'),
+            umask=dict(type='mode'),
             archive=dict(type='path'),
             separate_git_dir=dict(type='path'),
         ),

--- a/lib/ansible/modules/system/java_keystore.py
+++ b/lib/ansible/modules/system/java_keystore.py
@@ -52,7 +52,7 @@ options:
     mode:
         description:
           - Mode the file should be.
-        required: false
+        type: mode
     force:
         description:
           - Key store will be created even if it already exists.

--- a/lib/ansible/modules/web_infrastructure/htpasswd.py
+++ b/lib/ansible/modules/web_infrastructure/htpasswd.py
@@ -76,7 +76,7 @@ EXAMPLES = """
     password: '9s36?;fyNp'
     owner: root
     group: www-data
-    mode: 0640
+    mode: '0640'
 
 # Remove a user from a password file
 - htpasswd:

--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -33,6 +33,7 @@ options:
   mode:
     description:
       - File mode applied on versioned plugins.
+    type: mode
   name:
     description:
       - Plugin name.
@@ -705,7 +706,7 @@ def main():
     argument_spec.update(
         group=dict(default='jenkins'),
         jenkins_home=dict(default='/var/lib/jenkins'),
-        mode=dict(default='0644', type='raw'),
+        mode=dict(type='mode', default='0644'),
         name=dict(required=True),
         owner=dict(default='jenkins'),
         params=dict(type='dict'),

--- a/lib/ansible/plugins/doc_fragments/files.py
+++ b/lib/ansible/plugins/doc_fragments/files.py
@@ -25,7 +25,7 @@ options:
       C(u=rw,g=r,o=r)).
     - As of Ansible 2.6, the mode may also be the special string C(preserve).
     - When set to C(preserve) the file will be given the same permissions as the source file.
-    type: str
+    type: mode
   owner:
     description:
     - Name of the user that should own the file/directory, as would be fed to I(chown).

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -186,6 +186,8 @@ lib/ansible/modules/cloud/oneandone/oneandone_private_network.py E326
 lib/ansible/modules/cloud/oneandone/oneandone_public_ip.py E324
 lib/ansible/modules/cloud/oneandone/oneandone_public_ip.py E326
 lib/ansible/modules/cloud/oneandone/oneandone_server.py E326
+lib/ansible/modules/cloud/opennebula/one_service.py E325
+lib/ansible/modules/cloud/opennebula/one_vm.py E325
 lib/ansible/modules/cloud/openstack/os_flavor_facts.py E324
 lib/ansible/modules/cloud/openstack/os_flavor_facts.py E335
 lib/ansible/modules/cloud/openstack/os_image.py E324
@@ -695,6 +697,7 @@ lib/ansible/modules/packaging/language/pear.py E322
 lib/ansible/modules/packaging/language/pear.py E326
 lib/ansible/modules/packaging/language/pip.py E322
 lib/ansible/modules/packaging/language/pip.py E324
+lib/ansible/modules/packaging/language/pip.py E325
 lib/ansible/modules/packaging/os/apk.py E326
 lib/ansible/modules/packaging/os/apt.py E322
 lib/ansible/modules/packaging/os/apt.py E324

--- a/test/sanity/validate-modules/schema.py
+++ b/test/sanity/validate-modules/schema.py
@@ -81,7 +81,7 @@ suboption_schema = Schema(
         'version_added': Any(float, *string_types),
         'default': Any(None, float, int, bool, list, dict, *string_types),
         # Note: Types are strings, not literal bools, such as True or False
-        'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'str'),
+        'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'mode', 'mode_str', 'path', 'raw', 'str'),
         # Recursive suboptions
         'suboptions': Any(None, *list({str_type: Self} for str_type in string_types)),
     },
@@ -102,7 +102,7 @@ option_schema = Schema(
         'default': Any(None, float, int, bool, list, dict, *string_types),
         'suboptions': Any(None, *list_dict_suboption_schema),
         # Note: Types are strings, not literal bools, such as True or False
-        'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'str'),
+        'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'mode', 'mode_str', 'path', 'raw', 'str'),
     },
     extra=PREVENT_EXTRA
 )


### PR DESCRIPTION
##### SUMMARY
To avoid any dangerous situations with octal or integer values as Unix mode, it is better to always rely on using strings for Unix permissions or umasks. It adds clarity and uniformity, as the current ambiguous situation leads to unforeseen consequences (e.g. with indirected values being converted to integers). It would have been better if we always had only accepted string octal representation IMO.

This implements a deprecation warning if a string was not provided, but by Ansible v2.12 we will only accept string values for type `mode`. As a temporary measure we introduced a `mode_str` type to cover old `str`-type modes (whereas `mode` is using `raw`-type modes instead).

This PR also:
- fix all examples doing it wrong

This fixes #43256

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
apt_repository, copy, file, get_url, htpasswd, ini_file, java_keystore, jenkins_plugin, lineinfile, openssl_pkcs12, replace, stat, template, udm_share