### PR TITLE
Support non-launchconfig-based auto-scaling groups

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
@@ -170,7 +170,7 @@ min_size:
 mixed_instances_policy:
     description: >
       Object containing data about the mixed instance policy for the ASG. Only returned if the ASG is
-    based on a MixedInstancesPolicy
+      based on a MixedInstancesPolicy
     returned: success
     type: complex
 new_instances_protected_from_scale_in:

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
@@ -152,6 +152,7 @@ launch_template:
       based on a LaunchTemplate
     returned: success
     type: complex
+    sample: None
 load_balancer_names:
     description: List of load balancers names attached to the ASG.
     returned: success
@@ -173,6 +174,7 @@ mixed_instances_policy:
       based on a MixedInstancesPolicy
     returned: success
     type: complex
+    sample: None
 new_instances_protected_from_scale_in:
     description: Whether or not new instances a protected from automatic scaling in.
     returned: success

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
@@ -140,7 +140,9 @@ launch_config_name:
     type: str
     sample: "public-webapp-production-1"
 launch_configuration_name:
-    description: Name of launch configuration associated with the ASG.
+    description: > 
+      Name of launch configuration associated with the ASG. Only returned if the ASG is based on
+      a Launch Configuration (not LaunchTemplate or MixedInstancesPolicy)
     returned: success
     type: str
     sample: "public-webapp-production-1"
@@ -289,9 +291,11 @@ def find_asgs(conn, module, name=None, tags=None):
                 ],
                 "launch_config_name": "public-webapp-production-1",
                 "launch_configuration_name": "public-webapp-production-1",
+                "launch_template": {}",
                 "load_balancer_names": ["public-webapp-production-lb"],
                 "max_size": 4,
                 "min_size": 2,
+                "mixed_instances_policy: {}"
                 "new_instances_protected_from_scale_in": false,
                 "placement_group": None,
                 "status": None,
@@ -362,8 +366,9 @@ def find_asgs(conn, module, name=None, tags=None):
 
         if matched_name and matched_tags:
             asg = camel_dict_to_snake_dict(asg)
-            # compatibility with ec2_asg module
-            asg['launch_config_name'] = asg['launch_configuration_name']
+            if asg.get('launch_configuration_name'):
+                # compatibility with ec2_asg module
+                asg['launch_config_name'] = asg['launch_configuration_name']
             # workaround for https://github.com/ansible/ansible/pull/25015
             if 'target_group_ar_ns' in asg:
                 asg['target_group_arns'] = asg['target_group_ar_ns']

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
@@ -152,7 +152,7 @@ launch_template:
       based on a LaunchTemplate
     returned: success
     type: complex
-    sample: None
+    contains: None
 load_balancer_names:
     description: List of load balancers names attached to the ASG.
     returned: success
@@ -174,7 +174,7 @@ mixed_instances_policy:
       based on a MixedInstancesPolicy
     returned: success
     type: complex
-    sample: None
+    contains: None
 new_instances_protected_from_scale_in:
     description: Whether or not new instances a protected from automatic scaling in.
     returned: success

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
@@ -149,7 +149,7 @@ launch_configuration_name:
 launch_template:
     description: >
       Object containing data about the launch template for the ASG. Only returned if the ASG is
-    based on a LaunchTemplate
+      based on a LaunchTemplate
     returned: success
     type: complex
 load_balancer_names:

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_facts.py
@@ -140,12 +140,18 @@ launch_config_name:
     type: str
     sample: "public-webapp-production-1"
 launch_configuration_name:
-    description: > 
+    description: >
       Name of launch configuration associated with the ASG. Only returned if the ASG is based on
       a Launch Configuration (not LaunchTemplate or MixedInstancesPolicy)
     returned: success
     type: str
     sample: "public-webapp-production-1"
+launch_template:
+    description: >
+      Object containing data about the launch template for the ASG. Only returned if the ASG is
+    based on a LaunchTemplate
+    returned: success
+    type: complex
 load_balancer_names:
     description: List of load balancers names attached to the ASG.
     returned: success
@@ -161,6 +167,12 @@ min_size:
     returned: success
     type: int
     sample: 1
+mixed_instances_policy:
+    description: >
+      Object containing data about the mixed instance policy for the ASG. Only returned if the ASG is
+    based on a MixedInstancesPolicy
+    returned: success
+    type: complex
 new_instances_protected_from_scale_in:
     description: Whether or not new instances a protected from automatic scaling in.
     returned: success


### PR DESCRIPTION
##### SUMMARY
Fixes #47528

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_asg_facts

##### ADDITIONAL INFORMATION
This PR fixes the bug where the ec2_asg_facts module would throw an exception when encountering ASGs not based on launch configs (an asg can also be based on a LaunchTemplate or MixedInstancesPolicy). 
