### PR TITLE
Fix mandatory statement error for junos modules

### DIFF
--- a/lib/ansible/module_utils/network/junos/junos.py
+++ b/lib/ansible/module_utils/network/junos/junos.py
@@ -174,6 +174,7 @@ def commit_configuration(module, confirm=False, check=False, comment=None, confi
             else:
                 reply = conn.commit(comment=comment, confirmed=confirm, at_time=at_time, synchronize=synchronize)
     except ConnectionError as exc:
+        discard_changes(module)
         module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
     return reply
 

--- a/lib/ansible/module_utils/network/junos/junos.py
+++ b/lib/ansible/module_utils/network/junos/junos.py
@@ -174,7 +174,6 @@ def commit_configuration(module, confirm=False, check=False, comment=None, confi
             else:
                 reply = conn.commit(comment=comment, confirmed=confirm, at_time=at_time, synchronize=synchronize)
     except ConnectionError as exc:
-        discard_changes(module)
         module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
     return reply
 

--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -25,6 +25,7 @@ import re
 from itertools import chain
 from functools import wraps
 
+from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text
 from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.network.common.utils import to_list
@@ -103,7 +104,12 @@ class Cliconf(CliconfBase):
             if not isinstance(line, Mapping):
                 line = {'command': line}
             cmd = line['command']
-            results.append(self.send_command(**line))
+            try:
+                results.append(self.send_command(**line))
+            except AnsibleConnectionFailure as exc:
+                if "error: commit failed" in exc.message:
+                    self.discard_changes()
+                    raise
             requests.append(cmd)
 
         diff = self.compare_configuration()
@@ -111,7 +117,11 @@ class Cliconf(CliconfBase):
             resp['diff'] = diff
 
             if commit:
-                self.commit(comment=comment)
+                try:
+                    self.commit(comment=comment)
+                except AnsibleConnectionFailure:
+                    self.discard_changes()
+                    raise
             else:
                 self.discard_changes()
 
@@ -149,12 +159,19 @@ class Cliconf(CliconfBase):
             command += ' peers-synchronize'
 
         command += ' and-quit'
-        return self.send_command(command)
+
+        try:
+            response = self.send_command(command)
+        except AnsibleConnectionFailure:
+            self.discard_changes()
+            raise
+
+        return response
 
     @configure
     def discard_changes(self):
         command = 'rollback 0'
-        for cmd in chain(to_list(command), 'exit'):
+        for cmd in chain(to_list(command), ['exit']):
             self.send_command(cmd)
 
     @configure

--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -109,7 +109,7 @@ class Cliconf(CliconfBase):
             except AnsibleConnectionFailure as exc:
                 if "error: commit failed" in exc.message:
                     self.discard_changes()
-                    raise
+                raise
             requests.append(cmd)
 
         diff = self.compare_configuration()
@@ -117,11 +117,7 @@ class Cliconf(CliconfBase):
             resp['diff'] = diff
 
             if commit:
-                try:
-                    self.commit(comment=comment)
-                except AnsibleConnectionFailure:
-                    self.discard_changes()
-                    raise
+                self.commit(comment=comment)
             else:
                 self.discard_changes()
 

--- a/lib/ansible/plugins/terminal/junos.py
+++ b/lib/ansible/plugins/terminal/junos.py
@@ -37,7 +37,8 @@ class TerminalModule(TerminalBase):
 
     terminal_stderr_re = [
         re.compile(br"unknown command"),
-        re.compile(br"syntax error,")
+        re.compile(br"syntax error,"),
+        re.compile(br"error: commit failed")
     ]
 
     def on_open_shell(self):

--- a/lib/ansible/plugins/terminal/junos.py
+++ b/lib/ansible/plugins/terminal/junos.py
@@ -37,7 +37,7 @@ class TerminalModule(TerminalBase):
 
     terminal_stderr_re = [
         re.compile(br"unknown command"),
-        re.compile(br"syntax error,"),
+        re.compile(br"syntax error"),
         re.compile(br"error: commit failed")
     ]
 

--- a/test/integration/targets/junos_config/tests/cli_config/cli_basic.yaml
+++ b/test/integration/targets/junos_config/tests/cli_config/cli_basic.yaml
@@ -43,6 +43,17 @@
       - "result.changed == true"
       - "'ge-0/0/2' in result.diff.prepared"
 
+- name: remove root-authethication (test error scenario)
+  cli_config:
+    config: "delete system root-authentication"
+  ignore_errors: True
+  register: result
+
+- assert:
+    that:
+      - "result.failed == true"
+      - "'Missing mandatory statement' in result.msg"
+
 - name: teardown
   cli_config: *rm1
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #40267

*  Add error regex in junos terminal plugin to error out
   in case of commit fails

*  If the commit fails add logic to discard changes before exiting
   else next task will result in error
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
junos_netconf
cli_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
