### PR TITLE
Fail if api_url is None, sanity checked

### DIFF
--- a/changelogs/fragments/50309-gitlab-deloy-key-minor-bug.yml
+++ b/changelogs/fragments/50309-gitlab-deloy-key-minor-bug.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - api_url needs to have a value before making a requst, a checker has been add to the gitlab_deploy_key module. 
+  - This will make the module fail if the value of api_url is None and return a reasonable message. (https://github.com/ansible/ansible/pull/50309)

--- a/lib/ansible/modules/source_control/gitlab_deploy_key.py
+++ b/lib/ansible/modules/source_control/gitlab_deploy_key.py
@@ -193,6 +193,9 @@ def main():
     project = module.params['project']
     state = module.params['state']
 
+    if api_url is None:
+        module.fail_json(msg="api_url can't be empty")
+
     if not access_token and not private_token:
         module.fail_json(msg="need either access_token or private_token")
 


### PR DESCRIPTION
##### SUMMARY
Fail the play if the api_url is None

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module: gitlab_deploy_key

##### ADDITIONAL INFORMATION
```
- name: Add gitkey to Gitlab repo deploy_keys without api_url
   gitlab_deploy_key:
     api_url:
     private_token: "{{ git_access_token }}"
     project: "project/repo"
     title: "api-{{aws_profile}}"
     state: present
     key: "{{ ssh_pub_key }}"
```

```
msg before the change: "msg": "unknown url type: None/v4/projects/project/repo"
```

```
msg after the change: "msg": "api_url can't be empty"
```