### PR TITLE
Change the Packet.net section to be more consistent with the other *Cloud Guide pages.

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_packet.rst
+++ b/docs/docsite/rst/scenario_guides/guide_packet.rst
@@ -1,5 +1,5 @@
 **********************************
-Using Ansible with the Packet host
+Packet.net Guide
 **********************************
 
 Introduction


### PR DESCRIPTION
…
<!--- Your description here -->

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Saw the other cloud host pages were all formatted like "Amazon Web Services Guide" so I thought I would change this one to match.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
