### PR TITLE
openssh_keypair: prevent error when path includes no path

### DIFF
--- a/lib/ansible/modules/crypto/openssh_keypair.py
+++ b/lib/ansible/modules/crypto/openssh_keypair.py
@@ -272,7 +272,7 @@ def main():
     )
 
     # Check if Path exists
-    base_dir = os.path.dirname(module.params['path'])
+    base_dir = os.path.dirname(module.params['path']) or '.'
     if not os.path.isdir(base_dir):
         module.fail_json(
             name=base_dir,


### PR DESCRIPTION
##### SUMMARY
Prevents error when `path` includes no path, only a filename (i.e. references to a file in cwd).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssh_keypair
