### PR TITLE
allow for vault enterprise namespaces

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -53,6 +53,7 @@ DOCUMENTATION = """
       type: boolean
       default: True
     namespace:
+      version_added: "2.8"
       description: namespace where secrets reside. requires HVAC 0.7.0+ and Vault 0.11+
       default: None
 """

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -52,6 +52,9 @@ DOCUMENTATION = """
       description: controls verification and validation of SSL certificates, mostly you only want to turn off with self signed ones.
       type: boolean
       default: True
+    namespace:
+      description: namespace where secrets reside. requires HVAC 0.7.0+ and Vault 0.11+
+      default: None
 """
 
 EXAMPLES = """
@@ -77,6 +80,10 @@ EXAMPLES = """
 - name: authenticate with a Vault app role
   debug:
       msg: "{{ lookup('hashi_vault', 'secret=secret/hello:value auth_method=approle role_id=myroleid secret_id=mysecretid url=http://myvault:8200')}}"
+
+- name: Return all secrets from a path in a namespace
+  debug:
+    msg: "{{ lookup('hashi_vault', 'secret=secret/hello token=c975b780-d1be-8016-866b-01d0f9b688a5 url=http://myvault:8200 namespace=teama/admins')}}"
 """
 
 RETURN = """
@@ -109,6 +116,7 @@ class HashiVault:
     def __init__(self, **kwargs):
 
         self.url = kwargs.get('url', ANSIBLE_HASHI_VAULT_ADDR)
+        self.namespace = kwargs.get('namespace', None)
 
         # split secret arg, which has format 'secret/hello:value' into secret='secret/hello' and secret_field='value'
         s = kwargs.get('secret')
@@ -134,7 +142,10 @@ class HashiVault:
         self.verify = self.boolean_or_cacert(kwargs.get('validate_certs', True), kwargs.get('cacert', ''))
         if self.auth_method and self.auth_method != 'token':
             try:
-                self.client = hvac.Client(url=self.url, verify=self.verify)
+                if self.namespace is not None:
+                    self.client = hvac.Client(url=self.url, verify=self.verify, namespace=self.namespace)
+                else:
+                    self.client = hvac.Client(url=self.url, verify=self.verify)
                 # prefixing with auth_ to limit which methods can be accessed
                 getattr(self, 'auth_' + self.auth_method)(**kwargs)
             except AttributeError:
@@ -153,7 +164,10 @@ class HashiVault:
             if self.token is None:
                 raise AnsibleError("No Vault Token specified")
 
-            self.client = hvac.Client(url=self.url, token=self.token, verify=self.verify)
+            if self.namespace is not None:
+                self.client = hvac.Client(url=self.url, token=self.token, verify=self.verify, namespace=self.namespace)
+            else:
+                self.client = hvac.Client(url=self.url, token=self.token, verify=self.verify)
 
         if not self.client.is_authenticated():
             raise AnsibleError("Invalid Hashicorp Vault Token Specified for hashi_vault lookup")


### PR DESCRIPTION
SUMMARY
vault included a namespace feature for Enterprise users to segment vault into 'mini vaults'. this feature allows users to include a namespace in a hashi_vault lookup() call.

design:
pass namespace as parameter to Client class object, gets included as a header

users must upgrade to latest hvac, 0.7.0 and vault 0.11+ enterprise. to avoid issues, we test to see if namespace was passed as a param; if it has been, include it in the hvac Client object creation, if its not passed, do not include. if param is passed and user doesnt meet requirements, AnsibleError is thrown

ISSUE TYPE
Feature Pull Request

COMPONENT NAME
hashi_vault