### PR TITLE
fix order of dnf api operations so transactions don't fail (#50038)

### DIFF
--- a/changelogs/fragments/dnf-update-cache-broken-transaction.yaml
+++ b/changelogs/fragments/dnf-update-cache-broken-transaction.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "dnf - fix update_cache combined with install operation to not cause dnf transaction failure"

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -579,6 +579,15 @@ class DnfModule(YumDnf):
         except AttributeError:
             pass  # older versions of dnf didn't require this and don't have these methods
         try:
+            if self.update_cache:
+                try:
+                    base.update_cache()
+                except dnf.exceptions.RepoError as e:
+                    self.module.fail_json(
+                        msg="{0}".format(to_text(e)),
+                        results=[],
+                        rc=1
+                    )
             base.fill_sack(load_system_repo='auto')
         except dnf.exceptions.RepoError as e:
             self.module.fail_json(
@@ -592,8 +601,6 @@ class DnfModule(YumDnf):
         if self.security:
             key = {'advisory_type__eq': 'security'}
             base._update_security_filters = [base.sack.query().filter(**key)]
-        if self.update_cache:
-            base.update_cache()
         return base
 
     def list_items(self, command):

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -50,6 +50,7 @@
   dnf:
     name: sos
     state: present
+    update_cache: True
   register: dnf_result
 
 - name: check sos with rpm


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix order of dnf api operations so transactions don't fail

Previously dnf.base.fill_sack() was called before
dnf.base.update_cache() which apparently breaks dnf transaction
logic as per https://bugzilla.redhat.com/show_bug.cgi?id=1658694

Fixes #49060

Backport of #50038 

Signed-off-by: Adam Miller <admiller@redhat.com>
(cherry picked from commit ca084889c78230a5e86a3434cb4ccfc5b4d2d120)



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dnf
