### PR TITLE
unarchive: improved performance for tar-archives and introduced param…

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -87,7 +87,7 @@ options:
     version_added: "2.2"
   omit_check:
     description:
-      - By default unarchive will make a diff of the files in the archive and the destination, to check if it needs to 
+      - By default unarchive will make a diff of the files in the archive and the destination, to check if it needs to
         extract the archive and/or fix the file attributes afterwards.
       - The bigger the archive, the longer it takes. If you are sure you don't need this check, you can disable it and gain some performance.
     type: 'bool'


### PR DESCRIPTION
…eter to avoid unnecessary checks if not needed in the workflow

##### SUMMARY
Fixes #41207

Greatly improved performance, especially for tar-archives.
* The check, which archive-handler to use, has been cleaned up and improved.
  * It no longer abuses the _files_in_archive_ method
  * Only checks if its extractable with minimum overhead
* Introduced a parameter to omit the diff-check if not required

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
unarchive

##### ADDITIONAL INFORMATION
The new method `_is_extractable` uses the command `timeout` (if available on the system).
That's because the `tar`-command offers no fast way to check an archive to readability/extractability.
The only option is to try running tar with the `--list` option - but that can take very long, depending on the size of the archive and amount of files in it.
If the archive is not readable on the other hand, it will fail immediately. 
In our case, this change speeds up the task by 15 - 30 seconds - per archive.

Round about the same amount of time is saved by using the new parameter and omit the call to `is_unarchived`. We don't need this check for our use-case, so being able to disable it gives us another performance-benefit.

*Details for commands in different scenarios:*
```paste below
// without timeout:
> time tar -j --list -f tomcat-preview-18.0.0-SNAPSHOT.tar.bz2 > /dev/null
tar -j --list -f tomcat-preview-18.0.0-SNAPSHOT.tar.bz2 > /dev/null  15,74s user 0,38s system 102% cpu 15,797 total

// not extractable:
> time tar -z --list -f tomcat-preview-18.0.0-SNAPSHOT.tar.bz2 > /dev/null
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
tar -z --list -f tomcat-preview-18.0.0-SNAPSHOT.tar.bz2 > /dev/null  0,00s user 0,00s system 90% cpu 0,003 total

// return code with timeout:
> timeout 3 tar -j --list -f tomcat-preview-18.0.0-SNAPSHOT.tar.bz2 > /dev/null
> echo "$?"
124

// return code with timeout for small archive:
> timeout 10 tar -j --list -f tomcat-small-18.0.0-SNAPSHOT.tar.bz2 > /dev/null
> echo "$?"
0

// return code with timeout for wrong archive:
> timeout 3 tar -z --list -f tomcat-small-18.0.0-SNAPSHOT.tar.bz2 > /dev/null
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
> echo "$?"
2

```
