### PR TITLE
Switch Azure DB tests from GP_Gen4_2 to B_Gen5_1.

### DIFF
--- a/test/integration/targets/azure_rm_mysqldatabase/tasks/main.yml
+++ b/test/integration/targets/azure_rm_mysqldatabase/tasks/main.yml
@@ -8,9 +8,9 @@
     resource_group: "{{ resource_group }}"
     name: mysqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     version: 5.6
     enforce_ssl: True

--- a/test/integration/targets/azure_rm_postgresqldatabase/tasks/main.yml
+++ b/test/integration/targets/azure_rm_postgresqldatabase/tasks/main.yml
@@ -8,9 +8,9 @@
     resource_group: "{{ resource_group }}"
     name: postgresqlsrv{{ rpfx }}
     sku:
-        name: GP_Gen4_2
-        tier: GeneralPurpose
-    location: westus
+        name: B_Gen5_1
+        tier: Basic
+    location: westus2
     storage_mb: 51200
     enforce_ssl: True
     admin_username: zimxyz


### PR DESCRIPTION
##### SUMMARY

Switch Azure DB tests from GP_Gen4_2 to B_Gen5_1.
Also switch from uswest to uswest2.

GP_Gen4_2 is more expensive and is no longer available in all regions.
The uswest location is also more expensive than uswest2.

This is a bug fix since GP_Gen4_2 is no longer available in uswest.

Applying this fix directly to older stable branches as the tests have changed significantly in devel.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

azure_rm_mysqldatabase and azure_rm_postgresqldatabase integration tests