### PR TITLE
If product_name is set to OEM message read board name instead

### DIFF
--- a/changelogs/fragments/board-name-if-product-oem.yaml
+++ b/changelogs/fragments/board-name-if-product-oem.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-    - if product_name is set to "To be filled by O.E.M." read board_name instead
+    - Off-the-shelf motherboards may have product_name set to "To be filled by O.E.M.". Add board_name to linux hardware facts as an alternative.

--- a/changelogs/fragments/board-name-if-product-oem.yaml
+++ b/changelogs/fragments/board-name-if-product-oem.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - if product_name is set to "To be filled by O.E.M." read board_name instead

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -298,6 +298,8 @@ class LinuxHardware(Hardware):
                             dmi_facts['form_factor'] = FORM_FACTOR[int(data)]
                         except IndexError:
                             dmi_facts['form_factor'] = 'unknown (%s)' % data
+                    elif key == 'product_name' and 'To be filled by O.E.M.' in data:
+                        dmi_facts[key] = get_file_content(path.replace('product', 'board'))
                     else:
                         dmi_facts[key] = data
                 else:

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -284,6 +284,7 @@ class LinuxHardware(Hardware):
                 'bios_version': '/sys/devices/virtual/dmi/id/bios_version',
                 'form_factor': '/sys/devices/virtual/dmi/id/chassis_type',
                 'product_name': '/sys/devices/virtual/dmi/id/product_name',
+                'board_name': '/sys/devices/virtual/dmi/id/board_name',
                 'product_serial': '/sys/devices/virtual/dmi/id/product_serial',
                 'product_uuid': '/sys/devices/virtual/dmi/id/product_uuid',
                 'product_version': '/sys/devices/virtual/dmi/id/product_version',
@@ -298,8 +299,6 @@ class LinuxHardware(Hardware):
                             dmi_facts['form_factor'] = FORM_FACTOR[int(data)]
                         except IndexError:
                             dmi_facts['form_factor'] = 'unknown (%s)' % data
-                    elif key == 'product_name' and 'To be filled by O.E.M.' in data:
-                        dmi_facts[key] = get_file_content(path.replace('product', 'board'))
                     else:
                         dmi_facts[key] = data
                 else:
@@ -313,6 +312,7 @@ class LinuxHardware(Hardware):
                 'bios_version': 'bios-version',
                 'form_factor': 'chassis-type',
                 'product_name': 'system-product-name',
+                'board_name': 'baseboard-product-name',
                 'product_serial': 'system-serial-number',
                 'product_uuid': 'system-uuid',
                 'product_version': 'system-version',

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -282,9 +282,9 @@ class LinuxHardware(Hardware):
             DMI_DICT = {
                 'bios_date': '/sys/devices/virtual/dmi/id/bios_date',
                 'bios_version': '/sys/devices/virtual/dmi/id/bios_version',
+                'board_name': '/sys/devices/virtual/dmi/id/board_name',
                 'form_factor': '/sys/devices/virtual/dmi/id/chassis_type',
                 'product_name': '/sys/devices/virtual/dmi/id/product_name',
-                'board_name': '/sys/devices/virtual/dmi/id/board_name',
                 'product_serial': '/sys/devices/virtual/dmi/id/product_serial',
                 'product_uuid': '/sys/devices/virtual/dmi/id/product_uuid',
                 'product_version': '/sys/devices/virtual/dmi/id/product_version',
@@ -310,9 +310,9 @@ class LinuxHardware(Hardware):
             DMI_DICT = {
                 'bios_date': 'bios-release-date',
                 'bios_version': 'bios-version',
+                'board_name': 'baseboard-product-name',
                 'form_factor': 'chassis-type',
                 'product_name': 'system-product-name',
-                'board_name': 'baseboard-product-name',
                 'product_serial': 'system-serial-number',
                 'product_uuid': 'system-uuid',
                 'product_version': 'system-version',


### PR DESCRIPTION
##### SUMMARY
Some desktop motherboards(like gigabyte) may not have product field set. Instead we can use "Product Name" from the "Base Board Information" section of dmi to provide meaningful value. 
e.g. 

_System Information_
        Manufacturer: Gigabyte Technology Co., Ltd.
        <b>Product Name: To be filled by O.E.M.</b>
...
_Base Board Information_
        Manufacturer: Gigabyte Technology Co., Ltd.
        <b>Product Name: H61MA-D2V</b>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/facts/hardware/linux.py 
##### ADDITIONAL INFORMATION
very specific string to check for "To be filled by O.E.M." don't know if there are any other values that might come up for unset product_name field.

Not sure if there is any try/except required here since presence of dmi keys confirmed above and get_file_conent handles any empty/missing files. 


