### PR TITLE
Fix disk_index with current disk more than 7 due to scsi controller

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1644,7 +1644,11 @@ class PyVmomiHelper(PyVmomi):
         for expected_disk_spec in self.params.get('disk'):
             disk_modified = False
             # If we are manipulating and existing objects which has disks and disk_index is in disks
+<<<<<<< HEAD
             if vm_obj is not None and disks is not None and disk_index < len(disks):
+=======
+            if vm_obj is not None and disks is not None and disk_index < (len(disks) if len(disks) < 7 else len(disks) + 1):
+>>>>>>> a94905b... Correct pep8 style
                 diskspec = vim.vm.device.VirtualDeviceSpec()
                 # set the operation to edit so that it knows to keep other settings
                 diskspec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1644,15 +1644,11 @@ class PyVmomiHelper(PyVmomi):
         for expected_disk_spec in self.params.get('disk'):
             disk_modified = False
             # If we are manipulating and existing objects which has disks and disk_index is in disks
-<<<<<<< HEAD
-            if vm_obj is not None and disks is not None and disk_index < len(disks):
-=======
             if vm_obj is not None and disks is not None and disk_index < (len(disks) if len(disks) < 7 else len(disks) + 1):
->>>>>>> a94905b... Correct pep8 style
                 diskspec = vim.vm.device.VirtualDeviceSpec()
                 # set the operation to edit so that it knows to keep other settings
                 diskspec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
-                diskspec.device = disks[disk_index]
+                diskspec.device = disks[disk_index] if disk_index < 7 else disks[disk_index - 1]
             else:
                 diskspec = self.device_helper.create_scsi_disk(scsi_ctl, disk_index)
                 disk_modified = True


### PR DESCRIPTION
(cherry picked from commit a94905bdca70d53928880dfd08d50e259c50c0db)

Conflicts:
	lib/ansible/modules/cloud/vmware/vmware_guest.py

Fix disk_index with current disk more than 7 due to scsi controller

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When you already have 7 disk added to your VM, you can't add another disk since the index is incremented. The validation is wrong because the disk_index and the number of disk is not ajusted correctly.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Playbook:

    name: "test new disk when 7 disk exist"
    hosts: all
    gather_facts: no
    tasks:

        vmware_guest_disk_facts:
        hostname: "{{vmware_vcenter}}"
        username: "{{vmware_username}}"
        password: "{{vmware_password}}"
        validate_certs: no
        datacenter: "{{vmware_datacenter}}"
        name: "{{ inventory_hostname }}"
        delegate_to: localhost
        become: no
        register: vmware_add_disk_disk_facts

        name: Reset existing_disk
        set_fact:
        vmware_add_disk_existing_disk: ""

        name: Construire la liste des disques existants
        set_fact:
        vmware_add_disk_existing_disk: "{% if vmware_add_disk_existing_disk != '' %}{{vmware_add_disk_existing_disk}}+{% endif %}{{[{'size_kb': vmware_add_disk_disk_facts.guest_disk_facts[disk|string].capacity_in_kb,'type':'eagerzeroedthick'}]}}"
        when: vmware_add_disk_disk_facts.guest_disk_facts[disk|string] is defined
        loop: "{{range(0,15)|list}}"
        loop_control:
        loop_var: disk

        vmware_guest:
        hostname: "{{vmware_vcenter}}"
        username: "{{vmware_username}}"
        password: "{{vmware_password}}"
        validate_certs: no
        datacenter: "{{vmware_datacenter}}"
        name: "{{ inventory_hostname }}"
        disk: "{{vmware_add_disk_existing_disk}} + {{[{'size_gb': 10,'type':'eagerzeroedthick'}]}}"
        delegate_to: localhost
        become: no

Before change:
#ansible-playbook -i inventaire/nouvelle_vm.yml vmware-add-disk.yml

PLAY [test new disk when 7 disk exist] *******************************************************************************************************************************************************************************************************

