### PR TITLE
[2.7] Don't fail if a remote_addr with a '/' hits ansible_connection (#49781)

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -182,6 +182,7 @@ class ConnectionProcess(object):
     def shutdown(self):
         """ Shuts down the local domain socket
         """
+        lock_path = unfrackpath("%s/.ansible_pc_lock_%s" % os.path.split(self.socket_path))
         if os.path.exists(self.socket_path):
             try:
                 if self.sock:
@@ -195,6 +196,10 @@ class ConnectionProcess(object):
                     os.remove(self.socket_path)
                     setattr(self.connection, '_socket_path', None)
                     setattr(self.connection, '_connected', False)
+
+        if os.path.exists(lock_path):
+            os.remove(lock_path)
+
         display.display('shutdown complete', log_only=True)
 
 
@@ -249,8 +254,8 @@ def main():
         tmp_path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
         makedirs_safe(tmp_path)
 
-        lock_path = unfrackpath("%s/.ansible_pc_lock_%s" % (tmp_path, play_context.remote_addr))
         socket_path = unfrackpath(cp % dict(directory=tmp_path))
+        lock_path = unfrackpath("%s/.ansible_pc_lock_%s" % os.path.split(socket_path))
 
         with file_lock(lock_path):
             if not os.path.exists(socket_path):

--- a/changelogs/fragments/persistent-socket-lock-name.yaml
+++ b/changelogs/fragments/persistent-socket-lock-name.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+- Changes how ansible-connection names socket lock files. They now use
+  the same name as the socket itself, and as such do not lock other
+  attempts on connections to the same host, or cause issues with
+  overly-long hostnames.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

* Locks are now per-socket_path.

Locks use the same value as socket_path. Locks are also cleaned up in
shutdown like sockets.
(cherry picked from commit 61a649c)

Co-authored-by: Nathaniel Case <this.is@nathanielca.se>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-connection
