### PR TITLE
ansible test: re-enable mysql tests with fix

### DIFF
--- a/test/integration/targets/mysql_db/aliases
+++ b/test/integration/targets/mysql_db/aliases
@@ -1,4 +1,3 @@
-unstable
 destructive
 shippable/posix/group1
 skip/osx

--- a/test/integration/targets/mysql_user/aliases
+++ b/test/integration/targets/mysql_user/aliases
@@ -2,4 +2,3 @@ destructive
 shippable/posix/group1
 skip/osx
 skip/freebsd
-disabled

--- a/test/integration/targets/mysql_variables/aliases
+++ b/test/integration/targets/mysql_variables/aliases
@@ -2,4 +2,3 @@ destructive
 shippable/posix/group1
 skip/osx
 skip/freebsd
-disabled

--- a/test/integration/targets/setup_mysql_db/tasks/main.yml
+++ b/test/integration/targets/setup_mysql_db/tasks/main.yml
@@ -43,9 +43,28 @@
   with_items: "{{mysql_packages}}"
   when: ansible_pkg_mgr  ==  'yum'
 
-- name: install mysqldb_test rpm dependencies
-  dnf: name={{ item }} state=latest
-  with_items: "{{mysql_packages}}"
+- block:
+  # This is required as mariadb-server has a weak dependency on Python 2 which causes the test to break on Py3 hosts
+  - name: create test dnf.conf file to ignore weak dependencies
+    copy:
+      content: |
+        [main]
+        install_weak_deps=False
+      dest: '{{ output_dir }}/dnf.conf'
+    register: test_dnf_conf_copy
+
+  - name: install mysqldb_test rpm dependencies
+    dnf:
+      name: '{{ item }}'
+      state: latest
+      conf_file: '{{ test_dnf_conf_copy.dest }}'
+    with_items: "{{mysql_packages}}"
+
+  always:
+  - name: remove test dnf.conf file
+    file:
+      path: '{{ test_dnf_conf_copy.dest }}'
+      state: absent
   when: ansible_pkg_mgr  ==  'dnf'
 
 - name: install mysqldb_test debian dependencies

--- a/test/integration/targets/zabbix_host/aliases
+++ b/test/integration/targets/zabbix_host/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled


### PR DESCRIPTION
##### SUMMARY
The `setup_mysql_db` integration test target installs packages at the latest version which results in `mariadb-server` to install Python 2 and break that test environment. This PR changes the setup to only install if it is needed as `mariadb-server` is already pre-installed https://github.com/ansible/distro-test-containers/blob/master/fedora29-test-container/Dockerfile#L27 and also simplifies the steps.

The original code to install the latest was added when the test was created https://github.com/ansible/ansible/commit/24a3d55c78440bda5132f85fdf52f220a71a03b2 but I'm not sure if there is a valid reason to add more moving parts to the test.

Fixes https://github.com/ansible/ansible/issues/50386
Fixes https://github.com/ansible/ansible/issues/50394

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test integration tests for

* mysql_db
* mysql_user
* mysql_variables
* zabbix_host