### PR TITLE
Documentation fix for developing own plugin

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -164,7 +164,7 @@ To facilitate this there are a few of helper functions used in the example below
 
             # this method will parse 'common format' inventory sources and
             # update any options declared in DOCUMENTATION as needed
-            config = self._read_config_data(self, path)
+            config = self._read_config_data(path)
 
             # if NOT using _read_config_data you should call set_options directly,
             # to process any defined configuration for this plugin,


### PR DESCRIPTION
+label: docsite_pr

##### SUMMARY
Seems like `self` is not necessary in the call args

##### ISSUE TYPE
- Docs Pull Request

##### ADDITIONAL INFORMATION
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Followed the tutorial to develop custom plugin for ansible 2.7.5, however this location failed.