### PR TITLE
Revert "Fix incorrect examples with random filter"

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -395,7 +395,7 @@ To get a random item from a list::
 
 To get a random number between 0 and a specified number::
 
-    "{{ 59 | random }} * * * * root /script/from/cron"
+    "{{ 60 | random }} * * * * root /script/from/cron"
     # => '21 * * * * root /script/from/cron'
 
 Get a random number from 0 to 100 but in steps of 10::
@@ -412,7 +412,7 @@ Get a random number from 1 to 100 but in steps of 10::
 
 As of Ansible version 2.3, it's also possible to initialize the random number generator from a seed. This way, you can create random-but-idempotent numbers::
 
-    "{{ 59 | random(seed=inventory_hostname) }} * * * * root /script/from/cron"
+    "{{ 60 | random(seed=inventory_hostname) }} * * * * root /script/from/cron"
 
 
 Shuffle Filter


### PR DESCRIPTION
Reverts ansible/ansible#50137

This is incorrect, the behaviour is supposed to be as was displayed, this was altered in ea2b89c7ae69424055652db30f49182d4a987bf7 which was supposed to have been reverted also.