### PR TITLE
Update include_role description to discuss tasks: use

### DIFF
--- a/lib/ansible/modules/utilities/logic/include_role.py
+++ b/lib/ansible/modules/utilities/logic/include_role.py
@@ -21,7 +21,7 @@ module: include_role
 short_description: Load and execute a role
 description:
   - M(include_role) dynamically loads and executes a specified role as a task. It may be used (and has meaning) only
-    where Ansible tasks are allowed: inside a `pre_tasks:`, `tasks:`, or `post_tasks:` playbook object, or as a
+    where Ansible tasks are allowed - inside a `pre_tasks:`, `tasks:`, or `post_tasks:` playbook object, or as a
     task inside a role.
   - Unlike M(import_role), M(Loops), and M(Conditionals) apply to this statement.
   - The do until loop is not supported on M(include_role).

--- a/lib/ansible/modules/utilities/logic/include_role.py
+++ b/lib/ansible/modules/utilities/logic/include_role.py
@@ -20,7 +20,9 @@ author: Ansible Core Team (@ansible)
 module: include_role
 short_description: Load and execute a role
 description:
-  - When used underneath a `tasks:` directive, M(include_role) dynamically loads and executes a specified role as a task.
+  - M(include_role) dynamically loads and executes a specified role as a task. It may be used (and has meaning) only
+    where Ansible tasks are allowed: inside a `pre_tasks:`, `tasks:`, or `post_tasks:` playbook object, or as a
+    task inside a role.
   - Unlike M(import_role), M(Loops), and M(Conditionals) apply to this statement.
   - The do until loop is not supported on M(include_role).
   - This module is also supported for Windows targets.

--- a/lib/ansible/modules/utilities/logic/include_role.py
+++ b/lib/ansible/modules/utilities/logic/include_role.py
@@ -20,16 +20,15 @@ author: Ansible Core Team (@ansible)
 module: include_role
 short_description: Load and execute a role
 description:
-  - Loads and executes a role as a task dynamically. This frees roles from the `roles:` directive and allows them to be
-    treated more as tasks.
-  - Unlike M(import_role), most keywords, including loop, with_items, and conditionals, apply to this statement.
+  - When used underneath a `tasks:` directive, M(include_role) dynamically loads and executes a specified role as a task.
+  - Unlike M(import_role), M(Loops), and M(Conditionals) apply to this statement.
   - The do until loop is not supported on M(include_role).
   - This module is also supported for Windows targets.
 version_added: "2.2"
 options:
   apply:
     description:
-      - Accepts a hash of task keywords (e.g. C(tags), C(become)) that will be applied to the tasks within the include.
+      - Accepts a hash of task keywords (e.g. C(tags), C(become)) that will be applied to all tasks within the included role.
     version_added: '2.7'
   name:
     description:


### PR DESCRIPTION
##### SUMMARY
The previous description in this statement's description really threw me off, and is IMO ambiguous at best. 'Loads and executes a role as a task dynamically. This frees roles from the roles: directive and allows them to be treated more as tasks.'

For reference, I spent a long time trying to make include_role, with a loop, work under a roles: section. It doesn't work, but this documentation and its use of the roles: keyword in the opening, and the phrase '"more" as a task' muddies the waters.

+label: docsite_pr

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
include_role

##### ADDITIONAL INFORMATION