### PR TITLE
Pluribus Networks pn_dscp_map_pri_map module with Unit tests

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_dscp_map_pri_map.py
+++ b/lib/ansible/modules/network/netvisor/pn_dscp_map_pri_map.py
@@ -1,0 +1,162 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_dscp_map_pri_map
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.8"
+short_description: CLI command to modify dscp-map-pri-map
+description:
+  - This module can be used to update priority mappings in tables.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: False
+    type: str
+  state:
+    description:
+      - State the action to perform. Use 'update' to modify
+        the dscp-map-pri-map.
+    required: True
+    type: str
+    choices: ['update']
+  pn_pri:
+    description:
+      - CoS priority.
+    required: False
+    type: str
+  pn_name:
+    description:
+      - Name for the DSCP map.
+    required: False
+    type: str
+  pn_dsmap:
+    description:
+      - DSCP value(s).
+    required: False
+    type: str
+"""
+
+EXAMPLES = """
+- name: dscp map pri map modify
+  pn_dscp_map_pri_map:
+    pn_cliswitch: "sw01"
+    state: 'update'
+    pn_name: 'foo'
+    pn_pri: '0'
+    pn_dsmap: '40'
+
+- name: dscp map pri map modify
+  pn_dscp_map_pri_map:
+    pn_cliswitch: "sw01"
+    state: 'update'
+    pn_name: 'foo'
+    pn_pri: '1'
+    pn_dsmap: '8,10,12,14'
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: str
+stdout:
+  description: set of responses from the dscp-map-pri-map command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the dscp-map-pri-map command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+
+
+def check_cli(module, cli):
+    """
+    This method checks for idempotency using the dscp-map-show name command.
+    If a user with given name exists, return True else False.
+    :param module: The Ansible module to fetch input parameters
+    :param cli: The CLI string
+    """
+    name = module.params['pn_name']
+
+    cli += ' dscp-map-show name %s format name no-show-headers' % name
+    out = module.run_command(cli.split(), use_unsafe_shell=True)[1]
+
+    out = out.split()
+
+    return True if name in out else False
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    state_map = dict(
+        update='dscp-map-pri-map-modify'
+    )
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_pri=dict(required=False, type='str'),
+            pn_name=dict(required=False, type='str'),
+            pn_dsmap=dict(required=False, type='str'),
+        ),
+        required_if=(
+            ['state', 'update', ['pn_name', 'pn_pri']],
+        )
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    pri = module.params['pn_pri']
+    name = module.params['pn_name']
+    dsmap = module.params['pn_dsmap']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    NAME_EXISTS = check_cli(module, cli)
+
+    if command == 'dscp-map-pri-map-modify':
+        if NAME_EXISTS is False:
+            module.fail_json(
+                failed=True,
+                msg='Create dscp map with name %s before updating' % name
+            )
+        cli += ' %s ' % command
+        if pri:
+            cli += ' pri ' + pri
+        if name:
+            cli += ' name ' + name
+        if dsmap:
+            cli += ' dsmap ' + dsmap
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/netvisor/pn_dscp_map_pri_map.py
+++ b/lib/ansible/modules/network/netvisor/pn_dscp_map_pri_map.py
@@ -27,7 +27,7 @@ options:
     type: str
   state:
     description:
-      - State the action to perform. Use 'update' to modify
+      - State the action to perform. Use C(update) to modify
         the dscp-map-pri-map.
     required: True
     type: str

--- a/test/units/modules/network/netvisor/test_pn_dscp_map_pri_map.py
+++ b/test/units/modules/network/netvisor/test_pn_dscp_map_pri_map.py
@@ -7,20 +7,20 @@ __metaclass__ = type
 import json
 
 from units.compat.mock import patch
-from ansible.modules.network.netvisor import pn_dhcp_map_pri_map
+from ansible.modules.network.netvisor import pn_dscp_map_pri_map
 from units.modules.utils import set_module_args
 from .nvos_module import TestNvosModule, load_fixture
 
 
 class TestCpuClassModule(TestNvosModule):
 
-    module = pn_dhcp_map_pri_map
+    module = pn_dscp_map_pri_map
 
     def setUp(self):
