### PR TITLE
win_hyperv_guest: New Windows Hyper-V module

### DIFF
--- a/lib/ansible/modules/windows/win_hyperv_guest.ps1
+++ b/lib/ansible/modules/windows/win_hyperv_guest.ps1
@@ -13,9 +13,9 @@ $spec = @{
         state = @{ type = "str"; choices = "present", "absent", "created", "started", "stopped", "restarted"; default = "present" }
         force_stop = @{ type = "bool"; default = $false }
         hostserver = @{ type = "str"; }
+        generation = @{ type = "int"; choices = 1, 2; default = 1; }
         cpu = @{ type = "int"; default = 1 }
         memory = @{ type = "str"; default = "512MB" }
-        generation = @{ type = "int"; choices = 1, 2; default = 1; }
         disks = @{ type = "list";}
         network_adapters = @{ type = "list" }
         secure_boot = @{ type = "bool"; default = $false }

--- a/lib/ansible/modules/windows/win_hyperv_guest.ps1
+++ b/lib/ansible/modules/windows/win_hyperv_guest.ps1
@@ -1,0 +1,731 @@
+#!powershell
+
+# Copyright: (c) 2018, Ansible Project
+# Copyright: (c) 2018, Wilmar den Ouden <wilmaro@intermax.nl>
+# Copyright: (c) 2018, Intermax Cloudsourcing
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        name = @{ type = "str"; required = $true }
+        state = @{ type = "str"; choices = "present", "absent", "created", "started", "stopped", "restarted"; default = "present" }
+        force_stop = @{ type = "bool"; default = $false }
+        hostserver = @{ type = "str"; }
+        cpu = @{ type = "int"; default = 1 }
+        memory = @{ type = "str"; default = "512MB" }
+        generation = @{ type = "int"; choices = 1, 2; default = 1; }
+        disks = @{ type = "list";}
+        network_adapters = @{ type = "list" }
+        secure_boot = @{ type = "bool"; default = $false }
+        secure_boot_template = @{ type = "str"; choices = "MicrosoftWindows", "MicrosoftUEFICertificateAuthority"; default = $null }
+        wait_for_ip = @{ type = "bool"; default = $false }
+        timeout = @{ type = "int"; default = 30 }
+    }
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$name = $module.Params.name
+$state = $module.Params.state
+$force_stop = $module.Params.force_stop
+$hostserver = $module.Params.hostserver
+$cpu = $module.Params.cpu
+$memory = $module.Params.memory
+$generation = $module.Params.generation
+$disks = $module.Params.disks
+$network_adapters = $module.Params.network_adapters
+$secure_boot = $module.Params.secure_boot
+$secure_boot_template = $module.Params.secure_boot_template
+$wait_for_ip = $module.Params.wait_for_ip
+$timeout = $module.Params.timeout
+
+$module.Result.changed = $false
+
+if (($secure_boot) -and $generation -eq 1) {
+  # If secure_boot or secure_boot_template specified with generation 1 VM
+  $module.FailJson("Secure boot options are not valid for generation 1 machines")
+}
+elseif ((-not $secure_boot) -and $secure_boot_template) {
+  # If secure_boot is set to false and secure_boot_templace is specified
+  $module.FailJson("Secure_boot_template is not valid when secure_boot is false")
+}
+if ($disks) {
+  # When unique contains less items then the hashtable size there are duplicate paths
+  if (($disks | ForEach-Object { $_.path } | Select-Object -unique).Count -lt $disks.Count) {
+    $module.FailJson("There are duplicate disk paths defined")
+  }
+
+  $first_boot_counter = 0
+  foreach ($disk in $disks) {
+    if (-not $disk.size) {
+        $module.FailJson("No size is specified for $($disk.path)")
+    }
+
+    if ($disk.ContainsKey("parent_path")) {
+      # If disk contains parent_path do some checking
+      if ($([System.IO.Path]::GetExtension($disk.path)) -ne $([System.IO.Path]::GetExtension($disk.parent_path))) {
+        # If parent_path and disk_path have different extensions
+        $module.FailJson("The path and parent_path have different extensions $($disk.path) and $($disk.parent_path)")
+      }
+      elseif (-Not $(Test-Path -LiteralPath $disk.parent_path)) {
+        # If parent_path does not exist, module does not support creation of parent disks
+        $module.FailJson("The parent disk does not exist $($disk.parent_path)")
+      }
+    }
+    if ($disk.ContainsKey("first_boot_device")) {
+      if ($disk.first_boot_device) {
+        $first_boot_counter++
+        if ($generation -eq 1) {
+          # First_boot_device is not support on generation 1 machines since Set-VMBios has no such thing
+          $module.FailJson("The first_boot_device parameter is not supported for generation 1")
+        }
+      }
+      if ($first_boot_counter -gt 1) {
+        $module.FailJson("The first_boot_device parameter is set on multiple disks")
+      }
+    }
+  }
+}
+if ($network_adapters) {
+  # When unique contains less items then the hashtable size there are duplicate names
+  if (($network_adapters | ForEach-Object { $_.name } | Select-Object -unique).Count -lt $network_adapters.Count) {
+        $module.FailJson("There are duplicate network adapter names defined")
+  }
+}
+
+Function New-Guest() {
+  $new_vm_args = @{
+    Name               = $name
+    MemoryStartupBytes = $memory
+    Generation         = $generation
+    NoVHD              = $true
+  }
+
+  try {
+    $vm = New-VM @set_args @new_vm_args
+    $module.Result.changed = $true
+  }
+  catch {
+    $module.FailJson("Failed to create VM", $_.Exception.Message)
+  }
+
+  if ($vm) {
+    $vm_properties = @{
+      ProcessorCount = $cpu
+    }
+    Edit-Guest-Properties $vm $vm_properties
+
+    if ($secure_boot) {
+      $firmware_properties = @{
+        SecureBoot = if ($secure_boot) {"On"} else {"Off"}
+      }
+      if ($secure_boot_template) {
+        $firmware_properties.SecureBootTemplate = $secure_boot_template
+      }
+      Edit-Guest-Firmware $vm $firmware_properties
+    }
+
+    if ($disks) {
+      foreach ($disk in $disks) {
+        $vm_disk = Add-Guest-HardDiskDrive $vm $disk
+        if ($disk.ContainsKey('first_boot_device')) {
+          # If first_boot_device is defined
+          if ($disk.first_boot_device) {
+            Edit-Guest-Firmware $vm @{
+              FirstBootDevice = $vm_disk
+            }
+          }
+        }
+      }
+    }
+
+    if ($network_adapters) {
+      $vm_network_adapters = @()
+      foreach($vm_network_adapter in $vm.NetworkAdapters) {
+        $vm_network_adapters += @{
+          name = $vm_network_adapter.Name
+          switch_name = $vm_network_adapter.SwitchName
+        }
+      }
+      if ($vm_network_adapters.Count -eq 0) {
+        # No network adapter present on VM all adapters should be added
+        foreach($network_adapter in $network_adapters) {
+          Add-Guest-NetworkAdapter $vm $network_adapter
+        }
+      }
+      else {
+        # Network adapter present on VM, diff to determine what to do
+        $network_adapter_diffs = Compare-Object -ReferenceObject $network_adapters -DifferenceObject $vm_network_adapters -IncludeEqual -Property Name -PassThru
+        foreach ($diff in $network_adapter_diffs) {
+          if ($diff.SideIndicator -eq "<=") {
+            # Network adapter defined but not existing
+            Add-Guest-NetworkAdapter $vm $diff
+          }
+          elseif ($diff.SideIndicator -eq "==") {
+            # Adapter defined and existing, call update
+            Edit-Guest-NetworkAdapter $vm $diff
+          }
+          elseif ($diff.SideIndicator -eq "=>") {
+            # Adapter undefined but present on machine, so remove
+            Remove-Guest-NetworkAdapter $vm $diff
+          }
+        }
+      }
+    }
+  }
+  return $vm
+}
+
+#TODO: Implement diff_mode
+Function Edit-Guest([Microsoft.HyperV.PowerShell.VirtualMachine] $vm) {
+  $properties = @{
+    ProcessorCount = $cpu
+    MemoryStartup  = $memory
+  }
+  Edit-Guest-Properties $vm $properties
+
+  if ($secure_boot) {
+    $firmware_properties = @{
+      SecureBoot = if ($secure_boot) {"On"} else {"Off"}
+    }
+    if ($secure_boot_template) {
+      $firmware_properties.SecureBootTemplate = $secure_boot_template
+    }
+    Edit-Guest-Firmware $vm $firmware_properties
+  }
+
+  if ($disks) {
+    $vm_vhds = @()
+    foreach($vm_disk in $vm.HardDrives) {
+      # Get VHD matching the harddrive path, the HardDrive object lack properties like size and parentPath
+      $vm_vhd = Get-VHD @get_args -Path $vm_disk.Path
+      $vm_vhds += @{
+        path = $vm_vhd.Path
+        size = $vm_vhd.Size
+        parent_path = $vm_vhd.ParentPath
+      }
+    }
+    if ($vm_vhds.Count -eq 0) {
+      # No disk present on VM all disk should be added
+      foreach ($disk in $disks) {
+        Add-Guest-HardDiskDrive $vm $disk
+      }
+    } else {
+      # Disks present on VM, diff to determine what to do
+      $vhd_diffs = Compare-Object -ReferenceObject $disks -DifferenceObject $vm_vhds -IncludeEqual -Property Path -PassThru
+      foreach ($diff in $vhd_diffs) {
+        if ($diff.SideIndicator -eq "<=") {
+          # Disk defined but not existing
+          $vm_disk = Add-Guest-HardDiskDrive $vm $diff
+        }
+        elseif ($diff.SideIndicator -eq "==") {
+          # Disk defined and existing, call update
+          $vm_disk = Edit-Guest-HardDisk $vm $diff
+        }
+        elseif ($diff.SideIndicator -eq "=>") {
+          # Disk undefined but present on machine, so remove
+          Remove-Guest-HardDisk $vm $diff
+        }
+
+        if ($vm_disk -and $diff.ContainsKey('first_boot_device')) {
+          # If first_boot_device is defined
+          if ($diff.first_boot_device) {
+            Edit-Guest-Firmware $vm @{
+              FirstBootDevice = $vm_disk
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if ($network_adapters) {
+    $vm_network_adapters = @()
+    foreach($vm_network_adapter in $vm.NetworkAdapters) {
+      $vm_network_adapters += @{
+        name = $vm_network_adapter.Name
+        switch_name = $vm_network_adapter.SwitchName
+      }
+    }
+    if ($vm_network_adapters.Count -eq 0) {
+      # No network adapter present on VM all adapters should be added
+      foreach($network_adapter in $network_adapters) {
+        Add-Guest-NetworkAdapter $vm $network_adapter
+      }
+    }
+    else {
+      # Network adapter present on VM, diff to determine what to do
+      $network_adapter_diffs = Compare-Object -ReferenceObject $network_adapters -DifferenceObject $vm_network_adapters -IncludeEqual -Property Name -PassThru
+      foreach ($diff in $network_adapter_diffs) {
+        if ($diff.SideIndicator -eq "<=") {
+          # Network adapter defined but not existing
+          Add-Guest-NetworkAdapter $vm $diff
+        }
+        elseif ($diff.SideIndicator -eq "==") {
+          # Adapter defined and existing, call update
+          Edit-Guest-NetworkAdapter $vm $diff
+        }
+        elseif ($diff.SideIndicator -eq "=>") {
+          # Adapter undefined but present on machine, so remove
+          Remove-Guest-NetworkAdapter $vm $diff
+        }
+      }
+    }
+  }
+}
+
+Function Remove-Guest([Microsoft.HyperV.PowerShell.VirtualMachine] $vm) {
+  if ($module.CheckMode) {
+    return $module.Result.changed = $true
+  }
+
+  # Has to be poweredoff first
+  if ($vm.State -eq "Running") {
+    Stop-Guest $vm
+  }
+
+  # Remove-VM does not remove the harddisks
+  if ($disks) {
+    foreach ($disk in $disks) {
+      Remove-Guest-HardDisk $vm $disk
+    }
+  }
+
+  try {
+    Remove-VM @set_args -VM $vm -Force
+    $module.Result.changed = $true
+  }
+  catch {
+    $module.FailJson("Failed to remove VM", $_.Exception)
+  }
+  return $vm
+}
+
+Function New-VirtualHardDisk([hashtable] $disk) {
+  if ($module.CheckMode) {
+    return $module.Result.changed = $true
+  }
+
+  $new_vhd_args = @{
+    Path      = $disk.path
+    SizeBytes = $disk.size
+  }
+
+  if ($disk.ContainsKey("parent_path")) {
+    # If parent_path defined
+    $new_vhd_args.ParentPath = $disk.parent_path
+    $new_vhd_args.Differencing = $true
+  }
+  try {
+    New-VHD @set_args @new_vhd_args > $null
+    $module.Result.changed = $true
+  }
+  catch {
+    $module.FailJson("Failed to create VHD", $_.Exception)
+  }
+}
+
+Function Add-Guest-HardDiskDrive([Microsoft.HyperV.PowerShell.VirtualMachine] $vm, [Hashtable] $disk) {
+  if ($module.CheckMode) {
+    return $module.Result.changed = $true
+  }
+
+  if (-Not $(Test-Path -LiteralPath $disk.path)) {
+    New-VirtualHardDisk $disk
+  }
+  try {
+    $vm_disk = Add-VMHardDiskDrive @set_args -VM $vm -Path $disk.path -Passthru
+    $module.Result.changed = $true
+    return $vm_disk
+  }
+  catch {
+    $module.FailJson("Failed to add VHD", $_.Exception)
+  }
+}
+
+Function Edit-Guest-HardDisk([Microsoft.HyperV.PowerShell.VirtualMachine] $vm, [Hashtable] $disk) {
+  if ($module.CheckMode) {
+    return $module.Result.changed = $true
+  }
+
+  $vm_disk = $vm.HardDrives | Where-Object {$_.Path -eq $disk.path}
+  $vm_vhd = $vm_disk | Get-VHD @get_args
+
+  if ($disk.size -ne $vm_vhd.Size) {
+    try {
+      Resize-VHD @set_args -Path $disk.path -SizeBytes $disk.size
+      $module.Result.changed = $true
+    }
+    catch {
+      $module.FailJson("Failed to expand VHD", $_.Exception)
+    }
+  }
+  if ($disk.ContainsKey("first_boot_device")) {
+    if ($disk.first_boot_device) {
+        Edit-Guest-Firmware $vm @{
+        FirstBootDevice = $vm_disk
+      }
+    }
+  }
+}
+
+Function Remove-Guest-HardDisk([Microsoft.HyperV.PowerShell.VirtualMachine] $vm, [Hashtable] $disk) {
+  if ($module.CheckMode) {
+    return $module.Result.changed = $true
+  }
+
+  $vm_disk = $vm.HardDrives | Where-Object {$_.Path -eq $disk.path}
+  # When vm_disk not empty, the disk is connected to the VM
+  if ($vm_disk) {
+    # Remove disk from VM
+    try {
+      Remove-VMHardDiskDrive @set_args -VMHardDiskDrive $vm_disk
+      $module.Result.changed = $true
+    } catch {
+      $module.FailJson("Failed to remove VHD from VM", $_.Exception)
+    }
+    # When state absent remove VHD from disk
+    if ($state -eq "absent") {
+      try {
+        Remove-Item -LiteralPath $disk.path
+        $module.Result.changed = $true
+      } catch {
+        $module.FailJson("Failed to remove VHD from VM", $_.Exception)
+      }
+    }
+  }
+  else {
+    $module.FailJson("Failed to remove VHD: $($disk.path) not present on the VM")
+  }
+}
+Function Add-Guest-NetworkAdapter([Microsoft.HyperV.PowerShell.VirtualMachine] $vm, [Hashtable] $network_adapter) {
+  if ($module.CheckMode) {
+    return $module.Result.changed = $true
+  }
+
+  $add_network_args = @{
+    VM   = $vm
+    Name = $network_adapter.name
+  }
+
+  if ($network_adapter.ContainsKey("switch_name")) {
+    $add_network_args.SwitchName = $network_adapter.switch_name
+  }
+  try {
+    Add-VMNetworkAdapter @set_args @add_network_args
+    $module.Result.changed = $true
+  }
+  catch {
+    $module.FailJson("Failed to add network adapter", $_.Exception)
+  }
+}
+
+Function Edit-Guest-NetworkAdapter([Microsoft.HyperV.PowerShell.VirtualMachine] $vm, [Hashtable] $network_adapter) {
+  if ($module.CheckMode) {
+    return $module.Result.changed = $true
+  }
+
+  $vm_network_adapter = $vm.NetworkAdapters | Where-Object {$_.Name -eq $network_adapter.name}
+  if ($vm_network_adapter -is [System.Array]) {
+    $module.FailJson("Failed to update network adapter: Two network adapters found with the name: $($network_adapter.name)")
+  }
+
+  if ($network_adapter.ContainsKey("switch_name")) {
+    if ($vm_network_adapter.SwitchName) {
+      # Network adapter currently connected to switch, check for change
+      if ($network_adapter.switch_name -ne $vm_network_adapter.SwitchName) {
+        try {
+          Connect-VMNetworkAdapter @set_args -VMNetworkAdapter $vm_network_adapter -SwitchName $network_adapter.switch_name
+          $module.Result.changed = $true
+        }
+        catch {
+          $module.FailJson("Failed to update network adapter", $_.Exception)
+        }
+      }
+    } else {
+      # SwitchName is null, adapter not connected to switch
+      try {
+        Connect-VMNetworkAdapter @set_args -VMNetworkAdapter $vm_network_adapter -SwitchName $network_adapter.switch_name
+        $module.Result.changed = $true
+      }
+      catch {
+        $module.FailJson("Failed to update network adapter", $_.Exception)
+      }
+    }
+  }
+}
+
+Function Remove-Guest-NetworkAdapter([Microsoft.HyperV.PowerShell.VirtualMachine] $vm, [Hashtable] $network_adapter) {
+  if ($module.CheckMode) {
+    return $module.Result.changed = $true
+  }
+
+  $vm_network_adapter = $vm.NetworkAdapters | Where-Object {$_.Name -eq $network_adapter.name}
+  if ($vm_network_adapter -is [System.Array]) {
+    $module.FailJson("Failed to delete network adapter: Two network adapters found with the name: $($network_adapter.name)")
+  }
+  else {
+    try {
+      Remove-VMNetworkAdapter @set_args -VMNetworkAdapter $vm_network_adapter
+      $module.Result.changed = $true
+    }
+    catch {
+      $module.FailJson("Failed to delete network adapter", $_.Exception)
+    }
+  }
+}
+
+Function Edit-Guest-Properties([Microsoft.HyperV.PowerShell.VirtualMachine] $vm, [Hashtable] $properties) {
+  if ($module.CheckMode) {
+    return $module.Result.changed = $true
+  }
+
+  $set_vm_args = @{}
+  foreach ($property in $properties.GetEnumerator()) {
+    if ($vm.$($property.Name) -ne $property.Value) {
+      # If value differs append to arguments
+      if ($property.Name -eq "SecureBoot") {
+        # Set parameter is different from property of VM
+        $set_vm_args.EnableSecureBoot = $property.Value
+      }
+      else {
+        $set_vm_args.$($property.Name) = $property.Value
+      }
+    }
+  }
+  if ($set_vm_args.Count -ne 0) {
+    # If there is a parameter to set
+    try {
+      Set-VM -VM $vm @set_args @set_vm_args
+      $module.Result.changed = $true
+    }
+    catch {
+      $module.FailJson("Failed to update VM", $_.Exception)
+    }
+  }
+}
+
+Function Edit-Guest-Firmware([Microsoft.HyperV.PowerShell.VirtualMachine] $vm, [Hashtable] $firmware_values) {
+  if ($module.CheckMode) {
+    return $module.Result.changed = $true
+  }
+
+  $firmware_current_state = Get-VMFirmware @get_args -VM $vm
+  $set_firmware_args = @{}
+  foreach ($value in $firmware_values.GetEnumerator()) {
+    if ($value.Name -eq "FirstBootDevice") {
+      # Check if first in bootorder is the same disk as passed HardDiskDrive object
+      if ($firmware_current_state.BootOrder[0].Device.Path -ne $value.Value.Path) {
+        $set_firmware_args.$($value.Name) = $value.Value
+      }
+    }
+    elseif ($firmware_current_state.$($value.Name) -ne $value.Value) {
+      # If value differs from current state append to arguments
+      $set_firmware_args.$($item.Name) = $value.Value
+    }
+  }
+  if ($set_firmware_args.Count -ne 0) {
+    # If there is a parameter to set
+    try {
+      Set-VMFirmware -VM $vm @set_args @set_firmware_args
+      $module.Result.changed = $true
+    }
+    catch {
+      $module.FailJson("Failed to update firmware", $_.Exception)
+    }
+  }
+}
+
+Function Start-Guest([Microsoft.HyperV.PowerShell.VirtualMachine] $vm) {
+  if ($vm.State -eq "Off") {
+    if ($module.CheckMode) {
+      $module.Result.changed = $true
+      return
+    }
+
+    try {
+      Start-VM @set_args -VM $vm
+      $module.Result.changed = $true
+    }
+    catch {
+      $module.FailJson("Failed to start VM", $_.Exception)
+    }
+
+    if ($wait_for_ip) {
+      Wait-For-Ip $vm
+    }
+  }
+}
+
+Function Stop-Guest([Microsoft.HyperV.PowerShell.VirtualMachine] $vm) {
+  if ($vm.State -eq "Running") {
+    if ($module.CheckMode) {
+      $module.Result.changed = $true
+      return
+    }
+
+    $stop_args = @{
+      VM      = $vm
+      TurnOff = $force_stop
+    }
+    try {
+      Stop-VM @set_args @stop_args -Force
+      $module.Result.changed = $true
+    }
+    catch {
+      $module.FailJson("Failed to stop VM", $_.Exception)
+    }
+  }
+}
+
+Function Restart-Guest([Microsoft.HyperV.PowerShell.VirtualMachine] $vm) {
+  if ($vm.State -eq "Running") {
+    if ($module.CheckMode) {
+      $module.Result.changed = $true
+      return
+    }
+
+    try {
+      Restart-VM @set_args -VM $vm -Force
+      $module.Result.changed = $true
+    }
+    catch {
+      $module.FailJson("Failed to restart VM", $_.Exception)
+    }
+
+    if ($wait_for_ip) {
+      Wait-For-Ip $vm
+    }
+  }
+}
+
+Function Get-Guest() {
+  # Get current state of VM, returns empty hashtable on error
+  try {
+    $vm = Get-VM @get_args -Name $name
+  }
+  catch {
+    if ($_.Exception.Message -Match "Hyper-V was unable to find a virtual machine with name") {
+      # VM does not exist
+      $vm = @{
+        name  = $name
+        state = "absent"
+      }
+    }
+    else {
+      $module.FailJson("Failed to get state VM", $_.Exception)
+      $vm = @{}
+    }
+  }
+  return $vm
+}
+
+Function Format-Guest([Microsoft.HyperV.PowerShell.VirtualMachine] $vm) {
+  if ($vm.IsDeleted) {
+    # VM is deleted
+    return @{
+      name  = $vm.Name
+      state = "absent"
+    }
+  }
+  else {
+    # VM still exists
+    $vm_json = ConvertTo-Json -InputObject $vm -Depth 3
+    return ConvertFrom-Json -InputObject $vm_json
+  }
+}
+
+Function Wait-For-Ip([Microsoft.HyperV.PowerShell.VirtualMachine] $vm) {
+  $timer = [Diagnostics.Stopwatch]::StartNew()
+  # Loop until first network adapter has an IP address
+  while (-not ($vm.NetworkAdapters[0].IPAddresses.length -gt 0)) {
+    if ($timer.Elapsed.TotalSeconds -ge $timeout) {
+      # Break and error when timer exeeds timout set for waiting
+      $module.FailJson("Failed to get IPV4 for VM, timeout exceeded")
+      break;
+    }
+  }
+  $timer.Stop()
+}
+
+###################################################################
+#
+# MAIN
+#
+###################################################################
+$get_args = @{
+  ErrorAction = "Stop"
+}
+if ($hostserver) {
+  $get_args.ComputerName = $hostserver
+}
+
+$set_args = $get_args.Clone()
+$set_args.WhatIf = $module.CheckMode
+
+# Normalize disk_paths, from YAML comes with double backslash so -eq does not work with Hyper-V provided paths
+# Convert defined size of memory and disks to bytes by doing /1
+# TODO: Check if better function or implementation is available for normalizing disk paths
+foreach ($disk in $disks) {
+  $disk.path = $disk.path.Replace('\\', '\')
+  $disk.size = $disk.size / 1
+}
+$memory = $memory / 1
+
+$vm = Get-Guest
+
+if ($vm -is [Microsoft.HyperV.PowerShell.VirtualMachine]) {
+  # VM exists
+  if ($state -eq "present") {
+    Edit-Guest $vm
+    if ($vm.State -eq "Off") {
+      Start-Guest $vm
+    }
+  }
+  elseif ($state -eq "created") {
+    Edit-Guest $vm
+  }
+  elseif ($state -eq "absent") {
+    Remove-Guest $vm
+  }
+  elseif ($state -eq "started") {
+    Edit-Guest $vm
+    Start-Guest $vm
+  }
+  elseif ($state -eq "stopped") {
+    Edit-Guest $vm
+    Stop-Guest $vm
+  }
+  elseif ($state -eq "restarted") {
+    Edit-Guest $vm
+    if ($vm.State -eq "Running") {
+      Restart-Guest $vm
+    }
+    elseif ($vm.State -eq "Off") {
+      Start-Guest $vm
+    }
+  }
+}
+elseif ($vm.Count -gt 0) {
+  # Get-Guest returned a filled hashtable so curret state must be absent
+  if ($state -eq "present") {
+    $vm = New-Guest
+    if ($vm) {
+      Start-Guest $vm
+    }
+  }
+  elseif ($state -eq "created") {
+    $vm = New-Guest
+  }
+}
+
+# When VM is a object format to JSON for return
+if ($vm -is [Microsoft.HyperV.PowerShell.VirtualMachine]) {
+  $vm = Format-Guest $vm
+}
+
+$module.Result.instance = $vm
+$module.ExitJson()

--- a/lib/ansible/modules/windows/win_hyperv_guest.py
+++ b/lib/ansible/modules/windows/win_hyperv_guest.py
@@ -26,12 +26,14 @@ options:
   name:
     description:
       - Name of VM
+    type: str
     required: true
   state:
     description:
       - State of VM, for started, stopped, restarted and shutdown the VM needs to exist
       - Poweroperations are performed after state updates!
       - Important to notice for generation 1 VM's and disk updates, stopping the VM and the disk updates are seperate tasks
+    type: str
     required: false
     choices:
       - present
@@ -44,17 +46,19 @@ options:
   force_stop:
     description:
       - When true the virtual plug is pulled on the VM instead of a gentle shutdown (poweroff instead of shutdown)
+    type: bool
     required: false
     default: false
-    type: bool
   hostserver:
     description:
       - Server to host VM
+    type: str
     required: false
     default: null
   generation:
     description:
       - Specifies the generation of the VM, cannot be updated without recreating the VM
+    type: int
     required: false
     choices:
       - 1
@@ -63,11 +67,13 @@ options:
   cpu:
     description:
       - Sets the amount of cores of the VM
+    type: int
     required: false
     default: 1
   memory:
     description:
       - Sets the amount of memory for the VM.
+    type: str
     required: false
     default: 512MB
   disks:
@@ -83,6 +89,7 @@ options:
       - 'The following options are optional:'
       - ' - C(parent_path) (string): If set a parent of the disk to create a differencing disk (available since Server 2012)'
       - ' - C(first_boot_device) (bool): If set this disk will be set first boot device, only supported on a generarion 2 VM!'
+    type: list
     required: false
     default: null
   network_adapters:
@@ -96,10 +103,12 @@ options:
       - ' - C(name) (string): The name of the network adapter'
       - 'The following options are optional'
       - ' - C(switch_name) (string): Name of the switch to connect the adapter to'
+    type: list
     required: false
     default: null
   secure_boot:
     description: Enables or disables secure_boot
+    type: bool
     required: false
     default: false
   secure_boot_template:
@@ -110,16 +119,19 @@ options:
     choices:
       - MicrosoftWindows
       - MicrosoftUEFICertificateAuthority
+    type: str
     required: false
     default: null
   wait_for_ip:
     description:
       - When true waits until an IP address is set on the first network interface after starting or restarting
+    type: bool
     required: false
     default: false
   timeout:
     description:
       - Timeout in seconds for waiting on IPV4 address
+    type: int
     required: false
     default: 30
 '''

--- a/lib/ansible/modules/windows/win_hyperv_guest.py
+++ b/lib/ansible/modules/windows/win_hyperv_guest.py
@@ -1,0 +1,186 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Ansible Project
+# Copyright: (c) 2018, Wilmar den Ouden <wilmaro@intermax.nl>
+# Copyright: (c) 2018, Intermax Cloudsourcing
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {
+    'status': ['preview'],
+    'supported_by': 'community',
+    'metadata_version': '1.1'
+}
+
+DOCUMENTATION = r'''
+---
+module: win_hyperv_guest
+version_added: "2.9"
+author:
+  - Wilmar den Ouden (@wilmardo) <wilmaro@intermax.nl>
+short_description: Manages virtual machines in Hyper-V
+description:
+    - This module manages VM's on a Hyper-V host. It creates, destroys and performs powerfunctions.
+    - Hyper-V Module for Windows PowerShell needs to be installed
+options:
+  name:
+    description:
+      - Name of VM
+    required: true
+  state:
+    description:
+      - State of VM, for started, stopped, restarted and shutdown the VM needs to exist
+      - Poweroperations are performed after state updates!
+      - Important to notice for generation 1 VM's and disk updates, stopping the VM and the disk updates are seperate tasks
+    required: false
+    choices:
+      - present
+      - absent
+      - created
+      - started
+      - stopped
+      - restarted
+    default: present
+  force_stop:
+    description:
+      - When true the virtual plug is pulled on the VM instead of a gentle shutdown (poweroff instead of shutdown)
+    required: false
+    default: false
+    type: bool
+  hostserver:
+    description:
+      - Server to host VM
+    required: false
+    default: null
+  generation:
+    description:
+      - Specifies the generation of the VM, cannot be updated without recreating the VM
+    required: false
+    choices:
+      - 1
+      - 2
+    default: 1
+  cpu:
+    description:
+      - Sets the amount of cores of the VM
+    required: false
+    default: 1
+  memory:
+    description:
+      - Sets the amount of memory for the VM.
+    required: false
+    default: 512MB
+  disks:
+    description:
+      - Specifies the disks for the VM, of not specified no VHD will be created or added
+      - If the path exists the existing VHD will be attached
+      - 'If disks is specified with state: absent the disks will be deleted from the disk'
+      - If the size differs it will try to resize the VHD
+      - Resizing disks of running VM is only supported on a SCSI controller with VHDX disks
+      - 'The the following options are required per entry:'
+      - ' - C(path) (string): The path for the new or existing VHD'
+      - ' - C(size) (string): Size of the VHD specified as 1GB or 200MB'
+      - 'The following options are optional:'
+      - ' - C(parent_path) (string): If set a parent of the disk to create a differencing disk (available since Server 2012)'
+      - ' - C(first_boot_device) (bool): If set this disk will be set first boot device, only supported on a generarion 2 VM!'
+    required: false
+    default: null
+  network_adapters:
+    description:
+      - Specifies the network adapters for the VM,
+        if not specified one adapter will be created by Hyper-V (Network Adapter) but not connected to a switch
+      - Network Adapters are matched by name, when an adapter with a matching name is found but the switch_name differs
+        it connects the adapter to the specified switch.
+      - Therefore names must be unique!
+      - 'The below parameters are required per entry:'
+      - ' - C(name) (string): The name of the network adapter'
+      - 'The following options are optional'
+      - ' - C(switch_name) (string): Name of the switch to connect the adapter to'
+    required: false
+    default: null
+  secure_boot:
+    description: Enables or disables secure_boot
+    required: false
+    default: false
+  secure_boot_template:
+    description:
+      - Set the name of the Secure Boot template
+      - Can't be changed when VM is running!
+      - Only valid for generation 2 machines with secure_boot enabled
+    choices:
+      - MicrosoftWindows
+      - MicrosoftUEFICertificateAuthority
+    required: false
+    default: null
+  wait_for_ip:
+    description:
+      - When true waits until an IP address is set on the first network interface after starting or restarting
+    required: false
+    default: false
+  timeout:
+    description:
+      - Timeout in seconds for waiting on IPV4 address
+    required: false
+    default: 30
+'''
+
+EXAMPLES = r'''
+  - name: Create and start VM with default values
+    win_hyperv_guest:
+      name: Test
+
+  - name: Delete a VM without removing the disk from the host
+    win_hyperv_guest:
+      name: Test
+      state: absent
+
+  - name: Delete a VM and remove the disk from the host
+    win_hyperv_guest:
+      name: Test
+      disks:
+        - path: V:\hyper-v\disks\CentOS7-disk0.vhdx
+      state: absent
+
+  - name: Create generation 1 VM with 256MB memory and the default adapter (Network Adapter) connected to Internal Switch
+    win_hyperv_guest:
+      name: Test
+      generation: 1
+      memory: 256MB
+      network_adapters:
+        - name: Network Adapter
+          switch_name: Internal Switch
+
+  - name: >
+      Create generation 2 VM based of a parent disk and set as first boot device,
+      Sets MicrosoftUEFICertificateAuthority as secure boot template
+      and wait for an IP on the first network adapter.
+    win_hyperv_guest:
+      name: Test
+      cpu: 2
+      memory: 2048MB
+      disks:
+        - path: V:\hyper-v\disks\CentOS7-disk0.vhdx"
+          size: 20GB
+          parent_path: V:\hyper-v\parents\CentOS_7_template-disk1.vhdx
+          first_boot_device: true
+        - path: V:\hyper-v\disks\CentOS7-disk1.vhdx
+          size: 20GB
+      network_adapters:
+        - name: Network Adapter
+          switch_name: NATSwitch
+      secure_boot_template: MicrosoftUEFICertificateAuthority
+      wait_for_ip: true
+'''
+
+RETURN = r'''
+instance:
+  description: metadata about the new virtual machine
+  returned: always
+  type: dict
+  sample: None
+invocation:
+  description: parameters passed to the module
+  returned: always
+  type: dict
+  sample: None
+'''

--- a/test/integration/targets/win_hyperv_guest/aliases
+++ b/test/integration/targets/win_hyperv_guest/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group4

--- a/test/integration/targets/win_hyperv_guest/aliases
+++ b/test/integration/targets/win_hyperv_guest/aliases
@@ -1,1 +1,1 @@
-shippable/windows/group4
+unsupported

--- a/test/integration/targets/win_hyperv_guest/defaults/main.yml
+++ b/test/integration/targets/win_hyperv_guest/defaults/main.yml
@@ -1,0 +1,89 @@
+---
+test_hyperv_guest_path: '{{ win_output_dir }}\win_hyperv_guest'
+
+test_hyperv_guest_switch:
+  name: Ansible test
+
+test_hyperv_guest_parent_disk:
+  path: '{{ test_hyperv_guest_path }}\parent.vhdx'
+  size: 15MB
+
+test_hyperv_guest_vm:
+  name: Test machine
+  cpu: 1
+  memory: 512MB
+  disks:
+    - path: '{{ test_hyperv_guest_path }}\hdd.vhdx'
+      size: 5MB
+  network_adapters:
+    - name: Network Adapter
+      switch_name: "{{ test_hyperv_guest_switch.name }}"
+  generation: "{{ generation | default(omit) }}"  # Omit as default for removal without specifying generation
+  state: "{{ state | default('absent') }}"  # Absent as default for removal in task which has no support for vars like includes
+
+test_hyperv_guest_vm_update:
+  cpu: 2
+  memory: 1024MB
+
+# Empty network_adapters array so no adapters are removed
+test_hyperv_guest_disk_add:
+  disks:
+    - path: '{{ test_hyperv_guest_path }}\hdd.vhdx'
+      size: 5MB
+    - path: '{{ test_hyperv_guest_path }}\hdd1.vhdx'
+      size: 5MB
+  network_adapters: []
+
+test_hyperv_guest_disk_expand:
+  disks:
+    - path: '{{ test_hyperv_guest_path }}\hdd.vhdx'
+      size: 5MB
+    - path: '{{ test_hyperv_guest_path }}\hdd1.vhdx'
+      size: 10MB
+  network_adapters: []
+
+test_hyperv_guest_disk_first_boot_device:
+  disks:
+    - path: '{{ test_hyperv_guest_path }}\hdd.vhdx'
+      size: 5MB
+      first_boot_device: true
+    - path: '{{ test_hyperv_guest_path }}\hdd1.vhdx'
+      size: 10MB
+  network_adapters: []
+
+test_hyperv_guest_disk_first_boot_device_update:
+  disks:
+    - path: '{{ test_hyperv_guest_path }}\hdd.vhdx'
+      size: 5MB
+    - path: '{{ test_hyperv_guest_path }}\hdd1.vhdx'
+      size: 10MB
+      first_boot_device: true
+  network_adapters: []
+
+# Empty disk array so no disks are removed
+test_hyperv_guest_network_adapter_add:
+  disks: []
+  network_adapters:
+    - name: Network Adapter
+      switch_name: "{{ test_hyperv_guest_switch.name }}"
+    - name: Network Adapter 1
+
+test_hyperv_guest_network_adapter_update:
+  disks: []
+  network_adapters:
+    - name: Network Adapter
+      switch_name: "{{ test_hyperv_guest_switch.name }}"
+    - name: Network Adapter 1
+      switch_name: "{{ test_hyperv_guest_switch.name }}"
+
+test_hyperv_guest_vm_parent:
+  name: Test machine
+  disks:
+    - path: '{{ test_hyperv_guest_path }}\hdd.vhdx'
+      size: "{{ test_hyperv_guest_parent_disk.size }}"
+      parent_path: "{{ test_hyperv_guest_parent_disk.path }}"
+  network_adapters:
+    - name: Network Adapter
+      switch_name: "{{ test_hyperv_guest_switch.name }}"
+  generation: "{{ generation | default(omit) }}"  # Omit as default for removal without specifying generation
+  state: "{{ state | default('absent') }}"  # Absent as default for removal in task which has no support for vars like includes

--- a/test/integration/targets/win_hyperv_guest/tasks/assert_failing_checks.yml
+++ b/test/integration/targets/win_hyperv_guest/tasks/assert_failing_checks.yml
@@ -1,0 +1,151 @@
+---
+- name: test secure_boot=true and generation=1
+  win_hyperv_guest:
+    name: Test machine
+    secure_boot: true
+    generation: 1
+  register: secure_boot_true_and_generation_1
+  ignore_errors: true
+
+- name: assert fail of test secure_boot=true and generation=1
+  assert:
+    that:
+      - secure_boot_true_and_generation_1.msg == 'Secure boot options are not valid for generation 1 machines'
+
+- name: test secure_boot=false and secure_boot_template is set
+  win_hyperv_guest:
+    name: Test machine
+    secure_boot: false
+    secure_boot_template: MicrosoftWindows
+  register: secure_boot_false_and_secure_boot_template
+  ignore_errors: true
+
+- name: assert fail of test secure_boot=false and secure_boot_template is set
+  assert:
+    that:
+      - secure_boot_false_and_secure_boot_template.msg == 'Secure_boot_template is not valid when secure_boot is false'
+
+- name: test duplicate disk paths are defined
+  win_hyperv_guest:
+    name: Test machine
+    disks:
+      - path: C:\Temp\hdd.vhdx
+        size: 15MB
+      - path: C:\Temp\hdd.vhdx
+        size: 15MB
+  register: duplicate_disk_paths
+  ignore_errors: true
+
+- name: assert fail of test duplicate disk paths are defined
+  assert:
+    that:
+      - duplicate_disk_paths.msg == 'There are duplicate disk paths defined'
+
+- name: test disk without size
+  win_hyperv_guest:
+    name: Test machine
+    disks:
+      - path: C:\Temp\hdd.vhdx
+  register: disk_without_size
+  ignore_errors: true
+
+- name: assert fail of test disk without size
+  assert:
+    that:
+      - disk_without_size.msg == 'No size is specified for C:\\Temp\\hdd.vhdx'
+
+- name: test path and parent_path different extensions
+  win_hyperv_guest:
+    name: Test machine
+    disks:
+      - path: C:\Temp\hdd.vhdx
+        size: 15MB
+        parent_path: C:\Temp\parent.vhd
+  register: disk_path_extension_different_from_parent_path
+  ignore_errors: true
+
+- name: assert fail of test path and parent_path different extensions
+  assert:
+    that:
+      - disk_path_extension_different_from_parent_path.msg == 'The path and parent_path have different extensions C:\\Temp\\hdd.vhdx and C:\\Temp\\parent.vhd'
+
+- name: test parent_path does not exist
+  win_hyperv_guest:
+    name: Test machine
+    disks:
+      - path: C:\Temp\hdd.vhdx
+        size: 15MB
+        parent_path: C:\Temp\not_parent.vhdx
+  register: parent_path_non_existing
+  ignore_errors: true
+
+- name: assert fail of test parent_path does not exist
+  assert:
+    that:
+      - parent_path_non_existing.msg == 'The parent disk does not exist C:\\Temp\\not_parent.vhdx'
+
+- name: test first_boot_device=true and generation=1
+  win_hyperv_guest:
+    name: Test machine
+    disks:
+      - path: C:\Temp\hdd.vhdx
+        size: 15MB
+        first_boot_device: true
+    generation: 1
+  register: fist_boot_true_and_generation_1
+  ignore_errors: true
+
+- name: assert fail of test first_boot_device=true and generation=1
+  assert:
+    that:
+      - fist_boot_true_and_generation_1.msg == 'The first_boot_device parameter is not supported for generation 1'
+
+- name: test first_boot_device=true defined multiple times
+  win_hyperv_guest:
+    name: Test machine
+    generation: 2
+    disks:
+      - path: C:\Temp\hdd.vhdx
+        size: 15MB
+        first_boot_device: true
+      - path: C:\Temp\hdd1.vhdx
+        size: 15MB
+        first_boot_device: true
+  register: multiple_first_boot_devices
+  ignore_errors: true
+
+- name: assert fail of test first_boot_device=true defined multiple times
+  assert:
+    that:
+      - multiple_first_boot_devices.msg == 'The first_boot_device parameter is set on multiple disks'
+
+- name: test duplicate network_adapter names
+  win_hyperv_guest:
+    name: Test machine
+    network_adapters:
+      - name: Network Adapter
+      - name: Network Adapter
+  register: duplicate_network_adapter_names
+  ignore_errors: true
+
+- name: assert fail of test duplicate network_adapter names
+  assert:
+    that:
+      - duplicate_network_adapter_names.msg == 'There are duplicate network adapter names defined'
+
+- name: test wait_for_ip timout
+  win_hyperv_guest:
+    name: Test machine
+    timeout: 10
+    wait_for_ip: true
+  register: wait_for_ip_timeout
+  ignore_errors: true
+
+- name: assert fail of test wait_for_ip_timeout
+  assert:
+    that:
+      - wait_for_ip_timeout.msg == 'Failed to get IPV4 for VM, timeout exceeded'
+
+# Remove with Powershell since module might fail since it is not tested in this phase yet
+- name: Remove VM waiting for IP
+  win_command: powershell.exe "Stop-VM -Name 'Test machine' -TurnOff; Remove-VM -Name 'Test machine' -Force"

--- a/test/integration/targets/win_hyperv_guest/tasks/create_vm.yml
+++ b/test/integration/targets/win_hyperv_guest/tasks/create_vm.yml
@@ -1,0 +1,57 @@
+---
+# Test creation of VM
+- name: create generation {{ generation }} VM (check mode)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+  register: create_vm_check
+  check_mode: yes
+
+- name: get the result of create generation {{ generation }} VM (check mode)
+  win_command: |
+    powershell.exe "if (
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').State -eq 'Running') -and
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').ProcessorCount -eq {{ test_hyperv_guest_vm.cpu }}) -and
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').MemoryStartup -eq '{{ test_hyperv_guest_vm.memory }}' /1) -and
+      (Get-VMHardDiskDrive -VMName '{{ test_hyperv_guest_vm.name }}' | Where {$_.Path -eq '{{ test_hyperv_guest_vm.disks.0.path }}'}) -and
+      (Get-VHD -Path '{{ test_hyperv_guest_vm.disks.0.path }}').Size -eq ('{{ test_hyperv_guest_vm.disks.0.size }}' /1) -and
+      (Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_vm.network_adapters.0.name }}') -and
+      ((Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_vm.network_adapters.0.name }}').SwitchName -eq '{{ test_hyperv_guest_vm.network_adapters.0.switch_name }}'))
+        { 'true' } else { 'false' }"
+  register: create_vm_actual_check
+
+- name: assert create generation {{ generation }} VM (check mode)
+  assert:
+    that:
+      - create_vm_check is changed
+      - create_vm_actual_check.stdout == 'false\r\n'
+
+- name: create generation {{ generation }} VM
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+  register: create_vm
+
+- name: get the result of create generation {{ generation }} VM
+  win_command: |
+    powershell.exe "if (
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').State -eq 'Running') -and
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').ProcessorCount -eq {{ test_hyperv_guest_vm.cpu }}) -and
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').MemoryStartup -eq '{{ test_hyperv_guest_vm.memory }}' /1) -and
+      (Get-VMHardDiskDrive -VMName '{{ test_hyperv_guest_vm.name }}' | Where {$_.Path -eq '{{ test_hyperv_guest_vm.disks.0.path }}'}) -and
+      (Get-VHD -Path '{{ test_hyperv_guest_vm.disks.0.path }}').Size -eq ('{{ test_hyperv_guest_vm.disks.0.size }}' /1) -and
+      (Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_vm.network_adapters.0.name }}') -and
+      ((Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_vm.network_adapters.0.name }}').SwitchName -eq '{{ test_hyperv_guest_vm.network_adapters.0.switch_name }}'))
+        { 'true' } else { 'false' }"
+  register: create_vm_actual
+
+- name: assert create generation {{ generation }} VM
+  assert:
+    that:
+      - create_vm is changed
+      - create_vm_actual.stdout == 'true\r\n'
+
+- name: create generation {{ generation }} VM (idempotent)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+  register: create_vm_again
+
+- name: assert create generation {{ generation }} VM (idempotent)
+  assert:
+    that:
+    - not create_vm_again is changed

--- a/test/integration/targets/win_hyperv_guest/tasks/create_vm_parent_disk.yml
+++ b/test/integration/targets/win_hyperv_guest/tasks/create_vm_parent_disk.yml
@@ -1,0 +1,55 @@
+---
+# Test creation of VM of parent disk
+- name: create generation {{ generation }} VM with parent_disk (check mode)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm_parent }}"
+  register: create_vm_parent_check
+  check_mode: yes
+
+- name: get the result of create generation {{ generation }} VM with parent_disk (check mode)
+  win_command: |
+    powershell.exe "if (
+      ((Get-VM -Name '{{ test_hyperv_guest_vm_parent.name }}').State -eq 'Running') -and
+      (Get-VMHardDiskDrive -VMName '{{ test_hyperv_guest_vm_parent.name }}' | Where {$_.Path -eq '{{ test_hyperv_guest_vm_parent.disks.0.path }}'}) -and
+      (Get-VHD -Path '{{ test_hyperv_guest_vm_parent.disks.0.path }}').Size -eq ('{{ test_hyperv_guest_vm_parent.disks.0.size }}' /1) -and
+      ((Get-VHD -Path '{{ test_hyperv_guest_vm_parent.disks.0.path }}').ParentPath -eq '{{ test_hyperv_guest_vm_parent.disks.0.parent_path }}') -and
+      (Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm_parent.name }}' -Name '{{ test_hyperv_guest_vm_parent.network_adapters.0.name }}') -and
+      ((Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_vm_parent.network_adapters.0.name }}').SwitchName -eq '{{ test_hyperv_guest_vm_parent.network_adapters.0.switch_name }}'))
+        { 'true' } else { 'false' }"
+  register: create_vm_parent_actual_check
+
+- name: assert create generation {{ generation }} VM with parent_disk (check mode)
+  assert:
+    that:
+      - create_vm_parent_check is changed
+      - create_vm_parent_actual_check.stdout == 'false\r\n'
+
+- name: create generation {{ generation }} VM with parent_disk
+  win_hyperv_guest: "{{ test_hyperv_guest_vm_parent }}"
+  register: create_vm_parent
+
+- name: get the result of create generation {{ generation }} VM with parent_disk
+  win_command: |
+    powershell.exe "if (
+      ((Get-VM -Name '{{ test_hyperv_guest_vm_parent.name }}').State -eq 'Running') -and
+      (Get-VMHardDiskDrive -VMName '{{ test_hyperv_guest_vm_parent.name }}' | Where {$_.Path -eq '{{ test_hyperv_guest_vm_parent.disks.0.path }}'}) -and
+      (Get-VHD -Path '{{ test_hyperv_guest_vm_parent.disks.0.path }}').Size -eq ('{{ test_hyperv_guest_vm_parent.disks.0.size }}' /1) -and
+      ((Get-VHD -Path '{{ test_hyperv_guest_vm_parent.disks.0.path }}').ParentPath -eq '{{ test_hyperv_guest_vm_parent.disks.0.parent_path }}') -and
+      (Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm_parent.name }}' -Name '{{ test_hyperv_guest_vm_parent.network_adapters.0.name }}') -and
+      ((Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_vm_parent.network_adapters.0.name }}').SwitchName -eq '{{ test_hyperv_guest_vm_parent.network_adapters.0.switch_name }}'))
+        { 'true' } else { 'false' }"
+  register: create_vm_parent_actual
+
+- name: assert create generation {{ generation }} VM with parent_disk
+  assert:
+    that:
+      - create_vm_parent is changed
+      - create_vm_parent_actual.stdout == 'true\r\n'
+
+- name: create generation {{ generation }} VM with parent_disk (idempotent)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm_parent }}"
+  register: create_vm_parent_again
+
+- name: assert create generation {{ generation }} VM with parent_disk (idempotent)
+  assert:
+    that:
+    - not create_vm_parent_again is changed

--- a/test/integration/targets/win_hyperv_guest/tasks/delete_vm.yml
+++ b/test/integration/targets/win_hyperv_guest/tasks/delete_vm.yml
@@ -1,0 +1,47 @@
+---
+# Test deletion of VM
+- name: delete generation {{ generation }} VM (check mode)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_expand) }}"
+  register: delete_vm_check
+  check_mode: yes
+
+- name: get the result of delete generation {{ generation }} VM (check mode)
+  win_command: |
+    powershell.exe "if (
+      (-not (Get-VM -Name '{{ test_hyperv_guest_vm.name }}')) -and
+      (-not (Test-Path -Path '{{ test_hyperv_guest_vm.disks.0.path }}')))
+        { 'true' } else { 'false' }"
+  register: delete_vm_actual_check
+
+- name: assert delete generation {{ generation }} VM (check mode)
+  assert:
+    that:
+      - delete_vm_check is changed
+      - delete_vm_actual_check.stdout == 'false\r\n'
+
+- name: delete generation {{ generation }} VM
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+  register: delete_vm
+
+- name: get the result of delete generation {{ generation }} VM
+  win_command: |
+    powershell.exe "if (
+      (-not (Get-VM -Name '{{ test_hyperv_guest_vm.name }}')) -and
+      (-not (Test-Path -Path '{{ test_hyperv_guest_vm.disks.0.path }}')))
+        { 'true' } else { 'false' }"
+  register: delete_vm_actual
+
+- name: assert delete generation {{ generation }} VM
+  assert:
+      that:
+        - delete_vm is changed
+        - delete_vm_actual.stdout == 'true\r\n'
+
+- name: delete generation {{ generation }} VM (idempotent)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+  register: delete_vm_again
+
+- name: assert delete generation {{ generation }} VM (idempotent)
+  assert:
+    that:
+      - not delete_vm_again is changed

--- a/test/integration/targets/win_hyperv_guest/tasks/disk_tests.yml
+++ b/test/integration/targets/win_hyperv_guest/tasks/disk_tests.yml
@@ -1,0 +1,199 @@
+---
+# Add new VHD
+- name: add generation {{ generation }} VM disk (check mode)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_add) }}"
+  register: add_vm_disk_check
+  check_mode: yes
+
+- name: get the result of add generation {{ generation }} VM disk (check mode)
+  win_command: |
+    powershell.exe "if (
+      (Get-VMHardDiskDrive -VMName '{{ test_hyperv_guest_vm.name }}' | Where {$_.Path -eq '{{ test_hyperv_guest_disk_add.disks.1.path }}'}) -and
+      (Get-VHD -Path '{{ test_hyperv_guest_disk_add.disks.1.path }}').Size -eq ('{{ test_hyperv_guest_disk_add.disks.1.size }}' /1))
+        { 'true' } else { 'false' }"
+  register: add_vm_disk_actual_check
+
+- name: assert add generation {{ generation }} VM disk (check mode)
+  assert:
+    that:
+      - add_vm_disk_check is changed
+      - add_vm_disk_actual_check.stdout == 'false\r\n'
+
+- name: add generation {{ generation }} VM disk
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_add) }}"
+  register: add_vm_disk
+
+- name: get the result of add generation {{ generation }} VM disk
+  win_command: |
+    powershell.exe "if (
+      (Get-VMHardDiskDrive -VMName '{{ test_hyperv_guest_vm.name }}' | Where {$_.Path -eq '{{ test_hyperv_guest_disk_add.disks.1.path }}'}) -and
+      (Get-VHD -Path '{{ test_hyperv_guest_disk_add.disks.1.path }}').Size -eq ('{{ test_hyperv_guest_disk_add.disks.1.size }}' /1))
+        { 'true' } else { 'false' }"
+  register: add_vm_disk_actual
+
+- name: assert add generation {{ generation }} VM disk
+  assert:
+    that:
+      - add_vm_disk is changed
+      - add_vm_disk_actual.stdout == 'true\r\n'
+
+- name: add generation {{ generation }} VM disk (idempotent)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_add) }}"
+  register: add_vm_disk_again
+
+- name: assert add generation {{ generation }} VM disk (idempotent)
+  assert:
+    that:
+      - not add_vm_disk_again is changed
+
+# Expand newly added VHD from 5MB to 10MB
+- name: expand generation {{ generation }} VM disk (check mode)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_expand) }}"
+  register: expand_vm_disk_check
+  check_mode: yes
+
+- name: get the result of expand generation {{ generation }} VM disk (check mode)
+  win_command: |
+    powershell.exe "if (
+      (Get-VMHardDiskDrive -VMName '{{ test_hyperv_guest_vm.name }}' | Where {$_.Path -eq '{{ test_hyperv_guest_disk_expand.disks.1.path }}'}) -and
+      (Get-VHD -Path '{{ test_hyperv_guest_disk_expand.disks.1.path }}').Size -eq ('{{ test_hyperv_guest_disk_expand.disks.1.size }}' /1))
+        { 'true' } else { 'false' }"
+  register: expand_vm_disk_actual_check
+
+- name: assert expand generation {{ generation }} VM disk (check mode)
+  assert:
+    that:
+      - expand_vm_disk_check is changed
+      - expand_vm_disk_actual_check.stdout == 'false\r\n'
+
+- name: expand generation {{ generation }} VM disk
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_expand) }}"
+  register: expand_vm_disk
+
+- name: get the result of expand generation {{ generation }} VM disk
+  win_command: |
+    powershell.exe "if (
+      (Get-VMHardDiskDrive -VMName '{{ test_hyperv_guest_vm.name }}' | Where {$_.Path -eq '{{ test_hyperv_guest_disk_expand.disks.1.path }}'}) -and
+      (Get-VHD -Path '{{ test_hyperv_guest_disk_expand.disks.1.path }}').Size -eq ('{{ test_hyperv_guest_disk_expand.disks.1.size }}' /1))
+        { 'true' } else { 'false' }"
+  register: expand_vm_disk_actual
+
+- name: assert expand generation {{ generation }} VM disk
+  assert:
+    that:
+      - expand_vm_disk is changed
+      - expand_vm_disk_actual.stdout == 'true\r\n'
+
+- name: expand generation {{ generation }} VM disk (idempotent)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_expand) }}"
+  register: expand_vm_disk_again
+
+- name: assert expand generation {{ generation }} VM disk (idempotent)
+  assert:
+    that:
+      - not expand_vm_disk_again is changed
+
+- name: Include first_boot_device_test when generation == 2
+  include_tasks: first_boot_device_test.yml
+  when: generation == 2
+
+# Remove added VHD without 'state: absent' so disk should still exist on disk
+- name: remove generation {{ generation }} VM disk without absent (check mode)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+  register: remove_vm_disk_check
+  check_mode: yes
+
+- name: get the result of remove generation {{ generation }} VM disk without absent (check mode)
+  win_command: |
+    powershell.exe "if (
+      (-not (Get-VMHardDiskDrive -VMName '{{ test_hyperv_guest_vm.name }}' | Where {$_.Path -eq '{{ test_hyperv_guest_disk_expand.disks.1.path }}'})) -and
+      (Test-Path -Path '{{ test_hyperv_guest_disk_expand.disks.1.path }}'))
+        { 'true' } else { 'false' }"
+  register: remove_vm_disk_actual_check
+
+- name: assert remove generation {{ generation }} VM disk without absent (check mode)
+  assert:
+    that:
+      - remove_vm_disk_check is changed
+      - remove_vm_disk_actual_check.stdout == 'false\r\n'
+
+- name: remove generation {{ generation }} VM disk without absent
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+  register: remove_vm_disk
+
+- name: get the result of remove generation {{ generation }} VM disk without absent
+  win_command: |
+    powershell.exe "if (
+      (-not (Get-VMHardDiskDrive -VMName '{{ test_hyperv_guest_vm.name }}' | Where {$_.Path -eq '{{ test_hyperv_guest_disk_expand.disks.1.path }}'})) -and
+      (Test-Path -Path '{{ test_hyperv_guest_disk_expand.disks.1.path }}'))
+        { 'true' } else { 'false' }"
+  register: remove_vm_disk_actual
+
+- name: assert remove generation {{ generation }} VM disk without absent
+  assert:
+    that:
+      - remove_vm_disk is changed
+      - remove_vm_disk_actual.stdout == 'true\r\n'
+
+- name: remove generation {{ generation }} VM disk without absent (idempotent)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+  register: remove_vm_disk_again
+
+- name: assert remove generation {{ generation }} VM disk without absent (idempotent)
+  assert:
+    that:
+      - not remove_vm_disk_again is changed
+
+# Remount the removed disk to the VM
+- name: remount generation {{ generation }} VM disk (check mode)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_expand) }}"
+  register: remount_vm_disk_check
+  check_mode: yes
+
+- name: get the result of remount generation {{ generation }} VM disk (check mode)
+  win_command: |
+    powershell.exe "if (
+      (Get-VMHardDiskDrive -VMName '{{ test_hyperv_guest_vm.name }}' | Where {$_.Path -eq '{{ test_hyperv_guest_disk_expand.disks.1.path }}'}))
+        { 'true' } else { 'false' }"
+  register: remount_vm_disk_actual_check
+
+- name: assert remount generation {{ generation }} VM disk (check mode)
+  assert:
+    that:
+      - remount_vm_disk_check is changed
+      - remount_vm_disk_actual_check.stdout == 'false\r\n'
+
+- name: remount generation {{ generation }} VM disk
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_expand) }}"
+  register: remount_vm_disk
+
+- name: get the result of remount generation {{ generation }} VM disk
+  win_command: |
+    powershell.exe "if (
+      (Get-VMHardDiskDrive -VMName '{{ test_hyperv_guest_vm.name }}' | Where {$_.Path -eq '{{ test_hyperv_guest_disk_expand.disks.1.path }}'}))
+        { 'true' } else { 'false' }"
+  register: remount_vm_disk_actual
+
+- name: assert remount generation {{ generation }} VM disk
+  assert:
+    that:
+      - remount_vm_disk is changed
+      - remount_vm_disk_actual.stdout == 'true\r\n'
+
+- name: remount generation {{ generation }} VM disk (idempotent)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_expand) }}"
+  register: remount_vm_disk_again
+
+- name: assert remount generation {{ generation }} VM disk (idempotent)
+  assert:
+    that:
+      - not remount_vm_disk_again is changed
+
+# Remove added VHD again so VM is in default state (already tested not doing it again)
+- name: remove second hdd of generation {{ generation }} VM
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+
+- name: remove second hdd from disk
+  win_file:
+    path: "{{ test_hyperv_guest_disk_expand.disks.1.path }}"
+    state: absent

--- a/test/integration/targets/win_hyperv_guest/tasks/first_boot_device_test.yml
+++ b/test/integration/targets/win_hyperv_guest/tasks/first_boot_device_test.yml
@@ -1,0 +1,90 @@
+---
+# Set firstboot on first HDD
+- name: set first_boot_device (check mode)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_first_boot_device) }}"
+  register: set_first_boot_check
+  check_mode: yes
+
+- name: get the result of set first_boot_device (check mode)
+  win_command: |
+    powershell.exe "if (
+      (Get-VMFirmware -VMName '{{ test_hyperv_guest_vm.name }}').BootOrder[0].Device.Path -eq '{{ test_hyperv_guest_disk_first_boot_device.disks.0.path }}')
+        { 'true' } else { 'false' }"
+  register: set_first_boot_actual_check
+
+- name: assert set first_boot_device (check mode)
+  assert:
+    that:
+      - set_first_boot_check is changed
+      - set_first_boot_actual_check.stdout == 'false\r\n'
+
+- name: set first_boot_device
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_first_boot_device) }}"
+  register: set_first_boot
+
+- name: get the result of set first_boot_device
+  win_command: |
+    powershell.exe "if (
+      (Get-VMFirmware -VMName '{{ test_hyperv_guest_vm.name }}').BootOrder[0].Device.Path -eq '{{ test_hyperv_guest_disk_first_boot_device.disks.0.path }}')
+        { 'true' } else { 'false' }"
+  register: set_first_boot_actual
+
+- name: assert set first_boot_device
+  assert:
+    that:
+      - set_first_boot is changed
+      - set_first_boot_actual.stdout == 'true\r\n'
+
+- name: set first_boot_device (idempotent)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_first_boot_device) }}"
+  register: set_first_boot_again
+
+- name: assert set first_boot_device (idempotent)
+  assert:
+    that:
+      - not set_first_boot_again is changed
+
+# Update firstboot to second HDD
+- name: set first_boot_device (check mode)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_first_boot_device_update) }}"
+  register: update_first_boot_device_check
+  check_mode: yes
+
+- name: get the result of set first_boot_device (check mode)
+  win_command: |
+    powershell.exe "if (
+      (Get-VMFirmware -VMName '{{ test_hyperv_guest_vm.name }}').BootOrder[0].Device.Path -eq '{{ test_hyperv_guest_disk_first_boot_device_update.disks.1.path }}')
+        { 'true' } else { 'false' }"
+  register: update_first_boot_device_actual_check
+
+- name: assert set first_boot_device (check mode)
+  assert:
+    that:
+      - update_first_boot_device_check is changed
+      - update_first_boot_device_actual_check.stdout == 'false\r\n'
+
+- name: set first_boot_device
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_first_boot_device_update) }}"
+  register: update_first_boot_device
+
+- name: get the result of set first_boot_device
+  win_command: |
+    powershell.exe "if (
+      (Get-VMFirmware -VMName '{{ test_hyperv_guest_vm.name }}').BootOrder[0].Device.Path -eq '{{ test_hyperv_guest_disk_first_boot_device_update.disks.1.path }}')
+        { 'true' } else { 'false' }"
+  register: update_first_boot_device_actual
+
+- name: assert set first_boot_device
+  assert:
+    that:
+      - update_first_boot_device is changed
+      - update_first_boot_device_actual.stdout == 'true\r\n'
+
+- name: set first_boot_device (idempotent)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_disk_first_boot_device_update) }}"
+  register: update_first_boot_device_again
+
+- name: assert set first_boot_device (idempotent)
+  assert:
+    that:
+      - not update_first_boot_device_again is changed

--- a/test/integration/targets/win_hyperv_guest/tasks/main.yml
+++ b/test/integration/targets/win_hyperv_guest/tasks/main.yml
@@ -1,0 +1,201 @@
+---
+# Cannot use win_feature to install IIS on Server 2008.
+# Run a brief check and skip hosts that don't support
+# that operation
+- name: Check if win_feature will work on test host
+  win_command: powershell.exe "Get-WindowsFeature"
+  register: module_available
+  failed_when: False
+
+# block: only run when win_feature is available
+- block:
+    - name: Ensure Hyper-V features are installed
+      win_feature:
+        name: "Hyper-V"
+        state: present
+        include_management_tools: true
+      register: feature_install
+
+    - name: Reboot after feature install
+      win_reboot:
+      when: feature_install.reboot_required
+
+  when: module_available.rc == 0
+
+# block: only run when feature install in successful
+- block:
+    - name: ensure testing dir is cleaned
+      win_file:
+        path: "{{ test_hyperv_guest_path }}"
+        state: "{{ item }}"
+      with_items:
+        - absent
+        - directory
+
+    - name: Create internal vSwitch for testing
+      win_command: |
+        powershell.exe "New-VMSwitch -Name '{{ test_hyperv_guest_switch.name }}' -SwitchType Internal"
+
+    - name: Create VHD for parent disk testing
+      win_command: |
+        powershell.exe "New-VHD -Path '{{ test_hyperv_guest_parent_disk.path }}' -SizeBytes {{ test_hyperv_guest_parent_disk.size }}"
+
+    # Tests
+    # generation and state are used in defaults/main.yml > test_hyperv_guest_vm
+    # Therefore they need to be defined for each include
+
+    # Generation 2
+    - name: Include assert failing checks
+      include_tasks: assert_failing_checks.yml
+
+    - name: Include create of generation 2 VM
+      include_tasks: create_vm.yml
+      vars:
+        generation: 2
+        state: present
+
+    - name: Include side effect check
+      include_tasks: side_effect_check.yml
+      vars:
+        generation: 2
+        hyperv_state: running
+
+    # No live updates due not bootable OS
+    - name: shutdown generation 2 machine
+      win_hyperv_guest: "{{ test_hyperv_guest_vm | combine({'state': 'stopped'}) }}"
+
+    - name: Include update of generation 2 VM
+      include_tasks: update_vm.yml
+      vars:
+        generation: 2
+        state: stopped
+
+    - name: Include side effect check
+      include_tasks: side_effect_check.yml
+      vars:
+        generation: 2
+        hyperv_state: "off"
+
+    - name: start generation 2 machine
+      win_hyperv_guest: "{{ test_hyperv_guest_vm | combine({'state': 'started'}) }}"
+
+    - name: Include disk test for generation 2 VM
+      include_tasks: disk_tests.yml
+      vars:
+        generation: 2
+        state: present
+
+    - name: Include side effect check
+      include_tasks: side_effect_check.yml
+      vars:
+        generation: 2
+        hyperv_state: running
+
+    - name: Include network_adapter tests for generation 2 VM
+      include_tasks: network_adapter_tests.yml
+      vars:
+        generation: 2
+        state: present
+
+    - name: Include side effect check
+      include_tasks: side_effect_check.yml
+      vars:
+        generation: 2
+        hyperv_state: running
+
+    - name: Include delete of generation 2 VM
+      include_tasks: delete_vm.yml
+      vars:
+        generation: 2
+        state: absent
+
+    - name: Include create of generation 2 VM with parent_disk
+      include_tasks: create_vm_parent_disk.yml
+      vars:
+        generation: 2
+        state: present
+
+    - name: Include delete of generation 2 VM with parent_disk
+      include_tasks: delete_vm.yml
+      vars:
+        generation: 2
+        state: absent
+
+    # Generation 1
+    - name: Include create of generation 1 VM
+      include_tasks: create_vm.yml
+      vars:
+        generation: 1
+        state: present
+
+    - name: Include side effect check
+      include_tasks: side_effect_check.yml
+      vars:
+        generation: 1
+        hyperv_state: running
+
+    # Stop generation 1 no live updates possible
+    - name: shutdown generation 1 machine
+      win_hyperv_guest: "{{ test_hyperv_guest_vm | combine({'state': 'stopped'}) }}"
+
+    - name: Include update of generation 1 VM
+      include_tasks: update_vm.yml
+      vars:
+        generation: 1
+        state: stopped
+
+    - name: Include side effect check
+      include_tasks: side_effect_check.yml
+      vars:
+        generation: 1
+        hyperv_state: "off"
+
+    - name: Include disk tests for generation 1 VM
+      include_tasks: disk_tests.yml
+      vars:
+        generation: 1
+        state: stopped  # No live disk updates for a generation 1 VM
+
+    - name: Include side effect check
+      include_tasks: side_effect_check.yml
+      vars:
+        generation: 1
+        hyperv_state: "off"
+
+    - name: Include network_adapter tests for generation 1 VM
+      include_tasks: network_adapter_tests.yml
+      vars:
+        generation: 1
+        state: stopped  # No live network adapter updates for a generation 1 VM
+
+    - name: Include side effect check
+      include_tasks: side_effect_check.yml
+      vars:
+        generation: 1
+        hyperv_state: "off"
+
+    - name: Include delete of generation 1 VM
+      include_tasks: delete_vm.yml
+      vars:
+        generation: 1
+        state: absent
+
+  always:
+    # Remove without disks because they might not be created due an error
+    - name: Ensure test VM is deleted without disks
+      win_hyperv_guest: "{{ test_hyperv_guest_vm | combine( {'disks': []} )}}"
+
+    # Separate removal of disks with idempotent file module
+    # They could still exists due an error
+    - name: Ensure disks of VM are removed and testing dir
+      win_file:
+        path: "{{ test_hyperv_guest_path }}"
+        state: absent
+
+    - name: Remove internal vSwitch for testing
+      win_command: |
+        powershell.exe "Remove-VMSwitch -Name '{{ test_hyperv_guest_switch.name }}' -Force"
+
+  when:
+    - module_available.rc == 0
+    - feature_install.success == true

--- a/test/integration/targets/win_hyperv_guest/tasks/network_adapter_tests.yml
+++ b/test/integration/targets/win_hyperv_guest/tasks/network_adapter_tests.yml
@@ -1,0 +1,135 @@
+---
+# Add new network adapters
+- name: add generation {{ generation }} VM network adapter (check mode)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_network_adapter_add) }}"
+  register: add_vm_network_adapter_check
+  check_mode: yes
+
+- name: get the result of add generation {{ generation }} VM network adapter (check mode)
+  win_command: |
+    powershell.exe "if(
+      (Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_network_adapter_add.network_adapters.1.name }}'))
+        { 'true' } else { 'false' }"
+  register: add_vm_network_adapter_actual_check
+
+- name: assert create generation {{ generation }} VM network adapter (check mode)
+  assert:
+    that:
+      - add_vm_network_adapter_check is changed
+      - add_vm_network_adapter_actual_check.stdout == 'false\r\n'
+
+- name: add generation {{ generation }} VM network adapter
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_network_adapter_add) }}"
+  register: add_vm_network_adapter
+
+- name: get the result of add generation {{ generation }} VM network adapter
+  win_command: |
+    powershell.exe "if(
+      (Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_network_adapter_add.network_adapters.1.name }}'))
+        { 'true' } else { 'false' }"
+  register: add_vm_network_adapter_actual
+
+- name: assert add generation {{ generation }} VM network adapter
+  assert:
+    that:
+      - add_vm_network_adapter is changed
+      - add_vm_network_adapter_actual.stdout == 'true\r\n'
+
+- name: add generation {{ generation }} VM network adapter (idempotent)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_network_adapter_add) }}"
+  register: add_vm_network_adapter_again
+
+- name: assert add create generation {{ generation }} VM network adapter (idempotent)
+  assert:
+    that:
+      - not add_vm_network_adapter_again is changed
+
+# Connect new adapter to switch
+- name: update generation {{ generation }} VM network adapter (check mode)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_network_adapter_update) }}"
+  register: update_vm_network_adapter_check
+  check_mode: yes
+
+- name: get the result of update generation {{ generation }} VM network adapter (check mode)
+  win_command: |
+    powershell.exe "if (
+      (Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_network_adapter_update.network_adapters.1.name }}').SwitchName -eq '{{ test_hyperv_guest_network_adapter_update.network_adapters.1.switch_name }}')
+        { 'true' } else { 'false' }"
+  register: update_vm_network_adapter_actual_check
+
+- name: assert create generation {{ generation }} VM network adapter (check mode)
+  assert:
+    that:
+      - update_vm_network_adapter_check is changed
+      - update_vm_network_adapter_actual_check.stdout == 'false\r\n'
+
+- name: update generation {{ generation }} VM network adapter
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_network_adapter_update) }}"
+  register: update_vm_network_adapter
+
+- name: get the result of update generation {{ generation }} VM network adapter
+  win_command: |
+    powershell.exe "if (
+      (Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_network_adapter_update.network_adapters.1.name }}').SwitchName -eq '{{ test_hyperv_guest_network_adapter_update.network_adapters.1.switch_name }}')
+        { 'true' } else { 'false' }"
+  register: update_vm_network_adapter_actual
+
+- name: assert update generation {{ generation }} VM network adapter
+  assert:
+    that:
+      - update_vm_network_adapter is changed
+      - update_vm_network_adapter_actual.stdout == 'true\r\n'
+
+- name: update generation {{ generation }} VM network adapter (idempotent)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_network_adapter_update) }}"
+  register: update_vm_network_adapter_again
+
+- name: assert update create generation {{ generation }} VM network adapter (idempotent)
+  assert:
+    that:
+      - not update_vm_network_adapter_again is changed
+
+# Remove network adapter
+- name: remove generation {{ generation }} VM network adapter (check mode)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+  register: remove_vm_network_adapter_check
+  check_mode: yes
+
+- name: get the result of remove generation {{ generation }} VM network adapter (check mode)
+  win_command: |
+    powershell.exe "if (
+      -not (Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_network_adapter_update.network_adapters.1.name }}'))
+        { 'true' } else { 'false' }"
+  register: remove_vm_network_adapter_actual_check
+
+- name: assert remove generation {{ generation }} VM network adapter (check mode)
+  assert:
+    that:
+      - remove_vm_network_adapter_check is changed
+      - remove_vm_network_adapter_actual_check.stdout == 'false\r\n'
+
+- name: remove generation {{ generation }} VM network adapter
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+  register: remove_vm_network_adapter
+
+- name: get the result of remove generation {{ generation }} VM network adapter
+  win_command: |
+    powershell.exe "if (
+      -not (Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_network_adapter_update.network_adapters.1.name }}'))
+        { 'true' } else { 'false' }"
+  register: remove_vm_network_adapter_actual
+
+- name: assert remove generation {{ generation }} VM network adapter
+  assert:
+    that:
+      - remove_vm_network_adapter is changed
+      - remove_vm_network_adapter_actual.stdout == 'true\r\n'
+
+- name: remove generation {{ generation }} VM network adapter (idempotent)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+  register: remove_vm_network_adapter_again
+
+- name: assert remove generation {{ generation }} VM network adapter (idempotent)
+  assert:
+    that:
+      - not remove_vm_network_adapter_again is changed

--- a/test/integration/targets/win_hyperv_guest/tasks/side_effect_check.yml
+++ b/test/integration/targets/win_hyperv_guest/tasks/side_effect_check.yml
@@ -1,0 +1,24 @@
+---
+# Test if machine is in default state after running tests
+# Used to check if a operation leaves something behind
+- name: check if generation {{ generation }} VM is in default state
+  win_command: |
+    powershell.exe "if (
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').State -eq '{{ hyperv_state }}') -and
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').ProcessorCount -eq {{ test_hyperv_guest_vm.cpu }}) -and
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').MemoryStartup -eq '{{ test_hyperv_guest_vm.memory }}' /1) -and
+      (Get-VMHardDiskDrive -VMName '{{ test_hyperv_guest_vm.name }}' | Where {$_.Path -eq '{{ test_hyperv_guest_vm.disks.0.path }}'}) -and
+      ((Get-VHD -Path '{{ test_hyperv_guest_vm.disks.0.path }}').Size -eq ('{{ test_hyperv_guest_vm.disks.0.size }}' /1)) -and
+      (Test-Path -Path '{{ test_hyperv_guest_vm.disks.0.path }}') -and
+      (Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_vm.network_adapters.0.name }}') -and
+      ((Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_vm.network_adapters.0.name }}').SwitchName -eq '{{ test_hyperv_guest_vm.network_adapters.0.switch_name }}') -and
+      (-not (Get-VMHardDiskDrive -VMName '{{ test_hyperv_guest_vm.name }}' | Where {$_.Path -eq '{{ test_hyperv_guest_disk_expand.disks.1.path }}'})) -and
+      (-not (Test-Path -Path '{{ test_hyperv_guest_disk_expand.disks.1.path }}')) -and
+      (-not (Get-VMNetworkAdapter -VMName '{{ test_hyperv_guest_vm.name }}' -Name '{{ test_hyperv_guest_network_adapter_update.network_adapters.1.name }}')))
+        { 'true' } else { 'false' }"
+  register: no_side_effect
+
+- name: assert no side effects
+  assert:
+    that:
+      - no_side_effect.stdout == 'true\r\n'

--- a/test/integration/targets/win_hyperv_guest/tasks/update_vm.yml
+++ b/test/integration/targets/win_hyperv_guest/tasks/update_vm.yml
@@ -1,0 +1,94 @@
+---
+# Scale up memory and CPU
+- name: scale up generation {{ generation }} VM (check mode)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_vm_update) }}"
+  register: scale_up_vm_check
+  check_mode: yes
+
+- name: get the result of scale up generation {{ generation }} VM (check mode)
+  win_command: |
+    powershell.exe "if (
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').ProcessorCount -eq {{ test_hyperv_guest_vm_update.cpu }}) -and
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').MemoryStartup -eq '{{ test_hyperv_guest_vm_update.memory }}' /1))
+        { 'true' } else { 'false' }"
+  register: scale_up_vm_actual_check
+
+- name: assert scale up generation {{ generation }} VM (check mode)
+  assert:
+    that:
+      - scale_up_vm_check is changed
+      - scale_up_vm_actual_check.stdout == 'false\r\n'
+
+- name: scale up generation {{ generation }} VM
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_vm_update) }}"
+  register: scale_up_vm
+
+- name: get the result of scale up generation {{ generation }} VM
+  win_command: |
+    powershell.exe "if (
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').ProcessorCount -eq {{ test_hyperv_guest_vm_update.cpu }}) -and
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').MemoryStartup -eq '{{ test_hyperv_guest_vm_update.memory }}' /1))
+        { 'true' } else { 'false' }"
+  register: scale_up_vm_actual
+
+- name: assert scale up generation {{ generation }} VM
+  assert:
+    that:
+      - scale_up_vm is changed
+      - scale_up_vm_actual.stdout == 'true\r\n'
+
+- name: scale up generation {{ generation }} VM (idempotent)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm | combine(test_hyperv_guest_vm_update) }}"
+  register: scale_up_vm_again
+
+- name: assert scale up generation {{ generation }} VM (idempotent)
+  assert:
+    that:
+    - not scale_up_vm_again is changed
+
+# Scale down memory and CPU
+- name: scale down generation {{ generation }} VM (check mode)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+  register: scale_down_vm_check
+  check_mode: yes
+
+- name: get the result of scale down generation {{ generation }} VM (check mode)
+  win_command: |
+    powershell.exe "if (
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').ProcessorCount -eq {{ test_hyperv_guest_vm.cpu }}) -and
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').MemoryStartup -eq '{{ test_hyperv_guest_vm.memory }}' /1))
+        { 'true' } else { 'false' }"
+  register: scale_down_vm_actual_check
+
+- name: assert scale down generation {{ generation }} VM (check mode)
+  assert:
+    that:
+      - scale_down_vm_check is changed
+      - scale_down_vm_actual_check.stdout == 'false\r\n'
+
+- name: scale down generation {{ generation }} VM
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+  register: scale_down_vm
+
+- name: get the result of scale down generation {{ generation }} VM
+  win_command: |
+    powershell.exe "if (
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').ProcessorCount -eq {{ test_hyperv_guest_vm.cpu }}) -and
+      ((Get-VM -Name '{{ test_hyperv_guest_vm.name }}').MemoryStartup -eq '{{ test_hyperv_guest_vm.memory }}' /1))
+        { 'true' } else { 'false' }"
+  register: scale_down_vm_actual
+
+- name: assert scale down generation {{ generation }} VM
+  assert:
+    that:
+      - scale_down_vm is changed
+      - scale_down_vm_actual.stdout == 'true\r\n'
+
+- name: scale down generation {{ generation }} VM (idempotent)
+  win_hyperv_guest: "{{ test_hyperv_guest_vm }}"
+  register: scale_down_vm_again
+
+- name: assert scale down generation {{ generation }} VM (idempotent)
+  assert:
+    that:
+    - not scale_down_vm_again is changed


### PR DESCRIPTION
##### SUMMARY
Ansible Powershell for Hyper-V.
Supports most of the default operations and everything is idempotent.
Wrote test to support this claim ;) 

Design decisions:
* Network Adapter names and Internal Switch names should be unique otherwise the module does not know which one to assign.
* Tried to keep all operations in separate functions (New, Edit, Remove) for each individual component. The logic what to decide is in the `New-Guest` and `Edit-Guest` functions. Except for the power operations, those are decided in the main.
* `get_args` are passed to each get operation
* `set_args` are passed to each set operation

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
win_hyperv_guest

##### ADDITIONAL INFORMATION
Caveats:
 * Haven't been able to test this against a remote Hyper-V host (hostserver option). Also might be better to remove it completely? Somewhat obscure usecase to run Ansible on a host but letting it connect to a different host in the process?
* I think some of the pre-flight checks done in the module could be handled by the AnsibleModule options but I haven't wrapped my head arround it yet, suggestions welcome :)

Happy reviewing and a good 2019! 🎆 