### PR TITLE
Fix no metadata traceback in validate-modules.

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -1459,7 +1459,7 @@ class ModuleValidator(Validator):
             doc_info, docs = self._validate_docs()
 
             # See if current version => deprecated.removed_in, ie, should be docs only
-            if 'removed' in ast.literal_eval(doc_info['ANSIBLE_METADATA']['value'])['status']:
+            if isinstance(doc_info['ANSIBLE_METADATA']['value'], ast.Dict) and 'removed' in ast.literal_eval(doc_info['ANSIBLE_METADATA']['value'])['status']:
                 end_of_deprecation_should_be_removed_only = True
             elif docs and 'deprecated' in docs and docs['deprecated'] is not None:
                 try:


### PR DESCRIPTION
##### SUMMARY

Fix no metadata traceback in validate-modules.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

validate-modules

##### ADDITIONAL INFORMATION

Testing a module without `ANSIBLE_METADATA` results in a traceback:

```
Traceback (most recent call last):
  File "test/sanity/validate-modules/validate-modules", line 1679, in <module>
    main()
  File "test/sanity/validate-modules/validate-modules", line 1578, in main
    mv.validate()
  File "test/sanity/validate-modules/validate-modules", line 1454, in validate
    if 'ANSIBLE_METADATA' in doc_info and 'removed' in ast.literal_eval(doc_info['ANSIBLE_METADATA']['value'])['status']:
  File "/usr/lib/python3.6/ast.py", line 85, in literal_eval
    return _convert(node_or_string)
  File "/usr/lib/python3.6/ast.py", line 84, in _convert
    raise ValueError('malformed node or string: ' + repr(node))
ValueError: malformed node or string: None
```

First seen here: https://app.shippable.com/github/ansible/ansible/runs/98603/1/console