### PR TITLE
find: set pattern to default regex when use_regex specified

### DIFF
--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -95,3 +95,25 @@
           - 'find_test2.matched == 1'
           - 'find_test2.files[0].pw_name is defined'
           - 'find_test2.files[0].gr_name is defined'
+
+- name: exclude with regex
+  find:
+    paths: "{{ output_dir_test }}"
+    recurse: yes
+    use_regex: true
+    exclude: .*\.ogg
+  register: find_test3
+# Note that currently sane ways of doing this with map() or
+# selectattr() aren't available in centos6 era jinja2 ...
+- set_fact:
+    find_test3_list: >-
+      [ {% for f in find_test3.files %}
+      {{ f.path }}
+      {% if not loop.last %},{% endif %}
+      {% endfor %}
+      ]
+- debug: var=find_test3_list
+- name: assert we skipped the ogg file
+  assert:
+    that:
+      - '"{{ output_dir_test }}/e/f/g/h/8.ogg" not in find_test3_list'


### PR DESCRIPTION
##### SUMMARY

When using "use_regex: yes" and setting an excludes: without
specifying a pattern: the existing code passes the file-glob '*' to
the regex matcher.  This results in an internal invalid-regex
exception being thrown.

This maintains the old semantics of a default match-all for pattern:
but switches the default to '.*' when use_regex is specified.

The code made sense as-is before excludes: was added (2.5).  In that
case, it made no sense to set use_regex but *not* set a pattern.
However, with excludes: it now makes sense to only want to exclude a
given regex but not specify a specific matching pattern.

Closes: #50067

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
files/find.py