### PR TITLE
Add retries for Invoke-ScriptAnalyzer in pslint.

### DIFF
--- a/test/sanity/pslint/pslint.ps1
+++ b/test/sanity/pslint/pslint.ps1
@@ -4,11 +4,25 @@
 
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
+$WarningPreference = "Stop"
 
 $Results = @()
 
 ForEach ($Path in $Args) {
-    $Results += Invoke-ScriptAnalyzer -Path $Path -Setting $PSScriptRoot/settings.psd1
+    $Retries = 3
+
+    Do {
+        Try {
+            $Results += Invoke-ScriptAnalyzer -Path $Path -Setting $PSScriptRoot/settings.psd1 3> $null
+            $Retries = 0
+        }
+        Catch {
+            If (--$Retries -le 0) {
+                Throw
+            }
+        }
+    }
+    Until ($Retries -le 0)
 }
 
 ConvertTo-Json -InputObject $Results


### PR DESCRIPTION
##### SUMMARY

Add retries for Invoke-ScriptAnalyzer in pslint.

Hopefully this will work around the intermittent CI failures due to NullReferenceException, which then succeed on a retry.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

pslint

##### ADDITIONAL INFORMATION

Example failure: https://app.shippable.com/github/ansible/ansible/runs/99256/1/console

```
06:10 >>> Standard Error
06:10 Invoke-ScriptAnalyzer : Object reference not set to an instance of an object.
06:10 At /root/ansible/test/sanity/pslint/pslint.ps1:11 char:17
06:10 + ... $Results += Invoke-ScriptAnalyzer -Path $Path -Setting $PSScriptRoot/ ...
06:10 +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
06:10 + CategoryInfo          : InvalidOperation: (/root/ansible/l...ils.Legacy.psm1:String) [Invoke-ScriptAnalyzer], NullReferenceException
06:10 + FullyQualifiedErrorId : RULE_ERROR,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand
```