### PR TITLE
Fix issue #50535 - Traceback in tower_user when AWX authentication credentials invalid

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
@@ -62,6 +62,11 @@ options:
         - Before an update to the local repository before launching a job with this project.
       type: bool
       default: 'no'
+    job_timeout:
+      description:
+        - The timeout before which a project is not is not checked for an update.
+      type: int
+      default: 0
     organization:
       description:
         - Primary key of organization for project.
@@ -108,7 +113,7 @@ def main():
         scm_delete_on_update=dict(type='bool', default=False),
         scm_update_on_launch=dict(type='bool', default=False),
         local_path=dict(),
-
+        job_timeout=dict(type='int', default=0),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
@@ -127,6 +132,7 @@ def main():
     scm_clean = module.params.get('scm_clean')
     scm_delete_on_update = module.params.get('scm_delete_on_update')
     scm_update_on_launch = module.params.get('scm_update_on_launch')
+    job_timeout = module.params.get('job_timeout')
     state = module.params.get('state')
 
     json_output = {'project': name, 'state': state}
@@ -161,6 +167,7 @@ def main():
                                         scm_branch=scm_branch, scm_clean=scm_clean, credential=scm_credential,
                                         scm_delete_on_update=scm_delete_on_update,
                                         scm_update_on_launch=scm_update_on_launch,
+                                        job_template=job_template,
                                         create_on_missing=True)
                 json_output['id'] = result['id']
             elif state == 'absent':

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
@@ -75,7 +75,7 @@ from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, t
 
 try:
     import tower_cli
-    import tower_cli.utils.exceptions as exc
+    import tower_cli.exceptions as exc
 
     from tower_cli.conf import settings
 except ImportError:
@@ -119,10 +119,9 @@ def main():
                 json_output['id'] = result['id']
             elif state == 'absent':
                 result = user.delete(username=username)
-
         except (exc.ConnectionError, exc.BadRequest) as excinfo:
             module.fail_json(msg='Failed to update the user: {0}'.format(excinfo), changed=False)
-        except tower_cli.exceptions.AuthError as excinfo:
+        except exc.AuthError as excinfo:
             module.fail_json(msg='Invalid Tower authentication credentials'.format(excinfo), changed=False)
 
     json_output['changed'] = result['changed']

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
@@ -119,8 +119,11 @@ def main():
                 json_output['id'] = result['id']
             elif state == 'absent':
                 result = user.delete(username=username)
+
         except (exc.ConnectionError, exc.BadRequest) as excinfo:
             module.fail_json(msg='Failed to update the user: {0}'.format(excinfo), changed=False)
+        except tower_cli.exceptions.AuthError as excinfo:
+            module.fail_json(msg='Invalid Tower authentication credentials'.format(excinfo), changed=False)
 
     json_output['changed'] = result['changed']
     module.exit_json(**json_output)


### PR DESCRIPTION
##### SUMMARY
Fix issue #50535 - Traceback in tower_user when AWX authentication credentials invalid

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tower_user module

##### ADDITIONAL INFORMATION
I run the playbook with invalid AWX authentication credentials (tower_username/tower_password) in the playbook below.

```---
- hosts: awx
  gather_facts: "no"
  connection: local
  tasks:
    - name: Set AWX admin account
      tower_user:
        username: "{{ accounts.awx_root.username }}"
        password: "{{ accounts.awx_root.password }}"
        email: "{{ accounts.awx_root.email }}"
        superuser: "yes"
        state: present
        tower_host: "{{ awx_host }}"
        tower_username: "{{ accounts.init_setup.username }}"
        tower_password: "{{ accounts.init_setup.password }}"
        tower_verify_ssl: "{{ verify_ssl | default('no') }}"```

Before the change - output of using the "tower_user" module with incorrect AWX authentication credentials.
```
TASK [Set AWX admin account] *******************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: tower_cli.exceptions.AuthError: Invalid Tower authentication credentials (HTTP 401).
fatal: [awx1]: FAILED! => changed=false
  module_stderr: |-
    Traceback (most recent call last):
      File "/home/d069683/.ansible/tmp/ansible-tmp-1546595798.81-18639309082017/AnsiballZ_tower_user.py", line 113, in <module>
        _ansiballz_main()
      File "/home/d069683/.ansible/tmp/ansible-tmp-1546595798.81-18639309082017/AnsiballZ_tower_user.py", line 105, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/home/d069683/.ansible/tmp/ansible-tmp-1546595798.81-18639309082017/AnsiballZ_tower_user.py", line 48, in invoke_module
        imp.load_module('__main__', mod, module, MOD_DESC)
      File "/tmp/ansible_tower_user_payload_uMnpMh/__main__.py", line 131, in <module>
      File "/tmp/ansible_tower_user_payload_uMnpMh/__main__.py", line 118, in main
      File "/usr/local/lib/python2.7/dist-packages/tower_cli/models/base.py", line 698, in modify
        return self.write(pk, create_on_missing=create_on_missing, force_on_exists=True, **kwargs)
      File "/usr/local/lib/python2.7/dist-packages/tower_cli/models/base.py", line 361, in write
        **kwargs
      File "/usr/local/lib/python2.7/dist-packages/tower_cli/models/base.py", line 223, in _lookup
        existing_data = self.get(include_debug_header=include_debug_header, **read_params)
      File "/usr/local/lib/python2.7/dist-packages/tower_cli/models/base.py", line 486, in get
        response = self.read(pk=pk, fail_on_no_results=True, fail_on_multiple_results=True, **kwargs)
      File "/usr/local/lib/python2.7/dist-packages/tower_cli/models/base.py", line 288, in read
        r = client.get(url, params=kwargs)
      File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 521, in get
        return self.request('GET', url, **kwargs)
      File "/usr/local/lib/python2.7/dist-packages/tower_cli/api.py", line 255, in request
        raise exc.AuthError('Invalid Tower authentication credentials (HTTP 401).')
    tower_cli.exceptions.AuthError: Invalid Tower authentication credentials (HTTP 401).
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```
After the change - the output of using the "tower_user" module with incorrect AWX authentication credentials.
```TASK [Set AWX admin account] *******************************************************************************************
fatal: [awx1]: FAILED! =>
  msg: Unable to import tower_user due to invalid syntax
```
