### PR TITLE
Add a porting guide entry for ansible_distribution facts

### DIFF
--- a/changelogs/fragments/platform-dist-to-nir0s-distro.yaml
+++ b/changelogs/fragments/platform-dist-to-nir0s-distro.yaml
@@ -1,7 +1,7 @@
 ---
 minor_changes:
 - Python-3.8 removes platform.dist() from the standard library. To maintain
-  compatibility we've switched to an alternative library, nir0s/distro to
+  compatibility we've switched to an alternative library, nir0s/distro, to
   detect the distribution for fact gathering.  Distributions facts may change
   slightly as nir0s/distro has bugfixes which the standard library's
   platform.dist() has lacked.

--- a/changelogs/fragments/platform-dist-to-nir0s-distro.yaml
+++ b/changelogs/fragments/platform-dist-to-nir0s-distro.yaml
@@ -2,4 +2,6 @@
 minor_changes:
 - Python-3.8 removes platform.dist() from the standard library. To maintain
   compatibility we've switched to an alternative library, nir0s/distro to
-  detect the distribution for fact gathering.
+  detect the distribution for fact gathering.  Distributions facts may change
+  slightly as nir0s/distro has bugfixes which the standard library's
+  platform.dist() has lacked.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -17,21 +17,15 @@ This document is part of a collection on porting. The complete list of porting g
 Playbook
 ========
 
-No notable changes.
-
 Distribution Facts
 ------------------
 
 The information returned for the ``ansible_distribution_*`` group of facts may have changed
-slightly.  This is due to a switch away from code which will not run on Python-3.8 to a new backend
-library.  The new code fixes many bugs that the old backend was never going to address but in the
-process, may change some output.
+slightly.  Ansible 2.8 uses a new backend library for information about distributions: `nir0s/distro <https://github.com/nir0s/distro>`_. This library runs on Python-3.8 and fixes many bugs, including correcting release and version names.
 
-In general, ``ansible_distribution`` and ``ansible_distribution_major_version``, the two facts which are
-most relied upon by playbooks should not change (or else a bug should be filed for us to address the
-difference).  However, the other fields like ``ansible_distribution_release`` and
-``ansible_distribution_version`` may change if the old information was determined to have been
-erroneous.
+The two facts used in playbooks most often, ``ansible_distribution`` and ``ansible_distribution_major_version``, should not change. If you discover a change in these facts, please file a bug so we can address the
+difference.  However, other facts like ``ansible_distribution_release`` and
+``ansible_distribution_version`` may change as erroneous information gets corrected.
 
 
 Command Line

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -19,6 +19,20 @@ Playbook
 
 No notable changes.
 
+Distribution Facts
+------------------
+
+The information returned for the ``ansible_distribution_*`` group of facts may have changed
+slightly.  This is due to a switch away from code which will not run on Python-3.8 to a new backend
+library.  The new code fixes many bugs that the old backend was never going to address but in the
+process, may change some output.
+
+In general, ``ansible_distribution`` and ``ansible_distribution_major_version``, the two facts which are
+most relied upon by playbooks should not change (or else a bug should be filed for us to address the
+difference).  However, the other fields like ``ansible_distribution_release`` and
+``ansible_distribution_version`` may change if the old information was determined to have been
+erroneous.
+
 
 Command Line
 ============


### PR DESCRIPTION
Switching away from platform.distro() will cause changes sometimes due
to the new code using new sources of information that may be out of sync
with the old ones.  Just have to make people aware of that and also what
we are doing to mitigate it when appropriate.

Fixes #50141

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/porting_guides/porting_guide_2.8.rst

##### ADDITIONAL INFORMATION
This is the documentation fix promised for #50141.  That issue was determined to be a bugfix between 2.7 and 2.8 due to what upstream for the distributions think their version numbers should be so we should document that there will be changes in the distribution facts when people upgrade.