### PR TITLE
ec2_elb module Python 3 Compat

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_elb.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb.py
@@ -274,7 +274,7 @@ class ElbManager:
                 break
 
         if ec2_elbs:
-            lbs = sorted(lb for lb in elbs if lb.name in ec2_elbs)
+            lbs = sorted([lb for lb in elbs if lb.name in ec2_elbs], key=lambda lb: lb.__repr__())
         else:
             lbs = []
             for lb in elbs:


### PR DESCRIPTION
Python 3 sort() does not benefits automatic
typecast of objects into a string (as Python27
does).

Use a lambda to help the function sort the list
with `__repr__`

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When using this module on python3, it fails to sort() the LB objects that boto returns.

On python2, the automatic type casting was used during cmp was calling `__repr__` to cast as a string, then using `__lt__` to perform the operator comparison

I'm proposing to ensure compatibility between the two python versions by passing a lambda in kwargs. It uses the `__repr__` to fallback to string comparison.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_elb

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1/ have an ASG or two in you AWS account
2/ try to unregister an instance from it using ec2_elb module (https://docs.ansible.com/ansible/latest/modules/ec2_elb_module.html#id5 example here)
3/ enjoy failure (TypeError: '<' not supported between instances of 'LoadBalancer' and 'LoadBalancer')

