### PR TITLE
Add support for elements validation in argspec

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2089,7 +2089,7 @@ class AnsibleModule(object):
         for (k, v) in spec.items():
             wanted = v.get('elements', None)
             arg_type = v.get('type', None)
-            if k not in param:
+            if k not in param or wanted is None:
                 continue
 
             values = param[k]

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -846,6 +846,7 @@ class AnsibleModule(object):
             self._check_required_arguments()
             self._check_argument_types()
             self._check_argument_values()
+            self._check_argument_elements()
             self._check_required_together(required_together)
             self._check_required_one_of(required_one_of)
             self._check_required_if(required_if)
@@ -2024,6 +2025,7 @@ class AnsibleModule(object):
                         self._check_required_arguments(spec, param)
                         self._check_argument_types(spec, param)
                         self._check_argument_values(spec, param)
+                        self._check_argument_elements(spec, param)
 
                         self._check_required_together(v.get('required_together', None), param)
                         self._check_required_one_of(v.get('required_one_of', None), param)
@@ -2075,6 +2077,60 @@ class AnsibleModule(object):
             except (TypeError, ValueError) as e:
                 self.fail_json(msg="argument %s is of type %s and we were unable to convert to %s: %s" %
                                (k, type(value), wanted, to_native(e)))
+
+    def _check_argument_elements(self, spec=None, param=None):
+        ''' ensure all elements have the requested type '''
+
+        if spec is None:
+            spec = self.argument_spec
+        if param is None:
+            param = self.params
+
+        for (k, v) in spec.items():
+            wanted = v.get('elements', None)
+            arg_type = v.get('type', None)
+            if k not in param:
+                continue
+
+            values = param[k]
+            if values is None:
+                continue
+
+            if arg_type != 'list' or not isinstance(values, list):
+                msg = "Invalid type %s for option '%s'" % (arg_type, k)
+                if self._options_context:
+                    msg += " found in '%s'." % " -> ".join(self._options_context)
+                msg += ", elements value check is supported only with 'list' type"
+                self.fail_json(msg=msg)
+
+            if not callable(wanted):
+                if wanted is None:
+                    # Mostly we want to default to str.
+                    wanted = 'str'
+                try:
+                    type_checker = self._CHECK_ARGUMENT_TYPES_DISPATCHER[wanted]
+                except KeyError:
+                    msg = "implementation error: unknown type %s requested for option '%s'" % (wanted, k)
+                    if self._options_context:
+                        msg += " found in '%s'." % " -> ".join(self._options_context)
+                    self.fail_json(msg=msg)
+            else:
+                # set the type_checker to the callable, and reset wanted to the callable's name (or type if it doesn't have one, ala MagicMock)
+                type_checker = wanted
+                wanted = getattr(wanted, '__name__', to_native(type(wanted)))
+
+            validated_params = []
+            for value in values:
+                try:
+                    validated_params.append(type_checker(value))
+                except (TypeError, ValueError) as e:
+                    msg = "Elements value for option %s" % k
+                    if self._options_context:
+                        msg += " found in '%s'" % " -> ".join(self._options_context)
+                    msg += " is of type %s and we were unable to convert to %s: %s" % (type(value), wanted, to_native(e))
+                    self.fail_json(msg=msg)
+
+            param[k] = validated_params
 
     def _set_defaults(self, pre=True, spec=None, param=None):
         if spec is None:

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -345,11 +345,12 @@ class TestComplexOptions:
          ),
         # Check required_by options
         ({"foobar": [{"foo": "required", "bar": "good", "baz": "good", "bam4": "required_by", "bam1": "ok", "bam3": "yes"}]},
-         [{'bar': 'good', 'baz': 'good', 'bam1': 'ok', 'bam2': 'test', 'bam3': True, 'bam4': 'required_by', 'bam': None, 'foo': 'required'}]
+         [{'bar': 'good', 'baz': 'good', 'bam1': 'ok', 'bam2': 'test', 'bam3': True, 'bam4': 'required_by', 'bam': None, 'foo': 'required',
+           'bar1': None, 'bar2': None, 'bar3': None, 'bar4': None}]
          ),
         # Check for elements in sub-options
         ({"foobar": [{"foo": "good", "bam": "required_one_of", "bar1": [1, "good", "yes"], "bar2": ['1', 1], "bar3":['1.3', 1.3, 1]}]},
-         [{'foo': 'good', 'bam1': None, 'bam2': 'test', 'bam3': None, 'bar': None, 'baz': None, 'bam': 'required_one_of',
+         [{'foo': 'good', 'bam1': None, 'bam2': 'test', 'bam3': None, 'bam4': None, 'bar': None, 'baz': None, 'bam': 'required_one_of',
            'bar1': ["1", "good", "yes"], 'bar2': [1, 1], 'bar3': [1.3, 1.3, 1.0], 'bar4': None}]
          ),
     )
@@ -377,15 +378,16 @@ class TestComplexOptions:
          ),
         # Check required_by options
         ({"foobar": {"foo": "required", "bar": "good", "baz": "good", "bam4": "required_by", "bam1": "ok", "bam3": "yes"}},
-         {'bar': 'good', 'baz': 'good', 'bam1': 'ok', 'bam2': 'test', 'bam3': True, 'bam4': 'required_by', 'bam': None, 'foo': 'required'}
-        ),
+         {'bar': 'good', 'baz': 'good', 'bam1': 'ok', 'bam2': 'test', 'bam3': True, 'bam4': 'required_by', 'bam': None,
+          'foo': 'required', 'bar1': None, 'bar3': None, 'bar2': None, 'bar4': None}
+         ),
         # Check for elements in sub-options
         ({"foobar": {"foo": "good", "bam": "required_one_of", "bar1": [1, "good", "yes"],
                      "bar2": ['1', 1], "bar3": ['1.3', 1.3, 1]}},
-         {'foo': 'good', 'bam1': None, 'bam2': 'test', 'bam3': None, 'bar': None,
+         {'foo': 'good', 'bam1': None, 'bam2': 'test', 'bam3': None, 'bam4': None, 'bar': None,
           'baz': None, 'bam': 'required_one_of',
           'bar1': ["1", "good", "yes"], 'bar2': [1, 1], 'bar3': [1.3, 1.3, 1.0], 'bar4': None}
-        ),
+         ),
     )
 
     # (Parameters, failure message)

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -49,7 +49,8 @@ VALID_SPECS = (
     # Simple type=bool
     ({'arg': {'type': 'bool'}}, {'arg': True}, True),
     # Simple type=list elements=bool
-    ({'arg': {'type': 'list', 'elements': 'bool'}}, {'arg': [True, 'true', 1, 'yes', False, 'false', 'no', 0]}, [True, True, True, True, False, False, False, False]),
+    ({'arg': {'type': 'list', 'elements': 'bool'}}, {'arg': [True, 'true', 1, 'yes', False, 'false', 'no', 0]},
+     [True, True, True, True, False, False, False, False]),
     # Type=int with conversion from string
     ({'arg': {'type': 'bool'}}, {'arg': 'yes'}, True),
     # Type=str converts to string
@@ -72,7 +73,7 @@ INVALID_SPECS = (
     # Type is int; unable to convert float
     ({'arg': {'type': 'int'}}, {'arg': 42.1}, "'float'> cannot be converted to an int"),
     # Type is list, elements is int; unable to convert float
-    ({'arg': {'type': 'list', 'elements': 'int'}}, {'arg': [42.1, 32,2]}, "'float'> cannot be converted to an int"),
+    ({'arg': {'type': 'list', 'elements': 'int'}}, {'arg': [42.1, 32, 2]}, "'float'> cannot be converted to an int"),
     # type is a callable that fails to convert
     ({'arg': {'type': MOCK_VALIDATOR_FAIL}}, {'arg': "bad"}, "bad conversion"),
     # type is a list, elements is callable that fails to convert
@@ -350,7 +351,6 @@ class TestComplexOptions:
         ({"foobar": [{"foo": "good", "bam": "required_one_of", "bar1": [1, "good", "yes"], "bar2": ['1', 1], "bar3":['1.3', 1.3, 1]}]},
          [{'foo': 'good', 'bam1': None, 'bam2': 'test', 'bam3': None, 'bar': None, 'baz': None, 'bam': 'required_one_of',
            'bar1': ["1", "good", "yes"], 'bar2': [1, 1], 'bar3': [1.3, 1.3, 1.0], 'bar4': None}]
-
          ),
     )
 
@@ -378,10 +378,12 @@ class TestComplexOptions:
         # Check required_by options
         ({"foobar": {"foo": "required", "bar": "good", "baz": "good", "bam4": "required_by", "bam1": "ok", "bam3": "yes"}},
          {'bar': 'good', 'baz': 'good', 'bam1': 'ok', 'bam2': 'test', 'bam3': True, 'bam4': 'required_by', 'bam': None, 'foo': 'required'}
-         ),
+        ),
         # Check for elements in sub-options
