### PR TITLE
Add support for filtering using instance labels

### DIFF
--- a/contrib/inventory/gce.py
+++ b/contrib/inventory/gce.py
@@ -38,6 +38,7 @@ based on the data obtained from the libcloud Node object:
  - gce_status
  - gce_zone
  - gce_tags
+ - gce_labels
  - gce_metadata
  - gce_network
  - gce_subnetwork
@@ -49,6 +50,10 @@ When run in --list mode, instances are grouped by the following categories:
    An entry is created for each tag.  For example, if you have two instances
    with a common tag called 'foo', they will both be grouped together under
    the 'tag_foo' name.
+ - instance labels:
+   An entry is created for each label plus value.  For example, if you have two instances
+   with a common label called 'foo' and value 'bar', they will both be grouped together under
+   the 'label_foo_value_bar' name.
  - network name:
    the name of the network is appended to 'network_' (e.g. the 'default'
    network will result in a group named 'network_default')
@@ -392,6 +397,7 @@ class GceInventory(object):
             'gce_status': inst.extra['status'],
             'gce_zone': inst.extra['zone'].name,
             'gce_tags': inst.extra['tags'],
+            'gce_labels': inst.extra['labels'],
             'gce_metadata': md,
             'gce_network': net,
             'gce_subnetwork': subnet,
@@ -484,6 +490,15 @@ class GceInventory(object):
                     groups[tag].append(name)
                 else:
                     groups[tag] = [name]
+
+            labels = node.extra['labels']
+            if labels is not None:
+                for k, v in labels.items():
+                    label = 'label_%s_value_%s' % (k, v)
+                    if label in groups:
+                        groups[label].append(name)
+                    else:
+                        groups[label] = [name]
 
             net = node.extra['networkInterfaces'][0]['network'].split('/')[-1]
             net = 'network_%s' % net


### PR DESCRIPTION
##### SUMMARY
Currently, ansible only supports filters using GCE instance network tag. This pull request adds support for GCE instance labels.
All instances will be grouped like label_KEY_value_VALUE. Very similar on what we have on ec2 already and tags on gce.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gce.py

##### ADDITIONAL INFORMATION
Add label with key foo and with value bar at one instance. Run ansible:
```
ansible -m ping label_foo_value_bar
my-test-instance | SUCCESS => {
    "changed": false, 
    "ping": "pong"
}
```