### PR TITLE
Elliptic curve tests for crypto modules

### DIFF
--- a/test/integration/targets/openssl_certificate/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - block:
 
     - import_tasks: selfsigned.yml

--- a/test/integration/targets/openssl_certificate/tasks/ownca.yml
+++ b/test/integration/targets/openssl_certificate/tasks/ownca.yml
@@ -1,3 +1,4 @@
+---
 - name: Generate CA privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/ca_privatekey.pem'
@@ -126,5 +127,16 @@
     privatekey_path: "{{ output_dir }}/privatekey3.pem"
     ownca_path: '{{ output_dir }}/ca_cert.pem'
     ownca_privatekey_path: '{{ output_dir }}/ca_privatekey.pem'
-      
+
+- name: Generate ownca ECC certificate
+  openssl_certificate:
+    path: '{{ output_dir }}/ownca_cert_ecc.pem'
+    csr_path: '{{ output_dir }}/csr_ecc.csr'
+    privatekey_path: '{{ output_dir }}/privatekey_ecc.pem'
+    ownca_path: '{{ output_dir }}/ca_cert.pem'
+    ownca_privatekey_path: '{{ output_dir }}/ca_privatekey.pem'
+    provider: ownca
+    ownca_digest: sha256
+  register: ownca_certificate_ecc
+
 - import_tasks: ../tests/validate_ownca.yml

--- a/test/integration/targets/openssl_certificate/tasks/selfsigned.yml
+++ b/test/integration/targets/openssl_certificate/tasks/selfsigned.yml
@@ -1,3 +1,4 @@
+---
 - name: Generate privatekey
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey.pem'
@@ -133,5 +134,27 @@
     path: "{{ output_dir }}/cert3.pem"
     csr_path: "{{ output_dir }}/csr3.pem"
     privatekey_path: "{{ output_dir }}/privatekey3.pem"
-        
+
+- name: Generate privatekey
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey_ecc.pem'
+    type: ECC
+    curve: secp256k1
+
+- name: Generate CSR
+  openssl_csr:
+    path: '{{ output_dir }}/csr_ecc.csr'
+    privatekey_path: '{{ output_dir }}/privatekey_ecc.pem'
+    subject:
+      commonName: www.example.com
+
+- name: Generate selfsigned certificate
+  openssl_certificate:
+    path: '{{ output_dir }}/cert_ecc.pem'
+    csr_path: '{{ output_dir }}/csr_ecc.csr'
+    privatekey_path: '{{ output_dir }}/privatekey_ecc.pem'
+    provider: selfsigned
+    selfsigned_digest: sha256
+  register: selfsigned_certificate_ecc
+
 - import_tasks: ../tests/validate_selfsigned.yml

--- a/test/integration/targets/openssl_certificate/tests/validate_ownca.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate_ownca.yml
@@ -1,3 +1,4 @@
+---
 - name: Validate ownca certificate (test - verify CA)
   shell: 'openssl verify -CAfile {{ output_dir }}/ca_cert.pem {{ output_dir }}/ownca_cert.pem | sed "s/.*: \(.*\)/\1/g"'
   register: ownca_verify_ca
@@ -65,3 +66,18 @@
   assert:
     that:
       - ownca_cert3_notAfter.stdout == 'Oct 23 13:37:42 2019'
+
+- name: Validate ownca ECC certificate (test - ownca certificate pubkey)
+  shell: 'openssl x509 -noout -pubkey -in {{ output_dir }}/ownca_cert_ecc.pem'
+  register: ownca_cert_ecc_pubkey
+
+- name: Validate ownca ECC certificate (test - ownca issuer value)
+  shell: 'openssl x509 -noout  -in {{ output_dir}}/ownca_cert_ecc.pem -text | grep "Issuer" | sed "s/.*: \(.*\)/\1/g"'
+  register: ownca_cert_ecc_issuer
+
+- name: Validate ownca ECC certificate (assert)
+  assert:
+    that:
+      - ownca_cert_ecc_pubkey.stdout == privatekey_ecc_pubkey.stdout
+      # openssl 1.1.x adds a space between the output
+      - ownca_cert_ecc_issuer.stdout in ['CN=Example CA', 'CN = Example CA']

--- a/test/integration/targets/openssl_certificate/tests/validate_selfsigned.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate_selfsigned.yml
@@ -1,3 +1,4 @@
+---
 - name: Validate certificate (test - privatekey modulus)
   shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey.pem'
   register: privatekey_modulus
@@ -68,3 +69,16 @@
   assert:
     that:
       - cert3_notAfter.stdout == 'Oct 23 13:37:42 2019'
