### PR TITLE
Update changed_when and failed_when examples

### DIFF
--- a/changelogs/fragments/change_failed_when_example.yaml
+++ b/changelogs/fragments/change_failed_when_example.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Add examples in documentation to explain how to handle multiple conditions in changed_when and failed_when.

--- a/docs/docsite/rst/user_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/user_guide/playbooks_error_handling.rst
@@ -93,6 +93,15 @@ In previous version of Ansible, this can still be accomplished as follows::
         msg: "the command failed"
       when: "'FAILED' in command_result.stderr"
 
+You can also combine multiple conditions to specify this behavior as follows::
+
+    - name: Check if a file exists in temp and fail task if it does
+      command: ls /tmp/this_should_not_be_here
+      register: result
+      failed_when:
+        - '"No such" not in result.stdout'
+        - result.rc == 0
+
 .. _override_the_changed_result:
 
 Overriding The Changed Result
@@ -115,6 +124,15 @@ does not cause handlers to fire::
       # this will never report 'changed' status
       - shell: wall 'beep'
         changed_when: False
+
+You can also combine multiple conditions to override "changed" result::
+
+    - command: /bin/fake_command
+      register: result
+      ignore_errors: True
+      changed_when:
+        - '"ERROR" in result.stderr'
+        - result.rc == 2
 
 Aborting the play
 `````````````````


### PR DESCRIPTION
##### SUMMARY
Added examples in playbooks_error_handling doc for handlining
multiple conditions in changed_when and failed_when

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/change_failed_when_example.yaml
docs/docsite/rst/user_guide/playbooks_error_handling.rst
