### PR TITLE
Ecs service add features

### DIFF
--- a/changelogs/fragments/50059-ecs-service-add-features.yml
+++ b/changelogs/fragments/50059-ecs-service-add-features.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ecs_service - adds support for service_registries and scheduling_strategies. desired_count may now be none to support scheduling_strategies

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -602,9 +602,7 @@ def main():
                         loadBalancer['containerPort'] = int(loadBalancer['containerPort'])
 
                 if update:
-                    # If boto is not up to snuff, getting params will fail;
-                    # Move checks to where they matter vs generall at module level
-                    # So, boto3 of various versions supports various features.  Parameters that are not supported
+                    # check various parameters and boto versions and give a helpful erro in boto is not new enough for feature
 
                     if module.params['scheduling_strategy']:
                         if not module.botocore_at_least('1.10.37'):

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -567,10 +567,7 @@ def main():
                                                           module.params['desired_count'],
                                                           deploymentConfiguration,
                                                           network_configuration,
-<<<<<<< 61b5adcf316bcab84432cc4f0f1c22c411c5a071
                                                           module.params['health_check_grace_period_seconds'],
-=======
->>>>>>> Support UpdateService forceNewDeployment in ecs_service module
                                                           module.params['force_new_deployment'])
                 else:
                     try:

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -425,8 +425,7 @@ class EcsServiceManager:
             service=service_name,
             taskDefinition=task_definition,
             desiredCount=desired_count,
-            deploymentConfiguration=deployment_configuration,
-            forceNewDeployment=force_new_deployment)
+            deploymentConfiguration=deployment_configuration)
         if network_configuration:
             params['networkConfiguration'] = network_configuration
         if self.health_check_setable(params):

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -425,7 +425,8 @@ class EcsServiceManager:
             service=service_name,
             taskDefinition=task_definition,
             desiredCount=desired_count,
-            deploymentConfiguration=deployment_configuration)
+            deploymentConfiguration=deployment_configuration,
+            forceNewDeployment=force_new_deployment)
         if network_configuration:
             params['networkConfiguration'] = network_configuration
         if self.health_check_setable(params):
@@ -566,7 +567,10 @@ def main():
                                                           module.params['desired_count'],
                                                           deploymentConfiguration,
                                                           network_configuration,
+<<<<<<< 61b5adcf316bcab84432cc4f0f1c22c411c5a071
                                                           module.params['health_check_grace_period_seconds'],
+=======
+>>>>>>> Support UpdateService forceNewDeployment in ecs_service module
                                                           module.params['force_new_deployment'])
                 else:
                     try:

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -407,8 +407,11 @@ class EcsServiceManager:
         if (expected['load_balancers'] or []) != existing['loadBalancers']:
             return False
 
-        if (expected['desired_count'] or 0) != existing['desiredCount']:
-            return False
+        # expected is params. DAEMON scheduling strategy returns desired count equal to 
+        # number of instances running; don't check desired count if scheduling strat is daemon
+        if (expected['scheduling_strategy']!='DAEMON'):
+            if (expected['desired_count'] or 0) != existing['desiredCount']:
+                return False
 
         return True
 

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -421,7 +421,6 @@ class EcsServiceManager:
             serviceName=service_name,
             taskDefinition=task_definition,
             loadBalancers=load_balancers,
-            desiredCount=desired_count,
             clientToken=client_token,
             role=role,
             deploymentConfiguration=deployment_configuration,
@@ -436,6 +435,9 @@ class EcsServiceManager:
             params['healthCheckGracePeriodSeconds'] = health_check_grace_period_seconds
         if service_registries:
             params['serviceRegistries'] = service_registries
+        # desired count is not required if scheduling strategy is daemon
+        if desired_count is not None:
+            params['desiredCount']=desired_count
 
         if scheduling_strategy:
             params['schedulingStrategy'] = scheduling_strategy
@@ -449,7 +451,6 @@ class EcsServiceManager:
             cluster=cluster_name,
             service=service_name,
             taskDefinition=task_definition,
-            desiredCount=desired_count,
             deploymentConfiguration=deployment_configuration)
         if network_configuration:
             params['networkConfiguration'] = network_configuration
