### PR TITLE
(action/script) Fix windows absolute path detection

### DIFF
--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -66,7 +66,7 @@ class ActionModule(ActionBase):
             if chdir:
                 # Powershell is the only Windows-path aware shell
                 if self._connection._shell.SHELL_FAMILY == 'powershell' and \
-                        not self.windows_absolute_path_detection.matches(chdir):
+                        not self.windows_absolute_path_detection.match(chdir):
                     raise AnsibleActionFail('chdir %s must be an absolute path for a Windows remote node' % chdir)
                 # Every other shell is unix-path-aware.
                 if self._connection._shell.SHELL_FAMILY != 'powershell' and not chdir.startswith('/'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Script action plugin uses invalid regex method to detect windows absolute paths.
Should use 'match()' instead of 'matches()'.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugin/action/script.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
