### PR TITLE
Note that by default the regex test is identical to match, but can do much more

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -199,7 +199,7 @@ The following tests can provide information about a path on the controller::
     - debug:
         msg: "path is {{ (mypath is abs)|ternary('absolute','relative')}}"
 
-    - debug: 
+    - debug:
         msg: "path is the same file as path2"
       when: mypath is same_file(path2)
 
@@ -266,5 +266,3 @@ The following tasks are illustrative of the tests meant to check the status of t
        Have a question?  Stop by the google group!
    `irc.freenode.net <http://irc.freenode.net>`_
        #ansible IRC chat channel
-
-

--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -59,8 +59,7 @@ To match strings against a substring or a regular expression, use the "match", "
             msg: "matched pattern 4"
           when: url is regex("example.com/\w+/foo")
 
-'match' requires zero or more characters at the beginning of the string, while 'search' only requires matching a subset of the string.
-
+'match' requires zero or more characters at the beginning of the string, while 'search' only requires matching a subset of the string. By default, 'regex' works like `search`, but `regex` can be configured to perform other tests as well. 
 
 .. _testing_versions:
 


### PR DESCRIPTION
##### SUMMARY

It wasn't clear if the 'regex' test behaved like 'search', like 'match',
or like neither, without reading the code. Update the docs to be clear
it behaves like 'match'.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

Core test.