@@ -459,6 +460,9 @@ class EcsServiceManager:
             params['forceNewDeployment'] = force_new_deployment
         if healthcheck_grace_period:
             params['healthCheckGracePeriodSeconds'] = healthcheck_grace_period
+        # desired count is not required if scheduling strategy is daemon
+        if desired_count is not None:
+            params['desiredCount']=desired_count
 
         response = self.ecs.update_service(**params)
         return self.jsonize(response['service'])

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -344,7 +344,6 @@ try:
 except ImportError:
     pass  # handled by AnsibleAWSModule
 
-
 class EcsServiceManager:
     """Handles ECS Services"""
 
@@ -435,6 +434,8 @@ class EcsServiceManager:
             params['launchType'] = launch_type
         if self.health_check_setable(params) and health_check_grace_period_seconds is not None:
             params['healthCheckGracePeriodSeconds'] = health_check_grace_period_seconds
+        if service_registries:
+            params['serviceRegistries'] = service_registries
 
         if scheduling_strategy:
             params['schedulingStrategy'] = scheduling_strategy

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -530,7 +530,7 @@ def main():
                               required_together=[['load_balancers', 'role']])
 
     if module.params['state'] == 'present' and module.params['scheduling_strategy'] == 'REPLICA':
-        if not module.params['desired_count']:
+        if module.params['desired_count']==None:
             module.fail_json(msg='state is present, scheduling_strategy is REPLICA; missing desired_count')
 
     service_mgr = EcsServiceManager(module)

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
@@ -479,6 +479,53 @@
           - "update_ecs_service_with_vpc.service.networkConfiguration.awsvpcConfiguration.subnets|length == 2"
           - "update_ecs_service_with_vpc.service.networkConfiguration.awsvpcConfiguration.securityGroups|length == 1"
 
+    - name: create ecs_service using healthcheck_grace_period
+      ecs_service:
+        name: "{{ ecs_service_name }}-mft"
+        cluster: "{{ ecs_cluster_name }}"
+        load_balancers:
+          - targetGroupArn: "{{ elb_target_group_instance.target_group_arn }}"
+            containerName: "{{ ecs_task_name }}"
+            containerPort: "{{ ecs_task_container_port }}"
+        task_definition: "{{ ecs_task_name }}:{{ ecs_task_definition.taskdefinition.revision }}"
+        scheduling_strategy: "REPLICA"
+        healthcheck_grace_period: 10
+        desired_count: 1
+        state: present
+        <<: *aws_connection_info
+      register: ecs_service_creation_hcgp
+
+    - name: DEBUG
+      debug: var=ecs_service_creation_hcgp
+
+    - name: healthcheck_grace_period sets HealthChecGracePeriodSeconds
+      assert:
+        that:
+          - ecs_service_creation_hcgp.changed
+          - "{{ecs_service_creation_hcgp.service.healthCheckGracePeriodSeconds}} == 10"
+
+    - name: update ecs_service using healthcheck_grace_period
+      ecs_service:
+        name: "{{ ecs_service_name }}-mft"
+        cluster: "{{ ecs_cluster_name }}"
+        load_balancers:
+          - targetGroupArn: "{{ elb_target_group_instance.target_group_arn }}"
+            containerName: "{{ ecs_task_name }}"
+            containerPort: "{{ ecs_task_container_port }}"
+        task_definition: "{{ ecs_task_name }}:{{ ecs_task_definition.taskdefinition.revision }}"
+        desired_count: 1
+        healthcheck_grace_period: 30
+        state: present
+        <<: *aws_connection_info
+      register: ecs_service_creation_hcgp2
+      ignore_errors: no
+
+    - name: check that module returns success
+      assert:
+        that:
+          - ecs_service_creation_hcgp2.changed
+          - "{{ecs_service_creation_hcgp2.service.healthCheckGracePeriodSeconds}} == 30"
+
     - name: obtain facts for all ECS services in the cluster
       ecs_service_facts:
         cluster: "{{ ecs_cluster_name }}"
@@ -728,6 +775,21 @@
       ignore_errors: yes
       register: ecs_service_scale_down
 
