### PR TITLE
[stable-2.7] Do not filter out exception, warnings, deprecations on failure when using debug (#47588)

### DIFF
--- a/changelogs/fragments/callback-keep-more-debug-keys.yml
+++ b/changelogs/fragments/callback-keep-more-debug-keys.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- callbacks - Do not filter out exception, warnings, deprecations on failure when using debug (https://github.com/ansible/ansible/issues/47576)

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -50,6 +50,9 @@ except ImportError:
 __all__ = ["CallbackBase"]
 
 
+_DEBUG_ALLOWED_KEYS = frozenset(('msg', 'exception', 'warnings', 'deprecations'))
+
+
 class CallbackBase(AnsiblePlugin):
 
     '''
@@ -240,11 +243,11 @@ class CallbackBase(AnsiblePlugin):
         ''' removes data from results for display '''
 
         # mostly controls that debug only outputs what it was meant to
-        if task_name in ['debug']:
+        if task_name == 'debug':
             if 'msg' in result:
                 # msg should be alone
                 for key in list(result.keys()):
-                    if key != 'msg' and not key.startswith('_'):
+                    if key not in _DEBUG_ALLOWED_KEYS and not key.startswith('_'):
                         result.pop(key)
             else:
                 # 'var' value as field, so eliminate others and what is left should be varname


### PR DESCRIPTION
* Do not filter out exception, warnings, deprecations on failure when using debug. Fixes #47576

* Add changelog fragment
(cherry picked from commit 40e5d2c)


Co-authored-by: Matt Martz <matt@sivel.net>