### PR TITLE
Check metadata.status presence

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -293,7 +293,7 @@ def get_plugin_info(module_dir, limit_to=None, verbose=False):
         # use ansible core library to parse out doc metadata YAML and plaintext examples
         doc, examples, returndocs, metadata = plugin_docs.get_docstring(module_path, fragment_loader, verbose=verbose)
 
-        if metadata and 'removed' in metadata.get('status'):
+        if metadata and 'removed' in metadata.get('status', []):
             continue
 
         category = categories


### PR DESCRIPTION
##### SUMMARY
Generate error if metadata.status is empty or missing.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docs/bin/plugin_formatter.py

##### ADDITIONAL INFORMATION
Avoid errors like https://github.com/ansible/ansible/pull/50412#issuecomment-450643522