### PR TITLE
Fix docs typo at Special Variables

### DIFF
--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -126,7 +126,7 @@ Only the common ones are described as each connection/become/shell/etc plugin ca
 ansible_become_user
     The user Ansible 'becomes' after using privilege escalation. This must be available to the 'login user'.
 
-ansible_connecion
+ansible_connection
     The connection plugin actually used for the task on the target host.
 
 ansible_host


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I was building a list of Ansible special variables to perform a massive facts namespace migration and encountered an error at the following page:
https://docs.ansible.com/ansible/2.7/reference_appendices/special_variables.html

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
