### PR TITLE
add range_start and range_end agrs when query vm by a single id

### DIFF
--- a/lib/ansible/modules/cloud/opennebula/one_vm.py
+++ b/lib/ansible/modules/cloud/opennebula/one_vm.py
@@ -614,12 +614,12 @@ def get_vm_by_id(client, vm_id):
     # -2: All vms user can Use
     # -1: Vms belonging to the user and any of his groups - default
     # >= 0: UID User's vms
-    pool.info(filter=-2)
+    pool.info(filter=-2, range_start=int(vm_id), range_end=int(vm_id))
 
-    for vm in pool:
-        if str(vm.id) == str(vm_id):
-            return vm
-    return None
+    if len(pool) == 1:
+        return pool[0]
+    else:
+        return None
 
 
 def get_vms_by_ids(module, client, state, ids):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
now get_vm_by_id need iterate all vms in pool and this is very slow when user has a large vm pool. After adding 'range_start' and 'range_end', the performance is much better than before.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
opennebula
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I have 8000+ vms in my Opennebula cluster, so the performance matters  a lot. Below is a the comparison result between before and after the change.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
---------before change-----
time ansible -m one_vm -a "api_url='https://xxxx:2633/RPC2' instance_ids=xxxx" localhost -vvv
....
real	0m51.714s
user	0m49.952s
sys	0m2.932s
----------after change------
time ansible -m one_vm -a "api_url='https://xxxx:2633/RPC2' instance_ids=xxxx" localhost -vvv
...
real	0m1.165s
user	0m0.908s
sys	0m0.244s

```