+    - name: scale down multifunction-test service
+      ecs_service:
+        name: "{{ ecs_service_name }}-mft"
+        cluster: "{{ ecs_cluster_name }}"
+        state: present
+        load_balancers:
+          - targetGroupArn: "{{ elb_target_group_instance.target_group_arn }}"
+            containerName: "{{ ecs_task_name }}"
+            containerPort: "{{ ecs_task_container_port }}"
+        task_definition: "{{ ecs_task_name }}:{{ ecs_task_definition.taskdefinition.revision }}"
+        desired_count: 0
+        <<: *aws_connection_info
+      ignore_errors: yes
+      register: ecs_service_scale_down
+
     - name: scale down Fargate ECS service
       ecs_service:
         state: present
@@ -758,6 +820,14 @@
         state: absent
         cluster: "{{ ecs_cluster_name }}"
         name: "{{ ecs_service_name }}2"
+        <<: *aws_connection_info
+      ignore_errors: yes
+
+    - name: remove mft ecs service
+      ecs_service:
+        state: absent
+        cluster: "{{ ecs_cluster_name }}"
+        name: "{{ ecs_service_name }}-mft"
         <<: *aws_connection_info
       ignore_errors: yes
 

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
@@ -495,8 +495,6 @@
         <<: *aws_connection_info
       register: ecs_service_creation_hcgp
 
-    - name: DEBUG
-      debug: var=ecs_service_creation_hcgp
 
     - name: healthcheck_grace_period sets HealthChecGracePeriodSeconds
       assert:
@@ -525,6 +523,35 @@
         that:
           - ecs_service_creation_hcgp2.changed
           - "{{ecs_service_creation_hcgp2.service.healthCheckGracePeriodSeconds}} == 30"
+
+    - name: update ecs_service using service_registries
+      ecs_service:
+        name: "{{ ecs_service_name }}-service-registries"
+        cluster: "{{ ecs_cluster_name }}"
+        load_balancers:
+          - targetGroupArn: "{{ elb_target_group_instance.target_group_arn }}"
+            containerName: "{{ ecs_task_name }}"
+            containerPort: "{{ ecs_task_container_port }}"
+        service_registries:
+          - containerName: "{{ ecs_task_name }}"
+            containerPort: "{{ ecs_task_container_port }}"
+            ### TODO: Figure out how to get a service registry ARN without a service registry module.
+            registryArn: "{{ ecs_task_service_registry_arn }}"
+        task_definition: "{{ ecs_task_name }}:{{ ecs_task_definition.taskdefinition.revision }}"
+        desired_count: 1
+        healthcheck_grace_period: 30
+        state: present
+        <<: *aws_connection_info
+      register: ecs_service_creation_sr
+      ignore_errors: yes
+
+    - name: dump sr output
+      debug: var=ecs_service_creation_sr
+
+    - name: check that module returns success
+      assert:
+        that:
+          - ecs_service_creation_sr.changed
 
     - name: obtain facts for all ECS services in the cluster
       ecs_service_facts:
@@ -790,6 +817,20 @@
       ignore_errors: yes
       register: ecs_service_scale_down
 
+    - name: scale down service_registries service
+      ecs_service:
+        name: "{{ ecs_service_name }}-service-registries"
+        cluster: "{{ ecs_cluster_name }}"
+        state: present
+        load_balancers:
+          - targetGroupArn: "{{ elb_target_group_instance.target_group_arn }}"
+            containerName: "{{ ecs_task_name }}"
+            containerPort: "{{ ecs_task_container_port }}"
+        task_definition: "{{ ecs_task_name }}:{{ ecs_task_definition.taskdefinition.revision }}"
+        desired_count: 0
+        <<: *aws_connection_info
+      ignore_errors: yes
+      register: ecs_service_scale_down
     - name: scale down Fargate ECS service
       ecs_service:
         state: present
@@ -828,6 +869,14 @@
         state: absent
         cluster: "{{ ecs_cluster_name }}"
         name: "{{ ecs_service_name }}-mft"
+        <<: *aws_connection_info
+      ignore_errors: yes
+
+    - name: remove service_registries ecs service
+      ecs_service:
+        state: absent
+        cluster: "{{ ecs_cluster_name }}"
+        name: "{{ ecs_service_name }}-service-registries"
         <<: *aws_connection_info
       ignore_errors: yes
 

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
@@ -836,7 +836,7 @@
 
 
 
