### PR TITLE
Fix mandatory statement error for junos modules (#50074)

### DIFF
--- a/changelogs/fragments/junos_commit_error_fix.yaml
+++ b/changelogs/fragments/junos_commit_error_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix mandatory statement error for junos modules (https://github.com/ansible/ansible/pull/50138)

--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -26,6 +26,7 @@ import re
 from itertools import chain
 from functools import wraps
 
+from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text
 from ansible.module_utils.network.common.utils import to_list
 from ansible.plugins.cliconf import CliconfBase
@@ -103,7 +104,12 @@ class Cliconf(CliconfBase):
             if not isinstance(line, collections.Mapping):
                 line = {'command': line}
             cmd = line['command']
-            results.append(self.send_command(**line))
+            try:
+                results.append(self.send_command(**line))
+            except AnsibleConnectionFailure as exc:
+                if "error: commit failed" in exc.message:
+                    self.discard_changes()
+                raise
             requests.append(cmd)
 
         diff = self.compare_configuration()
@@ -149,12 +155,19 @@ class Cliconf(CliconfBase):
             command += ' peers-synchronize'
 
         command += ' and-quit'
-        return self.send_command(command)
+
+        try:
+            response = self.send_command(command)
+        except AnsibleConnectionFailure:
+            self.discard_changes()
+            raise
+
+        return response
 
     @configure
     def discard_changes(self):
         command = 'rollback 0'
-        for cmd in chain(to_list(command), 'exit'):
+        for cmd in chain(to_list(command), ['exit']):
             self.send_command(cmd)
 
     @configure

--- a/lib/ansible/plugins/terminal/junos.py
+++ b/lib/ansible/plugins/terminal/junos.py
@@ -41,7 +41,8 @@ class TerminalModule(TerminalBase):
 
     terminal_stderr_re = [
         re.compile(br"unknown command"),
-        re.compile(br"syntax error,")
+        re.compile(br"syntax error"),
+        re.compile(br"[\r\n]error:")
     ]
 
     def on_open_shell(self):

--- a/test/integration/targets/junos_config/tests/cli_config/cli_basic.yaml
+++ b/test/integration/targets/junos_config/tests/cli_config/cli_basic.yaml
@@ -43,6 +43,17 @@
       - "result.changed == true"
       - "'ge-0/0/2' in result.diff.prepared"
 
+- name: remove root-authethication (test error scenario)
+  cli_config:
+    config: "delete system root-authentication"
+  ignore_errors: True
+  register: result
+
+- assert:
+    that:
+      - "result.failed == true"
+      - "'Missing mandatory statement' in result.msg"
+
 - name: teardown
   cli_config: *rm1
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #40267

*  Add error regex in junos terminal plugin to error out
   in case of commit fails

*  If the commit fails, add logic to discard changes before exiting
   else next task will result in an error

* Add integration test

* Minor update

Merged to devel https://github.com/ansible/ansible/pull/50074

(cherry picked from commit cc8e90395a9892eb58efac02ae1ac9737853d694)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/cliconf/junos.py
plugins/terminal/junos.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
