### PR TITLE
Correct match test documentation

### DIFF
--- a/changelogs/fragments/32366-test-match_fix_docs.yaml
+++ b/changelogs/fragments/32366-test-match_fix_docs.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Fix documentation of match test. Match requires zero or more characters at beginning of the string.

--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -59,7 +59,7 @@ To match strings against a substring or a regular expression, use the "match", "
             msg: "matched pattern 4"
           when: url is regex("example.com/\w+/foo")
 
-'match' requires a complete match in the string, while 'search' only requires matching a subset of the string.
+'match' requires zero or more characters at the beginning of the string, while 'search' only requires matching a subset of the string.
 
 
 .. _testing_versions:


### PR DESCRIPTION
##### SUMMARY
Match test matches zero or more characters at the beginning of the string.

Fixes: #32366

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/32366-test-match_fix_docs.yaml
docs/docsite/rst/user_guide/playbooks_tests.rst