### PR TITLE
na_ontap_dns: Add new parameter skip_validation

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_dns.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_dns.py
@@ -43,7 +43,9 @@ options:
   skip_validation:
     type: bool
     description:
-    - If set to 'true', this option bypass the DNS check on the ONTAP.
+    - By default, all nameservers are checked to validate they are available to resolve.
+    - If you DNS servers are not yet installed or momentarily not available, you can set this option to 'true'
+    - to bypass the check for all servers specified in nameservers field.
     version_added: '2.8'
 '''
 

--- a/lib/ansible/modules/storage/netapp/na_ontap_dns.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_dns.py
@@ -40,6 +40,10 @@ options:
     description:
     - List of IPv4 addresses of name servers such as '123.123.123.123'.
 
+  skip_validation:
+	description:
+	- Skip configuration validation.
+
 '''
 
 EXAMPLES = """
@@ -52,6 +56,7 @@ EXAMPLES = """
         vserver:  "{{vservername}}"
         domains: sales.bar.com
         nameservers: 10.193.0.250,10.192.0.250
+		skip_validation: yes
 """
 
 RETURN = """
@@ -77,7 +82,8 @@ class NetAppOntapDns(object):
             state=dict(required=False, choices=['present', 'absent'], default='present'),
             vserver=dict(required=True, type='str'),
             domains=dict(required=False, type='list'),
-            nameservers=dict(required=False, type='list')
+            nameservers=dict(required=False, type='list'),
+            skip_validation=dict(required=False, type='bool')
         ))
 
         self.module = AnsibleModule(
@@ -112,6 +118,10 @@ class NetAppOntapDns(object):
             domain.set_content(each)
             domains.add_child_elem(domain)
         dns.add_child_elem(domains)
+        if self.parameters.get('skip_validation'):
+			validation = netapp_utils.zapi.NaElement('skip-config-validation')
+			validation.set_content( str( self.parameters['skip_validation']))
+			dns.add_child_elem(validation)
         try:
             self.server.invoke_successfully(dns, True)
         except netapp_utils.zapi.NaApiError as error:
@@ -151,6 +161,7 @@ class NetAppOntapDns(object):
         attrs['nameservers'] = [each.get_content() for each in nameservers.get_children()]
         domains = dns_info.get_child_by_name('domains')
         attrs['domains'] = [each.get_content() for each in domains.get_children()]
+        attrs['skip_validation'] = dns_info.get_child_by_name('skip-config-validation')
         return attrs
 
     def modify_dns(self, dns_attrs):
@@ -173,6 +184,10 @@ class NetAppOntapDns(object):
                 domains.add_child_elem(domain)
             dns.add_child_elem(domains)
         if changed:
+            if self.parameters.get('skip_validation'):
+                validation = netapp_utils.zapi.NaElement('skip-config-validation')
+                validation.set_content( str( self.parameters['skip_validation']))
+                dns.add_child_elem(validation)
             try:
                 self.server.invoke_successfully(dns, True)
             except netapp_utils.zapi.NaApiError as error:

--- a/lib/ansible/modules/storage/netapp/na_ontap_dns.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_dns.py
@@ -41,8 +41,8 @@ options:
     - List of IPv4 addresses of name servers such as '123.123.123.123'.
 
   skip_validation:
-	description:
-	- Skip configuration validation.
+    description:
+    - Skip configuration validation.
 
 '''
 
@@ -119,9 +119,9 @@ class NetAppOntapDns(object):
             domains.add_child_elem(domain)
         dns.add_child_elem(domains)
         if self.parameters.get('skip_validation'):
-			validation = netapp_utils.zapi.NaElement('skip-config-validation')
-			validation.set_content( str( self.parameters['skip_validation']))
-			dns.add_child_elem(validation)
+            validation = netapp_utils.zapi.NaElement('skip-config-validation')
+            validation.set_content( str( self.parameters['skip_validation']))
+            dns.add_child_elem(validation)
         try:
             self.server.invoke_successfully(dns, True)
         except netapp_utils.zapi.NaApiError as error:

--- a/lib/ansible/modules/storage/netapp/na_ontap_dns.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_dns.py
@@ -41,9 +41,10 @@ options:
     - List of IPv4 addresses of name servers such as '123.123.123.123'.
 
   skip_validation:
+    type: bool
     description:
-    - Skip configuration validation.
-
+    - If set to "TRUE", this option bypass the DNS check on the Ontap.
+    version_added: '2.8'
 '''
 
 EXAMPLES = """
@@ -56,7 +57,7 @@ EXAMPLES = """
         vserver:  "{{vservername}}"
         domains: sales.bar.com
         nameservers: 10.193.0.250,10.192.0.250
-		skip_validation: yes
+        skip_validation: yes
 """
 
 RETURN = """

--- a/lib/ansible/modules/storage/netapp/na_ontap_dns.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_dns.py
@@ -43,7 +43,7 @@ options:
   skip_validation:
     type: bool
     description:
-    - If set to "TRUE", this option bypass the DNS check on the Ontap.
+    - If set to 'true', this option bypass the DNS check on the Ontap.
     version_added: '2.8'
 '''
 
@@ -57,7 +57,7 @@ EXAMPLES = """
         vserver:  "{{vservername}}"
         domains: sales.bar.com
         nameservers: 10.193.0.250,10.192.0.250
-        skip_validation: yes
+        skip_validation: true
 """
 
 RETURN = """

--- a/lib/ansible/modules/storage/netapp/na_ontap_dns.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_dns.py
@@ -120,7 +120,7 @@ class NetAppOntapDns(object):
         dns.add_child_elem(domains)
         if self.parameters.get('skip_validation'):
             validation = netapp_utils.zapi.NaElement('skip-config-validation')
-            validation.set_content( str( self.parameters['skip_validation']))
+            validation.set_content(str(self.parameters['skip_validation']))
             dns.add_child_elem(validation)
         try:
             self.server.invoke_successfully(dns, True)
@@ -186,7 +186,7 @@ class NetAppOntapDns(object):
         if changed:
             if self.parameters.get('skip_validation'):
                 validation = netapp_utils.zapi.NaElement('skip-config-validation')
-                validation.set_content( str( self.parameters['skip_validation']))
+                validation.set_content(str(self.parameters['skip_validation']))
                 dns.add_child_elem(validation)
             try:
                 self.server.invoke_successfully(dns, True)

--- a/lib/ansible/modules/storage/netapp/na_ontap_dns.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_dns.py
@@ -43,7 +43,7 @@ options:
   skip_validation:
     type: bool
     description:
-    - If set to 'true', this option bypass the DNS check on the Ontap.
+    - If set to 'true', this option bypass the DNS check on the ONTAP.
     version_added: '2.8'
 '''
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add skip_validation parameter to bypass the DNS configuration check on the Netapp Ontap. Refers to the skip-config-validation parameter on the SDK.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
na_ontap_dns

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Tested on FAS8200 with DOT 9.4 with DNS and domain not reachabled (Create and Modify): OK

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
