### PR TITLE
Disable mysql_db

### DIFF
--- a/test/integration/targets/mysql_db/aliases
+++ b/test/integration/targets/mysql_db/aliases
@@ -1,3 +1,4 @@
+unstable
 destructive
 shippable/posix/group1
 skip/osx


### PR DESCRIPTION
##### SUMMARY

Failing due to
```
rpm -qp --requires /tmp/dnf.cache/updates-0b4cc238d1aa4ffe/packages/mariadb-rocksdb-engine-10.3.11-1.fc29.x86_64.rpm | fgrep python2
/usr/bin/python2
```

##### ISSUE TYPE
- Bugfix Pull Request
