### PR TITLE
Correct Errors in Documentation

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -18,7 +18,7 @@ module: docker_stack
 author: "Dario Zanzico (@dariko)"
 short_description: docker stack module
 description:
--   Manage docker stacks using the 'docker stack' command
+-   Manage docker stacks using the 'docker_stack' command
     on the target node
     (see examples)
 version_added: "2.8"
@@ -35,7 +35,7 @@ options:
         -   present
         -   absent
     compose:
-        required: true
+        required: false
         default: []
         description:
         -   List of compose definitions. Any element may be a string
@@ -119,6 +119,7 @@ EXAMPLES = '''
 
 -   name: deprovision 'stack1'
     docker_stack:
+        name: stack1
         state: absent
 '''
 

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -35,7 +35,6 @@ options:
         -   present
         -   absent
     compose:
-        required: false
         default: []
         description:
         -   List of compose definitions. Any element may be a string

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -41,7 +41,6 @@ options:
             referring to the path of the compose file on the target host
             or the YAML contents of a compose file nested as dictionary.
     prune:
-        required: false
         default: false
         description:
         -   If true will add the C(--prune) option to the C(docker stack deploy) command.
@@ -49,21 +48,18 @@ options:
             current stack definition.
         type: bool
     with_registry_auth:
-        required: false
         default: false
         description:
         -   If true will add the C(--with-registry-auth) option to the C(docker stack deploy) command.
             This will have docker send registry authentication details to Swarm agents.
         type: bool
     resolve_image:
-        required: false
         choices: ["always", "changed", "never"]
         description:
         -   If set will add the C(--resolve-image) option to the C(docker stack deploy) command.
             This will have docker query the registry to resolve image digest and
             supported platforms. If not set, docker use "always" by default.
     absent_retries:
-        required: false
         default: 0
         description:
         -   If C(>0) and C(state==absent) the module will retry up to
@@ -72,7 +68,6 @@ options:
             If the last try still reports the stack as not completely
             removed the module will fail.
     absent_retries_interval:
-        required: false
         default: 1
         description:
         -   Interval in seconds between C(absent_retries)

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -18,7 +18,7 @@ module: docker_stack
 author: "Dario Zanzico (@dariko)"
 short_description: docker stack module
 description:
--   Manage docker stacks using the 'docker_stack' command
+-   Manage docker stacks using the 'docker stack' command
     on the target node
     (see examples)
 version_added: "2.8"


### PR DESCRIPTION
According to the module, "compose" is not required, but the docs said it was - removed the "required" tag. Additionally, the example for removing a stack did not include the required "name" option (this method is why "compose" is not required.
+label: docsite_pr

##### SUMMARY
There were some errors in the documentation that did not match what the module required.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_stack.py

##### ADDITIONAL INFORMATION
Just minor changed to documentation.
