### PR TITLE
check elb type in compare_subnets for elbv2

### DIFF
--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -169,7 +169,7 @@ class ElasticLoadBalancerV2(object):
         # on the load balancer
         for subnet in self.elb['AvailabilityZones']:
             this_mapping = {'SubnetId': subnet['SubnetId']}
-            for address in subnet.get('LoadBalancerAddresses',[]):
+            for address in subnet.get('LoadBalancerAddresses', []):
                 if 'AllocationId' in address:
                     this_mapping['AllocationId'] = address['AllocationId']
                     break

--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -170,7 +170,7 @@ class ElasticLoadBalancerV2(object):
         for subnet in self.elb['AvailabilityZones']:
             this_mapping = {'SubnetId': subnet['SubnetId']}
             # when elb type is network, AZ may contain subnets with LoadBalancerAddresses as a property
-            if self.elb['Type']=='network':
+            if self.elb['Type'] == 'network':
                 for address in subnet['LoadBalancerAddresses']:
                     if 'AllocationId' in address:
                         this_mapping['AllocationId'] = address['AllocationId']

--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -169,10 +169,14 @@ class ElasticLoadBalancerV2(object):
         # on the load balancer
         for subnet in self.elb['AvailabilityZones']:
             this_mapping = {'SubnetId': subnet['SubnetId']}
-            for address in subnet['LoadBalancerAddresses']:
-                if 'AllocationId' in address:
-                    this_mapping['AllocationId'] = address['AllocationId']
-                    break
+            # when elb type is network, AZ may contain subnets with LoadBalancerAddresses as a property
+            if self.elb['Type']=='network':
+                for address in subnet['LoadBalancerAddresses']:
+                    if 'AllocationId' in address:
+                        this_mapping['AllocationId'] = address['AllocationId']
+                        break
+            # Application lb 'AvailabiltyZones property is [{u'SubnetId': 'subnet-xxxxxxxx', u'ZoneName': 'us-east-1c'},...]
+            # probably not necessary to check those when checking if an application LB has changed
 
             subnet_mapping_id_list.append(this_mapping)
 

--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -169,14 +169,10 @@ class ElasticLoadBalancerV2(object):
         # on the load balancer
         for subnet in self.elb['AvailabilityZones']:
             this_mapping = {'SubnetId': subnet['SubnetId']}
-            # when elb type is network, AZ may contain subnets with LoadBalancerAddresses as a property
-            if self.elb['Type'] == 'network':
-                for address in subnet['LoadBalancerAddresses']:
-                    if 'AllocationId' in address:
-                        this_mapping['AllocationId'] = address['AllocationId']
-                        break
-            # Application lb 'AvailabiltyZones property is [{u'SubnetId': 'subnet-xxxxxxxx', u'ZoneName': 'us-east-1c'},...]
-            # probably not necessary to check those when checking if an application LB has changed
+            for address in subnet.get('LoadBalancerAddresses',[]):
+                if 'AllocationId' in address:
+                    this_mapping['AllocationId'] = address['AllocationId']
+                    break
 
             subnet_mapping_id_list.append(this_mapping)
 


### PR DESCRIPTION
##### SUMMARY
Fixes #49558
Add a check for LB type before accessing property that may not be there.

NLB and ALB have different structures for AvailabilityZone property

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.create_load_balancer

For NLB:
```
'AvailabilityZones': [
  {
    'ZoneName': 'string',
    'SubnetId': 'string',
    'LoadBalancerAddresses': [
        {
          'IpAddress': 'string',
          'AllocationId': 'string'
        },
      ]
  },
],
```

For ALB
```
'AvailabilityZones': [
  {
    'SubnetId': 'subnet-8360a9e7',
    'ZoneName': 'us-west-2a',
  },
  {
    'SubnetId': 'subnet-b7d581c0',
    'ZoneName': 'us-west-2b',
  },
],
  ```



##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
elbv2.py
