### PR TITLE
ios_facts: added/enhanced interface features and merged to ansible_net_interfaces

### DIFF
--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -629,7 +629,7 @@ class Interfaces(FactsBase):
             return match.group(1)
 
     def parse_cdp_capabilities(self, data):
-        match = re.search(r'Capabilities: (.+)$', data, re.M)
+        match = re.search(r'Capabilities: (.+)\s{0,1}$', data, re.M)
         if match:
             return match.group(1)
 

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -619,17 +619,17 @@ class Interfaces(FactsBase):
             return match.group(1)
 
     def parse_cdp_platform(self, data):
-        match = re.search(r'^Platform: (\S+),', data, re.M)
+        match = re.search(r'^Platform: (.+),', data, re.M)
         if match:
             return match.group(1)
 
     def parse_cdp_address(self, data):
-        match = re.search(r'IP address: (\S+)', data, re.M)
+        match = re.search(r'IP address: (.+)$', data, re.M)
         if match:
             return match.group(1)
 
     def parse_cdp_capabilities(self, data):
-        match = re.search(r'Capabilities: (\S+)$', data, re.M)
+        match = re.search(r'Capabilities: (.+)$', data, re.M)
         if match:
             return match.group(1)
 

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -673,6 +673,7 @@ class Interfaces(FactsBase):
         if match:
             return match.group(1)
 
