### PR TITLE
Remove unnecessary workaround for Python 2.6 OrderedDict

### DIFF
--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -80,6 +80,7 @@ DOCUMENTATION = '''
 import os
 import time
 import re
+from collections import OrderedDict
 
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.plugins.callback import CallbackBase
@@ -89,16 +90,6 @@ try:
     HAS_JUNIT_XML = True
 except ImportError:
     HAS_JUNIT_XML = False
-
-try:
-    from collections import OrderedDict
-    HAS_ORDERED_DICT = True
-except ImportError:
-    try:
-        from ordereddict import OrderedDict
-        HAS_ORDERED_DICT = True
-    except ImportError:
-        HAS_ORDERED_DICT = False
 
 
 class CallbackModule(CallbackBase):
@@ -166,12 +157,7 @@ class CallbackModule(CallbackBase):
             self._display.warning('The `junit_xml` python module is not installed. '
                                   'Disabling the `junit` callback plugin.')
 
-        if HAS_ORDERED_DICT:
-            self._task_data = OrderedDict()
-        else:
-            self.disabled = True
-            self._display.warning('The `ordereddict` python module is not installed. '
-                                  'Disabling the `junit` callback plugin.')
+        self._task_data = OrderedDict()
 
         if not os.path.exists(self._output_dir):
             os.makedirs(self._output_dir)

--- a/test/runner/requirements/integration.txt
+++ b/test/runner/requirements/integration.txt
@@ -1,6 +1,5 @@
 cryptography
 jinja2
 junit-xml
-ordereddict ; python_version < '2.7'
 paramiko
 pyyaml


### PR DESCRIPTION
`collections.OrderedDict` has been available since Python 2.7. Support for Python 2.6 was removed from Ansible in commit ccf41bb2feb602f611d73ff999e89e27fe8bc9bb. Remove all workarounds.

https://docs.python.org/3/library/collections.html#collections.OrderedDict