### PR TITLE
Windows facts for licensing information

### DIFF
--- a/lib/ansible/modules/windows/win_product_facts.ps1
+++ b/lib/ansible/modules/windows/win_product_facts.ps1
@@ -57,50 +57,32 @@ if (-not $product_key) {
     }
 }
 
-try {
-    $license_info = Get-CimInstance SoftwareLicensingProduct | Where-Object PartialProductKey
+# Retrieve license information
+$license_info = Get-CimInstance SoftwareLicensingProduct | Where-Object PartialProductKey
 
-    switch ($license_info.LicenseStatus){
-        0 {
-            $winlicense_status="Unlicensed"
-        }
+$winlicense_status = switch ($license_info.LicenseStatus) {
+    0 { "Unlicensed" }
+    1 { "Licensed" }
+    2 { "OOBGrace" }
+    3 { "OOTGrace" }
+    4 { "NonGenuineGrace" }
+    5 { "Notification" }
+    6 { "ExtendedGrace" }
+    default { $null }
+}
 
-        1 {
-            $winlicense_status="Licensed"
-        }
-
-        2 {
-            $winlicense_status="OOBGrace"
-        }
-
-        3 {
-            $winlicense_status="OOTGrace"
-        }
-
-        4 {
-            $winlicense_status="NonGenuineGrace"
-        }
-
-        5 {
-            $winlicense_status="Notification"
-        }
-
-        6 {
-            $winlicense_status="ExtendedGrace"
-        }
-
-        default {
-            $winlicense_status="NA"
-        }
-    }
-
+if ($license_info.Name) {
     $winlicense_edition = $license_info.Name
-    $winlicense_channel = $license_info.ProductKeyChannel
+}
+else {
+    $winlicense_edition = $null
+}
 
-} catch {
-    $winlicense_edition = "NA"
-    $winlicense_channel = "NA"
-    $winlicense_status = "NA"
+if ($license_info.ProductKeyChannel) {
+    $winlicense_channel = $license_info.ProductKeyChannel
+}
+else {
+    $winlicense_channel = $null
 }
 
 

--- a/lib/ansible/modules/windows/win_product_facts.ps1
+++ b/lib/ansible/modules/windows/win_product_facts.ps1
@@ -57,9 +57,59 @@ if (-not $product_key) {
     }
 }
 
+try {
+    $license_info = Get-CimInstance SoftwareLicensingProduct | Where-Object PartialProductKey
+
+    switch ($license_info.LicenseStatus){
+        0 {
+            $winlicense_status="Unlicensed"
+        }
+
+        1 {
+            $winlicense_status="Licensed"
+        }
+
+        2 {
+            $winlicense_status="OOBGrace"
+        }
+
+        3 {
+            $winlicense_status="OOTGrace"
+        }
+
+        4 {
+            $winlicense_status="NonGenuineGrace"
+        }
+
+        5 {
+            $winlicense_status="Notification"
+        }
+
+        6 {
+            $winlicense_status="ExtendedGrace"
+        }
+
+        default {
+            $winlicense_status="NA"
+        }
+    }
+
+    $winlicense_edition = $license_info.Name
+    $winlicense_channel = $license_info.ProductKeyChannel
+
+} catch {
+    $winlicense_edition = "NA"
+    $winlicense_channel = "NA"
+    $winlicense_status = "NA"
+}
+
+
 $module.Result.ansible_facts = @{
     ansible_os_product_id = (Get-CimInstance Win32_OperatingSystem).SerialNumber
     ansible_os_product_key = $product_key
+    ansible_winlicense_edition = $winlicense_edition
+    ansible_winlicense_channel = $winlicense_channel 
+    ansible_winlicense_status = $winlicense_status 
 }
 
 $module.ExitJson()

--- a/lib/ansible/modules/windows/win_product_facts.ps1
+++ b/lib/ansible/modules/windows/win_product_facts.ps1
@@ -71,20 +71,8 @@ $winlicense_status = switch ($license_info.LicenseStatus) {
     default { $null }
 }
 
