### PR TITLE
Pure Storage facts fix (#50349)

### DIFF
--- a/changelogs/fragments/pure_facts_fix.yaml
+++ b/changelogs/fragments/pure_facts_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- purefa_facts and purefb_facts now correctly adds facts into main ansible_fact dictionary (https://github.com/ansible/ansible/pull/50349)

--- a/lib/ansible/modules/storage/purestorage/purefa_facts.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_facts.py
@@ -589,9 +589,7 @@ def main():
     if 'pgroups' in subset or 'all' in subset:
         facts['pgroups'] = generate_pgroups_dict(array)
 
-    result = dict(ansible_purefa_facts=facts,)
-
-    module.exit_json(**result)
+    module.exit_json(ansible_facts={'ansible_purefa_facts': facts})
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/storage/purestorage/purefb_facts.py
+++ b/lib/ansible/modules/storage/purestorage/purefb_facts.py
@@ -643,9 +643,7 @@ def main():
     if 'snapshots' in subset or 'all' in subset:
         facts['snapshots'] = generate_snap_dict(blade)
 
-    result = dict(ansible_purefb_facts=facts,)
-
-    module.exit_json(**result)
+    module.exit_json(ansible_facts={'ansible_purefb_facts': facts})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
* Fix facts not correctly passing into ansible_facts dict

(cherry picked from commit 507f89e6939b7e24b13a452d89ea4ca33cd815b5)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
storage/purestorage/purefa_facts