### PR TITLE
Remove the use of mock from validate-modules

### DIFF
--- a/test/sanity/validate-modules/module_args.py
+++ b/test/sanity/validate-modules/module_args.py
@@ -21,14 +21,7 @@ import sys
 
 from contextlib import contextmanager
 
-import mock
-
 from ansible.module_utils.six import reraise
-
-
-MODULE_CLASSES = [
-    'ansible.module_utils.basic.AnsibleModule',
-]
 
 
 class AnsibleModuleCallError(RuntimeError):
@@ -39,20 +32,37 @@ class AnsibleModuleImportError(ImportError):
     pass
 
 
+class _FakeAnsibleModule:
+    def __init__(self):
+        self.args = tuple()
+        self.kwargs = {}
+        self.called = False
+
+    def __call__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.called = True
+        raise AnsibleModuleCallError('AnsibleModuleCallError')
+
+    def _load_params(self):
+        pass
+
+
+def _fake_load_params():
+    pass
+
+
 @contextmanager
-def add_mocks(filename):
+def setup_env(filename):
     # Used to clean up imports later
     pre_sys_modules = list(sys.modules.keys())
 
-    module_mock = mock.MagicMock()
-    for module_class in MODULE_CLASSES:
-        p = mock.patch('%s.__init__' % module_class, new=module_mock).start()
-        p.side_effect = AnsibleModuleCallError('AnsibleModuleCallError')
-    mock.patch('ansible.module_utils.basic._load_params').start()
+    fake = _FakeAnsibleModule()
+    module = __import__('ansible.module_utils.basic').module_utils.basic
+    setattr(module, 'AnsibleModule', fake)
+    setattr(module, '_load_params', _fake_load_params)
 
-    yield module_mock
-
-    mock.patch.stopall()
+    yield fake
 
     # Clean up imports to prevent issues with mutable data being used in modules
     for k in list(sys.modules.keys()):
@@ -63,10 +73,13 @@ def add_mocks(filename):
 
 
 def get_argument_spec(filename):
-    with add_mocks(filename) as module_mock:
+    with setup_env(filename) as fake:
         try:
+            # We use ``module`` here instead of ``__main__``
+            # which helps with some import issues in this tool
+            # where modules may import things that conflict
             mod = imp.load_source('module', filename)
-            if not module_mock.call_args:
+            if not fake.called:
                 mod.main()
         except AnsibleModuleCallError:
             pass
@@ -74,10 +87,9 @@ def get_argument_spec(filename):
             reraise(AnsibleModuleImportError, AnsibleModuleImportError('%s' % e), sys.exc_info()[2])
 
     try:
-        args, kwargs = module_mock.call_args
         try:
-            return kwargs['argument_spec'], args, kwargs
+            return fake.kwargs['argument_spec'], fake.args, fake.kwargs
         except KeyError:
-            return args[0], args, kwargs
+            return fake.args[0], fake.args, fake.kwargs
     except TypeError:
         return {}, (), {}


### PR DESCRIPTION
##### SUMMARY
This PR removes the use of `mock` from `validate-modules`

In addition to removing a dependency and a small amount of complexity, this makes the code a tiny bit faster, and a little more clear.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
test/sanity/validate-modules/module_args.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```