### PR TITLE
added timestamps to ios_command module

### DIFF
--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -129,10 +129,10 @@ def get_config(module, flags=None):
         return cfg
 
 
-def run_commands(module, commands, check_rc=True):
+def run_commands(module, commands, check_rc=True, return_timestamps=False):
     connection = get_connection(module)
     try:
-        return connection.run_commands(commands=commands, check_rc=check_rc)
+        return connection.run_commands(commands=commands, check_rc=check_rc, return_timestamps=return_timestamps)
     except ConnectionError as exc:
         module.fail_json(msg=to_text(exc))
 

--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -198,7 +198,7 @@ def main():
     match = module.params['match']
 
     while retries > 0:
-        responses = run_commands(module, commands)
+        responses, timestamps = run_commands(module, commands, return_timestamps=True)
 
         for item in list(conditionals):
             if item(responses):
@@ -221,6 +221,7 @@ def main():
     result.update({
         'stdout': responses,
         'stdout_lines': list(to_lines(responses)),
+        'timestamps': timestamps
     })
 
     module.exit_json(**result)

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -27,6 +27,7 @@ from itertools import chain
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text
+from ansible.module_utils.basic import get_timestamp
 from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.network.common.config import NetworkConfig, dumps
@@ -273,11 +274,12 @@ class Cliconf(CliconfBase):
 
         return resp
 
-    def run_commands(self, commands=None, check_rc=True):
+    def run_commands(self, commands=None, check_rc=True, return_timestamps=False):
         if commands is None:
             raise ValueError("'commands' value is required")
 
         responses = list()
+        timestamps = list()
         for cmd in to_list(commands):
             if not isinstance(cmd, Mapping):
                 cmd = {'command': cmd}
@@ -288,14 +290,19 @@ class Cliconf(CliconfBase):
 
             try:
                 out = self.send_command(**cmd)
+                timestamp = get_timestamp()
             except AnsibleConnectionFailure as e:
                 if check_rc:
                     raise
                 out = getattr(e, 'err', to_text(e))
 
             responses.append(out)
+            timestamps.append(timestamp)
 
-        return responses
+        if return_timestamps:
+            return responses, timestamps
+        else:
+            return responses
 
     def get_defaults_flag(self):
         """

--- a/test/units/modules/network/ios/test_ios_command.py
+++ b/test/units/modules/network/ios/test_ios_command.py
@@ -22,6 +22,7 @@ __metaclass__ = type
 import json
 
 from units.compat.mock import patch
+from ansible.module_utils.basic import get_timestamp
 from ansible.modules.network.ios import ios_command
 from units.modules.utils import set_module_args
 from .ios_module import TestIosModule, load_fixture
@@ -46,6 +47,7 @@ class TestIosCommandModule(TestIosModule):
         def load_from_file(*args, **kwargs):
             module, commands = args
             output = list()
+            timestamps = list()
 
             for item in commands:
                 try:
@@ -55,7 +57,8 @@ class TestIosCommandModule(TestIosModule):
                     command = item['command']
                 filename = str(command).replace(' ', '_')
                 output.append(load_fixture(filename))
-            return output
+                timestamps.append(get_timestamp())
+            return output, timestamps
 
         self.run_commands.side_effect = load_from_file
 


### PR DESCRIPTION
ios_command module now returns timestamps field, which shows command execution time

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added information about time when command was issued on remote device.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**before**
```
ok: [ios1] => {
    "output": {
        "changed": false, 
        "failed": false, 
        "stdout": [
            "*16:32:49.138 MSK Wed Dec 26 2018", 
            "Neighbor ID     Pri   State           Dead Time   Address         Interface\n172.31.255.202    1   FULL/DR         00:00:39    10.10.10.20     TenGigabitEthernet1/3"
        ], 
        "stdout_lines": [
            [
                "*16:32:49.138 MSK Wed Dec 26 2018"
            ], 
            [
                "Neighbor ID     Pri   State           Dead Time   Address         Interface", 
                "172.31.255.202    1   FULL/DR         00:00:39    10.10.10.20     TenGigabitEthernet1/3"
            ]
        ]
    }
}
```

**after**
```
ok: [ios1] => {
    "output": {
        "changed": false, 
        "failed": false, 
        "stdout": [
            "*16:37:10.386 MSK Wed Dec 26 2018", 
            "Neighbor ID     Pri   State           Dead Time   Address         Interface\n172.31.255.202    1   FULL/DR         00:00:35    10.10.10.20     TenGigabitEthernet1/3"
        ], 
        "stdout_lines": [
            [
                "*16:37:10.386 MSK Wed Dec 26 2018"
            ], 
            [
                "Neighbor ID     Pri   State           Dead Time   Address         Interface", 
                "172.31.255.202    1   FULL/DR         00:00:35    10.10.10.20     TenGigabitEthernet1/3"
            ]
        ], 
        "timestamps": [
            "2018-12-26T16:37:10", 
            "2018-12-26T16:37:10"
        ]
    }
}
```