### PR TITLE
allow using --check on win_iis_webapppool module

### DIFF
--- a/changelogs/fragments/win_iis_webapppool-check-mode.yaml
+++ b/changelogs/fragments/win_iis_webapppool-check-mode.yaml
@@ -1,2 +1,2 @@
-bufixes:
+bugfixes:
 - win_iis_webapppool - Do not try and set attributes in check mode when the pool did not exist

--- a/changelogs/fragments/win_iis_webapppool-check-mode.yaml
+++ b/changelogs/fragments/win_iis_webapppool-check-mode.yaml
@@ -1,0 +1,2 @@
+bufixes:
+- win_iis_webapppool - Do not try and set attributes in check mode when the pool did not exist

--- a/lib/ansible/modules/windows/win_iis_webapppool.ps1
+++ b/lib/ansible/modules/windows/win_iis_webapppool.ps1
@@ -201,74 +201,75 @@ if ($state -eq "absent") {
         }
     }
 
-    # Modify pool based on parameters
-    foreach ($attribute in $attributes.GetEnumerator()) {
-        $attribute_key = $attribute.Name
-        $new_raw_value = $attribute.Value
-        $new_value = Convert-ToPropertyValue -pool $pool -attribute_key $attribute_key -attribute_value $new_raw_value
+    # Cannot run the below in check mode if the pool did not always exist
+    if ($pool) {
+        # Modify pool based on parameters
+        foreach ($attribute in $attributes.GetEnumerator()) {
+            $attribute_key = $attribute.Name
+            $new_raw_value = $attribute.Value
+            $new_value = Convert-ToPropertyValue -pool $pool -attribute_key $attribute_key -attribute_value $new_raw_value
 
-        $current_raw_value = Get-ItemProperty -Path IIS:\AppPools\$name -Name $attribute_key -ErrorAction SilentlyContinue
-        $current_value = Convert-ToPropertyValue -pool $pool -attribute_key $attribute_key -attribute_value $current_raw_value
+            $current_raw_value = Get-ItemProperty -Path IIS:\AppPools\$name -Name $attribute_key -ErrorAction SilentlyContinue
+            $current_value = Convert-ToPropertyValue -pool $pool -attribute_key $attribute_key -attribute_value $current_raw_value
 
-        $changed = Compare-Values -current $current_value -new $new_value
-        if ($changed -eq $true) {
-            if ($new_value -is [Array]) {
-                try {
-                    Clear-ItemProperty -Path IIS:\AppPools\$name -Name $attribute_key -WhatIf:$check_mode
-                } catch {
-                    Fail-Json -obj $result -message "Failed to clear attribute to Web App Pool $name. Attribute: $attribute_key, Exception: $($_.Exception.Message)"
-                }
-                foreach ($value in $new_value) {
+            $changed = Compare-Values -current $current_value -new $new_value
+            if ($changed -eq $true) {
+                if ($new_value -is [Array]) {
                     try {
-                        New-ItemProperty -Path IIS:\AppPools\$name -Name $attribute_key -Value @{value=$value} -WhatIf:$check_mode > $null
+                        Clear-ItemProperty -Path IIS:\AppPools\$name -Name $attribute_key -WhatIf:$check_mode
                     } catch {
-                        Fail-Json -obj $result -message "Failed to add new attribute to Web App Pool $name. Attribute: $attribute_key, Value: $value, Exception: $($_.Exception.Message)"
+                        Fail-Json -obj $result -message "Failed to clear attribute to Web App Pool $name. Attribute: $attribute_key, Exception: $($_.Exception.Message)"
+                    }
+                    foreach ($value in $new_value) {
+                        try {
+                            New-ItemProperty -Path IIS:\AppPools\$name -Name $attribute_key -Value @{value=$value} -WhatIf:$check_mode > $null
+                        } catch {
+                            Fail-Json -obj $result -message "Failed to add new attribute to Web App Pool $name. Attribute: $attribute_key, Value: $value, Exception: $($_.Exception.Message)"
+                        }
+                    }
+                } else {
+                    try {
+                        Set-ItemProperty -Path IIS:\AppPools\$name -Name $attribute_key -Value $new_value -WhatIf:$check_mode
+                    } catch {
+                        Fail-Json $result "Failed to set attribute to Web App Pool $name. Attribute: $attribute_key, Value: $new_value, Exception: $($_.Exception.Message)"
                     }
                 }
-            } else {
-              if (-not $check_mode) {
-                try {
-                    Set-ItemProperty -Path IIS:\AppPools\$name -Name $attribute_key -Value $new_value -WhatIf:$check_mode
-                } catch {
-                    Fail-Json $result "Failed to set attribute to Web App Pool $name. Attribute: $attribute_key, Value: $new_value, Exception: $($_.Exception.Message)"
-                }
-              }
+                $result.changed = $true
             }
-            $result.changed = $true
         }
-    }
 
-    # Set the state of the pool
-    if ($pool.State -eq "Stopped") {
-        if ($state -eq "started" -or $state -eq "restarted") {
-            if (-not $check_mode) {
-                try {
-                    Start-WebAppPool -Name $name > $null
-                } catch {
-                    Fail-Json $result "Failed to start Web App Pool $($name): $($_.Exception.Message)"
+        # Set the state of the pool
+        if ($pool.State -eq "Stopped") {
+            if ($state -eq "started" -or $state -eq "restarted") {
+                if (-not $check_mode) {
+                    try {
+                        Start-WebAppPool -Name $name > $null
+                    } catch {
+                        Fail-Json $result "Failed to start Web App Pool $($name): $($_.Exception.Message)"
+                    }
                 }
+                $result.changed = $true
             }
-            $result.changed = $true
-        }
-    } else {
-        if ($state -eq "stopped") {
-            if (-not $check_mode) {
-                try {
-                    Stop-WebAppPool -Name $name > $null
-                } catch {
-                    Fail-Json $result "Failed to stop Web App Pool $($name): $($_.Exception.Message)"
+        } else {
+            if ($state -eq "stopped") {
+                if (-not $check_mode) {
+                    try {
+                        Stop-WebAppPool -Name $name > $null
+                    } catch {
+                        Fail-Json $result "Failed to stop Web App Pool $($name): $($_.Exception.Message)"
+                    }
                 }
-            }
-            $result.changed = $true
-        } elseif ($state -eq "restarted") {
-            if (-not $check_mode) {
-                try {
-                    Restart-WebAppPool -Name $name > $null
-                } catch {
-                    Fail-Json $result "Failed to restart Web App Pool $($name): $($_.Exception.Message)"
+                $result.changed = $true
+            } elseif ($state -eq "restarted") {
+                if (-not $check_mode) {
+                    try {
+                        Restart-WebAppPool -Name $name > $null
+                    } catch {
+                        Fail-Json $result "Failed to restart Web App Pool $($name): $($_.Exception.Message)"
+                    }
                 }
+                $result.changed = $true
             }
-            $result.changed = $true
         }
     }
 }

--- a/lib/ansible/modules/windows/win_iis_webapppool.ps1
+++ b/lib/ansible/modules/windows/win_iis_webapppool.ps1
@@ -226,11 +226,13 @@ if ($state -eq "absent") {
                     }
                 }
             } else {
+              if (-not $check_mode) {
                 try {
                     Set-ItemProperty -Path IIS:\AppPools\$name -Name $attribute_key -Value $new_value -WhatIf:$check_mode
                 } catch {
                     Fail-Json $result "Failed to set attribute to Web App Pool $name. Attribute: $attribute_key, Value: $new_value, Exception: $($_.Exception.Message)"
                 }
+              }
             }
             $result.changed = $true
         }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allow using --check on win_iis_webapppool when the app pool has attributes to detect changes instead of failing

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_iis_webapppool

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

playbook

    #############################################################
    # Creating application pools
    #############################################################
    - name: Create application pool
      win_iis_webapppool:
        name:                           '{{ item.key }}'
        state: started
        attributes:
          managedRuntimeVersion:        '{{ item.value.managedRuntimeVersion }}'
          startMode:                    '{{ item.value.startMode }}'
          processModel.loadUserProfile: '{{ item.value.processModel_loadUserProfile }}'
          processModel.identityType:    '{{ item.value.processModel_identityType }}'
      with_dict: "{{ apppools }}"

vars file
apppools:
  abc_AppPool:
    managedRuntimeVersion: v4.0
    startMode: AlwaysRunning
    processModel_loadUserProfile: True
    processModel_identityType: NetworkService


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

BEFORE this fix
==============

MSG:

Failed to set attribute to Web App Pool AtTheRegister_AppPool. Attribute: processModel.identityType, Value: NetworkService, Exception: Cannot find path 'IIS:\AppPools\foobar_AppPool' because it does not exist.


PLAY RECAP *****************************************************************************************************************************************************************************
xxxxxxx               : ok=1    changed=0    unreachable=0    failed=1




AFTER this fix
==============

TASK [Create application pool] ***********************************************************************************************************************************************************
changed: [xxxxxx ] => (item={'value': {u'processModel_identityType': u'NetworkService', u'startMode': u'AlwaysRunning', u'managedRuntimeVersion': u'v4.0', u'processModel_loadUserProfile': True}, 'key': u'ThisDoesNotExist_AppPool'})


PLAY RECAP *******************************************************************************************************************************************************************************
xxxxxx : ok=4    changed=1    unreachable=0    failed=0


```
