### PR TITLE
Add default fact for NVMe support

### DIFF
--- a/changelogs/fragments/nvme_fact.yaml
+++ b/changelogs/fragments/nvme_fact.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Gather NVMe NQN fact (https://github.com/ansible/ansible/pull/50164)

--- a/lib/ansible/module_utils/facts/default_collectors.py
+++ b/lib/ansible/module_utils/facts/default_collectors.py
@@ -73,6 +73,7 @@ from ansible.module_utils.facts.network.hpux import HPUXNetworkCollector
 from ansible.module_utils.facts.network.hurd import HurdNetworkCollector
 from ansible.module_utils.facts.network.linux import LinuxNetworkCollector
 from ansible.module_utils.facts.network.iscsi import IscsiInitiatorNetworkCollector
+from ansible.module_utils.facts.network.nvme import NvmeInitiatorNetworkCollector
 from ansible.module_utils.facts.network.netbsd import NetBSDNetworkCollector
 from ansible.module_utils.facts.network.openbsd import OpenBSDNetworkCollector
 from ansible.module_utils.facts.network.sunos import SunOSNetworkCollector
@@ -151,6 +152,7 @@ _network = [
     HPUXNetworkCollector,
     HurdNetworkCollector,
     IscsiInitiatorNetworkCollector,
+    NvmeInitiatorNetworkCollector,
     LinuxNetworkCollector,
     NetBSDNetworkCollector,
     OpenBSDNetworkCollector,

--- a/lib/ansible/module_utils/facts/network/nvme.py
+++ b/lib/ansible/module_utils/facts/network/nvme.py
@@ -1,0 +1,55 @@
+# NVMe initiator related facts collection for Ansible.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import sys
+import subprocess
+
+from ansible.module_utils.facts.utils import get_file_content
+from ansible.module_utils.facts.network.base import NetworkCollector
+
+
+class NvmeInitiatorNetworkCollector(NetworkCollector):
+    name = 'nvme'
+    _fact_ids = set()
+
+    def collect(self, module=None, collected_facts=None):
+        """
+        Currently NVMe is only supported in some Linux distributions.
+        If NVMe is configured on the host then a file will have been created
+        during the NVMe driver installation. This file holds the unique NQN
+        of the host.
+
+        Example of contents of /etc/nvme/hostnqn:
+
+        # cat /etc/nvme/hostnqn
+        nqn.2014-08.org.nvmexpress:fc_lif:uuid:2cd61a74-17f9-4c22-b350-3020020c458d
+
+        """
+
+        nvme_facts = {}
+        nvme_facts['hostnqn'] = ""
+        if sys.platform.startswith('linux'):
+            for line in get_file_content('/etc/nvme/hostnqn', '').splitlines():
+                if line.startswith('#') or line.startswith(';') or line.strip() == '':
+                    continue
+                if line.startswith('nqn.'):
+                    nvme_facts['hostnqn'] = line
+                    break
+        return nvme_facts


### PR DESCRIPTION
##### SUMMARY
This new fact enables the discovery of NVMe initiator NQN value if a node has had NVMe configured.
External storage modules can use this information to automate external storage array configuration
for hosts.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module_utils/facts/network/nvme.py

##### ADDITIONAL INFORMATION
NVMe is currently only supported on some Linux distributions.