-    - name: scale down multifunction-test service
+    - name: scale down scheduling_strategy service
       ecs_service:
         name: "{{ ecs_service_name }}-replica"
         cluster: "{{ ecs_cluster_name }}"
@@ -910,7 +910,7 @@
         <<: *aws_connection_info
       ignore_errors: yes
 
-    - name: remove mft ecs service
+    - name: remove scheduling_strategy ecs service
       ecs_service:
         state: absent
         cluster: "{{ ecs_cluster_name }}"

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
@@ -479,7 +479,7 @@
           - "update_ecs_service_with_vpc.service.networkConfiguration.awsvpcConfiguration.subnets|length == 2"
           - "update_ecs_service_with_vpc.service.networkConfiguration.awsvpcConfiguration.securityGroups|length == 1"
 
-    - name: create ecs_service using healthcheck_grace_period
+    - name: create ecs_service using health_check_grace_period_seconds
       ecs_service:
         name: "{{ ecs_service_name }}-mft"
         cluster: "{{ ecs_cluster_name }}"
@@ -489,20 +489,20 @@
             containerPort: "{{ ecs_task_container_port }}"
         task_definition: "{{ ecs_task_name }}:{{ ecs_task_definition.taskdefinition.revision }}"
         scheduling_strategy: "REPLICA"
-        healthcheck_grace_period: 10
+        health_check_grace_period_seconds: 10
         desired_count: 1
         state: present
         <<: *aws_connection_info
       register: ecs_service_creation_hcgp
 
 
-    - name: healthcheck_grace_period sets HealthChecGracePeriodSeconds
+    - name: health_check_grace_period_seconds sets HealthChecGracePeriodSeconds
       assert:
         that:
           - ecs_service_creation_hcgp.changed
           - "{{ecs_service_creation_hcgp.service.healthCheckGracePeriodSeconds}} == 10"
 
-    - name: update ecs_service using healthcheck_grace_period
+    - name: update ecs_service using health_check_grace_period_seconds
       ecs_service:
         name: "{{ ecs_service_name }}-mft"
         cluster: "{{ ecs_cluster_name }}"
@@ -512,7 +512,7 @@
             containerPort: "{{ ecs_task_container_port }}"
         task_definition: "{{ ecs_task_name }}:{{ ecs_task_definition.taskdefinition.revision }}"
         desired_count: 1
-        healthcheck_grace_period: 30
+        health_check_grace_period_seconds: 30
         state: present
         <<: *aws_connection_info
       register: ecs_service_creation_hcgp2
@@ -540,7 +540,6 @@
 #           registryArn: "{{ ecs_task_service_registry_arn }}"
 #       task_definition: "{{ ecs_task_name }}:{{ ecs_task_definition.taskdefinition.revision }}"
 #       desired_count: 1
-#       healthcheck_grace_period: 30
 #       state: present
 #       <<: *aws_connection_info
 #     register: ecs_service_creation_sr
@@ -565,7 +564,6 @@
         scheduling_strategy: "REPLICA"
         task_definition: "{{ ecs_task_name }}:{{ ecs_task_definition.taskdefinition.revision }}"
         desired_count: 1
-        healthcheck_grace_period: 30
         state: present
         <<: *aws_connection_info
       register: ecs_service_creation_replica

--- a/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/playbooks/roles/ecs_cluster/tasks/main.yml
@@ -524,34 +524,51 @@
           - ecs_service_creation_hcgp2.changed
           - "{{ecs_service_creation_hcgp2.service.healthCheckGracePeriodSeconds}} == 30"
 
