### PR TITLE
Sanity fixes in various modules

### DIFF
--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -6,7 +6,7 @@
 # still belong to the author of the module, and may assign their own license
 # to the complete work.
 #
-# (c) 2017 Red Hat, Inc.
+# Copyright: (c) 2017, Red Hat Inc.
 #
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
@@ -26,7 +26,7 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
+
 
 import collections
 import json
@@ -44,43 +44,43 @@ from ansible.module_utils.urls import fetch_url
 _DEVICE_CONNECTION = None
 
 nxos_provider_spec = {
-    'host': dict(),
+    'host': dict(type='str'),
     'port': dict(type='int'),
 
-    'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
-    'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
-    'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE'])),
+    'username': dict(type='str', fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
+    'password': dict(type='str', no_log=True, fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD'])),
+    'ssh_keyfile': dict(type='str', fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE'])),
 
-    'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
-    'auth_pass': dict(no_log=True, fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS'])),
+    'authorize': dict(type='bool', fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE'])),
+    'auth_pass': dict(type='str', no_log=True, fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS'])),
 
     'use_ssl': dict(type='bool'),
-    'use_proxy': dict(default=True, type='bool'),
+    'use_proxy': dict(type='bool', default=True),
     'validate_certs': dict(type='bool'),
 
     'timeout': dict(type='int'),
 
-    'transport': dict(default='cli', choices=['cli', 'nxapi'])
+    'transport': dict(type='str', default='cli', choices=['cli', 'nxapi'])
 }
 nxos_argument_spec = {
     'provider': dict(type='dict', options=nxos_provider_spec),
 }
 nxos_top_spec = {
-    'host': dict(removed_in_version=2.9),
-    'port': dict(removed_in_version=2.9, type='int'),
+    'host': dict(type='str', removed_in_version=2.9),
+    'port': dict(type='int', removed_in_version=2.9),
 
-    'username': dict(removed_in_version=2.9),
-    'password': dict(removed_in_version=2.9, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.9),
+    'username': dict(type='str', removed_in_version=2.9),
+    'password': dict(type='str', no_log=True, removed_in_version=2.9),
+    'ssh_keyfile': dict(type='str', removed_in_version=2.9),
 
-    'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
-    'auth_pass': dict(removed_in_version=2.9, no_log=True),
+    'authorize': dict(type='bool', fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE'])),
+    'auth_pass': dict(type='str', no_log=True, removed_in_version=2.9),
 
-    'use_ssl': dict(removed_in_version=2.9, type='bool'),
-    'validate_certs': dict(removed_in_version=2.9, type='bool'),
-    'timeout': dict(removed_in_version=2.9, type='int'),
+    'use_ssl': dict(type='bool', removed_in_version=2.9),
+    'validate_certs': dict(type='bool', removed_in_version=2.9),
+    'timeout': dict(type='int', removed_in_version=2.9),
 
-    'transport': dict(removed_in_version=2.9, choices=['cli', 'nxapi'])
+    'transport': dict(type='str', choices=['cli', 'nxapi'], removed_in_version=2.9)
 }
 nxos_argument_spec.update(nxos_top_spec)
 

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1180,16 +1180,16 @@ def url_argument_spec():
     that will be requesting content via urllib/urllib2
     '''
     return dict(
-        url=dict(),
-        force=dict(default='no', aliases=['thirsty'], type='bool'),
-        http_agent=dict(default='ansible-httpget'),
-        use_proxy=dict(default='yes', type='bool'),
-        validate_certs=dict(default='yes', type='bool'),
-        url_username=dict(required=False),
-        url_password=dict(required=False, no_log=True),
-        force_basic_auth=dict(required=False, type='bool', default='no'),
-        client_cert=dict(required=False, type='path', default=None),
-        client_key=dict(required=False, type='path', default=None),
+        url=dict(type='str'),
+        force=dict(type='bool', default=False, aliases=['thirsty']),
+        http_agent=dict(type='str', default='ansible-httpget'),
+        use_proxy=dict(type='bool', default=True),
+        validate_certs=dict(type='bool', default=True),
+        url_username=dict(type='str'),
+        url_password=dict(type='str', no_log=True),
+        force_basic_auth=dict(type='bool', default=False),
+        client_cert=dict(type='path'),
+        client_key=dict(type='path'),
     )
 
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_rediscache.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_rediscache.py
@@ -285,7 +285,7 @@ class AzureRMRedisCaches(AzureRMModuleBase):
                 type='int'
             ),
             shard_count=dict(
-                type='ints'
+                type='int'
             ),
             static_ip=dict(
                 type='str'

--- a/lib/ansible/modules/cloud/scaleway/scaleway_security_group.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_security_group.py
@@ -24,26 +24,27 @@ version_added: "2.8"
 author: Antoine Barbare (@abarbare)
 description:
     - This module manages Security Group on Scaleway account
-      U(https://developer.scaleway.com)
+      U(https://developer.scaleway.com).
 extends_documentation_fragment: scaleway
 
 options:
   state:
     description:
       - Indicate desired state of the Security Group.
+    type: str
+    choices: [ absent, present ]
     default: present
-    choices:
-      - present
-      - absent
 
   organization:
     description:
-      - Organization identifier
+      - Organization identifier.
+    type: str
     required: true
 
   region:
     description:
       - Scaleway region to use (for example C(par1)).
+    type: str
     required: true
     choices:
       - ams1
@@ -53,37 +54,37 @@ options:
 
   name:
     description:
-      - Name of the Security Group
+      - Name of the Security Group.
+    type: str
     required: true
 
   description:
     description:
-      - Description of the Security Group
+      - Description of the Security Group.
+    type: str
 
   stateful:
     description:
-      - Create a stateful security group which allows established connections in and out
-    required: true
+      - Create a stateful security group which allows established connections in and out.
     type: bool
+    required: true
 
   inbound_default_policy:
     description:
-      - Default policy for incoming trafic
-    choices:
-      - accept
-      - drop
+      - Default policy for incoming trafic.
+    type: str
+    choices: [ accept, drop ]
 
   outbound_default_policy:
     description:
-      - Default policy for outcoming trafic
-    choices:
-      - accept
-      - drop
+      - Default policy for outcoming trafic.
+    type: str
+    choices: [ accept, drop ]
 
   organization_default:
-    type: bool
     description:
-      - Create security group to be the default one
+      - Create security group to be the default one.
+    type: bool
 '''
 
 EXAMPLES = '''
@@ -215,15 +216,15 @@ def core(module):
 def main():
     argument_spec = scaleway_argument_spec()
     argument_spec.update(dict(
-        state=dict(default='present', choices=['absent', 'present']),
-        organization=dict(required=True),
-        name=dict(required=True),
-        description=dict(),
-        region=dict(required=True, choices=SCALEWAY_LOCATION.keys()),
-        stateful=dict(required=True, type=bool),
-        inbound_default_policy=dict(choices=['accept', 'drop']),
-        outbound_default_policy=dict(choices=['accept', 'drop']),
-        organization_default=dict(type=bool),
+        state=dict(type='str', default='present', choices=['absent', 'present']),
+        organization=dict(type='str', required=True),
+        name=dict(type='str', required=True),
+        description=dict(type='str'),
+        region=dict(type='str', required=True, choices=SCALEWAY_LOCATION.keys()),
+        stateful=dict(type='bool', required=True),
+        inbound_default_policy=dict(type='str', choices=['accept', 'drop']),
+        outbound_default_policy=dict(type='str', choices=['accept', 'drop']),
+        organization_default=dict(type='bool'),
     ))
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/lib/ansible/modules/cloud/vmware/vmware_host_snmp.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_snmp.py
@@ -36,8 +36,8 @@ options:
     description:
         - Enable, disable, or reset the SNMP agent.
     type: str
-    choices: [ enabled, disabled, reset ]
-    default: 'disabled'
+    choices: [ disabled, enabled, reset ]
+    default: disabled
   community:
     description:
         - List of SNMP community strings.
@@ -54,10 +54,10 @@ options:
     default: []
   trap_filter:
     description:
-        - Comma separated list of trap oids for traps not to be sent by agent.
-        - E.g. [ 1.3.6.1.4.1.6876.4.1.1.0, 1.3.6.1.4.1.6876.4.1.1.1 ]
+        - A list of trap oids for traps not to be sent by agent,
+          e.g. [ 1.3.6.1.4.1.6876.4.1.1.0, 1.3.6.1.4.1.6876.4.1.1.1 ]
         - Use value C(reset) to clear settings.
-    type: str
+    type: list
   send_trap:
     description:
         - Send a test trap to validate the configuration.
@@ -69,13 +69,13 @@ options:
         - The embedded SNMP agent receives hardware events either from IPMI sensors C(sensors) or CIM indications C(indications).
     type: str
     choices: [ indications, sensors ]
-    default: 'indications'
+    default: indications
   log_level:
     description:
         - Syslog logging level.
     type: str
     choices: [ debug, info, warning, error ]
-    default: 'info'
+    default: info
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -468,13 +468,13 @@ def main():
     """Main"""
     argument_spec = vmware_argument_spec()
     argument_spec.update(
-        state=dict(default='disabled', choices=['enabled', 'disabled', 'reset']),
+        state=dict(type='str', default='disabled', choices=['enabled', 'disabled', 'reset']),
         snmp_port=dict(type='int', default=161),
         community=dict(type='list', default=[]),
-        trap_targets=dict(type='list', default=list(), required=False),
-        trap_filter=dict(type='list', required=False),
-        hw_source=dict(default='indications', choices=['indications', 'sensors']),
-        log_level=dict(default='info', choices=['debug', 'info', 'warning', 'error']),
+        trap_targets=dict(type='list', default=list()),
+        trap_filter=dict(type='list'),
+        hw_source=dict(type='str', default='indications', choices=['indications', 'sensors']),
+        log_level=dict(type='str', default='info', choices=['debug', 'info', 'warning', 'error']),
         send_trap=dict(type='bool', default=False),
     )
 

--- a/lib/ansible/modules/commands/psexec.py
+++ b/lib/ansible/modules/commands/psexec.py
@@ -74,7 +74,7 @@ options:
     description:
     - The timeout in seconds to wait when receiving the initial SMB negotiate
       response from the server.
-    type: str
+    type: int
     default: 60
   executable:
     description:

--- a/lib/ansible/modules/database/postgresql/postgresql_idx.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_idx.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {
 }
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: postgresql_idx
 short_description: Creates or drops indexes from a PostgreSQL database.
@@ -25,27 +25,34 @@ options:
   idxname:
     description:
       - Name of the index to create or drop.
+    type: str
     required: true
   db:
     description:
       - Name of database where the index will be created/dropped.
+    type: str
   port:
     description:
       - Database port to connect.
+    type: int
     default: 5432
   login_user:
     description:
       - User (role) used to authenticate with PostgreSQL.
+    type: str
     default: postgres
   login_password:
     description:
       - Password used to authenticate with PostgreSQL.
+    type: str
   login_host:
     description:
       - Host running PostgreSQL.
+    type: str
   login_unix_socket:
     description:
       - Path to a Unix domain socket for local connections.
+    type: str
   ssl_mode:
     description:
       - Determines whether or with what priority a secure SSL TCP/IP connection
@@ -53,36 +60,43 @@ options:
       - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for
         more information on the modes.
       - Default of C(prefer) matches libpq default.
+    type: str
     default: prefer
-    choices: ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
+    choices: [ allow, disable, prefer, require, verify-ca, verify-full ]
   ssl_rootcert:
     description:
       - Specifies the name of a file containing SSL certificate authority (CA)
         certificate(s). If the file exists, the server's certificate will be
         verified to be signed by one of these authorities.
+    type: str
   state:
     description:
       - Index state.
+    type: str
     default: present
     choices: ["present", "absent"]
   table:
     description:
       - Table to create index on it.
+    type: str
     required: true
   columns:
     description:
       - List of index columns.
+    type: str
   cond:
     description:
       - Index conditions.
+    type: str
   idxtype:
     description:
       - Index type (like btree, gist, gin, etc.).
+    type: str
   concurrent:
     description:
       - Enable or disable concurrent mode (CREATE / DROP INDEX CONCURRENTLY).
-    default: yes
     type: bool
+    default: yes
 notes:
    - The default authentication assumes that you are either logging in as or
      sudo'ing to the postgres account on the host.
@@ -266,17 +280,17 @@ def index_drop(cursor, module, idxname, concurrent=True):
 def main():
     argument_spec = pgutils.postgres_common_argument_spec()
     argument_spec.update(dict(
-        idxname=dict(required=True, aliases=['idxname']),
-        db=dict(default=''),
-        ssl_mode=dict(default='prefer', choices=[
-            'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
-        ssl_rootcert=dict(default=None),
-        state=dict(default="present", choices=["absent", "present"]),
-        concurrent=dict(type=bool, default="yes"),
-        table=dict(default=None),
-        idxtype=dict(default=None),
-        columns=dict(default=None),
-        cond=dict(default=None)
+        idxname=dict(type='str', required=True, aliases=['idxname']),
+        db=dict(type='str', default=''),
+        ssl_mode=dict(type='str', default='prefer', choices=[
+            'allow', 'disable', 'prefer', 'require', 'verify-ca', 'verify-full']),
+        ssl_rootcert=dict(type='str'),
+        state=dict(type='str', default="present", choices=["absent", "present"]),
+        concurrent=dict(type='bool', default=True),
+        table=dict(type='str'),
+        idxtype=dict(type='str'),
+        columns=dict(type='str'),
+        cond=dict(type='str')
     ))
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -15,111 +15,115 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: copy
-version_added: "historical"
-short_description: Copies files to remote locations
+version_added: historical
+short_description: Copy files to remote locations
 description:
     - The C(copy) module copies a file from the local or remote machine to a location on the remote machine.
-      Use the M(fetch) module to copy files from remote locations to the local box.
-      If you need variable interpolation in copied files, use the M(template) module.
+    - Use the M(fetch) module to copy files from remote locations to the local box.
+    - If you need variable interpolation in copied files, use the M(template) module.
     - For Windows targets, use the M(win_copy) module instead.
 options:
   src:
     description:
-      - Local path to a file to copy to the remote server; can be absolute or relative.
-        If path is a directory, it is copied recursively. In this case, if path ends
-        with "/", only inside contents of that directory are copied to destination.
-        Otherwise, if it does not end with "/", the directory itself with all contents
-        is copied. This behavior is similar to Rsync.
+    - Local path to a file to copy to the remote server.
+    - This can be absolute or relative.
+    - If path is a directory, it is copied recursively. In this case, if path ends
+      with "/", only inside contents of that directory are copied to destination.
+      Otherwise, if it does not end with "/", the directory itself with all contents
+      is copied. This behavior is similar to the C(rsync) command line tool.
   content:
     description:
-      - When used instead of I(src), sets the contents of a file directly to the specified value.
-        For anything advanced or with formatting also look at the template module.
-    version_added: "1.1"
+    - When used instead of I(src), sets the contents of a file directly to the specified value.
+    - For anything advanced or with formatting also look at the template module.
+    version_added: '1.1'
   dest:
     description:
-      - 'Remote absolute path where the file should be copied to. If I(src) is a directory, this must be a directory too.
-        If I(dest) is a nonexistent path and if either I(dest) ends with "/" or I(src) is a directory, I(dest) is created.
-        If I(src) and I(dest) are files, the parent directory of I(dest) isn''t created: the task fails if it doesn''t already exist.'
+    - Remote absolute path where the file should be copied to.
+    - If I(src) is a directory, this must be a directory too.
+    - If I(dest) is a non-existent path and if either I(dest) ends with "/" or I(src) is a directory, I(dest) is created.
+    - If I(src) and I(dest) are files, the parent directory of I(dest) is not created and the task fails if it does not already exist.
     required: yes
   backup:
     description:
-      - Create a backup file including the timestamp information so you can get
-        the original file back if you somehow clobbered it incorrectly.
+    - Create a backup file including the timestamp information so you can get the original file back if you somehow clobbered it incorrectly.
     type: bool
-    default: 'no'
-    version_added: "0.7"
+    default: no
+    version_added: '0.7'
   force:
     description:
-      - the default is C(yes), which will replace the remote file when contents
-        are different than the source. If C(no), the file will only be transferred
-        if the destination does not exist.
+    - Influence whether the remote file must always be replaced.
+    - If C(yes), the remote file will be replaced when contents are different than the source.
+    - If C(no), the file will only be transferred if the destination does not exist.
     type: bool
-    default: 'yes'
+    default: yes
     aliases: [ thirsty ]
-    version_added: "1.1"
+    version_added: '1.1'
   mode:
     description:
-      - "Mode the file or directory should be. For those used to I(/usr/bin/chmod) remember that
-        modes are actually octal numbers. You must either add a leading zero so that Ansible's
-        YAML parser knows it is an octal number (like C(0644) or C(01777)) or quote it
-        (like C('644') or C('1777')) so Ansible receives a string and can do its own conversion from
-        string into number.  Giving Ansible a number without following one of these rules will end
-        up with a decimal number which will have unexpected results.  As of version 1.8, the mode
-        may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).  As of
-        version 2.3, the mode may also be the special string C(preserve).  C(preserve) means that
-        the file will be given the same permissions as the source file."
+    - The permissions of the destination file or directory.
+    - For those used to I(/usr/bin/chmod) remember that modes are actually octal numbers.
+      You must either add a leading zero so that Ansible's YAML parser knows it is an octal number
+      (like C(0644) or C(01777))or quote it (like C('644') or C('1777')) so Ansible receives a string
+      and can do its own conversion from string into number. Giving Ansible a number without following
+      one of these rules will end up with a decimal number which will have unexpected results.
+    - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
+    - As of Ansible 2.3, the mode may also be the special string C(preserve).
+    - C(preserve) means that the file will be given the same permissions as the source file.
   directory_mode:
     description:
-      - When doing a recursive copy set the mode for the directories. If this is not set we will use the system
-        defaults. The mode is only set on directories which are newly created, and will not affect those that
-        already existed.
-    version_added: "1.5"
+    - When doing a recursive copy set the mode for the directories.
+    - If this is not set we will use the system defaults.
+    - The mode is only set on directories which are newly created, and will not affect those that already existed.
+    version_added: '1.5'
   remote_src:
     description:
-      - If C(no), it will search for I(src) at originating/master machine.
-      - If C(yes) it will go to the remote/target machine for the I(src). Default is C(no).
-      - I(remote_src) supports recursive copying as of version 2.8.
-      - I(remote_src) only works with C(mode=preserve) as of version 2.6.
+    - Influence whether I(src) needs to be transferred or already is present remotely.
+    - If C(no), it will search for I(src) at originating/master machine.
+    - If C(yes) it will go to the remote/target machine for the I(src).
+    - I(remote_src) supports recursive copying as of version 2.8.
+    - I(remote_src) only works with C(mode=preserve) as of version 2.6.
     type: bool
-    default: 'no'
-    version_added: "2.0"
+    default: no
+    version_added: '2.0'
   follow:
     description:
-      - This flag indicates that filesystem links in the destination, if they exist, should be followed.
+    - This flag indicates that filesystem links in the destination, if they exist, should be followed.
     type: bool
-    default: 'no'
-    version_added: "1.8"
+    default: no
+    version_added: '1.8'
   local_follow:
     description:
-      - This flag indicates that filesystem links in the source tree, if they exist, should be followed.
+    - This flag indicates that filesystem links in the source tree, if they exist, should be followed.
     type: bool
-    default: 'yes'
-    version_added: "2.4"
+    default: yes
+    version_added: '2.4'
   checksum:
     description:
-      - SHA1 checksum of the file being transferred. Used to validate that the copy of the file was successful.
-      - If this is not provided, ansible will use the local calculated checksum of the src file.
+    - SHA1 checksum of the file being transferred.
+    - Used to validate that the copy of the file was successful.
+    - If this is not provided, ansible will use the local calculated checksum of the src file.
     version_added: '2.5'
 extends_documentation_fragment:
-    - files
-    - validate
-    - decrypt
+- decrypt
+- files
+- validate
 notes:
-   - The M(copy) module recursively copy facility does not scale to lots (>hundreds) of files.
-     For alternative, see M(synchronize) module, which is a wrapper around C(rsync).
-   - For Windows targets, use the M(win_copy) module instead.
+- The M(copy) module recursively copy facility does not scale to lots (>hundreds) of files.
+- For alternative, see M(synchronize) module, which is a wrapper around the C(rsync) command line tool.
+- For Windows targets, use the M(win_copy) module instead.
 seealso:
 - module: assemble
+- module: fetch
 - module: file
 - module: template
 - module: win_copy
 author:
-    - Ansible Core Team
-    - Michael DeHaan
+- Ansible Core Team
+- Michael DeHaan
 '''
 
 EXAMPLES = r'''
-- name: example copying file with owner and permissions
+- name: Copy file with owner and permissions
   copy:
     src: /srv/myfiles/foo.conf
     dest: /etc/foo.conf
@@ -127,7 +131,7 @@ EXAMPLES = r'''
     group: foo
     mode: 0644
 
-- name: The same example as above, but using a symbolic mode equivalent to 0644
+- name: Copy file with owner and permission, using symbolic representation
   copy:
     src: /srv/myfiles/foo.conf
     dest: /etc/foo.conf
@@ -165,7 +169,7 @@ EXAMPLES = r'''
     remote_src: yes
     validate: /usr/sbin/visudo -cf %s
 
-- name: Copy using the 'content' for inline data
+- name: Copy using inline content
   copy:
     content: '# This file was moved to /etc/other.conf'
     dest: /etc/mine.conf
@@ -185,62 +189,62 @@ EXAMPLES = r'''
 
 RETURN = r'''
 dest:
-    description: destination file/path
+    description: Destination file/path
     returned: success
     type: string
     sample: /path/to/file.txt
 src:
-    description: source file used for the copy on the target machine
+    description: Source file used for the copy on the target machine
     returned: changed
     type: string
     sample: /home/httpd/.ansible/tmp/ansible-tmp-1423796390.97-147729857856000/source
 md5sum:
-    description: md5 checksum of the file after running copy
+    description: MD5 checksum of the file after running copy
     returned: when supported
     type: string
     sample: 2a5aeecc61dc98c4d780b14b330e3282
 checksum:
-    description: sha1 checksum of the file after running copy
+    description: SHA1 checksum of the file after running copy
     returned: success
     type: string
     sample: 6e642bb8dd5c2e027bf21dd923337cbb4214f827
 backup_file:
-    description: name of backup file created
+    description: Name of backup file created
     returned: changed and if backup=yes
     type: string
     sample: /path/to/file.txt.2015-02-12@22:09~
 gid:
-    description: group id of the file, after execution
+    description: Group id of the file, after execution
     returned: success
     type: int
     sample: 100
 group:
-    description: group of the file, after execution
+    description: Group of the file, after execution
     returned: success
     type: string
     sample: httpd
 owner:
-    description: owner of the file, after execution
+    description: Owner of the file, after execution
     returned: success
     type: string
     sample: httpd
 uid:
-    description: owner id of the file, after execution
+    description: Owner id of the file, after execution
     returned: success
     type: int
     sample: 100
 mode:
-    description: permissions of the target, after execution
+    description: Permissions of the target, after execution
     returned: success
     type: string
     sample: 0644
 size:
-    description: size of the target, after execution
+    description: Size of the target, after execution
     returned: success
     type: int
     sample: 1220
 state:
-    description: state of the target, after execution
+    description: State of the target, after execution
     returned: success
     type: string
     sample: file

--- a/lib/ansible/modules/files/read_csv.py
+++ b/lib/ansible/modules/files/read_csv.py
@@ -24,7 +24,7 @@ options:
   path:
     description:
     - The CSV filename to read data from.
-    type: str
+    type: path
     required: yes
     aliases: [ filename ]
   key:

--- a/lib/ansible/modules/files/stat.py
+++ b/lib/ansible/modules/files/stat.py
@@ -441,12 +441,12 @@ def format_output(module, path, st):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            path=dict(required=True, type='path'),
-            follow=dict(type='bool', default='no'),
+            path=dict(type='path', required=True),
+            follow=dict(type='bool', default=False),
             get_md5=dict(type='bool'),
-            get_checksum=dict(type='bool', default='yes'),
+            get_checksum=dict(type='bool', default=True),
             get_mime=dict(type='bool', default='yes', aliases=['mime', 'mime_type', 'mime-type']),
-            get_attributes=dict(type='bool', default='yes', aliases=['attr', 'attributes']),
+            get_attributes=dict(type='bool', default=True, aliases=['attr', 'attributes']),
             checksum_algorithm=dict(type='str', default='sha1',
                                     choices=['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512'],
                                     aliases=['checksum', 'checksum_algo']),

--- a/lib/ansible/modules/network/cloudengine/ce_aaa_server.py
+++ b/lib/ansible/modules/network/cloudengine/ce_aaa_server.py
@@ -20,7 +20,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: ce_aaa_server
 version_added: "2.4"
@@ -33,51 +33,62 @@ options:
     state:
         description:
             - Specify desired state of the resource.
+        type: str
+        choices: [ absent, present ]
         default: present
-        choices: ['present', 'absent']
     authen_scheme_name:
         description:
             - Name of an authentication scheme.
               The value is a string of 1 to 32 characters.
+        type: str
     first_authen_mode:
         description:
             - Preferred authentication mode.
+        type: str
         choices: ['invalid', 'local', 'hwtacacs', 'radius', 'none']
     author_scheme_name:
         description:
             - Name of an authorization scheme.
               The value is a string of 1 to 32 characters.
+        type: str
     first_author_mode:
         description:
             - Preferred authorization mode.
+        type: str
         choices: ['invalid', 'local', 'hwtacacs', 'if-authenticated', 'none']
     acct_scheme_name:
         description:
             - Accounting scheme name.
               The value is a string of 1 to 32 characters.
+        type: str
     accounting_mode:
         description:
             - Accounting Mode.
+        type: str
         choices: ['invalid', 'hwtacacs', 'radius', 'none']
     domain_name:
         description:
             - Name of a domain.
               The value is a string of 1 to 64 characters.
+        type: str
     radius_server_group:
         description:
             - RADIUS server group's name.
               The value is a string of 1 to 32 case-insensitive characters.
+        type: str
     hwtacas_template:
         description:
             - Name of a HWTACACS template.
               The value is a string of 1 to 32 case-insensitive characters.
+        type: str
     local_user_group:
         description:
             - Name of the user group where the user belongs. The user inherits all the rights of the user group.
               The value is a string of 1 to 32 characters.
+        type: str
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 
 - name: AAA server test
   hosts: cloudengine

--- a/lib/ansible/modules/network/dellos10/dellos10_command.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_command.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
-#
-# (c) 2015 Peter Sprygada, <psprygada@ansible.com>
-# Copyright (c) 2017 Dell Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2015, Peter Sprygada <psprygada@ansible.com>
+# Copyright: (c) 2017, Dell Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -35,6 +36,7 @@ options:
         is returned. If the I(wait_for) argument is provided, the
         module is not returned until the condition is satisfied or
         the number of retries has expired.
+    type: list
     required: true
   wait_for:
     description:
@@ -43,6 +45,7 @@ options:
         before moving forward. If the conditional is not true
         within the configured number of I(retries), the task fails.
         See examples.
+    type: list
     version_added: "2.2"
   match:
     description:
@@ -52,8 +55,9 @@ options:
         then all conditionals in the wait_for must be satisfied.  If
         the value is set to C(any) then only one of the values must be
         satisfied.
+    type: str
     default: all
-    choices: ['any', 'all']
+    choices: [ all, any ]
     version_added: "2.5"
   retries:
     description:
@@ -61,6 +65,7 @@ options:
         before it is considered failed. The command is run on the
         target device every retry and evaluated against the
         I(wait_for) conditions.
+    type: int
     default: 10
   interval:
     description:
@@ -68,6 +73,7 @@ options:
         of the command. If the command does not pass the specified
         conditions, the interval indicates how long to wait before
         trying the command again.
+    type: int
     default: 1
 """
 

--- a/lib/ansible/modules/network/dellos6/dellos6_command.py
+++ b/lib/ansible/modules/network/dellos6/dellos6_command.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
-#
-# (c) 2015 Peter Sprygada, <psprygada@ansible.com>
-# Copyright (c) 2016 Dell Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2015, Peter Sprygada <psprygada@ansible.com>
+# Copyright: (c) 2016, Dell Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -34,6 +35,7 @@ options:
         is returned. If the I(wait_for) argument is provided, the
         module is not returned until the condition is satisfied or
         the number of retries has expired.
+    type: list
     required: true
   wait_for:
     description:
@@ -42,6 +44,7 @@ options:
         before moving forward. If the conditional is not true
         within the configured number of I(retries), the task fails.
         See examples.
+    type: list
     version_added: "2.2"
   match:
     description:
@@ -51,8 +54,9 @@ options:
         then all conditionals in the wait_for must be satisfied.  If
         the value is set to C(any) then only one of the values must be
         satisfied.
+    type: str
     default: all
-    choices: ['any', 'all']
+    choices: [ all, any ]
     version_added: "2.5"
   retries:
     description:
@@ -60,6 +64,7 @@ options:
         before it is considered failed. The command is run on the
         target device every retry and evaluated against the
         I(wait_for) conditions.
+    type: int
     default: 10
   interval:
     description:
@@ -67,6 +72,7 @@ options:
         of the command. If the command does not pass the specified
         conditions, the interval indicates how long to wait before
         trying the command again.
+    type: int
     default: 1
 """
 

--- a/lib/ansible/modules/network/dellos9/dellos9_command.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_command.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python
-#
-# (c) 2015 Peter Sprygada, <psprygada@ansible.com>
-# Copyright (c) 2016 Dell Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2015, Peter Sprygada <psprygada@ansible.com>
+# Copyright: (c) 2016, Dell Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -34,6 +36,7 @@ options:
         is returned. If the I(wait_for) argument is provided, the
         module is not returned until the condition is satisfied or
         the number of retries has expired.
+    type: list
     required: true
   wait_for:
     description:
@@ -42,6 +45,7 @@ options:
         before moving forward. If the conditional is not true
         within the configured number of I(retries), the task fails.
         See examples.
+    type: list
     version_added: "2.2"
   match:
     description:
@@ -51,8 +55,9 @@ options:
         then all conditionals in the wait_for must be satisfied.  If
         the value is set to C(any) then only one of the values must be
         satisfied.
+    type: str
     default: all
-    choices: ['any', 'all']
+    choices: [ all, any ]
     version_added: "2.5"
   retries:
     description:
@@ -60,6 +65,7 @@ options:
         before it is considered failed. The command is run on the
         target device every retry and evaluated against the
         I(wait_for) conditions.
+    type: int
     default: 10
   interval:
     description:
@@ -67,6 +73,7 @@ options:
         of the command. If the command does not pass the specified
         conditions, the interval indicates how long to wait before
         trying the command again.
+    type: int
     default: 1
 
 notes:

--- a/lib/ansible/modules/remote_management/dellemc/idrac/dellemc_idrac_firmware.py
+++ b/lib/ansible/modules/remote_management/dellemc/idrac/dellemc_idrac_firmware.py
@@ -19,7 +19,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-DOCUMENTATION = """
+DOCUMENTATION = r'''
 ---
 module: dellemc_idrac_firmware
 short_description: Firmware update from a repository on a network share (CIFS, NFS).
@@ -32,42 +32,45 @@ description:
     - This feature is available only with iDRAC Enterprise License.
 options:
     idrac_ip:
-        required: True
         description: iDRAC IP Address.
+        type: str
+        required: True
     idrac_user:
-        required: True
         description: iDRAC username.
-    idrac_pwd:
+        type: str
         required: True
+    idrac_pwd:
         description: iDRAC user password.
+        type: str
+        required: True
     idrac_port:
-        required: False
         description: iDRAC port.
+        type: int
         default: 443
     share_name:
-        required: True
         description: CIFS or NFS Network share.
+        type: str
+        required: True
     share_user:
-        required: False
         description: Network share user in the format 'user@domain' or 'domain\\user' if user is
             part of a domain else 'user'. This option is mandatory for CIFS Network Share.
+        type: str
     share_pwd:
-        required: False
         description: Network share user password. This option is mandatory for CIFS Network Share.
+        type: str
     share_mnt:
-        required: True
         description: Local mount path of the network share with read-write permission for ansible user.
             This option is mandatory for Network Share.
+        type: str
+        required: True
     reboot:
-        required: False
         description: Whether to reboots after applying the updates or not.
-        default: False
         type: bool
+        default: false
     job_wait:
-        required: False
         description: Whether to wait for job completion or not.
         type: bool
-        default: True
+        default: true
     catalog_file_name:
         required: False
         description: Catalog file name relative to the I(share_name).
@@ -78,7 +81,7 @@ requirements:
     - "omsdk"
     - "python >= 2.7.5"
 author: "Rajeev Arakkal (@rajeevarakkal)"
-"""
+'''
 
 EXAMPLES = """
 ---
@@ -176,19 +179,19 @@ def update_firmware(idrac, module):
 def main():
     module = AnsibleModule(
         argument_spec={
-            "idrac_ip": {"required": True, "type": str},
-            "idrac_user": {"required": True, "type": str},
-            "idrac_pwd": {"required": True, "type": str, "no_log": True},
-            "idrac_port": {"required": False, "default": 443, "type": int},
+            "idrac_ip": {"required": True, "type": 'str'},
+            "idrac_user": {"required": True, "type": 'str'},
+            "idrac_pwd": {"required": True, "type": 'str', "no_log": True},
+            "idrac_port": {"required": False, "default": 443, "type": 'int'},
 
-            "share_name": {"required": True, "type": str},
-            "share_user": {"required": False, "type": str},
-            "share_pwd": {"required": False, "type": str, "no_log": True},
-            "share_mnt": {"required": True, "type": str},
+            "share_name": {"required": True, "type": 'str'},
+            "share_user": {"required": False, "type": 'str'},
+            "share_pwd": {"required": False, "type": 'str', "no_log": True},
+            "share_mnt": {"required": True, "type": 'str'},
 
-            "catalog_file_name": {"required": False, "type": str, "default": "Catalog.xml"},
-            "reboot": {"required": False, "type": bool, "default": False},
-            "job_wait": {"required": False, "type": bool, "default": True},
+            "catalog_file_name": {"required": False, "type": 'str', "default": "Catalog.xml"},
+            "reboot": {"required": False, "type": 'bool', "default": False},
+            "job_wait": {"required": False, "type": 'bool', "default": True},
         },
 
         supports_check_mode=False)

--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2013, Adam Miller (maxamillion@fedoraproject.org)
+# Copyright: (c) 2013, Adam Miller <maxamillion@fedoraproject.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -13,7 +13,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'community'}
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: firewalld
 short_description: Manage arbitrary ports/services with firewalld
@@ -23,36 +23,46 @@ version_added: "1.4"
 options:
   service:
     description:
-      - "Name of a service to add/remove to/from firewalld - service must be listed in output of firewall-cmd --get-services."
+      - Name of a service to add/remove to/from firewalld.
+      - The service must be listed in output of firewall-cmd --get-services.
+    type: str
   port:
     description:
-      - "Name of a port or port range to add/remove to/from firewalld. Must be in the form PORT/PROTOCOL or PORT-PORT/PROTOCOL for port ranges."
+      - Name of a port or port range to add/remove to/from firewalld.
+      - Must be in the form PORT/PROTOCOL or PORT-PORT/PROTOCOL for port ranges.
+    type: str
   rich_rule:
     description:
-      - "Rich rule to add/remove to/from firewalld."
+      - Rich rule to add/remove to/from firewalld.
+    type: str
   source:
     description:
-      - 'The source/network you would like to add/remove to/from firewalld'
+      - The source/network you would like to add/remove to/from firewalld.
+    type: str
     version_added: "2.0"
   interface:
     description:
-      - 'The interface you would like to add/remove to/from a zone in firewalld'
+      - The interface you would like to add/remove to/from a zone in firewalld.
+    type: str
     version_added: "2.1"
   icmp_block:
     description:
-      - 'The icmp block you would like to add/remove to/from a zone in firewalld'
+      - The icmp block you would like to add/remove to/from a zone in firewalld.
+    type: str
     version_added: "2.8"
   icmp_block_inversion:
     description:
-      - 'Enable/Disable inversion of icmp blocks for a zone in firewalld'
+      - Enable/Disable inversion of icmp blocks for a zone in firewalld.
+    type: str
     version_added: "2.8"
   zone:
     description:
       - >
-        The firewalld zone to add/remove to/from (NOTE: default zone can be configured per system but "public" is default from upstream. Available choices
-        can be extended based on per-system configs, listed here are "out of the box" defaults).
+        The firewalld zone to add/remove to/from (NOTE: default zone can be configured per system but "public" is default from upstream.
+      - Available choices can be extended based on per-system configs, listed here are "out of the box" defaults).
+      - Possible values include C(block), C(dmz), C(drop), C(external), C(home), C(internal), C(public), C(trusted), C(work) ]
+    type: str
     default: system-default(public)
-    choices: [ "work", "drop", "internal", "external", "trusted", "home", "dmz", "public", "block" ]
   permanent:
     description:
       - >
@@ -61,26 +71,33 @@ options:
     type: bool
   immediate:
     description:
-      - "Should this configuration be applied immediately, if set as permanent"
+      - Should this configuration be applied immediately, if set as permanent.
     type: bool
-    default: 'no'
+    default: no
     version_added: "1.9"
   state:
     description:
-      - >
-        Enable or disable a setting.
-        For ports: Should this port accept(enabled) or reject(disabled) connections.
-        The states "present" and "absent" can only be used in zone level operations (i.e. when no other parameters but zone and state are set).
+      - Enable or disable a setting.
+      - 'For ports: Should this port accept(enabled) or reject(disabled) connections.'
+      - The states C(present) and C(absent) can only be used in zone level operations (i.e. when no other parameters but zone and state are set).
+    type: str
     required: true
-    choices: [ "enabled", "disabled", "present", "absent" ]
+    choices: [ absent, disabled, enabled, present ]
   timeout:
     description:
-      - "The amount of time the rule should be in effect for when non-permanent."
+      - The amount of time the rule should be in effect for when non-permanent.
+    type: int
     default: 0
   masquerade:
     description:
-      - 'The masquerade setting you would like to enable/disable to/from zones within firewalld'
+      - The masquerade setting you would like to enable/disable to/from zones within firewalld.
+    type: str
     version_added: "2.1"
+  offline:
+    description:
+      - Whether to run this module even when firewalld is offline.
+    type: bool
+    version_added: "2.3"
 notes:
   - Not tested on any Debian based system.
   - Requires the python2 bindings of firewalld, which may not be installed by default.
@@ -96,7 +113,7 @@ requirements: [ 'firewalld >= 0.2.11' ]
 author: "Adam Miller (@maxamillion)"
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - firewalld:
     service: https
     permanent: yes
@@ -119,7 +136,7 @@ EXAMPLES = '''
     state: enabled
 
 - firewalld:
-    rich_rule: 'rule service name="ftp" audit limit value="1/m" accept'
+    rich_rule: rule service name="ftp" audit limit value="1/m" accept
     permanent: yes
     state: enabled
 
@@ -159,14 +176,11 @@ EXAMPLES = '''
 
 - name: Redirect port 443 to 8443 with Rich Rule
   firewalld:
-    rich_rule: rule family={{ item }} forward-port port=443 protocol=tcp to-port=8443
-    zone:      public
+    rich_rule: rule forward-port port=443 protocol=tcp to-port=8443
+    zone: public
     permanent: yes
     immediate: yes
-    state:     enabled
-  loop:
-    - ipv4
-    - ipv6
+    state: enabled
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -618,20 +632,20 @@ def main():
 
     module = AnsibleModule(
         argument_spec=dict(
-            icmp_block=dict(required=False, default=None),
-            icmp_block_inversion=dict(required=False, default=None),
-            service=dict(required=False, default=None),
-            port=dict(required=False, default=None),
-            rich_rule=dict(required=False, default=None),
-            zone=dict(required=False, default=None),
+            icmp_block=dict(type='str'),
+            icmp_block_inversion=dict(type='str'),
+            service=dict(type='str'),
+            port=dict(type='str'),
+            rich_rule=dict(type='str'),
+            zone=dict(type='str'),
             immediate=dict(type='bool', default=False),
-            source=dict(required=False, default=None),
-            permanent=dict(type='bool', required=False, default=None),
-            state=dict(choices=['enabled', 'disabled', 'present', 'absent'], required=True),
-            timeout=dict(type='int', required=False, default=0),
-            interface=dict(required=False, default=None),
-            masquerade=dict(required=False, default=None),
-            offline=dict(type='bool', required=False, default=None),
+            source=dict(type='str'),
+            permanent=dict(type='bool'),
+            state=dict(type='str', required=True, choices=['absent', 'disabled', 'enabled', 'present']),
+            timeout=dict(type='int', default=0),
+            interface=dict(type='str'),
+            masquerade=dict(type='str'),
+            offline=dict(type='bool'),
         ),
         supports_check_mode=True
     )

--- a/lib/ansible/utils/module_docs_fragments/a10.py
+++ b/lib/ansible/utils/module_docs_fragments/a10.py
@@ -27,31 +27,34 @@ options:
   host:
     description:
       - Hostname or IP of the A10 Networks device.
+    type: str
     required: true
   username:
     description:
       - An account with administrator privileges.
+    type: str
     required: true
-    aliases: ['user', 'admin']
+    aliases: [ admin, user ]
   password:
     description:
       - Password for the C(username) account.
+    type: str
     required: true
-    aliases: ['pass', 'pwd']
+    aliases: [ pass, pwd ]
   write_config:
     description:
       - If C(yes), any changes will cause a write of the running configuration
         to non-volatile memory. This will save I(all) configuration changes,
         including those that may have been made manually or through other modules,
         so care should be taken when specifying C(yes).
-    version_added: 2.2
     type: bool
-    default: 'no'
+    default: no
+    version_added: 2.2
   validate_certs:
     description:
       - If C(no), SSL certificates will not be validated. This should only be used
         on personally controlled devices using self-signed certificates.
-    version_added: 2.2
     type: bool
-    default: 'yes'
+    default: yes
+    version_added: 2.2
 """

--- a/lib/ansible/utils/module_docs_fragments/dellos10.py
+++ b/lib/ansible/utils/module_docs_fragments/dellos10.py
@@ -1,22 +1,8 @@
-#
-# (c) 2015, Peter Sprygada <psprygada@ansible.com>
-#
-# Copyright (c) 2016 Dell Inc.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2015, Peter Sprygada <psprygada@ansible.com>
+# Copyright: (c) 2016, Dell Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 
 class ModuleDocFragment(object):

--- a/lib/ansible/utils/module_docs_fragments/dellos6.py
+++ b/lib/ansible/utils/module_docs_fragments/dellos6.py
@@ -1,22 +1,8 @@
-#
-# (c) 2015, Peter Sprygada <psprygada@ansible.com>
-#
-# Copyright (c) 2016 Dell Inc.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2015, Peter Sprygada <psprygada@ansible.com>
+# Copyright: (c) 2016, Dell Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 
 class ModuleDocFragment(object):
@@ -33,32 +19,38 @@ options:
           - Specifies the DNS host name or address for connecting to the remote
             device over the specified transport.  The value of host is used as
             the destination address for the transport.
+        type: str
         required: true
       port:
         description:
           - Specifies the port to use when building the connection to the remote
             device.
+        type: int
         default: 22
       username:
         description:
           - User to authenticate the SSH session to the remote device. If the
             value is not specified in the task, the value of environment variable
             C(ANSIBLE_NET_USERNAME) will be used instead.
+        type: str
       password:
         description:
           - Password to authenticate the SSH session to the remote device. If the
             value is not specified in the task, the value of environment variable
             C(ANSIBLE_NET_PASSWORD) will be used instead.
+        type: str
       ssh_keyfile:
         description:
           - Path to an ssh key used to authenticate the SSH session to the remote
             device.  If the value is not specified in the task, the value of
             environment variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
+        type: str
       timeout:
         description:
           - Specifies idle timeout (in seconds) for the connection. Useful if the
             console freezes before continuing. For example when saving
             configurations.
+        type: int
         default: 10
 notes:
   - For more information on using Ansible to manage Dell EMC Network devices see U(https://www.ansible.com/ansible-dell-networking).

--- a/lib/ansible/utils/module_docs_fragments/dellos9.py
+++ b/lib/ansible/utils/module_docs_fragments/dellos9.py
@@ -1,22 +1,8 @@
-#
-# (c) 2015, Peter Sprygada <psprygada@ansible.com>
-#
-# Copyright (c) 2016 Dell Inc.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2015, Peter Sprygada <psprygada@ansible.com>
+# Copyright: (c) 2016, Dell Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 
 class ModuleDocFragment(object):
@@ -27,38 +13,45 @@ options:
   provider:
     description:
       - A dict object containing connection details.
+    type: dict
     suboptions:
       host:
         description:
           - Specifies the DNS host name or address for connecting to the remote
             device over the specified transport.  The value of host is used as
             the destination address for the transport.
+        type: str
         required: true
       port:
         description:
           - Specifies the port to use when building the connection to the remote
             device.
+        type: int
         default: 22
       username:
         description:
           - User to authenticate the SSH session to the remote device. If the
             value is not specified in the task, the value of environment variable
             C(ANSIBLE_NET_USERNAME) will be used instead.
+        type: str
       password:
         description:
           - Password to authenticate the SSH session to the remote device. If the
             value is not specified in the task, the value of environment variable
             C(ANSIBLE_NET_PASSWORD) will be used instead.
+        type: str
       ssh_keyfile:
         description:
           - Path to an ssh key used to authenticate the SSH session to the remote
             device.  If the value is not specified in the task, the value of
             environment variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
+        type: str
       timeout:
         description:
           - Specifies idle timeout (in seconds) for the connection. Useful if the
             console freezes before continuing. For example when saving
             configurations.
+        type: int
         default: 10
 notes:
   - For more information on using Ansible to manage Dell EMC Network devices see U(https://www.ansible.com/ansible-dell-networking).

--- a/lib/ansible/utils/module_docs_fragments/nxos.py
+++ b/lib/ansible/utils/module_docs_fragments/nxos.py
@@ -1,20 +1,7 @@
-#
-# (c) 2015, Peter Sprygada <psprygada@ansible.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2015, Peter Sprygada <psprygada@ansible.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 
 class ModuleDocFragment(object):
@@ -30,12 +17,14 @@ options:
       - For more information please see the L(NXOS Platform Options guide, ../network/user_guide/platform_nxos.html).
       - HORIZONTALLINE
       - A dict object containing connection details.
+    type: dict
     suboptions:
       host:
         description:
           - Specifies the DNS host name or address for connecting to the remote
             device over the specified transport.  The value of host is used as
             the destination address for the transport.
+        type: str
         required: true
       port:
         description:
@@ -43,6 +32,7 @@ options:
             device.  This value applies to either I(cli) or I(nxapi).  The port
             value will default to the appropriate transport common port if
             none is provided in the task.  (cli=22, http=80, https=443).
+        type: int
         default: 0 (use common port)
       username:
         description:
@@ -51,12 +41,14 @@ options:
             either the CLI login or the nxapi authentication depending on which
             transport is used. If the value is not specified in the task, the
             value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
+        type: str
       password:
         description:
           - Specifies the password to use to authenticate the connection to
             the remote device.  This is a common argument used for either I(cli)
             or I(nxapi) transports. If the value is not specified in the task, the
             value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
+        type: str
       authorize:
         description:
           - Instructs the module to enter privileged mode on the remote device
@@ -66,35 +58,37 @@ options:
             C(ANSIBLE_NET_AUTHORIZE) will be used instead.
         type: bool
         default: no
-        choices: ['yes', 'no']
-        version_added: 2.5.3
+        version_added: '2.5.3'
       auth_pass:
         description:
           - Specifies the password to use if required to enter privileged mode
             on the remote device.  If I(authorize) is false, then this argument
             does nothing. If the value is not specified in the task, the value of
             environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
-        default: none
-        version_added: 2.5.3
+        type: str
+        version_added: '2.5.3'
       timeout:
         description:
           - Specifies the timeout in seconds for communicating with the network device
             for either connecting or sending commands.  If the timeout is
             exceeded before the operation is completed, the module will error.
             NX-API can be slow to return on long-running commands (sh mac, sh bgp, etc).
+        type: int
         default: 10
-        version_added: 2.3
+        version_added: '2.3'
       ssh_keyfile:
         description:
           - Specifies the SSH key to use to authenticate the connection to
             the remote device.  This argument is only used for the I(cli)
             transport. If the value is not specified in the task, the
             value of environment variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
+        type: str
       transport:
         description:
           - Configures the transport connection to use when connecting to the
             remote device.  The transport argument supports connectivity to the
             device over cli (ssh) or nxapi.
+        type: str
         required: true
         default: cli
       use_ssl:
@@ -102,18 +96,19 @@ options:
           - Configures the I(transport) to use SSL if set to true only when the
             C(transport=nxapi), otherwise this value is ignored.
         type: bool
-        default: 'no'
+        default: no
       validate_certs:
         description:
           - If C(no), SSL certificates will not be validated. This should only be used
             on personally controlled sites using self-signed certificates.  If the transport
             argument is not nxapi, this value is ignored.
         type: bool
+        default: yes
       use_proxy:
         description:
           - If C(no), the environment variables C(http_proxy) and C(https_proxy) will be ignored.
         type: bool
-        default: 'yes'
+        default: yes
         version_added: "2.5"
 
 notes:

--- a/lib/ansible/utils/module_docs_fragments/url.py
+++ b/lib/ansible/utils/module_docs_fragments/url.py
@@ -55,10 +55,10 @@ options:
     description:
       - PEM formatted certificate chain file to be used for SSL client authentication.
       - This file can also include the key as well, and if the key is included, C(client_key) is not required.
-    type: str
+    type: path
   client_key:
     description:
       - PEM formatted file that contains your private key to be used for SSL client authentication.
       - If C(client_cert) contains both the certificate and key, this option is not required.
-    type: str
+    type: path
 '''

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -885,10 +885,7 @@ lib/ansible/modules/system/cron.py E324
 lib/ansible/modules/system/cronvar.py E324
 lib/ansible/modules/system/crypttab.py E324
 lib/ansible/modules/system/debconf.py E326
-lib/ansible/modules/system/firewalld.py E322
 lib/ansible/modules/system/firewalld.py E324
-lib/ansible/modules/system/firewalld.py E325
-lib/ansible/modules/system/firewalld.py E326
 lib/ansible/modules/system/iptables.py E326
 lib/ansible/modules/system/java_cert.py E324
 lib/ansible/modules/system/known_hosts.py E324


### PR DESCRIPTION
##### SUMMARY
Assorted sanity fixes.

This PR fixes the following items:
- Fix mistyped parameter types (using bool, int and str instead of 'bool', 'int' and 'str')
- Add missing parameter types to documentation
- Add missing parameter types to arg_spec

*NOTE: I appear to have pulled in a stashed version of my copy-module doc rewrite.*

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
Various modules