### PR TITLE
PR to remove intro configuration lines from running-config

### DIFF
--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -26,6 +26,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 import json
+import re
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback
@@ -126,6 +127,12 @@ def get_config(module, flags=None):
                 module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
         cfg = to_text(out, errors='surrogate_then_replace').strip()
         _DEVICE_CONFIGS[flag_str] = cfg
+        # remove configuration intro lines from running-config
+        cfg_build_obj = re.search(r'Building configuration.*(\n*)', cfg)
+        cfg_current_obj = re.search(r'Current configuration.*(\n*)', cfg)
+        if cfg_build_obj and cfg_current_obj:
+            cfg = cfg.strip(cfg_build_obj.group() + cfg_current_obj.group())
+
         return cfg
 
 

--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -26,7 +26,6 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 import json
-import re
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback
@@ -127,12 +126,6 @@ def get_config(module, flags=None):
                 module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
         cfg = to_text(out, errors='surrogate_then_replace').strip()
         _DEVICE_CONFIGS[flag_str] = cfg
-        # remove configuration intro lines from running-config
-        cfg_build_obj = re.search(r'Building configuration.*(\n*)', cfg)
-        cfg_current_obj = re.search(r'Current configuration.*(\n*)', cfg)
-        if cfg_build_obj and cfg_current_obj:
-            cfg = cfg.strip(cfg_build_obj.group() + cfg_current_obj.group())
-
         return cfg
 
 

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -203,6 +203,16 @@ options:
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
     version_added: "2.4"
+  remove_extraneous:
+    description:
+      - This argument will remove the intro lines 'Building configuration' and
+        'Current configuration' from current C(running-config) and hence can only
+        be used when backup argument is set to True i.e. yes and backup file is
+        written to the C(backup) folder in the playbook root directory or role
+        root directory, without the running-config intro lines.
+    type: bool
+    default: 'no'
+    version_added: "2.8"
 """
 
 EXAMPLES = """
@@ -287,6 +297,10 @@ EXAMPLES = """
   ios_config:
     backup: yes
     src: ios_template.j2
+- name: save backup config without the intro lines
+  ios_config:
+    backup: yes
+    remove_extraneous: yes
 """
 
 RETURN = """
@@ -317,6 +331,7 @@ from ansible.module_utils.network.ios.ios import ios_argument_spec
 from ansible.module_utils.network.ios.ios import check_args as ios_check_args
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.config import NetworkConfig, dumps
+
 
 def check_args(module, warnings):
     ios_check_args(module, warnings)

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -456,8 +456,8 @@ def main():
                 if cfg_build_obj and cfg_current_obj:
                     contents = contents.strip(cfg_build_obj.group() + cfg_current_obj.group())
                 result['__backup__'] = contents
-        else:
-            result['__backup__'] = contents
+            else:
+                result['__backup__'] = contents
 
     if any((module.params['lines'], module.params['src'])):
         match = module.params['match']

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -208,7 +208,7 @@ options:
       - This argument will remove lines from the backup that user want to filter
         and store as the backup config and backup file is written to the C(backup)
         folder in the playbook root directory or role root directory, without the
-        user input filter lines.
+        user input. See examples
     type: list
     default: None
     version_added: "2.8"
@@ -296,6 +296,7 @@ EXAMPLES = """
   ios_config:
     backup: yes
     src: ios_template.j2
+
 - name: save backup config without the intro lines
   ios_config:
     backup: yes

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -210,7 +210,6 @@ options:
         folder in the playbook root directory or role root directory, without the
         user input. See examples
     type: list
-    default: None
     version_added: "2.8"
 """
 

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -333,6 +333,9 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.config import NetworkConfig, dumps
 
 
+REMOVE_EXTRANEOUS_DEFAULT = 'Building configuration.*(\n*).*\nCurrent configuration.*\n*'
+
+
 def check_args(module, warnings):
     ios_check_args(module, warnings)
     if module.params['multiline_delimiter']:
@@ -450,11 +453,7 @@ def main():
         config = NetworkConfig(indent=1, contents=contents)
         if module.params['backup']:
             if module.params['remove_extraneous']:
-                # remove configuration intro lines from running-config
-                cfg_build_obj = re.search(r'Building configuration.*(\n*)', contents)
-                cfg_current_obj = re.search(r'Current configuration.*(\n*)', contents)
-                if cfg_build_obj and cfg_current_obj:
-                    contents = contents.strip(cfg_build_obj.group() + cfg_current_obj.group())
+                contents = re.sub(REMOVE_EXTRANEOUS_DEFAULT, '', contents)
                 result['__backup__'] = contents
             else:
                 result['__backup__'] = contents


### PR DESCRIPTION
Signed-off-by: Sumit Jaiswal <sjaiswal@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR to resolve the issue raised in bug #50029, and now `Building configuration...` and `Current configuration*` intro lines shall be removed from `ios` `running-config` out. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
