### PR TITLE
regex_escape: support POSIX basic regex

### DIFF
--- a/changelogs/fragments/regex-escape-basic.yaml
+++ b/changelogs/fragments/regex-escape-basic.yaml
@@ -1,0 +1,8 @@
+minor_changes:
+- |
+    regex_escape - added re_type option to enable escaping POSIX BRE chars
+
+    This distinction is necessary because escaping non-special chars such as
+    '(' or '{' turns them into special chars, the opposite of what is intended
+    by using regex_escape on strings being passed as a Basic Regular
+    Expression.

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1071,10 +1071,17 @@ To replace text in a string with regex, use the "regex_replace" filter::
 
 .. versionadded:: 2.0
 
-To escape special characters within a regex, use the "regex_escape" filter::
+To escape special characters within a standard python regex, use the "regex_escape" filter::
 
     # convert '^f.*o(.*)$' to '\^f\.\*o\(\.\*\)\$'
     {{ '^f.*o(.*)$' | regex_escape() }}
+
+To escape special characters within a basic regex, use the "regex_escape" filter with the re_type='basic' option::
+
+    # convert '^f.*o(.*)$' to '\^f\.\*o(\.\*)\$'
+    {{ '^f.*o(.*)$' | regex_escape('basic') }}
+
+.. versionadded:: 2.8
 
 
 Kubernetes Filters

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1076,12 +1076,12 @@ To escape special characters within a standard python regex, use the "regex_esca
     # convert '^f.*o(.*)$' to '\^f\.\*o\(\.\*\)\$'
     {{ '^f.*o(.*)$' | regex_escape() }}
 
+.. versionadded:: 2.8
+
 To escape special characters within a POSIX basic regex, use the "regex_escape" filter with the re_type='posix_basic' option::
 
     # convert '^f.*o(.*)$' to '\^f\.\*o(\.\*)\$'
     {{ '^f.*o(.*)$' | regex_escape('posix_basic') }}
-
-.. versionadded:: 2.8
 
 
 Kubernetes Filters

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1071,15 +1071,15 @@ To replace text in a string with regex, use the "regex_replace" filter::
 
 .. versionadded:: 2.0
 
-To escape special characters within a standard python regex, use the "regex_escape" filter::
+To escape special characters within a standard python regex, use the "regex_escape" filter (using the default re_type='python' option)::
 
     # convert '^f.*o(.*)$' to '\^f\.\*o\(\.\*\)\$'
     {{ '^f.*o(.*)$' | regex_escape() }}
 
-To escape special characters within a basic regex, use the "regex_escape" filter with the re_type='basic' option::
+To escape special characters within a POSIX basic regex, use the "regex_escape" filter with the re_type='posix_basic' option::
 
     # convert '^f.*o(.*)$' to '\^f\.\*o(\.\*)\$'
-    {{ '^f.*o(.*)$' | regex_escape('basic') }}
+    {{ '^f.*o(.*)$' | regex_escape('posix_basic') }}
 
 .. versionadded:: 2.8
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -185,9 +185,16 @@ def ternary(value, true_val, false_val, none_val=None):
         return false_val
 
 
-def regex_escape(string):
+def regex_escape(string, re_type='python'):
     '''Escape all regular expressions special characters from STRING.'''
-    return re.escape(string)
+    if re_type == 'python':
+        return re.escape(string)
+    elif re_type == 'basic':
+        # list of BRE special chars:
+        # https://en.wikibooks.org/wiki/Regular_Expressions/POSIX_Basic_Regular_Expressions
+        return regex_replace(string, r'([].[^$*\\])', r'\\\1')
+    else:
+        raise AnsibleFilterError('Invalid regex type (%s)' % re_type)
 
 
 def from_yaml(data):

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -189,10 +189,16 @@ def regex_escape(string, re_type='python'):
     '''Escape all regular expressions special characters from STRING.'''
     if re_type == 'python':
         return re.escape(string)
-    elif re_type == 'basic':
+    elif re_type == 'posix_basic':
         # list of BRE special chars:
         # https://en.wikibooks.org/wiki/Regular_Expressions/POSIX_Basic_Regular_Expressions
         return regex_replace(string, r'([].[^$*\\])', r'\\\1')
+    # TODO: implement posix_extended
+    # It's similar to, but different from python regex, which is similar to,
+    # but different from PCRE.  It's possible that re.escape would work here.
+    # https://remram44.github.io/regex-cheatsheet/regex.html#programs
+    elif re_type == 'posix_extended':
+        raise AnsibleFilterError('Regex type (%s) not yet implemented' % re_type)
     else:
         raise AnsibleFilterError('Invalid regex type (%s)' % re_type)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

    regex_escape - added re_type option to enable escaping POSIX BRE chars

    This distinction is necessary because escaping non-special chars such as
    '(' or '{' turns them into special chars, the opposite of what is intended
    by using regex_escape on strings being passed as a Basic Regular
    Expression.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
regex_escape

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