-if ($license_info.Name) {
-    $winlicense_edition = $license_info.Name
-}
-else {
-    $winlicense_edition = $null
-}
-
-if ($license_info.ProductKeyChannel) {
-    $winlicense_channel = $license_info.ProductKeyChannel
-}
-else {
-    $winlicense_channel = $null
-}
-
+$winlicense_edition = $license_info.Name
+$winlicense_channel = $license_info.ProductKeyChannel
 
 $module.Result.ansible_facts = @{
     ansible_os_product_id = (Get-CimInstance Win32_OperatingSystem).SerialNumber

--- a/lib/ansible/modules/windows/win_product_facts.ps1
+++ b/lib/ansible/modules/windows/win_product_facts.ps1
@@ -107,9 +107,9 @@ try {
 $module.Result.ansible_facts = @{
     ansible_os_product_id = (Get-CimInstance Win32_OperatingSystem).SerialNumber
     ansible_os_product_key = $product_key
-    ansible_winlicense_edition = $winlicense_edition
-    ansible_winlicense_channel = $winlicense_channel 
-    ansible_winlicense_status = $winlicense_status 
+    ansible_os_license_edition = $winlicense_edition
+    ansible_os_license_channel = $winlicense_channel 
+    ansible_os_license_status = $winlicense_status 
 }
 
 $module.ExitJson()

--- a/lib/ansible/modules/windows/win_product_facts.py
+++ b/lib/ansible/modules/windows/win_product_facts.py
@@ -11,13 +11,13 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: win_product_facts
-short_description: Provides Windows product information (product id, product key)
+short_description: Provides Windows product information (product id, product key, license status, license channel, license edition)
 description:
 - Provides Windows product information.
 version_added: '2.5'
-options: {}
 author:
 - Dag Wieers (@dagwieers)
+options: {}
 '''
 
 EXAMPLES = r'''
@@ -33,4 +33,7 @@ ansible_facts:
   sample:
     ansible_os_product_id: 00326-10000-00000-AA698
     ansible_os_product_key: T49TD-6VFBW-VV7HY-B2PXY-MY47H
+    ansible_winlicense_edition = Windows(R), ServerStandard edition
+    ansible_winlicense_channel = Volume:MAK
+    ansible_winlicense_status = Licensed
 '''

--- a/lib/ansible/modules/windows/win_product_facts.py
+++ b/lib/ansible/modules/windows/win_product_facts.py
@@ -33,7 +33,7 @@ ansible_facts:
   sample:
     ansible_os_product_id: 00326-10000-00000-AA698
     ansible_os_product_key: T49TD-6VFBW-VV7HY-B2PXY-MY47H
-    ansible_winlicense_edition = Windows(R), ServerStandard edition
-    ansible_winlicense_channel = Volume:MAK
-    ansible_winlicense_status = Licensed
+    ansible_winlicense_edition: Windows(R) ServerStandard edition
+    ansible_winlicense_channel: Volume:MAK
+    ansible_winlicense_status: Licensed
 '''

--- a/lib/ansible/modules/windows/win_product_facts.py
+++ b/lib/ansible/modules/windows/win_product_facts.py
@@ -11,13 +11,12 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: win_product_facts
-short_description: Provides Windows product information (product id, product key, license status, license channel, license edition)
+short_description: Provides Windows product and license information
 description:
 - Provides Windows product information.
 version_added: '2.5'
 author:
 - Dag Wieers (@dagwieers)
-options: {}
 '''
 
 EXAMPLES = r'''
@@ -33,7 +32,7 @@ ansible_facts:
   sample:
     ansible_os_product_id: 00326-10000-00000-AA698
     ansible_os_product_key: T49TD-6VFBW-VV7HY-B2PXY-MY47H
-    ansible_winlicense_edition: Windows(R) ServerStandard edition
-    ansible_winlicense_channel: Volume:MAK
-    ansible_winlicense_status: Licensed
+    ansible_os_license_edition: Windows(R) ServerStandard edition
+    ansible_os_license_channel: Volume:MAK
+    ansible_os_license_status: Licensed
 '''


### PR DESCRIPTION
Windows facts for licensing information added

##### SUMMARY
No available facts for windows licensing information - for things like activation status, license channel, and license edition.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

/lib/ansible/modules/windows/win_product_facts.ps1
/lib/ansible/modules/windows/win_product_facts.py

##### ADDITIONAL INFORMATION

The win_product_facts module now adds facts for ansible_os_license_edition, ansible_os_license_channel and ansible_os_license_status
