### PR TITLE
[stable-2.7] Fix reverse_inventory order to work on python3 (#49895)

### DIFF
--- a/changelogs/fragments/playbook-order-py3.yaml
+++ b/changelogs/fragments/playbook-order-py3.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-- host execution order - Fix ``reverse_inventory`` to work on python3

--- a/changelogs/fragments/playbook-order-py3.yaml
+++ b/changelogs/fragments/playbook-order-py3.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- host execution order - Fix ``reverse_inventory`` to work on python3

--- a/changelogs/fragments/playbook-order-reverse_inventory.yaml
+++ b/changelogs/fragments/playbook-order-reverse_inventory.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- host execution order - Fix ``reverse_inventory`` not to change the order of
+  the items before reversing on python2 and to not backtrace on python3

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -24,6 +24,9 @@ import os
 import re
 import itertools
 
+from operator import attrgetter
+from random import shuffle
+
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.inventory.data import InventoryData
@@ -368,14 +371,12 @@ class InventoryManager(object):
 
             # sort hosts list if needed (should only happen when called from strategy)
             if order in ['sorted', 'reverse_sorted']:
-                from operator import attrgetter
                 hosts = sorted(self._hosts_patterns_cache[pattern_hash][:], key=attrgetter('name'), reverse=(order == 'reverse_sorted'))
             elif order == 'reverse_inventory':
-                hosts = sorted(self._hosts_patterns_cache[pattern_hash][:], reverse=True)
+                hosts = self._hosts_patterns_cache[pattern_hash][::-1]
             else:
                 hosts = self._hosts_patterns_cache[pattern_hash][:]
                 if order == 'shuffle':
-                    from random import shuffle
                     shuffle(hosts)
                 elif order not in [None, 'inventory']:
                     raise AnsibleOptionsError("Invalid 'order' specified for inventory hosts: %s" % order)


### PR DESCRIPTION
(cherry picked from commit a0d71e7)


Co-authored-by: Matt Martz <matt@sivel.net>