### PR TITLE
Handle openstacksdk < 0.10.0: fix AttributeError

### DIFF
--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -125,8 +125,8 @@ def openstack_cloud_from_module(module, min_version='0.12.0'):
 
     if StrictVersion(sdk_version.__version__) < min_version:
         module.fail_json(
-            msg="To utilize this module, the installed version of"
-                "the openstacksdk library MUST be >={min_version}".format(
+            msg="To utilize this module, the installed version of "
+                "the openstacksdk library MUST be >={min_version}.".format(
                     min_version=min_version))
 
     cloud_config = module.params.pop('cloud', None)

--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -119,9 +119,9 @@ def openstack_cloud_from_module(module, min_version='0.12.0'):
         module.fail_json(msg='openstacksdk is required for this module')
 
     if min_version:
-        min_version = max(StrictVersion('0.10.0'), StrictVersion(min_version))
+        min_version = max(StrictVersion('0.12.0'), StrictVersion(min_version))
     else:
-        min_version = StrictVersion('0.10.0')
+        min_version = StrictVersion('0.12.0')
 
     if StrictVersion(sdk_version.__version__) < min_version:
         module.fail_json(

--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -114,15 +114,20 @@ def openstack_cloud_from_module(module, min_version='0.12.0'):
         # Due to the name shadowing we should import other way
         import importlib
         sdk = importlib.import_module('openstack')
+        sdk_version = importlib.import_module('openstack.version')
     except ImportError:
         module.fail_json(msg='openstacksdk is required for this module')
 
     if min_version:
-        if StrictVersion(sdk.version.__version__) < StrictVersion(min_version):
-            module.fail_json(
-                msg="To utilize this module, the installed version of"
-                    "the openstacksdk library MUST be >={min_version}".format(
-                        min_version=min_version))
+        min_version = max(StrictVersion('0.10.0'), StrictVersion(min_version))
+    else:
+        min_version = StrictVersion('0.10.0')
+
+    if StrictVersion(sdk_version.__version__) < min_version:
+        module.fail_json(
+            msg="To utilize this module, the installed version of"
+                "the openstacksdk library MUST be >={min_version}".format(
+                    min_version=min_version))
 
     cloud_config = module.params.pop('cloud', None)
     try:

--- a/lib/ansible/plugins/doc_fragments/openstack.py
+++ b/lib/ansible/plugins/doc_fragments/openstack.py
@@ -87,7 +87,7 @@ options:
     version_added: "2.3"
 requirements:
   - python >= 2.7
-  - openstacksdk
+  - openstacksdk >= 0.12.0
 notes:
   - The standard OpenStack environment variables, such as C(OS_USERNAME)
     may be used instead of providing explicit values.


### PR DESCRIPTION
##### SUMMARY
Handle openstacksdk < 0.10.0: fix `AttributeError`

Error was:

    The full traceback is:
    Traceback (most recent call last):
      File "$HOME/.ansible/tmp/ansible-tmp-1545612308.8-46792777824159/AnsiballZ_os_security_group.py", line 113, in <module>
        _ansiballz_main()
      File "$HOME/.ansible/tmp/ansible-tmp-1545612308.8-46792777824159/AnsiballZ_os_security_group.py", line 105, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "$HOME/.ansible/tmp/ansible-tmp-1545612308.8-46792777824159/AnsiballZ_os_security_group.py", line 48, in invoke_module
        imp.load_module('__main__', mod, module, MOD_DESC)
      File "/tmp/ansible_os_security_group_payload_keFTIJ/__main__.py", line 163, in <module>
      File "/tmp/ansible_os_security_group_payload_keFTIJ/__main__.py", line 115, in main
      File "/tmp/ansible_os_security_group_payload_keFTIJ/ansible_os_security_group_payload.zip/ansible/module_utils/openstack.py", line 121, in openstack_cloud_from_module
    AttributeError: 'module' object has no attribute 'version'

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/module_utils/openstack.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
