### PR TITLE
[stable-2.6] Add retries for Invoke-ScriptAnalyzer in pslint.

### DIFF
--- a/test/sanity/pslint/pslint.ps1
+++ b/test/sanity/pslint/pslint.ps1
@@ -4,11 +4,25 @@
 
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
+$WarningPreference = "Stop"
 
 $Results = @()
 
 ForEach ($Path in $Args) {
-    $Results += Invoke-ScriptAnalyzer -Path $Path -Setting $PSScriptRoot/settings.psd1
+    $Retries = 3
+
+    Do {
+        Try {
+            $Results += Invoke-ScriptAnalyzer -Path $Path -Setting $PSScriptRoot/settings.psd1 3> $null
+            $Retries = 0
+        }
+        Catch {
+            If (--$Retries -le 0) {
+                Throw
+            }
+        }
+    }
+    Until ($Retries -le 0)
 }
 
 ConvertTo-Json -InputObject $Results


### PR DESCRIPTION
##### SUMMARY

[stable-2.6] Add retries for Invoke-ScriptAnalyzer in pslint.

Hopefully this will work around the intermittent CI failures due
to NullReferenceException, which then succeed on a retry.

(cherry picked from commit 4bd60c313bac585ca012d9729fac8e65da4b2c67)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

pslint