-        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_dhcp_map_pri_map.run_cli')
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_dscp_map_pri_map.run_cli')
         self.run_nvos_commands = self.mock_run_nvos_commands.start()
 
-        self.mock_run_check_cli = patch('ansible.modules.network.netvisor.pn_dhcp_map_pri_map.check_cli')
+        self.mock_run_check_cli = patch('ansible.modules.network.netvisor.pn_dscp_map_pri_map.check_cli')
         self.run_check_cli = self.mock_run_check_cli.start()
 
     def tearDown(self):

--- a/test/units/modules/network/netvisor/test_pn_dscp_map_pri_map.py
+++ b/test/units/modules/network/netvisor/test_pn_dscp_map_pri_map.py
@@ -25,6 +25,7 @@ class TestCpuClassModule(TestNvosModule):
 
     def tearDown(self):
         self.mock_run_nvos_commands.stop()
+        self.mock_run_check_cli.stop()
 
     def run_cli_patch(self, module, cli, state_map):
         if state_map['update'] == 'dscp-map-pri-map-modify':
@@ -39,21 +40,21 @@ class TestCpuClassModule(TestNvosModule):
         if state == 'update':
             self.run_check_cli.return_value = True
 
-    def test_dhcp_map_pri_map_t1(self):
+    def test_dscp_map_pri_map_t1(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_pri': '0', 'pn_dsmap': '40', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
         expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dscp-map-pri-map-modify  pri 0 name foo dsmap 40'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
-    def test_dhcp_map_pri_map_t2(self):
+    def test_dscp_map_pri_map_t2(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_pri': '1', 'pn_dsmap': '8,10,12,14', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
         expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dscp-map-pri-map-modify  pri 1 name foo dsmap 8,10,12,14'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
-    def test_dhcp_map_pri_map_t3(self):
+    def test_dscp_map_pri_map_t3(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
                          'pn_pri': '2', 'pn_dsmap': '25', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')

--- a/test/units/modules/network/netvisor/test_pn_dscp_map_pri_map.py
+++ b/test/units/modules/network/netvisor/test_pn_dscp_map_pri_map.py
@@ -1,0 +1,61 @@
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from units.compat.mock import patch
+from ansible.modules.network.netvisor import pn_dhcp_map_pri_map
+from units.modules.utils import set_module_args
+from .nvos_module import TestNvosModule, load_fixture
+
+
+class TestCpuClassModule(TestNvosModule):
+
+    module = pn_dhcp_map_pri_map
+
+    def setUp(self):
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_dhcp_map_pri_map.run_cli')
+        self.run_nvos_commands = self.mock_run_nvos_commands.start()
+
+        self.mock_run_check_cli = patch('ansible.modules.network.netvisor.pn_dhcp_map_pri_map.check_cli')
+        self.run_check_cli = self.mock_run_check_cli.start()
+
+    def tearDown(self):
+        self.mock_run_nvos_commands.stop()
+
+    def run_cli_patch(self, module, cli, state_map):
+        if state_map['update'] == 'dscp-map-pri-map-modify':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        module.exit_json(**results)
+
+    def load_fixtures(self, commands=None, state=None, transport='cli'):
+        self.run_nvos_commands.side_effect = self.run_cli_patch
+        if state == 'update':
+            self.run_check_cli.return_value = True
+
+    def test_dhcp_map_pri_map_t1(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
+                         'pn_pri': '0', 'pn_dsmap': '40', 'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dscp-map-pri-map-modify  pri 0 name foo dsmap 40'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_dhcp_map_pri_map_t2(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
+                         'pn_pri': '1', 'pn_dsmap': '8,10,12,14', 'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dscp-map-pri-map-modify  pri 1 name foo dsmap 8,10,12,14'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_dhcp_map_pri_map_t3(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_name': 'foo',
+                         'pn_pri': '2', 'pn_dsmap': '25', 'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 dscp-map-pri-map-modify  pri 2 name foo dsmap 25'
+        self.assertEqual(result['cli_cmd'], expected_cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Point feature of dscp map pri map for Pluribus Networks Netvisor switches 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
pn_dscp_map_pri_map.py module with unit tests.

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```