### PR TITLE
Parse correctly header of RabbitMQ 3.7.9 responses

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
@@ -174,11 +174,13 @@ class RabbitMqUser(object):
 
     def _get_permissions(self):
         """Get permissions of the user from RabbitMQ."""
-        perms_out = [perm for perm in self._exec(['list_user_permissions', self.username], True) if perm.strip()]
+        perms_out = [perm.split('\t') for perm in self._exec(['list_user_permissions', self.username], True)
+                     if perm.strip()]
+        # Filter out headers from the output of the command
+        perms_out = [perm for perm in perms_out if perm != ["vhost", "configure", "write", "read"]]
 
         perms_list = list()
-        for perm in perms_out:
-            vhost, configure_priv, write_priv, read_priv = perm.split('\t')
+        for vhost, configure_priv, write_priv, read_priv in perms_out:
             if not self.bulk_permissions:
                 if vhost == self.permissions[0]['vhost']:
                     perms_list.append(dict(vhost=vhost, configure_priv=configure_priv,


### PR DESCRIPTION
##### SUMMARY
Added a filter to throw out header returned in user permissions query in RabbitMQ 3.7.9 and test to validate correct behavior

Fixes #48890, addresses final part of #29281

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py

##### ADDITIONAL INFORMATION
-
