### PR TITLE
Reap still running threads after timeout

### DIFF
--- a/lib/ansible/module_utils/facts/timeout.py
+++ b/lib/ansible/module_utils/facts/timeout.py
@@ -50,6 +50,8 @@ def timeout(seconds=None, error_message="Timer expired"):
             except multiprocessing.TimeoutError:
                 # This is an ansible.module_utils.common.facts.timeout.TimeoutError
                 raise TimeoutError('Timer expired after %s seconds' % timeout_value)
+            finally:
+                pool.terminate()
 
         return wrapper
 


### PR DESCRIPTION
This is an improvement to #49921 which reaps threads after the timeout
expires instead of letting them continue to take up resources.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts/timeout.py
