### PR TITLE
Fix for the new 2.8 feature to have modprobe check for builtins.

### DIFF
--- a/lib/ansible/modules/system/modprobe.py
+++ b/lib/ansible/modules/system/modprobe.py
@@ -52,6 +52,7 @@ EXAMPLES = '''
     params: 'numdummies=2'
 '''
 
+import os.path
 import shlex
 import traceback
 
@@ -94,7 +95,9 @@ def main():
             command = [module.get_bin_path('uname', True), '-r']
             rc, uname_kernel_release, err = module.run_command(command)
             module_file = '/' + name + '.ko'
-            with open('/lib/modules/' + uname_kernel_release + '/modules.builtin') as builtins:
+            builtin_path = os.path.join('/lib/modules/', uname_kernel_release.strip(),
+                                        'modules.builtin')
+            with open(builtin_path) as builtins:
                 for line in builtins:
                     if line.endswith(module_file):
                         present = True


### PR DESCRIPTION
uname output includes a newline.  strip() the newline so that the
filepath we construct points to the right place.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/modules/system/modprobe.py

##### ADDITIONAL INFORMATION

This is only needed in devel (2.8) as the feature is added in 2.8.

This should fix the problem reported here: https://github.com/ansible/ansible/pull/37150#issuecomment-449709296

\cc @winem   @cognifloyd