### PR TITLE
Revert range change

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -395,7 +395,7 @@ To get a random item from a list::
 
 To get a random number between 0 and a specified number::
 
-    "{{ 59 | random }} * * * * root /script/from/cron"
+    "{{ 60 | random }} * * * * root /script/from/cron"
     # => '21 * * * * root /script/from/cron'
 
 Get a random number from 0 to 100 but in steps of 10::
@@ -412,7 +412,7 @@ Get a random number from 1 to 100 but in steps of 10::
 
 As of Ansible version 2.3, it's also possible to initialize the random number generator from a seed. This way, you can create random-but-idempotent numbers::
 
-    "{{ 59 | random(seed=inventory_hostname) }} * * * * root /script/from/cron"
+    "{{ 60 | random(seed=inventory_hostname) }} * * * * root /script/from/cron"
 
 
 Shuffle Filter

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -213,7 +213,7 @@ def rand(environment, end, start=None, step=None, seed=None):
             start = 0
         if not step:
             step = 1
-        return r.randrange(start, end + 1, step)
+        return r.randrange(start, end, step)
     elif hasattr(end, '__iter__'):
         if start or step:
             raise AnsibleFilterError('start and step can only be used with integer values')


### PR DESCRIPTION
Previous change had been flagged for reverting but was missed and new docs reflect the incorrect behaviour.

reverts #50137 as it describes the behaviour we were supposed to have reverted from #27215
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
filters/random