### PR TITLE
docker_image: add network parameter

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -635,6 +635,7 @@ def main():
 
     option_minimal_versions = dict(
         cache_from=dict(docker_py_version='2.1.0', docker_api_version='1.25'),
+        network=dict(docker_py_version='2.4.0', docker_api_version='1.25'),
     )
 
     client = AnsibleDockerClient(

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -94,6 +94,11 @@ options:
     required: false
     version_added: "2.1"
     type: bool
+  network:
+    description:
+      - The network to use for RUN build instructions.
+    required: false
+    version_added: "2.8"
   nocache:
     description:
       - Do not use cache when building an image.
@@ -299,6 +304,7 @@ class ImageManager(DockerBaseClass):
         self.force = parameters.get('force')
         self.load_path = parameters.get('load_path')
         self.name = parameters.get('name')
+        self.network = parameters.get('network')
         self.nocache = parameters.get('nocache')
         self.path = parameters.get('path')
         self.pull = parameters.get('pull')
@@ -533,6 +539,7 @@ class ImageManager(DockerBaseClass):
             tag=self.name,
             rm=self.rm,
             nocache=self.nocache,
+            network_mode=self.network,
             timeout=self.http_timeout,
             pull=self.pull,
             forcerm=self.rm,
@@ -613,6 +620,7 @@ def main():
         http_timeout=dict(type='int'),
         load_path=dict(type='path'),
         name=dict(type='str', required=True),
+        network=dict(type='str'),
         nocache=dict(type='bool', default=False),
         path=dict(type='path', aliases=['build_path']),
         pull=dict(type='bool', default=True),

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -539,7 +539,6 @@ class ImageManager(DockerBaseClass):
             tag=self.name,
             rm=self.rm,
             nocache=self.nocache,
-            network_mode=self.network,
             timeout=self.http_timeout,
             pull=self.pull,
             forcerm=self.rm,
@@ -559,6 +558,8 @@ class ImageManager(DockerBaseClass):
             params['buildargs'] = self.buildargs
         if self.cache_from:
             params['cache_from'] = self.cache_from
+        if self.network:
+            params['network_mode'] = self.network
 
         for line in self.client.build(**params):
             # line = json.loads(line)

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -96,7 +96,7 @@ options:
     type: bool
   network:
     description:
-      - The network to use for RUN build instructions.
+      - The network to use for C(RUN) build instructions.
     required: false
     version_added: "2.8"
   nocache:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add a network parameter to the docker_image module to specify the network to use for RUN commands.

#45127 seems to be abandoned, so I picked it up. I cherrypicked @FiloSottile's commit to keep the credit.

Fixes #45127, #21433

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_image

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Called it network instead of network_mode as the latter seems like a
legacy of when there were just a few default options to choose from,
while now the name of an arbitrary network can be specified.