+
 FACT_SUBSETS = dict(
     default=Default,
     hardware=Hardware,
@@ -684,6 +685,7 @@ FACT_SUBSETS = dict(
 VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())
 
 warnings = list()
+
 
 def main():
     """main entry point for module execution

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -629,7 +629,7 @@ class Interfaces(FactsBase):
             return match.group(1)
 
     def parse_cdp_capabilities(self, data):
-        match = re.search(r'Capabilities: (.+)\s{0,1}$', data, re.M)
+        match = re.search(r'Capabilities: (\w+(\s+\w+){0,})\s+$', data, re.M)
         if match:
             return match.group(1)
 

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -138,10 +138,10 @@ ansible_net_all_ipv6_addresses:
   returned: when interfaces is configured
   type: list
 ansible_net_interfaces:
-  description: 
+  description:
     - A hash of all interfaces running on the system.
       Expanded with other interface related facts information like
-      CDP/LLDP neighbors, Port-Channels, type (access|trunk|routed), 
+      CDP/LLDP neighbors, Port-Channels, type (access|trunk|routed),
       access|voice vlans, trunk allowed vlans
   returned: when interfaces is configured
   type: dict
@@ -179,6 +179,7 @@ from ansible.module_utils.six.moves import zip
 
 class FactsBase(object):
 
+
     COMMANDS = list()
 
     def __init__(self, module):
@@ -194,6 +195,7 @@ class FactsBase(object):
 
 
 class Default(FactsBase):
+
 
     COMMANDS = ['show version']
 
@@ -253,6 +255,7 @@ class Default(FactsBase):
 
 class Hardware(FactsBase):
 
+
     COMMANDS = [
         'dir',
         'show memory statistics'
@@ -298,6 +301,7 @@ class Hardware(FactsBase):
 
 class Config(FactsBase):
 
+
     COMMANDS = ['show running-config']
 
     def populate(self):
@@ -311,6 +315,7 @@ class Config(FactsBase):
 
 
 class Interfaces(FactsBase):
+
 
     COMMANDS = [
         'show run | i interface|switchport mode|switchport trunk|switchport access|switchport voice|no switchport',
@@ -359,12 +364,9 @@ class Interfaces(FactsBase):
         if data:
             interfaces = self.parse_interfaces(data)
             self.facts['interfaces'] = self.populate_interfaces(interfaces)
-            self.update_interfaces_channel(self.facts['interfaces'], 
-                                           self.facts['etherchannels'])
-            self.update_interfaces_neighbors(self.facts['interfaces'],
-                                             self.facts['neighbors'])
-            self.update_interfaces_vlans(self.facts['interfaces'],
-                                             self.facts['ifvlans'])
+            self.update_interfaces_channel(self.facts['interfaces'], self.facts['etherchannels'])
+            self.update_interfaces_neighbors(self.facts['interfaces'], self.facts['neighbors'])
+            self.update_interfaces_vlans(self.facts['interfaces'], self.facts['ifvlans'])
 
         data = self.responses[5]
         if data:
@@ -415,6 +417,7 @@ class Interfaces(FactsBase):
                     memberintfid = self.parse_interface_id(memberintf)
                     if intfid == memberintfid:
                         self.facts['interfaces'][intf]['channel'] = chintf
+                        self.facts['interfaces'][intf]['channelmembers'] = members['members']
 
     def update_interfaces_neighbors(self, interfaces, neighbors):
         for intf, values in iteritems(interfaces):
@@ -661,8 +664,8 @@ class Interfaces(FactsBase):
                 if '-' not in i:
                     parsed.append(int(i))
                 else:
-                    l,h = map(int, i.split('-'))
-                    parsed += range(l,h+1)
+                    l, h = map(int, i.split('-'))
+                    parsed += range(l, h + 1)
             return parsed
 
     def parse_channel_vintf(self, data):

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -179,7 +179,6 @@ from ansible.module_utils.six.moves import zip
 
 class FactsBase(object):
 
-
     COMMANDS = list()
 
     def __init__(self, module):
@@ -195,7 +194,6 @@ class FactsBase(object):
 
 
 class Default(FactsBase):
-
 
     COMMANDS = ['show version']
 
@@ -255,7 +253,6 @@ class Default(FactsBase):
 
 class Hardware(FactsBase):
 
-
     COMMANDS = [
         'dir',
         'show memory statistics'
@@ -301,7 +298,6 @@ class Hardware(FactsBase):
 
 class Config(FactsBase):
 
-
     COMMANDS = ['show running-config']
 
     def populate(self):
@@ -315,7 +311,6 @@ class Config(FactsBase):
 
 
 class Interfaces(FactsBase):
-
 
     COMMANDS = [
         'show run | i interface|switchport mode|switchport trunk|switchport access|switchport voice|no switchport',
@@ -685,10 +680,10 @@ FACT_SUBSETS = dict(
     config=Config,
 )
 
+
 VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())
 
 warnings = list()
-
 
 def main():
     """main entry point for module execution

--- a/test/units/modules/network/ios/fixtures/ios_facts_show_etherchannel_summary
+++ b/test/units/modules/network/ios/fixtures/ios_facts_show_etherchannel_summary
@@ -1,0 +1,24 @@
+interface Port-channel10
+ switchport trunk encapsulation dot1q
+ switchport trunk allowed vlan 10,20
+ switchport mode trunk
+!
+interface GigabitEthernet0/9
+ description UPLINK
+ switchport trunk encapsulation dot1q
+ switchport trunk allowed vlan 10,20
+ switchport mode trunk
+ srr-queue bandwidth share 10 30 20 40
+ priority-queue out 
+ mls qos trust dscp
+ channel-group 10 mode active
+!
+interface GigabitEthernet0/10
+ description UPLINK
+ switchport trunk encapsulation dot1q
+ switchport trunk allowed vlan 10,20
+ switchport mode trunk
+ srr-queue bandwidth share 10 30 20 40
+ priority-queue out 
+ mls qos trust dscp
+ channel-group 10 mode active

--- a/test/units/modules/network/ios/fixtures/ios_facts_show_etherchannel_summary
+++ b/test/units/modules/network/ios/fixtures/ios_facts_show_etherchannel_summary
@@ -1,24 +1,18 @@
-interface Port-channel10
- switchport trunk encapsulation dot1q
- switchport trunk allowed vlan 10,20
- switchport mode trunk
-!
-interface GigabitEthernet0/9
- description UPLINK
- switchport trunk encapsulation dot1q
- switchport trunk allowed vlan 10,20
- switchport mode trunk
- srr-queue bandwidth share 10 30 20 40
- priority-queue out 
- mls qos trust dscp
- channel-group 10 mode active
-!
-interface GigabitEthernet0/10
- description UPLINK
- switchport trunk encapsulation dot1q
- switchport trunk allowed vlan 10,20
- switchport mode trunk
- srr-queue bandwidth share 10 30 20 40
- priority-queue out 
- mls qos trust dscp
- channel-group 10 mode active
+Flags:  D - down        P - bundled in port-channel
+        I - stand-alone s - suspended
+        H - Hot-standby (LACP only)
+        R - Layer3      S - Layer2
+        U - in use      f - failed to allocate aggregator
+
+        M - not in use, minimum links not met
+        u - unsuitable for bundling
+        w - waiting to be aggregated
+        d - default port
+
+
+Number of channel-groups in use: 1
+Number of aggregators:           1
+
+Group  Port-channel  Protocol    Ports
+------+-------------+-----------+-----------------------------------------------
+10     Po10(SU)        LACP      Gi0/9(P)    Gi0/10(D)  

--- a/test/units/modules/network/ios/fixtures/ios_facts_show_run
+++ b/test/units/modules/network/ios/fixtures/ios_facts_show_run
@@ -1,0 +1,19 @@
+interface GigabitEthernet0/2
+ description ACCESS-PORT-2
+ switchport access vlan 10
+ switchport mode access
+ switchport voice vlan 20
+ srr-queue bandwidth share 10 30 20 40
+ priority-queue out 
+ spanning-tree portfast
+ service-policy input qos-client-in
+!
+interface GigabitEthernet0/10
+ description UPLINK
+ switchport trunk encapsulation dot1q
+ switchport trunk allowed vlan 10,20
+ switchport mode trunk
+ srr-queue bandwidth share 10 30 20 40
+ priority-queue out 
+ mls qos trust dscp
+ channel-group 10 mode active

--- a/test/units/modules/network/ios/test_ios_facts.py
+++ b/test/units/modules/network/ios/test_ios_facts.py
@@ -109,23 +109,17 @@ class TestIosFactsModule(TestIosModule):
     def test_ios_facts_run(self):
         set_module_args(dict(gather_subset='interfaces'))
         result = self.execute_module()
-        assertCountEqual(
-            self,
-            result['ansible_facts']['ansible_net_ifvlans'].keys(), ['GigabitEthernet0/2', 'GigabitEthernet0/10']
-        )
+
         assertCountEqual(
             self,
             result['ansible_facts']['ansible_net_ifvlans']['GigabitEthernet0/2'],
-            [{'mode': 'access', 'vlanallowed': 'null', 'vlandata': '10', 'vlanvoice': '20'}]
+            {'mode': 'access', 'vlanallowed': 'null', 'vlandata': '10', 'vlanvoice': '20'}
         )
 
     def test_ios_facts_etherchannel(self):
         set_module_args(dict(gather_subset='interfaces'))
         result = self.execute_module()
-        assertCountEqual(
-            self,
-            result['ansible_facts']['ansible_net_etherchannels'].keys(), ['Po10']
-        )
+
         assertCountEqual(
             self,
             result['ansible_facts']['ansible_net_etherchannels']['Po10']['members'], ['Gi0/9', 'Gi0/10']

--- a/test/units/modules/network/ios/test_ios_facts.py
+++ b/test/units/modules/network/ios/test_ios_facts.py
@@ -99,7 +99,7 @@ class TestIosFactsModule(TestIosModule):
         assertCountEqual(
             self,
             result['ansible_facts']['ansible_net_neighbors']['GigabitEthernet1'],
-            [{'host': 'R2', 'port': 'GigabitEthernet2'}, {'host': 'R3', 'port': 'GigabitEthernet3'}]
+            [{'platform': 'cisco CSR1000V', 'address': '10.0.0.3', 'capabilities': 'Router IGMP', 'host': 'R2', 'port': 'GigabitEthernet2'}]
         )
         assertCountEqual(
             self,

--- a/test/units/modules/network/ios/test_ios_facts.py
+++ b/test/units/modules/network/ios/test_ios_facts.py
@@ -105,3 +105,28 @@ class TestIosFactsModule(TestIosModule):
             self,
             result['ansible_facts']['ansible_net_neighbors']['GigabitEthernet3'], [{'host': 'Rtest', 'port': 'Gi1'}]
         )
+
+    def test_ios_facts_run(self):
+        set_module_args(dict(gather_subset='interfaces'))
+        result = self.execute_module()
+        assertCountEqual(
+            self,
+            result['ansible_facts']['ansible_net_ifvlans'].keys(), ['GigabitEthernet0/2', 'GigabitEthernet0/10']
+        )
+        assertCountEqual(
+            self,
+            result['ansible_facts']['ansible_net_ifvlans']['GigabitEthernet0/2'],
+            [{'mode': 'access', 'vlanallowed': 'null', 'vlandata': '10', 'vlanvoice': '20'}]
+        )
+
+    def test_ios_facts_etherchannel(self):
+        set_module_args(dict(gather_subset='interfaces'))
+        result = self.execute_module()
+        assertCountEqual(
+            self,
+            result['ansible_facts']['ansible_net_etherchannels'].keys(), ['Po10']
+        )
+        assertCountEqual(
+            self,
+            result['ansible_facts']['ansible_net_etherchannels']['Po10']['members'], ['Gi0/9', 'Gi0/10']
+        )

--- a/test/units/modules/network/ios/test_ios_facts.py
+++ b/test/units/modules/network/ios/test_ios_facts.py
@@ -99,7 +99,8 @@ class TestIosFactsModule(TestIosModule):
         assertCountEqual(
             self,
             result['ansible_facts']['ansible_net_neighbors']['GigabitEthernet1'],
-            [{'platform': 'cisco CSR1000V', 'address': '10.0.0.3', 'capabilities': 'Router IGMP', 'host': 'R2', 'port': 'GigabitEthernet2'}]
+            [{'platform': 'cisco CSR1000V', 'address': '10.0.0.3', 'capabilities': 'Router IGMP', 'host': 'R2', 'port': 'GigabitEthernet2'},
+             {'platform': 'cisco CSR1000V', 'address': '10.0.0.4', 'capabilities': 'Router IGMP', 'host': 'R3', 'port': 'GigabitEthernet3'}]
         )
         assertCountEqual(
             self,


### PR DESCRIPTION
##### SUMMARY
Lots of tasks for network automation need more detailed facts information from devices. Especially regarding interface configuration depending on active states in plays.

Example: 
1. Configure QoS Service Policy for Uplinks only on trunks with cdp neighbor. If the interface is a Port-Channel member, configure the same all other channel members.
2. Configure another Policy for Client devices only on access ports with vlan 20 - with restrictive trust state.
3. Configure different QoS trust boundary on trunks with access-points as cdp neighbors.

Querying multiple show commands with parser and looping through in plays directly is a very painful task and plays get ugly very quick. To solve that and create more flexibility with facts for ios devices I propose to add functionality to ios_facts:

- Etherchannel information as hash - fact is called "etherchannels"
- Interface mode and vlan configuation (data/voice/trunk) - fact is called ifvlans"
- Enhanced cdp information - "platform", "address", "capabilities"
- Merge information (etherchannel, vlans, cdp) into ansible_net_interfaces to allow simpler playbook loops through these facts for interface related configuration.

The last topic is most important for me, interface related information should always be found in a comprehensive interface hash.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
[ios_facts](https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/network/ios/ios_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr)


##### ADDITIONAL INFORMATION
I tried my best to align to the existing code design, for that reason I decided to add my facts as separate hashes (listed above) and merge this information additionally to the ansible_net_interface hash. I do not see issues here, someone could address these facts directly or use the merged interface facts which will be the major case in my opinion.

Example ansible_net_interfaces output enriched with relevant information:
```
        "TenGigabitEthernet1/1/11": {
            "bandwidth": 10000000,
            "channel": "Po102",
            "channelmembers": [
                "Te1/1/11",
                "Te2/1/11"
            ],
            "description": "EXAMPLE PORT",
            "duplex": null,
            "ipv4": [],
            "lineprotocol": null,
            "macaddress": "f45b.3adc.0d3a",
            "mediatype": "10GBase-CU 2M",
            "mode": "trunk",
            "mtu": 9170,
            "neighbor": [
                {
                    "address": "172.22.22.93",
                    "capabilities": null,
                    "host": "STORAGE",
                    "platform": "FAS3220",
                    "port": "e2b"
                }
            ],
            "operstatus": "up",
            "type": "Ten Gigabit Ethernet Port",
            "vlanallowed": [
                3900
            ],
            "vlandata": null,
            "vlanvoice": null
        },
```
