### PR TITLE
Add AIX support to reboot module

### DIFF
--- a/changelogs/fragments/reboot-add-aix-support.yml
+++ b/changelogs/fragments/reboot-add-aix-support.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - reboot - add support for rebooting AIX (https://github.com/ansible/ansible/issues/49712)

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -46,6 +46,7 @@ class ActionModule(ActionBase):
         'solaris': 'who -b',
         'sunos': 'who -b',
         'vmkernel': 'grep booted /var/log/vmksummary.log | tail -n 1',
+        'aix': 'who -b',
     }
 
     SHUTDOWN_COMMANDS = {
@@ -62,6 +63,7 @@ class ActionModule(ActionBase):
         'solaris': '-y -g {delay_sec} -i 6 "{message}"',
         'sunos': '-y -g {delay_sec} -i 6 "{message}"',
         'vmkernel': '-d {delay_sec}',
+        'aix': '-Fr',
     }
 
     TEST_COMMANDS = {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently no AIX support for the reboot module as mentioned in #49712. Added correct params.

Fixes #49712
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
reboot
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
