### PR TITLE
hashi_vault lookup: add env variable VAULT_AUTH_METHOD

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -43,6 +43,8 @@ DOCUMENTATION = """
         - name: VAULT_SECRET_ID
     auth_method:
       description: authentication method used
+      env:
+        - name: VAULT_AUTH_METHOD
     mount_point:
       description: vault mount point, only required if you have a custom mount point
       default: ldap
@@ -130,7 +132,7 @@ class HashiVault:
         #
         # to enable a new auth backend, simply add a new 'def auth_<type>' method below.
         #
-        self.auth_method = kwargs.get('auth_method')
+        self.auth_method = kwargs.get('auth_method', os.environ.get('VAULT_AUTH_METHOD'))
         self.verify = self.boolean_or_cacert(kwargs.get('validate_certs', True), kwargs.get('cacert', ''))
         if self.auth_method and self.auth_method != 'token':
             try:


### PR DESCRIPTION
##### SUMMARY
I would like to introduce environment variable VAULT_AUTH_METHOD for hashi_vault lookup to manipulate authentication method.

With feature will be possible to switch between "AppRole" and "Token" methods using only environment variables.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/lookup/hashi_vault.py

##### ADDITIONAL INFORMATION
