### PR TITLE
cron - Makes name required (#37355)

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -189,12 +189,6 @@ EXAMPLES = r'''
     job: "YUMINTERACTIVE=0 /usr/sbin/yum-autoupdate"
     cron_file: ansible_yum-autoupdate
 
-- name: Removes a cron file from under /etc/cron.d
-  cron:
-    name: "yum autoupdate"
-    cron_file: ansible_yum-autoupdate
-    state: absent
-
 - name: Removes "APP_HOME" environment variable from crontab
   cron:
     name: APP_HOME
@@ -376,16 +370,6 @@ class CronTab(object):
 
     def do_remove_env(self, lines, decl):
         return None
-
-    def remove_job_file(self):
-        try:
-            os.unlink(self.cron_file)
-            return True
-        except OSError:
-            # cron file does not exist
-            return False
-        except Exception:
-            raise CronTabError("Unexpected error:", sys.exc_info()[0])
 
     def find_job(self, name, job=None):
         # attempt to find job by 'Ansible:' header comment
@@ -665,18 +649,6 @@ def main():
     if backup and not module.check_mode:
         (backuph, backup_file) = tempfile.mkstemp(prefix='crontab')
         crontab.write(backup_file)
-
-    if crontab.cron_file and not name and not do_install:
-        if module._diff:
-            diff['after'] = ''
-            diff['after_header'] = '/dev/null'
-        else:
-            diff = dict()
-        if module.check_mode:
-            changed = os.path.isfile(crontab.cron_file)
-        else:
-            changed = crontab.remove_job_file()
-        module.exit_json(changed=changed, cron_file=cron_file, state=state, diff=diff)
 
     if env:
         if ' ' in name:

--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -36,11 +36,8 @@ options:
   name:
     description:
       - Description of a crontab entry or, if env is set, the name of environment variable.
-      - Required if C(state=absent).
-      - Note that if name is not set and C(state=present), then a
-        new crontab entry will always be created, regardless of existing ones.
-      - This parameter will always be required in future releases.
     type: str
+    required: yes
   user:
     description:
       - The specific user whose crontab should be modified.
@@ -559,7 +556,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(type='str'),
+            name=dict(required=True, type='str'),
             user=dict(type='str'),
             job=dict(type='str', aliases=['value']),
             cron_file=dict(type='str'),

--- a/test/integration/targets/cron/aliases
+++ b/test/integration/targets/cron/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group3

--- a/test/integration/targets/cron/tasks/cron.yml
+++ b/test/integration/targets/cron/tasks/cron.yml
@@ -1,0 +1,68 @@
+# (c) 2018, Dane Summers <dsummers@pinedesk.biz>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: Create ansible user
+  user:
+    name: "{{ test_user }}"
+
+- name: Install crontab dependency for test
+  package:
+    name: cron
+    state: present
+
+##############################################################################
+- name: Create a crontab
+  cron:
+    name: "Test run a job"
+    job: /bin/date
+    state: present
+    user: "{{ test_user }}"
+    minute: 0
+  register: output
+
+- name: get crontab output
+  shell: "crontab -u {{ test_user }} -l"
+  register: crontab_output
+
+- name: verify output
+  assert:
+    that:
+      - output is changed
+      - output is not failed
+      - "'Test run a job' in output.jobs"
+      - "'#Ansible: Test run a job' in crontab_output.stdout_lines"
+      - "'0 * * * * /bin/date' in crontab_output.stdout_lines"
+##############################################################################
+- name: Remove a crontab
+  cron:
+    name: "Test run a job"
+    state: absent
+    user: "{{ test_user }}"
+  register: output
+
+- name: get crontab output
+  shell: "crontab -u {{ test_user }} -l"
+  register: crontab_output
+
+- name: verify output
+  assert:
+    that:
+      - output is changed
+      - output is not failed
+      - "[] == output.jobs"
+      - "'' == crontab_output.stdout"
+##############################################################################

--- a/test/integration/targets/cron/tasks/cron.yml
+++ b/test/integration/targets/cron/tasks/cron.yml
@@ -21,7 +21,7 @@
 
 - name: Install crontab dependency for test
   package:
-    name: cron
+    name: "{{ cron_package }}"
     state: present
 
 ##############################################################################
@@ -64,5 +64,6 @@
       - output is changed
       - output is not failed
       - "[] == output.jobs"
-      - "'' == crontab_output.stdout"
+      - "'#Ansible: Test run a job' not in crontab_output.stdout_lines"
+      - "'0 * * * * /bin/date' not in crontab_output.stdout_lines"
 ##############################################################################

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -15,6 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 - block:
+  - set_fact:
+      cron_package: cron
+  - set_fact:
+      cron_package: cronie
+    when: ansible_facts.os_family == "RedHat" or ansible_facts.os_family == "Suse"
   - include: cron.yml
     when: ansible_system == 'Linux'
 

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -1,0 +1,22 @@
+# (c) 2018, Dane Summers <dsummers@pinedesk.biz>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+- block:
+  - include: cron.yml
+    when: ansible_system == 'Linux'
+
+  vars:
+    test_user: ansible_user

--- a/test/units/modules/system/test_cron.py
+++ b/test/units/modules/system/test_cron.py
@@ -1,0 +1,113 @@
+from unittest import TestCase
+
+from ansible.modules.system import cron
+from units.compat.mock import ANY, call, patch
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+
+class TestCronTab(TestCase):
+    pass
+
+
+@patch('ansible.modules.system.cron.CronTab')
+class TestCron(ModuleTestCase):
+
+    def test_without_any_parameters(self, crontab_mock):
+        """When required parameters are not supplied, an error is returned"""
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({})
+            cron.main()
+
+    def test_add_crontab(self, crontab_mock):
+        """When no job exists, it is created."""
+        NAME = 'test task'
+        JOB = '/test/job'
+        set_module_args({
+            'name': NAME,
+            'job': JOB,
+        })
+
+        # No previous job exists
+        crontab_mock.return_value.find_job.return_value = []
+
+        with self.assertRaises(AnsibleExitJson) as result:
+            cron.main()
+            self.assertTrue(result.exception.args[0]['changed'])
+            self.assertEqual('present', result.exception.args[0]['state'])
+            self.assertEqual(NAME in result.exception.args[0]['jobs'])
+
+        # A CronTab object is constructed, doesn't find a job, and creates one:
+        get_cron_job = crontab_mock.return_value.get_cron_job
+        crontab_mock.assert_has_calls([
+            call(ANY, None, None),
+            call().get_cron_job('*', '*', '*', '*', '*', JOB, None, False),
+            call().find_job(NAME, get_cron_job.return_value),
+        ])
+        crontab_mock.assert_has_calls([
+            call().add_job(NAME, get_cron_job.return_value),
+            call().get_jobnames(),
+            call().get_envnames(),
+            call().write(),
+        ])
+
+    def test_update_crontab(self, crontab_mock):
+        """When job exists, it is updated."""
+        NAME = 'test task'
+        JOB = '/updated/job'
+        set_module_args({
+            'name': NAME,
+            'user': 'testuser',
+            'job': JOB,
+        })
+
+        # An old job is already set up:
+        crontab_mock.return_value.find_job.return_value = [NAME, '* * * * * testuser /old/job']
+
+        with self.assertRaises(AnsibleExitJson) as result:
+            cron.main()
+            self.assertTrue(result.exception.args[0]['changed'])
+            self.assertEqual('present', result.exception.args[0]['state'])
+            self.assertEqual(NAME in result.exception.args[0]['jobs'])
+
+        # A CronTab object is constructed, finds a job, and updates it:
+        get_cron_job = crontab_mock.return_value.get_cron_job
+        crontab_mock.assert_has_calls([
+            call(ANY, 'testuser', None),
+            call().get_cron_job('*', '*', '*', '*', '*', JOB, None, False),
+            call().find_job(NAME, get_cron_job.return_value),
+        ])
+        crontab_mock.assert_has_calls([
+            call().update_job(NAME, get_cron_job.return_value),
+            call().get_jobnames(),
+            call().get_envnames(),
+            call().write(),
+        ])
+
+    def test_delete_crontab(self, crontab_mock):
+        """When job exists and is deleted, it is removed."""
+        NAME = 'test task'
+        set_module_args({
+            'name': NAME,
+            'state': 'absent',
+        })
+
+        # Finds an old job is already set up:
+        crontab_mock.return_value.find_job.return_value = [NAME, '* * * * * /old/job']
+
+        with self.assertRaises(AnsibleExitJson) as result:
+            cron.main()
+            self.assertTrue(result.exception.args[0]['changed'])
+            self.assertEqual('absent', result.exception.args[0]['state'])
+            self.assertEqual(NAME in result.exception.args[0]['jobs'])
+
+        # A CronTab object is constructed, finds a job, and deletes it:
+        crontab_mock.assert_has_calls([
+            call(ANY, None, None),
+            call().find_job(NAME),
+        ])
+        crontab_mock.assert_has_calls([
+            call().remove_job(NAME),
+            call().get_jobnames(),
+            call().get_envnames(),
+            call().write(),
+        ])


### PR DESCRIPTION
##### SUMMARY

This change fixes a bug where the cron module was not idempotent unless the 'name' is provided.

 * This change makes the 'name' argument required, as discussed on the ticket.
 * Removes an undocumented feature that deleted `cron_file` when provided (if `name` was not provided). This could easily be replaced with the `file` module.
 * Adds minimal integration and unit tests to the module.

Fixes #37355

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

cron module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
