### PR TITLE
Pluribus Networks igmp snooping module with Unit tests

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_igmp_snooping.py
+++ b/lib/ansible/modules/network/netvisor/pn_igmp_snooping.py
@@ -60,7 +60,7 @@ options:
     description:
       - enable or disable IGMP snooping on vxlans.
     required: False
-    type: str
+    type: bool
   pn_query_max_response_time:
     description:
       - maximum response time, in seconds, advertised in IGMP queries.

--- a/lib/ansible/modules/network/netvisor/pn_igmp_snooping.py
+++ b/lib/ansible/modules/network/netvisor/pn_igmp_snooping.py
@@ -1,0 +1,210 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_igmp_snooping
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.8"
+short_description: CLI command to modify igmp-snooping
+description:
+  - This module can be used to modify Internet Group Management Protocol (IGMP) snooping.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: False
+    type: str
+  state:
+    description:
+      - State the action to perform. Use 'update' to modify the igmp-snooping.
+    required: True
+    type: str
+    choices: ['update']
+  pn_enable:
+    description:
+      - enable or disable IGMP snooping.
+    required: False
+    type: bool
+  pn_query_interval:
+    description:
+      - IGMP query interval in seconds.
+    required: False
+    type: str
+  pn_igmpv2_vlans:
+    description:
+      - VLANs on which to use IGMPv2 protocol.
+    required: False
+    type: str
+  pn_igmpv3_vlans:
+    description:
+      - VLANs on which to use IGMPv3 protocol.
+    required: False
+    type: str
+  pn_enable_vlans:
+    description:
+      - enable per VLAN IGMP snooping.
+    required: False
+    type: str
+  pn_vxlan:
+    description:
+      - enable or disable IGMP snooping on vxlans.
+    required: False
+    type: str
+  pn_query_max_response_time:
+    description:
+      - maximum response time, in seconds, advertised in IGMP queries.
+    required: False
+    type: str
+  pn_scope:
+    description:
+      - IGMP snooping scope - fabric or local.
+    required: False
+    choices: ['local', 'fabric']
+  pn_no_snoop_linklocal_vlans:
+    description:
+      - Remove snooping of link-local groups(224.0.0.0/24) on these vlans.
+    required: False
+    type: str
+  pn_snoop_linklocal_vlans:
+    description:
+      - Allow snooping of link-local groups(224.0.0.0/24) on these vlans.
+    required: False
+    type: str
+"""
+
+EXAMPLES = """
+- name: 'Modify IGMP Snooping'
+  pn_igmp_snooping:
+    pn_cliswitch: 'sw01'
+    state: 'update'
+    pn_vxlan: True
+    pn_enable_vlans: '1-399,401-4092'
+    pn_no_snoop_linklocal_vlans: 'none'
+    pn_igmpv3_vlans: '1-399,401-4092'
+
+- name: 'Modify IGMP Snooping'
+  pn_igmp_snooping:
+    pn_cliswitch: 'sw01'
+    state: 'update'
+    pn_vxlan: False
+    pn_enable_vlans: '1-399'
+    pn_no_snoop_linklocal_vlans: 'none'
+    pn_igmpv3_vlans: '1-399'
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: str
+stdout:
+  description: set of responses from the igmp-snooping command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the igmp-snooping command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli, booleanArgs
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    state_map = dict(
+        update='igmp-snooping-modify'
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_enable=dict(required=False, type='bool'),
+            pn_query_interval=dict(required=False, type='str'),
+            pn_igmpv2_vlans=dict(required=False, type='str'),
+            pn_igmpv3_vlans=dict(required=False, type='str'),
+            pn_enable_vlans=dict(required=False, type='str'),
+            pn_vxlan=dict(required=False, type='bool'),
+            pn_query_max_response_time=dict(required=False, type='str'),
+            pn_scope=dict(required=False, type='str',
+                          choices=['local', 'fabric']),
+            pn_no_snoop_linklocal_vlans=dict(required=False, type='str'),
+            pn_snoop_linklocal_vlans=dict(required=False, type='str'),
+        ),
+        required_one_of=[['pn_enable', 'pn_query_interval',
+                          'pn_igmpv2_vlans',
+                          'pn_igmpv3_vlans',
+                          'pn_enable_vlans',
+                          'pn_vxlan',
+                          'pn_query_max_response_time',
+                          'pn_scope',
+                          'pn_no_snoop_linklocal_vlans',
+                          'pn_snoop_linklocal_vlans']]
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    enable = module.params['pn_enable']
+    query_interval = module.params['pn_query_interval']
+    igmpv2_vlans = module.params['pn_igmpv2_vlans']
+    igmpv3_vlans = module.params['pn_igmpv3_vlans']
+    enable_vlans = module.params['pn_enable_vlans']
+    vxlan = module.params['pn_vxlan']
+    query_max_response_time = module.params['pn_query_max_response_time']
+    scope = module.params['pn_scope']
+    no_snoop_linklocal_vlans = module.params['pn_no_snoop_linklocal_vlans']
+    snoop_linklocal_vlans = module.params['pn_snoop_linklocal_vlans']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    if command == 'igmp-snooping-modify':
+        cli += ' %s ' % command
+
+        cli += booleanArgs(enable, 'enable', 'disable')
+        cli += booleanArgs(vxlan, 'vxlan', 'no-vxlan')
+
+        if query_interval:
+            cli += ' query-interval ' + query_interval
+        if igmpv2_vlans:
+            cli += ' igmpv2-vlans ' + igmpv2_vlans
+        if igmpv3_vlans:
+            cli += ' igmpv3-vlans ' + igmpv3_vlans
+        if enable_vlans:
+            cli += ' enable-vlans ' + enable_vlans
+        if query_max_response_time:
+            cli += ' query-max-response-time ' + query_max_response_time
+        if scope:
+            cli += ' scope ' + scope
+        if no_snoop_linklocal_vlans:
+            cli += ' no-snoop-linklocal-vlans ' + no_snoop_linklocal_vlans
+        if snoop_linklocal_vlans:
+            cli += ' snoop-linklocal-vlans ' + snoop_linklocal_vlans
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/netvisor/pn_igmp_snooping.py
+++ b/lib/ansible/modules/network/netvisor/pn_igmp_snooping.py
@@ -27,7 +27,7 @@ options:
     type: str
   state:
     description:
-      - State the action to perform. Use 'update' to modify the igmp-snooping.
+      - State the action to perform. Use C(update) to modify the igmp-snooping.
     required: True
     type: str
     choices: ['update']

--- a/test/units/modules/network/netvisor/test_pn_igmp_snooping.py
+++ b/test/units/modules/network/netvisor/test_pn_igmp_snooping.py
@@ -38,7 +38,8 @@ class TestAdminServiceModule(TestNvosModule):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_vxlan': True,
                          'pn_enable_vlans': '1-399,401-4092', 'pn_no_snoop_linklocal_vlans': 'none', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 igmp-snooping-modify  vxlan  enable-vlans 1-399,401-4092 no-snoop-linklocal-vlans none'
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 igmp-snooping-modify  vxlan  enable-vlans '
+        expected_cmd += '1-399,401-4092 no-snoop-linklocal-vlans none'
         self.assertEqual(result['cli_cmd'], expected_cmd)
 
     def test_igmp_snooping_modify_t2(self):

--- a/test/units/modules/network/netvisor/test_pn_igmp_snooping.py
+++ b/test/units/modules/network/netvisor/test_pn_igmp_snooping.py
@@ -1,0 +1,56 @@
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from units.compat.mock import patch
+from ansible.modules.network.netvisor import pn_igmp_snooping
+from units.modules.utils import set_module_args
+from .nvos_module import TestNvosModule, load_fixture
+
+
+class TestAdminServiceModule(TestNvosModule):
+
+    module = pn_igmp_snooping
+
+    def setUp(self):
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_igmp_snooping.run_cli')
+        self.run_nvos_commands = self.mock_run_nvos_commands.start()
+
+    def tearDown(self):
+        self.mock_run_nvos_commands.stop()
+
+    def run_cli_patch(self, module, cli, state_map):
+        if state_map['update'] == 'igmp-snooping-modify':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        module.exit_json(**results)
+
+    def load_fixtures(self, commands=None, state=None, transport='cli'):
+        self.run_nvos_commands.side_effect = self.run_cli_patch
+
+    def test_igmp_snooping_modify_t1(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_vxlan': True,
+                         'pn_enable_vlans': '1-399,401-4092', 'pn_no_snoop_linklocal_vlans': 'none', 'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 igmp-snooping-modify  vxlan  enable-vlans 1-399,401-4092 no-snoop-linklocal-vlans none'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_igmp_snooping_modify_t2(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_scope': 'local',
+                         'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 igmp-snooping-modify  scope local'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_igmp_snooping_modify_t3(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_vxlan': False,
+                         'pn_enable_vlans': '1-399', 'pn_igmpv3_vlans': '1-399', 'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 igmp-snooping-modify  no-vxlan  igmpv3-vlans 1-399 enable-vlans 1-399'
+        self.assertEqual(result['cli_cmd'], expected_cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Point feature of igmp snooping for Pluribus Networks Netvisor switches 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
pn_igmp_snooping.py module with unit tests.

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```