+
+- name: Validate ECC certificate (test - privatekey's pubkey)
+  shell: 'openssl ec -pubout -in {{ output_dir }}/privatekey_ecc.pem'
+  register: privatekey_ecc_pubkey
+
+- name: Validate ECC certificate (test - certificate pubkey)
+  shell: 'openssl x509 -noout -pubkey -in {{ output_dir }}/cert_ecc.pem'
+  register: cert_ecc_pubkey
+
+- name: Validate ECC certificate (assert)
+  assert:
+    that:
+      - cert_ecc_pubkey.stdout == privatekey_ecc_pubkey.stdout

--- a/test/integration/targets/openssl_csr/tasks/main.yml
+++ b/test/integration/targets/openssl_csr/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - block:
     - name: Generate privatekey
       openssl_privatekey:
@@ -65,6 +66,19 @@
         subject_alt_name: "DNS:www.ansible.com"
         ocsp_must_staple: true
       register: csr_ocsp_idempotency
+
+    - name: Generate ECC privatekey
+      openssl_privatekey:
+        path: '{{ output_dir }}/privatekey2.pem'
+        type: ECC
+        curve: secp256k1
+
+    - name: Generate CSR with ECC privatekey
+      openssl_csr:
+        path: '{{ output_dir }}/csr2.csr'
+        privatekey_path: '{{ output_dir }}/privatekey2.pem'
+        subject:
+          commonName: www.ansible.com
 
     - import_tasks: ../tests/validate.yml
 

--- a/test/integration/targets/openssl_csr/tests/validate.yml
+++ b/test/integration/targets/openssl_csr/tests/validate.yml
@@ -1,3 +1,4 @@
+---
 - name: Validate CSR (test - privatekey modulus)
   shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey.pem'
   register: privatekey_modulus
@@ -49,3 +50,21 @@
   assert:
     that:
       - csr_ocsp_idempotency is not changed
+
+- name: Validate ECC CSR (test - privatekey's public key)
+  shell: 'openssl ec -pubout -in {{ output_dir }}/privatekey2.pem'
+  register: privatekey_ecc_key
+
+- name: Validate ECC CSR (test - Common Name)
+  shell: "openssl req -noout -subject -in {{ output_dir }}/csr2.csr -nameopt oneline,-space_eq"
+  register: csr_ecc_cn
+
+- name: Validate ECC CSR (test - CSR pubkey)
+  shell: 'openssl req -noout -pubkey -in {{ output_dir }}/csr2.csr'
+  register: csr_ecc_pubkey
+
+- name: Validate ECC CSR (assert)
+  assert:
+    that:
+      - csr_ecc_cn.stdout.split('=')[-1] == 'www.ansible.com'
+      - csr_ecc_pubkey.stdout == privatekey_ecc_key.stdout

--- a/test/integration/targets/openssl_publickey/tasks/main.yml
+++ b/test/integration/targets/openssl_publickey/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - block:
     - name: Generate privatekey
       openssl_privatekey:
@@ -65,6 +66,17 @@
       openssl_publickey:
         path: '{{ output_dir }}/publickey4.pub'
         privatekey_path: '{{ output_dir }}/privatekey.pem'
+
+    - name: Generate privatekey 5 (ECC)
+      openssl_privatekey:
+        path: '{{ output_dir }}/privatekey5.pem'
+        type: ECC
+        curve: secp256k1
+
+    - name: Generate publickey 5 - PEM format
+      openssl_publickey:
+        path: '{{ output_dir }}/publickey5.pub'
+        privatekey_path: '{{ output_dir }}/privatekey5.pem'
 
     - import_tasks: ../tests/validate.yml
 

--- a/test/integration/targets/openssl_publickey/tests/validate.yml
+++ b/test/integration/targets/openssl_publickey/tests/validate.yml
@@ -1,3 +1,4 @@
+---
 - name: Validate public key (test - privatekey modulus)
   shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey.pem'
   register: privatekey_modulus
@@ -81,3 +82,17 @@
     that:
       - publickey4_modulus.stdout == privatekey4_modulus.stdout
   when: openssl_version.stdout is version('0.9.8zh', '>=')
+
+- name: Validate public key 5 (test - privatekey's pubkey)
+  command: 'openssl ec -in {{ output_dir }}/privatekey5.pem -pubout'
+  register: privatekey5_pubkey
+
+- name: Validate public key 5 (test - publickey pubkey)
+  # Fancy way of writing "cat {{ output_dir }}/publickey5.pub"
+  command: 'openssl ec -pubin -in {{ output_dir }}/publickey5.pub -pubout'
+  register: publickey5_pubkey
+
+- name: Validate public key 5 (assert)
+  assert:
+    that:
+      - publickey5_pubkey.stdout == privatekey5_pubkey.stdout


### PR DESCRIPTION
##### SUMMARY
Add ECC tests for openssl_certificate, openssl_csr and openssl_publickey, to demonstrate that they already support elliptic curves. Fixes #32626.

CC @thomwiggers @MarkusTeufelberger @Spredzy

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
openssl_certificate
openssl_csr
openssl_publickey
