### PR TITLE
[stable-2.6] Fix MySQL tests when running under Docker. (#50047)

### DIFF
--- a/test/integration/targets/setup_mysql_db/tasks/main.yml
+++ b/test/integration/targets/setup_mysql_db/tasks/main.yml
@@ -71,8 +71,14 @@
     line: 'mysql_server_enable="YES"'
   when: ansible_os_family == "FreeBSD"
 
-- name: start mysql_db service if not running
-  service: name={{ mysql_service }} state=started
+- name: apply work-around for OverlayFS issue
+  # https://github.com/docker/for-linux/issues/72#issuecomment-319904698
+  command: find /var/lib/mysql -type f -exec touch {} ;
+  # find will fail if mysql has never been started, as the directory won't exist
+  ignore_errors: yes
+
+- name: restart mysql_db service
+  service: name={{ mysql_service }} state=restarted
 
 - name: Detect socket path
   shell: >


### PR DESCRIPTION
##### SUMMARY

[stable-2.6] Fix MySQL tests when running under Docker. (#50047)

(cherry picked from commit 0ccd231afd51de0309ae0459fddb50e405e30ca8)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

mysql integration tests