### PR TITLE
Restrict search to filesystem of root search path

### DIFF
--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -107,6 +107,11 @@ options:
               to false will override this value, which is effectively depth 1.
               Default is unlimited depth.
         version_added: "2.6"
+    noxfs:
+        description:
+            - If true, filesystem boundaries will not be crossed.
+        type: bool
+        default: False
 notes:
     - For Windows targets, use the M(win_find) module instead.
 '''
@@ -363,6 +368,7 @@ def main():
             get_checksum=dict(type='bool', default='no'),
             use_regex=dict(type='bool', default='no'),
             depth=dict(type='int', default=None),
+            noxfs=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
     )
@@ -408,6 +414,10 @@ def main():
                     if depth > params['depth']:
                         del(dirs[:])
                         continue
+                if params['noxfs']:
+                    if root!=npath and os.path.ismount(os.path.normpath(root)):
+                        continue
+
                 looked = looked + len(files) + len(dirs)
                 for fsobj in (files + dirs):
                     fsname = os.path.normpath(os.path.join(root, fsobj))

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -415,7 +415,7 @@ def main():
                         del(dirs[:])
                         continue
                 if params['noxfs']:
-                    if root!=npath and os.path.ismount(os.path.normpath(root)):
+                    if root != npath and os.path.ismount(os.path.normpath(root)):
                         continue
 
                 looked = looked + len(files) + len(dirs)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
GNU findutils find command allows to restrict a search to a single filesystem using the "xdev" flag. Ansible's find module should offer the same feature.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes  #50389 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
find
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
