### PR TITLE
Pluribus Networks module for connection stat settings with UT's

### DIFF
--- a/lib/ansible/modules/network/netvisor/pn_connection_stats_settings.py
+++ b/lib/ansible/modules/network/netvisor/pn_connection_stats_settings.py
@@ -28,7 +28,7 @@ options:
     type: str
   state:
     description:
-      - State the action to perform. Use 'update' to modify the
+      - State the action to perform. Use C(update) to modify the
         connection-stats-settings.
     required: True
     type: str

--- a/lib/ansible/modules/network/netvisor/pn_connection_stats_settings.py
+++ b/lib/ansible/modules/network/netvisor/pn_connection_stats_settings.py
@@ -1,0 +1,269 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_connection_stats_settings
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.8"
+short_description: CLI command to modify connection-stats-settings
+description:
+  - This module can be used to modify the settings for collecting statistical
+    data about connections.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: False
+    type: str
+  state:
+    description:
+      - State the action to perform. Use 'update' to modify the
+        connection-stats-settings.
+    required: True
+    type: str
+    choices: ['update']
+  pn_enable:
+    description:
+      - Enable or disable collecting connections statistics.
+    required: False
+    type: bool
+  pn_connection_backup_enable:
+    description:
+      - Enable backup for connection statistics collection.
+    required: False
+    type: bool
+  pn_client_server_stats_max_memory:
+    description:
+      - maximum memory for client server statistics.
+    required: False
+    type: str
+  pn_connection_stats_log_disk_space:
+    description:
+      - disk-space allocated for statistics (including rotated log files).
+    required: False
+    type: str
+  pn_client_server_stats_log_enable:
+    description:
+      - Enable or disable statistics.
+    required: False
+    type: bool
+  pn_service_stat_max_memory:
+    description:
+      - maximum memory allowed for service statistics.
+    required: False
+    type: str
+  pn_connection_stats_log_interval:
+    description:
+      - interval to collect statistics.
+    required: False
+    type: str
+  pn_fabric_connection_backup_interval:
+    description:
+      - backup interval for fabric connection statistics collection.
+    required: False
+    type: str
+  pn_connection_backup_interval:
+    description:
+      - backup interval for connection statistics collection.
+    required: False
+    type: str
+  pn_connection_stats_log_enable:
+    description:
+      - enable or disable statistics.
+    required: False
+    type: bool
+  pn_fabric_connection_max_memory:
+    description:
+      - maximum memory allowed for fabric connection statistics.
+    required: False
+    type: str
+  pn_fabric_connection_backup_enable:
+    description:
+      - enable backup for fabric connection statistics collection.
+    required: False
+    type: bool
+  pn_client_server_stats_log_disk_space:
+    description:
+      - disk-space allocated for statistics (including rotated log files).
+    required: False
+    type: str
+  pn_connection_max_memory:
+    description:
+      - maximum memory allowed for connection statistics.
+    required: False
+    type: str
+  pn_connection_stats_max_memory:
+    description:
+      - maximum memory allowed for connection statistics.
+    required: False
+    type: str
+  pn_client_server_stats_log_interval:
+    description:
+      - interval to collect statistics.
+    required: False
+    type: str
+"""
+
+EXAMPLES = """
+- name: "Modify connection stats settings"
+  pn_connection_stats_settings:
+    pn_cliswitch: "sw01"
+    state: "update"
+    pn_enable: False
+    pn_fabric_connection_max_memory: "1000"
+
+- name: "Modify connection stats settings"
+  pn_connection_stats_settings:
+    pn_cliswitch: "sw01"
+    state: "update"
+    pn_enable: True
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: str
+stdout:
+  description: set of responses from the connection-stats-settings command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the connection-stats-settings
+               command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli, booleanArgs
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    state_map = dict(
+        update='connection-stats-settings-modify'
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_enable=dict(required=False, type='bool'),
+            pn_connection_backup_enable=dict(required=False, type='bool'),
+            pn_client_server_stats_max_memory=dict(required=False, type='str'),
+            pn_connection_stats_log_disk_space=dict(required=False,
+                                                    type='str'),
+            pn_client_server_stats_log_enable=dict(required=False,
+                                                   type='bool'),
+            pn_service_stat_max_memory=dict(required=False, type='str'),
+            pn_connection_stats_log_interval=dict(required=False, type='str'),
+            pn_fabric_connection_backup_interval=dict(required=False,
+                                                      type='str'),
+            pn_connection_backup_interval=dict(required=False, type='str'),
+            pn_connection_stats_log_enable=dict(required=False, type='bool'),
+            pn_fabric_connection_max_memory=dict(required=False, type='str'),
+            pn_fabric_connection_backup_enable=dict(required=False,
+                                                    type='bool'),
+            pn_client_server_stats_log_disk_space=dict(required=False,
+                                                       type='str'),
+            pn_connection_max_memory=dict(required=False, type='str'),
+            pn_connection_stats_max_memory=dict(required=False, type='str'),
+            pn_client_server_stats_log_interval=dict(required=False,
+                                                     type='str'),
+        ),
+        required_one_of=[['pn_enable', 'pn_connection_backup_enable',
+                          'pn_client_server_stats_max_memory',
+                          'pn_connection_stats_log_disk_space',
+                          'pn_client_server_stats_log_enable',
+                          'pn_service_stat_max_memory',
+                          'pn_connection_stats_log_interval',
+                          'pn_connection_backup_interval',
+                          'pn_connection_stats_log_enable',
+                          'pn_fabric_connection_max_memory',
+                          'pn_fabric_connection_backup_enable',
+                          'pn_client_server_stats_log_disk_space',
+                          'pn_connection_max_memory',
+                          'pn_connection_stats_max_memory',
+                          'pn_client_server_stats_log_interval']]
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    enable = module.params['pn_enable']
+    connection_backup_enable = module.params['pn_connection_backup_enable']
+    client_server_stats_max_memory = module.params['pn_client_server_stats_max_memory']
+    connection_stats_log_disk_space = module.params['pn_connection_stats_log_disk_space']
+    client_server_stats_log_enable = module.params['pn_client_server_stats_log_enable']
+    service_stat_max_memory = module.params['pn_service_stat_max_memory']
+    connection_stats_log_interval = module.params['pn_connection_stats_log_interval']
+    fabric_connection_backup_interval = module.params['pn_fabric_connection_backup_interval']
+    connection_backup_interval = module.params['pn_connection_backup_interval']
+    connection_stats_log_enable = module.params['pn_connection_stats_log_enable']
+    fabric_connection_max_memory = module.params['pn_fabric_connection_max_memory']
+    fabric_connection_backup_enable = module.params['pn_fabric_connection_backup_enable']
+    client_server_stats_log_disk_space = module.params['pn_client_server_stats_log_disk_space']
+    connection_max_memory = module.params['pn_connection_max_memory']
+    connection_stats_max_memory = module.params['pn_connection_stats_max_memory']
+    client_server_stats_log_interval = module.params['pn_client_server_stats_log_interval']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    if command == 'connection-stats-settings-modify':
+        cli += ' %s ' % command
+
+        cli += booleanArgs(enable, 'enable', 'disable')
+        cli += booleanArgs(connection_backup_enable, 'connection-backup-enable', 'connection-backup-disable')
+        cli += booleanArgs(client_server_stats_log_enable, 'client-server-stats-log-enable', 'client-server-stats-log-disable')
+        cli += booleanArgs(connection_stats_log_enable, 'connection-stats-log-enable', 'connection-stats-log-disable')
+        cli += booleanArgs(fabric_connection_backup_enable, 'fabric-connection-backup-enable', 'fabric-connection-backup-disable')
+
+        if client_server_stats_max_memory:
+            cli += ' client-server-stats-max-memory ' + client_server_stats_max_memory
+        if connection_stats_log_disk_space:
+            cli += ' connection-stats-log-disk-space ' + connection_stats_log_disk_space
+        if service_stat_max_memory:
+            cli += ' service-stat-max-memory ' + service_stat_max_memory
+        if connection_stats_log_interval:
+            cli += ' connection-stats-log-interval ' + connection_stats_log_interval
+        if fabric_connection_backup_interval:
+            cli += ' fabric-connection-backup-interval ' + fabric_connection_backup_interval
+        if connection_backup_interval:
+            cli += ' connection-backup-interval ' + connection_backup_interval
+        if fabric_connection_max_memory:
+            cli += ' fabric-connection-max-memory ' + fabric_connection_max_memory
+        if client_server_stats_log_disk_space:
+            cli += ' client-server-stats-log-disk-space ' + client_server_stats_log_disk_space
+        if connection_max_memory:
+            cli += ' connection-max-memory ' + connection_max_memory
+        if connection_stats_max_memory:
+            cli += ' connection-stats-max-memory ' + connection_stats_max_memory
+        if client_server_stats_log_interval:
+            cli += ' client-server-stats-log-interval ' + client_server_stats_log_interval
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/netvisor/test_pn_connection_stats_settings.py
+++ b/test/units/modules/network/netvisor/test_pn_connection_stats_settings.py
@@ -1,0 +1,65 @@
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from units.compat.mock import patch
+from ansible.modules.network.netvisor import pn_connection_stats_settings
+from units.modules.utils import set_module_args
+from .nvos_module import TestNvosModule, load_fixture
+
+
+class TestAdminServiceModule(TestNvosModule):
+
+    module = pn_connection_stats_settings
+
+    def setUp(self):
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_connection_stats_settings.run_cli')
+        self.run_nvos_commands = self.mock_run_nvos_commands.start()
+
+    def tearDown(self):
+        self.mock_run_nvos_commands.stop()
+
+    def run_cli_patch(self, module, cli, state_map):
+        if state_map['update'] == 'connection-stats-settings-modify':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        module.exit_json(**results)
+
+    def load_fixtures(self, commands=None, state=None, transport='cli'):
+        self.run_nvos_commands.side_effect = self.run_cli_patch
+
+    def test_connection_stats_settings_modify_t1(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_enable': False,
+                         'pn_fabric_connection_max_memory': '1000', 'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 connection-stats-settings-modify  disable  fabric-connection-max-memory 1000'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_connection_stats_settings_modify_t2(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_enable': True,
+                         'pn_connection_stats_log_enable': False, 'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 connection-stats-settings-modify  enable  connection-stats-log-disable '
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_connection_stats_settings_modify_t3(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_client_server_stats_max_memory': '60M',
+                         'pn_client_server_stats_log_disk_space': '40M', 'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 connection-stats-settings-modify  client-server-stats-max-memory '
+        expected_cmd += '60M client-server-stats-log-disk-space 40M'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_connection_stats_settings_modify_t4(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_connection_stats_max_memory': '45M',
+                         'pn_fabric_connection_backup_enable': False, 'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 connection-stats-settings-modify '
+        expected_cmd += ' fabric-connection-backup-disable  connection-stats-max-memory 45M'
+        self.assertEqual(result['cli_cmd'], expected_cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Point feature of connection stat settings for Pluribus Networks Netvisor switches 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
pn_connection_stats_settings.py module with unit tests.

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```