### PR TITLE
Specify limits of this module for data group members

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_data_group.py
+++ b/lib/ansible/modules/network/f5/bigip_data_group.py
@@ -19,6 +19,11 @@ short_description: Manage data groups on a BIG-IP
 description:
   - Allows for managing data groups on a BIG-IP. Data groups provide a way to store collections
     of values on a BIG-IP for later use in things such as LTM rules, iRules, and ASM policies.
+  - Data group members may be specified (in full) in a list, via an external file, or through a
+    content block.
+  - This module does NOT allow the addition, modification, or deletion of individual data group
+    members in a type C(internal) data group. The use of `state: absent` or `state: present`
+    in this module refers to the entire data group, not its members.
 version_added: 2.6
 options:
   name:


### PR DESCRIPTION
Explains that state: absent and state: present refers to the entire data group, not members. Also explains that this module does not handle addition, modification, and deletion of members in type `internal` data groups.

+label: docsite_pr

##### SUMMARY
Explains that state: absent and state: present refers to the entire data group, not members. Also explains that this module does not handle addition, modification, and deletion of members in type `internal` data groups.

Companion to  #50210, (which asks for this functionality in the future).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
bigip_data_group

##### ADDITIONAL INFORMATION
N/A