### PR TITLE
Fail if api_url is empty, checker

### DIFF
--- a/lib/ansible/modules/source_control/gitlab_deploy_key.py
+++ b/lib/ansible/modules/source_control/gitlab_deploy_key.py
@@ -192,6 +192,9 @@ def main():
     private_token = module.params['private_token']
     project = module.params['project']
     state = module.params['state']
+   
+    if api_url == None:
+        module.fail_json(msg="api_url can't be empty")
 
     if not access_token and not private_token:
         module.fail_json(msg="need either access_token or private_token")


### PR DESCRIPTION
##### SUMMARY
Fail the play if the api_url is None

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
Task trial
- name: Add gitkey to Gitlab repo deploy_keys
   gitlab_deploy_key:
     api_url: 
     private_token: "{{ git_access_token }}"
     project: "project/repo"
     title: "api-{{aws_profile}}"
     state: present
     key: "{{ pub_key['content'] | b64decode  }}"

<!--- Paste verbatim command output below, e.g. before and after your change -->
msg before the change:  "msg": "unknown url type: None/v4/projects/project/repo"
```
msg after the change: "msg": "api_url can't be empty"
```
