### PR TITLE
Simplify regex filter code

### DIFF
--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -120,8 +120,7 @@ def regex(value='', pattern='', ignorecase=False, multiline=False, match_type='s
     if multiline:
         flags |= re.M
     _re = re.compile(pattern, flags=flags)
-    _bool = __builtins__.get('bool')
-    return _bool(getattr(_re, match_type, 'search')(value))
+    return bool(getattr(_re, match_type, 'search')(value))
 
 
 def match(value, pattern='', ignorecase=False, multiline=False):


### PR DESCRIPTION
##### SUMMARY

This was written when we were redefining `bool` in the same module. As we aren't doing this any longer, simplify it back to just calling `bool()`.

##### ISSUE TYPE

Trivial code cleanup

##### COMPONENT NAME

Core test