### PR TITLE
 Give IncludedFile more context via ansible_search_path

### DIFF
--- a/changelogs/fragments/include_tasks_parent_templating.yml
+++ b/changelogs/fragments/include_tasks_parent_templating.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- include_tasks - Ensure we give IncludedFile the same context as TaskExecutor when templating the parent include path
+  allowing for lookups in the included file path (https://github.com/ansible/ansible/issues/49969)

--- a/test/integration/targets/include_import/parent_templating/playbook.yml
+++ b/test/integration/targets/include_import/parent_templating/playbook.yml
@@ -1,0 +1,11 @@
+# https://github.com/ansible/ansible/issues/49969
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - include_role:
+        name: test
+        public: true
+
+    - assert:
+        that:
+          - included_other is defined

--- a/test/integration/targets/include_import/parent_templating/roles/test/tasks/localhost.yml
+++ b/test/integration/targets/include_import/parent_templating/roles/test/tasks/localhost.yml
@@ -1,0 +1,1 @@
+- include_tasks: other.yml

--- a/test/integration/targets/include_import/parent_templating/roles/test/tasks/main.yml
+++ b/test/integration/targets/include_import/parent_templating/roles/test/tasks/main.yml
@@ -1,0 +1,1 @@
+- include_tasks: "{{ lookup('first_found', inventory_hostname ~ '.yml') }}"

--- a/test/integration/targets/include_import/parent_templating/roles/test/tasks/other.yml
+++ b/test/integration/targets/include_import/parent_templating/roles/test/tasks/other.yml
@@ -1,0 +1,2 @@
+- set_fact:
+    included_other: true

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -90,3 +90,7 @@ ansible-playbook run_once/playbook.yml "$@"
 # https://github.com/ansible/ansible/issues/48936
 ansible-playbook -v handler_addressing/playbook.yml 2>&1 | tee test_handler_addressing.out
 test "$(egrep -c 'include handler task|ERROR! The requested handler '"'"'do_import'"'"' was not found' test_handler_addressing.out)" = 2
+
+# https://github.com/ansible/ansible/issues/49969
+ansible-playbook -v parent_templating/playbook.yml 2>&1 | tee test_parent_templating.out
+test "$(egrep -c 'Templating the path of the parent include_tasks failed.' test_parent_templating.out)" = 0

--- a/test/units/playbook/test_included_file.py
+++ b/test/units/playbook/test_included_file.py
@@ -65,6 +65,7 @@ def test_process_include_results(mock_iterator, mock_variable_manager):
 
     parent_task_ds = {'debug': 'msg=foo'}
     parent_task = Task.load(parent_task_ds)
+    parent_task._play = None
 
     task_ds = {'include': 'include_test.yml'}
     loaded_task = TaskInclude.load(task_ds, task_include=parent_task)
@@ -91,12 +92,15 @@ def test_process_include_diff_files(mock_iterator, mock_variable_manager):
 
     parent_task_ds = {'debug': 'msg=foo'}
     parent_task = Task.load(parent_task_ds)
+    parent_task._play = None
 
     task_ds = {'include': 'include_test.yml'}
     loaded_task = TaskInclude.load(task_ds, task_include=parent_task)
+    loaded_task._play = None
 
     child_task_ds = {'include': 'other_include_test.yml'}
     loaded_child_task = TaskInclude.load(child_task_ds, task_include=loaded_task)
+    loaded_child_task._play = None
 
     return_data = {'include': 'include_test.yml'}
     # The task in the TaskResult has to be a TaskInclude so it has a .static attr
@@ -128,6 +132,9 @@ def test_process_include_simulate_free(mock_iterator, mock_variable_manager):
     parent_task_ds = {'debug': 'msg=foo'}
     parent_task1 = Task.load(parent_task_ds)
     parent_task2 = Task.load(parent_task_ds)
+
+    parent_task1._play = None
+    parent_task2._play = None
 
     task_ds = {'include': 'include_test.yml'}
     loaded_task1 = TaskInclude.load(task_ds, task_include=parent_task1)


### PR DESCRIPTION
##### SUMMARY

Give `IncludedFile` more context via `ansible_search_path` to template lookups. Fixes #49969

Additionally, this PR does 2 other things:

1. Moves instantiating `Templar` until after `task_vars` is updated. Not needed, but makes the code more clear.
1. Catch the problematic `templar.template`, provide a warning of what happened, and that we may fail to find the file later, and then continue on.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/included_file.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```