### PR TITLE
Fix yarn private dependencies

### DIFF
--- a/lib/ansible/modules/packaging/language/yarn.py
+++ b/lib/ansible/modules/packaging/language/yarn.py
@@ -214,9 +214,6 @@ class Yarn(object):
                     self.module.fail_json(msg="Path provided %s is not a directory" % self.path)
                 cwd = self.path
 
-                if not os.path.isfile(os.path.join(self.path, 'package.json')):
-                    self.module.fail_json(msg="Package.json does not exist in provided path.")
-
             rc, out, err = self.module.run_command(cmd, check_rc=check_rc, cwd=cwd)
             return out, err
 

--- a/lib/ansible/modules/packaging/language/yarn.py
+++ b/lib/ansible/modules/packaging/language/yarn.py
@@ -245,7 +245,11 @@ class Yarn(object):
             return installed, missing
 
         for dep in dependencies:
-            name, version = dep['name'].split('@')
+            if dep['name'].startswith('@'):
+                name, version = dep['name'][1:].split('@')
+                name = '@' + name
+            else:
+                name, version = dep['name'].split('@')
             installed.append(name)
 
         if self.name not in installed:

--- a/lib/ansible/modules/packaging/language/yarn.py
+++ b/lib/ansible/modules/packaging/language/yarn.py
@@ -235,7 +235,10 @@ class Yarn(object):
         result, error = self._exec(cmd, True, False)
 
         if error:
-            self.module.fail_json(msg=error)
+            error_data = [json.loads(line) for line in error.splitlines()]
+            errors_above_warn = [err for err in error_data if err['type'] != 'warning']
+            if errors_above_warn:
+                self.module.fail_json(msg=error)
 
         data = json.loads(result)
         try:


### PR DESCRIPTION
##### SUMMARY
This fixes multiple issues of the yarn module. 
- The yarn.list() method did not work with private npm dependencies which start with `@`
- The check if a package.json is already in the defined path is not necessary, as yarn creates a package.json if necessary
- Do not fail the module if all errors retrieved from yarn are warnings

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
yarn

##### ADDITIONAL INFORMATION
We would like to use the yarn module to install private dependencies in an empty directory. This works only if the above issues are fixed.