### PR TITLE
default: callback plugin allow unreachable task to stderr

### DIFF
--- a/changelogs/fragments/48069-default-callback-unreachable_stderr.yml
+++ b/changelogs/fragments/48069-default-callback-unreachable_stderr.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Allow default callback plugin to send unreachable host/task to stderr using toggle flag.

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -158,11 +158,10 @@ class CallbackModule(CallbackBase):
 
         delegated_vars = result._result.get('_ansible_delegated_vars', None)
         if delegated_vars:
-            self._display.display("fatal: [%s -> %s]: UNREACHABLE! => %s" % (result._host.get_name(), delegated_vars['ansible_host'],
-                                                                             self._dump_results(result._result)),
-                                  color=C.COLOR_UNREACHABLE)
+            msg = "fatal: [%s -> %s]: UNREACHABLE! => %s" % (result._host.get_name(), delegated_vars['ansible_host'], self._dump_results(result._result))
         else:
-            self._display.display("fatal: [%s]: UNREACHABLE! => %s" % (result._host.get_name(), self._dump_results(result._result)), color=C.COLOR_UNREACHABLE)
+            msg = "fatal: [%s]: UNREACHABLE! => %s" % (result._host.get_name(), self._dump_results(result._result))
+        self._display.display(msg, color=C.COLOR_UNREACHABLE, stderr=self.display_failed_stderr)
 
     def v2_playbook_on_no_hosts_matched(self):
         self._display.display("skipping: no hosts matched", color=C.COLOR_SKIP)

--- a/lib/ansible/utils/module_docs_fragments/default_callback.py
+++ b/lib/ansible/utils/module_docs_fragments/default_callback.py
@@ -28,8 +28,8 @@ class ModuleDocFragment(object):
         type: boolean
         version_added: '2.7'
       display_failed_stderr:
-        name: Use STDERR for failed tasks
-        description: "Toggle to control whether failed tasks are displayed to STDERR (vs. STDOUT)"
+        name: Use STDERR for failed and unreachable tasks
+        description: "Toggle to control whether failed and unreachable tasks are displayed to STDERR (vs. STDOUT)"
         default: False
         env:
           - name: ANSIBLE_DISPLAY_FAILED_STDERR

--- a/test/integration/inventory
+++ b/test/integration/inventory
@@ -75,3 +75,6 @@ localhost ansible_ssh_host=127.0.0.1 ansible_connection=local
 
 [azure]
 localhost ansible_ssh_host=127.0.0.1 ansible_connection=local
+
+[nonexistent]
+testhost5 ansible_host=169.254.199.200

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -36,6 +36,15 @@ cleanup() {
 	if [[ $INIT = 0 ]]; then
 		rm -rf "${OUTFILE}.*"
 	fi
+
+	if [[ -f "${BASEFILE}.unreachable.stdout" ]]; then
+	    rm -rf "${BASEFILE}.unreachable.stdout"
+	fi
+
+	if [[ -f "${BASEFILE}.unreachable.stderr" ]]; then
+	    rm -rf "${BASEFILE}.unreachable.stderr"
+	fi
+
 	# Restore TTY cols
 	if [[ -n ${TTY_COLS:-} ]]; then
 		stty cols "${TTY_COLS}"
@@ -105,3 +114,17 @@ export ANSIBLE_DISPLAY_OK_HOSTS=1
 export ANSIBLE_DISPLAY_FAILED_STDERR=1
 
 run_test failed_to_stderr
+
+# Default settings with unreachable tasks
+export DISPLAY_SKIPPED_HOSTS=1
+export ANSIBLE_DISPLAY_OK_HOSTS=1
+export ANSIBLE_DISPLAY_FAILED_STDERR=1
+
+# Check if UNREACHBLE is available in stderr
+set +e
+ansible-playbook -i ../../inventory test_2.yml > >(set +x; tee "${BASEFILE}.unreachable.stdout";) 2> >(set +x; tee "${BASEFILE}.unreachable.stderr" >&2) || true
+set -e
+if test "$(grep -c 'UNREACHABLE' "${BASEFILE}.unreachable.stderr")" -ne 1; then
+    echo "Test failed"
+    exit 1
+fi

--- a/test/integration/targets/callback_default/test_2.yml
+++ b/test/integration/targets/callback_default/test_2.yml
@@ -1,0 +1,6 @@
+- hosts: nonexistent
+  gather_facts: no
+  tasks:
+    - name: Test task for unreachable host
+      command: echo foo
+      ignore_errors: True


### PR DESCRIPTION
##### SUMMARY
Provide toggle flag to allow display of unreachable task to stderr
using default callback plugin.

Fixes: #48069

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
changelogs/fragments/48069-default-callback-unreachable_stderr.yml
lib/ansible/plugins/callback/default.py
lib/ansible/utils/module_docs_fragments/default_callback.py
