### PR TITLE
Remove older version_added information from docs

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -64,7 +64,7 @@ from ansible.utils._build_helpers import update_file_if_different
 
 # if a module is added in a version of Ansible older than this, don't print the version added information
 # in the module documentation because everyone is assumed to be running something newer than this already.
-TOO_OLD_TO_BE_NOTABLE = 1.3
+TOO_OLD_TO_BE_NOTABLE = 2.0
 
 # Get parent directory of the directory this script lives in
 MODULEDIR = os.path.abspath(os.path.join(


### PR DESCRIPTION
##### SUMMARY
Parameters added before v2.0 will not be mentioned as such.
We assume most if not all our users have moved to Ansible v2.0.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Module docs