### PR TITLE
added timestamps to asa_command module

### DIFF
--- a/lib/ansible/module_utils/network/asa/asa.py
+++ b/lib/ansible/module_utils/network/asa/asa.py
@@ -26,7 +26,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 from ansible.module_utils._text import to_text
-from ansible.module_utils.basic import env_fallback, return_values
+from ansible.module_utils.basic import env_fallback, return_values, get_timestamp
 from ansible.module_utils.network.common.utils import to_list, EntityCollection
 from ansible.module_utils.connection import exec_command
 from ansible.module_utils.connection import Connection, ConnectionError
@@ -119,12 +119,15 @@ def run_commands(module, commands, check_rc=True):
     commands = to_commands(module, to_list(commands))
 
     responses = list()
+    timestamps = list()
 
     for cmd in commands:
+        timestamp = get_timestamp()
         out = connection.get(**cmd)
         responses.append(to_text(out, errors='surrogate_then_replace'))
+        timestamps.append(timestamp)
 
-    return responses
+    return responses, timestamps
 
 
 def get_config(module, flags=None):

--- a/lib/ansible/modules/network/asa/asa_command.py
+++ b/lib/ansible/modules/network/asa/asa_command.py
@@ -112,8 +112,7 @@ failed_conditions:
 import time
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.asa.asa import asa_argument_spec, check_args
-from ansible.module_utils.network.asa.asa import run_commands
+from ansible.module_utils.network.asa.asa import asa_argument_spec, check_args, run_commands
 from ansible.module_utils.network.common.parsing import Conditional
 from ansible.module_utils.six import string_types
 
@@ -153,7 +152,7 @@ def main():
     match = module.params['match']
 
     while retries > 0:
-        responses = run_commands(module, commands)
+        responses, timestamps = run_commands(module, commands)
 
         for item in list(conditionals):
             if item(responses):
@@ -176,7 +175,8 @@ def main():
     result.update({
         'changed': False,
         'stdout': responses,
-        'stdout_lines': list(to_lines(responses))
+        'stdout_lines': list(to_lines(responses)),
+        'timestamps': timestamps
     })
 
     module.exit_json(**result)


### PR DESCRIPTION
asa_command module now returns timestamps field, which shows command execution time

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added information about time when command was issued on remote device.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
asa_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
**example playbook**
```yaml
- name: collect show commands from devices
  hosts: lab_asa
  connection: network_cli

  tasks:

    - name: collect show commands
      asa_command:
        commands:
          - "show clock"
          - "show context count"
      register: output

    - name: debug task
      debug:
        var: output
```

**before**
```
ok: [ASA-act] => {
    "output": {
        "changed": false, 
        "failed": false, 
        "stdout": [
            "16:15:10.329 MSK Wed Dec 19 2018", 
            "Total active Security Contexts: 9"
        ], 
        "stdout_lines": [
            [
                "16:15:10.329 MSK Wed Dec 19 2018"
            ], 
            [
                "Total active Security Contexts: 9"
            ]
        ]
    }
}
```

**after**
```
ok: [ASA-act] => {
    "output": {
        "changed": false, 
        "failed": false, 
        "stdout": [
            "16:21:17.639 MSK Wed Dec 19 2018", 
            "Total active Security Contexts: 9"
        ], 
        "stdout_lines": [
            [
                "16:21:17.639 MSK Wed Dec 19 2018"
            ], 
            [
                "Total active Security Contexts: 9"
            ]
        ], 
        "timestamps": [
            "2018-12-19T16:21:31", 
            "2018-12-19T16:21:31"
        ]
    }
}
```
