### PR TITLE
Update playbooks_intro.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_intro.rst
+++ b/docs/docsite/rst/user_guide/playbooks_intro.rst
@@ -407,7 +407,7 @@ As of Ansible 2.2, handlers can also "listen" to generic topics, and tasks can n
         - name: restart apache
           service:
             name: apache
-            state:restarted
+            state: restarted
           listen: "restart web services"
 
     tasks:


### PR DESCRIPTION
<!--- Edit type by adding space between key and value -->

+label: docsite_pr

##### SUMMARY
<!--- The line edited would give a yaml syntax error due to no space between the key-value separator ':' and the value 'restarted' -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Editing handlers section of the Ansible Playbook documentation -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
