### PR TITLE
[grafana_datasource] Fix typo for ds_type in examples section

### DIFF
--- a/lib/ansible/modules/monitoring/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana_datasource.py
@@ -245,7 +245,7 @@ EXAMPLES = '''
     grafana_user: "admin"
     grafana_password: "xxxxxx"
     org_id: "1"
-    ds_type: "elasticisearch"
+    ds_type: "elasticsearch"
     ds_url: "https://elastic.company.com:9200"
     database: "[logstash_]YYYY.MM.DD"
     basic_auth_user: "grafana"


### PR DESCRIPTION
replace ds_type elasticisearch by elasticsearch

+label: docsite_pr

##### SUMMARY
Fix typo in example section (elasticisearch -> elasticsearch)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
grafana_datasource
