### PR TITLE
Pluribus Networks port cos bw module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -246,6 +246,7 @@ files:
   $modules/network/netconf/netconf_rpc.py: $team_networking
   $modules/network/netscaler/: $team_netscaler
   $modules/network/netvisor/: $team_netvisor
+    maintainers: rajaspachipulusu17
   $modules/network/nos/: $team_extreme
   $modules/network/nuage/: pdellaert
   $modules/network/nxos/: $team_nxos

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -246,7 +246,6 @@ files:
   $modules/network/netconf/netconf_rpc.py: $team_networking
   $modules/network/netscaler/: $team_netscaler
   $modules/network/netvisor/: $team_netvisor
-    maintainers: rajaspachipulusu17
   $modules/network/nos/: $team_extreme
   $modules/network/nuage/: pdellaert
   $modules/network/nxos/: $team_nxos

--- a/lib/ansible/modules/network/netvisor/pn_port_cos_bw.py
+++ b/lib/ansible/modules/network/netvisor/pn_port_cos_bw.py
@@ -121,8 +121,7 @@ def main():
         required_if=(
             ['state', 'update', ['pn_cos', 'pn_port']],
         ),
-        required_one_of=(['pn_max_bw_limit', 'pn_cos', 'pn_weight'],
-        ),
+        required_one_of=(['pn_max_bw_limit', 'pn_cos', 'pn_weight']),
     )
 
     # Accessing the arguments

--- a/lib/ansible/modules/network/netvisor/pn_port_cos_bw.py
+++ b/lib/ansible/modules/network/netvisor/pn_port_cos_bw.py
@@ -121,7 +121,7 @@ def main():
         required_if=(
             ['state', 'update', ['pn_cos', 'pn_port']],
         ),
-        required_one_of=(['pn_max_bw_limit', 'pn_cos', 'pn_weight']),
+        required_one_of=(['pn_max_bw_limit', 'pn_min_bw_guarantee', 'pn_weight']),
     )
 
     # Accessing the arguments

--- a/lib/ansible/modules/network/netvisor/pn_port_cos_bw.py
+++ b/lib/ansible/modules/network/netvisor/pn_port_cos_bw.py
@@ -121,7 +121,7 @@ def main():
         required_if=(
             ['state', 'update', ['pn_cos', 'pn_port']],
         ),
-        required_one_of=(['pn_max_bw_limit', 'pn_min_bw_guarantee', 'pn_weight']),
+        required_one_of=[['pn_max_bw_limit', 'pn_min_bw_guarantee', 'pn_weight']],
     )
 
     # Accessing the arguments

