### PR TITLE
os_security_group_rule proper module exit when deleting rule 

### DIFF
--- a/changelogs/fragments/50076-os-sec-group-rule-proper-module-exit.yaml
+++ b/changelogs/fragments/50076-os-sec-group-rule-proper-module-exit.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - os_security_group_rule - os_security_group_rule doesn't exit properly when
+    secgroup doesn't exist and state=absent
+    (https://github.com/ansible/ansible/issues/50057)

--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -359,7 +359,7 @@ def main():
                 cloud.delete_security_group_rule(rule['id'])
                 changed = True
 
-            module.exit_json(changed=changed)
+        module.exit_json(changed=changed)
 
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e))


### PR DESCRIPTION
##### SUMMARY
When the security group the rule belongs to does not exist and
the state is absent, the module is not properly exited, leading
to a playbook execution failure.

Fixes issue #50057

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
os_security_group_rule

##### ANSIBLE VERSION
2.7.5

##### STEPS TO REPRODUCE

1. Provision the group / rule using the following playbook (substitute the vars):
```
---
- name: Create OpenStack's security group entities
  hosts: localhost
  gather_facts: no

  tasks:
  - name: Create security group
    os_security_group:
      cloud: "{{ cloud }}"
      name: "{{ secgroup_name }}"
      state: present
    register: sec_group

  - name: Create empty ICMP rule
    os_security_group_rule:
      cloud: "{{ cloud }}"
      security_group: "{{ sec_group.id }}"
      state: present
      protocol: icmp
      remote_ip_prefix: 0.0.0.0/0
```
2. Delete the rules / group using the following playbook:
```
---
- name: Cleanup OpenStack's security group entities
  hosts: localhost
  gather_facts: no

  tasks:
  - name: Delete empty ICMP rule
    os_security_group_rule:
      cloud: "{{ cloud }}"
      security_group: "{{ secgroup_name }}"
      state: absent
      protocol: icmp
      remote_ip_prefix: 0.0.0.0/0

  - name: Delete security group
    os_security_group:
      cloud: "{{ cloud }}"
      name: "{{ secgroup_name }}"
      state: absent
```
3. To assure idem-potency of the delete operation, re-do the previous step. 

##### EXPECTED RESULTS
```
TASK [Delete empty ICMP rule] **************************************************
ok: [localhost]

TASK [Delete security group] ***************************************************
ok: [localhost]
```
##### ACTUAL RESULTS
```
TASK [Delete empty ICMP rule] **************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "New-style module did not handle its own exit"}
```
