### PR TITLE
fix: ansible_kubectl_ssl_ca_cert variable

### DIFF
--- a/lib/ansible/plugins/connection/kubectl.py
+++ b/lib/ansible/plugins/connection/kubectl.py
@@ -153,7 +153,7 @@ DOCUMENTATION = """
         vars:
           - name: ansible_kubectl_verify_ssl
         env:
-          - name: K8s_AUTH_VERIFY_SSL
+          - name: K8S_AUTH_VERIFY_SSL
 """
 
 import distutils.spawn

--- a/lib/ansible/plugins/connection/kubectl.py
+++ b/lib/ansible/plugins/connection/kubectl.py
@@ -143,7 +143,7 @@ DOCUMENTATION = """
           - Path to a CA certificate used to authenticate with the API.
         default: ''
         vars:
-          - name: ansible_kubectl_cert_file
+          - name: ansible_kubectl_ssl_ca_cert
         env:
           - name: K8S_AUTH_SSL_CA_CERT
       kubectl_verify_ssl:

--- a/lib/ansible/plugins/connection/oc.py
+++ b/lib/ansible/plugins/connection/oc.py
@@ -137,7 +137,7 @@ DOCUMENTATION = """
         vars:
           - name: ansible_oc_verify_ssl
         env:
-          - name: K8s_AUTH_VERIFY_SSL
+          - name: K8S_AUTH_VERIFY_SSL
 """
 
 from ansible.plugins.connection.kubectl import Connection as KubectlConnection

--- a/lib/ansible/plugins/connection/oc.py
+++ b/lib/ansible/plugins/connection/oc.py
@@ -127,7 +127,7 @@ DOCUMENTATION = """
           - Path to a CA certificate used to authenticate with the API.
         default: ''
         vars:
-          - name: ansible_oc_cert_file
+          - name: ansible_oc_ssl_ca_cert
         env:
           - name: K8S_AUTH_SSL_CA_CERT
       oc_verify_ssl:


### PR DESCRIPTION
##### SUMMARY
Fix for `ansible_kubectl_ssl_ca_cert` variable.
There was specified `ansible_kubectl_cert_file` by mistake

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
kubectl and oc connection modules

##### ADDITIONAL INFORMATION