### PR TITLE
Fix compatibility with FreeIPA on Ubuntu 16.04

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_service.py
+++ b/lib/ansible/modules/identity/ipa/ipa_service.py
@@ -90,7 +90,7 @@ class ServiceIPAClient(IPAClient):
         super(ServiceIPAClient, self).__init__(module, host, port, protocol)
 
     def service_find(self, name):
-        return self._post_json(method='service_find', name=None, item={'all': True, 'krbcanonicalname': name})
+        return self._post_json(method='service_find', name=None, item={'all': True, 'krbprincipalname': name})
 
     def service_add(self, name, service):
         return self._post_json(method='service_add', name=name, item=service)


### PR DESCRIPTION
##### SUMMARY
The krbcanonicalname field does not exist in the FreeIPA version shipped with Ubuntu 16.04, causing the ipa_service role to fail.

I sadly do not have a more recent IPA machine to test this with. Preferably, we would first check krbcanonicalname and if that fails, fall back to krbprincipalname, but the _post_json function calls internal Ansible failure functions, making it impossible to catch failure of krbcanonicalname, so this would require much more refactoring of this module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ipa

##### ADDITIONAL INFORMATION
When talking to a host running FreeIPA on Ubuntu 16.04, before applying this patch, using ipa_service:
```
FAILED! => {"changed": false, "msg": "response service_find: Unknown option: krbcanonicalname"}
```
