### PR TITLE
Relative time support for crypto modules (openssl_certificate)

### DIFF
--- a/changelogs/fragments/50570-relative_time_crypto.yaml
+++ b/changelogs/fragments/50570-relative_time_crypto.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "openssl_certificate - Add support for relative time offsets in the selfsigned_not_before/selfsigned_not_after/ownca_not_before/ownca_not_after and valid_in parameters."
+  - "openssl_certificate - Add support for relative time offsets in the ``selfsigned_not_before``/``selfsigned_not_after``/``ownca_not_before``/``ownca_not_after`` and ``valid_in`` parameters."

--- a/changelogs/fragments/50570-relative_time_crypto.yaml
+++ b/changelogs/fragments/50570-relative_time_crypto.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "openssl_certificate - Add support for relative time offsets in the selfsigned_not_before/selfsigned_not_after/ownca_not_before/ownca_not_after and valid_in parameters."

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -141,16 +141,19 @@ def convert_relative_to_datetime(relative_time_string):
         # not matched
         return None
 
-    offset = datetime.timedelta(seconds=int(parsed_result.group("seconds")))
-    if parsed_result.group("weeks"):
+    offset = datetime.timedelta(0)
+    if parsed_result.group("weeks") is not None:
         offset += datetime.timedelta(weeks=int(parsed_result.group("weeks")))
-    if parsed_result.group("days"):
+    if parsed_result.group("days") is not None:
         offset += datetime.timedelta(days=int(parsed_result.group("days")))
-    if parsed_result.group("hours"):
+    if parsed_result.group("hours") is not None:
         offset += datetime.timedelta(hours=int(parsed_result.group("hours")))
-    if parsed_result.group("minutes"):
+    if parsed_result.group("minutes") is not None:
         offset += datetime.timedelta(
             minutes=int(parsed_result.group("minutes")))
+    if parsed_result.group("seconds") is not None:
+        offset += datetime.timedelta(
+            seconds=int(parsed_result.group("seconds")))
 
     if parsed_result.group("prefix") == "+":
         return datetime.datetime.utcnow() + offset

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -24,9 +24,11 @@ except ImportError:
     pass
 
 import abc
+import datetime
 import errno
 import hashlib
 import os
+import re
 
 from ansible.module_utils import six
 from ansible.module_utils._text import to_bytes
@@ -126,6 +128,34 @@ def parse_name_field(input_dict):
         else:
             result.append((key, input_dict[key]))
     return result
+
+
+def convert_relative_to_datetime(relative_time_string):
+    """Get a datetime.datetime or None from a string in the time format described in sshd_config(5)"""
+
+    parsed_result = re.match(
+        r"^(?P<prefix>[+-])((?P<weeks>\d+)[wW])?((?P<days>\d+)[dD])?((?P<hours>\d+)[hH])?((?P<minutes>\d+)[mM])?((?P<seconds>\d+)[sS]?)?$",
+        relative_time_string)
+
+    if parsed_result is None:
+        # not matched
+        return None
+
+    offset = datetime.timedelta(seconds=int(parsed_result.group("seconds")))
+    if parsed_result.group("weeks"):
+        offset += datetime.timedelta(weeks=int(parsed_result.group("weeks")))
+    if parsed_result.group("days"):
+        offset += datetime.timedelta(days=int(parsed_result.group("days")))
+    if parsed_result.group("hours"):
+        offset += datetime.timedelta(hours=int(parsed_result.group("hours")))
+    if parsed_result.group("minutes"):
+        offset += datetime.timedelta(
+            minutes=int(parsed_result.group("minutes")))
+
+    if parsed_result.group("prefix") == "+":
+        return datetime.datetime.utcnow() + offset
+    else:
+        return datetime.datetime.utcnow() - offset
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -137,8 +137,8 @@ def convert_relative_to_datetime(relative_time_string):
         r"^(?P<prefix>[+-])((?P<weeks>\d+)[wW])?((?P<days>\d+)[dD])?((?P<hours>\d+)[hH])?((?P<minutes>\d+)[mM])?((?P<seconds>\d+)[sS]?)?$",
         relative_time_string)
 
-    if parsed_result is None:
-        # not matched
+    if parsed_result is None or len(relative_time_string) == 1:
+        # not matched or only a single "+" or "-"
         return None
 
     offset = datetime.timedelta(0)

--- a/lib/ansible/modules/crypto/openssh_cert.py
+++ b/lib/ansible/modules/crypto/openssh_cert.py
@@ -21,7 +21,7 @@ author: "David Kainz (@lolcube)"
 version_added: "2.8"
 short_description: Generate OpenSSH host or user certificates.
 description:
-    - Generate and regenerate OpensSSH host or user certificates.
+    - Generate and regenerate OpenSSH host or user certificates.
 requirements:
     - "ssh-keygen"
 options:

--- a/lib/ansible/modules/crypto/openssh_cert.py
+++ b/lib/ansible/modules/crypto/openssh_cert.py
@@ -203,6 +203,7 @@ from datetime import timedelta
 from shutil import copy2
 from shutil import rmtree
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.crypto import convert_relative_to_datetime
 from ansible.module_utils._text import to_native
 
 
@@ -332,24 +333,12 @@ class Certificate(object):
     def convert_to_datetime(self, module, timestring):
 
         if self.is_relative(timestring):
-            dispatched_time = re.findall("^([+\\-])((\\d+)[w])?((\\d+)[d])?((\\d+)[h])?((\\d+)[m])?((\\d+)[s])?$", timestring, re.I)
-            if not dispatched_time:
-                module.fail_json(msg="'%s' is not a valid time format." % timestring)
-            dispatched_time = dispatched_time[0]
-            if dispatched_time[0] == "+":
-                return datetime.utcnow() + timedelta(
-                    weeks=int('0' + dispatched_time[2]),
-                    days=int('0' + dispatched_time[4]),
-                    hours=int('0' + dispatched_time[6]),
-                    minutes=int('0' + dispatched_time[8]),
-                    seconds=int('0' + dispatched_time[10]))
+            result = convert_relative_to_datetime(timestring)
+            if result is None:
+                module.fail_json(
+                    msg="'%s' is not a valid time format." % timestring)
             else:
-                return datetime.utcnow() - timedelta(
-                    weeks=int('0' + dispatched_time[2]),
-                    days=int('0' + dispatched_time[4]),
-                    hours=int('0' + dispatched_time[6]),
-                    minutes=int('0' + dispatched_time[8]),
-                    seconds=int('0' + dispatched_time[10]))
+                return result
         else:
             formats = ["%Y-%m-%d",
                        "%Y-%m-%d %H:%M:%S",

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -126,21 +126,21 @@ options:
     ownca_not_before:
         default: +0s
         description:
-            - The point in time the certificate is valid from. Time can be specified either as relative time or as absolute timestamp.
-              Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | ASN.1 TIME)
-              where timespec can be an integer + C([w | d | h | m | s]) (e.g. C(+32w1d2h).
-              Note that if using relative time this module is NOT idempotent.
-              If this value is not specified, the certificate will start being valid from now.
+            - "The point in time the certificate is valid from. Time can be specified either as relative time or as absolute timestamp.
+               Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | ASN.1 TIME)
+               where timespec can be an integer + C([w | d | h | m | s]) (e.g. C(+32w1d2h).
+               Note that if using relative time this module is NOT idempotent.
+               If this value is not specified, the certificate will start being valid from now."
         version_added: "2.7"
 
     ownca_not_after:
         default: +3650d
         description:
-            - The point in time at which the certificate stops being valid. Time can be specified either as relative time or as absolute timestamp.
-              Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | ASN.1 TIME)
-              where timespec can be an integer + C([w | d | h | m | s]) (e.g. C(+32w1d2h).
-              Note that if using relative time this module is NOT idempotent.
-              If this value is not specified, the certificate will stop being valid 10 years from now.
+            - "The point in time at which the certificate stops being valid. Time can be specified either as relative time or as absolute timestamp.
+               Time will always be interpreted as UTC. Valid formats are: C([+-]timespec | ASN.1 TIME)
+               where timespec can be an integer + C([w | d | h | m | s]) (e.g. C(+32w1d2h).
+               Note that if using relative time this module is NOT idempotent.
+               If this value is not specified, the certificate will stop being valid 10 years from now."
         version_added: "2.7"
 
     acme_accountkey_path:

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -452,6 +452,19 @@ class Certificate(crypto_utils.OpenSSLObject):
         self.csr = None
         self.module = module
 
+    def get_relative_time_option(self, input_string, input_name):
+        """Return an ASN1 formatted string if a relative timespec
+           or an ASN1 formatted string is provided."""
+        result = input_string
+        if result.startswith("+") or result.startswith("-"):
+            result = crypto_utils.convert_relative_to_datetime(
+                result).strftime("%Y%m%d%H%M%SZ")
+        if result is None:
+            raise CertificateError(
+                'The timespec %s for %s is not valid' %
+                input_string, input_name)
+        return result
+
     def check(self, module, perms_required=True):
         """Ensure the resource is in its desired state."""
 
@@ -511,22 +524,8 @@ class SelfSignedCertificate(Certificate):
 
     def __init__(self, module):
         super(SelfSignedCertificate, self).__init__(module)
-        self.notBefore = module.params['selfsigned_not_before']
-        if self.notBefore.startswith("+") or self.notBefore.startswith("-"):
-            self.notBefore = crypto_utils.convert_relative_to_datetime(
-                self.notBefore).strftime("%Y%m%d%H%M%SZ")
-        if self.notBefore is None:
-            raise CertificateError(
-                'The timespec %s for selfsigned_not_before is not valid' %
-                module.params['selfsigned_not_before'])
-        self.notAfter = module.params['selfsigned_not_after']
-        if self.notAfter.startswith("+") or self.notAfter.startswith("-"):
-            self.notAfter = crypto_utils.convert_relative_to_datetime(
-                self.notAfter).strftime("%Y%m%d%H%M%SZ")
-        if self.notAfter is None:
-            raise CertificateError(
-                'The timespec %s for selfsigned_not_after is not valid' %
-                module.params['selfsigned_not_after'])
+        self.notBefore = self.get_relative_time_option(module.params['selfsigned_not_before'], 'selfsigned_not_before')
+        self.notAfter = self.get_relative_time_option(module.params['selfsigned_not_after'], 'selfsigned_not_after')
         self.digest = module.params['selfsigned_digest']
         self.version = module.params['selfsigned_version']
         self.serial_number = randint(1000, 99999)
@@ -603,22 +602,8 @@ class OwnCACertificate(Certificate):
 
     def __init__(self, module):
         super(OwnCACertificate, self).__init__(module)
-        self.notBefore = module.params['ownca_not_before']
-        if self.notBefore.startswith("+") or self.notBefore.startswith("-"):
-            self.notBefore = crypto_utils.convert_relative_to_datetime(
-                self.notBefore).strftime("%Y%m%d%H%M%SZ")
-        if self.notBefore is None:
-            raise CertificateError(
-                'The timespec %s for ownca_not_before is not valid' %
-                module.params['ownca_not_before'])
-        self.notAfter = module.params['ownca_not_after']
-        if self.notAfter.startswith("+") or self.notAfter.startswith("-"):
-            self.notAfter = crypto_utils.convert_relative_to_datetime(
-                self.notAfter).strftime("%Y%m%d%H%M%SZ")
-        if self.notAfter is None:
-            raise CertificateError(
-                'The timespec %s for ownca_not_after is not valid' %
-                module.params['ownca_not_after'])
+        self.notBefore = self.get_relative_time_option(module.params['ownca_not_before'], 'ownca_not_before')
+        self.notAfter = self.get_relative_time_option(module.params['ownca_not_after'], 'ownca_not_after')
         self.digest = module.params['ownca_digest']
         self.version = module.params['ownca_version']
         self.serial_number = randint(1000, 99999)

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -464,7 +464,7 @@ class Certificate(crypto_utils.OpenSSLObject):
                 result).strftime("%Y%m%d%H%M%SZ")
         if result is None:
             raise CertificateError(
-                'The timespec %s for %s is not valid' %
+                'The timespec "%s" for %s is not valid' %
                 input_string, input_name)
         return result
 

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -871,7 +871,7 @@ class AssertOnlyCertificate(Certificate):
                         int(self.valid_in)
                     except ValueError:
                         raise CertificateError(
-                        'The supplied value for "valid_in" (%s) is not an integer or a valid timespec' % self.valid_in)
+                            'The supplied value for "valid_in" (%s) is not an integer or a valid timespec' % self.valid_in)
                     self.valid_in = "+" + self.valid_in + "s"
                 valid_in_asn1 = self.get_relative_time_option(self.valid_in, "valid_in")
                 valid_in_date = to_bytes(valid_in_asn1, errors='surrogate_or_strict')

--- a/test/integration/targets/openssl_certificate/tasks/ownca.yml
+++ b/test/integration/targets/openssl_certificate/tasks/ownca.yml
@@ -128,6 +128,17 @@
     ownca_path: '{{ output_dir }}/ca_cert.pem'
     ownca_privatekey_path: '{{ output_dir }}/ca_privatekey.pem'
 
+- name: Create ownca certificate with relative notBefore and notAfter
+  openssl_certificate:
+    provider: ownca
+    ownca_not_before: +1s
+    ownca_not_after: +52w
+    path: "{{ output_dir }}/ownca_cert4.pem"
+    csr_path: "{{ output_dir }}/csr.csr"
+    privatekey_path: "{{ output_dir }}/privatekey3.pem"
+    ownca_path: '{{ output_dir }}/ca_cert.pem'
+    ownca_privatekey_path: '{{ output_dir }}/ca_privatekey.pem'
+
 - name: Generate ownca ECC certificate
   openssl_certificate:
     path: '{{ output_dir }}/ownca_cert_ecc.pem'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Factor out relative timestamp handling from openssh_cert to module_utils/crypto to add it to more modules in the same category.

Fixes #50431 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
openssh_cert
openssl_certificate
module_utils/crypto.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Currently WIP to get some feedback from the CI system