-    - name: update ecs_service using service_registries
+# until ansible supports service registries, this test can't run.
+#   - name: update ecs_service using service_registries
+#     ecs_service:
+#       name: "{{ ecs_service_name }}-service-registries"
+#       cluster: "{{ ecs_cluster_name }}"
+#       load_balancers:
+#         - targetGroupArn: "{{ elb_target_group_instance.target_group_arn }}"
+#           containerName: "{{ ecs_task_name }}"
+#           containerPort: "{{ ecs_task_container_port }}"
+#       service_registries:
+#         - containerName: "{{ ecs_task_name }}"
+#           containerPort: "{{ ecs_task_container_port }}"
+#           ### TODO: Figure out how to get a service registry ARN without a service registry module.
+#           registryArn: "{{ ecs_task_service_registry_arn }}"
+#       task_definition: "{{ ecs_task_name }}:{{ ecs_task_definition.taskdefinition.revision }}"
+#       desired_count: 1
+#       healthcheck_grace_period: 30
+#       state: present
+#       <<: *aws_connection_info
+#     register: ecs_service_creation_sr
+#     ignore_errors: yes
+
+#   - name: dump sr output
+#     debug: var=ecs_service_creation_sr
+
+#   - name: check that module returns success
+#     assert:
+#       that:
+#         - ecs_service_creation_sr.changed
+
+    - name: update ecs_service using REPLICA scheduling_strategy
       ecs_service:
-        name: "{{ ecs_service_name }}-service-registries"
+        name: "{{ ecs_service_name }}-replica"
         cluster: "{{ ecs_cluster_name }}"
         load_balancers:
           - targetGroupArn: "{{ elb_target_group_instance.target_group_arn }}"
             containerName: "{{ ecs_task_name }}"
             containerPort: "{{ ecs_task_container_port }}"
-        service_registries:
-          - containerName: "{{ ecs_task_name }}"
-            containerPort: "{{ ecs_task_container_port }}"
-            ### TODO: Figure out how to get a service registry ARN without a service registry module.
-            registryArn: "{{ ecs_task_service_registry_arn }}"
+        scheduling_strategy: "REPLICA"
         task_definition: "{{ ecs_task_name }}:{{ ecs_task_definition.taskdefinition.revision }}"
         desired_count: 1
         healthcheck_grace_period: 30
         state: present
         <<: *aws_connection_info
-      register: ecs_service_creation_sr
-      ignore_errors: yes
-
-    - name: dump sr output
-      debug: var=ecs_service_creation_sr
-
-    - name: check that module returns success
-      assert:
-        that:
-          - ecs_service_creation_sr.changed
+      register: ecs_service_creation_replica
 
     - name: obtain facts for all ECS services in the cluster
       ecs_service_facts:
@@ -817,9 +834,11 @@
       ignore_errors: yes
       register: ecs_service_scale_down
 
-    - name: scale down service_registries service
+
+
+    - name: scale down multifunction-test service
       ecs_service:
-        name: "{{ ecs_service_name }}-service-registries"
+        name: "{{ ecs_service_name }}-replica"
         cluster: "{{ ecs_cluster_name }}"
         state: present
         load_balancers:
@@ -831,6 +850,25 @@
         <<: *aws_connection_info
       ignore_errors: yes
       register: ecs_service_scale_down
+
+
+# until ansible supports service registries, the test for it can't run and this
+# scale down is not needed
+#   - name: scale down service_registries service
+#     ecs_service:
+#       name: "{{ ecs_service_name }}-service-registries"
+#       cluster: "{{ ecs_cluster_name }}"
+#       state: present
+#       load_balancers:
+#         - targetGroupArn: "{{ elb_target_group_instance.target_group_arn }}"
+#           containerName: "{{ ecs_task_name }}"
+#           containerPort: "{{ ecs_task_container_port }}"
+#       task_definition: "{{ ecs_task_name }}:{{ ecs_task_definition.taskdefinition.revision }}"
+#       desired_count: 0
+#       <<: *aws_connection_info
+#     ignore_errors: yes
+#     register: ecs_service_scale_down
+
     - name: scale down Fargate ECS service
       ecs_service:
         state: present
@@ -872,13 +910,23 @@
         <<: *aws_connection_info
       ignore_errors: yes
 
-    - name: remove service_registries ecs service
+    - name: remove mft ecs service
       ecs_service:
         state: absent
         cluster: "{{ ecs_cluster_name }}"
-        name: "{{ ecs_service_name }}-service-registries"
+        name: "{{ ecs_service_name }}-replica"
         <<: *aws_connection_info
       ignore_errors: yes
+
+# until ansible supports service registries, the test for it can't run and this
+# removal is not needed
+#   - name: remove service_registries ecs service
+#     ecs_service:
+#       state: absent
+#       cluster: "{{ ecs_cluster_name }}"
+#       name: "{{ ecs_service_name }}-service-registries"
+#       <<: *aws_connection_info
+#     ignore_errors: yes
 
     - name: remove fargate ECS service 
       ecs_service:
