### PR TITLE
Restrict find module crossing filesystem boundaries

### DIFF
--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -428,9 +428,9 @@ def main():
                         continue
                 if params['noxfs']:
                     root = os.path.normpath(root)
-                    if root != npath and os.path.ismount(root) and \
-                      not any(pfilter(root if params['use_regex'] or os.path.isabs(p) else os.path.basename(root), \
-                                      [p], None, params['use_regex']) for p in params['noxfs_overrides']):
+                    if root != npath and os.path.ismount(root) \
+                       and not any(pfilter(root if params['use_regex'] or os.path.isabs(p) else os.path.basename(root),
+                       [p], None, params['use_regex']) for p in params['noxfs_overrides']):
                         del(dirs[:])
                         continue
 

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -380,6 +380,7 @@ def main():
             use_regex=dict(type='bool', default='no'),
             depth=dict(type='int', default=None),
             noxfs=dict(type='bool', default='no'),
+            noxfs_overrides=dict(type='list', default=[], aliases=['noxfs_override']),
         ),
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -369,7 +369,7 @@ def main():
             get_checksum=dict(type='bool', default='no'),
             use_regex=dict(type='bool', default='no'),
             depth=dict(type='int', default=None),
-            noxfs=dict(type='bool', default=False),
+            noxfs=dict(type='bool', default='no'),
         ),
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -417,7 +417,6 @@ def main():
                 if params['noxfs']:
                     if root != npath and os.path.ismount(os.path.normpath(root)):
                         del(dirs[:])
-                        del(files[:])
                         continue
 
                 looked = looked + len(files) + len(dirs)

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -107,6 +107,11 @@ options:
               to false will override this value, which is effectively depth 1.
               Default is unlimited depth.
         version_added: "2.6"
+    noxfs:
+        description:
+            - If true, filesystem boundaries will not be crossed.
+        type: bool
+        default: False
 notes:
     - For Windows targets, use the M(win_find) module instead.
 '''
@@ -363,6 +368,7 @@ def main():
             get_checksum=dict(type='bool', default='no'),
             use_regex=dict(type='bool', default='no'),
             depth=dict(type='int', default=None),
+            noxfs=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
     )
@@ -408,6 +414,12 @@ def main():
                     if depth > params['depth']:
                         del(dirs[:])
                         continue
+                if params['noxfs']:
+                    if root != npath and os.path.ismount(os.path.normpath(root)):
+                        del(dirs[:])
+                        del(files[:])
+                        continue
+
                 looked = looked + len(files) + len(dirs)
                 for fsobj in (files + dirs):
                     fsname = os.path.normpath(os.path.join(root, fsobj))

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -428,7 +428,9 @@ def main():
                         continue
                 if params['noxfs']:
                     root = os.path.normpath(root)
-                    if root != npath and os.path.ismount(root) and not any(pfilter(root if params['use_regex'] or os.path.isabs(p) else os.path.basename(root), [p], None, params['use_regex']) for p in params['noxfs_overrides']):
+                    if root != npath and os.path.ismount(root) and \
+                      not any(pfilter(root if params['use_regex'] or os.path.isabs(p) else os.path.basename(root), \
+                                      [p], None, params['use_regex']) for p in params['noxfs_overrides']):
                         del(dirs[:])
                         continue
 

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -430,7 +430,7 @@ def main():
                     root = os.path.normpath(root)
                     if root != npath and os.path.ismount(root) \
                        and not any(pfilter(root if params['use_regex'] or os.path.isabs(p) else os.path.basename(root),
-                       [p], None, params['use_regex']) for p in params['noxfs_overrides']):
+                                           [p], None, params['use_regex']) for p in params['noxfs_overrides']):
                         del(dirs[:])
                         continue
 

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -113,6 +113,16 @@ options:
         type: bool
         default: False
         version_added: "2.8"
+    noxfs_overrides:
+        description:
+            - If C(noxfs) is set to true, a directory will be scanned regardless if it is a mountpoint or not,
+              if it matches at least one element of C(noxfs_overrides) which contains (shell or regex) patterns,
+              which type is controlled by C(use_regex) option.
+            - Regex patterns match (at the beginning of) the absolute path, whereas globs match either
+              an absolute path or if relative, the basename of the path/directory under consideration.
+        aliases: ['noxfs_override']
+        default: []
+        version_added: "2.8"
 notes:
     - For Windows targets, use the M(win_find) module instead.
 '''
@@ -416,7 +426,8 @@ def main():
                         del(dirs[:])
                         continue
                 if params['noxfs']:
-                    if root != npath and os.path.ismount(os.path.normpath(root)):
+                    root = os.path.normpath(root)
+                    if root != npath and os.path.ismount(root) and not any(pfilter(root if params['use_regex'] or os.path.isabs(p) else os.path.basename(root), [p], None, params['use_regex']) for p in params['noxfs_overrides']):
                         del(dirs[:])
                         continue
 

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -112,6 +112,7 @@ options:
             - If true, filesystem boundaries will not be crossed.
         type: bool
         default: False
+        version_added: "2.8"
 notes:
     - For Windows targets, use the M(win_find) module instead.
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
GNU findutils find command allows to restrict a search to a single filesystem using the "xdev" flag. Ansible's find module should offer the same feature.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #50389 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
find
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
