### PR TITLE
added timestamps to iosxr_command module

### DIFF
--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -477,10 +477,10 @@ def load_config(module, command_filter, commit=False, replace=False,
     return diff
 
 
-def run_commands(module, commands, check_rc=True):
+def run_commands(module, commands, check_rc=True, return_timestamps=False):
     connection = get_connection(module)
     try:
-        return connection.run_commands(commands=commands, check_rc=check_rc)
+        return connection.run_commands(commands=commands, check_rc=check_rc, return_timestamps=return_timestamps)
     except ConnectionError as exc:
         module.fail_json(msg=to_text(exc))
 

--- a/lib/ansible/modules/network/iosxr/iosxr_command.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_command.py
@@ -178,7 +178,7 @@ def main():
     match = module.params['match']
 
     while retries > 0:
-        responses = run_commands(module, commands)
+        responses, timestamps = run_commands(module, commands, return_timestamps=True)
 
         for item in list(conditionals):
             if item(responses):
@@ -201,6 +201,7 @@ def main():
     result.update({
         'stdout': responses,
         'stdout_lines': list(to_lines(responses)),
+        'timestamps': timestamps
     })
 
     module.exit_json(**result)

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -24,6 +24,7 @@ import json
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text
+from ansible.module_utils.basic import get_timestamp
 from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.network.common.config import NetworkConfig, dumps
@@ -172,10 +173,11 @@ class Cliconf(CliconfBase):
 
         self.send_command(**cmd_obj)
 
-    def run_commands(self, commands=None, check_rc=True):
+    def run_commands(self, commands=None, check_rc=True, return_timestamps=False):
         if commands is None:
             raise ValueError("'commands' value is required")
         responses = list()
+        timestamps = list()
         for cmd in to_list(commands):
             if not isinstance(cmd, Mapping):
                 cmd = {'command': cmd}
@@ -185,6 +187,7 @@ class Cliconf(CliconfBase):
                 raise ValueError("'output' value %s is not supported for run_commands" % output)
 
             try:
+                timestamp = get_timestamp()
                 out = self.send_command(**cmd)
             except AnsibleConnectionFailure as e:
                 if check_rc:
@@ -203,7 +206,11 @@ class Cliconf(CliconfBase):
                     pass
 
                 responses.append(out)
-        return responses
+                timestamps.append(timestamp)
+        if return_timestamps:
+            return responses, timestamps
+        else:
+            return responses
 
     def discard_changes(self):
         self.send_command('abort')

--- a/test/units/modules/network/iosxr/test_iosxr_command.py
+++ b/test/units/modules/network/iosxr/test_iosxr_command.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat.mock import patch
+from ansible.module_utils.basic import get_timestamp
 from ansible.modules.network.iosxr import iosxr_command
 from units.modules.utils import set_module_args
 from .iosxr_module import TestIosxrModule, load_fixture
@@ -45,6 +46,7 @@ class TestIosxrCommandModule(TestIosxrModule):
         def load_from_file(*args, **kwargs):
             module, commands = args
             output = list()
+            timestamps = list()
 
             for item in commands:
                 try:
@@ -53,7 +55,8 @@ class TestIosxrCommandModule(TestIosxrModule):
                     command = item
                 filename = str(command).replace(' ', '_')
                 output.append(load_fixture(filename))
-            return output
+                timestamps.append(get_timestamp())
+            return output, timestamps
 
         self.run_commands.side_effect = load_from_file
 


### PR DESCRIPTION
iosxr_command module now returns timestamps field, which shows command execution time

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added information about time when command was issued on remote device.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iosxr_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**example playbook**
```yaml
- name: collect show commands from devices
  hosts: test_group
  connection: network_cli

  tasks:

    - name: collect show commands
      iosxr_command:
        commands:
          - "show clock"
          - "show run vrf mgmt"
      register: output

    - name: debug task
      debug:
        var: output
```

**before**
```
ok: [R01] => {
    "output": {
        "changed": false, 
        "failed": false, 
        "stdout": [
            "16:23:19.904 MSK Fri Jun 29 2018", 
            "vrf mgmt\n!"
        ], 
        "stdout_lines": [
            [
                "16:23:19.904 MSK Fri Jun 29 2018"
            ], 
            [
                "vrf mgmt", 
                "!"
            ]
        ]
    }
}
```

**after**
```
ok: [R01] => {
    "output": {
        "changed": false, 
        "failed": false, 
        "stdout": [
            "16:24:58.318 MSK Fri Jun 29 2018", 
            "vrf mgmt\n!"
        ], 
        "stdout_lines": [
            [
                "16:24:58.318 MSK Fri Jun 29 2018"
            ], 
            [
                "vrf mgmt", 
                "!"
            ]
        ], 
        "timestamps": [
            "2018-06-29T16:24:58", 
            "2018-06-29T16:24:58"
        ]
    }
}
```
