### PR TITLE
cloud/amazon/aws_config_recorder: add empty resourceTypes list if undefined

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_config_recorder.py
+++ b/lib/ansible/modules/cloud/amazon/aws_config_recorder.py
@@ -184,6 +184,10 @@ def main():
             params['recordingGroup'].update({
                 'resourceTypes': module.params.get('recording_group').get('resource_types')
             })
+        else:
+            params['recordingGroup'].update({
+                'resourceTypes': []
+            })
 
     client = module.client('config', retry_decorator=AWSRetry.jittered_backoff())
 


### PR DESCRIPTION
##### SUMMARY
`recordingGroup[].resourceTypes` exists even if it is not defined as a parameter for a AWS Config recorder.  When the module compares the parameters it has versus what is returned from AWS, the module then determines that there is a change due to the parameter mismatch (and thus will always return `changed`). This PR should fix this issue.  If the parameter is not set when the module is executed, this change adds a condition that will add an empty `resourceTypes` list.

Fixes #49453 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`aws_config_recorder`

##### ADDITIONAL INFORMATION
```
N/A
```
