### PR TITLE
workaround for win_power_plan on Windows 10.0.17134 and higher

### DIFF
--- a/lib/ansible/modules/windows/win_power_plan.ps1
+++ b/lib/ansible/modules/windows/win_power_plan.ps1
@@ -69,8 +69,12 @@ If ([System.Environment]::OSVersion.Version -ge '10.0.17134')
 
     Else
     {
-        $result.changed = $true
         powercfg /S $planGuid
+        if (-not $?)
+        {
+            Fail-Json $result "Failed to set the new plan '$name' ($planGuid) using powercfg"
+        }
+        $result.changed = $true
         $result.all_available_plans = Get-PowerPlans
         Exit-Json $result
     }

--- a/lib/ansible/modules/windows/win_power_plan.ps1
+++ b/lib/ansible/modules/windows/win_power_plan.ps1
@@ -58,7 +58,7 @@ If (! ($all_available_plans.ContainsKey($name)) )
 
 If ([System.Environment]::OSVersion.Version -ge '10.0.17134')
 {
-    $plan = Get-WmiObject -Class win32_powerplan -Namespace root\cimv2\power -Filter "ElementName='$name'"
+    $plan = Get-CimInstance -Name root\cimv2\power -Class Win32_PowerPlan -Filter "ElementName='$name'"
     $regex = [regex]"{(.*?)}$"
     $planGuid = $regex.Match($plan.instanceID.Tostring()).groups[1].value
 

--- a/lib/ansible/modules/windows/win_power_plan.ps1
+++ b/lib/ansible/modules/windows/win_power_plan.ps1
@@ -55,6 +55,27 @@ If (! ($all_available_plans.ContainsKey($name)) )
 #If false, means plan is not active and we move down to enable
 #Since the results here are the same whether check mode or not, no specific handling is required
 #for check mode.
+
+If ([System.Environment]::OSVersion.Version -ge '10.0.17134')
+{
+    $plan = Get-WmiObject -Class win32_powerplan -Namespace root\cimv2\power -Filter "ElementName='$name'"
+    $regex = [regex]"{(.*?)}$"
+    $planGuid = $regex.Match($plan.instanceID.Tostring()).groups[1].value
+
+    If ( $all_available_plans.item($name) )
+    {
+        Exit-Json $result
+    }
+
+    Else
+    {
+        $result.changed = $true
+        powercfg /S $planGuid
+        $result.all_available_plans = Get-PowerPlans
+        Exit-Json $result
+    }
+}
+
 If ( $all_available_plans.item($name) )
 {
     Exit-Json $result
@@ -76,4 +97,3 @@ Else
     $result.all_available_plans = Get-PowerPlans
     Exit-Json $result
 }
-


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a condition that uses the `powercfg` command on Windows version 10.0.17134 and higher, to set the desired power plan.
More information in https://github.com/ansible/ansible/issues/43827

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_power_plan

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**Before:**
```paste below
fatal: [test2019]: FAILED! => {
    "all_available_plans": {
        "Balanced": true,
        "High performance": false,
        "Power saver": false
    },
    "changed": false,
    "msg": "Failed to set the new plan: This method is not implemented in any class ",
    "power_plan_enabled": false,
    "power_plan_name": "high performance"
}
```

**After (first run):**
```
changed: [test2019] => {
    "all_available_plans": {
        "Balanced": false,
        "High performance": true,
        "Power saver": false
    },
    "changed": true,
    "power_plan_enabled": false,
    "power_plan_name": "high performance"
}
```

**Second run:**
```
ok: [test2019] => {
    "all_available_plans": {
        "Balanced": false,
        "High performance": true,
        "Power saver": false
    },
    "changed": false,
    "power_plan_enabled": true,
    "power_plan_name": "high performance"
}
```