### PR TITLE
assert: allow list of strings in msg or failed_msg

### DIFF
--- a/changelogs/fragments/48547-assert-incorrect_msg_type.yml
+++ b/changelogs/fragments/48547-assert-incorrect_msg_type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Added check for assert module for msg and failed_msg as a list or string types.

--- a/lib/ansible/plugins/action/assert.py
+++ b/lib/ansible/plugins/action/assert.py
@@ -45,14 +45,20 @@ class ActionModule(ActionBase):
         fail_msg = self._task.args.get('fail_msg', self._task.args.get('msg'))
         if fail_msg is None:
             fail_msg = 'Assertion failed'
-        elif not isinstance(fail_msg, string_types):
-            raise AnsibleError('Incorrect type for fail_msg or msg, expected string and got %s' % type(fail_msg))
+        elif isinstance(fail_msg, list):
+            if not all(isinstance(x, string_types) for x in fail_msg):
+                raise AnsibleError('Type of one of the elements in fail_msg or msg list is not string type')
+        elif not isinstance(fail_msg, (string_types, list)):
+            raise AnsibleError('Incorrect type for fail_msg or msg, expected a string or list and got %s' % type(fail_msg))
 
         success_msg = self._task.args.get('success_msg')
         if success_msg is None:
             success_msg = 'All assertions passed'
-        elif not isinstance(success_msg, string_types):
-            raise AnsibleError('Incorrect type for success_msg, expected string and got %s' % type(success_msg))
+        elif isinstance(success_msg, list):
+            if not all(isinstance(x, string_types) for x in success_msg):
+                raise AnsibleError('Type of one of the elements in success_msg list is not string type')
+        elif not isinstance(success_msg, (string_types, list)):
+            raise AnsibleError('Incorrect type for success_msg, expected a string or list and got %s' % type(success_msg))
 
         # make sure the 'that' items are a list
         thats = self._task.args['that']


### PR DESCRIPTION
##### SUMMARY
Added check for assert module for msg and failed_msg as a list or string types.

Fixes: #48547

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/48547-assert-incorrect_msg_type.yml
lib/ansible/plugins/action/assert.py
