### PR TITLE
gitlab_group: Remove forced lowercase on group_name

### DIFF
--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -199,7 +199,6 @@ def main():
         group_path = group_name.replace(" ", "_")
 
     group = GitLabGroup(module, git)
-    group_name = group_name.lower()
     group_exists = group.existsGroup(group_name)
 
     if group_exists and state == "absent":


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module force lowercase on group name. This PR remove that.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gitlab_group

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
