### PR TITLE
gitlab_group: Allow to create subgroups

### DIFF
--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -52,6 +52,7 @@ options:
             - The path of the group you want to create, this will be server_url/group_path
             - If not supplied, the group_name will be used.
     parent_id:
+        version_added: 2.8
         description:
             - The ID of the parent group
             - Is not used when group already exists. This means you cannot move the group with this module yet.
@@ -127,7 +128,7 @@ class GitLabGroup(object):
             group = self._gitlab.groups.create({
                 'name': name,
                 'path': path,
-                'parent_id': parent_id })
+                'parent_id': parent_id})
             changed = True
         else:
             group = self.groupObject


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enchancment of the module `gitlab_group`
Allow to pass `parent_id` parameter to create subgroup
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

gitlab_group

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Resolving issue #41347 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
gitlab_group:
  server_url: http://gitlab.dj-wasabi.local
  validate_certs: False
  login_token: WnUzDsxjy8230-Dy_k
  name: my_first_group
  parent_id: my_parent_group_id
  state: present
```
