### PR TITLE
Add new AnsibleTemplateError to more easily catch templating issues

### DIFF
--- a/changelogs/fragments/ansible-template-error.yml
+++ b/changelogs/fragments/ansible-template-error.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- Add new ``AnsibleTemplateError`` that various templating related exceptions inherit from,
+  making it easier to catch them without enumerating. (https://github.com/ansible/ansible/issues/50154)

--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -223,22 +223,27 @@ class AnsibleConnectionFailure(AnsibleRuntimeError):
     pass
 
 
-class AnsibleFilterError(AnsibleRuntimeError):
-    ''' a templating failure '''
-    pass
-
-
-class AnsibleLookupError(AnsibleRuntimeError):
-    ''' a lookup failure '''
-    pass
-
-
 class AnsibleCallbackError(AnsibleRuntimeError):
     ''' a callback failure '''
     pass
 
 
-class AnsibleUndefinedVariable(AnsibleRuntimeError):
+class AnsibleTemplateError(AnsibleRuntimeError):
+    '''A template related errror'''
+    pass
+
+
+class AnsibleFilterError(AnsibleTemplateError):
+    ''' a templating failure '''
+    pass
+
+
+class AnsibleLookupError(AnsibleTemplateError):
+    ''' a lookup failure '''
+    pass
+
+
+class AnsibleUndefinedVariable(AnsibleTemplateError):
     ''' a templating failure '''
     pass
 

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -32,7 +32,7 @@ except ImportError:
 from jinja2.exceptions import UndefinedError
 
 from ansible import constants as C
-from ansible.errors import AnsibleError, AnsibleParserError, AnsibleUndefinedVariable, AnsibleFileNotFound, AnsibleAssertionError
+from ansible.errors import AnsibleError, AnsibleParserError, AnsibleUndefinedVariable, AnsibleFileNotFound, AnsibleAssertionError, AnsibleTemplateError
 from ansible.inventory.host import Host
 from ansible.inventory.helpers import sort_groups, get_group_vars
 from ansible.module_utils._text import to_native
@@ -519,7 +519,7 @@ class VariableManager:
                     loop_terms = listify_lookup_plugin_terms(terms=task.loop, templar=self._templar,
                                                              loader=self._loader, fail_on_undefined=True, convert_bare=False)
                     items = lookup_loader.get(task.loop_with, loader=self._loader, templar=self._templar).run(terms=loop_terms, variables=vars_copy)
-                except AnsibleUndefinedVariable:
+                except AnsibleTemplateError:
                     # This task will be skipped later due to this, so we just setup
                     # a dummy array for the later code so it doesn't fail
                     items = [None]
@@ -528,7 +528,7 @@ class VariableManager:
         elif task.loop is not None:
             try:
                 items = self._templar.template(task.loop)
-            except AnsibleUndefinedVariable:
+            except AnsibleTemplateError:
                 # This task will be skipped later due to this, so we just setup
                 # a dummy array for the later code so it doesn't fail
                 items = [None]


### PR DESCRIPTION
##### SUMMARY
Add new AnsibleTemplateError to more easily catch templating issues. Fixes #50154 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/errors/__init__.py
lib/ansible/vars/manager.py
```

##### ADDITIONAL INFORMATION

When templating loop, we may get a lookup error, undefined var error, or filter error.  Make these exceptions inherit from a more generic `AnsibleTemplateError` to ease handling these exceptions.