--- a/lib/ansible/modules/network/netvisor/pn_port_cos_bw.py
+++ b/lib/ansible/modules/network/netvisor/pn_port_cos_bw.py
@@ -1,0 +1,159 @@
+#!/usr/bin/python
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: pn_port_cos_bw
+author: "Pluribus Networks (@rajaspachipulusu17)"
+version_added: "2.8"
+short_description: CLI command to modify port-cos-bw
+description:
+  - This module can be used to update bw settings for CoS queues.
+options:
+  pn_cliswitch:
+    description:
+      - Target switch to run the CLI on.
+    required: False
+    type: str
+  state:
+    description:
+      - State the action to perform. Use C(update) to modify the port-cos-bw.
+    required: True
+    type: str
+    choices: ['update']
+  pn_max_bw_limit:
+    description:
+      - Maximum b/w in percentage.
+    required: False
+    type: str
+  pn_cos:
+    description:
+      - CoS priority.
+    required: False
+    type: str
+  pn_port:
+    description:
+      - physical port number.
+    required: False
+    type: str
+  pn_weight:
+    description:
+      - Scheduling weight (1 to 127) after b/w guarantee met.
+    required: False
+    type: str
+    choices: ['priority', 'no-priority']
+  pn_min_bw_guarantee:
+    description:
+      - Minimum b/w in precentage.
+    required: False
+    type: str
+"""
+
+EXAMPLES = """
+- name: port cos bw modify
+  pn_port_cos_bw:
+    pn_cliswitch: "sw01"
+    state: "update"
+    pn_port: "1"
+    pn_cos: "0"
+    pn_min_bw_guarantee: "60"
+
+- name: port cos bw modify
+  pn_port_cos_bw:
+    pn_cliswitch: "sw01"
+    state: "update"
+    pn_port: "all"
+    pn_cos: "0"
+"""
+
+RETURN = """
+command:
+  description: the CLI command run on the target node.
+  returned: always
+  type: str
+stdout:
+  description: set of responses from the port-cos-bw command.
+  returned: always
+  type: list
+stderr:
+  description: set of error responses from the port-cos-bw command.
+  returned: on error
+  type: list
+changed:
+  description: indicates whether the CLI caused changes on the target.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netvisor.pn_nvos import pn_cli, run_cli
+
+
+def main():
+    """ This section is for arguments parsing """
+
+    state_map = dict(
+        update='port-cos-bw-modify'
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            pn_cliswitch=dict(required=False, type='str'),
+            state=dict(required=True, type='str',
+                       choices=state_map.keys()),
+            pn_max_bw_limit=dict(required=False, type='str'),
+            pn_cos=dict(required=False, type='str'),
+            pn_port=dict(required=False, type='str'),
+            pn_weight=dict(required=False, type='str',
+                           choices=['priority', 'no-priority']),
+            pn_min_bw_guarantee=dict(required=False, type='str'),
+        ),
+        required_if=(
+            ['state', 'update', ['pn_cos', 'pn_port']],
+        ),
+        required_one_of=(['pn_max_bw_limit', 'pn_cos', 'pn_weight'],
+        ),
+    )
+
+    # Accessing the arguments
+    cliswitch = module.params['pn_cliswitch']
+    state = module.params['state']
+    max_bw_limit = module.params['pn_max_bw_limit']
+    cos = module.params['pn_cos']
+    port = module.params['pn_port']
+    weight = module.params['pn_weight']
+    min_bw_guarantee = module.params['pn_min_bw_guarantee']
+
+    command = state_map[state]
+
+    # Building the CLI command string
+    cli = pn_cli(module, cliswitch)
+
+    if command == 'port-cos-bw-modify':
+        cli += ' %s ' % command
+        if max_bw_limit:
+            cli += ' max-bw-limit ' + max_bw_limit
+        if cos:
+            cli += ' cos ' + cos
+        if port:
+            cli += ' port ' + port
+        if weight:
+            cli += ' weight ' + weight
+        if min_bw_guarantee:
+            cli += ' min-bw-guarantee ' + min_bw_guarantee
+
+    run_cli(module, cli, state_map)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/netvisor/test_pn_port_cos_bw.py
+++ b/test/units/modules/network/netvisor/test_pn_port_cos_bw.py
@@ -1,0 +1,49 @@
+# Copyright: (c) 2018, Pluribus Networks
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from units.compat.mock import patch
+from ansible.modules.network.netvisor import pn_port_cos_bw
+from units.modules.utils import set_module_args
+from .nvos_module import TestNvosModule, load_fixture
+
+
+class TestAdminServiceModule(TestNvosModule):
+
+    module = pn_port_cos_bw
+
+    def setUp(self):
+        self.mock_run_nvos_commands = patch('ansible.modules.network.netvisor.pn_port_cos_bw.run_cli')
+        self.run_nvos_commands = self.mock_run_nvos_commands.start()
+
+    def tearDown(self):
+        self.mock_run_nvos_commands.stop()
+
+    def run_cli_patch(self, module, cli, state_map):
+        if state_map['update'] == 'port-cos-bw-modify':
+            results = dict(
+                changed=True,
+                cli_cmd=cli
+            )
+        module.exit_json(**results)
+
+    def load_fixtures(self, commands=None, state=None, transport='cli'):
+        self.run_nvos_commands.side_effect = self.run_cli_patch
+
+    def test_pn_port_cos_bw_modify_t1(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_port': '1',
+                         'pn_cos': '0', 'pn_min_bw_guarantee': '60', 'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 port-cos-bw-modify  cos 0 port 1 min-bw-guarantee 60'
+        self.assertEqual(result['cli_cmd'], expected_cmd)
+
+    def test_pn_port_cos_bw_modify_t2(self):
+        set_module_args({'pn_cliswitch': 'sw01', 'pn_port': 'all',
+                         'pn_cos': '1', 'state': 'update'})
+        result = self.execute_module(changed=True, state='update')
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 port-cos-bw-modify  cos 1 port all'
+        self.assertEqual(result['cli_cmd'], expected_cmd)

--- a/test/units/modules/network/netvisor/test_pn_port_cos_bw.py
+++ b/test/units/modules/network/netvisor/test_pn_port_cos_bw.py
@@ -43,7 +43,7 @@ class TestAdminServiceModule(TestNvosModule):
 
     def test_pn_port_cos_bw_modify_t2(self):
         set_module_args({'pn_cliswitch': 'sw01', 'pn_port': 'all',
-                         'pn_cos': '1', 'state': 'update'})
+                         'pn_cos': '1', 'pn_weight': 'priority', 'state': 'update'})
         result = self.execute_module(changed=True, state='update')
-        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 port-cos-bw-modify  cos 1 port all'
+        expected_cmd = '/usr/bin/cli --quiet -e --no-login-prompt  switch sw01 port-cos-bw-modify  cos 1 port all weight priority'
         self.assertEqual(result['cli_cmd'], expected_cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Point feature of port cos bw for Pluribus Networks Netvisor switches 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
pn_port_cos_bw.py module with unit tests.

##### ADDITIONAL INFORMATION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]

```