### PR TITLE
ansible test: re-enable mysql tests with fix (#50430) - 2.7

### DIFF
--- a/test/integration/targets/setup_mysql_db/tasks/main.yml
+++ b/test/integration/targets/setup_mysql_db/tasks/main.yml
@@ -42,9 +42,28 @@
   with_items: "{{mysql_packages}}"
   when: ansible_pkg_mgr  ==  'yum'
 
-- name: install mysqldb_test rpm dependencies
-  dnf: name={{ item }} state=latest
-  with_items: "{{mysql_packages}}"
+- block:
+  # This is required as mariadb-server has a weak dependency on Python 2 which causes the test to break on Py3 hosts
+  - name: create test dnf.conf file to ignore weak dependencies
+    copy:
+      content: |
+        [main]
+        install_weak_deps=False
+      dest: '{{ output_dir }}/dnf.conf'
+    register: test_dnf_conf_copy
+
+  - name: install mysqldb_test rpm dependencies
+    dnf:
+      name: '{{ item }}'
+      state: latest
+      conf_file: '{{ test_dnf_conf_copy.dest }}'
+    with_items: "{{mysql_packages}}"
+
+  always:
+  - name: remove test dnf.conf file
+    file:
+      path: '{{ test_dnf_conf_copy.dest }}'
+      state: absent
   when: ansible_pkg_mgr  ==  'dnf'
 
 - name: install mysqldb_test debian dependencies


### PR DESCRIPTION
(cherry picked from commit 6620facd195a3f030d592f2d28ca8daae04de6b9)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/50430. Will also require https://github.com/ansible/ansible/pull/50516 before tests will pass

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test setup_mysql_db tests