### PR TITLE
Don't try to detach OS disk from Virtual Machine when updating Managed Disk

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
@@ -263,14 +263,14 @@ class AzureRMManagedDisk(AzureRMModuleBase):
         # unmount from the old virtual machine and mount to the new virtual machine
         vm_name = parse_resource_id(disk_instance.get('managed_by', '')).get('name') if disk_instance else None
         if self.managed_by != vm_name:
-            if not self.check_mode:
-                if vm_name:
-                    if self.detach(vm_name, result):
-                        changed = True
-                if self.managed_by:
-                    if self.attach(self.managed_by, result):
-                        changed = True
-                result = self.get_managed_disk()
+            if vm_name:
+                if self.detach(vm_name, result):
+                    result = self.get_managed_disk()
+                    changed = True
+            if self.managed_by:
+                if self.attach(self.managed_by, result):
+                    result = self.get_managed_disk()
+                    changed = True
 
         if self.state == 'absent' and disk_instance:
             changed = True

--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
@@ -293,6 +293,10 @@ class AzureRMManagedDisk(AzureRMModuleBase):
         params = self.compute_models.ManagedDiskParameters(id=disk.get('id'), storage_account_type=disk.get('storage_account_type'))
         data_disk = self.compute_models.DataDisk(lun=lun, create_option=self.compute_models.DiskCreateOptionTypes.attach, managed_disk=params)
         vm.storage_profile.data_disks.append(data_disk)
+
+        if self.check_mode:
+            return True
+
         self._update_vm(vm_name, vm)
         return True
 
@@ -307,6 +311,10 @@ class AzureRMManagedDisk(AzureRMModuleBase):
         if len(vm.storage_profile.data_disks) == len(leftovers):
             self.fail("No disk with the name '{0}' was found".format(disk.get('name')))
         vm.storage_profile.data_disks = leftovers
+
+        if self.check_mode:
+            return True
+
         self._update_vm(vm_name, vm)
         return True
 


### PR DESCRIPTION
##### SUMMARY
This is pretty inconvenient bug, as azure_rm_managed_disk has to be created before VM using it as OS disk is created. When running same playbook again, idempotency check detects that the disk has been attached and tries to detach it. OS disks cannot be detached so it always fails.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_managed_disk

##### ADDITIONAL INFORMATION
