### PR TITLE
openssl_csr: idempotency doesn't work correctly for keyUsage

### DIFF
--- a/changelogs/fragments/50361-openssl_csr-idempotency.yml
+++ b/changelogs/fragments/50361-openssl_csr-idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_csr - fix problem with idempotency of keyUsage option."

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -456,7 +456,18 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
                 return set(current) == set(expected) and usages_ext[0].get_critical() == critical
 
         def _check_keyUsage(extensions):
-            return _check_keyUsage_(extensions, b'keyUsage', self.keyUsage, self.keyUsage_critical)
+            usages_ext = [ext for ext in extensions if ext.get_short_name() == b'keyUsage']
+            if (not usages_ext and self.keyUsage) or (usages_ext and not self.keyUsage):
+                return False
+            elif not usages_ext and not self.keyUsage:
+                return True
+            else:
+                # OpenSSL._util.lib.OBJ_txt2nid() always returns 0 for all keyUsage values
+                # (since keyUsage has a fixed bitfield for these values and is not extensible).
+                # Therefore, we create an extension for the wanted values, and compare the
+                # data of the extensions (which is the serialized bitfield).
+                expected_ext = crypto.X509Extension(b"keyUsage", False, ', '.join(self.keyUsage).encode('ascii'))
+                return usages_ext[0].get_data() == expected_ext.get_data() and usages_ext[0].get_critical() == self.keyUsage_critical
 
         def _check_extenededKeyUsage(extensions):
             return _check_keyUsage_(extensions, b'extendedKeyUsage', self.extendedKeyUsage, self.extendedKeyUsage_critical)

--- a/test/integration/targets/openssl_csr/tasks/main.yml
+++ b/test/integration/targets/openssl_csr/tasks/main.yml
@@ -4,12 +4,39 @@
       openssl_privatekey:
         path: '{{ output_dir }}/privatekey.pem'
 
+    - name: Generate CSR (check mode)
+      openssl_csr:
+        path: '{{ output_dir }}/csr.csr'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+        subject:
+          commonName: www.ansible.com
+      check_mode: yes
+      register: generate_csr_check
+
     - name: Generate CSR
       openssl_csr:
         path: '{{ output_dir }}/csr.csr'
         privatekey_path: '{{ output_dir }}/privatekey.pem'
         subject:
           commonName: www.ansible.com
+      register: generate_csr
+
+    - name: Generate CSR (idempotent)
+      openssl_csr:
+        path: '{{ output_dir }}/csr.csr'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+        subject:
+          commonName: www.ansible.com
+      register: generate_csr_check_idempotent
+
+    - name: Generate CSR (idempotent, check mode)
+      openssl_csr:
+        path: '{{ output_dir }}/csr.csr'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+        subject:
+          commonName: www.ansible.com
+      check_mode: yes
+      register: generate_csr_check_idempotent_check
 
     # keyUsage longname and shortname should be able to be used
     # interchangeably. Hence the long name is specified here
@@ -37,14 +64,43 @@
         subject:
           commonName: 'www.ansible.com'
         keyUsage:
+          - Key Agreement
           - digitalSignature
-          - keyAgreement
         extendedKeyUsage:
           - ipsecUser
           - qcStatements
           - DVCS
           - Biometric Info
       register: csr_ku_xku
+
+    - name: Generate CSR with KU and XKU (test XKU change)
+      openssl_csr:
+        path: '{{ output_dir }}/csr_ku_xku.csr'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+        subject:
+          commonName: 'www.ansible.com'
+        keyUsage:
+          - digitalSignature
+          - keyAgreement
+        extendedKeyUsage:
+          - ipsecUser
+          - qcStatements
+          - Biometric Info
+      register: csr_ku_xku_change
+
+    - name: Generate CSR with KU and XKU (test KU change)
+      openssl_csr:
+        path: '{{ output_dir }}/csr_ku_xku.csr'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+        subject:
+          commonName: 'www.ansible.com'
+        keyUsage:
+          - digitalSignature
+        extendedKeyUsage:
+          - ipsecUser
+          - qcStatements
+          - Biometric Info
+      register: csr_ku_xku_change_2
 
     - name: Generate CSR with old API
       openssl_csr:

--- a/test/integration/targets/openssl_csr/tests/validate.yml
+++ b/test/integration/targets/openssl_csr/tests/validate.yml
@@ -17,10 +17,20 @@
       - csr_cn.stdout.split('=')[-1] == 'www.ansible.com'
       - csr_modulus.stdout == privatekey_modulus.stdout
 
-- name: Validate CSR_KU_XKU (assert idempotency)
+- name: Validate CSR (check mode, idempotency)
+  assert:
+    that:
+      - generate_csr_check is changed
+      - generate_csr is changed
+      - generate_csr_check_idempotent is not changed
+      - generate_csr_check_idempotent_check is not changed
+
+- name: Validate CSR_KU_XKU (assert idempotency, change)
   assert:
     that:
       - csr_ku_xku is not changed
+      - csr_ku_xku_change is changed
+      - csr_ku_xku_change_2 is changed
 
 - name: Validate old_API CSR (test - Common Name)
   shell: "openssl req -noout -subject -in {{ output_dir }}/csr_oldapi.csr -nameopt oneline,-space_eq"


### PR DESCRIPTION
##### SUMMARY
The idempotency check for keyUsage can only distinguish between no keyUsage specified, and something specified as keyUsage. The problem is that the given values (extension and keyUsage module option) are converted to NIDs via `OpenSSL._util.lib.OBJ_txt2nid()`, which returns 0 for all valid keyUsage values. So the resulting integer sets are either empty, or consist of a single entry 0.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_csr
