### PR TITLE
[WIP] Fix copy module to reset filesystem acls

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -262,12 +262,50 @@ import tempfile
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils._text import to_bytes, to_native
+
+
+# The AnsibleModule object
+module = None
 
 
 class AnsibleModuleError(Exception):
     def __init__(self, results):
         self.results = results
+
+
+# Once we get run_command moved into common, we can move this into a common/files module.  We can't
+# until then because of the module.run_command() method.  We may need to move it into
+# basic::AnsibleModule() until then but if so, make it a private function so that we don't have to
+# keep it for backwards compatibility later.
+def del_facl(path, acl_tag, acl_qualifier=None):
+    """
+    :arg path: Filepath from which to remove an acl
+    :arg acl_tag: acl tag to remove.  POSIX1.e recognizes 'u', 'g', 'o', and 'm'
+    :arg acl_qualifier: if acl_tag is 'u' then this must be specified as a username or userid.  If
+        acl_tag is 'g' then this must be specified as a groupname or groupid.  Otherwise, this
+        should be unset.
+    """
+    if acl_tag not in ('u', 'g', 'o', 'm'):
+        raise ValueError('acl_tag must be one of "u", "g", "o", or "m"')
+
+    if not acl_qualifier:
+        if acl_tag == 'u':
+            raise ValueError('acl_qualifier must be set to a username or userid when acl_tag is "u"')
+        if acl_tag == 'g':
+            raise ValueError('acl_qualifier must be set to a groupname or groupid when acl_tag is "g"')
+
+    setfacl = get_bin_path('setfacl', True)
+    if acl_qualifier:
+        acl_string = '{0}:{1}'.format(acl_tag, acl_qualifier)
+    else:
+        acl_string = acl_tag
+    # Like: ['/usr/bin/setfacl', '-x', 'u:1000', '/etc/config.cfg']
+    acl_command = [setfacl, '-x', acl_string, path]
+    rc, out, err = module.run_command(acl_command)
+    if rc != 0:
+        raise RuntimeError('Error running setfacl: stdout: {0}; stderr: {1}'.format(out, err))
 
 
 def split_pre_existing_dir(dirname):
@@ -460,6 +498,8 @@ def copy_common_dirs(src, dest, module):
 
 def main():
 
+    global module
+
     module = AnsibleModule(
         # not checking because of daisy chain to file module
         argument_spec=dict(
@@ -625,6 +665,47 @@ def main():
                         else:
                             raise
                 module.atomic_move(b_mysrc, dest, unsafe_writes=module.params['unsafe_writes'])
+
+                if not remote_src:
+                    # If not remote_src, then the file was copied from the controller.  In that
+                    # case, any filesystem acls are artifacts of the copy rather than preservation
+                    # of existing attributes.  Get rid of them
+                    try:
+                        del_facl(dest, 'u', os.geteuid())
+                        del_facl(dest, 'm')
+                    except ValueError as e:
+                        if 'setfacl' in to_native(e):
+                            # No setfacl so we're okay.  The controller couldn't have set a facl
+                            # without the setfacl command
+                            pass
+                        else:
+                            raise
+                    except RuntimeError as e:
+                        # setfacl failed.
+                        # FIXME: separate out the following cases and do the appropriate thing:
+                        # * If any of the following raise errors, they can be ignored
+                        #   * If the filesystem we're copying to does not support facls
+                        #   * If we're running on python2 therefore the facls were not copied
+                        #   * If there were no facls to clear (because we we're not becoming an
+                        #     unprivileged user, for instance)
+                        #   * If the directory we copied into has a default acl, on python2, the
+                        #     file ends up with the directory's default acl.  On python3, if the
+                        #     file did not start with any acl, it will end up with the default acl.
+                        #     A failure to remove 'm' can be ignored.
+                        # * Treatment of default acls are a related bug.  On Python2, default acls
+                        #   are applied to the copied file.  On Python3, the default acls won't
+                        #   apply because we copied metadata that tells what the acls are.  Should
+                        #   we fix Python2 to not apply default acls (easier)? or fix Python3 to
+                        #   apply the default acls?
+                        # Perhaps it will be easier to:
+                        # * Make a clear_facl() function instead of del_facl().  It looks like Linux
+                        #   and freebsd support setfacl -b for this but other platforms (z/OS) do not.
+                        # * Make a get_facl() function and test:
+                        #   * Does the source file have acls?
+                        #   * Does the destination file have acls for the default acl and nothing
+                        #     else?
+                        pass
+
             except (IOError, OSError):
                 module.fail_json(msg="failed to copy: %s to %s" % (src, dest), traceback=traceback.format_exc())
         changed = True

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -356,6 +356,22 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 self._connection._shell.tmpdir = None
 
     def _transfer_file(self, local_path, remote_path):
+        """
+        Copy a file from the controller to a remote path
+
+        :arg local_path: Path on controller to transfer
+        :arg remote_path: Path on the remote system to transfer into
+
+        .. warning::
+            * When you use this function you likely want to use use fixup_perms2() on the
+              remote_path to make sure that the remote file is readable when the user becomes
+              a non-privileged user.
+            * If you use fixup_perms2() on the file and copy or move the file into place, you will
+              need to then remove filesystem acls on the file once it has been copied into place by
+              the module.  See how the copy module implements this for help.
+        """
+        # FIXME: find all the action plugins that use _transfer_files() and make sure they obey the
+        # above two raning notes.
         self._connection.put_file(local_path, remote_path)
         return remote_path
 

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -302,6 +302,10 @@ class ActionModule(ActionBase):
             self._remove_tempfile_if_content_defined(content, content_tempfile)
             self._loader.cleanup_tmp_file(source_full)
 
+            # FIXME: I don't think this is needed when PIPELINING=0 because the source is created
+            # world readable.  Access to the directory itself is controlled via fixup_perms2() as
+            # part of executing the module. Check that umask with scp/sftp/piped doesn't cause
+            # a problem before acting on this idea. (This idea would save a round-trip)
             # fix file permissions when the copy is done as a different user
             if remote_path:
                 self._fixup_perms2((self._connection._shell.tmpdir, remote_path))


### PR DESCRIPTION
The controller's fixup_perms2 uses filesystem acls to make the temporary
file for copy readable by an unprivileged become user.  On Python3, the
acls are then copied to the destination filename so we have to remove
them from there.

We can't remove them prior to the copy because we may not have
permission to read the file if the acls are not present.  We can't
remove them in atomic_move() because the move function shouldn't know
anything about controller features.  We may want to genrealize this into
a helper function, though.

Fixes #44412

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
* lib/ansible/modules/files/copy.py
* lib/ansible/modules/files/template.py
* lib/ansible/modules/files/assemble.py

Others which will be revealed after an audit of the code.

##### ADDITIONAL INFORMATION

This is still a work in progress.  See the FIXME comments in the commit for what else needs to be done.