### PR TITLE
iosxr_interface: changed interface config blocks parsing logic

### DIFF
--- a/lib/ansible/modules/network/iosxr/iosxr_interface.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_interface.py
@@ -297,14 +297,18 @@ class CliConfiguration(ConfigBase):
 
     def map_config_to_obj(self):
         data = get_config(self._module, config_filter='interface')
-        interfaces = data.strip().rstrip('!').split('!')
+        data_lines = data.splitlines()
+        start_indexes = [i for i, e in enumerate(data_lines) if e.startswith('interface')]
+        end_indexes = [i for i, e in enumerate(data_lines) if e == '!']
 
-        if not interfaces:
+        intf_configs = list()
+        for start_index, end_index in zip(start_indexes, end_indexes):
+            intf_configs.append([i.strip() for i in data_lines[start_index:end_index]])
+
+        if not intf_configs:
             return list()
 
-        for interface in interfaces:
-            intf_config = interface.strip().splitlines()
-
+        for intf_config in intf_configs:
             name = intf_config[0].strip().split()[1]
 
             active = 'act'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changed current logic of splitting 'show running-config interface' into interface config blocks since it worked incorrectly for following configuation examples:

**example ASR config**
```
interface TenGigE0/0/0/12
 bundle id 2 mode passive
 cdp
 lacp period short
 load-interval 30
 ethernet oam
  profile oam_test1
 !
!
interface TenGigE0/0/0/13
 cdp
!
! #eMS
interface FortyGigE0/7/1/0
 bundle id 200 mode passive
 cdp
 lacp period short
 load-interval 30
!
interface FortyGigE0/7/1/1
 bundle id 100 mode passive
 cdp
 lacp period short
 ! mtu 9018
 load-interval 30
!

```

changed the logic to rely on not just splitting by '!', but to rely on:
- line starts with 'interface'
- line is equal to '!'

P.S.: lines
! #eMS
and 
 ! mtu 9018
seems to be a cosmetic bug of IOS-XR.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iosxr_interface

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**current**
```paste below
interfaces = data.strip().rstrip('!').split('!')
for interface in interfaces:
    intf_config = interface.strip().splitlines()
    print intf_config
    
['interface TenGigE0/0/0/12', ' bundle id 2 mode passive', ' cdp', ' lacp period short', ' load-interval 30', ' ethernet oam', '  profile oam_test1']
[]
['interface TenGigE0/0/0/13', ' cdp']
[]
['#eMS', 'interface FortyGigE0/7/1/0', ' bundle id 200 mode passive', ' cdp', ' lacp period short', ' load-interval 30']
['interface FortyGigE0/7/1/1', ' bundle id 100 mode passive', ' cdp', ' lacp period short']
['mtu 9018', ' load-interval 30']

```

**changed**
```
data_lines = data.splitlines()
start_indexes = [i for i, e in enumerate(data_lines) if e.startswith('interface')]
end_indexes = [i for i, e in enumerate(data_lines) if e == '!']
intf_configs = list()
for start_index, end_index in zip(start_indexes, end_indexes):
    intf_configs.append([i.strip() for i in data_lines[start_index:end_index]])
    print intf_configs[-1]
    
['interface TenGigE0/0/0/12', 'bundle id 2 mode passive', 'cdp', 'lacp period short', 'load-interval 30', 'ethernet oam', 'profile oam_test1', '!']
['interface TenGigE0/0/0/13', 'cdp']
['interface FortyGigE0/7/1/0', 'bundle id 200 mode passive', 'cdp', 'lacp period short', 'load-interval 30']
['interface FortyGigE0/7/1/1', 'bundle id 100 mode passive', 'cdp', 'lacp period short', '! mtu 9018', 'load-interval 30']

```
