### PR TITLE
Fix junos terminal error regex

### DIFF
--- a/lib/ansible/plugins/terminal/junos.py
+++ b/lib/ansible/plugins/terminal/junos.py
@@ -38,7 +38,7 @@ class TerminalModule(TerminalBase):
     terminal_stderr_re = [
         re.compile(br"unknown command"),
         re.compile(br"syntax error"),
-        re.compile(br"error: commit failed")
+        re.compile(br"[\r\n]error:")
     ]
 
     def on_open_shell(self):


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #50513
*  Change junos terminal error regex to read error string
   correctly.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
