### PR TITLE
ufw: check values for direction depending on situation

### DIFF
--- a/changelogs/fragments/50402-ufw-check-direction.yml
+++ b/changelogs/fragments/50402-ufw-check-direction.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ufw: make sure that only valid values for ``direction`` are passed on."

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -418,7 +418,7 @@ def main():
                 execute(cmd + [[command], [value], [params['direction']]])
 
         elif command == 'rule':
-            if params['direction'] in ['outgoing', 'incoming', 'routed']:
+            if params['direction'] not in ['in', 'out', None]:
                 module.fail_json(msg='For rules, direction must be one of "in" and "out".')
             # Rules are constructed according to the long format
             #

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -400,6 +400,8 @@ def main():
                 execute(cmd + [[command], [value]])
 
         elif command == 'default':
+            if params['direction'] in ['in', 'out', None]:
+                module.fail_json(msg='For default, direction must be one of "outgoing", "incoming" and "routed".')
             if module.check_mode:
                 regexp = r'Default: (deny|allow|reject) \(incoming\), (deny|allow|reject) \(outgoing\), (deny|allow|reject|disabled) \(routed\)'
                 extract = re.search(regexp, pre_state)
@@ -416,6 +418,8 @@ def main():
                 execute(cmd + [[command], [value], [params['direction']]])
 
         elif command == 'rule':
+            if params['direction'] in ['outgoing', 'incoming', 'routed']:
+                module.fail_json(msg='For rules, direction must be one of "in" and "out".')
             # Rules are constructed according to the long format
             #
             # ufw [--dry-run] [route] [delete] [insert NUM] allow|deny|reject|limit [in|out on INTERFACE] [log|log-all] \

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -400,7 +400,7 @@ def main():
                 execute(cmd + [[command], [value]])
 
         elif command == 'default':
-            if params['direction'] in ['in', 'out', None]:
+            if params['direction'] not in ['outgoing', 'incoming', 'routed']:
                 module.fail_json(msg='For default, direction must be one of "outgoing", "incoming" and "routed".')
             if module.check_mode:
                 regexp = r'Default: (deny|allow|reject) \(incoming\), (deny|allow|reject) \(outgoing\), (deny|allow|reject|disabled) \(routed\)'


### PR DESCRIPTION
##### SUMMARY
If `default` is specified, `direction` must be one of `outgoing`, `incoming` and `routed`. If a rule is specified, `direction` must be not specified, or must be one of `in` and `out`. (If that's not the case, the generated `ufw` command will fail.)

This PR adds checks to improve the error messages given to the user.

CC @jbarotin

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ufw
