### PR TITLE
[Backport 2.7] allow openstack invetnory to work cacheless

### DIFF
--- a/changelogs/fragments/openstack_inventory_fix.yml
+++ b/changelogs/fragments/openstack_inventory_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - allow using openstack inventory plugin w/o a cache

--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -196,7 +196,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             source_data = cloud_inventory.list_hosts(
                 expand=expand_hostvars, fail_on_cloud_config=fail_on_errors)
 
-            self.cache.set(cache_key, source_data)
+            if self.cache is not None:
+                self.cache.set(cache_key, source_data)
 
         self._populate_from_source(source_data)
 


### PR DESCRIPTION
##### SUMMARY
fixes #50082

(cherry picked from commit a47671aad12f3527902424a81075ca31a43fef6a)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/openstack_inventory_fix.yml
lib/ansible/plugins/inventory/openstack.py