### PR TITLE
postgresql_user: set type of conn_limit

### DIFF
--- a/changelogs/fragments/38118-postgresql_user-fix_conn_limit_type.yml
+++ b/changelogs/fragments/38118-postgresql_user-fix_conn_limit_type.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - conn_limit type is set to 'int'.
+  - This will allow module to compare conn_limit with record value without type casting.

--- a/changelogs/fragments/38118-postgresql_user-fix_conn_limit_type.yml
+++ b/changelogs/fragments/38118-postgresql_user-fix_conn_limit_type.yml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
-  - conn_limit type is set to 'int'.
-  - This will allow module to compare conn_limit with record value without type casting.
+  - conn_limit type is set to 'int' in postgresql_user module. This will allow module to compare conn_limit with record value without type casting.

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -135,6 +135,7 @@ options:
     description:
       - Specifies the user connection limit.
     version_added: '2.4'
+    type: int
 notes:
    - The default authentication assumes that you are either logging in as or
      sudo'ing to the postgres account on the host.
@@ -742,7 +743,7 @@ def main():
         ssl_mode=dict(default='prefer', choices=[
             'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
         ssl_rootcert=dict(default=None),
-        conn_limit=dict(default=None)
+        conn_limit=dict(type='int', default=None)
     ))
     module = AnsibleModule(
         argument_spec=argument_spec,


### PR DESCRIPTION
##### SUMMARY
conn_limit type is set to 'int'. This will allow module
 to compare conn_limit with record value without type casting.

Fixes: #38118

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/38118-postgresql_user-fix_conn_limit_type.yml
lib/ansible/modules/database/postgresql/postgresql_user.py

##### ADDITIONAL INFORMATION
Based on @yuji-k64613  patch.