### PR TITLE
win_lineinfile - fix malformed returned json (#50066) - 2.6

### DIFF
--- a/changelogs/fragments/win_lineinfile-output.yaml
+++ b/changelogs/fragments/win_lineinfile-output.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_lineinfile - Fix issue where a malformed json block was returned causing an error

--- a/lib/ansible/modules/windows/win_lineinfile.ps1
+++ b/lib/ansible/modules/windows/win_lineinfile.ps1
@@ -183,7 +183,7 @@ function Present($path, $regexp, $line, $insertafter, $insertbefore, $create, $b
 		$result.msg = "line added";
 	}
 	ElseIf ($insertafter -eq "EOF" -or $index[1] -eq -1) {
-		$lines.Add($line);
+		$lines.Add($line) > $null;
 		$result.changed = $true;
 		$result.msg = "line added";
 	}
@@ -265,11 +265,11 @@ function Absent($path, $regexp, $line, $backup, $validate, $encodingobj, $linese
 			$match_found = $line -ceq $cur_line;
 		}
 		If ($match_found) {
-			$found.Add($cur_line);
+			$found.Add($cur_line) > $null;
 			$result.changed = $true;
 		}
 		Else {
-			$left.Add($cur_line);
+			$left.Add($cur_line) > $null;
 		}
 	}
 
@@ -351,7 +351,7 @@ ElseIf (Test-Path -Path $path) {
 			$max_preamble_len = $plen;
 		}
 		If ($plen -gt 0) {
-			$sortedlist.Add(-($plen * 1000000 + $encoding.CodePage), $encoding);
+			$sortedlist.Add(-($plen * 1000000 + $encoding.CodePage), $encoding) > $null;
 		}
 	}
 


### PR DESCRIPTION
(cherry picked from commit efda3eaf1cb84799287ae3569d2022b9f8a72f1d)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/50066

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_lineinfile