### PR TITLE
Adds occasion parameter to at module to allow more flexibility in scheduling at jobs

### DIFF
--- a/lib/ansible/modules/system/at.py
+++ b/lib/ansible/modules/system/at.py
@@ -34,6 +34,7 @@ options:
   validate_occasion:
     description:
       - Set this to no to turn off validation of the occasion string and try your luck.
+    type: bool
     default: yes
     version_added: "2.8"
   count:

--- a/lib/ansible/modules/system/at.py
+++ b/lib/ansible/modules/system/at.py
@@ -30,10 +30,12 @@ options:
     description:
      - Supply a specific date string to execute the job on.
      - Various formats are acceptable including midnight, noon, teatime, tomorrow, mon, JAN, next saturday, 2:45 PM DD/MM/YYYY, 4pm + 3 days or now + 60 minutes.
+    version_added: "2.8"
   validate_occasion:
     description:
       - Set this to no to turn off validation of the occasion string and try your luck.
     default: yes
+    version_added: "2.8"
   count:
     description:
      - The count of units in the future to execute the command or script file.
@@ -107,7 +109,8 @@ EXAMPLES = '''
     occasion: 2:30 PM 17.09.2099
 '''
 
-import os, re
+import os
+import re
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
@@ -220,13 +223,13 @@ def main():
         "fri",
         "sat",
         "sun",
-        '[0-2][0-9]\:[0-9][0-9]', # HH:MM
-        '[0-2][0-9]\:[0-9][0-9]\:[0-9][0-9]', # HH:MM:ss
-        '[0-9]+\:[0-5][0-9] [A|P]M', # 12:30 AM
-        '[0-9]+\:[0-5][0-9] [P|A]M [M|T|W|T|F|S][o|u|e|h|r|a][n|e|d|u|i|t]', # 9:30 PM Thu
-        'now \+ [0-9]+ (minutes*|hours*|days*|weeks*|months*|years*)', # now + 3 days
-        '[0-9]+ [A|P]M \+ [0-9]+ (minutes*|hours*|days*|weeks*|months*|years*)', # 4 PM + 55 minutes
-        '[0-9]+\:[0-9]+ [A|P]M (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]+', # 2:30 PM Sep 17
+        r'[0-2][0-9]\:[0-9][0-9]',  # HH:MM
+        r'[0-2][0-9]\:[0-9][0-9]\:[0-9][0-9]',  # HH:MM:ss
+        r'[0-9]+\:[0-5][0-9] [A|P]M',  # 12:30 AM
+        r'[0-9]+\:[0-5][0-9] [P|A]M [M|T|W|T|F|S][o|u|e|h|r|a][n|e|d|u|i|t]',  # 9:30 PM Thu
+        r'now \+ [0-9]+ (minutes*|hours*|days*|weeks*|months*|years*)',  # now + 3 days
+        r'[0-9]+ [A|P]M \+ [0-9]+ (minutes*|hours*|days*|weeks*|months*|years*)',  # 4 PM + 55 minutes
+        r'[0-9]+\:[0-9]+ [A|P]M (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]+',  # 2:30 PM Sep 17
     ]
     if (state == 'present' and ((count and not units) or (units and not count) or (not count and not units and not occasion))):
         module.fail_json(msg="present state requires count and units or occasion to be set")

--- a/lib/ansible/modules/system/at.py
+++ b/lib/ansible/modules/system/at.py
@@ -29,7 +29,7 @@ options:
   occasion:
     description:
      - Supply a specific date string to execute the job on.
-     - Various formats are acceptable including midnight, noon, teatime, tomorrow, mon, JAN, next saturday, 2:45 PM DD/MM/YYYY, 4pm + 3 days or now + 60 minutes.
+     - Various formats are acceptable including midnight, noon, teatime, tomorrow, mon, JAN, next saturday, 4pm + 3 days or now + 60 minutes.
     version_added: "2.8"
   validate_occasion:
     description:


### PR DESCRIPTION
##### SUMMARY

Adds parameter occasion to at module to allow more flexibility in scheduling at jobs. Jobs can be scheduled in a variety of ways, for example...

- tomorrow
- midnight
- teatime
- noon tomorrow
- next saturday
- 12:30 PM
- 12:30 AM Thu
- now + 3 minutes
- 2:30 PM 17.09.2099


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- at

##### ADDITIONAL INFORMATION

```ansible --version```

```
ansible 2.7.5
  config file = None
  configured module search path = ['/Users/rhyscampbell/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/python/3.6.4_2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.4 (default, Jan  6 2018, 11:51:59) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```
