### PR TITLE
Backport/2.7/50242 firewalld missing port protocol

### DIFF
--- a/changelogs/fragments/firewalld-missing-port-protocol.yml
+++ b/changelogs/fragments/firewalld-missing-port-protocol.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fix handling of firewalld port if protocol is missing

--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -567,8 +567,11 @@ def main():
     zone = module.params['zone']
 
     if module.params['port'] is not None:
-        port, protocol = module.params['port'].strip().split('/')
-        if protocol is None:
+        if '/' in module.params['port']:
+            port, protocol = module.params['port'].strip().split('/')
+        else:
+            protocol = None
+        if not protocol:
             module.fail_json(msg='improper port format (missing protocol?)')
     else:
         port = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
    Fix firewalld module failing on missing protocol. (#50242)

    Under Python 3.7 at least, the split of the port field fails
    ungracefully if there is no slash. The fix also addresses the
    case of an empty protocol after the slash.

    (cherry picked from commit 69deb738036fc8968be81794800c27c4c7b6565d)

    add changelog for #50242 (#50480)

    Signed-off-by: Adam Miller <admiller@redhat.com>
    (cherry picked from commit b81a74f5516f70623a3fb157fdd60ff1c5539154)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
firewalld


