### PR TITLE
edgeos_config: Fix sanitizing config lines

### DIFF
--- a/lib/ansible/modules/network/edgeos/edgeos_config.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_config.py
@@ -207,7 +207,7 @@ def diff_config(commands, config):
 def sanitize_config(config, result):
     result['filtered'] = list()
     for regex in CONFIG_FILTERS:
-        for index, line in enumerate(list(config)):
+        for index, line in reversed(list(enumerate(config))):
             if regex.search(line):
                 result['filtered'].append(line)
                 del config[index]


### PR DESCRIPTION
##### SUMMARY
Fix removing bad lines.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
edgeos_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Previously, the index got out of sync with the actual config list. Invoked with lines:
  - bad
  - first
  - bad
  - second

the sanitization would first delete index 0 and then index 2, which would result in the output
  - first
  - bad

By reversing the list, we avoid that problem (though a filter() would be nicer)

Before, it even could throw an IndexError if there was more than one "bad" line and one of them was one of the last lines:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
The full traceback is:
Traceback (most recent call last):
  File "/home/user/.ansible/tmp/ansible-local-3139RFv2ce/ansible-tmp-1546615496.83-150882357879813/AnsiballZ_edgeos_config.py", line 113, in <module>
    _ansiballz_main()
  File "/home/user/.ansible/tmp/ansible-local-3139RFv2ce/ansible-tmp-1546615496.83-150882357879813/AnsiballZ_edgeos_config.py", line 105, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/user/.ansible/tmp/ansible-local-3139RFv2ce/ansible-tmp-1546615496.83-150882357879813/AnsiballZ_edgeos_config.py", line 48, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/tmp/ansible_edgeos_config_payload_oyWkeY/__main__.py", line 287, in <module>
  File "/tmp/ansible_edgeos_config_payload_oyWkeY/__main__.py", line 274, in main
  File "/tmp/ansible_edgeos_config_payload_oyWkeY/__main__.py", line 226, in run
  File "/tmp/ansible_edgeos_config_payload_oyWkeY/__main__.py", line 213, in sanitize_config
IndexError: list assignment index out of range
```
