### PR TITLE
[stable-2.7] fix memtotal_mb rounding on VMWare and swaptotal_mb conversion from KB to MB

### DIFF
--- a/changelogs/fragments/windows_setup_memtotal.yml
+++ b/changelogs/fragments/windows_setup_memtotal.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup - fix the rounding of the ansible_memtotal_mb value on VMWare vm's (https://github.com/ansible/ansible/issues/49608)

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -298,8 +298,8 @@ if($gather_subset.Contains('memory')) {
     $win32_os = Get-LazyCimInstance Win32_OperatingSystem
     $ansible_facts += @{
         # Win32_PhysicalMemory is empty on some virtual platforms
-        ansible_memtotal_mb = ([math]::round($win32_cs.TotalPhysicalMemory / 1024 / 1024))
-        ansible_swaptotal_mb = ([math]::round($win32_os.TotalSwapSpaceSize / 1024 / 1024))
+        ansible_memtotal_mb = ([math]::ceiling($win32_cs.TotalPhysicalMemory / 1024 / 1024))
+        ansible_swaptotal_mb = ([math]::round($win32_os.TotalSwapSpaceSize / 1024))
     }
 }
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Cherry picked from commit cc3e43cb2051d210ebb7dfbea2cd3674b1ecf616
Original PR #49940 
Issue https://github.com/ansible/ansible/issues/49608

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
/lib/ansible/modules/windows/setup.ps1
