### PR TITLE
dnf - fix conf_file loading

### DIFF
--- a/changelogs/fragments/dnf-conf-file.yaml
+++ b/changelogs/fragments/dnf-conf-file.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- dnf - fix issue where ``conf_file`` was not being loaded properly

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -497,6 +497,17 @@ class DnfModule(YumDnf):
 
         conf = base.conf
 
+        # Change the configuration file path if provided, this must be done before conf.read() is called
+        if conf_file:
+            # Fail if we can't read the configuration file.
+            if not os.access(conf_file, os.R_OK):
+                self.module.fail_json(
+                    msg="cannot read configuration file", conf_file=conf_file,
+                    results=[],
+                )
+            else:
+                conf.config_file_path = conf_file
+
         # Read the configuration file
         conf.read()
 
@@ -544,17 +555,6 @@ class DnfModule(YumDnf):
 
         if self.download_only:
             conf.downloadonly = True
-
-        # Change the configuration file path if provided
-        if conf_file:
-            # Fail if we can't read the configuration file.
-            if not os.access(conf_file, os.R_OK):
-                self.module.fail_json(
-                    msg="cannot read configuration file", conf_file=conf_file,
-                    results=[],
-                )
-            else:
-                conf.config_file_path = conf_file
 
         # Default in dnf upstream is true
         conf.clean_requirements_on_remove = self.autoremove

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -627,41 +627,40 @@
     that:
       - "rpm_lsof_result is failed"
 
-- name: exclude lsof
-  lineinfile:
-    dest: /etc/dnf/dnf.conf
-    regexp: (^exclude=)(.)*
-    line: "exclude=lsof*"
-    state: present
+- name: create conf file that excludes lsof
+  copy:
+    content: |
+      [main]
+      exclude=lsof*
+    dest: '{{ output_dir }}/test-dnf.conf'
+  register: test_dnf_copy
 
-# begin test case where disable_excludes is supported
-- name: Try install lsof without disable_excludes
-  dnf: name=lsof state=latest
-  register: dnf_lsof_result
-  ignore_errors: True
+- block:
+  # begin test case where disable_excludes is supported
+  - name: Try install lsof without disable_excludes
+    dnf: name=lsof state=latest conf_file={{ test_dnf_copy.dest }}
+    register: dnf_lsof_result
+    ignore_errors: True
 
-- name: verify lsof did not install because it is in exclude list
-  assert:
-    that:
-      - "dnf_lsof_result is failed"
+  - name: verify lsof did not install because it is in exclude list
+    assert:
+      that:
+        - "dnf_lsof_result is failed"
 
-- name: install lsof with disable_excludes
-  dnf: name=lsof state=latest disable_excludes=all
-  register: dnf_lsof_result_using_excludes
+  - name: install lsof with disable_excludes
+    dnf: name=lsof state=latest disable_excludes=all conf_file={{ test_dnf_copy.dest }}
+    register: dnf_lsof_result_using_excludes
 
-- name: verify lsof did install using disable_excludes=all
-  assert:
-    that:
-      - "dnf_lsof_result_using_excludes is success"
-      - "dnf_lsof_result_using_excludes is changed"
-      - "dnf_lsof_result_using_excludes is not failed"
-
-- name: remove exclude lsof (cleanup dnf.conf)
-  lineinfile:
-    dest: /etc/dnf/dnf.conf
-    regexp: (^exclude=lsof*)
-    line: "exclude="
-    state: present
-
+  - name: verify lsof did install using disable_excludes=all
+    assert:
+      that:
+        - "dnf_lsof_result_using_excludes is success"
+        - "dnf_lsof_result_using_excludes is changed"
+        - "dnf_lsof_result_using_excludes is not failed"
+  always:
+  - name: remove exclude lsof conf file
+    file:
+      path: '{{ output_dir }}/test-dnf.conf'
+      state: absent
 
 # end test case where disable_excludes is supported


### PR DESCRIPTION
##### SUMMARY
Fix issue where the dnf module would ignore any `[main]` configs inside a conf_file. This is because `conf.config_file_path` needs to be set before `conf.read()` is called. Also updated a test to test out this issue instead of modifying the global `/etc/dnf/dnf.conf` file.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
dnf