-        ({"foobar": {"foo": "good", "bam": "required_one_of", "bar1": [1, "good", "yes"], "bar2": ['1', 1], "bar3":['1.3', 1.3, 1]}},
-         {'foo': 'good', 'bam1': None, 'bam2': 'test', 'bam3': None, 'bar': None, 'baz': None, 'bam': 'required_one_of',
+        ({"foobar": {"foo": "good", "bam": "required_one_of", "bar1": [1, "good", "yes"],
+                     "bar2": ['1', 1], "bar3": ['1.3', 1.3, 1]}},
+         {'foo': 'good', 'bam1': None, 'bam2': 'test', 'bam3': None, 'bar': None,
+          'baz': None, 'bam': 'required_one_of',
           'bar1': ["1", "good", "yes"], 'bar2': [1, 1], 'bar3': [1.3, 1.3, 1.0], 'bar4': None}
         ),
     )
@@ -487,7 +489,9 @@ class TestComplexOptions:
         assert isinstance(am.params['foobar']['baz'], str)
         assert am.params['foobar']['baz'] == 'test data'
 
-    @pytest.mark.parametrize('stdin', [{'foobar': {'foo': 'required', 'bam1': 'test', 'baz': 'data', 'bar': 'case', 'bar4': '~/test'}}], indirect=['stdin'])
+    @pytest.mark.parametrize('stdin',
+                             [{'foobar': {'foo': 'required', 'bam1': 'test', 'baz': 'data', 'bar': 'case', 'bar4': '~/test'}}],
+                             indirect=['stdin'])
     def test_elements_path_in_option(self, mocker, stdin, options_argspec_dict):
         """Test that the complex argspec works with elements path type"""
 

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -19,7 +19,6 @@ from ansible.module_utils.six.moves import builtins
 
 from units.mock.procenv import ModuleTestCase, swap_stdin_and_argv
 
-
 MOCK_VALIDATOR_FAIL = MagicMock(side_effect=TypeError("bad conversion"))
 # Data is argspec, argument, expected
 VALID_SPECS = (
@@ -138,6 +137,7 @@ def options_argspec_dict(options_argspec_list):
     # should test ok, for options in dict format.
     kwargs = options_argspec_list
     kwargs['argument_spec']['foobar']['type'] = 'dict'
+    kwargs['argument_spec']['foobar']['elements'] = None
 
     return kwargs
 

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -24,24 +24,42 @@ MOCK_VALIDATOR_FAIL = MagicMock(side_effect=TypeError("bad conversion"))
 VALID_SPECS = (
     # Simple type=int
     ({'arg': {'type': 'int'}}, {'arg': 42}, 42),
+    # Simple type=list, elements=int
+    ({'arg': {'type': 'list', 'elements': 'int'}}, {'arg': [42, 32]}, [42, 32]),
     # Type=int with conversion from string
     ({'arg': {'type': 'int'}}, {'arg': '42'}, 42),
+    # Type=list elements=int with conversion from string
+    ({'arg': {'type': 'list', 'elements': 'int'}}, {'arg': ['42', '32']}, [42, 32]),
     # Simple type=float
     ({'arg': {'type': 'float'}}, {'arg': 42.0}, 42.0),
+    # Simple type=list, elements=float
+    ({'arg': {'type': 'list', 'elements': 'float'}}, {'arg': [42.1, 32.2]}, [42.1, 32.2]),
     # Type=float conversion from int
     ({'arg': {'type': 'float'}}, {'arg': 42}, 42.0),
+    # type=list, elements=float conversion from int
+    ({'arg': {'type': 'list', 'elements': 'float'}}, {'arg': [42, 32]}, [42.0, 32.0]),
     # Type=float conversion from string
     ({'arg': {'type': 'float'}}, {'arg': '42.0'}, 42.0),
+    # type=list, elements=float conversion from string
+    ({'arg': {'type': 'list', 'elements': 'float'}}, {'arg': ['42.1', '32.2']}, [42.1, 32.2]),
     # Type=float conversion from string without decimal point
     ({'arg': {'type': 'float'}}, {'arg': '42'}, 42.0),
+    # Type=list elements=float conversion from string without decimal point
+    ({'arg': {'type': 'list', 'elements': 'float'}}, {'arg': ['42', '32.2']}, [42.0, 32.2]),
     # Simple type=bool
     ({'arg': {'type': 'bool'}}, {'arg': True}, True),
+    # Simple type=list elements=bool
+    ({'arg': {'type': 'list', 'elements': 'bool'}}, {'arg': [True, 'true', 1, 'yes', False, 'false', 'no', 0]}, [True, True, True, True, False, False, False, False]),
     # Type=int with conversion from string
     ({'arg': {'type': 'bool'}}, {'arg': 'yes'}, True),
     # Type=str converts to string
     ({'arg': {'type': 'str'}}, {'arg': 42}, '42'),
+    # Type=list elements=str simple converts to string
+    ({'arg': {'type': 'list', 'elements': 'str'}}, {'arg': ['42', '32']}, ['42', '32']),
     # Type is implicit, converts to string
     ({'arg': {'type': 'str'}}, {'arg': 42}, '42'),
+    # Type=list elements=str implicit converts to string
+    ({'arg': {'type': 'list', 'elements': 'str'}}, {'arg': [42, 32]}, ['42', '32']),
     # parameter is required
     ({'arg': {'required': True}}, {'arg': 42}, '42'),
 )
@@ -49,10 +67,16 @@ VALID_SPECS = (
 INVALID_SPECS = (
     # Type is int; unable to convert this string
     ({'arg': {'type': 'int'}}, {'arg': "bad"}, "invalid literal for int() with base 10: 'bad'"),
+    # Type is list elements is int; unable to convert this string
+    ({'arg': {'type': 'list', 'elements': 'int'}}, {'arg': [1, "bad"]}, "invalid literal for int() with base 10: 'bad'"),
     # Type is int; unable to convert float
     ({'arg': {'type': 'int'}}, {'arg': 42.1}, "'float'> cannot be converted to an int"),
+    # Type is list, elements is int; unable to convert float
+    ({'arg': {'type': 'list', 'elements': 'int'}}, {'arg': [42.1, 32,2]}, "'float'> cannot be converted to an int"),
     # type is a callable that fails to convert
     ({'arg': {'type': MOCK_VALIDATOR_FAIL}}, {'arg': "bad"}, "bad conversion"),
+    # type is a list, elements is callable that fails to convert
+    ({'arg': {'type': 'list', 'elements': MOCK_VALIDATOR_FAIL}}, {'arg': [1, "bad"]}, "bad conversion"),
     # unknown parameter
     ({'arg': {'type': 'int'}}, {'other': 'bad', '_ansible_module_name': 'ansible_unittest'},
      'Unsupported parameters for (ansible_unittest) module: other Supported parameters include: arg'),
@@ -69,6 +93,7 @@ def complex_argspec():
         bam=dict(),
         baz=dict(fallback=(basic.env_fallback, ['BAZ'])),
         bar1=dict(type='bool'),
+        bar3=dict(type='list', elements='path'),
         zardoz=dict(choices=['one', 'two']),
         zardoz2=dict(type='list', choices=['one', 'two', 'three']),
     )
@@ -91,6 +116,10 @@ def options_argspec_list():
     options_spec = dict(
         foo=dict(required=True, aliases=['dup']),
         bar=dict(),
+        bar1=dict(type='list', elements='str'),
+        bar2=dict(type='list', elements='int'),
+        bar3=dict(type='list', elements='float'),
+        bar4=dict(type='list', elements='path'),
         bam=dict(),
         baz=dict(fallback=(basic.env_fallback, ['BAZ'])),
         bam1=dict(),
@@ -278,6 +307,14 @@ class TestComplexArgSpecs:
         assert isinstance(am.params['zardoz2'], list)
         assert am.params['zardoz2'] == ['one', 'three']
 
+    @pytest.mark.parametrize('stdin', [{'foo': 'hello', 'bar3': ['~/test', 'test/']}], indirect=['stdin'])
+    def test_list_with_elements_path(self, capfd, mocker, stdin, complex_argspec):
+        """Test choices with list"""
+        am = basic.AnsibleModule(**complex_argspec)
+        assert isinstance(am.params['bar3'], list)
+        assert am.params['bar3'][0].startswith('/')
+        assert am.params['bar3'][1] == 'test/'
+
 
 class TestComplexOptions:
     """Test arg spec options"""
@@ -285,48 +322,68 @@ class TestComplexOptions:
     # (Parameters, expected value of module.params['foobar'])
     OPTIONS_PARAMS_LIST = (
         ({'foobar': [{"foo": "hello", "bam": "good"}, {"foo": "test", "bar": "good"}]},
-         [{'foo': 'hello', 'bam': 'good', 'bam2': 'test', 'bar': None, 'baz': None, 'bam1': None, 'bam3': None, 'bam4': None},
-          {'foo': 'test', 'bam': None, 'bam2': 'test', 'bar': 'good', 'baz': None, 'bam1': None, 'bam3': None, 'bam4': None},
-          ]),
+         [{'foo': 'hello', 'bam': 'good', 'bam2': 'test', 'bar': None, 'baz': None, 'bam1': None, 'bam3': None, 'bam4': None,
+           'bar1': None, 'bar2': None, 'bar3': None, 'bar4': None},
+          {'foo': 'test', 'bam': None, 'bam2': 'test', 'bar': 'good', 'baz': None, 'bam1': None, 'bam3': None, 'bam4': None,
+           'bar1': None, 'bar2': None, 'bar3': None, 'bar4': None}]
+         ),
         # Alias for required param
         ({'foobar': [{"dup": "test", "bar": "good"}]},
-         [{'foo': 'test', 'dup': 'test', 'bam': None, 'bam2': 'test', 'bar': 'good', 'baz': None, 'bam1': None, 'bam3': None, 'bam4': None}]
+         [{'foo': 'test', 'dup': 'test', 'bam': None, 'bam2': 'test', 'bar': 'good', 'baz': None, 'bam1': None, 'bam3': None, 'bam4': None,
+           'bar1': None, 'bar2': None, 'bar3': None, 'bar4': None}]
          ),
         # Required_if utilizing default value of the requirement
         ({'foobar': [{"foo": "bam2", "bar": "required_one_of"}]},
-         [{'bam': None, 'bam1': None, 'bam2': 'test', 'bam3': None, 'bam4': None, 'bar': 'required_one_of', 'baz': None, 'foo': 'bam2'}]
+         [{'bam': None, 'bam1': None, 'bam2': 'test', 'bam3': None, 'bam4': None, 'bar': 'required_one_of', 'baz': None, 'foo': 'bam2',
+           'bar1': None, 'bar2': None, 'bar3': None, 'bar4': None}]
          ),
         # Check that a bool option is converted
         ({"foobar": [{"foo": "required", "bam": "good", "bam3": "yes"}]},
-         [{'bam': 'good', 'bam1': None, 'bam2': 'test', 'bam3': True, 'bam4': None, 'bar': None, 'baz': None, 'foo': 'required'}]
+         [{'bam': 'good', 'bam1': None, 'bam2': 'test', 'bam3': True, 'bam4': None, 'bar': None, 'baz': None, 'foo': 'required',
+           'bar1': None, 'bar2': None, 'bar3': None, 'bar4': None}]
          ),
         # Check required_by options
         ({"foobar": [{"foo": "required", "bar": "good", "baz": "good", "bam4": "required_by", "bam1": "ok", "bam3": "yes"}]},
          [{'bar': 'good', 'baz': 'good', 'bam1': 'ok', 'bam2': 'test', 'bam3': True, 'bam4': 'required_by', 'bam': None, 'foo': 'required'}]
+         ),
+        # Check for elements in sub-options
+        ({"foobar": [{"foo": "good", "bam": "required_one_of", "bar1": [1, "good", "yes"], "bar2": ['1', 1], "bar3":['1.3', 1.3, 1]}]},
+         [{'foo': 'good', 'bam1': None, 'bam2': 'test', 'bam3': None, 'bar': None, 'baz': None, 'bam': 'required_one_of',
+           'bar1': ["1", "good", "yes"], 'bar2': [1, 1], 'bar3': [1.3, 1.3, 1.0], 'bar4': None}]
+
          ),
     )
 
     # (Parameters, expected value of module.params['foobar'])
     OPTIONS_PARAMS_DICT = (
         ({'foobar': {"foo": "hello", "bam": "good"}},
-         {'foo': 'hello', 'bam': 'good', 'bam2': 'test', 'bar': None, 'baz': None, 'bam1': None, 'bam3': None, 'bam4': None}
+         {'foo': 'hello', 'bam': 'good', 'bam2': 'test', 'bar': None, 'baz': None, 'bam1': None, 'bam3': None, 'bam4': None,
+          'bar1': None, 'bar2': None, 'bar3': None, 'bar4': None}
          ),
         # Alias for required param
         ({'foobar': {"dup": "test", "bar": "good"}},
-         {'foo': 'test', 'dup': 'test', 'bam': None, 'bam2': 'test', 'bar': 'good', 'baz': None, 'bam1': None, 'bam3': None, 'bam4': None}
+         {'foo': 'test', 'dup': 'test', 'bam': None, 'bam2': 'test', 'bar': 'good', 'baz': None, 'bam1': None, 'bam3': None, 'bam4': None,
+          'bar1': None, 'bar2': None, 'bar3': None, 'bar4': None}
          ),
         # Required_if utilizing default value of the requirement
         ({'foobar': {"foo": "bam2", "bar": "required_one_of"}},
-         {'bam': None, 'bam1': None, 'bam2': 'test', 'bam3': None, 'bam4': None, 'bar': 'required_one_of', 'baz': None, 'foo': 'bam2'}
+         {'bam': None, 'bam1': None, 'bam2': 'test', 'bam3': None, 'bam4': None, 'bar': 'required_one_of', 'baz': None, 'foo': 'bam2',
+          'bar1': None, 'bar2': None, 'bar3': None, 'bar4': None}
          ),
         # Check that a bool option is converted
         ({"foobar": {"foo": "required", "bam": "good", "bam3": "yes"}},
-         {'bam': 'good', 'bam1': None, 'bam2': 'test', 'bam3': True, 'bam4': None, 'bar': None, 'baz': None, 'foo': 'required'}
+         {'bam': 'good', 'bam1': None, 'bam2': 'test', 'bam3': True, 'bam4': None, 'bar': None, 'baz': None, 'foo': 'required',
+          'bar1': None, 'bar2': None, 'bar3': None, 'bar4': None}
          ),
         # Check required_by options
         ({"foobar": {"foo": "required", "bar": "good", "baz": "good", "bam4": "required_by", "bam1": "ok", "bam3": "yes"}},
          {'bar': 'good', 'baz': 'good', 'bam1': 'ok', 'bam2': 'test', 'bam3': True, 'bam4': 'required_by', 'bam': None, 'foo': 'required'}
          ),
+        # Check for elements in sub-options
+        ({"foobar": {"foo": "good", "bam": "required_one_of", "bar1": [1, "good", "yes"], "bar2": ['1', 1], "bar3":['1.3', 1.3, 1]}},
+         {'foo': 'good', 'bam1': None, 'bam2': 'test', 'bam3': None, 'bar': None, 'baz': None, 'bam': 'required_one_of',
+          'bar1': ["1", "good", "yes"], 'bar2': [1, 1], 'bar3': [1.3, 1.3, 1.0], 'bar4': None}
+        ),
     )
 
     # (Parameters, failure message)
@@ -429,6 +486,15 @@ class TestComplexOptions:
 
         assert isinstance(am.params['foobar']['baz'], str)
         assert am.params['foobar']['baz'] == 'test data'
+
+    @pytest.mark.parametrize('stdin', [{'foobar': {'foo': 'required', 'bam1': 'test', 'baz': 'data', 'bar': 'case', 'bar4': '~/test'}}], indirect=['stdin'])
+    def test_elements_path_in_option(self, mocker, stdin, options_argspec_dict):
+        """Test that the complex argspec works with elements path type"""
+
+        am = basic.AnsibleModule(**options_argspec_dict)
+
+        assert isinstance(am.params['foobar']['bar4'][0], str)
+        assert am.params['foobar']['bar4'][0].startswith('/')
 
     @pytest.mark.parametrize('stdin,spec,expected', [
         ({},


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #48473

*  Add support to validate the elements value in argspec
   when type is `list`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/basic.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
