### PR TITLE
Add auth_timeout parameter when supported by paramiko

### DIFF
--- a/changelogs/fragments/50448-paramiko_ssh_add_auth_timeout.yaml
+++ b/changelogs/fragments/50448-paramiko_ssh_add_auth_timeout.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - paramiko_ssh - add auth_timeout parameter to ssh.connect when supported by installed paramiko version. This will prevent "Authentication timeout" errors when a slow authentication step (>30s) happens with a host (https://github.com/ansible/ansible/issues/42596)


### PR DESCRIPTION
Paramiko 2.2 introduces the auth_timeout parameter. This will set the
parameter to the same value of the timeout parameter to prevent
"Authentication timeout" errors.

##### SUMMARY
If the paramiko version installed is at least 2.2 include the auth_timeout parameter to the connect method with the same value used for the timeout method. This will prevent "Authentication timeout" errors when a slow authentication step (>30s) happens with a host. This is common with some network devices.

Fixes #42596

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
paramiko_ssh connection plugin 

##### ADDITIONAL INFORMATION
I noticed that problem when using the network_cli connection plugin, which in turn uses the paramiko_ssh connection plugin.
