### PR TITLE
check if device path is a symbolic link

### DIFF
--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -372,8 +372,13 @@ def get_unlabeled_device_info(device, unit):
     parted cannot work because of a missing label. It always returns a 'unknown'
     label.
     """
-    device_name = os.path.basename(device)
-    base = "/sys/block/%s" % device_name
+    if os.path.islink(device):
+        devicelink = os.readlink(device)
+        device_name = os.path.basename(devicelink)
+        base = "/sys/block/%s" % device_name
+    else:
+        device_name = os.path.basename(device)
+        base = "/sys/block/%s" % device_name
 
     vendor = read_record(base + "/device/vendor", "Unknown")
     model = read_record(base + "/device/model", "model")

--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -375,10 +375,9 @@ def get_unlabeled_device_info(device, unit):
     if os.path.islink(device):
         devicelink = os.readlink(device)
         device_name = os.path.basename(devicelink)
-        base = "/sys/block/%s" % device_name
     else:
         device_name = os.path.basename(device)
-        base = "/sys/block/%s" % device_name
+    base = "/sys/block/%s" % device_name
 
     vendor = read_record(base + "/device/vendor", "Unknown")
     model = read_record(base + "/device/model", "model")


### PR DESCRIPTION
multipath device is a symbolic link, for this kind of situation function get_unlabeled_device_info can not get right info

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Issue https://github.com/ansible/ansible/issues/31266 opened for this, but closed without fix.
```
