### PR TITLE
[2.7] openssl_*: prevent error when path includes no path

### DIFF
--- a/changelogs/fragments/50322-openssl-path-error.yml
+++ b/changelogs/fragments/50322-openssl-path-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_* - fix error when ``path`` contains a file name without path."

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -1041,7 +1041,7 @@ def main():
     if module.params['provider'] != 'assertonly' and module.params['csr_path'] is None:
         module.fail_json(msg='csr_path is required when provider is not assertonly')
 
-    base_dir = os.path.dirname(module.params['path'])
+    base_dir = os.path.dirname(module.params['path']) or '.'
     if not os.path.isdir(base_dir):
         module.fail_json(
             name=base_dir,

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -552,7 +552,7 @@ def main():
     except AttributeError:
         module.fail_json(msg='You need to have PyOpenSSL>=0.15 to generate CSRs')
 
-    base_dir = os.path.dirname(module.params['path'])
+    base_dir = os.path.dirname(module.params['path']) or '.'
     if not os.path.isdir(base_dir):
         module.fail_json(name=base_dir, msg='The directory %s does not exist or the file is not a directory' % base_dir)
 

--- a/lib/ansible/modules/crypto/openssl_dhparam.py
+++ b/lib/ansible/modules/crypto/openssl_dhparam.py
@@ -191,7 +191,7 @@ def main():
         add_file_common_args=True,
     )
 
-    base_dir = os.path.dirname(module.params['path'])
+    base_dir = os.path.dirname(module.params['path']) or '.'
     if not os.path.isdir(base_dir):
         module.fail_json(
             name=base_dir,

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -312,7 +312,7 @@ def main():
     if not pyopenssl_found:
         module.fail_json(msg='The python pyOpenSSL library is required')
 
-    base_dir = os.path.dirname(module.params['path'])
+    base_dir = os.path.dirname(module.params['path']) or '.'
     if not os.path.isdir(base_dir):
         module.fail_json(
             name=base_dir,

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -271,7 +271,7 @@ def main():
     if not pyopenssl_found:
         module.fail_json(msg='the python pyOpenSSL module is required')
 
-    base_dir = os.path.dirname(module.params['path'])
+    base_dir = os.path.dirname(module.params['path']) or '.'
     if not os.path.isdir(base_dir):
         module.fail_json(
             name=base_dir,

--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -269,7 +269,7 @@ def main():
     if not pyopenssl_found:
         module.fail_json(msg='the python pyOpenSSL module is required')
 
-    base_dir = os.path.dirname(module.params['path'])
+    base_dir = os.path.dirname(module.params['path']) or '.'
     if not os.path.isdir(base_dir):
         module.fail_json(
             name=base_dir,


### PR DESCRIPTION
##### SUMMARY
Backport of #50322 to stable-2.7: fix wrong error message when `path` option is used with a filename without a path.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate
openssl_csr
openssl_dhparam
openssl_pkcs12
openssl_privatekey
openssl_publickey
