### PR TITLE
Switch remaining Azure DB tests to new SKUs.

### DIFF
--- a/test/integration/targets/azure_rm_mysqlserver/tasks/main.yml
+++ b/test/integration/targets/azure_rm_mysqlserver/tasks/main.yml
@@ -8,9 +8,9 @@
     resource_group: "{{ resource_group }}"
     name: mysqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     version: 5.6
     enforce_ssl: True
@@ -28,9 +28,9 @@
     resource_group: "{{ resource_group }}"
     name: mysqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     version: 5.6
     enforce_ssl: True
@@ -48,9 +48,9 @@
     resource_group: "{{ resource_group }}"
     name: mysqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     version: 5.6
     enforce_ssl: True

--- a/test/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
+++ b/test/integration/targets/azure_rm_postgresqlserver/tasks/main.yml
@@ -8,9 +8,9 @@
     resource_group: "{{ resource_group }}"
     name: postgresqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     enforce_ssl: True
     admin_username: zimxyz
@@ -27,9 +27,9 @@
     resource_group: "{{ resource_group }}"
     name: postgresqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     enforce_ssl: True
     admin_username: zimxyz
@@ -46,9 +46,9 @@
     resource_group: "{{ resource_group }}"
     name: postgresqlsrv{{ rpfx }}
     sku:
-      name: GP_Gen4_2
-      tier: GeneralPurpose
-    location: westus
+      name: B_Gen5_1
+      tier: Basic
+    location: westus2
     storage_mb: 51200
     enforce_ssl: True
     admin_username: zimxyz


### PR DESCRIPTION
##### SUMMARY

Switch remaining Azure DB tests to new SKUs.

This fixes tests which are failing due to unavailable SKUs:

GP_Gen4_2 -> B_Gen5_1
westus -> westus2

Both changes result in lower costs to run tests as well.

Changes derived from: https://github.com/ansible/ansible/pull/45444

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

azure_rm_mysqlserver and azure_rm_postgresqlserver integration tests