### PR TITLE
Add support for check mode in aws_s3_cors module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3_cors.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3_cors.py
@@ -146,7 +146,7 @@ def destroy_bucket_cors(connection, module):
     try:
         connection.get_bucket_cors(Bucket=name)
         exists = True
-    except ClientError: # NoSuchCORSConfiguration
+    except ClientError:   # NoSuchCORSConfiguration
         exists = False
 
     try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds support for check mode in aws_s3_cors module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_s3_cors

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I tested 8 patterns on `Ansible 2.7.5`. I verified this on my AWS account.

- `state: present`
    1. S3 bucket without CORS config and module with check mode
        - return 'changed', no affect
    1. S3 bucket without CORS config and module without check mode
        - return 'changed', affect
    1. S3 bucket with CORS config and module with check mode
        - return 'ok'
    1. S3 bucket with CORS config and module without check mode
        - return 'ok'
- `state: absent`
    1. S3 bucket without CORS config and module with check mode
        - return 'ok'
    1. S3 bucket without CORS config and module without check mode
        - return 'ok'
    1. S3 bucket with CORS config and module with check mode
        - return 'changed', no affect
    1. S3 bucket with CORS config and module without check mode
        - return 'changed', affect