TASK [vmware_guest_disk_facts] ***************************************************************************************************************************************************************************************************************
ok: [vm1 -> localhost]

TASK [Reset existing_disk] *******************************************************************************************************************************************************************************************************************
ok: [vm1]

TASK [Construire la liste des disques existants] *********************************************************************************************************************************************************************************************
ok: [vm1] => (item=0)
ok: [vm1] => (item=1)
ok: [vm1] => (item=2)
ok: [vm1] => (item=3)
ok: [vm1] => (item=4)
ok: [vm1] => (item=5)
ok: [vm1] => (item=6)
skipping: [vm1] => (item=7)
skipping: [vm1] => (item=8)
skipping: [vm1] => (item=9)
skipping: [vm1] => (item=10)
skipping: [vm1] => (item=11)
skipping: [vm1] => (item=12)
skipping: [vm1] => (item=13)
skipping: [vm1] => (item=14)

TASK [vmware_guest] **************************************************************************************************************************************************************************************************************************
changed: [vm1 -> localhost]

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
vm1 : ok=4    changed=1    unreachable=0    failed=0

# ansible-playbook -i inventaire/nouvelle_vm.yml vmware-add-disk.yml


PLAY [test new disk when 7 disk exist] *******************************************************************************************************************************************************************************************************

TASK [vmware_guest_disk_facts] ***************************************************************************************************************************************************************************************************************
ok: [vm1 -> localhost]

TASK [Reset existing_disk] *******************************************************************************************************************************************************************************************************************
ok: [vm1]

TASK [Construire la liste des disques existants] *********************************************************************************************************************************************************************************************
ok: [vm1] => (item=0)
ok: [vm1] => (item=1)
ok: [vm1] => (item=2)
ok: [vm1] => (item=3)
ok: [vm1] => (item=4)
ok: [vm1] => (item=5)
ok: [vm1] => (item=6)
ok: [vm1] => (item=7)
skipping: [vm1] => (item=8)
skipping: [vm1] => (item=9)
skipping: [vm1] => (item=10)
skipping: [vm1] => (item=11)
skipping: [vm1] => (item=12)
skipping: [vm1] => (item=13)
skipping: [vm1] => (item=14)

TASK [vmware_guest] **************************************************************************************************************************************************************************************************************************
fatal: [vm1 -> localhost]: FAILED! => {"changed": true, "msg": "Invalid configuration for device '0'."}
        to retry, use: --limit @/home/path/ansible/vmware-add-disk.retry

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
vm1 : ok=3    changed=0    unreachable=0    failed=1





After change:
# ansible-playbook -i inventaire/nouvelle_vm.yml  vmware-add-disk.yml

PLAY [test new disk when 7 disk exist] *******************************************************************************************************************************************************************************************************

TASK [vmware_guest_disk_facts] ***************************************************************************************************************************************************************************************************************
ok: [vm1 -> localhost]

TASK [Reset existing_disk] *******************************************************************************************************************************************************************************************************************
ok: [vm1]

TASK [Construire la liste des disques existants] *********************************************************************************************************************************************************************************************
ok: [vm1] => (item=0)
ok: [vm1] => (item=1)
ok: [vm1] => (item=2)
ok: [vm1] => (item=3)
ok: [vm1] => (item=4)
ok: [vm1] => (item=5)
ok: [vm1] => (item=6)
ok: [vm1] => (item=7)
skipping: [vm1] => (item=8)
skipping: [vm1] => (item=9)
skipping: [vm1] => (item=10)
skipping: [vm1] => (item=11)
skipping: [vm1] => (item=12)
skipping: [vm1] => (item=13)
skipping: [vm1] => (item=14)

TASK [vmware_guest] **************************************************************************************************************************************************************************************************************************
changed: [vm1 -> localhost]

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
vm1 : ok=4    changed=1    unreachable=0    failed=0


```
