### PR TITLE
Add downloaded state to pip module to call pip download

### DIFF
--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -97,6 +97,52 @@
       - squash_param.results|length == 1
       - squash_param.results[0].name|sort == pip_test_packages|sort
 
+# Tests of pip downloaded state
+- name: create pylibs test directory
+  file:
+    state: directory
+    name: "{{ output_dir }}/pylibs"
+
+- name: ensure pylibs directory is empty
+  command: rm -rf {{ output_dir }}/pylibs/*
+
+- name: test first download of package directly
+  pip:
+    chdir: "{{ output_dir }}/pylibs"
+    name: Bottle
+    state: downloaded
+  register: first_pip_download
+
+- name: assert that task result is changed with the first call to pip download
+  assert:
+    that: first_pip_download is changed
+
+- name: download a second time and confirm not changed
+  pip:
+    chdir: "{{ output_dir }}/pylibs"
+    name: Bottle
+    state: downloaded
+  register: second_pip_download
+
+- name: assert that task result is not changed with the second call to pip download
+  assert:
+    that: second_pip_download is not changed
+
+- name: find downloaded python packages
+  find:
+    paths: "{{ output_dir }}/pylibs"
+    patterns: "*.tar.gz,*.whl"
+    recurse: no
+    file_type: file
+  register: pip_dl_files_found
+
+- name: ensure that files were downloaded
+  assert:
+    that: pip_dl_files_found.files | length > 0
+
+- name: clear out the pylibs directory
+  command: rm -rf {{ output_dir }}/pylibs/*
+
 # Test virtualenv installations
 
 - name: "make sure the test env doesn't exist"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I often use the pip download command to download python libraries that are dependencies for projects. I figure adding a `downloaded` state which essentially just calls pip download would make sense.  It would allow downloading all dependencies for a project using the pip module and then later pointing pip at that directory with extra_args containing  -f/--find-links pointing at the directory that the dependencies were downloaded to. This would avoid the need to call pip download with the command/shell module.


Some example uses below

```
- name: download library by name
  become: no
  pip:
    chdir: /myapp/pylibs
    name: Bottle
    state: downloaded
    executable: /usr/local/bin/pip2.7

- name: download from reqs file
  become: no
  pip:
    chdir: "{{ pylib_cache }}"
    requirements: /myapp/requirements.txt
    state: downloaded
```

Something to note, the download option was added with version 8.0 (I believe that's the version based on https://pip.pypa.io/en/stable/news/#id18), so this switches to `install --download` if the download command is not found.


<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
pip module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.8.0.dev0
  config file = None
  configured module search path = ['${HOME}/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = ${HOME}/repos/py3venvs/ans-dev/lib/python3.7/site-packages/ansible-2.8.0.dev0-py3.7.egg/ansible
  executable location = ${HOME}/repos/py3venvs/ans-dev/bin/ansible
  python version = 3.7.0 (default, Jul 23 2018, 20:24:19) [Clang 9.0.0 (clang-900.0.39.2)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

