### PR TITLE
added SQS policy removal support

### DIFF
--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -57,7 +57,7 @@ options:
     version_added: "2.1"
   redrive_policy:
     description:
-      - json dict with the redrive_policy (see example)
+      - json dict with the redrive_policy (see examples)
     version_added: "2.2"
 extends_documentation_fragment:
     - aws
@@ -121,6 +121,11 @@ EXAMPLES = '''
     redrive_policy:
       maxReceiveCount: 5
       deadLetterTargetArn: arn:aws:sqs:eu-west-1:123456789012:my-dead-queue
+
+# Remove redrive policy
+- sqs_queue:
+    name: my-queue
+    redrive_policy: {}
 
 # Delete SQS queue
 - sqs_queue:

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -219,7 +219,7 @@ def update_sqs_queue(queue,
 
 
 def set_queue_attribute(queue, attribute, value, check_mode=False):
-    if not value and value != 0:
+    if not value and value not in (0, {}):
         return False
 
     try:
@@ -229,7 +229,7 @@ def set_queue_attribute(queue, attribute, value, check_mode=False):
 
     # convert dict attributes to JSON strings (sort keys for comparing)
     if attribute in ['Policy', 'RedrivePolicy']:
-        value = json.dumps(value, sort_keys=True)
+        value = json.dumps(value, sort_keys=True) if value else ''
         if existing_value:
             existing_value = json.dumps(json.loads(existing_value), sort_keys=True)
 


### PR DESCRIPTION
##### SUMMARY
`sqs_queue` is currently unable to remove existing external access or redrive policies. The proposed fix allows syntax like this to remove them:
```yaml
sqs_queue:
  name: foo
  redrive_policy: {}
```

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
`sqs_queue` module