@@ -888,7 +936,7 @@
         <<: *aws_connection_info
       ignore_errors: yes
       register: ecs_fargate_service_network_with_awsvpc
- 
+
     - name: remove ecs task definition
       ecs_taskdefinition:
         containers: "{{ ecs_task_containers }}"

--- a/test/integration/targets/ecs_cluster/runme.sh
+++ b/test/integration/targets/ecs_cluster/runme.sh
@@ -12,6 +12,14 @@ trap 'rm -rf "${MYTMPDIR}"' EXIT
 # but for the python3 tests we need virtualenv to use python3
 PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
 
+# Test healthcheck_grace_period
+# applies for botocore < 1.8.4
+# healthcheck_grace_period is only valid if there's a load balancer associated
+virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.8.20"
+source "${MYTMPDIR}/botocore-1.8.20/bin/activate"
+$PYTHON -m pip install 'botocore==1.8.20' boto3
+ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/network_healthcheck_grace_period.yml "$@"
+
 # Test graceful failure for older versions of botocore
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.7.40"
 source "${MYTMPDIR}/botocore-1.7.40/bin/activate"
@@ -38,6 +46,8 @@ virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.8
 source "${MYTMPDIR}/botocore-1.8.5/bin/activate"
 $PYTHON -m pip install 'botocore>1.8.4' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/network_force_new_deployment.yml "$@"
+
+
 
 # Run full test suite
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"

--- a/test/integration/targets/ecs_cluster/runme.sh
+++ b/test/integration/targets/ecs_cluster/runme.sh
@@ -12,11 +12,6 @@ trap 'rm -rf "${MYTMPDIR}"' EXIT
 # but for the python3 tests we need virtualenv to use python3
 PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
 
-# Run full test suite
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
-source "${MYTMPDIR}/botocore-recent/bin/activate"
-$PYTHON -m pip install 'botocore>=1.8.4' boto3
-ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/full_test.yml "$@"
 
 
 # Test graceful failure for older versions of botocore
@@ -45,8 +40,6 @@ virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.8
 source "${MYTMPDIR}/botocore-1.8.5/bin/activate"
 $PYTHON -m pip install 'botocore>1.8.4' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/network_force_new_deployment.yml "$@"
-
-
 
 # Run full test suite
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"

--- a/test/integration/targets/ecs_cluster/runme.sh
+++ b/test/integration/targets/ecs_cluster/runme.sh
@@ -12,13 +12,12 @@ trap 'rm -rf "${MYTMPDIR}"' EXIT
 # but for the python3 tests we need virtualenv to use python3
 PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
 
-# Test healthcheck_grace_period
-# applies for botocore < 1.8.4
-# healthcheck_grace_period is only valid if there's a load balancer associated
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.8.20"
-source "${MYTMPDIR}/botocore-1.8.20/bin/activate"
-$PYTHON -m pip install 'botocore==1.8.20' boto3
-ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/network_healthcheck_grace_period.yml "$@"
+# Run full test suite
+virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
+source "${MYTMPDIR}/botocore-recent/bin/activate"
+$PYTHON -m pip install 'botocore>=1.8.4' boto3
+ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/full_test.yml "$@"
+
 
 # Test graceful failure for older versions of botocore
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.7.40"

--- a/test/integration/targets/ecs_cluster/runme.sh
+++ b/test/integration/targets/ecs_cluster/runme.sh
@@ -44,5 +44,5 @@ ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../c
 # Run full test suite
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
 source "${MYTMPDIR}/botocore-recent/bin/activate"
-$PYTHON -m pip install 'botocore>=1.8.4' boto3
+$PYTHON -m pip install 'botocore>=1.10.37' boto3 # version 1.10.37 for scheduling strategy
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/full_test.yml "$@"


### PR DESCRIPTION
##### SUMMARY
Adds features for service registries (part of service discovery) and scheduling strategy

Plays nicely with PRs #49033 and #48764; addresses issue #40285; makes PR #48726 obsolete.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ecs_service

##### ADDITIONAL INFORMATION
When using scheduling strategy: DAEMON, desired count isn't used and comes back as the size of the cluster.